### PR TITLE
fix(desktop): hide sandbox prompts from command center

### DIFF
--- a/products/desktop/packages/core/src/command-center/eligibility.test.ts
+++ b/products/desktop/packages/core/src/command-center/eligibility.test.ts
@@ -1,13 +1,17 @@
 import type { Task } from "@posthog/shared/domain-types";
 import { describe, expect, it } from "vitest";
-import { selectAvailableTasks, workspaceIdSet } from "./eligibility";
+import {
+  isSandboxPromptTask,
+  selectAvailableTasks,
+  workspaceIdSet,
+} from "./eligibility";
 
-function makeTask(id: string): Task {
+function makeTask(id: string, title = id): Task {
   return {
     id,
     task_number: 1,
     slug: id,
-    title: id,
+    title,
     description: "",
     created_at: "",
     updated_at: "",
@@ -24,5 +28,26 @@ describe("selectAvailableTasks", () => {
       workspaceIds: workspaceIdSet({ a: {}, b: {}, c: {} }),
     });
     expect(result.map((t) => t.id)).toEqual(["c"]);
+  });
+
+  it("excludes internal sandbox prompt tasks", () => {
+    const sandboxPrompt = makeTask(
+      "sandbox-task",
+      "[sandbox_prompt:repo_selection] Choose a repository",
+    );
+    const visibleTask = makeTask("visible-task", "Fix the login flow");
+
+    const result = selectAvailableTasks([sandboxPrompt, visibleTask], {
+      assignedIds: new Set(),
+      archivedIds: new Set(),
+      workspaceIds: workspaceIdSet({
+        "sandbox-task": {},
+        "visible-task": {},
+      }),
+    });
+
+    expect(result.map((task) => task.id)).toEqual(["visible-task"]);
+    expect(isSandboxPromptTask(sandboxPrompt)).toBe(true);
+    expect(isSandboxPromptTask(visibleTask)).toBe(false);
   });
 });

--- a/products/desktop/packages/core/src/command-center/eligibility.ts
+++ b/products/desktop/packages/core/src/command-center/eligibility.ts
@@ -6,11 +6,17 @@ export interface CellEligibilityInput {
   workspaceIds: { has(id: string): boolean };
 }
 
+export function isSandboxPromptTask(task: Task): boolean {
+  // This prefix is a server-owned wire marker for internal sandbox work.
+  return task.title.startsWith("[sandbox_prompt:");
+}
+
 export function isTaskEligibleForCell(
   task: Task,
   input: CellEligibilityInput,
 ): boolean {
   return (
+    !isSandboxPromptTask(task) &&
     !input.assignedIds.has(task.id) &&
     !input.archivedIds.has(task.id) &&
     input.workspaceIds.has(task.id)

--- a/products/desktop/packages/ui/src/features/command-center/hooks/useAutofillCommandCenter.test.ts
+++ b/products/desktop/packages/ui/src/features/command-center/hooks/useAutofillCommandCenter.test.ts
@@ -352,6 +352,37 @@ describe("useAutofillCommandCenter", () => {
     ]);
   });
 
