### PR TITLE
fix(oauth): validate token user status on bearer auth paths

### DIFF
--- a/ee/api/agentic_provisioning/authentication.py
+++ b/ee/api/agentic_provisioning/authentication.py
@@ -205,7 +205,7 @@ class ProvisioningBearerAuthentication(BaseAuthentication):
     Raises :class:`ProvisioningError` (rendered in the view's envelope) on failure.
     """
 
-    def authenticate(self, request: Request) -> tuple[User | None, OAuthAccessToken]:
+    def authenticate(self, request: Request) -> tuple[User, OAuthAccessToken]:
         try:
             access_token = resolve_bearer_access_token(request)
         except BearerTokenError as exc:
@@ -223,7 +223,15 @@ class ProvisioningBearerAuthentication(BaseAuthentication):
         if not app.provisioning.can_provision_resources:
             raise ProvisioningError("forbidden", "Resource provisioning not enabled for this partner", status=403)
 
-        return access_token.user, access_token
+        # Deactivating a user drops their login sessions but leaves OAuth tokens intact, so the
+        # token has to fail closed here the way `posthog.auth._validate_token` does for the main
+        # API. A token with no user cannot identify a caller at all, and the views downstream
+        # read `request.user` as a User, so it fails closed too.
+        user = access_token.user
+        if user is None or not user.is_active:
+            raise ProvisioningError("unauthorized", "Authentication failed", status=401)
+
+        return user, access_token
 
     def authenticate_header(self, request: Request) -> str:
         return "Bearer"

--- a/ee/api/agentic_provisioning/test/test_oauth_token.py
+++ b/ee/api/agentic_provisioning/test/test_oauth_token.py
@@ -295,6 +295,16 @@ class TestOAuthTokenExchange(ProvisioningTestBase):
         assert "revoked" in body["error_description"]
         assert OAuthAccessToken.objects.count() == tokens_before
 
+    def test_refresh_rejected_when_user_deactivated(self):
+        first = self._request_bearer_token().json()
+
+        self.user.is_active = False
+        self.user.save()
+
+        res = self._refresh(first["refresh_token"])
+        assert res.status_code == 400
+        assert res.json()["error"] == "invalid_grant"
+
     def test_refresh_allowed_when_token_postdates_session_revoke(self):
         self._stamp_session_revoke(timezone.now() - timedelta(hours=1))
         first = self._request_bearer_token()

--- a/ee/api/agentic_provisioning/test/test_provisioning_auth.py
+++ b/ee/api/agentic_provisioning/test/test_provisioning_auth.py
@@ -273,6 +273,15 @@ class TestProvisioningAuthentication(ProvisioningTestBase):
         res = self._wizard_account_request("req_inactive_pkce", "inactive-pkce@example.com", challenge)
         assert res.status_code == 401
 
+    def test_deactivated_user_bearer_token_rejected(self):
+        token = self._get_bearer_token()
+
+        self.user.is_active = False
+        self.user.save()
+
+        res = self._post_with_bearer("/api/agentic/provisioning/resources", {}, token=token)
+        assert res.status_code == 401
+
     # --- can_provision_resources enforcement ---
 
     def test_partner_without_can_provision_resources_rejected(self):

--- a/ee/api/agentic_provisioning/test/test_resources.py
+++ b/ee/api/agentic_provisioning/test/test_resources.py
@@ -78,6 +78,26 @@ class TestProvisioningResources(ProvisioningTestBase):
         )
         assert res.status_code == 403
 
+    @parameterized.expand(
+        [
+            ("access_control_revoked",),
+            ("org_membership_removed",),
+        ]
+    )
+    def test_get_resource_rejected_after_team_access_lost(self, revocation: str):
+        token = self._get_bearer_token()
+
+        if revocation == "access_control_revoked":
+            self._restrict_team_access(self.team)
+        else:
+            self.organization_membership.delete()
+
+        res = self._get_with_bearer(
+            f"/api/agentic/provisioning/resources/{self.team.id}",
+            token=token,
+        )
+        assert res.status_code == 403
+
     def test_get_resource_invalid_id_returns_400(self):
         token = self._get_bearer_token()
         res = self._get_with_bearer(

--- a/ee/api/agentic_provisioning/test/test_resources.py
+++ b/ee/api/agentic_provisioning/test/test_resources.py
@@ -80,22 +80,25 @@ class TestProvisioningResources(ProvisioningTestBase):
 
     @parameterized.expand(
         [
-            ("access_control_revoked",),
-            ("org_membership_removed",),
+            ("read_access_control_revoked", "read", "access_control"),
+            ("read_org_membership_removed", "read", "membership"),
+            ("create_access_control_revoked", "create", "access_control"),
+            ("create_org_membership_removed", "create", "membership"),
         ]
     )
-    def test_get_resource_rejected_after_team_access_lost(self, revocation: str):
+    def test_resource_endpoints_rejected_after_team_access_lost(self, _name: str, endpoint: str, revocation: str):
         token = self._get_bearer_token()
 
-        if revocation == "access_control_revoked":
+        if revocation == "access_control":
             self._restrict_team_access(self.team)
         else:
             self.organization_membership.delete()
 
-        res = self._get_with_bearer(
-            f"/api/agentic/provisioning/resources/{self.team.id}",
-            token=token,
-        )
+        if endpoint == "read":
+            res = self._get_with_bearer(f"/api/agentic/provisioning/resources/{self.team.id}", token=token)
+        else:
+            res = self._post_with_bearer("/api/agentic/provisioning/resources", {}, token=token)
+
         assert res.status_code == 403
 
     def test_get_resource_invalid_id_returns_400(self):

--- a/ee/api/agentic_provisioning/views/base.py
+++ b/ee/api/agentic_provisioning/views/base.py
@@ -34,6 +34,7 @@ from ee.api.agentic_provisioning.ratelimits import (
 )
 from ee.api.agentic_provisioning.region_proxy import RegionProxyMixin
 from ee.api.agentic_provisioning.serializers import first_error_message
+from ee.api.agentic_provisioning.tokens import user_can_access_team
 
 
 class ProvisioningAPIView(RegionProxyMixin, APIView):
@@ -197,7 +198,17 @@ class BearerResourceAPIView(ProvisioningAPIView):
     region_proxy_strategy = "bearer_lookup"
     authentication_classes = [ProvisioningBearerAuthentication]
 
-    def parse_resource_team_id(self, resource_id: str, access_token: OAuthAccessToken) -> int:
+    def _resolve_scoped_team(self, resource_id: str, access_token: OAuthAccessToken) -> tuple[int, Team | None]:
+        """Resolve the resource id to its team, enforcing the token's scope and live access.
+
+        ``scoped_teams`` is a snapshot taken when the token was minted, so it outlives the
+        access it records. Re-run the check the scope was built from (see
+        ``compute_partner_scoped_teams``), so an org removal or an access-control change
+        applies to the next request instead of waiting for the token to be refreshed.
+
+        Returns the team id even when the team is gone, so the caller decides whether a
+        missing team is a 404 or a no-op.
+        """
         try:
             team_id = int(resource_id)
         except (ValueError, TypeError):
@@ -207,14 +218,21 @@ class BearerResourceAPIView(ProvisioningAPIView):
             raise ProvisioningError(
                 "forbidden", "Resource not accessible with this token", resource_id=resource_id, status=403
             )
-        return team_id
 
-    def get_team(self, team_id: int, resource_id: str) -> Team:
-        try:
-            return Team.objects.get(id=team_id)
-        except Team.DoesNotExist:
-            raise ProvisioningError("not_found", "Resource not found", resource_id=resource_id, status=404)
+        team = Team.objects.select_related("organization").filter(id=team_id).first()
+        # A team that no longer exists has no access left to re-check.
+        if team is not None and (access_token.user is None or not user_can_access_team(access_token.user, team)):
+            raise ProvisioningError(
+                "forbidden", "Resource not accessible with this token", resource_id=resource_id, status=403
+            )
+        return team_id, team
+
+    def parse_resource_team_id(self, resource_id: str, access_token: OAuthAccessToken) -> int:
+        return self._resolve_scoped_team(resource_id, access_token)[0]
 
     def get_scoped_team(self, resource_id: str, access_token: OAuthAccessToken) -> Team:
         """Resolve the resource id to its team, enforcing the token's team scope."""
-        return self.get_team(self.parse_resource_team_id(resource_id, access_token), resource_id)
+        _, team = self._resolve_scoped_team(resource_id, access_token)
+        if team is None:
+            raise ProvisioningError("not_found", "Resource not found", resource_id=resource_id, status=404)
+        return team

--- a/ee/api/agentic_provisioning/views/base.py
+++ b/ee/api/agentic_provisioning/views/base.py
@@ -221,11 +221,21 @@ class BearerResourceAPIView(ProvisioningAPIView):
 
         team = Team.objects.select_related("organization").filter(id=team_id).first()
         # A team that no longer exists has no access left to re-check.
-        if team is not None and (access_token.user is None or not user_can_access_team(access_token.user, team)):
+        if team is not None:
+            self.assert_team_access(team, access_token, resource_id=resource_id)
+        return team_id, team
+
+    def assert_team_access(self, team: Team, access_token: OAuthAccessToken, *, resource_id: str = "") -> None:
+        """Re-check that the token's user can still reach the team.
+
+        Every bearer endpoint that acts on a team calls this, whether it found the team through
+        the request's resource id or through the token's own scope. The scope alone does not
+        answer the question: it records the access the user had when the token was minted.
+        """
+        if access_token.user is None or not user_can_access_team(access_token.user, team):
             raise ProvisioningError(
                 "forbidden", "Resource not accessible with this token", resource_id=resource_id, status=403
             )
-        return team_id, team
 
     def parse_resource_team_id(self, resource_id: str, access_token: OAuthAccessToken) -> int:
         return self._resolve_scoped_team(resource_id, access_token)[0]

--- a/ee/api/agentic_provisioning/views/oauth_token.py
+++ b/ee/api/agentic_provisioning/views/oauth_token.py
@@ -330,6 +330,15 @@ class OAuthTokenView(ProvisioningAPIView):
             user = old_refresh.user
             old_scoped_teams = old_refresh.scoped_teams or []
 
+            # Deactivation drops the user's login sessions but leaves their OAuth tokens
+            # intact, and the team check below answers only about membership and roles, so a
+            # deactivated user still passes it. Without this gate the partner rotates into a
+            # fresh token pair for as long as it keeps refreshing. Checked before any token
+            # row is mutated, like the other fail-closed gates here.
+            if not user.is_active:
+                capture_provisioning_event("token_exchange", "user_inactive", grant_type="refresh_token")
+                raise ProvisioningError("invalid_grant", "User is not active; re-authorize.")
+
             # base_team_id at refresh: the first team in the prior scope. The consent team
             # (authorized at grant time) has the lowest id and sorts first at issuance;
             # partner-provisioned teams are always created later, so they take higher ids

--- a/ee/api/agentic_provisioning/views/resources.py
+++ b/ee/api/agentic_provisioning/views/resources.py
@@ -114,6 +114,9 @@ class ResourcesCreateView(BearerResourceAPIView):
                     "resource_created", "error", partner=app, error_code="team_not_found", team_id=team_id
                 )
                 raise ProvisioningError("team_not_found", "Team not found", resource_id=str(team_id), status=404)
