### PR TITLE
feat(cohorts): apply backfill seeds in batches

### DIFF
--- a/rust/cohort-stream-processor/clippy.toml
+++ b/rust/cohort-stream-processor/clippy.toml
@@ -15,6 +15,8 @@ disallowed-methods = [
     { path = "cohort_stream_processor::store::rocks::CohortStore::get_merge_drain_applied", reason = "async code must read through StoreHandle or run_section; sync contexts need a module-level allow — see store/handle.rs" },
     { path = "cohort_stream_processor::store::rocks::CohortStore::get_merge_applied", reason = "async code must read through StoreHandle or run_section; sync contexts need a module-level allow — see store/handle.rs" },
     { path = "cohort_stream_processor::store::rocks::CohortStore::get_tombstone", reason = "async code must read through StoreHandle; sync contexts need a module-level allow — see store/handle.rs" },
+    { path = "cohort_stream_processor::store::rocks::CohortStore::multi_get_person_records", reason = "async code must read through StoreHandle; sync contexts need a module-level allow — see store/handle.rs" },
+    { path = "cohort_stream_processor::store::rocks::CohortStore::multi_get_tombstones", reason = "async code must read through StoreHandle; sync contexts need a module-level allow — see store/handle.rs" },
     { path = "cohort_stream_processor::store::rocks::CohortStore::get_pending_transfer", reason = "async code must read through StoreHandle; sync contexts need a module-level allow — see store/handle.rs" },
     { path = "cohort_stream_processor::store::rocks::CohortStore::clear_pending_transfer", reason = "async code must write through StoreHandle; sync contexts need a module-level allow — see store/handle.rs" },
     { path = "cohort_stream_processor::store::rocks::CohortStore::scan_pending_transfers", reason = "async code must scan through StoreHandle; sync contexts need a module-level allow — see store/handle.rs" },

--- a/rust/cohort-stream-processor/src/config.rs
+++ b/rust/cohort-stream-processor/src/config.rs
@@ -15,7 +15,7 @@ use tracing::warn;
 use crate::partitions::pacing::{AgeMs, Hysteresis, SeedPacingConfig, UsedPct};
 use crate::store::durability::DurabilityConfig;
 use crate::store::{OffloadConfig, OffloadMode, StoreConfig};
-use crate::workers::{CascadeConfig, EventNameGating, TransferRetryPolicy};
+use crate::workers::{CascadeConfig, EventNameGating, SeedBatchLimits, TransferRetryPolicy};
 
 const POOL_NAME: &str = "posthog_cohort";
 
@@ -278,9 +278,20 @@ pub struct Config {
     pub cohort_seed_person_live_margin_ms: i64,
 
     /// Seeds applied as one unit: one batched read pass, one stage-1 commit, one stage-2 recompute
-    /// and one produce round trip per batch, instead of per seed. `1` restores the per-seed apply.
+    /// and one produce round trip per leg per batch, instead of per seed. `1` restores the per-seed
+    /// apply.
     #[envconfig(from = "COHORT_SEED_APPLY_BATCH_MAX", default = "256")]
     pub cohort_seed_apply_batch_max: usize,
+
+    /// Fan-out units one apply batch may expand to, where a seed weighs one per leaf its condition
+    /// reaches plus one per cohort each leaf backs. Bounds the run's leaf reads and recomputes,
+    /// which the seed count alone does not: one seed can reach any number of cohorts.
+    ///
+    /// Typical fan-out is one to six units per seed, so a full 256-seed run weighs under 1.5k and
+    /// the count cap binds; this cap only binds above ~16 units per seed, and its ceiling (4096
+    /// units, about 4k leaf reads plus at most 4k recomputes) is a sub-second run.
+    #[envconfig(from = "COHORT_SEED_APPLY_BATCH_MAX_FANOUT", default = "4096")]
+    pub cohort_seed_apply_batch_max_fanout: usize,
 
     /// Live-priority gate: pause a seed partition once its live watermark age reaches this (ms).
     /// `0` disables the trigger.
@@ -680,11 +691,16 @@ impl Config {
         Duration::from_millis(self.cohort_seed_reconcile_tick_interval_ms)
     }
 
-    /// The seed apply batch ceiling as a proven-positive count, so the grouping loop cannot be
+    /// The seed apply batch ceilings as proven-positive counts, so the grouping loop cannot be
     /// handed a zero that would never close a batch.
-    pub fn seed_apply_batch_max(&self) -> anyhow::Result<NonZeroUsize> {
-        NonZeroUsize::new(self.cohort_seed_apply_batch_max)
-            .context("COHORT_SEED_APPLY_BATCH_MAX must be greater than zero (1 = apply per seed).")
+    pub fn seed_batch_limits(&self) -> anyhow::Result<SeedBatchLimits> {
+        Ok(SeedBatchLimits {
+            max_seeds: NonZeroUsize::new(self.cohort_seed_apply_batch_max).context(
+                "COHORT_SEED_APPLY_BATCH_MAX must be greater than zero (1 = apply per seed).",
+            )?,
+            max_fanout: NonZeroUsize::new(self.cohort_seed_apply_batch_max_fanout)
+                .context("COHORT_SEED_APPLY_BATCH_MAX_FANOUT must be greater than zero.")?,
+        })
     }
 
     /// The seed consumer's pacing gates. `0` on a pause threshold disables that trigger; an
@@ -815,7 +831,7 @@ impl Config {
             );
         }
 
-        self.seed_apply_batch_max()?;
+        self.seed_batch_limits()?;
 
         // A negative margin biases the person-seed verdict toward the seed, letting a stale scan
         // overwrite fresher live state.
@@ -1186,6 +1202,7 @@ mod tests {
             cohort_seed_reconcile_scan_page: 256,
             cohort_seed_reconcile_tick_interval_ms: 2_000,
             cohort_seed_apply_batch_max: 256,
+            cohort_seed_apply_batch_max_fanout: 4096,
             cohort_seed_person_apply_enabled: false,
             cohort_seed_person_live_margin_ms: 900_000,
             cohort_seed_live_lag_pause_ms: 120_000,
@@ -1271,13 +1288,19 @@ mod tests {
     /// `1` is the documented hatch back to the per-seed apply, so the floor has to be `1`, not `0`:
     /// a zero ceiling would make the knob silently meaningless instead of failing the boot.
     #[test]
-    fn the_seed_apply_batch_ceiling_defaults_to_256_and_refuses_zero() {
+    fn the_seed_apply_batch_ceilings_default_and_refuse_zero() {
         let defaults = Config::init_from_hashmap(&std::collections::HashMap::new()).unwrap();
         assert_eq!(defaults.cohort_seed_apply_batch_max, 256);
-        assert_eq!(defaults.seed_apply_batch_max().unwrap().get(), 256);
+        assert_eq!(defaults.cohort_seed_apply_batch_max_fanout, 4096);
+        assert_eq!(
+            defaults.seed_batch_limits().unwrap(),
+            SeedBatchLimits::default(),
+            "the deps default must mirror the env default",
+        );
 
         let mut config = test_config();
         config.cohort_seed_apply_batch_max = 1;
+        config.cohort_seed_apply_batch_max_fanout = 1;
         assert!(config.validate_startup().is_ok());
 
         config.cohort_seed_apply_batch_max = 0;
@@ -1285,7 +1308,15 @@ mod tests {
             .validate_startup()
             .unwrap_err()
             .to_string()
-            .contains("COHORT_SEED_APPLY_BATCH_MAX"),);
+            .contains("COHORT_SEED_APPLY_BATCH_MAX must"),);
+
+        config.cohort_seed_apply_batch_max = 256;
+        config.cohort_seed_apply_batch_max_fanout = 0;
+        assert!(config
+            .validate_startup()
+            .unwrap_err()
+            .to_string()
+            .contains("COHORT_SEED_APPLY_BATCH_MAX_FANOUT"),);
     }
 
     #[test]

--- a/rust/cohort-stream-processor/src/config.rs
+++ b/rust/cohort-stream-processor/src/config.rs
@@ -1,5 +1,6 @@
 //! Service configuration, loaded from environment variables via `envconfig`.
 
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -275,6 +276,11 @@ pub struct Config {
     /// clock skew; ties go to live.
     #[envconfig(from = "COHORT_SEED_PERSON_LIVE_MARGIN_MS", default = "900000")]
     pub cohort_seed_person_live_margin_ms: i64,
+
+    /// Seeds applied as one unit: one batched read pass, one stage-1 commit, one stage-2 recompute
+    /// and one produce round trip per batch, instead of per seed. `1` restores the per-seed apply.
+    #[envconfig(from = "COHORT_SEED_APPLY_BATCH_MAX", default = "256")]
+    pub cohort_seed_apply_batch_max: usize,
 
     /// Live-priority gate: pause a seed partition once its live watermark age reaches this (ms).
     /// `0` disables the trigger.
@@ -674,6 +680,13 @@ impl Config {
         Duration::from_millis(self.cohort_seed_reconcile_tick_interval_ms)
     }
 
+    /// The seed apply batch ceiling as a proven-positive count, so the grouping loop cannot be
+    /// handed a zero that would never close a batch.
+    pub fn seed_apply_batch_max(&self) -> anyhow::Result<NonZeroUsize> {
+        NonZeroUsize::new(self.cohort_seed_apply_batch_max)
+            .context("COHORT_SEED_APPLY_BATCH_MAX must be greater than zero (1 = apply per seed).")
+    }
+
     /// The seed consumer's pacing gates. `0` on a pause threshold disables that trigger; an
     /// enabled trigger requires `0 < resume < pause` (and `pause <= 100` for the disk share) so a
     /// flapping or never-releasing pair is refused at startup.
@@ -801,6 +814,8 @@ impl Config {
                  controls can be consumed; enable the seed consumer or turn reconcile off.",
             );
         }
+
+        self.seed_apply_batch_max()?;
 
         // A negative margin biases the person-seed verdict toward the seed, letting a stale scan
         // overwrite fresher live state.
@@ -1170,6 +1185,7 @@ mod tests {
             cohort_seed_reconcile_enabled: false,
             cohort_seed_reconcile_scan_page: 256,
             cohort_seed_reconcile_tick_interval_ms: 2_000,
+            cohort_seed_apply_batch_max: 256,
             cohort_seed_person_apply_enabled: false,
             cohort_seed_person_live_margin_ms: 900_000,
             cohort_seed_live_lag_pause_ms: 120_000,
@@ -1250,6 +1266,26 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("COHORT_SEED_RECONCILE_TICK_INTERVAL_MS"),);
+    }
+
+    /// `1` is the documented hatch back to the per-seed apply, so the floor has to be `1`, not `0`:
+    /// a zero ceiling would make the knob silently meaningless instead of failing the boot.
+    #[test]
+    fn the_seed_apply_batch_ceiling_defaults_to_256_and_refuses_zero() {
+        let defaults = Config::init_from_hashmap(&std::collections::HashMap::new()).unwrap();
+        assert_eq!(defaults.cohort_seed_apply_batch_max, 256);
+        assert_eq!(defaults.seed_apply_batch_max().unwrap().get(), 256);
+
+        let mut config = test_config();
+        config.cohort_seed_apply_batch_max = 1;
+        assert!(config.validate_startup().is_ok());
+
+        config.cohort_seed_apply_batch_max = 0;
+        assert!(config
+            .validate_startup()
+            .unwrap_err()
+            .to_string()
+            .contains("COHORT_SEED_APPLY_BATCH_MAX"),);
     }
 
     #[test]

--- a/rust/cohort-stream-processor/src/consumers/events.rs
+++ b/rust/cohort-stream-processor/src/consumers/events.rs
@@ -1903,7 +1903,7 @@ mod tests {
             register_transfer_enabled: true,
             reconcile,
             person_seed: crate::workers::PersonSeedDeps::default(),
-            seed_apply_batch_max: crate::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
+            seed_batch: crate::workers::SeedBatchLimits::default(),
         });
         let dispatcher = EventDispatcher::new(
             PartitionRouter::new(64),
@@ -2614,7 +2614,7 @@ mod tests {
             register_transfer_enabled: false,
             reconcile,
             person_seed: crate::workers::PersonSeedDeps::default(),
-            seed_apply_batch_max: crate::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
+            seed_batch: crate::workers::SeedBatchLimits::default(),
         });
         let dispatcher = Arc::new(EventDispatcher::new(
             PartitionRouter::new(64),

--- a/rust/cohort-stream-processor/src/consumers/events.rs
+++ b/rust/cohort-stream-processor/src/consumers/events.rs
@@ -1903,6 +1903,7 @@ mod tests {
             register_transfer_enabled: true,
             reconcile,
             person_seed: crate::workers::PersonSeedDeps::default(),
+            seed_apply_batch_max: crate::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
         });
         let dispatcher = EventDispatcher::new(
             PartitionRouter::new(64),
@@ -2613,6 +2614,7 @@ mod tests {
             register_transfer_enabled: false,
             reconcile,
             person_seed: crate::workers::PersonSeedDeps::default(),
+            seed_apply_batch_max: crate::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
         });
         let dispatcher = Arc::new(EventDispatcher::new(
             PartitionRouter::new(64),

--- a/rust/cohort-stream-processor/src/main.rs
+++ b/rust/cohort-stream-processor/src/main.rs
@@ -263,6 +263,7 @@ async fn async_main(config: Config) -> Result<()> {
             enabled: config.cohort_seed_person_apply_enabled,
             live_margin_ms: config.cohort_seed_person_live_margin_ms,
         },
+        seed_apply_batch_max: config.seed_apply_batch_max()?,
     });
 
     // Cheap `Arc` clones taken before the originals move into the dispatcher: the checkpoint sweeper
@@ -846,6 +847,7 @@ fn log_startup(config: &Config) {
         cohort_seed_reconcile_enabled = config.cohort_seed_reconcile_enabled,
         cohort_seed_reconcile_scan_page = config.cohort_seed_reconcile_scan_page,
         cohort_seed_reconcile_tick_interval_ms = config.cohort_seed_reconcile_tick_interval_ms,
+        cohort_seed_apply_batch_max = config.cohort_seed_apply_batch_max,
         "starting cohort-stream-processor",
     );
 }

--- a/rust/cohort-stream-processor/src/main.rs
+++ b/rust/cohort-stream-processor/src/main.rs
@@ -263,7 +263,7 @@ async fn async_main(config: Config) -> Result<()> {
             enabled: config.cohort_seed_person_apply_enabled,
             live_margin_ms: config.cohort_seed_person_live_margin_ms,
         },
-        seed_apply_batch_max: config.seed_apply_batch_max()?,
+        seed_batch: config.seed_batch_limits()?,
     });
 
     // Cheap `Arc` clones taken before the originals move into the dispatcher: the checkpoint sweeper
@@ -848,6 +848,7 @@ fn log_startup(config: &Config) {
         cohort_seed_reconcile_scan_page = config.cohort_seed_reconcile_scan_page,
         cohort_seed_reconcile_tick_interval_ms = config.cohort_seed_reconcile_tick_interval_ms,
         cohort_seed_apply_batch_max = config.cohort_seed_apply_batch_max,
+        cohort_seed_apply_batch_max_fanout = config.cohort_seed_apply_batch_max_fanout,
         "starting cohort-stream-processor",
     );
 }

--- a/rust/cohort-stream-processor/src/merge/tombstone_redirect.rs
+++ b/rust/cohort-stream-processor/src/merge/tombstone_redirect.rs
@@ -8,6 +8,8 @@
 //! lands on a different partition (re-keyed and re-produced). The chain `origin` is always the
 //! straggler's own person id, since it keys into `redirect_dedup`.
 
+use std::collections::HashMap;
+
 use metrics::counter;
 use tracing::{debug, warn};
 use uuid::Uuid;
@@ -108,13 +110,7 @@ fn read_tombstone(
     let Some(bytes) = store.get_tombstone(&key)? else {
         return Ok(None);
     };
-    match Tombstone::decode(&bytes) {
-        Ok(tombstone) => Ok(Some(tombstone)),
-        Err(error) => {
-            debug!(partition_id, %person, error = %error, "corrupt tombstone; treating as not merged");
-            Ok(None)
-        }
-    }
+    Ok(decode_tombstone(partition_id, person, &bytes))
 }
 
 /// Async twin of [`resolve`] over the [`StoreHandle`] facade; each hop reads on the caller's