+  it("removes a persisted sandbox prompt task without refilling the grid", () => {
+    useCommandCenterStore.setState({
+      cells: ["sandbox-task", "existing", null, null],
+      activeTaskId: "sandbox-task",
+      hasAutofilled: true,
+    });
+    setQueries({
+      tasks: [
+        makeTask({
+          id: "sandbox-task",
+          title: "[sandbox_prompt:repo_selection] Choose a repository",
+        }),
+        makeTask({ id: "visible-task" }),
+      ],
+      workspaces: {
+        "sandbox-task": makeWorkspace("sandbox-task"),
+        "visible-task": makeWorkspace("visible-task"),
+      },
+    });
+
+    renderHook(() => useAutofillCommandCenter());
+
+    expect(useCommandCenterStore.getState().cells).toEqual([
+      null,
+      "existing",
+      null,
+      null,
+    ]);
+    expect(useCommandCenterStore.getState().activeTaskId).toBeNull();
+  });
+
   it("marks autofilled when the grid is already full so removals do not refill", () => {
     useCommandCenterStore.setState({ cells: ["a", "b", "c", "d"] });
     setQueries({

--- a/products/desktop/packages/ui/src/features/command-center/hooks/useAutofillCommandCenter.ts
+++ b/products/desktop/packages/ui/src/features/command-center/hooks/useAutofillCommandCenter.ts
@@ -1,5 +1,8 @@
 import { selectAutofillCandidates } from "@posthog/core/command-center/autofill";
-import { workspaceIdSet } from "@posthog/core/command-center/eligibility";
+import {
+  isSandboxPromptTask,
+  workspaceIdSet,
+} from "@posthog/core/command-center/eligibility";
 import { useEffect } from "react";
 import { useArchivedTaskIds } from "../../archive/useArchivedTaskIds";
 import { useTasks } from "../../tasks/useTasks";
@@ -14,16 +17,30 @@ export function useAutofillCommandCenter(): void {
   const cells = useCommandCenterStore((s) => s.cells);
   const hasAutofilled = useCommandCenterStore((s) => s.hasAutofilled);
   const autofillCells = useCommandCenterStore((s) => s.autofillCells);
+  const removeTaskById = useCommandCenterStore((s) => s.removeTaskById);
 
   useEffect(() => {
+    if (!tasksFetched) return;
+
+    const sandboxPromptIds = new Set(
+      tasks.filter(isSandboxPromptTask).map((task) => task.id),
+    );
+    for (const taskId of sandboxPromptIds) {
+      removeTaskById(taskId);
+    }
+
     // One-time bootstrap: the persisted `hasAutofilled` flag stops empty cells
     // from being re-filled every time the Command Center remounts.
     if (hasAutofilled) return;
     if (!workspacesFetched || !workspaces) return;
-    if (!tasksFetched) return;
 
-    const emptySlots = cells.filter((id) => id == null).length;
-    const assignedIds = new Set(cells.filter((id): id is string => id != null));
+    const visibleCells = cells.map((id) =>
+      id && sandboxPromptIds.has(id) ? null : id,
+    );
+    const emptySlots = visibleCells.filter((id) => id == null).length;
+    const assignedIds = new Set(
+      visibleCells.filter((id): id is string => id != null),
+    );
     const candidates = selectAutofillCandidates(tasks, {
       assignedIds,
       archivedIds: archivedTaskIds,
@@ -42,5 +59,6 @@ export function useAutofillCommandCenter(): void {
     tasksFetched,
     archivedTaskIds,
     autofillCells,
+    removeTaskById,
   ]);
 }


### PR DESCRIPTION
## Problem

People monitoring user work in Command Center can see internal sandbox prompt tasks beside the tasks they chose.

These implementation tasks use raw `[sandbox_prompt:…]` titles and can displace useful work in the grid.

## Changes

- Command Center excludes sandbox prompt tasks from its picker and automatic placement.
- Stored grids remove matching tasks after task data loads, without refilling a curated grid.
- Screenshot not included: the change removes an implementation task and adds no new UI state.

## How did you test this code?

- Added core coverage for excluding sandbox prompt tasks from eligible Command Center tasks.
- Added UI coverage for removing a stored sandbox prompt task without refilling the grid.
- Ran the focused core and UI Vitest suites, the desktop type check, the desktop linter, and CI preflight.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs changed. This only filters implementation tasks inside Command Center.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The PostHog Slack app used repository tools and the `/posthog-desktop`, `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, and `/writing-pr-descriptions` skills.

Public artifact check: the test data is invented, and the PR contains no private session material.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1788373103545139?thread_ts=1788373103.545139&cid=C09G8Q32R6F)*
