### PR TITLE
chore(csp): remove unused font-src origins

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -1213,7 +1213,7 @@ class CSPMiddleware:
                 "default-src 'self'",
                 f"style-src 'self' 'unsafe-inline' {resource_url} https://fonts.googleapis.com",
                 f"script-src 'self' 'nonce-{nonce}' {resource_url} https://*.i.posthog.com",
-                f"font-src 'self' {resource_url} https://app-static.eu.posthog.com https://app-static-prod.posthog.com https://d1sdjtjk6xzm7.cloudfront.net https://fonts.gstatic.com https://cdn.jsdelivr.net https://assets.faircado.com https://use.typekit.net",
+                f"font-src 'self' {resource_url} https://app-static.eu.posthog.com https://app-static-prod.posthog.com https://fonts.gstatic.com https://cdn.jsdelivr.net",
                 "worker-src 'self'",
                 "child-src 'none'",
                 "object-src 'none'",


### PR DESCRIPTION
## Problem

The app `font-src` allowlist names three origins that serve no PostHog font. Enforcing the policy later would ship all three.

- `assets.faircado.com` and `use.typekit.net` arrived in #39824, taken from violation reports. Those reports came from browser extensions running against our own pages, not from anything we serve.
- `d1sdjtjk6xzm7.cloudfront.net` arrived earlier, in #39735. It is not the CloudFront distribution behind either static asset host. `app-static-prod.posthog.com` resolves to `d2rjsfpxkfgaxp.cloudfront.net` and `app-static.eu.posthog.com` to `d29mdp3tlm5oa1.cloudfront.net`.
- No file under `frontend/`, `products/`, `common/`, or `posthog/` references any of the three, outside the middleware itself.

A violation report names what a policy blocked. It does not say whether we asked for the resource. An origin added from a report alone widens the policy to cover traffic we do not control.

## Changes

- Nothing changes for a user. The app policy is report-only, so no request is blocked before or after this PR.
- Remove the three origins from `font-src`.

## How did you test this code?

No new tests. The change removes three strings from one policy directive, and the existing `TestCSPMiddleware` cases already cover the header the middleware emits.

Ran `posthog/test/test_middleware.py::TestCSPMiddleware` locally: 10 passed.

Not checked: whether any production page loads a font from a removed origin. Nothing is enforced, so a wrong removal appears as a violation report naming a PostHog source file, not as a broken page. Querying `$csp_violation` for these hosts after the change confirms it either way.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this PR. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `superpowers:brainstorming`, `superpowers:using-git-worktrees`.

The three origins surfaced while classifying seven days of `$csp_violation` reports across both cloud regions, ahead of a larger effort to enforce a policy. That analysis put ~94% of violations in PostHog's own code and identified browser extensions as the source of the two font origins from #39824. Checking the third was not part of the original scope; it was added after a DNS lookup showed it backs neither static asset host.

An earlier revision pinned the whole `font-src` set in a test. That test was dropped: it asserted the literal directive string, so any deliberate future edit would rewrite it rather than be caught by it.

https://claude.ai/code/session_01HgRWtAJHBL2hQArpctxYr4
