### PR TITLE
feat(replay-vision): discard a section's edits from the goal overview

### DIFF
--- a/products/replay_vision/backend/scanner_draft.py
+++ b/products/replay_vision/backend/scanner_draft.py
@@ -64,6 +64,9 @@ _MAX_DESCRIPTION_LENGTH = 1_000
 _MAX_PROMPT_LENGTH = 20_000
 _MAX_RATIONALE_LENGTH = 500
 _MAX_DRAFT_TAGS = 12
+# Every drafted vocabulary ends with this catch-all. The response schema forces at least one tag, so
+# without one a session the dimension does not describe is pushed into the least wrong real category.
+_NOT_APPLICABLE_TAG = "N/A"
 _DEFAULT_SCALE = (0, 10)
 # Draft-only sanity bounds. Create accepts any min < max, but a drafted scale outside every plausible
 # rubric (0-10, 1-5, 0-100) is model noise, not intent, so it falls back to the default.
@@ -372,7 +375,8 @@ Pick the single type that best fits the goal, then draft the scanner:
   is about (e.g. a checkout question when most sessions never open checkout), so those sessions aren't
   forced into a no.
 - For classifiers: 4-8 lowercase snake_case tags that are distinct, non-overlapping categories along the
-  dimension. No vague catch-alls ("other", "misc").
+  dimension. No vague catch-alls ("other", "misc", "n/a"): an "N/A" category is added for you, and it
+  covers the sessions the dimension does not describe.
 - filter_screens / filter_events: when the goal targets one specific flow, screen, or feature, narrow which
   sessions get scanned: up to 1 screen and up to 2 events a session must include, each copied EXACTLY from
   the briefing's screens and custom events lists (anything not in those lists is discarded). The filters
@@ -581,8 +585,16 @@ def _normalized_config(parsed: _LlmDraft) -> dict[str, Any]:
             scanner_config["allow_inconclusive"] = True
     elif parsed.scanner_type == "classifier":
         # Order-preserving dedup of slugified tags, dropping anything that slugs to empty.
-        tags = list(dict.fromkeys(s for t in parsed.tags if (s := slugify_tag(t))))[:_MAX_DRAFT_TAGS]
-        scanner_config["tags"] = tags
+        tags = list(dict.fromkeys(s for t in parsed.tags if (s := slugify_tag(t))))
+        # The catch-all goes last and is never a duplicate of a drafted tag, so a session the
+        # dimension does not describe has somewhere to land.
+        na_slug = slugify_tag(_NOT_APPLICABLE_TAG)
+        tags = [t for t in tags if t != na_slug][: _MAX_DRAFT_TAGS - 1]
+        # The catch-all can't stand in for a vocabulary, so a draft that lost every real tag still fails
+        # here rather than opening the wizard on a classifier that only ever answers "N/A".
+        if not tags:
+            raise DraftError("draft config invalid: classifier has no categories")
+        scanner_config["tags"] = [*tags, _NOT_APPLICABLE_TAG]
         scanner_config["multi_label"] = parsed.multi_label
     elif parsed.scanner_type == "scorer":
         scale_min, scale_max = parsed.scale_min, parsed.scale_max
@@ -769,7 +781,8 @@ Pick the single type that best fits the goal, then draft the scanner:
   is about (e.g. a checkout question when most sessions never open checkout), so those sessions aren't
   forced into a no.
 - For classifiers: 4-8 lowercase snake_case tags that are distinct, non-overlapping categories along the
-  dimension. No vague catch-alls ("other", "misc").
+  dimension. No vague catch-alls ("other", "misc", "n/a"): an "N/A" category is added for you, and it
+  covers the sessions the dimension does not describe.
 - filter_pages and filter_events: which sessions get scanned. Two ways to narrow, and you can use
   either or both.
   - filter_pages: the pages list is what the product actually calls things, so map the goal's words

--- a/products/replay_vision/backend/tests/test_scanner_draft.py
+++ b/products/replay_vision/backend/tests/test_scanner_draft.py
@@ -155,8 +155,15 @@ class TestFinalize:
             )
         )
 
-        assert result.scanner_config["tags"] == ["pricing_page", "abandoned_cart"]
+        assert result.scanner_config["tags"] == ["pricing_page", "abandoned_cart", "N/A"]
         assert result.scanner_config["multi_label"] is True
