### PR TITLE
feat(desktop): show coming soon MCP servers

### DIFF
--- a/products/desktop/packages/api-client/src/generated.ts
+++ b/products/desktop/packages/api-client/src/generated.ts
@@ -15162,6 +15162,7 @@ export namespace Schemas {
          */
         icon_domain: string;
         category?: MCPServerCategoryEnum | undefined;
+        is_coming_soon?: boolean | undefined;
     };
     /**
      * A conversion goal counted from an action.

--- a/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayServersHome.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayServersHome.tsx
@@ -395,9 +395,11 @@ function RecommendedTemplateCard({
   connecting: boolean;
   onConnect: () => void;
 }) {
+  const comingSoon = template.is_coming_soon === true;
+
   return (
     <div
-      className={`relative rounded-md border border-gray-5 bg-gray-2 ${disabled ? "opacity-60" : ""}`}
+      className={`relative rounded-md border border-gray-5 bg-gray-2 ${disabled || comingSoon ? "opacity-60" : ""}`}
     >
       <div className="grid w-full grid-cols-[36px_1fr] items-center gap-3 rounded-md p-4 pr-[132px]">
         <ServerIcon
@@ -415,6 +417,11 @@ function RecommendedTemplateCard({
                 Off
               </Badge>
             )}
+            {comingSoon && (
+              <Badge color="gray" variant="soft" size="1">
+                Coming soon
+              </Badge>
+            )}
           </Flex>
           <Text
             color="gray"
@@ -427,7 +434,7 @@ function RecommendedTemplateCard({
           >
             {template.description || template.url}
           </Text>
-          {disabled && (
+          {disabled && !comingSoon && (
             <Text color="gray" className="text-xs">
               Disabled — enable it in Team settings
             </Text>
@@ -435,7 +442,11 @@ function RecommendedTemplateCard({
         </Flex>
       </div>
       <div className="absolute top-4 right-4">
-        {disabled ? null : connecting ? (
+        {comingSoon ? (
+          <Button variant="soft" color="gray" size="1" disabled>
+            Coming soon
+          </Button>
+        ) : disabled ? null : connecting ? (
           <Button variant="solid" size="1" disabled>
             <Spinner size="1" /> Authorizing…
           </Button>

--- a/products/desktop/packages/ui/src/features/mcp-servers/components/parts/ServerCard.test.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-servers/components/parts/ServerCard.test.tsx
@@ -1,0 +1,39 @@
+import type { McpRecommendedServer } from "@posthog/api-client/posthog-client";
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { expect, it, vi } from "vitest";
+import { ServerCard } from "./ServerCard";
+
+vi.mock("./icons", () => ({
+  ServerIcon: () => <div aria-hidden="true" />,
+}));
+
+it("shows a coming-soon server without allowing connection", async () => {
+  const user = userEvent.setup();
+  const onConnect = vi.fn();
+  const server = {
+    id: "slack",
+    name: "Slack",
+    url: "https://mcp.slack.com/mcp",
+    icon_domain: "slack.com",
+    is_coming_soon: true,
+  } as McpRecommendedServer;
+
+  render(
+    <Theme>
+      <ServerCard
+        server={server}
+        installed={false}
+        isInstalling={false}
+        onOpen={vi.fn()}
+        onConnect={onConnect}
+      />
+    </Theme>,
+  );
+
+  const button = screen.getByRole("button", { name: "Coming soon" });
+  expect(button).toBeDisabled();
+  await user.click(button);
+  expect(onConnect).not.toHaveBeenCalled();
+});

--- a/products/desktop/packages/ui/src/features/mcp-servers/components/parts/ServerCard.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-servers/components/parts/ServerCard.tsx
@@ -24,6 +24,7 @@ export function ServerCard({
   const categoryLabel = MCP_CATEGORIES.find(
     (c) => c.id === server.category,
   )?.label;
+  const comingSoon = server.is_coming_soon === true;
 
   return (
     <div className="group relative rounded-md border border-gray-5 bg-gray-2 transition-colors hover:border-gray-7 hover:bg-gray-3">
@@ -49,6 +50,11 @@ export function ServerCard({
                   weight="fill"
                   className="shrink-0 text-green-10"
                 />
+              )}
+              {comingSoon && (
+                <Badge color="gray" variant="soft" size="1">
+                  Coming soon
+                </Badge>
               )}
             </Flex>
             {server.description && (
@@ -92,10 +98,10 @@ export function ServerCard({
             variant="solid"
             size="1"
             onClick={onConnect}
-            disabled={isInstalling}
+            disabled={isInstalling || comingSoon}
           >
             {isInstalling ? <Spinner size="1" /> : null}
-            Connect
+            {comingSoon ? "Coming soon" : "Connect"}
           </Button>
         )}
       </div>

--- a/products/desktop/packages/ui/src/features/mcp-servers/components/parts/ServerDetailView.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-servers/components/parts/ServerDetailView.tsx
@@ -125,6 +125,11 @@ export function ServerDetailView({
                 {statusLabel}
               </Badge>
             )}
+            {template?.is_coming_soon && (
+              <Badge color="gray" variant="soft">
+                Coming soon
+              </Badge>
+            )}
           </Flex>
           {description && (
             <Text color="gray" className="text-sm">
@@ -169,14 +174,14 @@ export function ServerDetailView({
                 variant="solid"
                 size="2"
                 onClick={onConnect}
-                disabled={isInstalling}
+                disabled={isInstalling || template?.is_coming_soon}
               >
                 {isInstalling ? (
                   <Spinner size="1" />
                 ) : (
                   <DownloadSimple size={12} />
                 )}
-                Connect
+                {template?.is_coming_soon ? "Coming soon" : "Connect"}
               </Button>
             )}
             {installation && (


### PR DESCRIPTION
## Problem

Desktop should show planned MCP integrations without offering a connection that the backend will reject.

## Changes

- Coming-soon servers display a badge and disabled action in the marketplace, details view, and gateway.
- The generated Desktop API client includes the catalog availability field.

Refs #93867

## How did you test this code?

Added a component test confirming the Coming soon action is disabled and cannot start a connection.

The Desktop API client and UI packages typecheck successfully.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The preceding stack layer documents the shared coming-soon behavior. No additional Desktop documentation is needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Desktop Codex implemented this with /posthog-desktop, /writing-ui-components, /writing-user-facing-copy, /writing-tests, and /writing-pr-descriptions.

This is separate from the backend layer because Desktop ships on an independent release schedule.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
