### PR TITLE
fix(ci): pass jest flags to the selective node run, not test patterns

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -625,9 +625,15 @@ jobs:
                     # related set first and shards that, so the shards stay disjoint.
                     # --passWithNoTests because a shard can legitimately receive nothing once
                     # the set is narrowed; the serial script does not set it itself.
+                    #
+                    # No `--` before the appended flags. pnpm forwards the separator itself into
+                    # the script's argv, and jest reads everything after a `--` as a test path
+                    # pattern, so the flags arrive as patterns that match nothing. The serial lane
+                    # then exits 1 on "No tests found", and the parallel lane exits 0 because its
+                    # script already carries --passWithNoTests, reporting green over an empty run.
                     if [ "$TEST_MODE" = "selective" ]; then
                       # shellcheck disable=SC2086
-                      cd nodejs && pnpm run test:${{ matrix.lane }} -- --passWithNoTests --findRelatedTests $TEST_FILES
+                      cd nodejs && pnpm run test:${{ matrix.lane }} --passWithNoTests --findRelatedTests $TEST_FILES
                     else
                       cd nodejs && pnpm run test:${{ matrix.lane }}
                     fi


### PR DESCRIPTION
## Problem

Anyone opening a Node PR that changes only `nodejs/**` sees three red serial shards and a red `Node.js Tests Pass` gate, and the green parallel lane next to them ran no tests at all.

Both lanes take the same broken command. The selective step appends its flags after a `--`:

```
pnpm run test:serial -- --passWithNoTests --findRelatedTests $TEST_FILES
```

- pnpm forwards that separator into the script's argv, so jest receives a literal `--`.
- jest reads everything after a `--` as a test path pattern.
- `--passWithNoTests`, `--findRelatedTests`, and every changed file arrive as patterns, and match nothing.

The two lanes then fail in opposite directions, because only one script carries `--passWithNoTests` of its own:

| Lane | Script has `--passWithNoTests` | Result |
| --- | --- | --- |
| serial | no | exits 1 on "No tests found" — three red shards |
| parallel | yes | exits 0 over a run that executed no tests |

The parallel half is the worse one. It reports a green required check for zero coverage, so a Node PR in selective mode is not tested by either lane today.

## Changes

- Node PRs run their related tests again, in both lanes, instead of failing on the serial side and passing vacuously on the parallel side.
- The `--` is gone from the selective invocation. pnpm claims neither flag, so both reach jest.
- A comment records why the separator cannot come back.

Everything else in the step is unchanged. jest still resolves the related set before sharding, as the existing comment describes.

> [!WARNING]
> This restores real test execution to the parallel lane. Expect it to surface failures on open PRs that the empty runs were hiding. Those are pre-existing failures, not new ones.

The fix needs nothing new on a branch, so open PRs pick it up without rebasing.

## How did you test this code?

Automated tests only, and CI on this PR does not cover the change.

> [!NOTE]
> The green Node checks here prove nothing about this fix. `ci-nodejs.yml` is in the workflow's own `node_full` list, so changing it forces full mode. This run reports `config_change; running the full jest suite` and takes the `else` branch, never the selective branch this PR edits.

That is structural, not an oversight in this PR: no PR that edits this file can run the selective path, because the `node_full` check precedes the file-list logic. The path is only reachable from a PR that changes `nodejs/**/*.ts` and nothing else, which is why a broken invocation survived here. Verification comes after this lands, on the next Node-source-only PR.

Verified against pnpm 10.29.3, the version pinned in `packageManager`:

<details>
<summary>Argument forwarding, with and without the separator</summary>

A script echoing its arguments, invoked the way the workflow invokes the test scripts:

```
=== with -- (what CI does today) ===
ARG: --config
ARG: j.js
ARG: --shard=1/1
ARG: --testPathIgnorePatterns=a|b
ARG: --
ARG: --passWithNoTests
ARG: --findRelatedTests
ARG: src/x.ts

=== without -- ===
ARG: --config
ARG: j.js
ARG: --shard=1/1
ARG: --testPathIgnorePatterns=a|b
ARG: --passWithNoTests
ARG: --findRelatedTests
ARG: src/x.ts
```

Running the real serial script with the separator reproduces the CI failure:

```
Pattern: --passWithNoTests|--findRelatedTests|src/logs/log-pattern-mask.ts - 0 matches
No tests found, exiting with code 1
```

Without it, jest resolves the related set and shards it, selecting real suites.

</details>

Not run: the selected suites themselves do not pass in this sandbox, because `@posthog/hogvm` is not built here. They fail the same way on an unmodified checkout. `bin/hogli lint:workflows` passes all 8 checks, and `hogli ci:preflight` reports no failures. `actionlint` is not installed in this environment and did not run.

No new tests. The regression this guards against is a workflow argument bug, which the repo has no test surface for.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found by Claude Code while investigating red CI on [#93844](https://github.com/PostHog/posthog/pull/93844). The stack trace surfaced by `--log-failed` pointed at `postgres-parity.test.ts`, which was a later step in the same job and a red herring. The actual failure was the jest argument line above.

Skills invoked: `/authoring-ci-workflows`, `/writing-pr-descriptions`.

The alternative was leaving the `--` and adding `--passWithNoTests` to the serial script. That would have turned the serial lane green while still running nothing, matching the parallel lane's current behavior and hiding the bug rather than fixing it.