+
+    def test_classifier_always_gets_one_catch_all_category_last(self):
+        # A session the dimension does not describe needs somewhere to land, and a catch-all the model
+        # drafted itself must not end up alongside the one added here.
+        result = _finalize(_draft(scanner_type="classifier", tags=["browsing", "n/a", "purchasing"]))
+
+        assert result.scanner_config["tags"] == ["browsing", "purchasing", "N/A"]
 
     @pytest.mark.parametrize(
         "scale_min,scale_max",
@@ -456,7 +463,7 @@ class TestDraftScannerEndpoint(_VisionAPITestCase):
             "scanner_type": "classifier",
             "scanner_config": {
                 "prompt": "Classify the session by primary user intent.",
-                "tags": ["browsing", "purchasing"],
+                "tags": ["browsing", "purchasing", "N/A"],
                 "multi_label": False,
             },
             "rationale": "A classifier fits because you want the mix of visit intents, not a single yes/no.",

--- a/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.stories.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.stories.tsx
@@ -754,6 +754,30 @@ export const ScannerEditorGoalOverview: StoryObj = {
     ],
 }
 
+// A section opened from the goal overview: the footer returns to the overview, keeps or throws away
+// this section's edits, and can still discard the whole drafted scanner.
+export const ScannerEditorGoalSectionEdit: StoryObj = {
+    parameters: {
+        pageUrl: `${urls.replayVisionScannerDetails('new')}?from=overview`,
+        featureFlags: { [FEATURE_FLAGS.VISION_GOAL_BASED_CREATION_FLOW]: 'test' },
+    },
+    decorators: [
+        (StoryFn) => {
+            const logic = replayScannerLogic({ id: 'new' })
+            logic.mount()
+            logic.actions.setScannerValues({
+                name: goalDraft.name,
+                description: goalDraft.description,
+                scanner_config: goalDraft.scanner_config as ScannerConfig,
+            })
+            // The snapshot the section was entered with, plus an edit on top, so "Discard changes" is live.
+            logic.actions.setSectionEditSnapshot(logic.values.scanner)
+            logic.actions.setScannerValues({ name: 'Billing drop-off watcher' })
+            return <StoryFn />
+        },
+    ],
+}
+
 // The overview while the draft is still generating: the loading bar and skeleton the user sees
 // right after submitting the two questions.
 export const ScannerEditorGoalOverviewLoading: StoryObj = {

--- a/products/replay_vision/frontend/replay_scanners/ScannerEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ScannerEditorScene.tsx
@@ -497,8 +497,10 @@ function EditorFooter({
     const ownsDurationFilter = step === 'triggers' || step === 'budget'
     const durationError = ownsDurationFilter ? durationValidationError : null
     const saveDisabledReason = getReplayVisionEditDisabledReason(scanner?.user_access_level) ?? durationError
-    // Editing one section from the goal overview: the edit is already in the form state, so the only
-    // action needed is to return to the overview, where the whole draft is reviewed and created.
+    // Editing one section from the goal overview: the edit is already in the form state, so keeping it
+    // is just a return to the overview, where the whole draft is reviewed and created. The button still
+    // reads "Save changes" — beside "Discard changes", a bare "Back to overview" reads like leaving
+    // without keeping the edit.
     const { from, ...overviewParams } = searchParams
     const fromOverview = from === 'overview'
 
@@ -555,9 +557,9 @@ function EditorFooter({
                             type="primary"
                             to={scannerStepUrlWithParams('overview', scannerId, overviewParams)}
                             disabledReason={saveDisabledReason ?? undefined}
-                            data-attr="vision-editor-back-to-overview"
+                            data-attr="vision-editor-save-section-edits"
                         >
-                            Back to overview
+                            Save changes
                         </LemonButton>
                     </div>
                 </div>

--- a/products/replay_vision/frontend/replay_scanners/ScannerEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ScannerEditorScene.tsx
@@ -476,9 +476,11 @@ function EditorFooter({
     onAdvance: () => void
     onSave: () => void
 }): JSX.Element {
-    const { scanner, durationValidationError, hasUnsavedChanges } = useValues(replayScannerLogic({ id: scannerId }))
+    const { scanner, durationValidationError, hasUnsavedChanges, hasSectionEditChanges } = useValues(
+        replayScannerLogic({ id: scannerId })
+    )
     const { searchParams } = useValues(router)
-    const { discardScannerDraft } = useActions(replayScannerLogic({ id: scannerId }))
+    const { discardScannerDraft, discardSectionEdits } = useActions(replayScannerLogic({ id: scannerId }))
     const { dataProcessingAccepted, dataProcessingApprovalDisabledReason } = useValues(aiConsentLogic)
     const [consentRequested, setConsentRequested] = useState(false)
     // The backend rejects scanner creation without org AI consent, so the popover interposes at
@@ -525,7 +527,7 @@ function EditorFooter({
             {/* The duration field lives on the recordings step, so budget needs the error spelled out. */}
             {step === 'budget' && durationError ? <div className="text-danger text-sm">{durationError}</div> : null}
             {fromOverview ? (
-                <div className="flex flex-wrap items-center justify-end gap-2">
+                <div className="flex flex-wrap items-center justify-between gap-2">
                     <LemonButton
                         type="tertiary"
                         onClick={handleCancel}
@@ -534,14 +536,30 @@ function EditorFooter({
                     >
                         Discard scanner
                     </LemonButton>
-                    <LemonButton
-                        type="primary"
-                        to={scannerStepUrlWithParams('overview', scannerId, overviewParams)}
-                        disabledReason={saveDisabledReason ?? undefined}
-                        data-attr="vision-editor-back-to-overview"
-                    >
-                        Back to overview
-                    </LemonButton>
+                    <div className="flex flex-wrap items-center gap-2">
+                        <LemonButton
+                            type="secondary"
+                            onClick={() => discardSectionEdits()}
+                            disabledReason={
+                                isSubmitting
+                                    ? 'Saving…'
+                                    : !hasSectionEditChanges
+                                      ? "You haven't changed anything here"
+                                      : undefined
+                            }
+                            data-attr="vision-editor-discard-section-edits"
+                        >
+                            Discard changes
+                        </LemonButton>
+                        <LemonButton
+                            type="primary"
+                            to={scannerStepUrlWithParams('overview', scannerId, overviewParams)}
+                            disabledReason={saveDisabledReason ?? undefined}
+                            data-attr="vision-editor-back-to-overview"
+                        >
+                            Back to overview
+                        </LemonButton>
+                    </div>
                 </div>
             ) : (
                 <div className="flex flex-wrap items-center justify-between gap-2">

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerGoalOverview.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerGoalOverview.tsx
@@ -14,7 +14,7 @@ import { urls } from 'scenes/urls'
 import { getReplayVisionEditDisabledReason } from '../../utils/accessControl'
 import { creditsToUsd, formatCreditCount } from '../../utils/credits'
 import { replayScannerLogic } from '../replayScannerLogic'
-import { ScannerEditorStep, scannerStepUrlWithParams } from '../scannerEditorSceneLogic'
+import { ScannerEditorStep } from '../scannerEditorSceneLogic'
 import { OBSERVATION_CREDITS_BY_MODEL, SCANNER_TYPE_TAG_TYPE, modelName, scannerTypeLabel } from '../types'
 
 /** Why the draft chose this model, doubling as the guidance on when each tier fits. Keyed by the
@@ -68,7 +68,7 @@ function OverviewSection({
     scannerId: string
     children: React.ReactNode
 }): JSX.Element {
-    const { searchParams } = useValues(router)
+    const { editScannerSection } = useActions(replayScannerLogic({ id: scannerId }))
     return (
         <div className="bg-bg-light border rounded-lg p-4 flex items-start justify-between gap-4">
             <div className="flex-1 min-w-0 space-y-2">
@@ -86,11 +86,7 @@ function OverviewSection({
                 <LemonButton
                     size="small"
                     type="secondary"
-                    onClick={() =>
-                        router.actions.push(
-                            scannerStepUrlWithParams(editStep, scannerId, { ...searchParams, from: 'overview' })
-                        )
-                    }
+                    onClick={() => editScannerSection(editStep)}
                     data-attr={`vision-goal-overview-edit-${editStep}`}
                 >
                     Edit

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerGoalOverview.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerGoalOverview.tsx
@@ -160,7 +160,7 @@ export function ScannerGoalOverview({ scannerId }: { scannerId: string }): JSX.E
 
     return (
         <div className="flex flex-col gap-3">
-            <OverviewSection label="What it understood" scannerId={scannerId}>
+            <OverviewSection label="Agent overview" scannerId={scannerId}>
                 <div className="text-sm">{goalDraft?.rationale?.trim() || scanner.description}</div>
             </OverviewSection>
 
@@ -346,7 +346,7 @@ function ScannerGoalOverviewSkeleton(): JSX.Element {
     return (
         <div className="flex flex-col gap-3">
             <DraftLoadingBar />
-            {['What it understood', 'Name', 'What it will ask', 'Eligible recordings', 'Sampling and budget'].map(
+            {['Agent overview', 'Name', 'What it will ask', 'Eligible recordings', 'Sampling and budget'].map(
                 (label) => (
                     <div key={label} className="bg-bg-light border rounded-lg p-4 space-y-2">
                         <div className="text-xs text-tertiary uppercase tracking-wide">{label}</div>

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
@@ -1233,6 +1233,47 @@ describe('replayScannerLogic', () => {
         })
     })
 
+    describe('editing one section from the goal overview', () => {
+        beforeEach(() => {
+            teamLogic.mount()
+        })
+
+        it('restores the section snapshot and returns to the overview on discard', async () => {
+            logic.actions.setScannerValues({ name: 'Drafted', description: 'From the goal' })
+            logic.actions.editScannerSection('details')
+            await expectLogic(logic).toFinishAllListeners()
+            expect(router.values.searchParams.from).toBe('overview')
+
+            logic.actions.setScannerValues({ name: 'Edited' })
+            expect(logic.values.hasSectionEditChanges).toBe(true)
+
+            logic.actions.discardSectionEdits()
+            await expectLogic(logic).toFinishAllListeners()
+            expect(logic.values.scanner?.name).toBe('Drafted')
+            expect(logic.values.hasSectionEditChanges).toBe(false)
+            expect(router.values.location.pathname).toContain(urls.replayVisionScannerOverview('new'))
+            // The rest of the drafted scanner survives, so only this section's edits were thrown away.
+            expect(logic.values.scanner?.description).toBe('From the goal')
+        })
+
+        it('keeps the snapshot across a reload, so discarding still works', async () => {
+            logic.actions.setScannerValues({ name: 'Drafted' })
+            logic.actions.editScannerSection('details')
+            await expectLogic(logic).toFinishAllListeners()
+            logic.actions.setScannerValues({ name: 'Edited' })
+            logic.unmount()
+
+            logic = replayScannerLogic({ id: 'new' })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+            expect(logic.values.scanner?.name).toBe('Edited')
+
+            logic.actions.discardSectionEdits()
+            await expectLogic(logic).toFinishAllListeners()
+            expect(logic.values.scanner?.name).toBe('Drafted')
+        })
+    })
+
     describe('hasUnsavedChanges', () => {
         it('is false when no original scanner is loaded', () => {
             expect(logic.values.hasUnsavedChanges).toBe(false)

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -76,6 +76,7 @@ import { consumeGoalDraftIntent } from './goalDraftIntent'
 import { clearScannerDraft, readScannerDraft, writeScannerDraft } from './scannerDraft'
 import {
     SCANNER_EDITOR_STEPS,
+    type ScannerEditorStep,
     firstErroredScannerStep,
     scannerEditorSceneLogic,
     scannerStepUrl,
@@ -304,6 +305,7 @@ export interface replayScannerLogicValues {
     goalDraftLoading: boolean
     hasActiveObservationFilters: boolean
     hasObservationsInFlight: boolean
+    hasSectionEditChanges: boolean
     hasUnsavedChanges: boolean
     isNew: boolean
     isScannerSubmitting: boolean
@@ -346,6 +348,7 @@ export interface replayScannerLogicValues {
     scannerTouched: boolean
     scannerTouches: Record<string, boolean>
     scannerValidationErrors: DeepPartialMap<ScannerFormValues, ValidationErrorType>
+    sectionEditSnapshot: ScannerFormValues | null
     showScannerErrors: boolean
     sidePanelContext: SidePanelSceneContext | null
     tagSuggestions: TagSuggestionApi[]
@@ -382,6 +385,12 @@ export interface replayScannerLogicActions {
     }
     discardScannerDraft: () => {
         value: true
+    }
+    discardSectionEdits: () => {
+        value: true
+    }
+    editScannerSection: (step: ScannerEditorStep) => {
+        step: ScannerEditorStep
     }
     dismissTagSuggestions: () => {
         value: true
@@ -623,6 +632,9 @@ export interface replayScannerLogicActions {
     setScannerValues: (values: DeepPartial<ScannerFormValues>) => {
         values: DeepPartial<ScannerFormValues>
     }
+    setSectionEditSnapshot: (snapshot: ScannerFormValues | null) => {
+        snapshot: ScannerFormValues | null
+    }
     startFromTemplate: (templateKey: string | null) => {
         templateKey: string | null
     }
@@ -676,6 +688,7 @@ export interface replayScannerLogicMeta {
         isNew: (id: string) => boolean
         durationValidationError: (scanner: ScannerFormValues) => string | null
         hasUnsavedChanges: (scanner: ScannerFormValues, originalScanner: ScannerFormValues | null) => boolean
+        hasSectionEditChanges: (scanner: ScannerFormValues, sectionEditSnapshot: ScannerFormValues | null) => boolean
         hasObservationsInFlight: (observationStatsApi: ObservationStatsApi | null) => boolean
         hasActiveObservationFilters: (
             observationStatusFilter: ObservationStatusEnumApi[],
@@ -737,6 +750,10 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
         setScannerType: (scannerType: ScannerType) => ({ scannerType }),
         startFromTemplate: (templateKey: string | null) => ({ templateKey }),
         discardScannerDraft: true,
+        // The goal overview's per-section Edit: snapshots the config, then opens the step that edits it.
+        editScannerSection: (step: ScannerEditorStep) => ({ step }),
+        setSectionEditSnapshot: (snapshot: ScannerFormValues | null) => ({ snapshot }),
+        discardSectionEdits: true,
         setScannerDraftSavedAt: (savedAt: number | null) => ({ savedAt }),
         // Fired only after an actual API write, unlike submitScannerSuccess (which the advance path emits too).
         scannerSaved: (scanner: ScannerFormValues) => ({ scanner }),
@@ -1047,6 +1064,17 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                 detachExperimentContext: () => null,
             },
         ],
+        // The config as it stood when a section was opened from the goal overview, so that section's
+        // edits can be thrown away on their own without discarding the whole drafted scanner.
+        sectionEditSnapshot: [
+            null as ScannerFormValues | null,
+            {
+                setSectionEditSnapshot: (_, { snapshot }) => snapshot,
+                startFromTemplate: () => null,
+                discardScannerDraft: () => null,
+                scannerSaved: () => null,
+            },
+        ],
         originalScanner: [
             null as ScannerFormValues | null,
             {
@@ -1316,6 +1344,16 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                 return !objectsEqual(omitStamps(scanner), omitStamps(original))
             },
         ],
+        // Whether the section opened from the goal overview holds edits worth throwing away.
+        hasSectionEditChanges: [
+            (s) => [s.scanner, s.sectionEditSnapshot],
+            (scanner: ReplayScanner | null, snapshot: ScannerFormValues | null): boolean => {
+                if (!scanner || !snapshot) {
+                    return false
+                }
+                return !objectsEqual(omitStamps(scanner), omitStamps(snapshot))
+            },
+        ],
         hasObservationsInFlight: [
             (s) => [s.observationStatsApi],
             (stats: ObservationStatsApi | null): boolean => (stats?.status_counts.in_flight ?? 0) > 0,
@@ -1479,7 +1517,7 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                 actions.setScannerDraftSavedAt(null)
                 return
             }
-            const savedAt = writeScannerDraft(teamId, values.scanner)
+            const savedAt = writeScannerDraft(teamId, values.scanner, values.sectionEditSnapshot)
             if (savedAt === null) {
                 // A failed write leaves any older draft behind; drop it so it can't resurrect stale edits.
                 clearScannerDraft()
@@ -1597,6 +1635,8 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                         if (draft) {
                             actions.setScannerValues(draft.scanner)
                             actions.setScannerDraftSavedAt(draft.savedAt)
+                            // Reloading inside a section edit keeps its "Discard changes" working.
+                            actions.setSectionEditSnapshot(draft.sectionSnapshot)
                             // A draft made from an experiment prefill carries targeting the
                             // loadScannerSuccess above (a bare newScanner) didn't see.
                             actions.rebuildExperimentContext()
@@ -1846,6 +1886,26 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                 const base = newScanner(templateKey, teamLogic.values.currentTeam?.name)
                 const context = values.experimentContext
                 actions.resetScanner(context ? prefillScannerForExperiment(base, context) : base)
+            },
+            editScannerSection: ({ step }) => {
+                // Snapshot before the step opens: every edit made there is measured against this,
+                // and discarding the section restores it.
+                actions.setSectionEditSnapshot(values.scanner)
+                persistDraft()
+                const { from: _from, ...params } = router.values.searchParams
+                router.actions.push(scannerStepUrlWithParams(step, props.id, { ...params, from: 'overview' }))
+            },
+            discardSectionEdits: () => {
+                const snapshot = values.sectionEditSnapshot
+                const { from: _from, ...params } = router.values.searchParams
+                if (snapshot) {
+                    actions.resetScanner(snapshot)
+                    actions.setSectionEditSnapshot(null)
+                    // The restored filter, model and dials change what the overview projects.
+                    actions.requestScannerEstimate()
+                    persistDraft()
+                }
+                router.actions.push(scannerStepUrlWithParams('overview', props.id, params))
             },
             discardScannerDraft: () => {
                 // Storage holds one draft, and it belongs to the new-scanner wizard.

--- a/products/replay_vision/frontend/replay_scanners/scannerDraft.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerDraft.ts
@@ -9,20 +9,28 @@ interface StoredScannerDraft {
     teamId: number
     savedAt: number
     scanner: ScannerFormValues
+    sectionSnapshot?: ScannerFormValues | null
 }
 
 export interface ScannerDraft {
     scanner: ScannerFormValues
     savedAt: number
+    /** The config as it stood when the user opened a section from the goal overview, so "Discard changes" survives a reload. */
+    sectionSnapshot: ScannerFormValues | null
 }
 
-export function writeScannerDraft(teamId: number, scanner: ScannerFormValues): number | null {
+export function writeScannerDraft(
+    teamId: number,
+    scanner: ScannerFormValues,
+    sectionSnapshot: ScannerFormValues | null = null
+): number | null {
     const savedAt = Date.now()
     const draft: StoredScannerDraft = {
         version: DRAFT_VERSION,
         teamId,
         savedAt,
         scanner,
+        sectionSnapshot,
     }
     try {
         localStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft))
@@ -48,7 +56,7 @@ export function readScannerDraft(teamId: number): ScannerDraft | null {
         ) {
             return null
         }
-        return { scanner: draft.scanner, savedAt: draft.savedAt }
+        return { scanner: draft.scanner, savedAt: draft.savedAt, sectionSnapshot: draft.sectionSnapshot ?? null }
     } catch {
         return null
     }


### PR DESCRIPTION
## Problem

Someone drafting a scanner through the goal-based flow can click into a section from the overview to change it. Those edits save as they type, so the footer only offered two ways out: keep them, or discard the entire drafted scanner. There was no way to back out of one section's changes.

## Changes

- A "Discard changes" button in the section footer puts the section back the way it was when it was opened, then returns to the overview. It is disabled until something in the section actually changed.
- The footer now reads: "Discard scanner" on the left, "Discard changes" and "Save changes" on the right. The primary button used to say "Back to overview", which read like leaving without keeping the edit.
- The state the section was opened with is stored with the saved draft, so reloading mid-edit keeps the button working.
- Every classifier the agent drafts now ends its category list with "N/A", so a session the dimension doesn't describe has somewhere to land instead of being pushed into the least wrong real category. The draft prompt stops the model from coining its own catch-all.
- The overview's first section is now titled "Agent overview" instead of "What it understood".
- Mechanical: the overview's per-section Edit button now goes through a logic action that takes the snapshot before navigating.

A new Storybook story, `ScannerEditorGoalSectionEdit`, renders the section footer in this state.

A section opened from the overview, with the new **Discard changes** button in the footer:

![Section edit footer with Discard scanner, Discard changes, and Save changes](https://raw.githubusercontent.com/PostHog/pr-assets/a8a42ad052fe2268390a8cf59fccfefa72411d59/2026/09/8b657057-c56d-445b-a71b-b84c1472f15d.png)

The overview it returns to, with the renamed first section:

![Goal overview with the first section titled Agent overview](https://raw.githubusercontent.com/PostHog/pr-assets/c0baabcc3dfda2cba373de7f10fc255e51f2449a/2026/09/bf97ff9b-6a06-47d1-b7ac-22129be70254.png)

## How did you test this code?

Automated (run locally): the Jest suites for `replayScannerLogic` and `scannerDraft`, and the backend `test_scanner_draft` suite (plus the draft and classifier cases in `test_api` and `test_max_tools`). Two new cases cover regressions nothing else caught — discarding restores only the edited section and leaves the rest of the draft alone, and the snapshot survives a remount so the button still works after a reload. A backend case covers the catch-all landing last exactly once, even when the model drafts its own.

Rendered both stories in Storybook with a headless browser — the screenshots above come from that run. The flow was not exercised against a running app,.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (PostHog Desktop). The snapshot lives in `replayScannerLogic` rather than in the component, so both the section edit and the discard stay in kea, and it rides along in the existing localStorage draft record rather than in a second storage key. No confirmation dialog: the button is only enabled when there is something to discard, and its label already says what it does.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*



