### PR TITLE
fix(plugins): restrict local plugin installs to development

### DIFF
--- a/products/cdp/backend/api/test/test_plugin.py
+++ b/products/cdp/backend/api/test/test_plugin.py
@@ -1,4 +1,6 @@
+import os
 import json
+import tempfile
 from datetime import datetime
 from typing import Any, Optional, cast
 from zoneinfo import ZoneInfo
@@ -8,6 +10,8 @@ from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, QueryMatchingTest, snapshot_postgres_queries
 from unittest import mock
 from unittest.mock import patch
+
+from django.test import override_settings
 
 from rest_framework import status
 
@@ -605,6 +609,18 @@ class TestPluginAPI(APIBaseTest, QueryMatchingTest):
         )
         self.assertEqual(Plugin.objects.count(), 1)
         self.assertEqual(mock_reload.call_count, 1)
+
+    @override_settings(DEBUG=False)
+    def test_create_plugin_rejects_local_file_url(self, mock_get, mock_reload):
+        with tempfile.TemporaryDirectory() as plugin_dir:
+            with open(os.path.join(plugin_dir, "plugin.json"), "w") as plugin_json:
+                json.dump({"name": "on-disk", "description": "contents of a file on the server"}, plugin_json)
+
+            response = self.client.post("/api/organizations/@current/plugins/", {"url": f"file:{plugin_dir}"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+        self.assertEqual(Plugin.objects.count(), 0)
+        self.assertEqual(PluginSourceFile.objects.count(), 0)
 
     def test_create_plugin_version_range_eq_current(self, mock_get, mock_reload):
         with self.is_cloud(False):

--- a/products/cdp/backend/models/plugin.py
+++ b/products/cdp/backend/models/plugin.py
@@ -50,6 +50,10 @@ def update_validated_data_from_url(validated_data: dict[str, Any], url: str) -> 
     """If remote plugin, download the archive and get up-to-date validated_data from there. Returns plugin.json."""
     plugin_json: Optional[dict[str, Any]]
     if url.startswith("file:"):
+        # A local plugin reads its plugin.json from the app server's filesystem, and the caller chooses the path.
+        # Only local development installs plugins this way, so refuse the scheme everywhere else.
+        if not settings.DEBUG:
+            raise ValidationError("Must be a GitHub/GitLab repository or a npm package URL!")
         plugin_path = url[5:]
         plugin_json_path = os.path.join(plugin_path, "plugin.json")
         plugin_json = cast(Optional[dict[str, Any]], load_json_file(plugin_json_path))


### PR DESCRIPTION
## Problem

- Installing a plugin from a `file:` URL returns a 500 and leaves a half-created plugin row behind. Self-hosted organizations reach this path by default, because new organizations there start at the `root` plugin access level.
- A `file:` install never succeeds outside local development. `sync_from_plugin_archive` needs an archive, a `file:` install has none, and the failure lands after `Plugin.objects.create()` has already committed the row.
- The `file:` branch reads a caller-supplied path off the app server's filesystem. Nothing scoped that branch to development.

## Changes

- Installing a plugin from a `file:` URL now returns a 400 and creates no plugin row. The message matches every other unsupported URL: "Must be a GitHub/GitLab repository or a npm package URL!".
- `update_validated_data_from_url` rejects the `file:` scheme unless `settings.DEBUG` is set, so local plugin development is unchanged.
- The guard sits in the shared helper rather than in `PluginSerializer.create`, so it covers every caller of that helper.
- The guard reads the `url` string. It does not read `plugin_type`, which the request can set and which the helper overwrites anyway.
- `PLUGINS_PREINSTALLED_URLS` is unaffected. `preinstall_plugins_for_new_organization` already wraps `install()` in `except Exception`, so a `file:` entry there still prints a warning and organization creation still succeeds.
- No user interface changes.

## How did you test this code?

- Added `test_create_plugin_rejects_local_file_url` to `products/cdp/backend/api/test/test_plugin.py`. It catches a regression where the `file:` branch runs outside development. No existing test covered that branch.
- The test writes a real `plugin.json` to a temporary directory, posts `file:<dir>` under `@override_settings(DEBUG=False)`, and asserts a 400 with no `Plugin` row. Tests otherwise run with `DEBUG=1`, set in `posthog/settings/overrides.py`.
- Ran `products/cdp/backend/api/test/test_plugin.py` and `posthog/plugins/` locally. The new test fails on the parent commit and passes on this one.
- Not run: the wider backend suite. No manual check against a running instance.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No doc under `docs/` describes installing a plugin from a `file:` URL.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5) wrote the change. Session: https://claude.ai/code/session_01CzNCfEs9A9fA9muPKpwBLU
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.
- The first design removed the `file:` branch outright. Running the endpoint showed local installs are a real development path, so the change gates on `settings.DEBUG` instead.
- An orphaned `Plugin` row survives any failure inside `sync_from_plugin_archive`, because `install()` commits the row first and wraps nothing in a transaction. This PR does not address that. It deserves its own change.
- Public artifact: the diff, the test fixture, and this description carry nothing from the session that is not already public. The test writes an invented `plugin.json`.

https://claude.ai/code/session_01CzNCfEs9A9fA9muPKpwBLU