@@ -185,13 +181,70 @@ async fn read_tombstone_offloaded(
     let Some(bytes) = handle.get_tombstone(&key, lane).await? else {
         return Ok(None);
     };
-    match Tombstone::decode(&bytes) {
-        Ok(tombstone) => Ok(Some(tombstone)),
+    Ok(decode_tombstone(partition_id, person, &bytes))
+}
+
+/// Decode one stored tombstone, or `None` when the bytes are corrupt. A corrupt marker reads as
+/// "not merged", which is the same degrade a missing marker gets.
+fn decode_tombstone(partition_id: u16, person: Uuid, bytes: &[u8]) -> Option<Tombstone> {
+    match Tombstone::decode(bytes) {
+        Ok(tombstone) => Some(tombstone),
         Err(error) => {
             debug!(partition_id, %person, error = %error, "corrupt tombstone; treating as not merged");
-            Ok(None)
+            None
         }
     }
+}
+
+/// Resolve many `(team, person)` keys at once, reading every chain's first hop in one batched
+/// `multi_get`.
+///
+/// `persons` must be distinct; a repeat costs a redundant read and resolves to the same verdict.
+/// Only a chain whose first hop lands back on this partition needs its later hops walked one at a
+/// time, and that requires a merge to have happened, so a backfill batch normally pays exactly one
+/// read for the whole run.
+pub async fn resolve_batch_offloaded(
+    handle: &StoreHandle,
+    partition_id: u16,
+    persons: &[(TeamId, Uuid)],
+    partition_count: u32,
+    lane: ReadLane,
+) -> Result<HashMap<(TeamId, Uuid), Resolution>, StoreError> {
+    let keys: Vec<TombstoneKey> = persons
+        .iter()
+        .map(|&(team_id, person)| TombstoneKey {
+            partition_id,
+            team_id: team_id.0 as u64,
+            person,
+        })
+        .collect();
+    let values = handle.multi_get_tombstones(keys, lane).await?;
+
+    let mut resolved = HashMap::with_capacity(persons.len());
+    for (&(team_id, person), bytes) in persons.iter().zip(values) {
+        let first = bytes
+            .as_deref()
+            .and_then(|bytes| decode_tombstone(partition_id, person, bytes));
+        let resolution = match first {
+            None => Resolution::NotMerged,
+            Some(tombstone)
+                if partition_of(team_id, &tombstone.new_person, partition_count) as u16
+                    != partition_id =>
+            {
+                Resolution::CrossPartition {
+                    target_person: tombstone.new_person,
+                    origin: person,
+                }
+            }
+            // The chain continues here, so the remaining hops need their own reads.
+            Some(_) => {
+                resolve_offloaded(handle, partition_id, team_id, person, partition_count, lane)
+                    .await?
+            }
+        };
+        resolved.insert((team_id, person), resolution);
+    }
+    Ok(resolved)
 }
 
 /// Record an inline redirect metric. Cross-partition redirects are counted separately via

--- a/rust/cohort-stream-processor/src/merge/tombstone_redirect.rs
+++ b/rust/cohort-stream-processor/src/merge/tombstone_redirect.rs
@@ -129,8 +129,31 @@ pub async fn resolve_offloaded(
     else {
         return Ok(Resolution::NotMerged);
     };
+    walk_from(
+        handle,
+        partition_id,
+        team_id,
+        person,
+        first,
+        partition_count,
+        lane,
+    )
+    .await
+}
 
-    let origin = person;
+/// Follow a chain from its already-read first hop. Shared by the single and batched resolvers, so
+/// a batched read's decoded hop is never re-read: the walk starts from its target and checks that
+/// target's partition before touching the store again.
+async fn walk_from(
+    handle: &StoreHandle,
+    partition_id: u16,
+    team_id: TeamId,
+    origin: Uuid,
+    first: Tombstone,
+    partition_count: u32,
+    lane: ReadLane,
+) -> Result<Resolution, StoreError> {
+    let team = team_id.0 as u64;
     let mut current = first.new_person;
 
     for _hop in 0..MAX_TOMBSTONE_HOPS {
@@ -197,12 +220,16 @@ fn decode_tombstone(partition_id: u16, person: Uuid, bytes: &[u8]) -> Option<Tom
 }
 
 /// Resolve many `(team, person)` keys at once, reading every chain's first hop in one batched
-/// `multi_get`.
+/// `multi_get` and walking the rest from there.
 ///
 /// `persons` must be distinct; a repeat costs a redundant read and resolves to the same verdict.
 /// Only a chain whose first hop lands back on this partition needs its later hops walked one at a
 /// time, and that requires a merge to have happened, so a backfill batch normally pays exactly one
 /// read for the whole run.
+///
+/// A short `multi_get` yields a map missing those keys. The caller must treat a missing key as a
+/// failure, never as `NotMerged`: applying a seed to a person that may have merged away is durable
+/// state nothing downstream can retract.
 pub async fn resolve_batch_offloaded(
     handle: &StoreHandle,
     partition_id: u16,
@@ -227,19 +254,17 @@ pub async fn resolve_batch_offloaded(
             .and_then(|bytes| decode_tombstone(partition_id, person, bytes));
         let resolution = match first {
             None => Resolution::NotMerged,
-            Some(tombstone)
-                if partition_of(team_id, &tombstone.new_person, partition_count) as u16
-                    != partition_id =>
-            {
-                Resolution::CrossPartition {
-                    target_person: tombstone.new_person,
-                    origin: person,
-                }
-            }
-            // The chain continues here, so the remaining hops need their own reads.
-            Some(_) => {
-                resolve_offloaded(handle, partition_id, team_id, person, partition_count, lane)
-                    .await?
+            Some(first) => {
+                walk_from(
+                    handle,
+                    partition_id,
+                    team_id,
+                    person,
+                    first,
+                    partition_count,
+                    lane,
+                )
+                .await?
             }
         };
         resolved.insert((team_id, person), resolution);
@@ -274,7 +299,7 @@ mod tests {
 
     use crate::merge::transfer::Tombstone;
     use crate::partitions::partitioner::COHORT_PARTITION_COUNT;
-    use crate::store::StoreConfig;
+    use crate::store::{OffloadConfig, OffloadMode, StoreConfig};
 
     const TEAM: TeamId = TeamId(7);
 
@@ -430,6 +455,66 @@ mod tests {
             resolve(&store, part, TEAM, p_old, COHORT_PARTITION_COUNT).unwrap(),
             Resolution::Inline { origin, .. } if origin == p_old,
         ));
+    }
+
+    /// The batched read decodes only the first hop, so the rest of a chain is walked from that
+    /// hop. A walk that stopped there would resolve a two-hop chain to its middle person, and a
+    /// walk that restarted from the origin would pass every test while paying the first read twice.
+    #[tokio::test]
+    async fn a_batched_first_hop_still_walks_the_rest_of_the_chain() {
+        let (_dir, store) = temp_store();
+        let handle = StoreHandle::new(
+            store.clone(),
+            OffloadConfig {
+                mode: OffloadMode::All,
+                event_read_permits: 16,
+                maintenance_permits: 6,
+            },
+        );
+        let p_old = Uuid::from_u128(0xA11CE);
+        let part = partition(p_old);
+        let mut on_part = (1u128..)
+            .map(Uuid::from_u128)
+            .filter(|p| partition(*p) == part && *p != p_old);
+        let (p_mid, p_final, p_unmerged, p_leaving) = (
+            on_part.next().unwrap(),
+            on_part.next().unwrap(),
+            on_part.next().unwrap(),
+            on_part.next().unwrap(),
+        );
+        let p_far = person_not_on(part);
+        write_tombstone(&store, part, p_old, p_mid);
+        write_tombstone(&store, part, p_mid, p_final);
+        write_tombstone(&store, part, p_leaving, p_far);
+
+        let resolved = resolve_batch_offloaded(
+            &handle,
+            part,
+            &[(TEAM, p_old), (TEAM, p_unmerged), (TEAM, p_leaving)],
+            COHORT_PARTITION_COUNT,
+            ReadLane::Maintenance,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resolved.len(), 3, "one verdict per key asked");
+        assert_eq!(
+            resolved[&(TEAM, p_old)],
+            Resolution::Inline {
+                final_person: p_final,
+                origin: p_old,
+            },
+            "the chain converges past the batched hop and the origin stays the first person",
+        );
+        assert_eq!(resolved[&(TEAM, p_unmerged)], Resolution::NotMerged);
+        assert_eq!(
+            resolved[&(TEAM, p_leaving)],
+            Resolution::CrossPartition {
+                target_person: p_far,
+                origin: p_leaving,
+            },
+            "a first hop that leaves the partition is a hand-off, not a walk",
+        );
     }
 
     #[test]

--- a/rust/cohort-stream-processor/src/observability/metrics.rs
+++ b/rust/cohort-stream-processor/src/observability/metrics.rs
@@ -516,6 +516,17 @@ pub const PERSON_SEED_REKEY_HOP_CAPPED_TOTAL: &str = "cohort_person_seeds_rekey_
 /// Failed person-seed re-key produces; the seed offset is held (counter).
 pub const PERSON_SEED_REKEY_PRODUCE_FAILURE_TOTAL: &str =
     "cohort_person_seeds_rekey_produce_failure_total";
+/// Seeds applied as one batched unit, labelled by `kind` (`tile`|`person`) (histogram). The
+/// distance from `COHORT_SEED_APPLY_BATCH_MAX` is how much of the produce round trip a batch
+/// actually amortizes.
+pub const SEED_APPLY_BATCH_SIZE: &str = "cohort_seed_apply_batch_size";
+/// Wall-clock per batch stage, labelled by `kind` and `stage` (`resolve`|`read`|`fold`|
+/// `stage1_commit`|`recompute`|`produce`|`stage2_commit`) (histogram, seconds). Whichever stage
+/// dominates is the next lever.
+pub const SEED_APPLY_BATCH_DURATION_SECONDS: &str = "cohort_seed_apply_batch_duration_seconds";
+/// Batches that held their first offset instead of marking, labelled by `kind` and the `stage` that
+/// failed (counter). Pairs with [`SEED_HELD_OFFSET_GAUGE`], which shows the pinned floor.
+pub const SEED_APPLY_BATCHES_HELD_TOTAL: &str = "cohort_seed_apply_batches_held_total";
 /// The seed commit floor pinned by a sticky offset hold, labelled by `partition` (gauge).
 /// **Alert on a sustained non-zero level.**
 pub const SEED_HELD_OFFSET_GAUGE: &str = "seed_held_offset";
@@ -880,6 +891,15 @@ mod tests {
             "cohort_person_seeds_rekey_produce_failure_total",
         );
         // The held-offset gauge deliberately mirrors merge_held_offset/cascade_held_offset.
+        assert_eq!(SEED_APPLY_BATCH_SIZE, "cohort_seed_apply_batch_size");
+        assert_eq!(
+            SEED_APPLY_BATCH_DURATION_SECONDS,
+            "cohort_seed_apply_batch_duration_seconds",
+        );
+        assert_eq!(
+            SEED_APPLY_BATCHES_HELD_TOTAL,
+            "cohort_seed_apply_batches_held_total",
+        );
         assert_eq!(SEED_HELD_OFFSET_GAUGE, "seed_held_offset");
         assert_eq!(SEED_FENCED_PARTITIONS, "cohort_seed_fenced_partitions");
         assert_eq!(SEED_FENCE_DEFICIT_MS, "cohort_seed_fence_deficit_ms");

--- a/rust/cohort-stream-processor/src/observability/metrics.rs
+++ b/rust/cohort-stream-processor/src/observability/metrics.rs
@@ -521,8 +521,8 @@ pub const PERSON_SEED_REKEY_PRODUCE_FAILURE_TOTAL: &str =
 /// actually amortizes.
 pub const SEED_APPLY_BATCH_SIZE: &str = "cohort_seed_apply_batch_size";
 /// Wall-clock per batch stage, labelled by `kind` and `stage` (`resolve`|`read`|`fold`|
-/// `stage1_commit`|`recompute`|`produce`|`stage2_commit`) (histogram, seconds). Whichever stage
-/// dominates is the next lever.
+/// `produce_leaf`|`stage1_commit`|`recompute`|`produce_composed`|`produce_cascades`|
+/// `stage2_commit`) (histogram, seconds). Whichever stage dominates is the next lever.
 pub const SEED_APPLY_BATCH_DURATION_SECONDS: &str = "cohort_seed_apply_batch_duration_seconds";
 /// Batches that held their first offset instead of marking, labelled by `kind` and the `stage` that
 /// failed (counter). Pairs with [`SEED_HELD_OFFSET_GAUGE`], which shows the pinned floor.

--- a/rust/cohort-stream-processor/src/observability/metrics.rs
+++ b/rust/cohort-stream-processor/src/observability/metrics.rs
@@ -527,6 +527,10 @@ pub const SEED_APPLY_BATCH_DURATION_SECONDS: &str = "cohort_seed_apply_batch_dur
 /// Batches that held their first offset instead of marking, labelled by `kind` and the `stage` that
 /// failed (counter). Pairs with [`SEED_HELD_OFFSET_GAUGE`], which shows the pinned floor.
 pub const SEED_APPLY_BATCHES_HELD_TOTAL: &str = "cohort_seed_apply_batches_held_total";
+/// Runs closed while grouping, labelled by `kind` and `cause` (`count`|`fanout`|`kind_change`|
+/// `end`) (counter). `count` should dominate; a `fanout` rate means the catalog fans seeds out far
+/// wider than `COHORT_SEED_APPLY_BATCH_MAX_FANOUT` assumes.
+pub const SEED_APPLY_BATCHES_CLOSED_TOTAL: &str = "cohort_seed_apply_batches_closed_total";
 /// The seed commit floor pinned by a sticky offset hold, labelled by `partition` (gauge).
 /// **Alert on a sustained non-zero level.**
 pub const SEED_HELD_OFFSET_GAUGE: &str = "seed_held_offset";
@@ -899,6 +903,10 @@ mod tests {
         assert_eq!(
             SEED_APPLY_BATCHES_HELD_TOTAL,
             "cohort_seed_apply_batches_held_total",
+        );
+        assert_eq!(
+            SEED_APPLY_BATCHES_CLOSED_TOTAL,
+            "cohort_seed_apply_batches_closed_total",
         );
         assert_eq!(SEED_HELD_OFFSET_GAUGE, "seed_held_offset");
         assert_eq!(SEED_FENCED_PARTITIONS, "cohort_seed_fenced_partitions");

--- a/rust/cohort-stream-processor/src/producer/cascade.rs
+++ b/rust/cohort-stream-processor/src/producer/cascade.rs
@@ -93,6 +93,12 @@ impl CaptureCascadeSink {
     pub fn messages(&self) -> Vec<CascadeMessage> {
         self.0.recorded()
     }
+
+    /// Produce calls, failed ones included. A failed produce records no messages, so this is what
+    /// tells "never submitted" from "submitted and failed".
+    pub fn produce_calls(&self) -> usize {
+        self.0.calls()
+    }
 }
 
 #[async_trait]

--- a/rust/cohort-stream-processor/src/producer/merge.rs
+++ b/rust/cohort-stream-processor/src/producer/merge.rs
@@ -113,6 +113,9 @@ const FAIL_ALWAYS: usize = usize::MAX;
 pub(crate) struct Capture<T> {
     items: Arc<Mutex<Vec<T>>>,
     fail_remaining: Arc<AtomicUsize>,
+    /// Produce calls, not items. Batching is only observable here: the same items over one call
+    /// instead of many is exactly the change a batched apply makes.
+    calls: Arc<AtomicUsize>,
 }
 
 impl<T> Clone for Capture<T> {
@@ -120,6 +123,7 @@ impl<T> Clone for Capture<T> {
         Self {
             items: self.items.clone(),
             fail_remaining: self.fail_remaining.clone(),
+            calls: self.calls.clone(),
         }
     }
 }
@@ -129,6 +133,7 @@ impl<T> Default for Capture<T> {
         Self {
             items: Arc::default(),
             fail_remaining: Arc::default(),
+            calls: Arc::default(),
         }
     }
 }
@@ -138,6 +143,7 @@ impl<T> Capture<T> {
         Self {
             items: Arc::default(),
             fail_remaining: Arc::new(AtomicUsize::new(n)),
+            calls: Arc::default(),
         }
     }
 
@@ -146,6 +152,7 @@ impl<T> Capture<T> {
     }
 
     pub(crate) fn produce(&self, items: Vec<T>) -> Vec<Result<(), KafkaProduceError>> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
         let should_fail = self
             .fail_remaining
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| match n {
@@ -166,6 +173,11 @@ impl<T> Capture<T> {
             .expect("Capture mutex poisoned")
             .extend(items);
         acks
+    }
+
+    /// Produce calls made so far, failed ones included.
+    pub(crate) fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
     }
 }
 

--- a/rust/cohort-stream-processor/src/producer/merge.rs
+++ b/rust/cohort-stream-processor/src/producer/merge.rs
@@ -1,6 +1,7 @@
 //! Merge-protocol producers for `cohort_merge_state_transfer` and straggler re-keys back into
 //! `cohort_stream_events`.
 
+use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -105,14 +106,39 @@ fn stream_event_key(event: &CohortStreamEvent) -> Option<String> {
     }
 }
 
-const FAIL_ALWAYS: usize = usize::MAX;
+/// How a capture double fails its produces. Failing is the one thing the real producer does that a
+/// recorder cannot, so the plan is the whole of the double's behaviour beyond recording.
+#[derive(Debug, Clone, Copy)]
+enum FailurePlan {
+    /// Fail every record of `count` consecutive calls, after `skip` calls that ack.
+    Calls { skip: usize, count: usize },
+    /// On the first call, fail every `every`-th record and record and ack the rest; every later
+    /// call acks. This is the mixed acknowledgement a real broker returns.
+    PartialFirst { every: NonZeroUsize },
+}
 
-/// Shared produce recorder for test doubles: records items and can fail the next `n` (or all)
-/// produces.
+impl FailurePlan {
+    /// Whether record `record` of call `call` (both 0-based) fails.
+    fn fails(self, call: usize, record: usize) -> bool {
+        match self {
+            Self::Calls { skip, count } => (skip..skip.saturating_add(count)).contains(&call),
+            Self::PartialFirst { every } => call == 0 && (record + 1).is_multiple_of(every.get()),
+        }
+    }
+}
+
+impl Default for FailurePlan {
+    fn default() -> Self {
+        Self::Calls { skip: 0, count: 0 }
+    }
+}
+
+/// Shared produce recorder for test doubles: records the items it acks and fails the rest
+/// according to its [`FailurePlan`].
 #[derive(Debug)]
 pub(crate) struct Capture<T> {
     items: Arc<Mutex<Vec<T>>>,
-    fail_remaining: Arc<AtomicUsize>,
+    plan: FailurePlan,
     /// Produce calls, not items. Batching is only observable here: the same items over one call
     /// instead of many is exactly the change a batched apply makes.
     calls: Arc<AtomicUsize>,
@@ -122,7 +148,7 @@ impl<T> Clone for Capture<T> {
     fn clone(&self) -> Self {
         Self {
             items: self.items.clone(),
-            fail_remaining: self.fail_remaining.clone(),
+            plan: self.plan,
             calls: self.calls.clone(),
         }
     }
@@ -130,49 +156,51 @@ impl<T> Clone for Capture<T> {
 
 impl<T> Default for Capture<T> {
     fn default() -> Self {
-        Self {
-            items: Arc::default(),
-            fail_remaining: Arc::default(),
-            calls: Arc::default(),
-        }
+        Self::with_plan(FailurePlan::default())
     }
 }
 
 impl<T> Capture<T> {
-    pub(crate) fn failing_first(n: usize) -> Self {
+    fn with_plan(plan: FailurePlan) -> Self {
         Self {
             items: Arc::default(),
-            fail_remaining: Arc::new(AtomicUsize::new(n)),
+            plan,
             calls: Arc::default(),
         }
     }
 
+    pub(crate) fn failing_first(n: usize) -> Self {
+        Self::failing_calls(0, n)
+    }
+
     pub(crate) fn failing_always() -> Self {
-        Self::failing_first(FAIL_ALWAYS)
+        Self::failing_calls(0, usize::MAX)
+    }
+
+    /// Fail the `count` calls after `skip` acked ones, then ack again.
+    pub(crate) fn failing_calls(skip: usize, count: usize) -> Self {
+        Self::with_plan(FailurePlan::Calls { skip, count })
+    }
+
+    /// On the first call, fail every `every`-th record and record and ack the rest.
+    pub(crate) fn partially_failing_first(every: NonZeroUsize) -> Self {
+        Self::with_plan(FailurePlan::PartialFirst { every })
     }
 
     pub(crate) fn produce(&self, items: Vec<T>) -> Vec<Result<(), KafkaProduceError>> {
-        self.calls.fetch_add(1, Ordering::SeqCst);
-        let should_fail = self
-            .fail_remaining
-            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| match n {
-                0 => None,
-                FAIL_ALWAYS => Some(FAIL_ALWAYS),
-                n => Some(n - 1),
+        let call = self.calls.fetch_add(1, Ordering::SeqCst);
+        let mut recorded = self.items.lock().expect("Capture mutex poisoned");
+        items
+            .into_iter()
+            .enumerate()
+            .map(|(record, item)| {
+                if self.plan.fails(call, record) {
+                    return Err(KafkaProduceError::KafkaProduceCanceled);
+                }
+                recorded.push(item);
+                Ok(())
             })
-            .is_ok();
-        if should_fail {
-            return items
-                .into_iter()
-                .map(|_| Err(KafkaProduceError::KafkaProduceCanceled))
-                .collect();
-        }
-        let acks = (0..items.len()).map(|_| Ok(())).collect();
-        self.items
-            .lock()
-            .expect("Capture mutex poisoned")
-            .extend(items);
-        acks
+            .collect()
     }
 
     /// Produce calls made so far, failed ones included.

--- a/rust/cohort-stream-processor/src/producer/mod.rs
+++ b/rust/cohort-stream-processor/src/producer/mod.rs
@@ -10,6 +10,8 @@ pub mod marker;
 pub mod merge;
 pub mod seed;
 
+use std::num::NonZeroUsize;
+
 use async_trait::async_trait;
 use chrono::Utc;
 use common_kafka::kafka_producer::KafkaProduceError;
@@ -178,6 +180,18 @@ impl CaptureSink {
 
     pub fn failing_first(n: usize) -> Self {
         Self(Capture::failing_first(n))
+    }
+
+    /// Fail the `count` produces after `skip` acked ones, so a failure can be aimed at one leg of
+    /// a multi-leg pipeline.
+    pub fn failing_calls(skip: usize, count: usize) -> Self {
+        Self(Capture::failing_calls(skip, count))
+    }
+
+    /// On the first produce, fail every `every`-th change and ack the rest: the mixed
+    /// acknowledgement a real broker returns.
+    pub fn partially_failing_first(every: NonZeroUsize) -> Self {
+        Self(Capture::partially_failing_first(every))
     }
 
     pub fn changes(&self) -> Vec<CohortMembershipChange> {

--- a/rust/cohort-stream-processor/src/producer/mod.rs
+++ b/rust/cohort-stream-processor/src/producer/mod.rs
@@ -183,6 +183,11 @@ impl CaptureSink {
     pub fn changes(&self) -> Vec<CohortMembershipChange> {
         self.0.recorded()
     }
+
+    /// Produce calls, not changes. One call per apply batch is what the batching buys.
+    pub fn produce_calls(&self) -> usize {
+        self.0.calls()
+    }
 }
 
 #[async_trait]

--- a/rust/cohort-stream-processor/src/store/handle.rs
+++ b/rust/cohort-stream-processor/src/store/handle.rs
@@ -306,6 +306,19 @@ impl StoreHandle {
         .await
     }
 
+    /// Batch-read `cf_person_records` values, preserving input order. Keys are taken by value so
+    /// the closure is trivially `'static`.
+    pub async fn multi_get_person_records(
+        &self,
+        keys: Vec<PersonRecordKey>,
+        lane: ReadLane,
+    ) -> Result<Vec<Option<Vec<u8>>>, StoreError> {
+        self.read("multi_get_person_records", lane, move |store| {
+            store.multi_get_person_records(&keys)
+        })
+        .await
+    }
+
     /// Read one event's full state snapshot in a single mixed-CF `multi_get` (behavioral keys plus
     /// the optional person-record key). The event fold's hot-path read, on the Event lane. Keys are
     /// taken by value so the closure is trivially `'static`.
@@ -384,6 +397,22 @@ impl StoreHandle {
         let key = *key;
         self.read("get_tombstone", lane, move |store| {
             store.get_tombstone(&key)
+        })
+        .await
+    }
+
+    /// Batch-read redirect tombstones, preserving input order. One hop per key: a chain that
+    /// continues on this partition still needs [`tombstone_redirect::resolve_offloaded`] for that
+    /// person.
+    ///
+    /// [`tombstone_redirect::resolve_offloaded`]: crate::merge::tombstone_redirect::resolve_offloaded
+    pub async fn multi_get_tombstones(
+        &self,
+        keys: Vec<TombstoneKey>,
+        lane: ReadLane,
+    ) -> Result<Vec<Option<Vec<u8>>>, StoreError> {
+        self.read("multi_get_tombstones", lane, move |store| {
+            store.multi_get_tombstones(&keys)
         })
         .await
     }

--- a/rust/cohort-stream-processor/src/store/rocks.rs
+++ b/rust/cohort-stream-processor/src/store/rocks.rs
@@ -472,6 +472,36 @@ impl CohortStore {
         self.get(Cf::PersonRecords, &key.encode())
     }
 
+    /// Batch-read several `cf_person_records` values in one call, preserving input order.
+    pub fn multi_get_person_records(
+        &self,
+        keys: &[PersonRecordKey],
+    ) -> Result<Vec<Option<Vec<u8>>>, StoreError> {
+        // An empty batch is not a read: skip it so it records no phantom read-latency sample.
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+        let handle = self.cf(Cf::PersonRecords)?;
+        let encoded: Vec<_> = keys.iter().map(PersonRecordKey::encode).collect();
+        let started = Instant::now();
+        let results = self
+            .db
+            .multi_get_cf(encoded.iter().map(|key| (handle, key.as_slice())));
+        record_multi_get(started, keys.len());
+        results
+            .into_iter()
+            .map(|result| {
+                result.map_err(|source| {
+                    counter!(STORE_ERRORS_TOTAL, "op" => OP_MULTI_GET).increment(1);
+                    StoreError::Backend {
+                        op: OP_MULTI_GET,
+                        source,
+                    }
+                })
+            })
+            .collect()
+    }
+
     /// Read one event's full state snapshot in a single mixed-CF `multi_get`: the `behavioral` keys
     /// (in order) plus, when `record` is given, the person's `cf_person_records` key as the final
     /// lookup.
@@ -848,6 +878,37 @@ impl CohortStore {
 
     pub fn get_tombstone(&self, key: &TombstoneKey) -> Result<Option<Vec<u8>>, StoreError> {
         self.get(Cf::MergeTombstones, &key.encode())
+    }
+
+    /// Batch-read several `cf_merge_tombstones` values in one call, preserving input order. Reads
+    /// the first hop only; a chain that continues on this partition still needs per-person hops.
+    pub fn multi_get_tombstones(
+        &self,
+        keys: &[TombstoneKey],
+    ) -> Result<Vec<Option<Vec<u8>>>, StoreError> {
+        // An empty batch is not a read: skip it so it records no phantom read-latency sample.
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+        let handle = self.cf(Cf::MergeTombstones)?;
+        let encoded: Vec<_> = keys.iter().map(TombstoneKey::encode).collect();
+        let started = Instant::now();
+        let results = self
+            .db
+            .multi_get_cf(encoded.iter().map(|key| (handle, key.as_slice())));
+        record_multi_get(started, keys.len());
+        results
+            .into_iter()
+            .map(|result| {
+                result.map_err(|source| {
+                    counter!(STORE_ERRORS_TOTAL, "op" => OP_MULTI_GET).increment(1);
+                    StoreError::Backend {
+                        op: OP_MULTI_GET,
+                        source,
+                    }
+                })
+            })
+            .collect()
     }
 
     /// Clear one outbox slot once its transfer is acked.
@@ -1633,6 +1694,58 @@ mod tests {
         assert!(
             store.multi_get_behavioral(&[]).unwrap().is_empty(),
             "an empty key set reads no values",
+        );
+    }
+
+    /// The two batched reads feed overlays indexed by request position, so an absent key that
+    /// shifted the results would pair one person's bytes with another person's key.
+    #[test]
+    fn multi_get_person_records_and_tombstones_preserve_order_and_report_absent_keys() {
+        let dir = TempDir::new().unwrap();
+        let store = CohortStore::open(&StoreConfig {
+            path: dir.path().join("db"),
+            ..StoreConfig::default()
+        })
+        .unwrap();
+
+        let tombstone_key = |person: u128| TombstoneKey {
+            partition_id: 3,
+            team_id: 7,
+            person: Uuid::from_u128(person),
+        };
+        store
+            .write_batch(|batch| {
+                batch.put::<PersonRecords>(&record_key(3, 1), b"alpha");
+                batch.put::<PersonRecords>(&record_key(3, 2), b"bravo");
+                batch.put_tombstone(&tombstone_key(1), b"charlie");
+                batch.put_tombstone(&tombstone_key(2), b"delta");
+            })
+            .unwrap();
+
+        let records = store
+            .multi_get_person_records(&[record_key(3, 1), record_key(3, 9), record_key(3, 2)])
+            .unwrap();
+        assert_eq!(records.len(), 3);
+        assert_eq!(records[0].as_deref(), Some(b"alpha".as_slice()));
+        assert_eq!(records[1], None);
+        assert_eq!(records[2].as_deref(), Some(b"bravo".as_slice()));
+        assert!(store.multi_get_person_records(&[]).unwrap().is_empty());
+
+        let tombstones = store
+            .multi_get_tombstones(&[tombstone_key(1), tombstone_key(9), tombstone_key(2)])
+            .unwrap();
+        assert_eq!(tombstones.len(), 3);
+        assert_eq!(tombstones[0].as_deref(), Some(b"charlie".as_slice()));
+        assert_eq!(tombstones[1], None);
+        assert_eq!(tombstones[2].as_deref(), Some(b"delta".as_slice()));
+        assert!(store.multi_get_tombstones(&[]).unwrap().is_empty());
+
+        assert_eq!(
+            store
+                .multi_get_person_records(&[PersonRecordKey::new(4, 7, Uuid::from_u128(1))])
+                .unwrap(),
+            vec![None],
+            "the person-record read is partition-scoped by its key prefix",
         );
     }
 

--- a/rust/cohort-stream-processor/src/workers/cascade_path.rs
+++ b/rust/cohort-stream-processor/src/workers/cascade_path.rs
@@ -449,6 +449,7 @@ mod tests {
             register_transfer_enabled: false,
             reconcile: crate::workers::ReconcileDeps::default(),
             person_seed: crate::workers::PersonSeedDeps::default(),
+            seed_apply_batch_max: crate::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
         };
         // The cascade was dispatched this tenure, so its ceiling is raised — mirrors the dispatcher.
         deps.cascade_tracker

--- a/rust/cohort-stream-processor/src/workers/cascade_path.rs
+++ b/rust/cohort-stream-processor/src/workers/cascade_path.rs
@@ -449,7 +449,7 @@ mod tests {
             register_transfer_enabled: false,
             reconcile: crate::workers::ReconcileDeps::default(),
             person_seed: crate::workers::PersonSeedDeps::default(),
-            seed_apply_batch_max: crate::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
+            seed_batch: crate::workers::SeedBatchLimits::default(),
         };
         // The cascade was dispatched this tenure, so its ceiling is raised — mirrors the dispatcher.
         deps.cascade_tracker

--- a/rust/cohort-stream-processor/src/workers/merge_path.rs
+++ b/rust/cohort-stream-processor/src/workers/merge_path.rs
@@ -5,7 +5,6 @@
 //! [`handle_apply`] applies a `MergeStateTransfer` on P_new's worker. Both produce their own
 //! membership output and mark their own [`OffsetTracker`].
 
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -39,6 +38,7 @@ use crate::stage1::transition::LeafTransition;
 use crate::store::{BehavioralKey, PendingTransferKey, ReadLane, StoreHandle};
 use crate::sweep::EvictionQueue;
 use crate::workers::person_seed_path::PersonSeedDeps;
+use crate::workers::seed_batch::SeedBatchLimits;
 use crate::workers::stage2_path::compose_stage2;
 use crate::workers::worker::{
     affected_leaves, first_cascades, produce_cascades, produce_membership, transition_metric_label,
@@ -83,10 +83,6 @@ impl TransferRetryPolicy {
 /// Default merge-CF GC per-tick, per-CF scan cap when the deps are built without explicit config
 /// (tests). Mirrors `Config::merge_gc_scan_limit`'s default.
 pub const DEFAULT_MERGE_GC_SCAN_LIMIT: usize = 10_000;
-
-/// Default seed apply batch ceiling when the deps are built without explicit config (tests).
-/// Mirrors `Config::cohort_seed_apply_batch_max`'s default.
-pub const DEFAULT_SEED_APPLY_BATCH_MAX: NonZeroUsize = NonZeroUsize::new(256).expect("256 > 0");
 
 /// Cascade depth/fan-out caps and the master gate. With `enabled` false the cascade transport is
 /// inert (the producer builds nothing, the consumer drains without re-evaluating).
@@ -144,9 +140,8 @@ pub struct MergeWorkerDeps {
     pub reconcile: ReconcileDeps,
     /// Person-property seed admission and its live-priority margin.
     pub person_seed: PersonSeedDeps,
-    /// Ceiling on the seeds one apply batch folds before it commits and produces. `1` restores the
-    /// per-seed apply, which is the hatch if batching ever misbehaves.
-    pub seed_apply_batch_max: NonZeroUsize,
+    /// Ceilings on what one apply batch folds before it commits and produces.
+    pub seed_batch: SeedBatchLimits,
 }
 
 impl MergeWorkerDeps {
@@ -169,7 +164,7 @@ impl MergeWorkerDeps {
             register_transfer_enabled: false,
             reconcile: ReconcileDeps::default(),
             person_seed: PersonSeedDeps::default(),
-            seed_apply_batch_max: DEFAULT_SEED_APPLY_BATCH_MAX,
+            seed_batch: SeedBatchLimits::default(),
         })
     }
 }
@@ -923,7 +918,7 @@ mod tests {
             register_transfer_enabled: false,
             reconcile: ReconcileDeps::default(),
             person_seed: PersonSeedDeps::default(),
-            seed_apply_batch_max: DEFAULT_SEED_APPLY_BATCH_MAX,
+            seed_batch: SeedBatchLimits::default(),
         }
     }
 

--- a/rust/cohort-stream-processor/src/workers/merge_path.rs
+++ b/rust/cohort-stream-processor/src/workers/merge_path.rs
@@ -5,6 +5,7 @@
 //! [`handle_apply`] applies a `MergeStateTransfer` on P_new's worker. Both produce their own
 //! membership output and mark their own [`OffsetTracker`].
 
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -83,6 +84,10 @@ impl TransferRetryPolicy {
 /// (tests). Mirrors `Config::merge_gc_scan_limit`'s default.
 pub const DEFAULT_MERGE_GC_SCAN_LIMIT: usize = 10_000;
 
+/// Default seed apply batch ceiling when the deps are built without explicit config (tests).
+/// Mirrors `Config::cohort_seed_apply_batch_max`'s default.
+pub const DEFAULT_SEED_APPLY_BATCH_MAX: NonZeroUsize = NonZeroUsize::new(256).expect("256 > 0");
+
 /// Cascade depth/fan-out caps and the master gate. With `enabled` false the cascade transport is
 /// inert (the producer builds nothing, the consumer drains without re-evaluating).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -139,6 +144,9 @@ pub struct MergeWorkerDeps {
     pub reconcile: ReconcileDeps,
     /// Person-property seed admission and its live-priority margin.
     pub person_seed: PersonSeedDeps,
+    /// Ceiling on the seeds one apply batch folds before it commits and produces. `1` restores the
+    /// per-seed apply, which is the hatch if batching ever misbehaves.
+    pub seed_apply_batch_max: NonZeroUsize,
 }
 
 impl MergeWorkerDeps {
@@ -161,6 +169,7 @@ impl MergeWorkerDeps {
             register_transfer_enabled: false,
             reconcile: ReconcileDeps::default(),
             person_seed: PersonSeedDeps::default(),
+            seed_apply_batch_max: DEFAULT_SEED_APPLY_BATCH_MAX,
         })
     }
 }
@@ -914,6 +923,7 @@ mod tests {
             register_transfer_enabled: false,
             reconcile: ReconcileDeps::default(),
             person_seed: PersonSeedDeps::default(),
+            seed_apply_batch_max: DEFAULT_SEED_APPLY_BATCH_MAX,
         }
     }
 

--- a/rust/cohort-stream-processor/src/workers/mod.rs
+++ b/rust/cohort-stream-processor/src/workers/mod.rs
@@ -19,10 +19,10 @@ pub use event_path::{
 pub use merge_gc::{handle_merge_gc, MergeGcCursor};
 pub use merge_path::{
     CascadeConfig, MergeWorkerDeps, TransferRetryPolicy, DEFAULT_MERGE_GC_SCAN_LIMIT,
-    DEFAULT_SEED_APPLY_BATCH_MAX,
 };
 pub use person_seed_path::PersonSeedDeps;
 pub use reconcile::{ReconcileBacklog, ReconcileDeps, DEFAULT_RECONCILE_SCAN_PAGE};
+pub use seed_batch::SeedBatchLimits;
 pub use stage2_gc::{handle_stage2_orphan_gc, Stage2GcCursor};
 pub use stage2_path::compose_stage2;
 pub use worker::Stage1Worker;

--- a/rust/cohort-stream-processor/src/workers/mod.rs
+++ b/rust/cohort-stream-processor/src/workers/mod.rs
@@ -6,6 +6,7 @@ pub mod merge_gc;
 pub mod merge_path;
 pub mod person_seed_path;
 pub mod reconcile;
+pub mod seed_batch;
 pub mod seed_path;
 pub mod stage2_gc;
 pub mod stage2_path;
@@ -18,6 +19,7 @@ pub use event_path::{
 pub use merge_gc::{handle_merge_gc, MergeGcCursor};
 pub use merge_path::{
     CascadeConfig, MergeWorkerDeps, TransferRetryPolicy, DEFAULT_MERGE_GC_SCAN_LIMIT,
+    DEFAULT_SEED_APPLY_BATCH_MAX,
 };
 pub use person_seed_path::PersonSeedDeps;
 pub use reconcile::{ReconcileBacklog, ReconcileDeps, DEFAULT_RECONCILE_SCAN_PAGE};

--- a/rust/cohort-stream-processor/src/workers/person_seed_path.rs
+++ b/rust/cohort-stream-processor/src/workers/person_seed_path.rs
@@ -37,12 +37,13 @@ use crate::stage1::transition::LeafTransition;
 use crate::stage2::{single_leaf_transition_register_writes, stage_register_writes};
 use crate::store::{PersonPrefix, PersonRecordKey, PersonRecords, ReadLane, StagedBatch};
 use crate::workers::seed_batch::{
-    produce_seed_output, recompose_batch, settle, Admitted, ApplyStage, SeedApplyDeps, SeedHold,
-    SeedKind, SeedReKeys, SeedRun, StageClock, TouchedPersons,
+    produce_cascade_output, produce_composed_output, produce_leaf_output, recompose_batch, settle,
+    Admitted, ApplyStage, SeedApplyDeps, SeedHold, SeedKind, SeedReKeys, SeedRun, StageClock,
+    TouchedPersons,
 };
 use crate::workers::seed_path::{route_seed, tag_seed, SeedRoute};
 use crate::workers::stage2_path::commit_stage2_writes;
-use crate::workers::worker::transition_metric_label;
+use crate::workers::worker::{first_cascades, transition_metric_label};
 
 /// Person-property seed admission for the partition workers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -68,8 +69,9 @@ impl Default for PersonSeedDeps {
 /// Apply one run of person seeds as a unit, then mark its whole span or hold its first offset.
 ///
 /// Shares the tile path's shape: one batched tombstone resolve, one batched record read, one
-/// stage-1 commit, one stage-2 recompose, one concurrent produce, one stage-2 commit. The overlay
-/// gives read-your-writes within the run, so a second seed for the same person merges onto the first
+/// produce of the single-leaf output, one stage-1 commit, one stage-2 recompose, one produce of the
+/// composed output, one produce of the cascades, one stage-2 commit. The overlay gives
+/// read-your-writes within the run, so a second seed for the same person merges onto the first
 /// seed's record rather than the bytes the read pass saw.
 pub(crate) async fn apply_person_batch(
     deps: &SeedApplyDeps<'_>,
@@ -104,7 +106,12 @@ async fn apply_person_seeds(
     stages.mark(ApplyStage::Read);
 
     let now_ms = Utc::now().timestamp_millis();
-    let folded = fold_person_seeds(
+    let FoldedPersonSeeds {
+        staged,
+        changes: leaf_changes,
+        touched,
+        outcomes,
+    } = fold_person_seeds(
         deps.merge.person_seed.live_margin_ms,
         &locals,
         &mut overlay,
@@ -113,22 +120,32 @@ async fn apply_person_seeds(
     );
     stages.mark(ApplyStage::Fold);
 
+    // Cascades ride the last leg, so every membership change is acked before any referrer hears
+    // of it; built here from a borrow, before the changes move into their produce.
+    let source_offset = run.span().last.0;
+    let mut cascades = first_cascades(deps.merge, &leaf_changes, source_offset);
+    produce_leaf_output(deps, leaf_changes, SeedReKeys::Persons(re_keys)).await?;
+    stages.mark(ApplyStage::ProduceLeaf);
+
     // One batch, so a register is never stranded without the matched set that justifies it.
-    if !folded.staged.is_empty() {
+    if !staged.is_empty() {
         deps.handle
-            .commit(folded.staged)
+            .commit(staged)
             .await
             .map_err(SeedHold::store(ApplyStage::Stage1Commit))?;
     }
     stages.mark(ApplyStage::Stage1Commit);
 
-    let recomposed = recompose_batch(deps, &snapshot, folded.touched, now_ms, clock).await?;
+    let mut recomposed = recompose_batch(deps, &snapshot, touched, now_ms, clock).await?;
     stages.mark(ApplyStage::Recompute);
 
-    let mut changes = folded.changes;
-    changes.extend(recomposed.changes.iter().cloned());
-    produce_seed_output(deps, changes, SeedReKeys::Persons(re_keys), run.span().last).await?;
-    stages.mark(ApplyStage::Produce);
+    let composed = std::mem::take(&mut recomposed.changes);
+    cascades.extend(first_cascades(deps.merge, &composed, source_offset));
+    produce_composed_output(deps, composed).await?;
+    stages.mark(ApplyStage::ProduceComposed);
+
+    produce_cascade_output(deps, cascades).await?;
+    stages.mark(ApplyStage::ProduceCascades);
 
     commit_stage2_writes(deps.handle, &recomposed.writes)
         .await
@@ -139,7 +156,7 @@ async fn apply_person_seeds(
     // Counted last: a failure holds the run, and the redelivery re-derives every verdict against the
     // records this attempt already wrote, so counting any earlier counts one seed twice under two
     // different arms.
-    for outcome in folded.outcomes {
+    for outcome in outcomes {
         outcome.record();
     }
     Ok(())
@@ -590,6 +607,8 @@ fn effective_hashes(filters: &TeamFilters, seed: &PersonSeed) -> Option<Effectiv
 // Tests seed and assert against `CohortStore` directly, the sanctioned direct-store surface.
 #[allow(clippy::disallowed_methods)]
 mod tests {
+    use std::num::NonZeroUsize;
+
     use chrono_tz::UTC;
     use cohort_core::seed::{ClaimEpoch, ConditionHash, RunId, ScannedAtMs};
     use serde_json::{json, Value};
@@ -1272,12 +1291,14 @@ mod tests {
         assert_eq!(shell.committable(partition_id), Some(7));
     }
 
+    /// The composed leg fails after the single-leaf leg acked and stage 1 committed, so the replay
+    /// merges to `Unchanged` and has only the composed flip left to re-derive.
     #[tokio::test]
     async fn a_failed_membership_produce_holds_and_the_replay_re_derives_the_composed_flip() {
         let (person, partition_id) = dormant_person();
         let mut shell = Shell::with_sinks(
             mixed_cohorts(),
-            CaptureSink::failing_first(1),
+            CaptureSink::failing_calls(1, 1),
             CaptureSeedTileSink::new(),
         );
         shell.live_pageview(partition_id, person, None);
@@ -1287,7 +1308,7 @@ mod tests {
         assert_eq!(shell.committable(partition_id), None, "held for redelivery");
         assert!(
             shell.record(partition_id, person).is_some(),
-            "stage 1 committed before the produce",
+            "stage 1 committed once the single-leaf leg acked",
         );
         assert!(
             shell.stage2(partition_id, person, 2).is_none(),
@@ -1298,13 +1319,82 @@ mod tests {
         let changes = shell.sink.changes();
         assert_eq!(
             changes.len(),
-            1,
+            2,
             "the Unchanged replay re-derives the composed flip only",
         );
-        assert_eq!(changes[0].cohort_id, 2);
-        assert_eq!(changes[0].origin, Some(ChangeOrigin::Seed));
+        assert_eq!(
+            changes[0].cohort_id, 1,
+            "the single-leaf leg acked first time"
+        );
+        assert_eq!(changes[1].cohort_id, 2);
+        assert_eq!(changes[1].origin, Some(ChangeOrigin::Seed));
         assert!(shell.stage2(partition_id, person, 2).unwrap().in_cohort);
         assert_eq!(shell.committable(partition_id), Some(3));
+    }
+
+    /// A broker acks per record, so a run can come back half acked. Committing stage 1 under that
+    /// would make the replay skip as live-fresh and never re-emit the records that failed. Producing
+    /// before the commit means the replay re-folds every seed and re-emits every change.
+    #[tokio::test]
+    async fn a_partially_acked_person_produce_commits_no_record_and_the_replay_re_emits_every_change(
+    ) {
+        let (person, partition_id) = dormant_person();
+        let other = (0x5EEE_u128..)
+            .map(Uuid::from_u128)
+            .find(|p| partition_of(TEAM, p, COHORT_PARTITION_COUNT) as u16 == partition_id)
+            .expect("some uuid hashes onto the same partition");
+        let mut shell = Shell::with_sinks(
+            mixed_cohorts(),
+            CaptureSink::partially_failing_first(NonZeroUsize::new(2).unwrap()),
+            CaptureSeedTileSink::new(),
+        );
+        for p in [person, other] {
+            shell.live_pageview(partition_id, p, None);
+        }
+        let scanned = now_ms();
+        let seeds = || {
+            vec![
+                (seed_for(person, &[PERSON_HASH], &[PERSON_HASH], scanned), 5),
+                (seed_for(other, &[PERSON_HASH], &[PERSON_HASH], scanned), 6),
+            ]
+        };
+
+        shell.run_batch(partition_id, seeds()).await;
+
+        assert_eq!(shell.committable(partition_id), None, "held for redelivery");
+        assert_eq!(
+            shell.sink.changes().len(),
+            1,
+            "the acked record is already downstream; the failed one is what must not be lost",
+        );
+        for p in [person, other] {
+            assert!(
+                shell.record(partition_id, p).is_none(),
+                "no record for {p}: the run committed nothing",
+            );
+            assert!(
+                shell.stage2(partition_id, p, 1).is_none(),
+                "no register for {p}: the run committed nothing",
+            );
+        }
+
+        shell.run_batch(partition_id, seeds()).await;
+
+        let changes = shell.sink.changes();
+        for p in [person, other] {
+            for cohort_id in [1, 2] {
+                assert!(
+                    changes.iter().any(|change| {
+                        change.person_id == p.to_string()
+                            && change.cohort_id == cohort_id
+                            && change.status == MembershipStatus::Entered
+                    }),
+                    "the replay re-folded and re-emitted {p}'s entry into cohort {cohort_id}",
+                );
+            }
+        }
+        // The tenure-sticky hold pins the committable at the held first offset.
+        assert_eq!(shell.committable(partition_id), Some(5));
     }
 
     /// The held replay can arrive after a live event has already re-derived the same matched set.
@@ -1315,9 +1405,10 @@ mod tests {
     #[tokio::test]
     async fn a_live_fresh_skip_still_recomposes_a_stage_2_bit_a_held_attempt_never_wrote() {
         let (person, partition_id) = dormant_person();
+        // The composed leg is the one that fails, so stage 1 is committed under the hold.
         let mut shell = Shell::with_sinks(
             mixed_cohorts(),
-            CaptureSink::failing_first(1),
+            CaptureSink::failing_calls(1, 1),
             CaptureSeedTileSink::new(),
         );
         shell.live_pageview(partition_id, person, None);
@@ -1534,6 +1625,12 @@ mod tests {
             None,
             "the failed produce holds, so nothing in the batch commits",
         );
+        for p in [person, other] {
+            assert!(
+                shell.record(partition_id, p).is_none(),
+                "no record for {p}: the single-leaf leg failed before stage 1 committed",
+            );
+        }
         assert!(
             shell.stage2(partition_id, person, 2).is_none(),
             "the composed bit must stay unwritten under the failed produce",

--- a/rust/cohort-stream-processor/src/workers/person_seed_path.rs
+++ b/rust/cohort-stream-processor/src/workers/person_seed_path.rs
@@ -38,8 +38,8 @@ use crate::stage2::{single_leaf_transition_register_writes, stage_register_write
 use crate::store::{PersonPrefix, PersonRecordKey, PersonRecords, ReadLane, StagedBatch};
 use crate::workers::seed_batch::{
     produce_cascade_output, produce_composed_output, produce_leaf_output, recompose_batch, settle,
-    Admitted, ApplyStage, SeedApplyDeps, SeedHold, SeedKind, SeedReKeys, SeedRun, StageClock,
-    TouchedPersons,
+    Admitted, ApplyStage, BatchRecompose, SeedApplyDeps, SeedHold, SeedKind, SeedReKeys, SeedRun,
+    StageClock, TouchedPersons,
 };
 use crate::workers::seed_path::{route_seed, tag_seed, SeedRoute};
 use crate::workers::stage2_path::commit_stage2_writes;
@@ -136,10 +136,13 @@ async fn apply_person_seeds(
     }
     stages.mark(ApplyStage::Stage1Commit);
 
-    let mut recomposed = recompose_batch(deps, &snapshot, touched, now_ms, clock).await?;
+    let BatchRecompose {
+        changes: composed,
+        writes: stage2_writes,
+        counts: stage2_counts,
+    } = recompose_batch(deps, &snapshot, touched, now_ms, clock).await?;
     stages.mark(ApplyStage::Recompute);
 
-    let composed = std::mem::take(&mut recomposed.changes);
     cascades.extend(first_cascades(deps.merge, &composed, source_offset));
     produce_composed_output(deps, composed).await?;
     stages.mark(ApplyStage::ProduceComposed);
@@ -147,11 +150,11 @@ async fn apply_person_seeds(
     produce_cascade_output(deps, cascades).await?;
     stages.mark(ApplyStage::ProduceCascades);
 
-    commit_stage2_writes(deps.handle, &recomposed.writes)
+    commit_stage2_writes(deps.handle, &stage2_writes)
         .await
         .map_err(SeedHold::store(ApplyStage::Stage2Commit))?;
     stages.mark(ApplyStage::Stage2Commit);
-    recomposed.record_metrics();
+    stage2_counts.record();
 
     // Counted last: a failure holds the run, and the redelivery re-derives every verdict against the
     // records this attempt already wrote, so counting any earlier counts one seed twice under two

--- a/rust/cohort-stream-processor/src/workers/person_seed_path.rs
+++ b/rust/cohort-stream-processor/src/workers/person_seed_path.rs
@@ -79,24 +79,24 @@ pub(crate) async fn apply_person_batch(
     run: SeedRun<PersonSeed>,
 ) {
     let span = run.span();
-    let mut stages = StageClock::start(SeedKind::Person, run.len());
-    let outcome = apply_person_seeds(deps, clock, &mut stages, &run).await;
+    // The clock starts past the gate, so a skipped run is no sample of the batch size.
+    let outcome = if deps.merge.person_seed.enabled {
+        let mut stages = StageClock::start(SeedKind::Person, run.len());
+        apply_person_seeds(deps, clock, &mut stages, &run).await
+    } else {
+        skip_gate_off(deps.partition_id, &run);
+        Ok(())
+    };
     settle(deps, SeedKind::Person, span, outcome);
 }
 
-/// The ordered apply. Each `?` holds the whole run; every early `return Ok(())` is a terminal skip
-/// whose offsets commit.
+/// The ordered apply. Each `?` holds the whole run.
 async fn apply_person_seeds(
     deps: &SeedApplyDeps<'_>,
     clock: &mut LastUpdatedClock,
     stages: &mut StageClock,
     run: &SeedRun<PersonSeed>,
 ) -> Result<(), SeedHold> {
-    if !deps.merge.person_seed.enabled {
-        skip_gate_off(deps.partition_id, run);
-        return Ok(());
-    }
-
     let snapshot = deps.catalog.load();
     let RoutedPersonSeeds { locals, re_keys } =
         route_person_seeds(deps, &snapshot, run.items()).await?;

--- a/rust/cohort-stream-processor/src/workers/person_seed_path.rs
+++ b/rust/cohort-stream-processor/src/workers/person_seed_path.rs
@@ -1,14 +1,15 @@
 //! Applies person-property seeds to `cf_person_records`, giving dormant persons leaf state that
 //! otherwise only arrives on a live event carrying `person_properties`.
 //!
-//! [`Apply::run`] is the algorithm; the other [`Apply`] methods are its I/O steps and the free
+//! [`apply_person_seeds`] is the algorithm; the functions around it are its I/O steps and the free
 //! functions below are pure. Every step that must not commit returns [`SeedHold`], so the
-//! `Ok ⇒ mark, Err ⇒ hold` decision lives in [`handle_person_seed`] alone.
+//! `Ok ⇒ mark, Err ⇒ hold` decision lives in one place per run.
 //!
 //! Ordering against live traffic is [`person_seed_verdict`]'s job, not the apply fence's: a person
 //! seed carries no arrival bound over the event stream, so it admits fence-open. The partition-wide
 //! live-lag, disk, and channel-full holds still apply.
 
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::Arc;
 
 use chrono::Utc;
@@ -17,16 +18,15 @@ use metrics::counter;
 use tracing::{debug, warn};
 use uuid::Uuid;
 
-use crate::filters::manager::CatalogHandle;
 use crate::filters::reverse_index::TeamFilters;
+use crate::filters::{FilterCatalog, TeamId};
 use crate::merge::tombstone_redirect::{self, MAX_CROSS_PARTITION_REDIRECT_HOPS};
 use crate::observability::metrics::{
     PERSON_SEEDS_APPLIED_TOTAL, PERSON_SEEDS_DROPPED_TOTAL, PERSON_SEEDS_SKIPPED_TOTAL,
     PERSON_SEEDS_UNCHANGED_TOTAL, PERSON_SEED_HASHES_DROPPED_TOTAL,
-    PERSON_SEED_PRIOR_CORRUPT_TOTAL, PERSON_SEED_REKEYED_TOTAL, PERSON_SEED_REKEY_HOP_CAPPED_TOTAL,
-    PERSON_SEED_REKEY_PRODUCE_FAILURE_TOTAL, STAGE1_TRANSITIONS,
+    PERSON_SEED_PRIOR_CORRUPT_TOTAL, PERSON_SEED_REKEY_HOP_CAPPED_TOTAL, STAGE1_TRANSITIONS,
 };
-use crate::producer::{map_transition, CohortMembershipChange, MembershipSink};
+use crate::producer::{map_transition, CohortMembershipChange, LastUpdatedClock};
 use crate::stage1::key::LeafStateKey;
 use crate::stage1::person_record::{
     apply_person_seed, person_seed_verdict, MatchedSet, PersonRecord, PersonSeedOutcome,
@@ -35,15 +35,14 @@ use crate::stage1::person_record::{
 use crate::stage1::state::StateVariant;
 use crate::stage1::transition::LeafTransition;
 use crate::stage2::{single_leaf_transition_register_writes, stage_register_writes};
-use crate::store::{
-    PersonPrefix, PersonRecordKey, PersonRecords, ReadLane, StagedBatch, StoreError, StoreHandle,
+use crate::store::{PersonPrefix, PersonRecordKey, PersonRecords, ReadLane, StagedBatch};
+use crate::workers::seed_batch::{
+    produce_seed_output, recompose_batch, settle, Admitted, ApplyStage, SeedApplyDeps, SeedHold,
+    SeedKind, SeedReKeys, SeedRun, StageClock, TouchedPersons,
 };
-use crate::workers::merge_path::MergeWorkerDeps;
-use crate::workers::seed_path::{hold, mark_processed, route_seed, tag_seed, SeedRoute};
-use crate::workers::stage2_path::{commit_stage2_writes, recompute_stage2};
-use crate::workers::worker::{
-    first_cascades, produce_cascades, produce_membership, transition_metric_label,
-};
+use crate::workers::seed_path::{route_seed, tag_seed, SeedRoute};
+use crate::workers::stage2_path::commit_stage2_writes;
+use crate::workers::worker::transition_metric_label;
 
 /// Person-property seed admission for the partition workers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -66,336 +65,336 @@ impl Default for PersonSeedDeps {
     }
 }
 
-/// Handle one person seed on its owning partition worker; touches the seed tracker only.
+/// Apply one run of person seeds as a unit, then mark its whole span or hold its first offset.
 ///
-/// `Ok` means every durable effect landed, or the seed was skipped on purpose, and the offset may
-/// commit. [`SeedHold`] means Kafka must redeliver.
-#[allow(clippy::too_many_arguments)]
-pub(crate) async fn handle_person_seed(
-    partition_id: u16,
-    handle: &StoreHandle,
-    catalog: &CatalogHandle,
-    sink: &Arc<dyn MembershipSink>,
-    merge: &MergeWorkerDeps,
-    last_updated: &str,
-    seed: &PersonSeed,
-    offset: i64,
+/// Shares the tile path's shape: one batched tombstone resolve, one batched record read, one
+/// stage-1 commit, one stage-2 recompose, one concurrent produce, one stage-2 commit. The overlay
+/// gives read-your-writes within the run, so a second seed for the same person merges onto the first
+/// seed's record rather than the bytes the read pass saw.
+pub(crate) async fn apply_person_batch(
+    deps: &SeedApplyDeps<'_>,
+    clock: &mut LastUpdatedClock,
+    run: SeedRun<PersonSeed>,
 ) {
-    let apply = Apply {
+    let span = run.span();
+    let mut stages = StageClock::start(SeedKind::Person, run.len());
+    let outcome = apply_person_seeds(deps, clock, &mut stages, &run).await;
+    settle(deps, SeedKind::Person, span, outcome);
+}
+
+/// The ordered apply. Each `?` holds the whole run; every early `return Ok(())` is a terminal skip
+/// whose offsets commit.
+async fn apply_person_seeds(
+    deps: &SeedApplyDeps<'_>,
+    clock: &mut LastUpdatedClock,
+    stages: &mut StageClock,
+    run: &SeedRun<PersonSeed>,
+) -> Result<(), SeedHold> {
+    if !deps.merge.person_seed.enabled {
+        skip_gate_off(deps.partition_id, run);
+        return Ok(());
+    }
+
+    let snapshot = deps.catalog.load();
+    let RoutedPersonSeeds { locals, re_keys } =
+        route_person_seeds(deps, &snapshot, run.items()).await?;
+    stages.mark(ApplyStage::Resolve);
+
+    let mut overlay = read_person_records(deps, &locals).await?;
+    stages.mark(ApplyStage::Read);
+
+    let now_ms = Utc::now().timestamp_millis();
+    let folded = fold_person_seeds(
+        deps.merge.person_seed.live_margin_ms,
+        &locals,
+        &mut overlay,
+        clock,
+        now_ms,
+    );
+    stages.mark(ApplyStage::Fold);
+
+    // One batch, so a register is never stranded without the matched set that justifies it.
+    if !folded.staged.is_empty() {
+        deps.handle
+            .commit(folded.staged)
+            .await
+            .map_err(SeedHold::store(ApplyStage::Stage1Commit))?;
+    }
+    stages.mark(ApplyStage::Stage1Commit);
+
+    let recomposed = recompose_batch(deps, &snapshot, folded.touched, now_ms, clock).await?;
+    stages.mark(ApplyStage::Recompute);
+
+    let mut changes = folded.changes;
+    changes.extend(recomposed.changes.iter().cloned());
+    produce_seed_output(deps, changes, SeedReKeys::Persons(re_keys), run.span().last).await?;
+    stages.mark(ApplyStage::Produce);
+
+    commit_stage2_writes(deps.handle, &recomposed.writes)
+        .await
+        .map_err(SeedHold::store(ApplyStage::Stage2Commit))?;
+    stages.mark(ApplyStage::Stage2Commit);
+    recomposed.record_metrics();
+
+    // Counted last: a failure holds the run, and the redelivery re-derives every verdict against the
+    // records this attempt already wrote, so counting any earlier counts one seed twice under two
+    // different arms.
+    for outcome in folded.outcomes {
+        outcome.record();
+    }
+    Ok(())
+}
+
+/// A gate-off run is one message per scanned person, so this stays off `warn!` and leans on
+/// `cohort_person_seeds_skipped_total{reason="apply_disabled"}` for the signal.
+fn skip_gate_off(partition_id: u16, run: &SeedRun<PersonSeed>) {
+    counter!(PERSON_SEEDS_SKIPPED_TOTAL, "reason" => "apply_disabled").increment(run.len() as u64);
+    debug!(
         partition_id,
-        handle,
-        catalog,
-        sink,
-        merge,
-        last_updated,
-        seed,
-        offset,
-    };
-    match apply.run().await {
-        Ok(()) => mark_processed(&merge.seed_tracker, partition_id, offset),
-        Err(held) => {
-            warn!(
-                partition_id,
-                team_id = seed.team_id().0,
-                run_id = %seed.run_id().0,
-                error = %held,
-                "person seed apply failed; holding the seed offset for redelivery",
-            );
-            hold(&merge.seed_tracker, partition_id, offset);
-        }
-    }
+        seeds = run.len(),
+        "person seeds skipped while person apply is disabled; re-produce the run after enabling",
+    );
 }
 
-/// A failure that must not commit. `stage` is what tells an operator which half of the apply broke.
-#[derive(Debug, thiserror::Error)]
-enum SeedHold {
-    #[error("{stage}: {source}")]
-    Store {
-        stage: &'static str,
-        source: StoreError,
-    },
-    #[error("{stage}: {errors} message(s) failed to produce")]
-    Produce { stage: &'static str, errors: usize },
-}
-
-impl SeedHold {
-    /// `map_err` adapter that labels a store failure with the step that hit it.
-    fn store(stage: &'static str) -> impl FnOnce(StoreError) -> Self {
-        move |source| Self::Store { stage, source }
-    }
-}
-
-struct Apply<'a> {
-    partition_id: u16,
-    handle: &'a StoreHandle,
-    catalog: &'a CatalogHandle,
-    sink: &'a Arc<dyn MembershipSink>,
-    merge: &'a MergeWorkerDeps,
-    last_updated: &'a str,
+/// One seed that applies on this partition, with everything its fold needs resolved once.
+struct LocalPersonSeed<'a> {
     seed: &'a PersonSeed,
-    offset: i64,
+    /// The tombstone chain's survivor, or the seed's own person when nothing merged.
+    person: Uuid,
+    filters: Arc<TeamFilters>,
+    effective: EffectiveHashes,
+    /// This seed's record row, resolved once. The read pass and the fold both key off it, so
+    /// neither can build a key the other does not have.
+    record_key: PersonRecordKey,
 }
 
-impl Apply<'_> {
-    /// Each `return Ok(())` is a terminal skip whose offset commits; each `?` holds it.
-    async fn run(&self) -> Result<(), SeedHold> {
-        if !self.merge.person_seed.enabled {
-            self.skip_gate_off();
-            return Ok(());
-        }
+struct RoutedPersonSeeds<'a> {
+    locals: Vec<LocalPersonSeed<'a>>,
+    /// Seeds whose survivor lives on another partition, handed back to the seed topic.
+    re_keys: Vec<PersonSeed>,
+}
 
-        let snapshot = self.catalog.load();
-        let Some(filters) = snapshot.team(self.seed.team_id()) else {
+/// Resolve the run's tombstones in one read and split it into local applies and hand-offs.
+async fn route_person_seeds<'a>(
+    deps: &SeedApplyDeps<'_>,
+    snapshot: &FilterCatalog,
+    seeds: &'a [Admitted<PersonSeed>],
+) -> Result<RoutedPersonSeeds<'a>, SeedHold> {
+    let mut known: Vec<(&PersonSeed, Arc<TeamFilters>, EffectiveHashes)> =
+        Vec::with_capacity(seeds.len());
+    let mut persons: Vec<(TeamId, Uuid)> = Vec::new();
+    let mut seen: HashSet<(TeamId, Uuid)> = HashSet::new();
+    for Admitted { work: seed, .. } in seeds {
+        let Some(filters) = snapshot.team(seed.team_id()) else {
             counter!(PERSON_SEEDS_DROPPED_TOTAL, "reason" => "team_absent").increment(1);
-            return Ok(());
+            continue;
         };
-
         // Ahead of the tombstone resolution: the catalog is team-wide, so a seed nothing backs is
         // dropped identically on the survivor's partition, and resolving first would spend a store
         // read and possibly a cross-partition re-produce on a message already doomed.
-        let Some(effective) = effective_hashes(filters, self.seed) else {
+        let Some(effective) = effective_hashes(filters, seed) else {
             counter!(PERSON_SEEDS_DROPPED_TOTAL, "reason" => "no_effective_hashes").increment(1);
-            return Ok(());
+            continue;
         };
-
-        let Target::Local(person) = self.resolve_target().await? else {
-            return Ok(());
-        };
-
-        let record_key =
-            PersonPrefix::new(self.partition_id, self.seed.team_id().0 as u64, person).record_key();
-        let prior = self.read_record(&record_key).await?;
-        let verdict = person_seed_verdict(
-            &prior,
-            self.seed.scanned_at_ms(),
-            self.merge.person_seed.live_margin_ms,
-            filters.catalog_fingerprint,
-        );
-        // A live-fresh skip is not merged at all: the stored state already subsumes the seed.
-        let update = match verdict {
-            PersonSeedVerdict::SkipLiveFresh => RecordUpdate::Unchanged,
-            _ => record_update(
-                &prior,
-                self.seed,
-                person,
-                &effective,
-                self.merge.person_seed.live_margin_ms,
-            ),
-        };
-
-        let now_ms = Utc::now().timestamp_millis();
-        self.commit_stage1(filters, &record_key, &update, now_ms)
-            .await?;
-        if recomposes(&update, verdict, &prior) {
-            self.emit(filters, &effective.leaves(person), &update, now_ms)
-                .await?;
+        if seen.insert((seed.team_id(), seed.person_id())) {
+            persons.push((seed.team_id(), seed.person_id()));
         }
-        // Counted last: an emit failure holds the offset, and the redelivery re-derives the verdict
-        // against the record this attempt already wrote, so counting any earlier counts one seed
-        // twice under two different arms.
-        update.record_metric(verdict);
-        Ok(())
+        known.push((seed, filters.clone(), effective));
     }
 
-    /// A gate-off run is one message per scanned person, so this stays off `warn!` and leans on
-    /// `cohort_person_seeds_skipped_total{reason="apply_disabled"}` for the signal.
-    fn skip_gate_off(&self) {
-        counter!(PERSON_SEEDS_SKIPPED_TOTAL, "reason" => "apply_disabled").increment(1);
-        debug!(
-            partition_id = self.partition_id,
-            team_id = self.seed.team_id().0,
-            run_id = %self.seed.run_id().0,
-            "person seed skipped while person apply is disabled; re-produce the run after enabling",
-        );
-    }
+    // A read failure is fail-stop: a seed applied to a merged-away person is durable state that
+    // nothing downstream can retract.
+    let resolutions = tombstone_redirect::resolve_batch_offloaded(
+        deps.handle,
+        deps.partition_id,
+        &persons,
+        deps.merge.partition_count,
+        ReadLane::Maintenance,
+    )
+    .await
+    .map_err(SeedHold::store(ApplyStage::Resolve))?;
 
-    /// A read failure is fail-stop: a seed applied to a merged-away person is durable state that
-    /// nothing downstream can retract.
-    async fn resolve_target(&self) -> Result<Target, SeedHold> {
-        let resolution = tombstone_redirect::resolve_offloaded(
-            self.handle,
-            self.partition_id,
-            self.seed.team_id(),
-            self.seed.person_id(),
-            self.merge.partition_count,
-            ReadLane::Maintenance,
-        )
-        .await
-        .map_err(SeedHold::store("tombstone preflight"))?;
-
-        match route_seed(self.seed, resolution, MAX_CROSS_PARTITION_REDIRECT_HOPS) {
-            SeedRoute::ApplyLocal { person } => Ok(Target::Local(person)),
-            SeedRoute::ReProduce { seed: rekeyed } => self.hand_off(rekeyed).await,
-            SeedRoute::CapExhausted { person } => Ok(self.degrade_to(person)),
-        }
-    }
-
-    /// Re-produce onto the survivor's partition. This is the seed's only remaining copy, so the
-    /// caller may not commit until exactly one `Ok` acks; an empty ack vector is a failure, not a
-    /// vacuous success.
-    async fn hand_off(&self, rekeyed: PersonSeed) -> Result<Target, SeedHold> {
-        let acks = self
-            .merge
-            .seed_tile_sink
-            .produce_person(vec![rekeyed])
-            .await;
-        if !matches!(acks.as_slice(), [Ok(())]) {
-            counter!(PERSON_SEED_REKEY_PRODUCE_FAILURE_TOTAL).increment(1);
-            return Err(SeedHold::Produce {
-                stage: "re-key produce",
-                errors: 1,
+    let mut routed = RoutedPersonSeeds {
+        locals: Vec::with_capacity(known.len()),
+        re_keys: Vec::new(),
+    };
+    for (seed, filters, effective) in known {
+        let Some(&resolution) = resolutions.get(&(seed.team_id(), seed.person_id())) else {
+            return Err(SeedHold::ShortRead {
+                stage: ApplyStage::Resolve,
+                asked: persons.len(),
+                answered: resolutions.len(),
             });
-        }
-        counter!(PERSON_SEED_REKEYED_TOTAL).increment(1);
-        Ok(Target::HandedOff)
-    }
-
-    /// Apply at the best-known target once the hop budget is spent, matching the tile and event
-    /// paths: an orphaned row beats a silent seed loss, and holding the offset instead would stall
-    /// every later seed on the partition behind a tombstone cycle that will never resolve.
-    ///
-    /// The row lands under this worker's partition prefix, which the survivor's own worker never
-    /// reads. Unlike the tile path's orphan, no sweep owns it — only the `cf_person_records` TTL
-    /// reclaims it, and `apply_person_seed` floors `last_seen_ms` at the scan instant so it does age
-    /// out wherever `COHORT_PERSON_RECORD_TTL_DAYS` is set.
-    fn degrade_to(&self, person: Uuid) -> Target {
-        counter!(PERSON_SEED_REKEY_HOP_CAPPED_TOTAL).increment(1);
-        warn!(
-            partition_id = self.partition_id,
-            team_id = self.seed.team_id().0,
-            %person,
-            hops = self.seed.redirect_hops(),
-            "person seed redirect hop cap hit (corrupt tombstone cycle?); applying inline at the best-known target",
-        );
-        Target::Local(person)
-    }
-
-    /// Maintenance lane: backfill must not contend with live event reads.
-    ///
-    /// A row that exists but does not decode is counted here, the way the event path counts it: the
-    /// apply rebuilds from an absent baseline, so without the counter a real codec failure is
-    /// indistinguishable from a dormant person that never had a record.
-    async fn read_record(&self, key: &PersonRecordKey) -> Result<PriorRecord, SeedHold> {
-        let stored = self
-            .handle
-            .get_person_record(key, ReadLane::Maintenance)
-            .await
-            .map_err(SeedHold::store("person record read"))?;
-        let prior = PriorRecord::decode(stored.as_deref());
-        if matches!(prior, PriorRecord::Corrupt) {
-            counter!(PERSON_SEED_PRIOR_CORRUPT_TOTAL).increment(1);
-        }
-        Ok(prior)
-    }
-
-    /// One batch, so a register is never stranded without the matched set that justifies it.
-    async fn commit_stage1(
-        &self,
-        filters: &TeamFilters,
-        key: &PersonRecordKey,
-        update: &RecordUpdate,
-        now_ms: i64,
-    ) -> Result<(), SeedHold> {
-        let RecordUpdate::Changed {
-            record,
-            transitions,
-        } = update
-        else {
-            return Ok(());
         };
-
-        let mut staged = StagedBatch::default();
-        staged.put::<PersonRecords>(key, &record.encode());
-        for transition in transitions {
-            stage_register_writes(
-                &mut staged,
-                single_leaf_transition_register_writes(
-                    filters,
-                    self.partition_id,
-                    transition,
-                    now_ms,
-                ),
-            );
-        }
-        self.handle
-            .commit(staged)
-            .await
-            .map_err(SeedHold::store("person record commit"))
-    }
-
-    /// Recomposes every evaluated leaf, not just the ones this seed flipped, so a crash between the
-    /// two commits heals on replay ([`recomposes`] is what admits the healing pass). The stage-2 bits
-    /// land only after both produces ack, which keeps a composed flip re-derivable instead of lost
-    /// against a flipped bit.
-    ///
-    /// Single-leaf changes are not re-derivable that way: the replay merges to `Unchanged` and
-    /// mints no transition, so a failed membership produce drops them. Their register row did
-    /// commit with stage 1, which is what lets the reconcile snapshot repair them.
-    async fn emit(
-        &self,
-        filters: &TeamFilters,
-        leaves: &[(LeafStateKey, Uuid)],
-        update: &RecordUpdate,
-        now_ms: i64,
-    ) -> Result<(), SeedHold> {
-        let mut changes = single_leaf_changes(filters, update.transitions(), self.last_updated);
-        let recompute = recompute_stage2(
-            self.partition_id,
-            self.handle,
+        let person = match route_seed(seed, resolution, MAX_CROSS_PARTITION_REDIRECT_HOPS) {
+            SeedRoute::ApplyLocal { person } => person,
+            SeedRoute::ReProduce { seed: rekeyed } => {
+                routed.re_keys.push(rekeyed);
+                continue;
+            }
+            SeedRoute::CapExhausted { person } => degrade_to(deps.partition_id, seed, person),
+        };
+        routed.locals.push(LocalPersonSeed {
+            seed,
+            person,
             filters,
-            leaves,
-            now_ms,
-            self.last_updated,
-            ReadLane::Maintenance,
-        )
-        .await
-        .map_err(SeedHold::store("stage 2 recompute"))?;
-        changes.extend(recompute.changes.iter().cloned());
-
-        tag_seed(&mut changes, self.seed.run_id());
-        self.produce(changes).await?;
-
-        commit_stage2_writes(self.handle, &recompute.writes)
-            .await
-            .map_err(SeedHold::store("stage 2 commit"))?;
-        recompute.record_metrics();
-        // Nothing to schedule: person-property membership has no window, so the sweep never owns
-        // these leaves.
-        Ok(())
+            effective,
+            record_key: PersonPrefix::new(deps.partition_id, seed.team_id().0 as u64, person)
+                .record_key(),
+        });
     }
-
-    async fn produce(&self, changes: Vec<CohortMembershipChange>) -> Result<(), SeedHold> {
-        // Built first: the cascade payload embeds the change, and `produce_membership` consumes it.
-        let cascades = first_cascades(self.merge, &changes, self.offset);
-
-        let errors = if changes.is_empty() {
-            0
-        } else {
-            produce_membership(self.sink, changes).await
-        };
-        if errors > 0 {
-            return Err(SeedHold::Produce {
-                stage: "membership produce",
-                errors,
-            });
-        }
-
-        let errors = produce_cascades(self.merge, cascades).await;
-        if errors > 0 {
-            return Err(SeedHold::Produce {
-                stage: "cascade produce",
-                errors,
-            });
-        }
-        Ok(())
-    }
+    Ok(routed)
 }
 
-/// Where a seed's work belongs once its tombstone chain is resolved.
-enum Target {
-    Local(Uuid),
-    /// Re-produced to the survivor's partition; this worker is done with it.
-    HandedOff,
+/// Apply at the best-known target once the hop budget is spent, matching the tile and event paths:
+/// an orphaned row beats a silent seed loss, and holding the offset instead would stall every later
+/// seed on the partition behind a tombstone cycle that will never resolve.
+///
+/// The row lands under this worker's partition prefix, which the survivor's own worker never reads.
+/// Unlike the tile path's orphan, no sweep owns it — only the `cf_person_records` TTL reclaims it,
+/// and `apply_person_seed` floors `last_seen_ms` at the scan instant so it does age out wherever
+/// `COHORT_PERSON_RECORD_TTL_DAYS` is set.
+fn degrade_to(partition_id: u16, seed: &PersonSeed, person: Uuid) -> Uuid {
+    counter!(PERSON_SEED_REKEY_HOP_CAPPED_TOTAL).increment(1);
+    warn!(
+        partition_id,
+        team_id = seed.team_id().0,
+        %person,
+        hops = seed.redirect_hops(),
+        "person seed redirect hop cap hit (corrupt tombstone cycle?); applying inline at the best-known target",
+    );
+    person
+}
+
+/// Read every record the run will fold into, once.
+///
+/// Maintenance lane: backfill must not contend with live event reads. A row that exists but does not
+/// decode is counted here, the way the event path counts it: the apply rebuilds from an absent
+/// baseline, so without the counter a real codec failure is indistinguishable from a dormant person
+/// that never had a record.
+async fn read_person_records(
+    deps: &SeedApplyDeps<'_>,
+    locals: &[LocalPersonSeed<'_>],
+) -> Result<BTreeMap<PersonRecordKey, PriorRecord>, SeedHold> {
+    let distinct: BTreeSet<PersonRecordKey> = locals.iter().map(|local| local.record_key).collect();
+    let keys: Vec<PersonRecordKey> = distinct.into_iter().collect();
+    let values = deps
+        .handle
+        .multi_get_person_records(keys.clone(), ReadLane::Maintenance)
+        .await
+        .map_err(SeedHold::store(ApplyStage::Read))?;
+    SeedHold::check_read(ApplyStage::Read, keys.len(), values.len())?;
+
+    Ok(keys
+        .into_iter()
+        .zip(values)
+        .map(|(key, bytes)| {
+            let prior = PriorRecord::decode(bytes.as_deref());
+            if matches!(prior, PriorRecord::Corrupt) {
+                counter!(PERSON_SEED_PRIOR_CORRUPT_TOTAL).increment(1);
+            }
+            (key, prior)
+        })
+        .collect())
+}
+
+#[derive(Default)]
+struct FoldedPersonSeeds {
+    staged: StagedBatch,
+    /// Single-leaf membership changes, one `last_updated` per seed that flipped something.
+    changes: Vec<CohortMembershipChange>,
+    touched: TouchedPersons,
+    outcomes: Vec<PersonSeedMetric>,
+}
+
+/// Fold every seed into the overlay in offset order, staging its record and registers. Pure apart
+/// from its counters: the store is not touched, so a failure later in the pipeline replays this
+/// identically.
+fn fold_person_seeds(
+    live_margin_ms: i64,
+    locals: &[LocalPersonSeed<'_>],
+    overlay: &mut BTreeMap<PersonRecordKey, PriorRecord>,
+    clock: &mut LastUpdatedClock,
+    now_ms: i64,
+) -> FoldedPersonSeeds {
+    let mut folded = FoldedPersonSeeds::default();
+
+    for local in locals {
+        let key = local.record_key;
+        let partition_id = key.0.partition_id;
+        let (verdict, update, recompose) = {
+            let prior = overlay
+                .get(&key)
+                .expect("the read pass keyed off the same record key, so every seed has a prior");
+            let verdict = person_seed_verdict(
+                prior,
+                local.seed.scanned_at_ms(),
+                live_margin_ms,
+                local.filters.catalog_fingerprint,
+            );
+            // A live-fresh skip is not merged at all: the stored state already subsumes the seed.
+            let update = match verdict {
+                PersonSeedVerdict::SkipLiveFresh => RecordUpdate::Unchanged,
+                _ => record_update(
+                    prior,
+                    local.seed,
+                    local.person,
+                    &local.effective,
+                    live_margin_ms,
+                ),
+            };
+            let recompose = recomposes(&update, verdict, prior);
+            (verdict, update, recompose)
+        };
+
+        if let RecordUpdate::Changed {
+            record,
+            transitions,
+        } = &update
+        {
+            folded.staged.put::<PersonRecords>(&key, &record.encode());
+            for transition in transitions {
+                stage_register_writes(
+                    &mut folded.staged,
+                    single_leaf_transition_register_writes(
+                        &local.filters,
+                        partition_id,
+                        transition,
+                        now_ms,
+                    ),
+                );
+            }
+        }
+
+        // Recomposes every evaluated leaf, not just the ones this seed flipped, so a crash between
+        // the two commits heals on replay.
+        if recompose {
+            for (leaf, person) in local.effective.leaves(local.person) {
+                folded
+                    .touched
+                    .touch(local.seed.team_id(), person, local.seed.run_id(), leaf);
+            }
+        }
+
+        let transitions = update.transitions();
+        if !transitions.is_empty() {
+            let last_updated = clock.next();
+            let start = folded.changes.len();
+            folded.changes.extend(single_leaf_changes(
+                &local.filters,
+                transitions,
+                &last_updated,
+            ));
+            tag_seed(&mut folded.changes[start..], local.seed.run_id());
+        }
+
+        folded.outcomes.push(update.metric(verdict));
+        // Read-your-writes: a later seed for the same person merges onto this record.
+        if let RecordUpdate::Changed { record, .. } = update {
+            overlay.insert(key, PriorRecord::Present(record));
+        }
+    }
+    folded
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -417,17 +416,36 @@ impl RecordUpdate {
         }
     }
 
-    /// `verdict` labels the writing arm only: an unchanged merge says nothing about which verdict
-    /// admitted it.
-    fn record_metric(&self, verdict: PersonSeedVerdict) {
+    /// The counter this seed lands on. `verdict` labels the writing arm only: an unchanged merge
+    /// says nothing about which verdict admitted it.
+    fn metric(&self, verdict: PersonSeedVerdict) -> PersonSeedMetric {
         match (self, verdict) {
-            (_, PersonSeedVerdict::SkipLiveFresh) => {
+            (_, PersonSeedVerdict::SkipLiveFresh) => PersonSeedMetric::SkippedStaleVsLive,
+            (Self::Changed { .. }, _) => PersonSeedMetric::Applied(verdict),
+            (Self::Unchanged, _) => PersonSeedMetric::Unchanged,
+        }
+    }
+}
+
+/// One seed's counted outcome, decided during the fold and recorded only once the batch's durable
+/// effects land — a batch counted mid-flight would count every seed twice when it replays.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PersonSeedMetric {
+    SkippedStaleVsLive,
+    Applied(PersonSeedVerdict),
+    Unchanged,
+}
+
+impl PersonSeedMetric {
+    fn record(self) {
+        match self {
+            Self::SkippedStaleVsLive => {
                 counter!(PERSON_SEEDS_SKIPPED_TOTAL, "reason" => "stale_vs_live").increment(1);
             }
-            (Self::Changed { .. }, _) => {
+            Self::Applied(verdict) => {
                 counter!(PERSON_SEEDS_APPLIED_TOTAL, "verdict" => verdict.as_str()).increment(1);
             }
-            (Self::Unchanged, _) => counter!(PERSON_SEEDS_UNCHANGED_TOTAL).increment(1),
+            Self::Unchanged => counter!(PERSON_SEEDS_UNCHANGED_TOTAL).increment(1),
         }
     }
 }
@@ -578,23 +596,27 @@ mod tests {
     use tempfile::TempDir;
 
     use crate::consumers::events::CohortStreamEvent;
-    use crate::filters::{CohortId, FilterCatalog, TeamFiltersBuilder, TeamId};
+    use crate::filters::manager::CatalogHandle;
+    use crate::filters::{CohortId, TeamFiltersBuilder};
     use crate::merge::transfer::Tombstone;
     use crate::partitions::offset_tracker::OffsetTracker;
     use crate::partitions::partitioner::{partition_of, COHORT_PARTITION_COUNT};
     use crate::partitions::watermarks::LiveWatermarks;
     use crate::producer::{
         CaptureCascadeSink, CaptureSeedTileSink, CaptureSink, CaptureStreamEventSink,
-        CaptureTransferSink, ChangeOrigin, MembershipStatus,
+        CaptureTransferSink, ChangeOrigin, MembershipSink, MembershipStatus,
     };
     use crate::stage1::person_record::{PropsFingerprint, Stamp};
     use crate::stage1::state::AppliedOffsets;
     use crate::stage2::state::Stage2State;
+    use crate::store::StoreHandle;
     use crate::store::{
         CohortStore, OffloadConfig, OffloadMode, Stage2Key, StoreConfig, TombstoneKey,
     };
     use crate::workers::event_path::{process_event_gated, EventNameGating};
+    use crate::workers::seed_batch::{Admitted, SeedApplyDeps, SeedOffset, SeedRun};
     use crate::workers::stage2_path::compose_stage2;
+    use crate::workers::MergeWorkerDeps;
     use crate::workers::{CascadeConfig, ReconcileDeps, TransferRetryPolicy};
 
     use super::*;
@@ -677,6 +699,7 @@ mod tests {
         sink: CaptureSink,
         seed_sink: CaptureSeedTileSink,
         deps: MergeWorkerDeps,
+        clock: LastUpdatedClock,
     }
 
     impl Shell {
@@ -728,6 +751,7 @@ mod tests {
                     enabled: true,
                     live_margin_ms: MARGIN_MS,
                 },
+                seed_apply_batch_max: crate::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
             };
             Self {
                 _dir: dir,
@@ -738,23 +762,47 @@ mod tests {
                 sink,
                 seed_sink,
                 deps,
+                clock: LastUpdatedClock::default(),
             }
         }
 
+        /// One seed through the batch pipeline, so every case below also pins that a run of one
+        /// behaves exactly as the per-seed apply did.
         async fn run(&mut self, partition_id: u16, seed: &PersonSeed, offset: i64) {
+            self.run_batch(partition_id, vec![(seed.clone(), offset)])
+                .await;
+        }
+
+        async fn run_batch(&mut self, partition_id: u16, seeds: Vec<(PersonSeed, i64)>) {
+            let highest = seeds
+                .iter()
+                .map(|(_, offset)| *offset)
+                .max()
+                .expect("a dispatched batch is non-empty");
             self.deps
                 .seed_tracker
-                .mark_dispatched(partition_id as i32, offset + 1);
+                .mark_dispatched(partition_id as i32, highest + 1);
             let sink: Arc<dyn MembershipSink> = Arc::new(self.sink.clone());
-            handle_person_seed(
-                partition_id,
-                &self.handle,
-                &self.catalog,
-                &sink,
-                &self.deps,
-                LAST_UPDATED,
-                seed,
-                offset,
+            let run = SeedRun::new(
+                seeds
+                    .into_iter()
+                    .map(|(work, offset)| Admitted {
+                        work,
+                        offset: SeedOffset(offset),
+                    })
+                    .collect(),
+            )
+            .expect("a dispatched batch is non-empty");
+            apply_person_batch(
+                &SeedApplyDeps {
+                    partition_id,
+                    handle: &self.handle,
+                    catalog: &self.catalog,
+                    sink: &sink,
+                    merge: &self.deps,
+                },
+                &mut self.clock,
+                run,
             )
             .await;
         }
@@ -1359,5 +1407,145 @@ mod tests {
             seeded.stamp < live.stamp,
             "the seed installs a floor a margin below its scan, never the live event's own stamp",
         );
+    }
+
+    // ---- batched apply: properties only a run of several seeds can break ----
+
+    /// The change fields a batch must reproduce exactly. `last_updated` is excluded on purpose: it
+    /// is minted per apply, so two shells never agree on it.
+    fn change_shape(changes: &[CohortMembershipChange]) -> Vec<(i32, String, MembershipStatus)> {
+        changes
+            .iter()
+            .map(|change| (change.cohort_id, change.person_id.clone(), change.status))
+            .collect()
+    }
+
+    /// Without read-your-writes the second seed would score its verdict against the bytes the read
+    /// pass saw, so a retraction that follows its own scan in the same run would mint no `Left`.
+    #[tokio::test]
+    async fn two_seeds_for_one_person_in_one_batch_settle_as_two_batches_do() {
+        let (person, partition_id) = dormant_person();
+        let scanned = now_ms();
+        let seeds = || {
+            vec![
+                (seed_for(person, &[PERSON_HASH], &[PERSON_HASH], scanned), 0),
+                (
+                    seed_for(person, &[PERSON_HASH], &[], scanned + MARGIN_MS + 1),
+                    1,
+                ),
+            ]
+        };
+
+        let mut batched = Shell::new(mixed_cohorts());
+        batched.run_batch(partition_id, seeds()).await;
+
+        let mut separately = Shell::new(mixed_cohorts());
+        for (seed, offset) in seeds() {
+            separately.run(partition_id, &seed, offset).await;
+        }
+
+        assert_eq!(
+            batched.record(partition_id, person),
+            separately.record(partition_id, person),
+            "one batch must settle on the same record as two",
+        );
+        assert_eq!(
+            change_shape(&batched.sink.changes()),
+            change_shape(&separately.sink.changes()),
+            "batching must not add or drop a transition",
+        );
+        assert_eq!(
+            batched.sink.changes().last().map(|change| change.status),
+            Some(MembershipStatus::Left),
+            "the retraction still lands after the entry it undoes",
+        );
+        assert_eq!(batched.committable(partition_id), Some(2));
+    }
+
+    #[tokio::test]
+    async fn a_run_of_person_seeds_rides_one_membership_produce() {
+        const SEEDS: usize = 5;
+        let mut shell = Shell::new(mixed_cohorts());
+        // Every person on partition 0, so one worker owns the whole run.
+        shell.deps.partition_count = 1;
+        let scanned = now_ms();
+        let seeds: Vec<_> = (0..SEEDS)
+            .map(|i| {
+                (
+                    seed_for(
+                        Uuid::from_u128(0x5EED_0000 + i as u128),
+                        &[PERSON_HASH],
+                        &[PERSON_HASH],
+                        scanned,
+                    ),
+                    i as i64,
+                )
+            })
+            .collect();
+
+        shell.run_batch(0, seeds).await;
+
+        assert_eq!(
+            shell.sink.changes().len(),
+            SEEDS,
+            "each person entered the single-leaf cohort",
+        );
+        assert_eq!(
+            shell.sink.produce_calls(),
+            1,
+            "one membership produce for the whole run, not one per seed",
+        );
+        assert_eq!(shell.committable(0), Some(SEEDS as i64));
+    }
+
+    /// A batch is all-or-nothing on its offsets: the floor must sit at the *first* seed, so the
+    /// redelivery replays every seed the failed produce covered.
+    #[tokio::test]
+    async fn a_failed_membership_produce_holds_the_person_batchs_first_offset() {
+        let (person, partition_id) = dormant_person();
+        let other = (0x5EEE_u128..)
+            .map(Uuid::from_u128)
+            .find(|p| partition_of(TEAM, p, COHORT_PARTITION_COUNT) as u16 == partition_id)
+            .expect("some uuid hashes onto the same partition");
+        let mut shell = Shell::with_sinks(
+            mixed_cohorts(),
+            CaptureSink::failing_first(1),
+            CaptureSeedTileSink::new(),
+        );
+        shell.live_pageview(partition_id, person, None);
+        let scanned = now_ms();
+        let seeds = |first: i64| {
+            vec![
+                (
+                    seed_for(person, &[PERSON_HASH], &[PERSON_HASH], scanned),
+                    first,
+                ),
+                (
+                    seed_for(other, &[PERSON_HASH], &[PERSON_HASH], scanned),
+                    first + 1,
+                ),
+            ]
+        };
+
+        shell.run_batch(partition_id, seeds(5)).await;
+
+        assert_eq!(
+            shell.committable(partition_id),
+            None,
+            "the failed produce holds, so nothing in the batch commits",
+        );
+        assert!(
+            shell.stage2(partition_id, person, 2).is_none(),
+            "the composed bit must stay unwritten under the failed produce",
+        );
+
+        shell.run_batch(partition_id, seeds(5)).await;
+
+        assert!(
+            shell.stage2(partition_id, person, 2).unwrap().in_cohort,
+            "the replay re-derived the composed flip and committed its bit",
+        );
+        // The tenure-sticky hold pins the committable at the held first offset.
+        assert_eq!(shell.committable(partition_id), Some(5));
     }
 }

--- a/rust/cohort-stream-processor/src/workers/person_seed_path.rs
+++ b/rust/cohort-stream-processor/src/workers/person_seed_path.rs
@@ -770,7 +770,7 @@ mod tests {
                     enabled: true,
                     live_margin_ms: MARGIN_MS,
                 },
-                seed_apply_batch_max: crate::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
+                seed_batch: crate::workers::SeedBatchLimits::default(),
             };
             Self {
                 _dir: dir,

--- a/rust/cohort-stream-processor/src/workers/seed_batch.rs
+++ b/rust/cohort-stream-processor/src/workers/seed_batch.rs
@@ -1,0 +1,737 @@
+//! Batched seed apply: a channel batch's seeds become same-kind runs, and each run reaches exactly
+//! one mark or one hold.
+//!
+//! Applying seeds one at a time costs one awaited produce per seed that flips anything, so a worker
+//! spends its time waiting on Kafka instead of folding. A run amortizes that: one read pass, one
+//! stage-1 commit, one stage-2 recompute over the deduplicated leaves, one concurrent produce, one
+//! stage-2 commit, one mark. The recovery story is unchanged, because stage 1 is idempotent through
+//! max-merge and the stage-2 bits still commit only after the produces ack — a hold pins the run's
+//! *first* offset, and the redelivery replays the whole run.
+//!
+//! This module owns the run boundaries and the vocabulary both pipelines share (offsets, spans,
+//! stages, holds, the joined produce). Each fold lives with its seed kind: tiles in
+//! [`seed_path`](super::seed_path), person seeds in [`person_seed_path`](super::person_seed_path).
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::time::Instant;
+
+use cohort_core::seed::{PersonSeed, ReconcileTile, RunId, SeedTile};
+use metrics::{counter, histogram};
+use uuid::Uuid;
+
+use crate::consumers::seeds::{SeedSkipReason, SeedWork};
+use crate::filters::manager::CatalogHandle;
+use crate::filters::{FilterCatalog, TeamId};
+use crate::observability::metrics::{
+    PERSON_SEED_REKEYED_TOTAL, PERSON_SEED_REKEY_PRODUCE_FAILURE_TOTAL,
+    SEED_APPLY_BATCHES_HELD_TOTAL, SEED_APPLY_BATCH_DURATION_SECONDS, SEED_APPLY_BATCH_SIZE,
+    SEED_REKEYED_TOTAL, SEED_REKEY_PRODUCE_FAILURE_TOTAL, SEED_TILES_SKIPPED_TOTAL,
+};
+use crate::producer::{CohortMembershipChange, LastUpdatedClock, MembershipSink};
+use crate::stage1::key::LeafStateKey;
+use crate::stage2::state::Stage2State;
+use crate::store::{BehavioralKey, ReadLane, Stage2Key, StoreError, StoreHandle};
+use crate::sweep::EvictionQueue;
+use crate::workers::merge_path::MergeWorkerDeps;
+use crate::workers::person_seed_path::apply_person_batch;
+use crate::workers::reconcile::ReconcileQueue;
+use crate::workers::seed_path::{
+    admit_reconcile, apply_tile_batch, hold, mark_processed, tag_seed,
+};
+use crate::workers::stage2_path::{recompute_stage2, Stage2Recompute};
+use crate::workers::worker::{first_cascades, produce_cascades, produce_membership};
+
+/// One message's offset on `cohort_stream_seed_events`. Distinct from every other topic's offsets,
+/// which the seed tracker must never see.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct SeedOffset(pub i64);
+
+/// The offsets a run must act on: `first` is what a failure holds, `last` is what a success marks.
+/// Marking `last` releases every offset in between, which is exactly what a run that either wholly
+/// succeeds or wholly replays needs.
+///
+/// `first` is the run's *lowest* offset, not its leading one. The seed consumer delivers in offset
+/// order, but a hold above the true minimum would pin the commit floor past a seed that was never
+/// applied, so the span is derived rather than assumed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct OffsetSpan {
+    pub first: SeedOffset,
+    pub last: SeedOffset,
+}
+
+/// One seed with the offset that must be marked or held for it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Admitted<T> {
+    pub work: T,
+    pub offset: SeedOffset,
+}
+
+/// A non-empty run of one seed kind, applied as one unit. Construction is the only place emptiness
+/// is checked, so [`span`](Self::span) can never be asked about a run with no offsets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SeedRun<T> {
+    items: Vec<Admitted<T>>,
+    span: OffsetSpan,
+}
+
+impl<T> SeedRun<T> {
+    /// `None` for an empty run: a group with no offsets could neither mark nor hold.
+    pub(crate) fn new(items: Vec<Admitted<T>>) -> Option<Self> {
+        let first = items.iter().map(|item| item.offset).min()?;
+        let last = items
+            .iter()
+            .map(|item| item.offset)
+            .max()
+            .expect("a run with a lowest offset has a highest one too");
+        Some(Self {
+            items,
+            span: OffsetSpan { first, last },
+        })
+    }
+
+    pub(crate) fn span(&self) -> OffsetSpan {
+        self.span
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    pub(crate) fn items(&self) -> &[Admitted<T>] {
+        &self.items
+    }
+}
+
+/// A channel batch's seeds, split so each group is applied by exactly one handler.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SeedGroup {
+    Tiles(SeedRun<SeedTile>),
+    Persons(SeedRun<PersonSeed>),
+    /// Control tiles stay single: admission defers one offset and orders one queue entry, which a
+    /// run of them could not express.
+    Reconcile(Admitted<ReconcileTile>),
+    /// Consume-side skips stay single: each one commits its own offset and does no work.
+    Skip(Admitted<SeedSkipReason>),
+}
+
+/// Split `seeds` into same-kind runs in offset order, capping each run at `max`.
+///
+/// Pure and total: every input seed lands in exactly one group, and the groups' offsets stay in the
+/// order they arrived, which is what keeps a reconcile tile behind its run's data tiles.
+pub(crate) fn group_seeds(seeds: Vec<Admitted<SeedWork>>, max: NonZeroUsize) -> Vec<SeedGroup> {
+    let mut groups = Vec::new();
+    let mut tiles: Vec<Admitted<SeedTile>> = Vec::new();
+    let mut persons: Vec<Admitted<PersonSeed>> = Vec::new();
+
+    for Admitted { work, offset } in seeds {
+        match work {
+            SeedWork::Tile(tile) => {
+                flush(&mut persons, SeedGroup::Persons, &mut groups);
+                tiles.push(Admitted { work: tile, offset });
+                if tiles.len() >= max.get() {
+                    flush(&mut tiles, SeedGroup::Tiles, &mut groups);
+                }
+            }
+            SeedWork::Person(seed) => {
+                flush(&mut tiles, SeedGroup::Tiles, &mut groups);
+                persons.push(Admitted { work: seed, offset });
+                if persons.len() >= max.get() {
+                    flush(&mut persons, SeedGroup::Persons, &mut groups);
+                }
+            }
+            SeedWork::Reconcile(tile) => {
+                flush(&mut tiles, SeedGroup::Tiles, &mut groups);
+                flush(&mut persons, SeedGroup::Persons, &mut groups);
+                groups.push(SeedGroup::Reconcile(Admitted { work: tile, offset }));
+            }
+            SeedWork::Skip(reason) => {
+                flush(&mut tiles, SeedGroup::Tiles, &mut groups);
+                flush(&mut persons, SeedGroup::Persons, &mut groups);
+                groups.push(SeedGroup::Skip(Admitted {
+                    work: reason,
+                    offset,
+                }));
+            }
+        }
+    }
+
+    flush(&mut tiles, SeedGroup::Tiles, &mut groups);
+    flush(&mut persons, SeedGroup::Persons, &mut groups);
+    groups
+}
+
+/// Close the run accumulated in `items`, if any, as one group.
+fn flush<T>(
+    items: &mut Vec<Admitted<T>>,
+    into: fn(SeedRun<T>) -> SeedGroup,
+    groups: &mut Vec<SeedGroup>,
+) {
+    if let Some(run) = SeedRun::new(std::mem::take(items)) {
+        groups.push(into(run));
+    }
+}
+
+/// Which apply pipeline a batch metric belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SeedKind {
+    Tile,
+    Person,
+}
+
+impl SeedKind {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Tile => "tile",
+            Self::Person => "person",
+        }
+    }
+}
+
+/// The ordered steps every seed batch takes. Doubles as the `stage` metric label, so the histogram
+/// and the held counter can never name a step the pipeline does not have.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ApplyStage {
+    /// Tombstone resolution and cross-partition routing.
+    Resolve,
+    /// The batched state read that seeds the overlay.
+    Read,
+    /// The pure fold of every seed into the overlay.
+    Fold,
+    Stage1Commit,
+    Recompute,
+    Produce,
+    Stage2Commit,
+}
+
+impl ApplyStage {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Resolve => "resolve",
+            Self::Read => "read",
+            Self::Fold => "fold",
+            Self::Stage1Commit => "stage1_commit",
+            Self::Recompute => "recompute",
+            Self::Produce => "produce",
+            Self::Stage2Commit => "stage2_commit",
+        }
+    }
+}
+
+impl std::fmt::Display for ApplyStage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Which topic a batch's produce failed on. All three are issued together, so the leg is what tells
+/// an operator where to look.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProduceLeg {
+    Membership,
+    Cascade,
+    /// The cross-partition hand-off back onto the seed topic.
+    ReKey,
+}
+
+impl std::fmt::Display for ProduceLeg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Membership => "membership",
+            Self::Cascade => "cascade",
+            Self::ReKey => "re-key",
+        })
+    }
+}
+
+/// A failure that must not commit. Every pipeline step that can leave durable state half-written
+/// returns this, so the `Ok ⇒ mark, Err ⇒ hold` decision lives at one site per pipeline.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SeedHold {
+    #[error("{stage}: {source}")]
+    Store {
+        stage: ApplyStage,
+        source: StoreError,
+    },
+    #[error("{leg} produce: {errors} message(s) failed")]
+    Produce { leg: ProduceLeg, errors: usize },
+    /// A batched read did not answer every key it was asked about. RocksDB answers one slot per
+    /// key, so this is a backend contract break rather than a data problem — and pairing a slot
+    /// with the wrong key would fold one person's tile onto another person's state, so the run
+    /// holds instead.
+    #[error("{stage}: batched read answered {answered} of {asked} keys")]
+    ShortRead {
+        stage: ApplyStage,
+        asked: usize,
+        answered: usize,
+    },
+}
+
+impl SeedHold {
+    /// `map_err` adapter that labels a store failure with the step that hit it.
+    pub(crate) fn store(stage: ApplyStage) -> impl FnOnce(StoreError) -> Self {
+        move |source| Self::Store { stage, source }
+    }
+
+    /// `Ok` when a batched read answered every key; the run's hold otherwise.
+    pub(crate) fn check_read(stage: ApplyStage, asked: usize, answered: usize) -> Result<(), Self> {
+        if asked == answered {
+            return Ok(());
+        }
+        Err(Self::ShortRead {
+            stage,
+            asked,
+            answered,
+        })
+    }
+
+    pub(crate) fn stage(&self) -> ApplyStage {
+        match self {
+            Self::Store { stage, .. } | Self::ShortRead { stage, .. } => *stage,
+            Self::Produce { .. } => ApplyStage::Produce,
+        }
+    }
+}
+
+/// Splits one batch's wall clock into per-stage samples: each [`mark`](Self::mark) records the time
+/// since the previous one. A batch that holds records no sample for the failed stage — the held
+/// counter carries that instead, so the histogram stays a picture of completed work.
+pub(crate) struct StageClock {
+    kind: SeedKind,
+    last: Instant,
+}
+
+impl StageClock {
+    pub(crate) fn start(kind: SeedKind, size: usize) -> Self {
+        histogram!(SEED_APPLY_BATCH_SIZE, "kind" => kind.as_str()).record(size as f64);
+        Self {
+            kind,
+            last: Instant::now(),
+        }
+    }
+
+    pub(crate) fn mark(&mut self, stage: ApplyStage) {
+        let now = Instant::now();
+        histogram!(
+            SEED_APPLY_BATCH_DURATION_SECONDS,
+            "kind" => self.kind.as_str(),
+            "stage" => stage.as_str(),
+        )
+        .record(now.duration_since(self.last).as_secs_f64());
+        self.last = now;
+    }
+}
+
+/// Everything an apply pipeline borrows for a whole channel batch. All shared, so the worker stays
+/// the single owner of its mutable state (eviction queue, reconcile queue, output clock).
+#[derive(Clone, Copy)]
+pub(crate) struct SeedApplyDeps<'a> {
+    pub partition_id: u16,
+    pub handle: &'a StoreHandle,
+    pub catalog: &'a CatalogHandle,
+    pub sink: &'a Arc<dyn MembershipSink>,
+    pub merge: &'a MergeWorkerDeps,
+}
+
+/// A batch's cross-partition hand-offs. One kind per batch, because a group is one kind.
+#[derive(Debug)]
+pub(crate) enum SeedReKeys {
+    Tiles(Vec<SeedTile>),
+    Persons(Vec<PersonSeed>),
+}
+
+/// Produce a batch's membership changes, their first-hop cascades, and its re-keys concurrently,
+/// then require every leg to have fully acked.
+///
+/// The three topics are independent, so issuing them together costs one round trip instead of
+/// three. A leg that fails holds the batch: replay re-derives the stage-2 flips (their bits are
+/// still unwritten) and re-produces the re-keys, which are idempotent at the target.
+pub(crate) async fn produce_seed_output(
+    deps: &SeedApplyDeps<'_>,
+    changes: Vec<CohortMembershipChange>,
+    re_keys: SeedReKeys,
+    source_offset: SeedOffset,
+) -> Result<(), SeedHold> {
+    // Built from a borrow before `changes` moves into the produce; gate-off allocates nothing.
+    let cascades = first_cascades(deps.merge, &changes, source_offset.0);
+    let (membership_errors, cascade_errors, re_key_errors) = tokio::join!(
+        produce_membership_if_any(deps.sink, changes),
+        produce_cascades(deps.merge, cascades),
+        produce_re_keys(deps.merge, re_keys),
+    );
+
+    for (leg, errors) in [
+        (ProduceLeg::Membership, membership_errors),
+        (ProduceLeg::Cascade, cascade_errors),
+        (ProduceLeg::ReKey, re_key_errors),
+    ] {
+        if errors > 0 {
+            return Err(SeedHold::Produce { leg, errors });
+        }
+    }
+    Ok(())
+}
+
+async fn produce_membership_if_any(
+    sink: &Arc<dyn MembershipSink>,
+    changes: Vec<CohortMembershipChange>,
+) -> usize {
+    if changes.is_empty() {
+        return 0;
+    }
+    produce_membership(sink, changes).await
+}
+
+/// Re-produce a batch's hand-offs, awaiting exactly one `Ok` per seed. A re-keyed seed has no other
+/// copy, so a short ack vector is a failure, never a vacuous success.
+async fn produce_re_keys(merge: &MergeWorkerDeps, re_keys: SeedReKeys) -> usize {
+    match re_keys {
+        SeedReKeys::Tiles(tiles) => {
+            if tiles.is_empty() {
+                return 0;
+            }
+            let expected = tiles.len();
+            let acks = merge.seed_tile_sink.produce(tiles).await;
+            let errors = ack_errors(&acks, expected);
+            if errors > 0 {
+                counter!(SEED_REKEY_PRODUCE_FAILURE_TOTAL).increment(errors as u64);
+            } else {
+                counter!(SEED_REKEYED_TOTAL).increment(expected as u64);
+            }
+            errors
+        }
+        SeedReKeys::Persons(seeds) => {
+            if seeds.is_empty() {
+                return 0;
+            }
+            let expected = seeds.len();
+            let acks = merge.seed_tile_sink.produce_person(seeds).await;
+            let errors = ack_errors(&acks, expected);
+            if errors > 0 {
+                counter!(PERSON_SEED_REKEY_PRODUCE_FAILURE_TOTAL).increment(errors as u64);
+            } else {
+                counter!(PERSON_SEED_REKEYED_TOTAL).increment(expected as u64);
+            }
+            errors
+        }
+    }
+}
+
+fn ack_errors<E>(acks: &[Result<(), E>], expected: usize) -> usize {
+    acks.iter().filter(|result| result.is_err()).count() + acks.len().abs_diff(expected)
+}
+
+/// The persons a batch touched: which leaves each one needs recomposed, and the run of the last
+/// seed that touched them, which is the provenance its recomposed changes carry.
+///
+/// Keeping a person whole matters: splitting their leaves across two recompose calls would evaluate
+/// the same cohort twice against the same uncommitted bit and emit the flip twice.
+#[derive(Debug, Default)]
+pub(crate) struct TouchedPersons {
+    per_person: BTreeMap<(TeamId, Uuid), PersonTouch>,
+}
+
+#[derive(Debug)]
+struct PersonTouch {
+    run: RunId,
+    leaves: BTreeSet<LeafStateKey>,
+}
+
+impl TouchedPersons {
+    pub(crate) fn touch(&mut self, team_id: TeamId, person: Uuid, run: RunId, leaf: LeafStateKey) {
+        let touch = self
+            .per_person
+            .entry((team_id, person))
+            .or_insert_with(|| PersonTouch {
+                run,
+                leaves: BTreeSet::new(),
+            });
+        touch.run = run;
+        touch.leaves.insert(leaf);
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.per_person.is_empty()
+    }
+
+    /// One recompose call per `(team, run)`: the team owns the catalog that composes the leaves, the
+    /// run owns their provenance tag.
+    fn groups(self) -> BTreeMap<(TeamId, RunId), Vec<(LeafStateKey, Uuid)>> {
+        let mut groups: BTreeMap<(TeamId, RunId), Vec<(LeafStateKey, Uuid)>> = BTreeMap::new();
+        for ((team_id, person), touch) in self.per_person {
+            let group = groups.entry((team_id, touch.run)).or_default();
+            group.extend(touch.leaves.into_iter().map(|leaf| (leaf, person)));
+        }
+        groups
+    }
+}
+
+/// A batch's stage-2 recompose, uncommitted: the flips to produce and the `cf_stage2` writes that
+/// may land only once those produces ack.
+#[derive(Default)]
+pub(crate) struct BatchRecompose {
+    pub changes: Vec<CohortMembershipChange>,
+    pub writes: Vec<(Stage2Key, Stage2State)>,
+    recomputes: Vec<Stage2Recompute>,
+}
+
+impl BatchRecompose {
+    /// Call only once the writes committed, so a failed commit's redelivery cannot double-count.
+    pub(crate) fn record_metrics(&self) {
+        for recompute in &self.recomputes {
+            recompute.record_metrics();
+        }
+    }
+}
+
+/// Recompose stage 2 for everything the batch touched, once per `(team, run)`.
+///
+/// The changes carry one batch-final `last_updated`, newer than every single-leaf change the fold
+/// minted, so a composed flip wins LWW against the leaf flip that caused it.
+pub(crate) async fn recompose_batch(
+    deps: &SeedApplyDeps<'_>,
+    snapshot: &FilterCatalog,
+    touched: TouchedPersons,
+    now_ms: i64,
+    clock: &mut LastUpdatedClock,
+) -> Result<BatchRecompose, SeedHold> {
+    if touched.is_empty() {
+        return Ok(BatchRecompose::default());
+    }
+    let last_updated = clock.next();
+
+    let mut recomposed = BatchRecompose::default();
+    for ((team_id, run), leaves) in touched.groups() {
+        // Only teams this same snapshot already resolved reach here, so the miss arm is dead; it
+        // degrades to skipping one team's recompose rather than killing the partition worker.
+        let Some(filters) = snapshot.team(team_id) else {
+            continue;
+        };
+        let mut recompute = recompute_stage2(
+            deps.partition_id,
+            deps.handle,
+            filters,
+            &leaves,
+            now_ms,
+            &last_updated,
+            ReadLane::Maintenance,
+        )
+        .await
+        .map_err(SeedHold::store(ApplyStage::Recompute))?;
+
+        // The changes are cloned rather than moved: `record_metrics` counts them after the commit.
+        let mut changes = recompute.changes.clone();
+        tag_seed(&mut changes, run);
+        recomposed.changes.extend(changes);
+        recomposed
+            .writes
+            .extend(std::mem::take(&mut recompute.writes));
+        recomposed.recomputes.push(recompute);
+    }
+    Ok(recomposed)
+}
+
+/// Settle one batch: mark its whole span, or hold its first offset and count the failed stage.
+pub(crate) fn settle(
+    deps: &SeedApplyDeps<'_>,
+    kind: SeedKind,
+    span: OffsetSpan,
+    outcome: Result<(), SeedHold>,
+) {
+    match outcome {
+        Ok(()) => mark_processed(&deps.merge.seed_tracker, deps.partition_id, span.last),
+        Err(held) => {
+            counter!(
+                SEED_APPLY_BATCHES_HELD_TOTAL,
+                "kind" => kind.as_str(),
+                "stage" => held.stage().as_str(),
+            )
+            .increment(1);
+            tracing::warn!(
+                partition_id = deps.partition_id,
+                kind = kind.as_str(),
+                first_offset = span.first.0,
+                last_offset = span.last.0,
+                error = %held,
+                "seed batch apply failed; holding the batch's first seed offset for redelivery",
+            );
+            hold(&deps.merge.seed_tracker, deps.partition_id, span.first);
+        }
+    }
+}
+
+/// Apply one channel batch's seed groups in order on the owning partition worker.
+///
+/// A group that holds pins the commit floor at its own first offset; later groups still run and
+/// mark, and the floor keeps their marks from leapfrogging the hold — the same envelope as the
+/// per-seed path, now at batch granularity.
+pub(crate) async fn handle_seed_groups(
+    deps: SeedApplyDeps<'_>,
+    queue: &mut EvictionQueue<BehavioralKey>,
+    reconcile_queue: &mut ReconcileQueue,
+    clock: &mut LastUpdatedClock,
+    groups: Vec<SeedGroup>,
+) {
+    for group in groups {
+        match group {
+            SeedGroup::Tiles(run) => apply_tile_batch(&deps, queue, clock, run).await,
+            SeedGroup::Persons(run) => apply_person_batch(&deps, clock, run).await,
+            SeedGroup::Reconcile(admitted) => admit_reconcile(
+                deps.partition_id,
+                deps.merge,
+                reconcile_queue,
+                &admitted.work,
+                admitted.offset,
+            ),
+            SeedGroup::Skip(admitted) => {
+                counter!(SEED_TILES_SKIPPED_TOTAL, "reason" => admitted.work.as_str()).increment(1);
+                mark_processed(&deps.merge.seed_tracker, deps.partition_id, admitted.offset);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use cohort_core::seed::{
+        BehavioralShapeHash, ClaimEpoch, ConditionHash, ReconcileScope, RunId, SChunkMs,
+        ScannedAtMs,
+    };
+    use uuid::Uuid;
+
+    use crate::filters::{CohortId, TeamId};
+
+    use super::*;
+
+    const TEAM: TeamId = TeamId(7);
+
+    fn hash() -> ConditionHash {
+        ConditionHash::parse("0123456789abcdef").unwrap()
+    }
+
+    fn tile() -> SeedTile {
+        SeedTile::new(
+            TEAM,
+            Uuid::from_u128(1),
+            hash(),
+            NonZeroU32::new(1).unwrap(),
+            20_614,
+            SChunkMs(1),
+            RunId(Uuid::nil()),
+            ClaimEpoch(1),
+        )
+    }
+
+    fn person() -> PersonSeed {
+        PersonSeed::new(
+            TEAM,
+            Uuid::from_u128(2),
+            vec![hash()],
+            vec![],
+            ScannedAtMs(1),
+            RunId(Uuid::nil()),
+            ClaimEpoch(1),
+        )
+        .unwrap()
+    }
+
+    fn reconcile() -> ReconcileTile {
+        ReconcileTile::new(
+            TEAM,
+            CohortId(1),
+            ReconcileScope::Behavioral(BehavioralShapeHash::parse("0123456789abcdef").unwrap()),
+            RunId(Uuid::nil()),
+        )
+    }
+
+    fn admitted(work: SeedWork, offset: i64) -> Admitted<SeedWork> {
+        Admitted {
+            work,
+            offset: SeedOffset(offset),
+        }
+    }
+
+    /// The offsets each group would act on: `(first, last)` per group, in group order.
+    fn spans(groups: &[SeedGroup]) -> Vec<(i64, i64)> {
+        groups
+            .iter()
+            .map(|group| match group {
+                SeedGroup::Tiles(run) => (run.span().first.0, run.span().last.0),
+                SeedGroup::Persons(run) => (run.span().first.0, run.span().last.0),
+                SeedGroup::Reconcile(admitted) => (admitted.offset.0, admitted.offset.0),
+                SeedGroup::Skip(admitted) => (admitted.offset.0, admitted.offset.0),
+            })
+            .collect()
+    }
+
+    fn max(n: usize) -> NonZeroUsize {
+        NonZeroUsize::new(n).unwrap()
+    }
+
+    /// A run that leaked across a kind boundary would hand tiles to the person fold, or hand a
+    /// reconcile tile's offset to a batch that marks past it.
+    #[test]
+    fn runs_break_at_every_kind_change_and_control_seeds_stay_single() {
+        let groups = group_seeds(
+            vec![
+                admitted(SeedWork::Tile(tile()), 0),
+                admitted(SeedWork::Tile(tile()), 1),
+                admitted(SeedWork::Person(person()), 2),
+                admitted(SeedWork::Reconcile(reconcile()), 3),
+                admitted(SeedWork::Tile(tile()), 4),
+                admitted(SeedWork::Skip(SeedSkipReason::UnknownKind), 5),
+                admitted(SeedWork::Tile(tile()), 6),
+            ],
+            max(256),
+        );
+
+        assert!(matches!(groups[0], SeedGroup::Tiles(ref run) if run.len() == 2));
+        assert!(matches!(groups[1], SeedGroup::Persons(ref run) if run.len() == 1));
+        assert!(matches!(groups[2], SeedGroup::Reconcile(_)));
+        assert!(matches!(groups[3], SeedGroup::Tiles(ref run) if run.len() == 1));
+        assert!(matches!(groups[4], SeedGroup::Skip(_)));
+        assert!(matches!(groups[5], SeedGroup::Tiles(ref run) if run.len() == 1));
+        assert_eq!(
+            spans(&groups),
+            vec![(0, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)],
+            "every group holds its own first and marks its own last",
+        );
+    }
+
+    #[test]
+    fn a_run_longer_than_the_cap_splits_into_capped_groups() {
+        let seeds: Vec<_> = (0..7)
+            .map(|offset| admitted(SeedWork::Tile(tile()), offset))
+            .collect();
+
+        let groups = group_seeds(seeds, max(3));
+
+        assert_eq!(groups.len(), 3);
+        assert_eq!(spans(&groups), vec![(0, 2), (3, 5), (6, 6)]);
+    }
+
+    /// The zero-cost hatch: `COHORT_SEED_APPLY_BATCH_MAX=1` must reproduce the per-seed apply.
+    #[test]
+    fn a_cap_of_one_yields_one_group_per_seed() {
+        let seeds: Vec<_> = (0..3)
+            .map(|offset| admitted(SeedWork::Tile(tile()), offset))
+            .collect();
+
+        let groups = group_seeds(seeds, max(1));
+
+        assert_eq!(spans(&groups), vec![(0, 0), (1, 1), (2, 2)]);
+    }
+
+    #[test]
+    fn an_empty_batch_yields_no_groups() {
+        assert!(group_seeds(Vec::new(), max(256)).is_empty());
+    }
+
+    #[test]
+    fn an_empty_run_has_no_span_so_it_cannot_become_a_group() {
+        assert!(SeedRun::<SeedTile>::new(Vec::new()).is_none());
+    }
+}

--- a/rust/cohort-stream-processor/src/workers/seed_batch.rs
+++ b/rust/cohort-stream-processor/src/workers/seed_batch.rs
@@ -25,11 +25,13 @@ use uuid::Uuid;
 use crate::cascade::CascadeMessage;
 use crate::consumers::seeds::{SeedSkipReason, SeedWork};
 use crate::filters::manager::CatalogHandle;
+use crate::filters::reverse_index::TeamFilters;
 use crate::filters::{FilterCatalog, TeamId};
 use crate::observability::metrics::{
     PERSON_SEED_REKEYED_TOTAL, PERSON_SEED_REKEY_PRODUCE_FAILURE_TOTAL,
-    SEED_APPLY_BATCHES_HELD_TOTAL, SEED_APPLY_BATCH_DURATION_SECONDS, SEED_APPLY_BATCH_SIZE,
-    SEED_REKEYED_TOTAL, SEED_REKEY_PRODUCE_FAILURE_TOTAL, SEED_TILES_SKIPPED_TOTAL,
+    SEED_APPLY_BATCHES_CLOSED_TOTAL, SEED_APPLY_BATCHES_HELD_TOTAL,
+    SEED_APPLY_BATCH_DURATION_SECONDS, SEED_APPLY_BATCH_SIZE, SEED_REKEYED_TOTAL,
+    SEED_REKEY_PRODUCE_FAILURE_TOTAL, SEED_TILES_SKIPPED_TOTAL,
 };
 use crate::producer::{CohortMembershipChange, LastUpdatedClock, MembershipSink};
 use crate::stage1::key::LeafStateKey;
@@ -118,39 +120,125 @@ pub(crate) enum SeedGroup {
     Skip(Admitted<SeedSkipReason>),
 }
 
-/// Split `seeds` into same-kind runs in offset order, capping each run at `max`.
+/// The two ceilings on one apply run. Both bound the unit of work a hold replays: `max_seeds` the
+/// messages, `max_fanout` the leaf reads and recomputes they expand to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SeedBatchLimits {
+    /// Seeds per run. `1` restores the per-seed apply, which is the hatch if batching misbehaves.
+    pub max_seeds: NonZeroUsize,
+    /// Fan-out units per run, as [`seed_fanout`] weighs them. A run closes before the seed that
+    /// would exceed it; a seed heavier than the whole budget still runs alone.
+    pub max_fanout: NonZeroUsize,
+}
+
+impl Default for SeedBatchLimits {
+    /// Mirrors the `COHORT_SEED_APPLY_BATCH_MAX*` defaults, for deps built without explicit config.
+    fn default() -> Self {
+        Self {
+            max_seeds: NonZeroUsize::new(256).expect("256 > 0"),
+            max_fanout: NonZeroUsize::new(4096).expect("4096 > 0"),
+        }
+    }
+}
+
+/// How much work one seed expands to: one unit per leaf its condition reaches, plus one per cohort
+/// each leaf backs (a single-leaf register write or a stage-2 recompute).
+///
+/// Pure. A seed the catalog cannot place weighs one, so a run of them is still bounded by the count
+/// cap rather than by nothing. Control and skip seeds weigh nothing: they are always their own
+/// group.
+pub(crate) fn seed_fanout(catalog: &FilterCatalog, work: &SeedWork) -> usize {
+    let reached = match work {
+        SeedWork::Tile(tile) => catalog.team(tile.team_id()).map_or(0, |filters| {
+            condition_fanout(filters, &tile.condition_hash().as_bytes())
+        }),
+        SeedWork::Person(seed) => catalog.team(seed.team_id()).map_or(0, |filters| {
+            seed.evaluated()
+                .iter()
+                .map(|hash| hash.as_bytes())
+                .filter(|hash| filters.person_property_conditions.contains(hash))
+                .map(|hash| condition_fanout(filters, &hash))
+                .sum()
+        }),
+        SeedWork::Reconcile(_) | SeedWork::Skip(_) => return 0,
+    };
+    reached.max(1)
+}
+
+fn condition_fanout(filters: &TeamFilters, condition_hash: &[u8; 16]) -> usize {
+    let cohorts_backed = |lsk: &LeafStateKey| {
+        filters
+            .by_lsk_to_single_leaf_cohorts
+            .get(lsk)
+            .map_or(0, Vec::len)
+            + filters
+                .by_lsk_to_composable_cohorts
+                .get(lsk)
+                .map_or(0, Vec::len)
+    };
+    filters
+        .by_condition_to_lsk
+        .get(condition_hash)
+        .map_or(0, |lsks| {
+            lsks.iter().map(|lsk| 1 + cohorts_backed(lsk)).sum()
+        })
+}
+
+/// Why a run closed. `count` should dominate; a `fanout` rate says the catalog fans seeds out far
+/// wider than the defaults assume.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CloseCause {
+    Count,
+    Fanout,
+    /// The next seed is of another kind, or a control seed.
+    KindChange,
+    /// The channel batch ran out.
+    End,
+}
+
+impl CloseCause {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Count => "count",
+            Self::Fanout => "fanout",
+            Self::KindChange => "kind_change",
+            Self::End => "end",
+        }
+    }
+}
+
+/// Split `seeds` into same-kind runs in offset order, each within `limits` under `weigh`.
 ///
 /// Pure and total: every input seed lands in exactly one group, and the groups' offsets stay in the
 /// order they arrived, which is what keeps a reconcile tile behind its run's data tiles.
-pub(crate) fn group_seeds(seeds: Vec<Admitted<SeedWork>>, max: NonZeroUsize) -> Vec<SeedGroup> {
+pub(crate) fn group_seeds(
+    seeds: Vec<Admitted<SeedWork>>,
+    limits: SeedBatchLimits,
+    weigh: impl Fn(&SeedWork) -> usize,
+) -> Vec<SeedGroup> {
     let mut groups = Vec::new();
-    let mut tiles: Vec<Admitted<SeedTile>> = Vec::new();
-    let mut persons: Vec<Admitted<PersonSeed>> = Vec::new();
+    let mut tiles = OpenRun::new(SeedKind::Tile, SeedGroup::Tiles);
+    let mut persons = OpenRun::new(SeedKind::Person, SeedGroup::Persons);
 
     for Admitted { work, offset } in seeds {
+        let weight = weigh(&work);
         match work {
             SeedWork::Tile(tile) => {
-                flush(&mut persons, SeedGroup::Persons, &mut groups);
-                tiles.push(Admitted { work: tile, offset });
-                if tiles.len() >= max.get() {
-                    flush(&mut tiles, SeedGroup::Tiles, &mut groups);
-                }
+                persons.close(CloseCause::KindChange, &mut groups);
+                tiles.admit(Admitted { work: tile, offset }, weight, limits, &mut groups);
             }
             SeedWork::Person(seed) => {
-                flush(&mut tiles, SeedGroup::Tiles, &mut groups);
-                persons.push(Admitted { work: seed, offset });
-                if persons.len() >= max.get() {
-                    flush(&mut persons, SeedGroup::Persons, &mut groups);
-                }
+                tiles.close(CloseCause::KindChange, &mut groups);
+                persons.admit(Admitted { work: seed, offset }, weight, limits, &mut groups);
             }
             SeedWork::Reconcile(tile) => {
-                flush(&mut tiles, SeedGroup::Tiles, &mut groups);
-                flush(&mut persons, SeedGroup::Persons, &mut groups);
+                tiles.close(CloseCause::KindChange, &mut groups);
+                persons.close(CloseCause::KindChange, &mut groups);
                 groups.push(SeedGroup::Reconcile(Admitted { work: tile, offset }));
             }
             SeedWork::Skip(reason) => {
-                flush(&mut tiles, SeedGroup::Tiles, &mut groups);
-                flush(&mut persons, SeedGroup::Persons, &mut groups);
+                tiles.close(CloseCause::KindChange, &mut groups);
+                persons.close(CloseCause::KindChange, &mut groups);
                 groups.push(SeedGroup::Skip(Admitted {
                     work: reason,
                     offset,
@@ -159,19 +247,65 @@ pub(crate) fn group_seeds(seeds: Vec<Admitted<SeedWork>>, max: NonZeroUsize) -> 
         }
     }
 
-    flush(&mut tiles, SeedGroup::Tiles, &mut groups);
-    flush(&mut persons, SeedGroup::Persons, &mut groups);
+    tiles.close(CloseCause::End, &mut groups);
+    persons.close(CloseCause::End, &mut groups);
     groups
 }
 
-/// Close the run accumulated in `items`, if any, as one group.
-fn flush<T>(
-    items: &mut Vec<Admitted<T>>,
+/// A run of one kind still accepting seeds, with the fan-out it has admitted so far.
+struct OpenRun<T> {
+    kind: SeedKind,
     into: fn(SeedRun<T>) -> SeedGroup,
-    groups: &mut Vec<SeedGroup>,
-) {
-    if let Some(run) = SeedRun::new(std::mem::take(items)) {
-        groups.push(into(run));
+    items: Vec<Admitted<T>>,
+    fanout: usize,
+}
+
+impl<T> OpenRun<T> {
+    fn new(kind: SeedKind, into: fn(SeedRun<T>) -> SeedGroup) -> Self {
+        Self {
+            kind,
+            into,
+            items: Vec::new(),
+            fanout: 0,
+        }
+    }
+
+    /// Admit one seed, closing the run around it as the limits demand: before, when its weight
+    /// would overflow the fan-out budget; after, when it fills the count.
+    ///
+    /// An empty run always admits, so a seed heavier than the whole budget still applies alone
+    /// instead of never being marked or held.
+    fn admit(
+        &mut self,
+        item: Admitted<T>,
+        weight: usize,
+        limits: SeedBatchLimits,
+        groups: &mut Vec<SeedGroup>,
+    ) {
+        let overflows = self.fanout.saturating_add(weight) > limits.max_fanout.get();
+        if overflows && !self.items.is_empty() {
+            self.close(CloseCause::Fanout, groups);
+        }
+        self.items.push(item);
+        self.fanout = self.fanout.saturating_add(weight);
+        if self.items.len() >= limits.max_seeds.get() {
+            self.close(CloseCause::Count, groups);
+        }
+    }
+
+    /// Close the run, if non-empty, as one group.
+    fn close(&mut self, cause: CloseCause, groups: &mut Vec<SeedGroup>) {
+        let Some(run) = SeedRun::new(std::mem::take(&mut self.items)) else {
+            return;
+        };
+        self.fanout = 0;
+        counter!(
+            SEED_APPLY_BATCHES_CLOSED_TOTAL,
+            "kind" => self.kind.as_str(),
+            "cause" => cause.as_str(),
+        )
+        .increment(1);
+        groups.push((self.into)(run));
     }
 }
 
@@ -640,7 +774,9 @@ mod tests {
     };
     use uuid::Uuid;
 
-    use crate::filters::{CohortId, TeamId};
+    use serde_json::{json, Value};
+
+    use crate::filters::{CohortId, TeamFiltersBuilder, TeamId};
 
     use super::*;
 
@@ -705,15 +841,29 @@ mod tests {
             .collect()
     }
 
-    fn max(n: usize) -> NonZeroUsize {
-        NonZeroUsize::new(n).unwrap()
+    fn limits(max_seeds: usize, max_fanout: usize) -> SeedBatchLimits {
+        SeedBatchLimits {
+            max_seeds: NonZeroUsize::new(max_seeds).unwrap(),
+            max_fanout: NonZeroUsize::new(max_fanout).unwrap(),
+        }
+    }
+
+    /// Group under the count cap alone: every seed weighs one and the fan-out budget is unbounded.
+    fn group_by_count(seeds: Vec<Admitted<SeedWork>>, max_seeds: usize) -> Vec<SeedGroup> {
+        group_seeds(seeds, limits(max_seeds, usize::MAX), |_| 1)
+    }
+
+    fn tiles(offsets: std::ops::Range<i64>) -> Vec<Admitted<SeedWork>> {
+        offsets
+            .map(|offset| admitted(SeedWork::Tile(tile()), offset))
+            .collect()
     }
 
     /// A run that leaked across a kind boundary would hand tiles to the person fold, or hand a
     /// reconcile tile's offset to a batch that marks past it.
     #[test]
     fn runs_break_at_every_kind_change_and_control_seeds_stay_single() {
-        let groups = group_seeds(
+        let groups = group_by_count(
             vec![
                 admitted(SeedWork::Tile(tile()), 0),
                 admitted(SeedWork::Tile(tile()), 1),
@@ -723,7 +873,7 @@ mod tests {
                 admitted(SeedWork::Skip(SeedSkipReason::UnknownKind), 5),
                 admitted(SeedWork::Tile(tile()), 6),
             ],
-            max(256),
+            256,
         );
 
         assert!(matches!(groups[0], SeedGroup::Tiles(ref run) if run.len() == 2));
@@ -741,11 +891,7 @@ mod tests {
 
     #[test]
     fn a_run_longer_than_the_cap_splits_into_capped_groups() {
-        let seeds: Vec<_> = (0..7)
-            .map(|offset| admitted(SeedWork::Tile(tile()), offset))
-            .collect();
-
-        let groups = group_seeds(seeds, max(3));
+        let groups = group_by_count(tiles(0..7), 3);
 
         assert_eq!(groups.len(), 3);
         assert_eq!(spans(&groups), vec![(0, 2), (3, 5), (6, 6)]);
@@ -754,18 +900,137 @@ mod tests {
     /// The zero-cost hatch: `COHORT_SEED_APPLY_BATCH_MAX=1` must reproduce the per-seed apply.
     #[test]
     fn a_cap_of_one_yields_one_group_per_seed() {
-        let seeds: Vec<_> = (0..3)
-            .map(|offset| admitted(SeedWork::Tile(tile()), offset))
-            .collect();
-
-        let groups = group_seeds(seeds, max(1));
+        let groups = group_by_count(tiles(0..3), 1);
 
         assert_eq!(spans(&groups), vec![(0, 0), (1, 1), (2, 2)]);
     }
 
     #[test]
     fn an_empty_batch_yields_no_groups() {
-        assert!(group_seeds(Vec::new(), max(256)).is_empty());
+        assert!(group_by_count(Vec::new(), 256).is_empty());
+    }
+
+    /// The budget bounds what a run expands to, so it has to be checked before a seed is admitted:
+    /// applied after, every run would overshoot by one seed's whole fan-out.
+    #[test]
+    fn a_run_closes_before_the_next_seed_would_exceed_the_fanout_budget() {
+        let groups = group_seeds(tiles(0..5), limits(256, 10), |_| 4);
+
+        assert_eq!(spans(&groups), vec![(0, 1), (2, 3), (4, 4)]);
+    }
+
+    /// A seed heavier than the whole budget can never fit, so an empty run must still admit it:
+    /// refusing would leave the seed neither marked nor held, and the partition wedged behind it.
+    #[test]
+    fn a_seed_heavier_than_the_whole_budget_still_forms_a_run_of_one() {
+        let groups = group_seeds(tiles(0..3), limits(256, 10), |_| 1000);
+
+        assert_eq!(spans(&groups), vec![(0, 0), (1, 1), (2, 2)]);
+    }
+
+    /// The weight is the work a seed expands to: the leaves its condition reaches and the cohorts
+    /// each leaf backs. Counting leaves alone would let a hash shared by many cohorts weigh one.
+    #[test]
+    fn seed_fanout_counts_the_cohorts_a_condition_reaches_not_its_leaves() {
+        const SHARED: &str = "0123456789abcdef";
+        const PAIRED: &str = "fedcba9876543210";
+        const PERSON: &str = "person0000000001";
+        let behavioral = |condition_hash: &str| {
+            json!({
+                "type": "behavioral", "value": "performed_event", "key": "$pageview",
+                "time_value": 7, "time_interval": "day",
+                "conditionHash": condition_hash,
+                "bytecode": ["_H", 1, 32, "$pageview", 32, "event", 1, 1, 11],
+            })
+        };
+        let person_property = json!({
+            "type": "person", "key": "email", "value": "a@b.com", "operator": "exact",
+            "conditionHash": PERSON,
+            "bytecode": ["_H", 1, 32, "a@b.com", 32, "email", 32, "properties", 32, "person", 1, 3, 11],
+        });
+        let cohort =
+            |leaves: Vec<Value>| json!({ "properties": { "type": "AND", "values": leaves } });
+        let mut builder = TeamFiltersBuilder::default();
+        // Three single-leaf cohorts and two composable ones share the leaf behind SHARED.
+        for id in 1..=3 {
+            builder
+                .add_cohort(CohortId(id), TEAM, &cohort(vec![behavioral(SHARED)]))
+                .unwrap();
+        }
+        for id in 4..=5 {
+            builder
+                .add_cohort(
+                    CohortId(id),
+                    TEAM,
+                    &cohort(vec![behavioral(SHARED), behavioral(PAIRED)]),
+                )
+                .unwrap();
+        }
+        builder
+            .add_cohort(CohortId(6), TEAM, &cohort(vec![person_property]))
+            .unwrap();
+        let catalog = FilterCatalog::from_teams([(TEAM, builder.freeze(chrono_tz::UTC))]);
+        let tile_with = |team: TeamId, condition_hash: &str| {
+            SeedWork::Tile(SeedTile::new(
+                team,
+                Uuid::from_u128(1),
+                ConditionHash::parse(condition_hash).unwrap(),
+                NonZeroU32::new(1).unwrap(),
+                20_614,
+                SChunkMs(1),
+                RunId(Uuid::nil()),
+                ClaimEpoch(1),
+            ))
+        };
+
+        assert_eq!(
+            seed_fanout(&catalog, &tile_with(TEAM, SHARED)),
+            6,
+            "one leaf, plus three single-leaf and two composable cohorts",
+        );
+        assert_eq!(
+            seed_fanout(&catalog, &tile_with(TEAM, PAIRED)),
+            3,
+            "one leaf, plus the two composable cohorts alone",
+        );
+        assert_eq!(
+            seed_fanout(&catalog, &tile_with(TEAM, "no_such_cond0000")),
+            1,
+            "a hash the catalog no longer resolves still weighs one",
+        );
+        assert_eq!(
+            seed_fanout(&catalog, &tile_with(TeamId(99), SHARED)),
+            1,
+            "an unknown team still weighs one",
+        );
+
+        let person_seed = SeedWork::Person(
+            PersonSeed::new(
+                TEAM,
+                Uuid::from_u128(2),
+                // SHARED is behavioral, so the person path drops it before it can weigh anything.
+                vec![
+                    ConditionHash::parse(SHARED).unwrap(),
+                    ConditionHash::parse(PERSON).unwrap(),
+                ],
+                vec![],
+                ScannedAtMs(1),
+                RunId(Uuid::nil()),
+                ClaimEpoch(1),
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            seed_fanout(&catalog, &person_seed),
+            2,
+            "the person leaf plus its one single-leaf cohort; the behavioral hash weighs nothing",
+        );
+
+        assert_eq!(seed_fanout(&catalog, &SeedWork::Reconcile(reconcile())), 0);
+        assert_eq!(
+            seed_fanout(&catalog, &SeedWork::Skip(SeedSkipReason::UnknownKind)),
+            0
+        );
     }
 
     #[test]

--- a/rust/cohort-stream-processor/src/workers/seed_batch.rs
+++ b/rust/cohort-stream-processor/src/workers/seed_batch.rs
@@ -3,13 +3,14 @@
 //!
 //! Applying seeds one at a time costs one awaited produce per seed that flips anything, so a worker
 //! spends its time waiting on Kafka instead of folding. A run amortizes that: one read pass, one
-//! stage-1 commit, one stage-2 recompute over the deduplicated leaves, one concurrent produce, one
-//! stage-2 commit, one mark. The recovery story is unchanged, because stage 1 is idempotent through
-//! max-merge and the stage-2 bits still commit only after the produces ack — a hold pins the run's
-//! *first* offset, and the redelivery replays the whole run.
+//! produce of the fold's own output, one stage-1 commit, one stage-2 recompute over the
+//! deduplicated leaves, one produce of the composed flips, one produce of the cascades, one stage-2
+//! commit, one mark. Every produce acks before the state it reports commits, so a failed leg holds
+//! the run's *first* offset with its durable effects either absent or idempotently re-appliable,
+//! and the redelivery replays the whole run.
 //!
 //! This module owns the run boundaries and the vocabulary both pipelines share (offsets, spans,
-//! stages, holds, the joined produce). Each fold lives with its seed kind: tiles in
+//! stages, holds, the produce legs). Each fold lives with its seed kind: tiles in
 //! [`seed_path`](super::seed_path), person seeds in [`person_seed_path`](super::person_seed_path).
 
 use std::collections::{BTreeMap, BTreeSet};
@@ -21,6 +22,7 @@ use cohort_core::seed::{PersonSeed, ReconcileTile, RunId, SeedTile};
 use metrics::{counter, histogram};
 use uuid::Uuid;
 
+use crate::cascade::CascadeMessage;
 use crate::consumers::seeds::{SeedSkipReason, SeedWork};
 use crate::filters::manager::CatalogHandle;
 use crate::filters::{FilterCatalog, TeamId};
@@ -41,7 +43,7 @@ use crate::workers::seed_path::{
     admit_reconcile, apply_tile_batch, hold, mark_processed, tag_seed,
 };
 use crate::workers::stage2_path::{recompute_stage2, Stage2Recompute};
-use crate::workers::worker::{first_cascades, produce_cascades, produce_membership};
+use crate::workers::worker::{produce_cascades, produce_membership};
 
 /// One message's offset on `cohort_stream_seed_events`. Distinct from every other topic's offsets,
 /// which the seed tracker must never see.
@@ -199,9 +201,15 @@ pub(crate) enum ApplyStage {
     Read,
     /// The pure fold of every seed into the overlay.
     Fold,
+    /// Leg 1: the fold's single-leaf changes and the run's re-keys, before anything commits.
+    ProduceLeaf,
     Stage1Commit,
     Recompute,
-    Produce,
+    /// Leg 2: the recompose's composed flips, before their bits commit.
+    ProduceComposed,
+    /// Leg 3: first-hop cascades for every change the run emitted, after both membership legs
+    /// acked.
+    ProduceCascades,
     Stage2Commit,
 }
 
@@ -211,9 +219,11 @@ impl ApplyStage {
             Self::Resolve => "resolve",
             Self::Read => "read",
             Self::Fold => "fold",
+            Self::ProduceLeaf => "produce_leaf",
             Self::Stage1Commit => "stage1_commit",
             Self::Recompute => "recompute",
-            Self::Produce => "produce",
+            Self::ProduceComposed => "produce_composed",
+            Self::ProduceCascades => "produce_cascades",
             Self::Stage2Commit => "stage2_commit",
         }
     }
@@ -225,20 +235,34 @@ impl std::fmt::Display for ApplyStage {
     }
 }
 
-/// Which topic a batch's produce failed on. All three are issued together, so the leg is what tells
-/// an operator where to look.
+/// Which output a batch's produce failed on. The leg names the topic for the operator and the
+/// stage for the metric, so one failure can never be filed under the wrong step.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ProduceLeg {
-    Membership,
+    /// Single-leaf membership, minted by the fold.
+    LeafMembership,
+    /// Composed membership, minted by the stage-2 recompose.
+    ComposedMembership,
     Cascade,
     /// The cross-partition hand-off back onto the seed topic.
     ReKey,
 }
 
+impl ProduceLeg {
+    pub(crate) fn stage(self) -> ApplyStage {
+        match self {
+            Self::LeafMembership | Self::ReKey => ApplyStage::ProduceLeaf,
+            Self::ComposedMembership => ApplyStage::ProduceComposed,
+            Self::Cascade => ApplyStage::ProduceCascades,
+        }
+    }
+}
+
 impl std::fmt::Display for ProduceLeg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(match self {
-            Self::Membership => "membership",
+            Self::LeafMembership => "leaf membership",
+            Self::ComposedMembership => "composed membership",
             Self::Cascade => "cascade",
             Self::ReKey => "re-key",
         })
@@ -289,7 +313,7 @@ impl SeedHold {
     pub(crate) fn stage(&self) -> ApplyStage {
         match self {
             Self::Store { stage, .. } | Self::ShortRead { stage, .. } => *stage,
-            Self::Produce { .. } => ApplyStage::Produce,
+            Self::Produce { leg, .. } => leg.stage(),
         }
     }
 }
@@ -341,36 +365,50 @@ pub(crate) enum SeedReKeys {
     Persons(Vec<PersonSeed>),
 }
 
-/// Produce a batch's membership changes, their first-hop cascades, and its re-keys concurrently,
-/// then require every leg to have fully acked.
+/// Leg 1: produce the fold's single-leaf changes and the run's re-keys together, before anything
+/// commits.
 ///
-/// The three topics are independent, so issuing them together costs one round trip instead of
-/// three. A leg that fails holds the batch: replay re-derives the stage-2 flips (their bits are
-/// still unwritten) and re-produces the re-keys, which are idempotent at the target.
-pub(crate) async fn produce_seed_output(
+/// Both are minted by the pure fold, so a failure here leaves the store untouched and the
+/// redelivery re-folds the same seeds and re-emits them. The two topics are independent, so issuing
+/// them together costs one round trip instead of two.
+pub(crate) async fn produce_leaf_output(
     deps: &SeedApplyDeps<'_>,
     changes: Vec<CohortMembershipChange>,
     re_keys: SeedReKeys,
-    source_offset: SeedOffset,
 ) -> Result<(), SeedHold> {
-    // Built from a borrow before `changes` moves into the produce; gate-off allocates nothing.
-    let cascades = first_cascades(deps.merge, &changes, source_offset.0);
-    let (membership_errors, cascade_errors, re_key_errors) = tokio::join!(
+    let (membership_errors, re_key_errors) = tokio::join!(
         produce_membership_if_any(deps.sink, changes),
-        produce_cascades(deps.merge, cascades),
         produce_re_keys(deps.merge, re_keys),
     );
+    require_acked(ProduceLeg::LeafMembership, membership_errors)?;
+    require_acked(ProduceLeg::ReKey, re_key_errors)
+}
 
-    for (leg, errors) in [
-        (ProduceLeg::Membership, membership_errors),
-        (ProduceLeg::Cascade, cascade_errors),
-        (ProduceLeg::ReKey, re_key_errors),
-    ] {
-        if errors > 0 {
-            return Err(SeedHold::Produce { leg, errors });
-        }
+/// Leg 2: produce the recompose's composed flips, after the stage-1 commit and before the stage-2
+/// commit, so a failure leaves their bits unwritten and the redelivery re-derives them.
+pub(crate) async fn produce_composed_output(
+    deps: &SeedApplyDeps<'_>,
+    changes: Vec<CohortMembershipChange>,
+) -> Result<(), SeedHold> {
+    let errors = produce_membership_if_any(deps.sink, changes).await;
+    require_acked(ProduceLeg::ComposedMembership, errors)
+}
+
+/// Leg 3: produce the first-hop cascades of every change the run emitted, once both membership
+/// legs have acked, so a referrer can never learn of a flip before the membership topic does.
+pub(crate) async fn produce_cascade_output(
+    deps: &SeedApplyDeps<'_>,
+    cascades: Vec<CascadeMessage>,
+) -> Result<(), SeedHold> {
+    let errors = produce_cascades(deps.merge, cascades).await;
+    require_acked(ProduceLeg::Cascade, errors)
+}
+
+fn require_acked(leg: ProduceLeg, errors: usize) -> Result<(), SeedHold> {
+    if errors == 0 {
+        return Ok(());
     }
-    Ok(())
+    Err(SeedHold::Produce { leg, errors })
 }
 
 async fn produce_membership_if_any(

--- a/rust/cohort-stream-processor/src/workers/seed_batch.rs
+++ b/rust/cohort-stream-processor/src/workers/seed_batch.rs
@@ -44,7 +44,7 @@ use crate::workers::reconcile::ReconcileQueue;
 use crate::workers::seed_path::{
     admit_reconcile, apply_tile_batch, hold, mark_processed, tag_seed,
 };
-use crate::workers::stage2_path::{recompute_stage2, Stage2Recompute};
+use crate::workers::stage2_path::{recompute_stage2, Stage2Counts, Stage2Recompute};
 use crate::workers::worker::{produce_cascades, produce_membership};
 
 /// One message's offset on `cohort_stream_seed_events`. Distinct from every other topic's offsets,
@@ -645,16 +645,8 @@ impl TouchedPersons {
 pub(crate) struct BatchRecompose {
     pub changes: Vec<CohortMembershipChange>,
     pub writes: Vec<(Stage2Key, Stage2State)>,
-    recomputes: Vec<Stage2Recompute>,
-}
-
-impl BatchRecompose {
-    /// Call only once the writes committed, so a failed commit's redelivery cannot double-count.
-    pub(crate) fn record_metrics(&self) {
-        for recompute in &self.recomputes {
-            recompute.record_metrics();
-        }
-    }
+    /// Record only once the writes committed, so a failed commit's redelivery cannot double-count.
+    pub counts: Stage2Counts,
 }
 
 /// Recompose stage 2 for everything the batch touched, once per `(team, run)`.
@@ -680,7 +672,11 @@ pub(crate) async fn recompose_batch(
         let Some(filters) = snapshot.team(team_id) else {
             continue;
         };
-        let mut recompute = recompute_stage2(
+        let Stage2Recompute {
+            mut changes,
+            writes,
+            counts,
+        } = recompute_stage2(
             deps.partition_id,
             deps.handle,
             filters,
@@ -692,14 +688,10 @@ pub(crate) async fn recompose_batch(
         .await
         .map_err(SeedHold::store(ApplyStage::Recompute))?;
 
-        // The changes are cloned rather than moved: `record_metrics` counts them after the commit.
-        let mut changes = recompute.changes.clone();
         tag_seed(&mut changes, run);
         recomposed.changes.extend(changes);
-        recomposed
-            .writes
-            .extend(std::mem::take(&mut recompute.writes));
-        recomposed.recomputes.push(recompute);
+        recomposed.writes.extend(writes);
+        recomposed.counts += counts;
     }
     Ok(recomposed)
 }

--- a/rust/cohort-stream-processor/src/workers/seed_batch.rs
+++ b/rust/cohort-stream-processor/src/workers/seed_batch.rs
@@ -619,6 +619,8 @@ impl TouchedPersons {
                 run,
                 leaves: BTreeSet::new(),
             });
+        // Last run wins: the person must stay in one recompose group, so their composed flips
+        // carry the provenance of the last run that touched them.
         touch.run = run;
         touch.leaves.insert(leaf);
     }

--- a/rust/cohort-stream-processor/src/workers/seed_path.rs
+++ b/rust/cohort-stream-processor/src/workers/seed_path.rs
@@ -1,10 +1,11 @@
 //! The seed-tile apply path: a pure, clock-free core ([`merge_tile_into_leaf`]) that mirrors the
 //! live fold minus dedup (slide-before-evaluate, max-merge of the tile's absolute count,
-//! structural-equality `Unchanged` — the whole of tile idempotency), and an imperative shell
-//! ([`handle_seed`]) ordered stage-1 commit → stage-2 recompute → produce → stage-2 commit → mark.
-//! Committing the stage-2 bits after the produces ack makes a failed produce re-derivable on
-//! replay; store/produce failures hold the seed offset.
+//! structural-equality `Unchanged` — the whole of tile idempotency), and a batched imperative shell
+//! ([`apply_tile_batch`]) ordered stage-1 commit → stage-2 recompose → produce → stage-2 commit →
+//! mark. Committing the stage-2 bits after the produces ack makes a failed produce re-derivable on
+//! replay; store/produce failures hold the batch's first seed offset.
 
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::num::NonZeroU32;
 use std::sync::Arc;
 
@@ -16,20 +17,17 @@ use uuid::Uuid;
 
 use cohort_core::seed::{PersonSeed, ReconcileTile, RunId, SeedTile};
 
-use crate::consumers::seeds::SeedWork;
-use crate::filters::manager::CatalogHandle;
 use crate::filters::reverse_index::{LeafStateMeta, TeamFilters};
-use crate::filters::TeamId;
+use crate::filters::{FilterCatalog, TeamId};
 use crate::merge::tombstone_redirect::{self, Resolution, MAX_CROSS_PARTITION_REDIRECT_HOPS};
 use crate::observability::metrics::{
     COHORT_STREAM_OFFSET_AHEAD_OF_DISPATCH, RECONCILE_JOBS_ENQUEUED_TOTAL,
-    RECONCILE_JOBS_SUPERSEDED_TOTAL, SEED_HELD_OFFSET_GAUGE, SEED_REKEYED_TOTAL,
-    SEED_REKEY_HOP_CAPPED_TOTAL, SEED_REKEY_PRODUCE_FAILURE_TOTAL, SEED_TILES_APPLIED_TOTAL,
-    SEED_TILES_DROPPED_TOTAL, SEED_TILES_SKIPPED_TOTAL, SEED_TILES_UNCHANGED_TOTAL,
-    STAGE1_STATE_DECODE_ERROR, STAGE1_TRANSITIONS,
+    RECONCILE_JOBS_SUPERSEDED_TOTAL, SEED_HELD_OFFSET_GAUGE, SEED_REKEY_HOP_CAPPED_TOTAL,
+    SEED_TILES_APPLIED_TOTAL, SEED_TILES_DROPPED_TOTAL, SEED_TILES_SKIPPED_TOTAL,
+    SEED_TILES_UNCHANGED_TOTAL, STAGE1_STATE_DECODE_ERROR, STAGE1_TRANSITIONS,
 };
 use crate::partitions::offset_tracker::{MarkOutcome, OffsetTracker};
-use crate::producer::{map_transition, ChangeOrigin, CohortMembershipChange, MembershipSink};
+use crate::producer::{map_transition, ChangeOrigin, CohortMembershipChange, LastUpdatedClock};
 use crate::stage1::bucket_tz::{
     daily_bucket_len, day_idx_in_tz, start_of_day_ms_in_tz, window_start_for_now, DayIdx,
 };
@@ -43,15 +41,16 @@ use crate::stage1::transition::{LeafTransition, TransitionKind};
 use crate::stage2::{
     leaf_membership, single_leaf_register_writes, stage_register_writes, MembershipRegisterSource,
 };
-use crate::store::{Behavioral, BehavioralKey, PersonPrefix, ReadLane, StagedBatch, StoreHandle};
+use crate::store::{Behavioral, BehavioralKey, PersonPrefix, ReadLane, StagedBatch};
 use crate::sweep::EvictionQueue;
 use crate::workers::merge_path::MergeWorkerDeps;
-use crate::workers::person_seed_path::handle_person_seed;
 use crate::workers::reconcile::{ReconcileQueue, SupersedeOutcome};
-use crate::workers::stage2_path::{commit_stage2_writes, recompute_stage2};
-use crate::workers::worker::{
-    first_cascades, produce_cascades, produce_membership, transition_metric_label,
+use crate::workers::seed_batch::{
+    produce_seed_output, recompose_batch, settle, Admitted, ApplyStage, SeedApplyDeps, SeedHold,
+    SeedKind, SeedOffset, SeedReKeys, SeedRun, StageClock, TouchedPersons,
 };
+use crate::workers::stage2_path::commit_stage2_writes;
+use crate::workers::worker::transition_metric_label;
 
 /// A seed kind that can be re-keyed onto a merge survivor.
 pub(crate) trait RekeyableSeed: Sized {
@@ -497,261 +496,433 @@ fn finish(
     }
 }
 
-/// Handle one seed message on its owning partition worker; marks or holds the seed tracker only.
-#[allow(clippy::too_many_arguments)]
-pub(crate) async fn handle_seed(
-    partition_id: u16,
-    handle: &StoreHandle,
-    catalog: &CatalogHandle,
-    sink: &Arc<dyn MembershipSink>,
-    merge: &MergeWorkerDeps,
+/// Apply one run of day-tiles as a unit, then mark its whole span or hold its first offset.
+///
+/// The run pays one batched tombstone resolve, one batched state read, one stage-1 commit, one
+/// stage-2 recompose over the deduplicated leaves, one concurrent produce and one stage-2 commit —
+/// whatever its length. Replay is unchanged: stage 1 is idempotent through max-merge, and the
+/// stage-2 bits still land only after the produces ack, so a held run re-derives its composed flips.
+pub(crate) async fn apply_tile_batch(
+    deps: &SeedApplyDeps<'_>,
     queue: &mut EvictionQueue<BehavioralKey>,
-    reconcile_queue: &mut ReconcileQueue,
-    last_updated: &str,
-    work: &SeedWork,
-    offset: i64,
+    clock: &mut LastUpdatedClock,
+    run: SeedRun<SeedTile>,
 ) {
-    let tile = match work {
-        SeedWork::Skip(reason) => {
-            counter!(SEED_TILES_SKIPPED_TOTAL, "reason" => reason.as_str()).increment(1);
-            mark_processed(&merge.seed_tracker, partition_id, offset);
-            return;
-        }
-        SeedWork::Reconcile(tile) => {
-            admit_reconcile(partition_id, merge, reconcile_queue, tile, offset);
-            return;
-        }
-        SeedWork::Person(seed) => {
-            handle_person_seed(
-                partition_id,
-                handle,
-                catalog,
-                sink,
-                merge,
-                last_updated,
-                seed,
-                offset,
-            )
-            .await;
-            return;
-        }
-        SeedWork::Tile(tile) => tile,
-    };
+    let span = run.span();
+    let mut stages = StageClock::start(SeedKind::Tile, run.len());
+    let outcome = apply_tiles(deps, queue, clock, &mut stages, &run).await;
+    settle(deps, SeedKind::Tile, span, outcome);
+}
 
-    let snapshot = catalog.load();
-    let Some(team_filters) = snapshot.team(tile.team_id()) else {
-        counter!(SEED_TILES_DROPPED_TOTAL, "reason" => "team_absent").increment(1);
-        mark_processed(&merge.seed_tracker, partition_id, offset);
-        return;
-    };
-    let filters: &TeamFilters = team_filters;
+/// The ordered apply. Every `?` leaves durable state either untouched or idempotently re-appliable,
+/// which is what lets the caller turn one `Err` into one hold.
+async fn apply_tiles(
+    deps: &SeedApplyDeps<'_>,
+    queue: &mut EvictionQueue<BehavioralKey>,
+    clock: &mut LastUpdatedClock,
+    stages: &mut StageClock,
+    run: &SeedRun<SeedTile>,
+) -> Result<(), SeedHold> {
+    let snapshot = deps.catalog.load();
+
+    let RoutedTiles { locals, re_keys } = route_tiles(deps, &snapshot, run.items()).await?;
+    stages.mark(ApplyStage::Resolve);
+
+    let mut overlay = read_leaf_slots(deps, &locals).await?;
+    stages.mark(ApplyStage::Read);
+
+    // One instant for the whole run: `last_evaluated_at_ms` is a freshness stamp, and every tile in
+    // the run slides against the same "now".
+    let now_ms = Utc::now().timestamp_millis();
+    let folded = fold_tiles(&locals, &mut overlay, clock, now_ms);
+    stages.mark(ApplyStage::Fold);
+
+    // Order: stage-1 commit → stage-2 recompose → produce → stage-2 commit → schedule → mark.
+    commit_tile_stage1(deps, &overlay, now_ms).await?;
+    stages.mark(ApplyStage::Stage1Commit);
+
+    let recomposed = recompose_batch(deps, &snapshot, folded.touched, now_ms, clock).await?;
+    stages.mark(ApplyStage::Recompute);
+
+    let mut changes = folded.changes;
+    changes.extend(recomposed.changes.iter().cloned());
+    produce_seed_output(deps, changes, SeedReKeys::Tiles(re_keys), run.span().last).await?;
+    stages.mark(ApplyStage::Produce);
+
+    commit_stage2_writes(deps.handle, &recomposed.writes)
+        .await
+        .map_err(SeedHold::store(ApplyStage::Stage2Commit))?;
+    stages.mark(ApplyStage::Stage2Commit);
+    recomposed.record_metrics();
+
+    for (key, deadline) in folded.schedules {
+        queue.schedule(key, deadline);
+    }
+    Ok(())
+}
+
+/// One tile that applies on this partition, with everything its fold needs resolved once.
+struct LocalTile<'a> {
+    tile: &'a SeedTile,
+    /// The tombstone chain's survivor, or the tile's own person when nothing merged.
+    person: Uuid,
+    filters: Arc<TeamFilters>,
+    /// The leaves this tile's condition still resolves to. Never empty: a tile that references none
+    /// is dropped during routing.
+    lsks: Vec<LeafStateKey>,
+    /// This tile's slice of the store, resolved once. The read pass and the fold both key off it,
+    /// so neither can build a key the other does not have.
+    prefix: PersonPrefix,
+}
+
+struct RoutedTiles<'a> {
+    locals: Vec<LocalTile<'a>>,
+    /// Tiles whose survivor lives on another partition, handed back to the seed topic.
+    re_keys: Vec<SeedTile>,
+}
+
+/// Resolve the run's tombstones in one read and split it into local applies and hand-offs.
+async fn route_tiles<'a>(
+    deps: &SeedApplyDeps<'_>,
+    snapshot: &FilterCatalog,
+    tiles: &'a [Admitted<SeedTile>],
+) -> Result<RoutedTiles<'a>, SeedHold> {
+    let mut known: Vec<(&SeedTile, Arc<TeamFilters>)> = Vec::with_capacity(tiles.len());
+    let mut persons: Vec<(TeamId, Uuid)> = Vec::new();
+    let mut seen: HashSet<(TeamId, Uuid)> = HashSet::new();
+    for Admitted { work: tile, .. } in tiles {
+        let Some(filters) = snapshot.team(tile.team_id()) else {
+            counter!(SEED_TILES_DROPPED_TOTAL, "reason" => "team_absent").increment(1);
+            continue;
+        };
+        if seen.insert((tile.team_id(), tile.person_id())) {
+            persons.push((tile.team_id(), tile.person_id()));
+        }
+        known.push((tile, filters.clone()));
+    }
 
     // A read failure is fail-stop: a tile mis-applied to a merged-away person is durable state
     // reconcile cannot retract.
-    let resolution = match tombstone_redirect::resolve_offloaded(
-        handle,
-        partition_id,
-        tile.team_id(),
-        tile.person_id(),
-        merge.partition_count,
+    let resolutions = tombstone_redirect::resolve_batch_offloaded(
+        deps.handle,
+        deps.partition_id,
+        &persons,
+        deps.merge.partition_count,
         ReadLane::Maintenance,
     )
     .await
-    {
-        Ok(resolution) => resolution,
-        Err(error) => {
-            warn!(
-                partition_id,
-                team_id = tile.team_id().0,
-                error = %error,
-                "seed tombstone preflight read failed; holding the seed offset for redelivery",
-            );
-            hold(&merge.seed_tracker, partition_id, offset);
-            return;
-        }
+    .map_err(SeedHold::store(ApplyStage::Resolve))?;
+
+    let mut routed = RoutedTiles {
+        locals: Vec::with_capacity(known.len()),
+        re_keys: Vec::new(),
     };
-    let person = match route_seed(tile, resolution, MAX_CROSS_PARTITION_REDIRECT_HOPS) {
-        SeedRoute::ApplyLocal { person } => person,
-        SeedRoute::ReProduce { seed: rekeyed } => {
-            // Ack before mark; the tile has no other copy. Exactly one Ok ack — an empty vector
-            // would make an `all(is_ok)` guard vacuously true and commit past a lost tile.
-            let acks = merge.seed_tile_sink.produce(vec![rekeyed]).await;
-            if matches!(acks.as_slice(), [Ok(())]) {
-                counter!(SEED_REKEYED_TOTAL).increment(1);
-                mark_processed(&merge.seed_tracker, partition_id, offset);
-            } else {
-                counter!(SEED_REKEY_PRODUCE_FAILURE_TOTAL).increment(1);
-                warn!(
-                    partition_id,
-                    team_id = tile.team_id().0,
-                    "seed tile re-key produce failed; holding the seed offset for redelivery",
-                );
-                hold(&merge.seed_tracker, partition_id, offset);
+    for (tile, filters) in known {
+        let Some(&resolution) = resolutions.get(&(tile.team_id(), tile.person_id())) else {
+            return Err(SeedHold::ShortRead {
+                stage: ApplyStage::Resolve,
+                asked: persons.len(),
+                answered: resolutions.len(),
+            });
+        };
+        let person = match route_seed(tile, resolution, MAX_CROSS_PARTITION_REDIRECT_HOPS) {
+            SeedRoute::ApplyLocal { person } => person,
+            SeedRoute::ReProduce { seed: rekeyed } => {
+                routed.re_keys.push(rekeyed);
+                continue;
             }
-            return;
+            SeedRoute::CapExhausted { person } => {
+                counter!(SEED_REKEY_HOP_CAPPED_TOTAL).increment(1);
+                // Same degrade as the event path: orphaned-but-bounded state (the survivor's live
+                // path never reads this slice) that ages out via eviction, preferred over a silent
+                // tile loss.
+                warn!(
+                    partition_id = deps.partition_id,
+                    team_id = tile.team_id().0,
+                    %person,
+                    hops = tile.redirect_hops(),
+                    "seed redirect hop cap hit (corrupt tombstone cycle?); applying inline at the best-known target",
+                );
+                person
+            }
+        };
+        let lsks = filters
+            .by_condition_to_lsk
+            .get(&tile.condition_hash().as_bytes())
+            .cloned()
+            .unwrap_or_default();
+        if lsks.is_empty() {
+            // Expected for a stale/edited cohort: the hash no longer resolves.
+            counter!(SEED_TILES_DROPPED_TOTAL, "reason" => "no_referencing_leaves").increment(1);
+            continue;
         }
-        SeedRoute::CapExhausted { person } => {
-            counter!(SEED_REKEY_HOP_CAPPED_TOTAL).increment(1);
-            // Same degrade as the event path: orphaned-but-bounded state (the survivor's live
-            // path never reads this slice) that ages out via eviction, preferred over a silent
-            // tile loss.
-            warn!(
-                partition_id,
-                team_id = tile.team_id().0,
-                %person,
-                hops = tile.redirect_hops(),
-                "seed redirect hop cap hit (corrupt tombstone cycle?); applying inline at the best-known target",
-            );
-            person
-        }
-    };
-
-    let lsks: &[LeafStateKey] = filters
-        .by_condition_to_lsk
-        .get(&tile.condition_hash().as_bytes())
-        .map_or(&[], Vec::as_slice);
-    if lsks.is_empty() {
-        // Expected for a stale/edited cohort: the hash no longer resolves.
-        counter!(SEED_TILES_DROPPED_TOTAL, "reason" => "no_referencing_leaves").increment(1);
-        mark_processed(&merge.seed_tracker, partition_id, offset);
-        return;
+        routed.locals.push(LocalTile {
+            tile,
+            person,
+            filters,
+            lsks,
+            prefix: PersonPrefix::new(deps.partition_id, tile.team_id().0 as u64, person),
+        });
     }
-
-    let prefix = PersonPrefix::new(partition_id, tile.team_id().0 as u64, person);
-    let keys: Vec<BehavioralKey> = lsks.iter().map(|&lsk| prefix.behavioral_key(lsk)).collect();
-    // Maintenance lane: backfill must not contend with live event reads.
-    let values = match handle
-        .multi_get_behavioral(keys, ReadLane::Maintenance)
-        .await
-    {
-        Ok(values) => values,
-        Err(error) => {
-            warn!(
-                partition_id,
-                team_id = tile.team_id().0,
-                error = %error,
-                "seed state read failed; holding the seed offset for redelivery",
-            );
-            hold(&merge.seed_tracker, partition_id, offset);
-            return;
-        }
-    };
-
-    let now_ms = Utc::now().timestamp_millis();
-    let now_day = day_idx_in_tz(now_ms, filters.timezone);
-    let TileApplication {
-        staged,
-        transitions,
-        stage2_leaves,
-        schedules,
-    } = apply_tile_to_leaves(
-        filters, &prefix, lsks, values, tile, person, now_day, now_ms,
-    );
-
-    // Order: stage-1 commit → stage-2 recompute → produce → stage-2 commit → schedule → mark.
-    if !staged.is_empty() {
-        if let Err(error) = handle.commit(staged).await {
-            warn!(
-                partition_id,
-                team_id = tile.team_id().0,
-                error = %error,
-                "seed state commit failed; holding the seed offset for redelivery",
-            );
-            hold(&merge.seed_tracker, partition_id, offset);
-            return;
-        }
-    }
-
-    let mut changes: Vec<CohortMembershipChange> = Vec::new();
-    for transition in &transitions {
-        if let Some(kind) = transition_metric_label(filters, transition) {
-            counter!(STAGE1_TRANSITIONS, "kind" => kind).increment(1);
-        }
-        changes.extend(map_transition(filters, transition, last_updated));
-    }
-    // `event_ms := now_ms`: `last_evaluated_at_ms` is a freshness stamp, and the worker-batch
-    // `last_updated` makes backfill flips win LWW downstream.
-    let recompute = match recompute_stage2(
-        partition_id,
-        handle,
-        filters,
-        &stage2_leaves,
-        now_ms,
-        last_updated,
-        ReadLane::Maintenance,
-    )
-    .await
-    {
-        Ok(recompute) => recompute,
-        Err(error) => {
-            warn!(
-                partition_id,
-                team_id = tile.team_id().0,
-                error = %error,
-                "seed stage 2 recompute failed; holding the seed offset for redelivery",
-            );
-            hold(&merge.seed_tracker, partition_id, offset);
-            return;
-        }
-    };
-    changes.extend(recompute.changes.iter().cloned());
-
-    tag_seed(&mut changes, tile.run_id());
-    // Only the cascade topic can re-evaluate cohort-of-cohort referrers; gate-off builds nothing.
-    let cascades = first_cascades(merge, &changes, offset);
-    if !changes.is_empty() {
-        let errors = produce_membership(sink, changes).await;
-        if errors > 0 {
-            // Replay re-derives the stage-2 flips (bits unwritten); a lost single-leaf change is
-            // not re-emitted — the reconcile snapshot heals that class.
-            warn!(
-                partition_id,
-                team_id = tile.team_id().0,
-                errors,
-                "seed membership produce failed; holding the seed offset for redelivery",
-            );
-            hold(&merge.seed_tracker, partition_id, offset);
-            return;
-        }
-    }
-    let cascade_errors = produce_cascades(merge, cascades).await;
-    if cascade_errors > 0 {
-        warn!(
-            partition_id,
-            team_id = tile.team_id().0,
-            errors = cascade_errors,
-            "seed cascade produce failed; holding the seed offset for redelivery",
-        );
-        hold(&merge.seed_tracker, partition_id, offset);
-        return;
-    }
-
-    // The bits commit only after both produces ack, so a failed produce is re-derived on replay
-    // instead of lost against a flipped bit; replay duplicates are LWW-safe downstream.
-    if let Err(error) = commit_stage2_writes(handle, &recompute.writes).await {
-        warn!(
-            partition_id,
-            team_id = tile.team_id().0,
-            error = %error,
-            "seed stage 2 commit failed; holding the seed offset for redelivery",
-        );
-        hold(&merge.seed_tracker, partition_id, offset);
-        return;
-    }
-    recompute.record_metrics();
-
-    for (key, deadline) in schedules {
-        queue.schedule(key, deadline);
-    }
-    mark_processed(&merge.seed_tracker, partition_id, offset);
+    Ok(routed)
 }
 
-fn admit_reconcile(
+/// One leaf's state inside a run's overlay, so a second tile for the same leaf folds onto the first
+/// tile's result instead of the bytes the read pass saw.
+enum LeafSlot {
+    /// Read from the store, not yet folded into.
+    Untouched(Option<StatefulRecord>),
+    /// Folded at least once. `write` is what stages the row and its membership registers.
+    Touched {
+        record: StatefulRecord,
+        write: LeafWrite,
+        /// Whether any tile in the run actually advanced the state. A run that only ever merged to
+        /// `Unchanged` still repairs the membership register, but re-writing a byte-identical
+        /// `cf_behavioral` row would spend the store's write budget on nothing — the steady state
+        /// of a re-run chunk.
+        merged: bool,
+    },
+    /// Stored bytes that do not decode. Never folded into and never overwritten: rebuilding from an
+    /// absent baseline would silently drop whatever the unreadable row held.
+    Corrupt,
+}
+
+impl LeafSlot {
+    fn decode(bytes: Option<Vec<u8>>) -> Self {
+        match bytes {
+            None => Self::Untouched(None),
+            Some(bytes) => match StatefulRecord::decode(&bytes) {
+                Ok(record) => Self::Untouched(Some(record)),
+                Err(_) => {
+                    counter!(STAGE1_STATE_DECODE_ERROR).increment(1);
+                    Self::Corrupt
+                }
+            },
+        }
+    }
+
+    /// The state the next tile merges into.
+    fn prev(&self) -> Option<StatefulRecord> {
+        match self {
+            Self::Untouched(prev) => prev.clone(),
+            Self::Touched { record, .. } => Some(record.clone()),
+            Self::Corrupt => None,
+        }
+    }
+
+    /// Whether an earlier tile in this run already advanced the slot's state.
+    fn already_merged(&self) -> bool {
+        matches!(self, Self::Touched { merged: true, .. })
+    }
+}
+
+/// What one touched leaf needs to stage its row's single-leaf membership registers.
+struct LeafWrite {
+    filters: Arc<TeamFilters>,
+    meta: LeafStateMeta,
+    source: MembershipRegisterSource,
+}
+
+#[derive(Default)]
+struct FoldedTiles {
+    /// Single-leaf membership changes, one `last_updated` per tile that flipped something.
+    changes: Vec<CohortMembershipChange>,
+    touched: TouchedPersons,
+    schedules: Vec<(BehavioralKey, i64)>,
+}
+
+/// Fold every tile into the overlay in offset order. Pure apart from its counters: the store is not
+/// touched, so a failure later in the pipeline replays this identically.
+fn fold_tiles(
+    locals: &[LocalTile<'_>],
+    overlay: &mut BTreeMap<BehavioralKey, LeafSlot>,
+    clock: &mut LastUpdatedClock,
+    now_ms: i64,
+) -> FoldedTiles {
+    let mut folded = FoldedTiles::default();
+    for local in locals {
+        let filters = local.filters.as_ref();
+        let now_day = day_idx_in_tz(now_ms, filters.timezone);
+        let mut transitions: Vec<LeafTransition> = Vec::new();
+
+        for &lsk in &local.lsks {
+            let Some(meta) = filters.by_lsk.get(&lsk) else {
+                counter!(SEED_TILES_DROPPED_TOTAL, "reason" => SeedDropReason::MetaIncomplete.as_str())
+                    .increment(1);
+                continue;
+            };
+            let key = local.prefix.behavioral_key(lsk);
+            let slot = overlay
+                .get_mut(&key)
+                .expect("the read pass keyed off the same prefix, so every folded leaf has a slot");
+            if matches!(slot, LeafSlot::Corrupt) {
+                counter!(SEED_TILES_DROPPED_TOTAL, "reason" => "corrupt_state").increment(1);
+                continue;
+            }
+
+            let identity = LeafIdentity {
+                team_id: local.tile.team_id(),
+                lsk,
+                person_id: local.person,
+                condition_hash: local.tile.condition_hash().as_bytes(),
+            };
+            let already_merged = slot.already_merged();
+            let (record, merged) = match merge_tile_into_leaf(
+                meta,
+                filters.timezone,
+                identity,
+                local.tile.day_idx(),
+                local.tile.count_nonzero(),
+                slot.prev(),
+                now_day,
+                now_ms,
+            ) {
+                LeafMergeOutcome::Merged {
+                    record,
+                    transition,
+                    deadline_ms,
+                } => {
+                    counter!(SEED_TILES_APPLIED_TOTAL, "variant" => record.state.variant().as_str())
+                        .increment(1);
+                    if let Some(transition) = transition {
+                        transitions.push(transition);
+                    }
+                    if deadline_ms != i64::MAX {
+                        folded.schedules.push((key, deadline_ms));
+                    }
+                    (record, true)
+                }
+                LeafMergeOutcome::Unchanged { record } => {
+                    counter!(SEED_TILES_UNCHANGED_TOTAL, "variant" => meta.variant.as_str())
+                        .increment(1);
+                    (record, already_merged)
+                }
+                LeafMergeOutcome::Dropped(reason) => {
+                    counter!(SEED_TILES_DROPPED_TOTAL, "reason" => reason.as_str()).increment(1);
+                    continue;
+                }
+            };
+
+            *slot = LeafSlot::Touched {
+                record,
+                write: LeafWrite {
+                    filters: local.filters.clone(),
+                    meta: *meta,
+                    source: MembershipRegisterSource {
+                        partition_id: local.prefix.partition_id,
+                        team_id: identity.team_id,
+                        person_id: identity.person_id,
+                        leaf_state_key: lsk,
+                    },
+                },
+                merged,
+            };
+            // Merged *and* Unchanged both recompose Stage 2, so a crash between the two commits
+            // self-heals on replay.
+            folded
+                .touched
+                .touch(local.tile.team_id(), local.person, local.tile.run_id(), lsk);
+        }
+
+        if !transitions.is_empty() {
+            let last_updated = clock.next();
+            let start = folded.changes.len();
+            for transition in &transitions {
+                if let Some(kind) = transition_metric_label(filters, transition) {
+                    counter!(STAGE1_TRANSITIONS, "kind" => kind).increment(1);
+                }
+                folded
+                    .changes
+                    .extend(map_transition(filters, transition, &last_updated));
+            }
+            tag_seed(&mut folded.changes[start..], local.tile.run_id());
+        }
+    }
+    folded
+}
+
+/// Read every leaf the run will fold into, once, and decode it into the overlay.
+async fn read_leaf_slots(
+    deps: &SeedApplyDeps<'_>,
+    locals: &[LocalTile<'_>],
+) -> Result<BTreeMap<BehavioralKey, LeafSlot>, SeedHold> {
+    let mut distinct: BTreeSet<BehavioralKey> = BTreeSet::new();
+    for local in locals {
+        distinct.extend(
+            local
+                .lsks
+                .iter()
+                .map(|&lsk| local.prefix.behavioral_key(lsk)),
+        );
+    }
+    let keys: Vec<BehavioralKey> = distinct.into_iter().collect();
+    // Maintenance lane: backfill must not contend with live event reads.
+    let values = deps
+        .handle
+        .multi_get_behavioral(keys.clone(), ReadLane::Maintenance)
+        .await
+        .map_err(SeedHold::store(ApplyStage::Read))?;
+    SeedHold::check_read(ApplyStage::Read, keys.len(), values.len())?;
+    Ok(keys
+        .into_iter()
+        .zip(values)
+        .map(|(key, bytes)| (key, LeafSlot::decode(bytes)))
+        .collect())
+}
+
+/// Stage every touched leaf's membership-register overwrite, plus the row itself for the leaves a
+/// tile actually advanced, then commit them as one batch.
+///
+/// Staging only the final state per key equals staging every intermediate write, because
+/// `single_leaf_register_writes` is a complete overwrite and the record is the fold's fixed point.
+async fn commit_tile_stage1(
+    deps: &SeedApplyDeps<'_>,
+    overlay: &BTreeMap<BehavioralKey, LeafSlot>,
+    now_ms: i64,
+) -> Result<(), SeedHold> {
+    let staged = stage_tile_writes(overlay, now_ms);
+    if staged.is_empty() {
+        return Ok(());
+    }
+    deps.handle
+        .commit(staged)
+        .await
+        .map_err(SeedHold::store(ApplyStage::Stage1Commit))
+}
+
+/// The pure half of [`commit_tile_stage1`]: what the run writes, given the settled overlay.
+fn stage_tile_writes(overlay: &BTreeMap<BehavioralKey, LeafSlot>, now_ms: i64) -> StagedBatch {
+    let mut staged = StagedBatch::default();
+    for (key, slot) in overlay {
+        let LeafSlot::Touched {
+            record,
+            write,
+            merged,
+        } = slot
+        else {
+            continue;
+        };
+        stage_seed_membership_registers(
+            &mut staged,
+            &write.filters,
+            write.source,
+            &write.meta,
+            &record.state,
+            now_ms,
+        );
+        if *merged {
+            staged.put::<Behavioral>(key, &record.encode());
+        }
+    }
+    staged
+}
+
+pub(crate) fn admit_reconcile(
     partition_id: u16,
     merge: &MergeWorkerDeps,
     queue: &mut ReconcileQueue,
     tile: &ReconcileTile,
-    offset: i64,
+    offset: SeedOffset,
 ) {
     if !merge.reconcile.enabled {
         counter!(SEED_TILES_SKIPPED_TOTAL, "reason" => "reconcile_disabled").increment(1);
@@ -767,12 +938,13 @@ fn admit_reconcile(
     }
 
     let kind = tile.scope().kind();
-    let deferred = match queue.supersede_if_newer(tile.team_id(), tile.cohort_id(), kind, offset) {
-        SupersedeOutcome::NoQueuedJob => merge.seed_tracker.defer(partition_id as i32, offset),
+    let deferred = match queue.supersede_if_newer(tile.team_id(), tile.cohort_id(), kind, offset.0)
+    {
+        SupersedeOutcome::NoQueuedJob => merge.seed_tracker.defer(partition_id as i32, offset.0),
         SupersedeOutcome::Replaced(superseded) => {
             let (replacement, outcome) = merge
                 .seed_tracker
-                .replace_deferred(superseded, offset)
+                .replace_deferred(superseded, offset.0)
                 .expect("a queued reconcile must retain its deferred offset in the current tenure");
             match outcome {
                 MarkOutcome::WithinDispatch => {}
@@ -794,7 +966,7 @@ fn admit_reconcile(
                 team_id = tile.team_id().0,
                 cohort_id = tile.cohort_id().0,
                 run_id = %tile.run_id().0,
-                offset,
+                offset = offset.0,
                 "replayed reconcile seed retained the newer or equal queued job",
             );
             mark_processed(&merge.seed_tracker, partition_id, offset);
@@ -804,120 +976,6 @@ fn admit_reconcile(
 
     queue.enqueue(tile.clone(), deferred);
     counter!(RECONCILE_JOBS_ENQUEUED_TOTAL, "kind" => kind.as_str()).increment(1);
-}
-
-/// What one tile staged across its referencing leaves.
-#[derive(Default)]
-struct TileApplication {
-    staged: StagedBatch,
-    transitions: Vec<LeafTransition>,
-    /// Merged *and* Unchanged leaves both recompose Stage 2, so a crash between the two commits
-    /// self-heals on replay.
-    stage2_leaves: Vec<(LeafStateKey, Uuid)>,
-    schedules: Vec<(BehavioralKey, i64)>,
-}
-
-/// Fold the tile into every referencing leaf.
-#[allow(clippy::too_many_arguments)]
-fn apply_tile_to_leaves(
-    filters: &TeamFilters,
-    prefix: &PersonPrefix,
-    lsks: &[LeafStateKey],
-    values: Vec<Option<Vec<u8>>>,
-    tile: &SeedTile,
-    person: Uuid,
-    now_day: DayIdx,
-    now_ms: i64,
-) -> TileApplication {
-    let count = tile.count_nonzero();
-    let mut application = TileApplication::default();
-    for (&lsk, bytes) in lsks.iter().zip(values) {
-        let Some(meta) = filters.by_lsk.get(&lsk) else {
-            counter!(SEED_TILES_DROPPED_TOTAL, "reason" => SeedDropReason::MetaIncomplete.as_str())
-                .increment(1);
-            continue;
-        };
-        let prev = match bytes {
-            None => None,
-            Some(bytes) => match StatefulRecord::decode(&bytes) {
-                Ok(record) => Some(record),
-                Err(_) => {
-                    counter!(STAGE1_STATE_DECODE_ERROR).increment(1);
-                    counter!(SEED_TILES_DROPPED_TOTAL, "reason" => "corrupt_state").increment(1);
-                    continue;
-                }
-            },
-        };
-        let identity = LeafIdentity {
-            team_id: tile.team_id(),
-            lsk,
-            person_id: person,
-            condition_hash: tile.condition_hash().as_bytes(),
-        };
-        match merge_tile_into_leaf(
-            meta,
-            filters.timezone,
-            identity,
-            tile.day_idx(),
-            count,
-            prev,
-            now_day,
-            now_ms,
-        ) {
-            LeafMergeOutcome::Merged {
-                record,
-                transition,
-                deadline_ms,
-            } => {
-                counter!(SEED_TILES_APPLIED_TOTAL, "variant" => record.state.variant().as_str())
-                    .increment(1);
-                let key = prefix.behavioral_key(lsk);
-                stage_seed_membership_registers(
-                    &mut application.staged,
-                    filters,
-                    MembershipRegisterSource {
-                        partition_id: prefix.partition_id,
-                        team_id: identity.team_id,
-                        person_id: identity.person_id,
-                        leaf_state_key: identity.lsk,
-                    },
-                    meta,
-                    &record.state,
-                    now_ms,
-                );
-                application.staged.put::<Behavioral>(&key, &record.encode());
-                application.stage2_leaves.push((lsk, person));
-                if let Some(transition) = transition {
-                    application.transitions.push(transition);
-                }
-                if deadline_ms != i64::MAX {
-                    application.schedules.push((key, deadline_ms));
-                }
-            }
-            LeafMergeOutcome::Unchanged { record } => {
-                counter!(SEED_TILES_UNCHANGED_TOTAL, "variant" => meta.variant.as_str())
-                    .increment(1);
-                stage_seed_membership_registers(
-                    &mut application.staged,
-                    filters,
-                    MembershipRegisterSource {
-                        partition_id: prefix.partition_id,
-                        team_id: identity.team_id,
-                        person_id: identity.person_id,
-                        leaf_state_key: identity.lsk,
-                    },
-                    meta,
-                    &record.state,
-                    now_ms,
-                );
-                application.stage2_leaves.push((lsk, person));
-            }
-            LeafMergeOutcome::Dropped(reason) => {
-                counter!(SEED_TILES_DROPPED_TOTAL, "reason" => reason.as_str()).increment(1);
-            }
-        }
-    }
-    application
 }
 
 fn stage_seed_membership_registers(
@@ -943,14 +1001,14 @@ pub(crate) fn tag_seed(changes: &mut [CohortMembershipChange], run_id: RunId) {
 }
 
 /// Advance the seed tracker past `offset`. A mark beyond the dispatch ceiling is capped and counted.
-pub(crate) fn mark_processed(tracker: &OffsetTracker, partition_id: u16, offset: i64) {
+pub(crate) fn mark_processed(tracker: &OffsetTracker, partition_id: u16, offset: SeedOffset) {
     if let MarkOutcome::CappedAheadOfDispatch =
-        tracker.mark_processed(partition_id as i32, offset + 1)
+        tracker.mark_processed(partition_id as i32, offset.0 + 1)
     {
         counter!(COHORT_STREAM_OFFSET_AHEAD_OF_DISPATCH).increment(1);
         warn!(
             partition_id,
-            next_offset = offset + 1,
+            next_offset = offset.0 + 1,
             "seed offset mark exceeded the dispatch ceiling and was capped (F1 invariant violation)",
         );
     }
@@ -958,8 +1016,8 @@ pub(crate) fn mark_processed(tracker: &OffsetTracker, partition_id: u16, offset:
 
 /// Pin the seed commit floor at the failed offset so Kafka redelivers it; emit
 /// [`SEED_HELD_OFFSET_GAUGE`] so the stall is visible.
-pub(crate) fn hold(tracker: &OffsetTracker, partition_id: u16, offset: i64) {
-    let floor = tracker.hold(partition_id as i32, offset);
+pub(crate) fn hold(tracker: &OffsetTracker, partition_id: u16, offset: SeedOffset) {
+    let floor = tracker.hold(partition_id as i32, offset.0);
     gauge!(SEED_HELD_OFFSET_GAUGE, "partition" => partition_id.to_string()).set(floor as f64);
 }
 
@@ -980,19 +1038,22 @@ mod tests {
         SeedTile,
     };
 
-    use crate::consumers::seeds::SeedSkipReason;
-    use crate::filters::{CohortId, FilterCatalog, TeamFiltersBuilder};
+    use crate::consumers::seeds::{SeedSkipReason, SeedWork};
+    use crate::filters::manager::CatalogHandle;
+    use crate::filters::{CohortId, TeamFiltersBuilder};
     use crate::merge::transfer::Tombstone;
     use crate::partitions::partitioner::{partition_of, COHORT_PARTITION_COUNT};
     use crate::producer::{
-        CaptureReconcileMarkerSink, CaptureSeedTileSink, CaptureSink, MembershipStatus,
+        CaptureReconcileMarkerSink, CaptureSeedTileSink, CaptureSink, MembershipSink,
+        MembershipStatus,
     };
     use crate::stage1::state::AppliedOffsets;
     use crate::stage2::state::Stage2State;
     use crate::store::{
-        CohortStore, OffloadConfig, OffloadMode, Stage2Key, StoreConfig, TombstoneKey,
+        CohortStore, OffloadConfig, OffloadMode, Stage2Key, StoreConfig, StoreHandle, TombstoneKey,
     };
     use crate::workers::event_path::{process_event_gated, EventNameGating};
+    use crate::workers::seed_batch::{group_seeds, handle_seed_groups};
 
     use super::*;
 
@@ -1802,6 +1863,7 @@ mod tests {
         deps: MergeWorkerDeps,
         queue: EvictionQueue<BehavioralKey>,
         reconcile_queue: ReconcileQueue,
+        clock: LastUpdatedClock,
     }
 
     impl Shell {
@@ -1875,6 +1937,7 @@ mod tests {
                     ..crate::workers::ReconcileDeps::default()
                 },
                 person_seed: crate::workers::PersonSeedDeps::default(),
+                seed_apply_batch_max: crate::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
             };
             let reconcile_queue =
                 ReconcileQueue::new(0, deps.reconcile.backlog.clone(), handle.clone());
@@ -1890,25 +1953,46 @@ mod tests {
                 deps,
                 queue: EvictionQueue::new(),
                 reconcile_queue,
+                clock: LastUpdatedClock::default(),
             }
         }
 
+        /// One seed through the batch pipeline, so every case below also pins that a run of one
+        /// behaves exactly as the per-seed apply did.
         async fn run(&mut self, partition_id: u16, work: SeedWork, offset: i64) {
+            self.run_batch(partition_id, vec![(work, offset)]).await;
+        }
+
+        /// A whole channel batch of seeds, dispatched the way the worker dispatches them.
+        async fn run_batch(&mut self, partition_id: u16, seeds: Vec<(SeedWork, i64)>) {
+            let highest = seeds
+                .iter()
+                .map(|(_, offset)| *offset)
+                .max()
+                .expect("a dispatched batch is non-empty");
             self.deps
                 .seed_tracker
-                .mark_dispatched(partition_id as i32, offset + 1);
+                .mark_dispatched(partition_id as i32, highest + 1);
             let sink: Arc<dyn MembershipSink> = Arc::new(self.sink.clone());
-            handle_seed(
-                partition_id,
-                &self.handle,
-                &self.catalog,
-                &sink,
-                &self.deps,
+            let admitted = seeds
+                .into_iter()
+                .map(|(work, offset)| Admitted {
+                    work,
+                    offset: SeedOffset(offset),
+                })
+                .collect();
+            handle_seed_groups(
+                SeedApplyDeps {
+                    partition_id,
+                    handle: &self.handle,
+                    catalog: &self.catalog,
+                    sink: &sink,
+                    merge: &self.deps,
+                },
                 &mut self.queue,
                 &mut self.reconcile_queue,
-                "2026-06-15 12:00:00.000000",
-                &work,
-                offset,
+                &mut self.clock,
+                group_seeds(admitted, self.deps.seed_apply_batch_max),
             )
             .await;
         }
@@ -2493,5 +2577,396 @@ mod tests {
         );
         assert_eq!(changes[1].status, MembershipStatus::Entered);
         assert_eq!(changes[1].origin, Some(ChangeOrigin::Seed));
+    }
+
+    // ---- batched apply: properties only a run of several seeds can break ----
+
+    /// A re-run chunk is mostly `Unchanged`, so re-writing byte-identical `cf_behavioral` rows would
+    /// spend the store's write budget on nothing. The register still has to be staged: it is what
+    /// repairs a row a failed produce left behind.
+    #[test]
+    fn an_unchanged_leaf_stages_its_register_but_not_its_state_row() {
+        let filters = Arc::new(build_filters(
+            vec![(1, wrap(vec![single_leaf_json(7)]))],
+            UTC,
+        ));
+        let lsk = filters.by_condition_to_lsk[&HASH][0];
+        let meta = *filters.by_lsk.get(&lsk).unwrap();
+        let person = Uuid::from_u128(0x5EED);
+        let key = PersonPrefix::new(0, TEAM.0 as u64, person).behavioral_key(lsk);
+        let (record, _, _) = merged(merge(&meta, now_day(), 1, None));
+        let write = || LeafWrite {
+            filters: filters.clone(),
+            meta,
+            source: MembershipRegisterSource {
+                partition_id: 0,
+                team_id: TEAM,
+                person_id: person,
+                leaf_state_key: lsk,
+            },
+        };
+
+        let staged = |merged: bool| {
+            stage_tile_writes(
+                &BTreeMap::from([(
+                    key,
+                    LeafSlot::Touched {
+                        record: record.clone(),
+                        write: write(),
+                        merged,
+                    },
+                )]),
+                NOW_MS,
+            )
+            .len()
+        };
+
+        assert_eq!(
+            staged(true),
+            2,
+            "a merged leaf writes its row and its register"
+        );
+        assert_eq!(
+            staged(false),
+            1,
+            "an unchanged leaf writes the register only"
+        );
+    }
+
+    /// Every leaf state the batch could have written for `person`, in catalog order.
+    fn leaf_states(shell: &Shell, partition_id: u16, person: Uuid) -> Vec<Option<Vec<u8>>> {
+        let snapshot = shell.catalog.load();
+        let filters = snapshot.team(TEAM).expect("the test catalog holds TEAM");
+        let prefix = PersonPrefix::new(partition_id, TEAM.0 as u64, person);
+        filters
+            .by_condition_to_lsk
+            .get(&HASH)
+            .map_or_else(Vec::new, |lsks| {
+                lsks.iter()
+                    .map(|&lsk| {
+                        shell
+                            .store
+                            .get_behavioral(&prefix.behavioral_key(lsk))
+                            .unwrap()
+                    })
+                    .collect()
+            })
+    }
+
+    /// Without read-your-writes each tile would fold onto the bytes the read pass saw, so the last
+    /// tile's record would overwrite the earlier days and the count would never reach the threshold.
+    #[tokio::test]
+    async fn two_days_in_one_batch_reach_the_same_state_as_two_batches() {
+        let person = Uuid::from_u128(0x5EED);
+        let partition_id = partition_of(TEAM, &person, COHORT_PARTITION_COUNT) as u16;
+        let cohorts = vec![(1, wrap(vec![multiple_leaf_json(7, "gte", 2)]))];
+        let (yesterday, today) = (today() - 1, today());
+
+        let mut batched = Shell::new(cohorts.clone());
+        batched
+            .run_batch(
+                partition_id,
+                vec![
+                    (SeedWork::Tile(tile_for(person, yesterday, 1)), 0),
+                    (SeedWork::Tile(tile_for(person, today, 1)), 1),
+                ],
+            )
+            .await;
+
+        let mut separately = Shell::new(cohorts);
+        separately
+            .run(
+                partition_id,
+                SeedWork::Tile(tile_for(person, yesterday, 1)),
+                0,
+            )
+            .await;
+        separately
+            .run(partition_id, SeedWork::Tile(tile_for(person, today, 1)), 1)
+            .await;
+
+        assert_eq!(
+            leaf_states(&batched, partition_id, person),
+            leaf_states(&separately, partition_id, person),
+            "one batch must settle on the same stage-1 state as two",
+        );
+        let changes = batched.sink.changes();
+        assert_eq!(
+            changes.len(),
+            1,
+            "the second day crosses the gte-2 threshold"
+        );
+        assert_eq!(changes[0].status, MembershipStatus::Entered);
+        assert_eq!(
+            changes.len(),
+            separately.sink.changes().len(),
+            "batching must not add or drop a transition",
+        );
+        assert_eq!(
+            batched.sink.produce_calls(),
+            1,
+            "the whole batch rides one membership produce",
+        );
+        assert_eq!(batched.committable(partition_id), Some(2));
+
+        // Redelivery of the whole run: max-merge makes every tile `Unchanged`, so the run converges
+        // instead of re-emitting.
+        let settled = leaf_states(&batched, partition_id, person);
+        batched
+            .run_batch(
+                partition_id,
+                vec![
+                    (SeedWork::Tile(tile_for(person, yesterday, 1)), 0),
+                    (SeedWork::Tile(tile_for(person, today, 1)), 1),
+                ],
+            )
+            .await;
+        assert_eq!(batched.sink.changes().len(), 1, "no duplicate flip");
+        assert_eq!(
+            leaf_states(&batched, partition_id, person),
+            settled,
+            "the replayed run is a no-op on stage 1",
+        );
+    }
+
+    /// The batch ceiling is the round-trip budget: a run longer than it has to split, or one slow
+    /// produce would hold an unbounded number of seeds.
+    #[tokio::test]
+    async fn a_run_longer_than_the_cap_pays_one_produce_per_capped_group() {
+        const TILES: usize = 300;
+        let mut shell = Shell::new(vec![(1, wrap(vec![single_leaf_json(7)]))]);
+        // Every person on partition 0, so one worker owns the whole run.
+        shell.deps.partition_count = 1;
+        let seeds: Vec<_> = (0..TILES)
+            .map(|i| {
+                (
+                    SeedWork::Tile(tile_for(
+                        Uuid::from_u128(0x5EED_0000 + i as u128),
+                        today(),
+                        1,
+                    )),
+                    i as i64,
+                )
+            })
+            .collect();
+
+        shell.run_batch(0, seeds).await;
+
+        assert_eq!(
+            shell.sink.changes().len(),
+            TILES,
+            "every person entered the single-leaf cohort",
+        );
+        assert_eq!(
+            shell.sink.produce_calls(),
+            TILES.div_ceil(shell.deps.seed_apply_batch_max.get()),
+            "one membership produce per capped group, not one per tile",
+        );
+        assert_eq!(shell.committable(0), Some(TILES as i64));
+    }
+
+    /// A batch is all-or-nothing on its offsets: the floor must sit at the *first* seed, so the
+    /// redelivery replays every tile the failed produce covered.
+    #[tokio::test]
+    async fn a_failed_membership_produce_holds_the_batchs_first_offset() {
+        let person = Uuid::from_u128(0x5EED);
+        let partition_id = partition_of(TEAM, &person, COHORT_PARTITION_COUNT) as u16;
+        // Both leaves share the tile's hash, so the flip is stage-2-derived and re-derivable.
+        let mut shell = Shell::with_sink(
+            vec![(
+                1,
+                wrap(vec![single_leaf_json(7), multiple_leaf_json(7, "gte", 1)]),
+            )],
+            CaptureSink::failing_first(1),
+            CaptureSeedTileSink::new(),
+        );
+        let stage2_key = Stage2Key {
+            partition_id,
+            team_id: TEAM.0 as u64,
+            cohort_id: 1,
+            person_id: person,
+        };
+        let batch = |first: i64| {
+            vec![
+                (SeedWork::Tile(tile_for(person, today() - 1, 1)), first),
+                (SeedWork::Tile(tile_for(person, today(), 1)), first + 1),
+            ]
+        };
+
+        shell.run_batch(partition_id, batch(5)).await;
+
+        assert_eq!(
+            shell.committable(partition_id),
+            None,
+            "the failed produce holds, so nothing in the batch commits",
+        );
+        assert!(
+            shell.store.get_stage2(&stage2_key).unwrap().is_none(),
+            "the stage-2 bit must stay unwritten under the failed produce",
+        );
+
+        shell.run_batch(partition_id, batch(5)).await;
+
+        let changes = shell.sink.changes();
+        assert_eq!(
+            changes.len(),
+            1,
+            "the replay re-derived the composed flip exactly once",
+        );
+        assert_eq!(changes[0].status, MembershipStatus::Entered);
+        assert!(
+            Stage2State::decode(&shell.store.get_stage2(&stage2_key).unwrap().unwrap())
+                .unwrap()
+                .in_cohort,
+        );
+        // The tenure-sticky hold pins the committable at the held first offset.
+        assert_eq!(shell.committable(partition_id), Some(5));
+    }
+
+    #[tokio::test]
+    async fn a_batch_of_rekeys_requires_one_ack_per_tile_before_it_marks() {
+        let (p_old, partition_id, p_new) = cross_partition_pair();
+        let other = (p_new.as_u128() + 1..)
+            .map(Uuid::from_u128)
+            .find(|p| partition_of(TEAM, p, COHORT_PARTITION_COUNT) as u16 == partition_id)
+            .expect("some uuid hashes onto p_old's partition");
+        let mut shell = Shell::new(vec![(1, wrap(vec![single_leaf_json(7)]))]);
+        write_tombstone(&shell.store, partition_id, p_old, p_new);
+        write_tombstone(&shell.store, partition_id, other, p_new);
+
+        shell
+            .run_batch(
+                partition_id,
+                vec![
+                    (SeedWork::Tile(tile_for(p_old, today(), 1)), 7),
+                    (SeedWork::Tile(tile_for(other, today(), 2)), 8),
+                ],
+            )
+            .await;
+
+        assert_eq!(shell.seed_sink.tiles().len(), 2, "both tiles re-keyed");
+        assert!(shell.sink.changes().is_empty(), "neither applied locally");
+        assert_eq!(shell.committable(partition_id), Some(9));
+
+        // A short ack vector must read as a failure, not as `all(is_ok)` over what did come back.
+        let mut short = Shell::new(vec![(1, wrap(vec![single_leaf_json(7)]))]);
+        write_tombstone(&short.store, partition_id, p_old, p_new);
+        write_tombstone(&short.store, partition_id, other, p_new);
+        short.deps.seed_tile_sink = Arc::new(EmptyAckSink);
+        short
+            .run_batch(
+                partition_id,
+                vec![
+                    (SeedWork::Tile(tile_for(p_old, today(), 1)), 7),
+                    (SeedWork::Tile(tile_for(other, today(), 2)), 8),
+                ],
+            )
+            .await;
+        assert_eq!(short.committable(partition_id), None, "held for redelivery");
+    }
+
+    /// Two runs sharing a person in one batch must still recompose that person once: splitting their
+    /// leaves by run would evaluate the cohort twice against the same uncommitted bit and emit the
+    /// composed flip twice.
+    #[tokio::test]
+    async fn two_runs_touching_one_person_emit_the_composed_flip_once() {
+        let person = Uuid::from_u128(0x5EED);
+        let partition_id = partition_of(TEAM, &person, COHORT_PARTITION_COUNT) as u16;
+        let mut shell = Shell::new(vec![(
+            1,
+            wrap(vec![single_leaf_json(7), multiple_leaf_json(7, "gte", 1)]),
+        )]);
+        let other_run = |day: DayIdx| {
+            SeedTile::new(
+                TEAM,
+                person,
+                ConditionHash::parse("0123456789abcdef").unwrap(),
+                count(1),
+                day,
+                SChunkMs(1_700_000_000_000),
+                RunId(Uuid::from_u128(0xC0FFEE)),
+                ClaimEpoch(1),
+            )
+        };
+
+        shell
+            .run_batch(
+                partition_id,
+                vec![
+                    (SeedWork::Tile(tile_for(person, today() - 1, 1)), 0),
+                    (SeedWork::Tile(other_run(today())), 1),
+                ],
+            )
+            .await;
+
+        let composed: Vec<_> = shell
+            .sink
+            .changes()
+            .into_iter()
+            .filter(|change| change.cohort_id == 1)
+            .collect();
+        assert_eq!(composed.len(), 1, "one flip, not one per run");
+        assert_eq!(
+            composed[0].run_id,
+            Some(RunId(Uuid::from_u128(0xC0FFEE))),
+            "the last run to touch the person owns the provenance",
+        );
+    }
+
+    /// A run spans teams whenever two backfills interleave on one partition. Folding a tile against
+    /// the wrong team's catalog would read the wrong leaves and write the wrong registers.
+    #[tokio::test]
+    async fn a_batch_spanning_two_teams_applies_each_against_its_own_catalog() {
+        const OTHER_TEAM: TeamId = TeamId(9);
+        let person = Uuid::from_u128(0x5EED);
+        let partition_id = partition_of(TEAM, &person, COHORT_PARTITION_COUNT) as u16;
+        let mut shell = Shell::new(vec![(1, wrap(vec![single_leaf_json(7)]))]);
+        shell.catalog = Arc::new(CatalogHandle::from_catalog(FilterCatalog::from_teams([
+            (
+                TEAM,
+                build_filters(vec![(1, wrap(vec![single_leaf_json(7)]))], UTC),
+            ),
+            (OTHER_TEAM, {
+                let mut builder = TeamFiltersBuilder::default();
+                builder
+                    .add_cohort(CohortId(2), OTHER_TEAM, &wrap(vec![single_leaf_json(7)]))
+                    .unwrap();
+                builder.freeze(UTC)
+            }),
+        ])));
+        let other_team_tile = SeedTile::new(
+            OTHER_TEAM,
+            person,
+            ConditionHash::parse("0123456789abcdef").unwrap(),
+            count(1),
+            today(),
+            SChunkMs(1_700_000_000_000),
+            RunId(Uuid::from_u128(0xBF)),
+            ClaimEpoch(1),
+        );
+
+        shell
+            .run_batch(
+                partition_id,
+                vec![
+                    (SeedWork::Tile(tile_for(person, today(), 1)), 0),
+                    (SeedWork::Tile(other_team_tile), 1),
+                ],
+            )
+            .await;
+
+        let mut entered: Vec<(i32, i32)> = shell
+            .sink
+            .changes()
+            .iter()
+            .map(|change| (change.team_id, change.cohort_id))
+            .collect();
+        entered.sort_unstable();
+        assert_eq!(
+            entered,
+            vec![(TEAM.0, 1), (OTHER_TEAM.0, 2)],
+            "each team's tile entered its own cohort",
+        );
+        assert_eq!(shell.committable(partition_id), Some(2));
     }
 }

--- a/rust/cohort-stream-processor/src/workers/seed_path.rs
+++ b/rust/cohort-stream-processor/src/workers/seed_path.rs
@@ -1072,7 +1072,7 @@ mod tests {
         CohortStore, OffloadConfig, OffloadMode, Stage2Key, StoreConfig, StoreHandle, TombstoneKey,
     };
     use crate::workers::event_path::{process_event_gated, EventNameGating};
-    use crate::workers::seed_batch::{group_seeds, handle_seed_groups};
+    use crate::workers::seed_batch::{group_seeds, handle_seed_groups, seed_fanout};
 
     use super::*;
 
@@ -1964,7 +1964,7 @@ mod tests {
                     ..crate::workers::ReconcileDeps::default()
                 },
                 person_seed: crate::workers::PersonSeedDeps::default(),
-                seed_apply_batch_max: crate::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
+                seed_batch: crate::workers::SeedBatchLimits::default(),
             };
             let reconcile_queue =
                 ReconcileQueue::new(0, deps.reconcile.backlog.clone(), handle.clone());
@@ -2008,6 +2008,12 @@ mod tests {
                     offset: SeedOffset(offset),
                 })
                 .collect();
+            let groups = {
+                let snapshot = self.catalog.load();
+                group_seeds(admitted, self.deps.seed_batch, |work| {
+                    seed_fanout(&snapshot, work)
+                })
+            };
             handle_seed_groups(
                 SeedApplyDeps {
                     partition_id,
@@ -2019,7 +2025,7 @@ mod tests {
                 &mut self.queue,
                 &mut self.reconcile_queue,
                 &mut self.clock,
-                group_seeds(admitted, self.deps.seed_apply_batch_max),
+                groups,
             )
             .await;
         }
@@ -2895,7 +2901,7 @@ mod tests {
         );
         assert_eq!(
             shell.sink.produce_calls(),
-            TILES.div_ceil(shell.deps.seed_apply_batch_max.get()),
+            TILES.div_ceil(shell.deps.seed_batch.max_seeds.get()),
             "one membership produce per capped group, not one per tile",
         );
         assert_eq!(shell.committable(0), Some(TILES as i64));

--- a/rust/cohort-stream-processor/src/workers/seed_path.rs
+++ b/rust/cohort-stream-processor/src/workers/seed_path.rs
@@ -49,8 +49,8 @@ use crate::workers::merge_path::MergeWorkerDeps;
 use crate::workers::reconcile::{ReconcileQueue, SupersedeOutcome};
 use crate::workers::seed_batch::{
     produce_cascade_output, produce_composed_output, produce_leaf_output, recompose_batch, settle,
-    Admitted, ApplyStage, SeedApplyDeps, SeedHold, SeedKind, SeedOffset, SeedReKeys, SeedRun,
-    StageClock, TouchedPersons,
+    Admitted, ApplyStage, BatchRecompose, SeedApplyDeps, SeedHold, SeedKind, SeedOffset,
+    SeedReKeys, SeedRun, StageClock, TouchedPersons,
 };
 use crate::workers::stage2_path::commit_stage2_writes;
 use crate::workers::worker::{first_cascades, transition_metric_label};
@@ -560,10 +560,13 @@ async fn apply_tiles(
         queue.schedule(key, deadline);
     }
 
-    let mut recomposed = recompose_batch(deps, &snapshot, touched, now_ms, clock).await?;
+    let BatchRecompose {
+        changes: composed,
+        writes: stage2_writes,
+        counts: stage2_counts,
+    } = recompose_batch(deps, &snapshot, touched, now_ms, clock).await?;
     stages.mark(ApplyStage::Recompute);
 
-    let composed = std::mem::take(&mut recomposed.changes);
     cascades.extend(first_cascades(deps.merge, &composed, source_offset));
     produce_composed_output(deps, composed).await?;
     stages.mark(ApplyStage::ProduceComposed);
@@ -571,11 +574,11 @@ async fn apply_tiles(
     produce_cascade_output(deps, cascades).await?;
     stages.mark(ApplyStage::ProduceCascades);
 
-    commit_stage2_writes(deps.handle, &recomposed.writes)
+    commit_stage2_writes(deps.handle, &stage2_writes)
         .await
         .map_err(SeedHold::store(ApplyStage::Stage2Commit))?;
     stages.mark(ApplyStage::Stage2Commit);
-    recomposed.record_metrics();
+    stage2_counts.record();
     Ok(())
 }
 

--- a/rust/cohort-stream-processor/src/workers/seed_path.rs
+++ b/rust/cohort-stream-processor/src/workers/seed_path.rs
@@ -1,9 +1,11 @@
 //! The seed-tile apply path: a pure, clock-free core ([`merge_tile_into_leaf`]) that mirrors the
 //! live fold minus dedup (slide-before-evaluate, max-merge of the tile's absolute count,
 //! structural-equality `Unchanged` — the whole of tile idempotency), and a batched imperative shell
-//! ([`apply_tile_batch`]) ordered stage-1 commit → stage-2 recompose → produce → stage-2 commit →
-//! mark. Committing the stage-2 bits after the produces ack makes a failed produce re-derivable on
-//! replay; store/produce failures hold the batch's first seed offset.
+//! ([`apply_tile_batch`]) ordered produce single-leaf output → stage-1 commit → stage-2 recompose →
+//! produce composed output → produce cascades → stage-2 commit → mark. Every produce acks before
+//! the state it reports commits, so a failed produce replays with that state either untouched
+//! (single-leaf) or re-derivable (composed); store/produce failures hold the batch's first seed
+//! offset.
 
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::num::NonZeroU32;
@@ -46,11 +48,12 @@ use crate::sweep::EvictionQueue;
 use crate::workers::merge_path::MergeWorkerDeps;
 use crate::workers::reconcile::{ReconcileQueue, SupersedeOutcome};
 use crate::workers::seed_batch::{
-    produce_seed_output, recompose_batch, settle, Admitted, ApplyStage, SeedApplyDeps, SeedHold,
-    SeedKind, SeedOffset, SeedReKeys, SeedRun, StageClock, TouchedPersons,
+    produce_cascade_output, produce_composed_output, produce_leaf_output, recompose_batch, settle,
+    Admitted, ApplyStage, SeedApplyDeps, SeedHold, SeedKind, SeedOffset, SeedReKeys, SeedRun,
+    StageClock, TouchedPersons,
 };
 use crate::workers::stage2_path::commit_stage2_writes;
-use crate::workers::worker::transition_metric_label;
+use crate::workers::worker::{first_cascades, transition_metric_label};
 
 /// A seed kind that can be re-keyed onto a merge survivor.
 pub(crate) trait RekeyableSeed: Sized {
@@ -498,10 +501,12 @@ fn finish(
 
 /// Apply one run of day-tiles as a unit, then mark its whole span or hold its first offset.
 ///
-/// The run pays one batched tombstone resolve, one batched state read, one stage-1 commit, one
-/// stage-2 recompose over the deduplicated leaves, one concurrent produce and one stage-2 commit —
-/// whatever its length. Replay is unchanged: stage 1 is idempotent through max-merge, and the
-/// stage-2 bits still land only after the produces ack, so a held run re-derives its composed flips.
+/// The run pays one batched tombstone resolve, one batched state read, one produce of its
+/// single-leaf output, one stage-1 commit, one stage-2 recompose over the deduplicated leaves, one
+/// produce of its composed output, one produce of its cascades and one stage-2 commit — whatever
+/// its length. A held run replays cleanly: a leaf-leg failure committed nothing, and stage 1 is
+/// idempotent through max-merge while the stage-2 bits land only after every produce acks, so a
+/// later failure re-derives the composed flips.
 pub(crate) async fn apply_tile_batch(
     deps: &SeedApplyDeps<'_>,
     queue: &mut EvictionQueue<BehavioralKey>,
@@ -534,30 +539,43 @@ async fn apply_tiles(
     // One instant for the whole run: `last_evaluated_at_ms` is a freshness stamp, and every tile in
     // the run slides against the same "now".
     let now_ms = Utc::now().timestamp_millis();
-    let folded = fold_tiles(&locals, &mut overlay, clock, now_ms);
+    let FoldedTiles {
+        changes: leaf_changes,
+        touched,
+        schedules,
+    } = fold_tiles(&locals, &mut overlay, clock, now_ms);
     stages.mark(ApplyStage::Fold);
 
-    // Order: stage-1 commit → stage-2 recompose → produce → stage-2 commit → schedule → mark.
+    // Cascades ride the last leg, so every membership change is acked before any referrer hears
+    // of it; built here from a borrow, before the changes move into their produce.
+    let source_offset = run.span().last.0;
+    let mut cascades = first_cascades(deps.merge, &leaf_changes, source_offset);
+    produce_leaf_output(deps, leaf_changes, SeedReKeys::Tiles(re_keys)).await?;
+    stages.mark(ApplyStage::ProduceLeaf);
+
     commit_tile_stage1(deps, &overlay, now_ms).await?;
     stages.mark(ApplyStage::Stage1Commit);
+    // The rows are durable from here, so their deadlines are owed whatever the later legs do.
+    for (key, deadline) in schedules {
+        queue.schedule(key, deadline);
+    }
 
-    let recomposed = recompose_batch(deps, &snapshot, folded.touched, now_ms, clock).await?;
+    let mut recomposed = recompose_batch(deps, &snapshot, touched, now_ms, clock).await?;
     stages.mark(ApplyStage::Recompute);
 
-    let mut changes = folded.changes;
-    changes.extend(recomposed.changes.iter().cloned());
-    produce_seed_output(deps, changes, SeedReKeys::Tiles(re_keys), run.span().last).await?;
-    stages.mark(ApplyStage::Produce);
+    let composed = std::mem::take(&mut recomposed.changes);
+    cascades.extend(first_cascades(deps.merge, &composed, source_offset));
+    produce_composed_output(deps, composed).await?;
+    stages.mark(ApplyStage::ProduceComposed);
+
+    produce_cascade_output(deps, cascades).await?;
+    stages.mark(ApplyStage::ProduceCascades);
 
     commit_stage2_writes(deps.handle, &recomposed.writes)
         .await
         .map_err(SeedHold::store(ApplyStage::Stage2Commit))?;
     stages.mark(ApplyStage::Stage2Commit);
     recomposed.record_metrics();
-
-    for (key, deadline) in folded.schedules {
-        queue.schedule(key, deadline);
-    }
     Ok(())
 }
 
@@ -1026,6 +1044,7 @@ pub(crate) fn hold(tracker: &OffsetTracker, partition_id: u16, offset: SeedOffse
 #[allow(clippy::disallowed_methods)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::num::NonZeroUsize;
 
     use chrono_tz::America::New_York;
     use chrono_tz::UTC;
@@ -1889,9 +1908,17 @@ mod tests {
             cohorts: Vec<(i32, Value)>,
             cascade_sink: crate::producer::CaptureCascadeSink,
         ) -> Self {
+            Self::with_cascade_and_sink(cohorts, CaptureSink::new(), cascade_sink)
+        }
+
+        fn with_cascade_and_sink(
+            cohorts: Vec<(i32, Value)>,
+            sink: CaptureSink,
+            cascade_sink: crate::producer::CaptureCascadeSink,
+        ) -> Self {
             Self::build(
                 cohorts,
-                CaptureSink::new(),
+                sink,
                 CaptureSeedTileSink::new(),
                 cascade_sink,
                 crate::workers::CascadeConfig {
@@ -2400,6 +2427,115 @@ mod tests {
             )
             .await;
         assert_eq!(shell.committable(partition_id), None, "held for redelivery");
+        assert!(
+            leaf_states(&shell, partition_id, person)
+                .iter()
+                .all(Option::is_none),
+            "the single-leaf output is produced before stage 1 commits, so a failure leaves no row",
+        );
+    }
+
+    /// A broker acks per record, so a run can come back half acked. Committing stage 1 under that
+    /// would make the replay fold to `Unchanged` and never re-emit the records that failed: a
+    /// single-leaf membership lost for good. Producing before the commit means the replay re-folds
+    /// every tile and re-emits every change.
+    #[tokio::test]
+    async fn a_partially_acked_single_leaf_produce_commits_nothing_and_the_replay_re_emits_every_change(
+    ) {
+        let mut shell = Shell::with_sink(
+            vec![(1, wrap(vec![single_leaf_json(7)]))],
+            CaptureSink::partially_failing_first(NonZeroUsize::new(2).unwrap()),
+            CaptureSeedTileSink::new(),
+        );
+        // Every person on partition 0, so one worker owns the whole run.
+        shell.deps.partition_count = 1;
+        let persons: Vec<Uuid> = (0..3u128)
+            .map(|i| Uuid::from_u128(0x5EED_0000 + i))
+            .collect();
+        // Offsets start above zero: the tracker reads a zero floor as "never processed".
+        let batch = || {
+            persons
+                .iter()
+                .zip(5i64..)
+                .map(|(&person, offset)| (SeedWork::Tile(tile_for(person, today(), 1)), offset))
+                .collect::<Vec<_>>()
+        };
+        let register_key = |person: Uuid| Stage2Key {
+            partition_id: 0,
+            team_id: TEAM.0 as u64,
+            cohort_id: 1,
+            person_id: person,
+        };
+
+        shell.run_batch(0, batch()).await;
+
+        assert_eq!(shell.committable(0), None, "held for redelivery");
+        assert_eq!(
+            shell.sink.changes().len(),
+            2,
+            "the acked records are already downstream; the failed one is what must not be lost",
+        );
+        for &person in &persons {
+            assert!(
+                leaf_states(&shell, 0, person).iter().all(Option::is_none),
+                "no leaf row for {person}: the run committed nothing",
+            );
+            assert!(
+                shell
+                    .store
+                    .get_stage2(&register_key(person))
+                    .unwrap()
+                    .is_none(),
+                "no register for {person}: the run committed nothing",
+            );
+        }
+        assert!(
+            shell.queue.is_empty(),
+            "no eviction is owed for a row that was never written",
+        );
+
+        shell.run_batch(0, batch()).await;
+
+        let changes = shell.sink.changes();
+        for &person in &persons {
+            assert!(
+                changes.iter().any(|change| {
+                    change.person_id == person.to_string()
+                        && change.status == MembershipStatus::Entered
+                }),
+                "the replay re-folded and re-emitted {person}'s entry",
+            );
+        }
+        // The tenure-sticky hold pins the committable at the held first offset.
+        assert_eq!(shell.committable(0), Some(5));
+    }
+
+    /// A cascade tells a referrer about a flip the membership topic has not confirmed. Under a
+    /// joined produce the cascade leg is submitted regardless of how the membership leg fares.
+    #[tokio::test]
+    async fn a_failed_membership_produce_never_submits_the_cascade_leg() {
+        let person = Uuid::from_u128(0x5EED);
+        let partition_id = partition_of(TEAM, &person, COHORT_PARTITION_COUNT) as u16;
+        let mut shell = Shell::with_cascade_and_sink(
+            vec![(1, wrap(vec![single_leaf_json(7)]))],
+            CaptureSink::failing_first(1),
+            crate::producer::CaptureCascadeSink::new(),
+        );
+
+        shell
+            .run(
+                partition_id,
+                SeedWork::Tile(tile_for(person, today(), 1)),
+                3,
+            )
+            .await;
+
+        assert_eq!(shell.committable(partition_id), None, "held for redelivery");
+        assert_eq!(
+            shell.cascade_sink.produce_calls(),
+            0,
+            "the cascade leg runs only after the membership legs ack",
+        );
     }
 
     /// A seeded flip that never cascades leaves cohort-of-cohort referrers permanently stale.

--- a/rust/cohort-stream-processor/src/workers/stage2_path.rs
+++ b/rust/cohort-stream-processor/src/workers/stage2_path.rs
@@ -26,6 +26,7 @@ use crate::stage2::CohortEligibility;
 use crate::store::{
     BehavioralKey, PersonRecordKey, ReadLane, Stage2Key, StagedBatch, StoreError, StoreHandle,
 };
+use crate::workers::worker::count_by_status;
 
 /// `affected_leaves` is the touched `(leaf, person)` set; `lane` is the read lane every recompute
 /// read runs on (`Maintenance` on the seed path, so backfill never contends with live reads).
@@ -59,16 +60,56 @@ pub async fn compose_stage2(
 pub(crate) struct Stage2Recompute {
     pub changes: Vec<CohortMembershipChange>,
     pub writes: Vec<(Stage2Key, Stage2State)>,
-    evaluated: u64,
+    /// Taken as the changes were minted, so they can move into their produce while the counts
+    /// wait for the commit.
+    pub counts: Stage2Counts,
 }
 
 impl Stage2Recompute {
     /// Call only once the writes committed, so a failed commit's redelivery cannot double-count.
     pub(crate) fn record_metrics(&self) {
-        counter!(STAGE2_COHORTS_EVALUATED).increment(self.evaluated);
-        for change in &self.changes {
-            counter!(STAGE2_TRANSITIONS, "kind" => change.status.as_str()).increment(1);
+        self.counts.record();
+    }
+}
+
+/// What a recompute counted: cohorts evaluated and flips by direction. A compact stand-in for the
+/// changes themselves, so a caller can give those up and still count them later.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct Stage2Counts {
+    evaluated: u64,
+    entered: u64,
+    left: u64,
+}
+
+impl Stage2Counts {
+    fn of(evaluated: u64, changes: &[CohortMembershipChange]) -> Self {
+        let (entered, left) = count_by_status(changes);
+        Self {
+            evaluated,
+            entered,
+            left,
         }
+    }
+
+    /// Call only once the writes committed, so a failed commit's redelivery cannot double-count.
+    pub(crate) fn record(self) {
+        counter!(STAGE2_COHORTS_EVALUATED).increment(self.evaluated);
+        for (status, count) in [
+            (MembershipStatus::Entered, self.entered),
+            (MembershipStatus::Left, self.left),
+        ] {
+            if count > 0 {
+                counter!(STAGE2_TRANSITIONS, "kind" => status.as_str()).increment(count);
+            }
+        }
+    }
+}
+
+impl std::ops::AddAssign for Stage2Counts {
+    fn add_assign(&mut self, other: Self) {
+        self.evaluated += other.evaluated;
+        self.entered += other.entered;
+        self.left += other.left;
     }
 }
 
@@ -126,10 +167,11 @@ pub(crate) async fn recompute_stage2(
         }
     }
 
+    let counts = Stage2Counts::of(evaluated, &changes);
     Ok(Stage2Recompute {
         changes,
         writes,
-        evaluated,
+        counts,
     })
 }
 

--- a/rust/cohort-stream-processor/src/workers/worker.rs
+++ b/rust/cohort-stream-processor/src/workers/worker.rs
@@ -317,12 +317,16 @@ async fn run_worker(
                         work: *work,
                         offset: SeedOffset(offset),
                     }];
-                    // `Peekable` has no put-back, so the predicate and the pattern below it have to
-                    // name the same variant. They are one line apart deliberately; a drift would
-                    // end the run early and leave that seed unmarked, so Kafka would replay it.
-                    while let Some(ShuffleMessage::Seed { work, offset, .. }) =
+                    // `Peekable` has no put-back, so a message the predicate admits is consumed
+                    // for good. The pattern below names the same variant; a drift between the two
+                    // would silently discard a non-seed message, hence the panic rather than an
+                    // early end of the run.
+                    while let Some(message) =
                         messages.next_if(|message| matches!(message, ShuffleMessage::Seed { .. }))
                     {
+                        let ShuffleMessage::Seed { work, offset, .. } = message else {
+                            unreachable!("the seed-run predicate admitted a non-seed message");
+                        };
                         seeds.push(Admitted {
                             work: *work,
                             offset: SeedOffset(offset),

--- a/rust/cohort-stream-processor/src/workers/worker.rs
+++ b/rust/cohort-stream-processor/src/workers/worker.rs
@@ -49,7 +49,7 @@ use crate::workers::merge_gc::{handle_merge_gc, MergeGcCursor};
 use crate::workers::merge_path::{handle_apply, handle_merge, handle_redrive, MergeWorkerDeps};
 use crate::workers::reconcile::{handle_reconcile_drain, ReconcileQueue};
 use crate::workers::seed_batch::{
-    group_seeds, handle_seed_groups, Admitted, SeedApplyDeps, SeedOffset,
+    group_seeds, handle_seed_groups, seed_fanout, Admitted, SeedApplyDeps, SeedOffset,
 };
 use crate::workers::stage2_gc::{handle_stage2_orphan_gc, Stage2GcCursor};
 use crate::workers::stage2_path::compose_stage2;
@@ -352,6 +352,12 @@ async fn run_worker(
                     {
                         break;
                     }
+                    // Weighed against one snapshot, dropped before the await: the apply loads
+                    // its own.
+                    let groups = {
+                        let snapshot = catalog.load();
+                        group_seeds(seeds, merge.seed_batch, |work| seed_fanout(&snapshot, work))
+                    };
                     handle_seed_groups(
                         SeedApplyDeps {
                             partition_id,
@@ -363,7 +369,7 @@ async fn run_worker(
                         &mut queue,
                         &mut reconcile_queue,
                         &mut last_updated_clock,
-                        group_seeds(seeds, merge.seed_apply_batch_max),
+                        groups,
                     )
                     .await;
                 }
@@ -1247,7 +1253,7 @@ mod tombstone_redirect_tests {
             register_transfer_enabled: false,
             reconcile: crate::workers::ReconcileDeps::default(),
             person_seed: crate::workers::PersonSeedDeps::default(),
-            seed_apply_batch_max: crate::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
+            seed_batch: crate::workers::SeedBatchLimits::default(),
         })
     }
 
@@ -1370,7 +1376,7 @@ mod tombstone_redirect_tests {
             register_transfer_enabled: false,
             reconcile: crate::workers::ReconcileDeps::default(),
             person_seed: crate::workers::PersonSeedDeps::default(),
-            seed_apply_batch_max: crate::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
+            seed_batch: crate::workers::SeedBatchLimits::default(),
         })
     }
 
@@ -1398,7 +1404,7 @@ mod tombstone_redirect_tests {
             register_transfer_enabled: false,
             reconcile: crate::workers::ReconcileDeps::default(),
             person_seed: crate::workers::PersonSeedDeps::default(),
-            seed_apply_batch_max: crate::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
+            seed_batch: crate::workers::SeedBatchLimits::default(),
         })
     }
 

--- a/rust/cohort-stream-processor/src/workers/worker.rs
+++ b/rust/cohort-stream-processor/src/workers/worker.rs
@@ -48,7 +48,9 @@ use crate::workers::event_path::{
 use crate::workers::merge_gc::{handle_merge_gc, MergeGcCursor};
 use crate::workers::merge_path::{handle_apply, handle_merge, handle_redrive, MergeWorkerDeps};
 use crate::workers::reconcile::{handle_reconcile_drain, ReconcileQueue};
-use crate::workers::seed_path::handle_seed;
+use crate::workers::seed_batch::{
+    group_seeds, handle_seed_groups, Admitted, SeedApplyDeps, SeedOffset,
+};
 use crate::workers::stage2_gc::{handle_stage2_orphan_gc, Stage2GcCursor};
 use crate::workers::stage2_path::compose_stage2;
 use crate::workers::sweep_callback::{sweep_evict, EvictionAction, SweepDropReason};
@@ -182,7 +184,8 @@ async fn run_worker(
         // Set when a pre-arm flush fails: holds the whole batch's offset so Kafka replays it.
         let mut held = false;
 
-        for message in batch {
+        let mut messages = batch.into_iter().peekable();
+        while let Some(message) = messages.next() {
             let last_updated = last_updated_clock.next();
             match message {
                 ShuffleMessage::Event {
@@ -308,13 +311,37 @@ async fn run_worker(
                     offset,
                     broker_ts_ms: _,
                 } => {
-                    // Worker receipt is the first point that both proves this exact seed landed and
-                    // orders its ceiling before even a zero-work handler can mark it processed.
-                    // The dispatcher also records the delivered batch maximum, but that post-send
-                    // accounting can race a fast worker on a multithreaded runtime.
+                    // Seeds arrive as their own sub-batch, so taking the whole consecutive run is
+                    // what lets one produce round trip cover hundreds of them.
+                    let mut seeds = vec![Admitted {
+                        work: *work,
+                        offset: SeedOffset(offset),
+                    }];
+                    // `Peekable` has no put-back, so the predicate and the pattern below it have to
+                    // name the same variant. They are one line apart deliberately; a drift would
+                    // end the run early and leave that seed unmarked, so Kafka would replay it.
+                    while let Some(ShuffleMessage::Seed { work, offset, .. }) =
+                        messages.next_if(|message| matches!(message, ShuffleMessage::Seed { .. }))
+                    {
+                        seeds.push(Admitted {
+                            work: *work,
+                            offset: SeedOffset(offset),
+                        });
+                    }
+                    // Worker receipt is the first point that both proves these exact seeds landed
+                    // and orders their ceiling before even a zero-work handler can mark them
+                    // processed. The dispatcher also records the delivered batch maximum, but that
+                    // post-send accounting can race a fast worker on a multithreaded runtime. The
+                    // ceiling is monotonic, so raising it once to the run's highest offset is the
+                    // same as raising it per seed.
+                    let highest = seeds
+                        .iter()
+                        .map(|seed| seed.offset.0)
+                        .max()
+                        .expect("the run holds at least the seed that opened it");
                     merge
                         .seed_tracker
-                        .mark_dispatched(partition_id as i32, offset + 1);
+                        .mark_dispatched(partition_id as i32, highest + 1);
                     if flush_event_changes_before_inline(
                         &sink,
                         &mut buffer,
@@ -325,17 +352,18 @@ async fn run_worker(
                     {
                         break;
                     }
-                    handle_seed(
-                        partition_id,
-                        &handle,
-                        &catalog,
-                        &sink,
-                        &merge,
+                    handle_seed_groups(
+                        SeedApplyDeps {
+                            partition_id,
+                            handle: &handle,
+                            catalog: &catalog,
+                            sink: &sink,
+                            merge: &merge,
+                        },
                         &mut queue,
                         &mut reconcile_queue,
-                        &last_updated,
-                        &work,
-                        offset,
+                        &mut last_updated_clock,
+                        group_seeds(seeds, merge.seed_apply_batch_max),
                     )
                     .await;
                 }
@@ -1070,7 +1098,12 @@ mod tombstone_redirect_tests {
     use tempfile::TempDir;
     use tokio::sync::mpsc;
 
-    use cohort_core::seed::{BehavioralShapeHash, ReconcileScope, ReconcileTile, RunId};
+    use cohort_core::seed::{
+        BehavioralShapeHash, ClaimEpoch, ConditionHash, ReconcileScope, ReconcileTile, RunId,
+        SChunkMs, SeedTile,
+    };
+
+    use std::num::NonZeroU32;
 
     use crate::consumers::seeds::SeedWork;
     use crate::filters::{CohortId, FilterCatalog, TeamFiltersBuilder};
@@ -1080,6 +1113,7 @@ mod tombstone_redirect_tests {
         CaptureCascadeSink, CaptureReconcileMarkerSink, CaptureSink, CaptureStreamEventSink,
         CaptureTransferSink,
     };
+    use crate::stage1::bucket_tz::day_idx_in_tz;
     use crate::stage1::person_record::PersonRecord;
     use crate::stage1::state::AppliedOffsets;
     use crate::stage2::state::Stage2State;
@@ -1213,7 +1247,97 @@ mod tombstone_redirect_tests {
             register_transfer_enabled: false,
             reconcile: crate::workers::ReconcileDeps::default(),
             person_seed: crate::workers::PersonSeedDeps::default(),
+            seed_apply_batch_max: crate::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
         })
+    }
+
+    /// Cohort 1 backed by one behavioral leaf, so a day-tile alone flips it.
+    fn behavioral_catalog() -> Arc<CatalogHandle> {
+        let leaf = json!({
+            "type": "behavioral", "value": "performed_event", "key": "$pageview",
+            "time_value": 7, "time_interval": "day",
+            "conditionHash": "0123456789abcdef",
+            "bytecode": ["_H", 1, 32, "$pageview", 32, "event", 1, 1, 11],
+        });
+        let cohort = json!({ "properties": { "type": "AND", "values": [leaf] } });
+        let mut builder = TeamFiltersBuilder::default();
+        builder
+            .add_cohort(CohortId(1), TeamId(TEAM), &cohort)
+            .unwrap();
+        Arc::new(CatalogHandle::from_catalog(FilterCatalog::from_teams([(
+            TeamId(TEAM),
+            builder.freeze(UTC),
+        )])))
+    }
+
+    /// Deps that route every person onto partition 0, so one worker owns a whole seed run.
+    fn single_partition_deps() -> Arc<MergeWorkerDeps> {
+        let mut deps = Arc::try_unwrap(merge_deps_with(CaptureStreamEventSink::new()))
+            .unwrap_or_else(|_| panic!("test owns the only dependency Arc"));
+        deps.partition_count = 1;
+        Arc::new(deps)
+    }
+
+    fn seed_tile(person: Uuid) -> SeedTile {
+        SeedTile::new(
+            TeamId(TEAM),
+            person,
+            ConditionHash::parse("0123456789abcdef").unwrap(),
+            NonZeroU32::new(1).unwrap(),
+            day_idx_in_tz(chrono::Utc::now().timestamp_millis(), UTC),
+            SChunkMs(1_700_000_000_000),
+            RunId(Uuid::from_u128(0xBF)),
+            ClaimEpoch(1),
+        )
+    }
+
+    /// The worker has to take a channel batch's whole consecutive seed run as one apply. Handing
+    /// each seed to the pipeline on its own would put every tile back on its own produce round trip,
+    /// which is the cost the batching exists to remove.
+    #[tokio::test]
+    async fn a_channel_batch_of_seeds_pays_one_membership_produce() {
+        const TILES: usize = 3;
+        let (_dir, store) = temp_store();
+        let membership = CaptureSink::new();
+        let merge = single_partition_deps();
+        let seed_tracker = merge.seed_tracker.clone();
+        let events_tracker = Arc::new(OffsetTracker::new());
+
+        run_batch(
+            0,
+            &store,
+            behavioral_catalog(),
+            &membership,
+            &events_tracker,
+            merge,
+            0,
+            (0..TILES)
+                .map(|i| ShuffleMessage::Seed {
+                    work: Box::new(SeedWork::Tile(seed_tile(Uuid::from_u128(
+                        0x5EED_0000 + i as u128,
+                    )))),
+                    offset: i as i64,
+                    broker_ts_ms: None,
+                })
+                .collect(),
+        )
+        .await;
+
+        assert_eq!(
+            membership.changes().len(),
+            TILES,
+            "every tile entered the single-leaf cohort",
+        );
+        assert_eq!(
+            membership.produce_calls(),
+            1,
+            "the worker applied the run as one batch",
+        );
+        assert_eq!(
+            seed_tracker.committable_offsets().get(&0),
+            Some(&(TILES as i64)),
+            "the whole run's span is marked",
+        );
     }
 
     fn reconcile_deps() -> (Arc<MergeWorkerDeps>, CaptureReconcileMarkerSink) {
@@ -1246,6 +1370,7 @@ mod tombstone_redirect_tests {
             register_transfer_enabled: false,
             reconcile: crate::workers::ReconcileDeps::default(),
             person_seed: crate::workers::PersonSeedDeps::default(),
+            seed_apply_batch_max: crate::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
         })
     }
 
@@ -1273,6 +1398,7 @@ mod tombstone_redirect_tests {
             register_transfer_enabled: false,
             reconcile: crate::workers::ReconcileDeps::default(),
             person_seed: crate::workers::PersonSeedDeps::default(),
+            seed_apply_batch_max: crate::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
         })
     }
 

--- a/rust/cohort-stream-processor/tests/cascade_consumer.rs
+++ b/rust/cohort-stream-processor/tests/cascade_consumer.rs
@@ -468,7 +468,7 @@ async fn spawn_instance(
         register_transfer_enabled: false,
         reconcile: cohort_stream_processor::workers::ReconcileDeps::default(),
         person_seed: cohort_stream_processor::workers::PersonSeedDeps::default(),
-        seed_apply_batch_max: cohort_stream_processor::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
+        seed_batch: cohort_stream_processor::workers::SeedBatchLimits::default(),
     });
 
     let dispatcher = Arc::new(EventDispatcher::new(

--- a/rust/cohort-stream-processor/tests/cascade_consumer.rs
+++ b/rust/cohort-stream-processor/tests/cascade_consumer.rs
@@ -468,6 +468,7 @@ async fn spawn_instance(
         register_transfer_enabled: false,
         reconcile: cohort_stream_processor::workers::ReconcileDeps::default(),
         person_seed: cohort_stream_processor::workers::PersonSeedDeps::default(),
+        seed_apply_batch_max: cohort_stream_processor::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
     });
 
     let dispatcher = Arc::new(EventDispatcher::new(

--- a/rust/cohort-stream-processor/tests/merge_consumer.rs
+++ b/rust/cohort-stream-processor/tests/merge_consumer.rs
@@ -624,7 +624,7 @@ async fn spawn_instance(
         register_transfer_enabled: false,
         reconcile: cohort_stream_processor::workers::ReconcileDeps::default(),
         person_seed: cohort_stream_processor::workers::PersonSeedDeps::default(),
-        seed_apply_batch_max: cohort_stream_processor::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
+        seed_batch: cohort_stream_processor::workers::SeedBatchLimits::default(),
     });
 
     let dispatcher = Arc::new(EventDispatcher::new(

--- a/rust/cohort-stream-processor/tests/merge_consumer.rs
+++ b/rust/cohort-stream-processor/tests/merge_consumer.rs
@@ -624,6 +624,7 @@ async fn spawn_instance(
         register_transfer_enabled: false,
         reconcile: cohort_stream_processor::workers::ReconcileDeps::default(),
         person_seed: cohort_stream_processor::workers::PersonSeedDeps::default(),
+        seed_apply_batch_max: cohort_stream_processor::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
     });
 
     let dispatcher = Arc::new(EventDispatcher::new(

--- a/rust/cohort-stream-processor/tests/merge_durability.rs
+++ b/rust/cohort-stream-processor/tests/merge_durability.rs
@@ -722,6 +722,7 @@ async fn spawn_instance(
         register_transfer_enabled: false,
         reconcile: cohort_stream_processor::workers::ReconcileDeps::default(),
         person_seed: cohort_stream_processor::workers::PersonSeedDeps::default(),
+        seed_apply_batch_max: cohort_stream_processor::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
     });
 
     let dispatcher = Arc::new(EventDispatcher::new(

--- a/rust/cohort-stream-processor/tests/merge_durability.rs
+++ b/rust/cohort-stream-processor/tests/merge_durability.rs
@@ -722,7 +722,7 @@ async fn spawn_instance(
         register_transfer_enabled: false,
         reconcile: cohort_stream_processor::workers::ReconcileDeps::default(),
         person_seed: cohort_stream_processor::workers::PersonSeedDeps::default(),
-        seed_apply_batch_max: cohort_stream_processor::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
+        seed_batch: cohort_stream_processor::workers::SeedBatchLimits::default(),
     });
 
     let dispatcher = Arc::new(EventDispatcher::new(

--- a/rust/cohort-stream-processor/tests/seed_consumer.rs
+++ b/rust/cohort-stream-processor/tests/seed_consumer.rs
@@ -674,7 +674,7 @@ async fn spawn_instance(
             marker_sink,
         },
         person_seed: cohort_stream_processor::workers::PersonSeedDeps::default(),
-        seed_apply_batch_max: cohort_stream_processor::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
+        seed_batch: cohort_stream_processor::workers::SeedBatchLimits::default(),
     });
 
     let dispatcher = Arc::new(EventDispatcher::new(

--- a/rust/cohort-stream-processor/tests/seed_consumer.rs
+++ b/rust/cohort-stream-processor/tests/seed_consumer.rs
@@ -674,6 +674,7 @@ async fn spawn_instance(
             marker_sink,
         },
         person_seed: cohort_stream_processor::workers::PersonSeedDeps::default(),
+        seed_apply_batch_max: cohort_stream_processor::workers::DEFAULT_SEED_APPLY_BATCH_MAX,
     });
 
     let dispatcher = Arc::new(EventDispatcher::new(


### PR DESCRIPTION
## Problem

A large behavioral cohort backfill takes days to land, and live cohort updates on the partitions it touches trail it the whole time.

The processor awaits one Kafka produce per seed that flips a cohort, then a second one for its cascade. A partition worker spends its time waiting rather than folding. It also drains a single channel, so live events queue behind every seed already admitted to it.

## Changes

- A worker applies a run of consecutive seeds as one unit, so the run pays one produce round trip instead of one per seed.
- The membership, cascade and handoff produces now go out together instead of one after another.
- `COHORT_SEED_APPLY_BATCH_MAX` caps a run at 256 seeds. Setting it to `1` restores the per seed apply.
- Cohort membership results do not change. Only the rate the backfill lands at moves.

Mechanism, for review:

- New `workers/seed_batch.rs` splits a channel batch into same kind runs and drives each run to a mark or a hold.
- An overlay carries each leaf's state across the run. A second seed for one person folds onto the first seed's result, not onto the bytes the read pass saw.
- A run holds its lowest offset on failure and marks its highest on success.
- Replay is unchanged. Stage 1 stays idempotent through max merge, and the stage 2 bits still land only after the produces ack.
- Two new batched store reads replace the per seed tombstone and person record reads.
- Three metrics report batch size, per stage duration, and held batches by stage.

The offset accounting and the overlay carry the risk. The store reads, the config knob and the metrics are mechanical.

> [!NOTE]
> The ceiling defaults to 256, so batching is live the moment the image rolls. Going back to the per seed apply needs a charts change and a second roll.

## How did you test this code?

Every existing seed and person seed test now runs through the batch pipeline as a run of one. Those pin the rewrite against the behavior it replaces.

New tests, grouped by the regression each group catches:

- Equivalence. A run reaches the same stored state and the same transitions as applying its seeds one at a time, for tiles and for person seeds. Without the overlay a run keeps only its last seed's work.
- Offsets. A failed produce holds the run's lowest offset, writes no stage 2 bit, and the replay derives the flip again exactly once. A short ack vector on the handoff leg counts as failure, so nothing commits past a seed the processor never produced.
- Grouping. Runs break at every kind change and a reconcile tile stays on its own. A run longer than the ceiling splits, and the worker takes a channel batch's whole seed run.
- Fan out. A person touched by two runs recomposes once. A run spanning two teams folds each seed against its own catalog.
- Writes. An unchanged leaf stages its membership register and skips its state row, which is the replay path.

Four of these ran against a deliberately broken build first, one per group above except writes, so they fail when the thing they name breaks.

The three broker backed `seed_consumer` end to end tests pass against a local Kafka.

Not checked: the suites gated on object storage, and any behavior under production load.

## Docs update

No.