### PR TITLE
feat(signals): route eval-report signal summaries through the ai-gateway

### DIFF
--- a/posthog/temporal/ai_observability/eval_reports/emit_signal.py
+++ b/posthog/temporal/ai_observability/eval_reports/emit_signal.py
@@ -130,7 +130,12 @@ def _build_eval_report_signal_prompt(inputs: EmitEvalReportSignalInputs, content
 async def summarize_report_for_signal(
     inputs: EmitEvalReportSignalInputs, content: dict[str, Any]
 ) -> EvalReportSignalSummary:
-    """Use the signals LLM to produce a signal-sized summary of a report run."""
+    """Use the signals LLM to produce a signal-sized summary of a report run.
+
+    `ai_product` is the Go-gateway opt-in. A call without it routes to the legacy Python
+    gateway under the bare `signals` slug. This tag stays separate from the report agent's
+    `aio_eval_reports`: a budget denial on one must not stop the other.
+    """
     user_prompt = _build_eval_report_signal_prompt(inputs, content)
 
     def validate(text: str) -> EvalReportSignalSummary:
@@ -144,6 +149,7 @@ async def summarize_report_for_signal(
         validate=validate,
         thinking=True,
         stage="eval_report_signal_summary",
+        ai_product="aio_eval_reports_for_signals",
     )
 
 

--- a/posthog/temporal/ai_observability/eval_reports/test/test_emit_signal.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_emit_signal.py
@@ -12,6 +12,7 @@ from posthog.temporal.ai_observability.eval_reports.emit_signal import (
     EvalReportSignalSummary,
     _build_eval_report_signal_prompt,
     emit_eval_report_signal_activity,
+    summarize_report_for_signal,
 )
 
 from products.signals.backend.models import SignalSourceConfig
@@ -123,6 +124,23 @@ async def _setup_org_not_ai_approved(ateam):
         source_type=SignalSourceConfig.SourceType.EVALUATION_REPORT,
         enabled=True,
     )
+
+
+# `ai_product` is the Go-gateway opt-in. Dropping it reverts this site to the Python gateway
+# and unattributes its spend, with no call failing to show it.
+@pytest.mark.asyncio
+async def test_eval_report_summary_opts_in_as_aio_eval_reports_for_signals():
+    summary = EvalReportSignalSummary(title="Pass rate dropped", description="d", significance=0.5)
+    with patch(
+        "posthog.temporal.ai_observability.eval_reports.emit_signal.call_llm",
+        new=AsyncMock(return_value=summary),
+    ) as summary_call:
+        result = await summarize_report_for_signal(_make_inputs(team_id=1), _make_content())
+
+    assert result is summary
+    kwargs = summary_call.call_args.kwargs
+    assert kwargs["ai_product"] == "aio_eval_reports_for_signals"
+    assert kwargs["stage"] == "eval_report_signal_summary"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Eval-report signal summaries are the one in-process signals stage still running on the legacy Python gateway, untagged, under the broad `signals` slug. Every other in-process stage moved already.

## Changes

Opts the eval-report emitter in to the Go gateway.

- `summarize_report_for_signal` now passes **`ai_product="aio_eval_reports_for_signals"`**. That argument is the **routing switch** in the signals LLM helper: a call without it stays on the legacy path, with no failure to notice.
- The tag sits in the AI observability namespace, matching where the work happens: the emitter runs on the LLMA worker and reads the LLMA report model, and only its terminal call crosses into Signals. It stays separate from the report agent's `aio_eval_reports` and from `signals_eval`, the offline eval-fixture generator's tag, because the gateway meters **admission budgets per product** and a denial on one must not stop the others.
- One test pins the product and stage on the call.

No config change: the workers already carry `AI_GATEWAY_URL` and `AI_GATEWAY_API_KEY`. The new product has **no daily budget** on the gateway yet, so it runs under the team caps until one is set.

## How did you test this code?

`posthog/temporal/ai_observability/eval_reports/test/test_emit_signal.py` and `products/signals/backend/test/test_llm.py` locally. The new test fails with an assertion error when the tag is changed to the sibling `aio_eval_reports`, so it pins the exact product and not merely its presence. Not run: the database-backed activity tests in the same module.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Claude Opus 5) authored this under direction; requires human review.