+            # The project_id branch above re-checks access inside resolve_or_create_project_team;
+            # this branch takes the team straight off the token's scope, so it checks here.
+            self.assert_team_access(team, access_token, resource_id=str(team_id))
 
         capture_provisioning_event(
             "resource_created",

--- a/ee/partners/stripe/api/provisioning/authentication.py
+++ b/ee/partners/stripe/api/provisioning/authentication.py
@@ -31,7 +31,7 @@ class StripeBearerAuthentication(BaseAuthentication):
     Raises :class:`SpecError` (rendered in the view's envelope) on failure.
     """
 
-    def authenticate(self, request: Request) -> tuple[User | None, OAuthAccessToken]:
+    def authenticate(self, request: Request) -> tuple[User, OAuthAccessToken]:
         auth_header = request.headers.get("authorization", "")
         if not auth_header.startswith("Bearer "):
             raise SpecError("unauthorized", "Missing bearer token", status=401)
@@ -55,7 +55,15 @@ class StripeBearerAuthentication(BaseAuthentication):
         if app is None or not is_stripe_oauth_app(app):
             raise SpecError("unauthorized", "Authentication failed", status=401)
 
-        return access_token.user, access_token
+        # Deactivating a user drops their login sessions but leaves OAuth tokens intact, so the
+        # token has to fail closed here the way `posthog.auth._validate_token` does for the main
+        # API. A token with no user cannot identify a caller at all, and the views downstream
+        # read `request.user` as a User, so it fails closed too.
+        user = access_token.user
+        if user is None or not user.is_active:
+            raise SpecError("unauthorized", "Authentication failed", status=401)
+
+        return user, access_token
 
     def authenticate_header(self, request: Request) -> str:
         return "Bearer"

--- a/ee/partners/stripe/api/provisioning/test/test_oauth_token.py
+++ b/ee/partners/stripe/api/provisioning/test/test_oauth_token.py
@@ -164,6 +164,16 @@ class TestOAuthToken(StripeProvisioningTestBase):
             "error_description": "Authorization code was not issued for the Stripe Projects app",
         }
 
+    def test_refresh_rejected_when_user_deactivated(self):
+        first = self._request_bearer_token().json()
+
+        self.user.is_active = False
+        self.user.save()
+
+        res = self._post_token({"grant_type": "refresh_token", "refresh_token": first["refresh_token"]})
+        assert res.status_code == 400
+        assert res.json()["error"] == "invalid_grant"
+
     def test_refresh_token_from_non_stripe_app_not_rotatable(self):
         other_app = self._create_other_partner_app()
         refresh_value = generate_random_oauth_refresh_token(None)

--- a/ee/partners/stripe/api/provisioning/test/test_resources.py
+++ b/ee/partners/stripe/api/provisioning/test/test_resources.py
@@ -6,10 +6,14 @@ from django.utils import timezone
 
 from parameterized import parameterized
 
+from posthog.constants import AvailableFeature
 from posthog.models.oauth import OAuthAccessToken
+from posthog.models.organization import OrganizationMembership
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.team.team_provisioning_config import TeamProvisioningConfig
 from posthog.models.utils import generate_random_oauth_access_token
+
+from products.access_control.backend.models.access_control import AccessControl
 
 from ee.partners.stripe.api.provisioning.test.base import BASE_PATH, StripeProvisioningTestBase
 
@@ -47,6 +51,43 @@ class TestResources(StripeProvisioningTestBase):
         assert first.json()["id"] == second.json()["id"]
         # A project_id provisions a dedicated team, distinct from the consent team.
         assert first.json()["id"] != str(self.team.id)
+
+    def test_deactivated_user_bearer_token_rejected(self):
+        token = self._get_bearer_token()
+
+        self.user.is_active = False
+        self.user.save()
+
+        res = self._post_signed_with_bearer(RESOURCES_URL, data={}, token=token)
+        assert res.status_code == 401
+
+    @parameterized.expand(
+        [
+            ("access_control_revoked",),
+            ("org_membership_removed",),
+        ]
+    )
+    def test_get_resource_rejected_after_team_access_lost(self, revocation: str):
+        token = self._get_bearer_token()
+
+        if revocation == "access_control_revoked":
+            self.organization.available_product_features = [
+                {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+            ]
+            self.organization.save()
+            self.organization_membership.level = OrganizationMembership.Level.MEMBER
+            self.organization_membership.save()
+            AccessControl.objects.create(
+                team=self.team,
+                access_level="none",
+                resource="project",
+                resource_id=str(self.team.id),
+            )
+        else:
+            self.organization_membership.delete()
+
+        res = self._get_signed_with_bearer(f"{RESOURCES_URL}/{self.team.id}", token=token)
+        assert res.status_code == 403
 
     def test_unknown_service_rejected(self):
         token = self._get_bearer_token()

--- a/ee/partners/stripe/api/provisioning/test/test_resources.py
+++ b/ee/partners/stripe/api/provisioning/test/test_resources.py
@@ -63,14 +63,16 @@ class TestResources(StripeProvisioningTestBase):
 
     @parameterized.expand(
         [
-            ("access_control_revoked",),
-            ("org_membership_removed",),
+            ("read_access_control_revoked", "read", "access_control"),
+            ("read_org_membership_removed", "read", "membership"),
+            ("create_access_control_revoked", "create", "access_control"),
+            ("create_org_membership_removed", "create", "membership"),
         ]
     )
-    def test_get_resource_rejected_after_team_access_lost(self, revocation: str):
+    def test_resource_endpoints_rejected_after_team_access_lost(self, _name: str, endpoint: str, revocation: str):
         token = self._get_bearer_token()
 
-        if revocation == "access_control_revoked":
+        if revocation == "access_control":
             self.organization.available_product_features = [
                 {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
             ]
@@ -86,7 +88,11 @@ class TestResources(StripeProvisioningTestBase):
         else:
             self.organization_membership.delete()
 
-        res = self._get_signed_with_bearer(f"{RESOURCES_URL}/{self.team.id}", token=token)
+        if endpoint == "read":
+            res = self._get_signed_with_bearer(f"{RESOURCES_URL}/{self.team.id}", token=token)
+        else:
+            res = self._post_signed_with_bearer(RESOURCES_URL, data={}, token=token)
+
         assert res.status_code == 403
 
     def test_unknown_service_rejected(self):

--- a/ee/partners/stripe/api/provisioning/views.py
+++ b/ee/partners/stripe/api/provisioning/views.py
@@ -71,6 +71,7 @@ from ee.partners.stripe.api.provisioning.core import (
     remove_team_from_token_scopes,
     resolve_or_create_project_team,
     set_provisioning_service_id,
+    user_can_access_team,
 )
 from ee.partners.stripe.api.provisioning.exceptions import Envelope, PreRenderedError, SpecError, render_spec_error
 from ee.partners.stripe.api.provisioning.region_proxy import RegionProxyMixin
@@ -485,6 +486,16 @@ class OAuthTokenView(StripeProvisioningAPIView):
             # consent team from the refreshed scope. If the prior token was somehow empty-
             # scoped, fall back to zero so the helper short-circuits without claiming a team.
             base_team_id = old_scoped_teams[0] if old_scoped_teams else 0
+
+            # Deactivation drops the user's login sessions but leaves their OAuth tokens
+            # intact, and the team check below answers only about membership and roles, so a
+            # deactivated user still passes it. Without this gate the partner rotates into a
+            # fresh token pair for as long as it keeps refreshing. Checked before any token
+            # row is mutated, like the other fail-closed gates here.
+            if not user.is_active:
+                capture_provisioning_event("token_exchange", "user_inactive", grant_type="refresh_token")
+                raise SpecError("invalid_grant", "User is not active; re-authorize.")
+
             scoped_teams = compute_partner_scoped_teams(oauth_app, user, base_team_id)
             # Same fail-closed rule as issuance: an empty scoped_teams is unrestricted under the
             # standard permission check, so a refresh whose base team vanished or whose access was
@@ -575,12 +586,17 @@ class StripeResourceAPIView(SignatureCheckedMixin, StripeProvisioningAPIView):
         except (ValueError, TypeError):
             raise SpecError("invalid_resource_id", "Invalid resource ID", resource_id=resource_id)
 
-        # TODO: latent bug - this checks only the token's issuance-time scoped_teams,
-        # not the user's current team-level access. If the user is later removed from
-        # the team/org, the (long-lived) bearer can still read/rotate/update/remove
-        # the resource until it is refreshed (refresh re-derives scope via
-        # compute_partner_scoped_teams). Revalidate live access here to close it.
         if team_id not in (access_token.scoped_teams or []):
+            raise SpecError("forbidden", "Resource not accessible with this token", resource_id=resource_id, status=403)
+
+        # `scoped_teams` is a snapshot taken when the token was minted, and tokens here last a
+        # year, so it outlives the access it records by a long way. Re-run the check the scope
+        # was built from (see `compute_partner_scoped_teams`), so an org removal or an
+        # access-control change applies to the next request instead of waiting for a refresh.
+        # A team that no longer exists has no access left to re-check; `get_team` decides what
+        # a missing team means for each endpoint.
+        team = Team.objects.select_related("organization").filter(id=team_id).first()
+        if team is not None and (access_token.user is None or not user_can_access_team(access_token.user, team)):
             raise SpecError("forbidden", "Resource not accessible with this token", resource_id=resource_id, status=403)
         return team_id
 

--- a/ee/partners/stripe/api/provisioning/views.py
+++ b/ee/partners/stripe/api/provisioning/views.py
@@ -589,16 +589,25 @@ class StripeResourceAPIView(SignatureCheckedMixin, StripeProvisioningAPIView):
         if team_id not in (access_token.scoped_teams or []):
             raise SpecError("forbidden", "Resource not accessible with this token", resource_id=resource_id, status=403)
 
-        # `scoped_teams` is a snapshot taken when the token was minted, and tokens here last a
-        # year, so it outlives the access it records by a long way. Re-run the check the scope
-        # was built from (see `compute_partner_scoped_teams`), so an org removal or an
-        # access-control change applies to the next request instead of waiting for a refresh.
         # A team that no longer exists has no access left to re-check; `get_team` decides what
         # a missing team means for each endpoint.
         team = Team.objects.select_related("organization").filter(id=team_id).first()
-        if team is not None and (access_token.user is None or not user_can_access_team(access_token.user, team)):
-            raise SpecError("forbidden", "Resource not accessible with this token", resource_id=resource_id, status=403)
+        if team is not None:
+            self.assert_team_access(team, access_token, resource_id=resource_id)
         return team_id
+
+    def assert_team_access(self, team: Team, access_token: OAuthAccessToken, *, resource_id: str = "") -> None:
+        """Re-check that the token's user can still reach the team.
+
+        Every bearer endpoint that acts on a team calls this, whether it found the team through
+        the request's resource id or through the token's own scope. `scoped_teams` is a snapshot
+        taken when the token was minted, and tokens here last a year, so it outlives the access
+        it records by a long way. Re-running the check the scope was built from (see
+        `compute_partner_scoped_teams`) makes an org removal or an access-control change apply
+        to the next request instead of waiting for a refresh.
+        """
+        if access_token.user is None or not user_can_access_team(access_token.user, team):
+            raise SpecError("forbidden", "Resource not accessible with this token", resource_id=resource_id, status=403)
 
     def get_team(self, team_id: int, resource_id: str) -> Team:
         try:
@@ -662,6 +671,9 @@ class ResourcesCreateView(StripeResourceAPIView):
                     "resource_created", "error", partner=app, error_code="team_not_found", team_id=team_id
                 )
                 raise SpecError("team_not_found", "Team not found", resource_id=str(team_id), status=404)
+            # The project_id branch above re-checks access inside resolve_or_create_project_team;
+            # this branch takes the team straight off the token's scope, so it checks here.
+            self.assert_team_access(team, access_token, resource_id=str(team_id))
 
         # TODO: latent bug - this runs on every call, so a repeated create for
         # an existing team overwrites its service_id (not idempotent), and the

--- a/posthog/api/oauth/test_views.py
+++ b/posthog/api/oauth/test_views.py
@@ -3975,6 +3975,41 @@ class TestOAuthAPI(APIBaseTest):
         data = response.json()
         self.assertFalse(data["active"])
 
+    @parameterized.expand(
+        [
+            ("access_token_deactivated_user", "access_token", "deactivated", False),
+            ("refresh_token_deactivated_user", "refresh_token", "deactivated", False),
+            # Client-credentials grants have no resource owner, so a userless access
+            # token must stay introspectable. OAuthRefreshToken.user is not nullable.
+            ("access_token_without_user", "access_token", "userless", True),
+        ]
+    )
+    def test_introspection_reflects_token_user_status(
+        self, _name: str, token_type: str, user_state: str, expected_active: bool
+    ):
+        access_token, refresh_token = self._create_access_and_refresh_tokens()
+        token = access_token if token_type == "access_token" else refresh_token
+
+        if user_state == "deactivated":
+            self.user.is_active = False
+            self.user.save()
+        else:
+            access_token.user = None
+            access_token.save()
+
+        response = self.post(
+            "/oauth/introspect/",
+            {"token": token.token},
+            headers={
+                "Authorization": self.get_basic_auth_header(
+                    "test_confidential_client_id", "test_confidential_client_secret"
+                )
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["active"], expected_active)
+
     def test_self_introspection_with_revoked_token_fails(self):
         """A revoked (deleted) token cannot self-introspect."""
         access_token, _ = self._create_access_and_refresh_tokens(scopes="openid")

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -1985,6 +1985,20 @@ class ConfidentialClientOnlyOAuthValidator(OAuthValidator):
         return getattr(request.client, "client_type", None) == AbstractApplication.CLIENT_CONFIDENTIAL
 
 
+def _token_user_is_active(token: OAuthAccessToken | OAuthRefreshToken) -> bool:
+    """Whether the token's resource owner can still act.
+
+    Deactivating a user drops their login sessions but leaves their OAuth tokens intact, so a
+    token minted before the deactivation stays usable until it expires. Callers that authorize
+    on this response rather than merely describe a token - the Streamlit proxy is one - would
+    otherwise keep letting a deactivated user in for the rest of the token's life.
+
+    A token with no user is a client-credentials grant, which has no resource owner to check.
+    """
+    user = token.user
+    return user is None or user.is_active
+
+
 @method_decorator(csrf_exempt, name="dispatch")
 @method_decorator(login_not_required, name="dispatch")
 class OAuthIntrospectTokenView(ClientProtectedScopedResourceView):
@@ -2124,6 +2138,8 @@ class OAuthIntrospectTokenView(ClientProtectedScopedResourceView):
             # RFC 7662 Section 2.2: expired tokens MUST return {"active": false}
             if not access_token.is_valid():
                 return JsonResponse({"active": False}, status=200)
+            if not _token_user_is_active(access_token):
+                return JsonResponse({"active": False}, status=200)
             data = {
                 "active": True,
                 "token_type": "access_token",
@@ -2146,6 +2162,8 @@ class OAuthIntrospectTokenView(ClientProtectedScopedResourceView):
 
         if refresh_token:
             if credential_client_id and getattr(refresh_token.application, "client_id", None) != credential_client_id:
+                return JsonResponse({"active": False}, status=200)
+            if not _token_user_is_active(refresh_token):
                 return JsonResponse({"active": False}, status=200)
             # Refresh tokens lack scope and exp fields on AbstractRefreshToken,
             # so we only return the fields that are available

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -1985,20 +1985,6 @@ class ConfidentialClientOnlyOAuthValidator(OAuthValidator):
         return getattr(request.client, "client_type", None) == AbstractApplication.CLIENT_CONFIDENTIAL
 
 
-def _token_user_is_active(token: OAuthAccessToken | OAuthRefreshToken) -> bool:
-    """Whether the token's resource owner can still act.
-
-    Deactivating a user drops their login sessions but leaves their OAuth tokens intact, so a
-    token minted before the deactivation stays usable until it expires. Callers that authorize
-    on this response rather than merely describe a token - the Streamlit proxy is one - would
-    otherwise keep letting a deactivated user in for the rest of the token's life.
-
-    A token with no user is a client-credentials grant, which has no resource owner to check.
-    """
-    user = token.user
-    return user is None or user.is_active
-
-
 @method_decorator(csrf_exempt, name="dispatch")
 @method_decorator(login_not_required, name="dispatch")
 class OAuthIntrospectTokenView(ClientProtectedScopedResourceView):
@@ -2138,7 +2124,11 @@ class OAuthIntrospectTokenView(ClientProtectedScopedResourceView):
             # RFC 7662 Section 2.2: expired tokens MUST return {"active": false}
             if not access_token.is_valid():
                 return JsonResponse({"active": False}, status=200)
-            if not _token_user_is_active(access_token):
+            # Deactivating a user drops their login sessions but leaves their OAuth tokens
+            # intact, and callers that authorize on this response rather than merely describe a
+            # token (the Streamlit proxy is one) would keep letting them in until it expires.
+            # `user` is null for a client-credentials grant, which has no resource owner.
+            if access_token.user is not None and not access_token.user.is_active:
                 return JsonResponse({"active": False}, status=200)
             data = {
                 "active": True,
@@ -2163,7 +2153,7 @@ class OAuthIntrospectTokenView(ClientProtectedScopedResourceView):
         if refresh_token:
             if credential_client_id and getattr(refresh_token.application, "client_id", None) != credential_client_id:
                 return JsonResponse({"active": False}, status=200)
-            if not _token_user_is_active(refresh_token):
+            if not refresh_token.user.is_active:
                 return JsonResponse({"active": False}, status=200)
             # Refresh tokens lack scope and exp fields on AbstractRefreshToken,
             # so we only return the fields that are available


### PR DESCRIPTION
## Problem

- A partner integration keeps reaching a project after the user behind it loses access, until the token expires.
- Deactivating a user deletes their login sessions and leaves their OAuth tokens untouched, so each auth path has to make that check itself.
- The main API does: `posthog/auth.py` rejects a token whose user is inactive. The provisioning bearer paths and token introspection do not.
- A token's `scoped_teams` is a snapshot from mint time. The resource endpoints trust it for the life of the token, and Stripe partner tokens last a year.
- Refresh does not correct either gap. It re-derives scope through `UserAccessControl`, which answers about membership and roles, not about `is_active`.

## Changes

- A partner loses access to a project on the next request after the user loses it, rather than at the next token refresh.
- The resource endpoints re-run `user_can_access_team` per request instead of trusting the token's stored scope.
- The create endpoint gets that check too. It reads the team straight off the token's scope, so it does not pass through the resource id path the other endpoints use.
- Provisioning bearer auth rejects a token whose user is inactive or absent, matching `posthog/auth.py`.
- Refresh rejects an inactive user before it mutates any token row, alongside the existing fail-closed gates.
- Token introspection reports `active: false` when the token's resource owner is inactive. Userless client-credentials tokens keep reporting active, because they have no resource owner.
- The Stripe partner surface carries its own copy of these endpoints and gets the same changes. That replaces a `TODO` comment which named the stale-scope half.
- Mechanical: both surfaces gain a named `assert_team_access` helper, so the check has one greppable name rather than a condition repeated per endpoint. `BearerResourceAPIView.get_team` is gone, since `get_scoped_team` now resolves the team itself.

> [!WARNING]
> Removing a resource now returns 403 once the user loses access to that team, where it used to succeed. A `TeamProvisioningConfig` row for such a team stays until someone clears it. Removing a resource whose team was deleted still works.

Nothing a user sees changes in the UI. The affected surfaces are partner APIs and the Streamlit iframe proxy.

## How did you test this code?

Every test below failed before the fix and passes after.

- Bearer auth: a token for a deactivated user reached the provisioning endpoints. Covers both surfaces.
- Resource scope: a token reached its team after the user lost access, through the read endpoint and through the create endpoint, and for two revocations - a project access control set to `none`, and org membership deleted. Covers both surfaces.
- Refresh: a deactivated user's refresh token minted a fresh token pair. Covers both surfaces.
- Introspection: a token for a deactivated user reported `active: true`. A third case guards the opposite direction, so a userless client-credentials token cannot be broken by this check.

Not checked: the Streamlit auth proxy end to end. It runs inside a sandbox image and is covered here only through the introspection response it reads. Its revocation window is now the proxy's 60 second introspection cache.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow or API contract changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code ([session](https://claude.ai/code/session_01BRqvVoMMSCGqTGPNKCnJBx)). Skills invoked: `/triage-vuln`, `/writing-tests`, `/writing-pr-descriptions`.

The work started on the agentic provisioning surface alone and widened twice. `UserAccessControl` holds no reference to `is_active`, so the refresh path could not close the deactivation case on its own and needed its own gate. The Stripe partner surface then turned out to hold a second copy of the same endpoints, on year-long tokens.

The first round of this PR put the team access check only on the path that resolves a team from the request's resource id. Review caught that the create endpoint reads the team from the token's scope instead and so skipped it. The check now sits behind a shared helper both paths call.

Two paths were left alone on purpose. The authorization code exchange still mints for a deactivated user, because the bearer check now makes that token unusable at the point of use. `DeepLinksView` reads the token's scope directly, but only to build a `/project/<id>` redirect, and the session it mints is the user's own, so app-level access control gates it.

Follow-up worth doing separately: route every bearer endpoint's team resolution through one resolver, so the check cannot be skipped by adding an endpoint rather than by forgetting a call.

Public artifact: nothing here draws on a customer conversation, ticket, or log. Every test builds its own fixtures through the existing test bases.
