### PR TITLE
fix(retention): age events out on the 1st of the month

### DIFF
--- a/frontend/src/scenes/insights/dataRetention/exceedsRetention.test.ts
+++ b/frontend/src/scenes/insights/dataRetention/exceedsRetention.test.ts
@@ -37,6 +37,24 @@ describe('exceedsRetention', () => {
             false,
         ],
         ['a resolved range past the window warns', insightViz('-3y'), undefined, '2023-06-15', RETENTION_MONTHS, true],
+        // The floor sits on the 1st of the month: 2025-06-10 is inside the window on 2026-06-15 even though it is
+        // more than 12 months old.
+        [
+            'a resolved range after the 1st of the boundary month is fine',
+            insightViz('-13m'),
+            undefined,
+            '2025-06-10',
+            RETENTION_MONTHS,
+            false,
+        ],
+        [
+            'a resolved range before the boundary month warns',
+            insightViz('-13m'),
+            undefined,
+            '2025-05-20',
+            RETENTION_MONTHS,
+            true,
+        ],
         ['no resolved range yet stays quiet', insightViz('-3y'), undefined, undefined, RETENTION_MONTHS, false],
         // "All time" resolves to the earliest event the floored query can see, so the resolved range never reaches
         // past the window; the requested range has to carry the warning.

--- a/frontend/src/scenes/insights/dataRetention/exceedsRetention.ts
+++ b/frontend/src/scenes/insights/dataRetention/exceedsRetention.ts
@@ -48,5 +48,6 @@ export function exceedsRetention({
     if (!resolvedDateFrom) {
         return false
     }
-    return dayjs(resolvedDateFrom).isBefore(dayjs().subtract(retentionMonths, 'month'))
+    // The query floor sits on the 1st of the month, so data ages out on the 1st, not on the day of its timestamp.
+    return dayjs(resolvedDateFrom).isBefore(dayjs().startOf('month').subtract(retentionMonths, 'month'))
 }

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -69,19 +69,21 @@ def team_id_guard_for_table(table_type: ast.TableOrSelectType, context: HogQLCon
 
 
 def retention_floor_for_table(table_type: ast.TableOrSelectType, retention_months: int) -> ast.Expr:
-    """Floor an events-table scan to ``timestamp > now() - toIntervalMonth(retention_months)``.
+    """Floor an events-table scan to ``timestamp >= toStartOfMonth(now()) - toIntervalMonth(retention_months)``.
 
     Sibling to ``team_id_guard_for_table``: a mandatory, context-derived guard added at the lowest level on the
     events table, so the events-data-retention cap can't be bypassed by query-supplied date filters or modifiers.
-    Uses a calendar-month interval so the boundary lands on the exact date (no leap-year / 365-day drift).
+    The floor sits on the 1st of a month so data ages out on the 1st of the month after the window, which keeps
+    month-over-month and year-over-year comparisons whole. ``now()`` carries the project timezone, so the 1st is the
+    customer's 1st.
     """
     field_table_type = _table_filter_type(table_type)
     return ast.CompareOperation(
-        op=ast.CompareOperationOp.Gt,
+        op=ast.CompareOperationOp.GtEq,
         left=ast.Field(chain=["timestamp"], type=ast.FieldType(name="timestamp", table_type=field_table_type)),
         right=ast.ArithmeticOperation(
             op=ast.ArithmeticOperationOp.Sub,
-            left=ast.Call(name="now", args=[]),
+            left=ast.Call(name="toStartOfMonth", args=[ast.Call(name="now", args=[])]),
             right=ast.Call(name="toIntervalMonth", args=[ast.Constant(value=retention_months)]),
         ),
         type=ast.BooleanType(),

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -260,7 +260,7 @@ class TestPrinter(BaseTest):
         context = HogQLContext(team_id=self.team.pk, team=self.team, enable_select_queries=True)
         sql = self._select("select count() from events", context=context)
         assert f"toIntervalMonth({months})" in sql
-        assert "greater(events.timestamp, minus(now" in sql
+        assert "greaterOrEquals(events.timestamp, minus(toStartOfMonth(now" in sql
 
     @override_settings(EVENTS_DATA_RETENTION_ENFORCED=False)
     def test_events_retention_floor_not_applied_when_disabled(self):
@@ -275,7 +275,7 @@ class TestPrinter(BaseTest):
         self.team.event_retention_months = 12
         context = HogQLContext(team_id=self.team.pk, team=self.team, enable_select_queries=True)
         sql = self._select("select count() from persons", context=context)
-        assert "greater(events.timestamp, minus(now" not in sql
+        assert "greaterOrEquals(events.timestamp, minus(toStartOfMonth(now" not in sql
         assert "toIntervalMonth(12)" not in sql
 
     @override_settings(EVENTS_DATA_RETENTION_ENFORCED=True)

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -148,7 +148,7 @@ from posthog.hogql_queries.validation.validation import (
 from posthog.models import Team, User
 from posthog.models.instance_setting import get_instance_setting
 from posthog.models.team import WeekStartDay
-from posthog.models.team.event_retention import events_retention_months_for_team
+from posthog.models.team.event_retention import events_retention_floor_date, events_retention_months_for_team
 from posthog.query_cache import QueryCache, count_query_cache_hit, retention_ttl
 from posthog.query_cache.failures import (
     BUDGET_EXTENDED,
@@ -2623,7 +2623,9 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         # retention. Only set when enforced, so non-cohort teams' keys are unchanged.
         retention_months = events_retention_months_for_team(self.team, self.team.pk)
         if retention_months is not None:
-            payload["events_retention_floor_months"] = retention_months
+            payload["events_retention_floor_from"] = events_retention_floor_date(
+                self.team, retention_months
+            ).isoformat()
 
         return payload
 

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -496,6 +496,23 @@ class TestQueryRunner(BaseTest):
         cache_key = runner.get_cache_key()
         assert cache_key == "cache_42_c034c5f92d23cb2399f6c087694175b7e6950739ea60b0ec7cf2665d2ae82d50"
 
+    @override_settings(EVENTS_DATA_RETENTION_ENFORCED=True)
+    def test_cache_key_rolls_over_when_the_retention_floor_moves(self):
+        TestQueryRunner = self.setup_test_query_runner_class()
+        self.team.event_retention_months = 12
+        self.team.save()
+        runner = TestQueryRunner(query={"some_attr": "bla"}, team=self.team)
+
+        with freeze_time("2026-09-02"):
+            early_in_month = runner.get_cache_key()
+        with freeze_time("2026-09-20"):
+            later_in_month = runner.get_cache_key()
+        with freeze_time("2026-10-01"):
+            next_month = runner.get_cache_key()
+
+        assert early_in_month == later_in_month
+        assert next_month != early_in_month
+
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=False, PERSON_ON_EVENTS_V2_OVERRIDE=False)
     def test_cache_key_runner_subclass(self):
         TestQueryRunner = self.setup_test_query_runner_class()

--- a/posthog/models/team/event_retention.py
+++ b/posthog/models/team/event_retention.py
@@ -1,8 +1,12 @@
+from datetime import date, datetime
 from typing import TYPE_CHECKING, Optional
+from zoneinfo import ZoneInfo
 
 from django.conf import settings
+from django.utils import timezone
 
 import posthoganalytics
+from dateutil.relativedelta import relativedelta
 
 from posthog.cloud_utils import is_cloud
 from posthog.constants import AvailableFeature
@@ -98,6 +102,22 @@ def organization_events_retention_months(organization: "Organization") -> int:
     return parse_events_feature_to_months(organization.get_available_feature(EVENTS_DATA_RETENTION_FEATURE))
 
 
+def events_retention_floor_date(team: Team, retention_months: int) -> date:
+    """The first day the floor keeps: the 1st of the current month in the project timezone, minus the window.
+
+    Mirrors the ``toStartOfMonth(now()) - toIntervalMonth(N)`` predicate the printer injects, so a cache key built
+    from it rolls over on the same day the query's floor moves.
+    """
+    today = datetime.now(ZoneInfo(team.timezone)).date()
+    return today.replace(day=1) - relativedelta(months=retention_months)
+
+
+def shrinks_apply_today() -> bool:
+    # Hidden data may only appear on the 1st of a month, so a shorter window waits for the next 1st. The nightly
+    # sync runs every day and applies it then; longer windows never wait.
+    return timezone.now().day == 1
+
+
 def reconcile_organization_events_retention(organization: "Organization") -> int:
     """Align the org's teams with its entitlement-derived retention window; returns teams updated.
 
@@ -105,8 +125,7 @@ def reconcile_organization_events_retention(organization: "Organization") -> int
     """
     organization.refresh_from_db(fields=["available_product_features"])
     target_months = organization_events_retention_months(organization)
-    return (
-        Team.objects.filter(organization=organization)
-        .exclude(event_retention_months=target_months)
-        .update(event_retention_months=target_months)
-    )
+    teams = Team.objects.filter(organization=organization).exclude(event_retention_months=target_months)
+    if not shrinks_apply_today():
+        teams = teams.filter(event_retention_months__lt=target_months)
+    return teams.update(event_retention_months=target_months)

--- a/posthog/models/team/test/test_event_retention.py
+++ b/posthog/models/team/test/test_event_retention.py
@@ -1,5 +1,6 @@
 from typing import cast
 
+from freezegun import freeze_time
 from posthog.test.base import BaseTest
 
 from parameterized import parameterized
@@ -33,6 +34,7 @@ class TestParseEventsFeatureToMonths:
         assert parse_events_feature_to_months(cast(ProductFeature | None, feature)) == expected
 
 
+@freeze_time("2026-09-01")
 class TestReconcileOrganizationEventsRetention(BaseTest):
     def _set_retention_feature(self, limit: int, unit: str) -> None:
         Organization.objects.filter(pk=self.organization.pk).update(
@@ -57,6 +59,24 @@ class TestReconcileOrganizationEventsRetention(BaseTest):
         Team.objects.filter(pk=self.team.pk).update(event_retention_months=84)
 
         assert reconcile_organization_events_retention(self.organization) == 0
+
+    @freeze_time("2026-09-15")
+    def test_shorter_window_waits_for_the_first_of_the_month(self) -> None:
+        Team.objects.filter(pk=self.team.pk).update(event_retention_months=84)
+        self._set_retention_feature(1, "year")
+
+        assert reconcile_organization_events_retention(self.organization) == 0
+        self.team.refresh_from_db()
+        assert self.team.event_retention_months == 84
+
+    @freeze_time("2026-09-15")
+    def test_longer_window_applies_immediately(self) -> None:
+        Team.objects.filter(pk=self.team.pk).update(event_retention_months=12)
+        self._set_retention_feature(7, "years")
+
+        assert reconcile_organization_events_retention(self.organization) == 1
+        self.team.refresh_from_db()
+        assert self.team.event_retention_months == 84
 
     def test_reconciles_from_persisted_entitlement_not_snapshot(self) -> None:
         Team.objects.filter(pk=self.team.pk).update(event_retention_months=84)

--- a/posthog/temporal/sync_events_retention/activities.py
+++ b/posthog/temporal/sync_events_retention/activities.py
@@ -6,7 +6,7 @@ from temporalio import activity
 
 from posthog.constants import AvailableFeature
 from posthog.models.team import Team
-from posthog.models.team.event_retention import parse_events_feature_to_months
+from posthog.models.team.event_retention import parse_events_feature_to_months, shrinks_apply_today
 from posthog.ph_client import ph_scoped_capture
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_write_only_logger
@@ -61,11 +61,14 @@ async def sync_events_retention(input: SyncEventsRetentionInput) -> SyncEventsRe
 
             teams_to_update: list[Team] = []
             changes: list[dict] = []
+            apply_shrinks = shrinks_apply_today()
             for team in teams:
                 retention_feature = team.organization.get_available_feature(
                     AvailableFeature.PRODUCT_ANALYTICS_DATA_RETENTION
                 )
                 target_months = parse_events_feature_to_months(retention_feature)
+                if target_months < team.event_retention_months and not apply_shrinks:
+                    continue
                 if team.event_retention_months != target_months:
                     changes.append(
                         {

--- a/posthog/temporal/tests/sync_events_retention/test_activities.py
+++ b/posthog/temporal/tests/sync_events_retention/test_activities.py
@@ -16,6 +16,17 @@ from posthog.temporal.sync_events_retention.types import SyncEventsRetentionInpu
 # exactly those — which is how a select_related/.only() FieldError shipped undetected.
 
 
+SHRINKS_APPLY_TODAY = "posthog.temporal.sync_events_retention.activities.shrinks_apply_today"
+
+
+# freezegun trips a metaclass conflict inside pydantic.v1 when the activity imports it lazily, so the
+# first-of-the-month clock is patched rather than frozen. The clock itself is covered by the reconcile tests.
+@pytest.fixture(autouse=True)
+def _first_of_the_month():
+    with patch(SHRINKS_APPLY_TODAY, return_value=True):
+        yield
+
+
 async def _team_with_features(features: list[dict], *, current_months: int) -> Team:
     org = await sync_to_async(Organization.objects.create)(name="test-org")
     team = await sync_to_async(Team.objects.create)(
@@ -84,6 +95,23 @@ async def test_syncs_all_teams_across_batches():
     for team in teams:
         await sync_to_async(team.refresh_from_db)()
         assert team.event_retention_months == 12
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_shorter_window_waits_for_the_first_of_the_month():
+    features = [{"key": "product_analytics_data_retention", "limit": 1, "unit": "year"}]
+    shrinking = await _team_with_features(features, current_months=84)
+    growing = await _team_with_features(features, current_months=6)
+
+    with patch(SHRINKS_APPLY_TODAY, return_value=False):
+        result = await ActivityEnvironment().run(sync_events_retention, SyncEventsRetentionInput(dry_run=False))
+
+    await sync_to_async(shrinking.refresh_from_db)()
+    await sync_to_async(growing.refresh_from_db)()
+    assert shrinking.event_retention_months == 84
+    assert growing.event_retention_months == 12
+    assert result.total_updated == 1
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
## Problem

A customer on a plan with events retention sees their oldest events disappear on a rolling boundary: an event from July 14 goes away on July 14 a year later, at the exact minute. The retention policy in [the events data retention RFC](https://github.com/PostHog/requests-for-comments-internal/pull/1062) and the docs page in [PostHog/posthog.com#19927](https://github.com/PostHog/posthog.com/pull/19927) promise something else: events age out on the 1st of the month after the window ends, so month-over-month and year-over-year comparisons stay whole, and a downgrade hides data on the 1st of the next month rather than the same hour.

- The printer injects `timestamp > now() - toIntervalMonth(N)` on every events scan.
- The nightly sync and the instant reconcile write a shorter window to the team as soon as billing reports it.

## Changes

- Events older than the window now disappear on the 1st of a month, in the project's timezone. The injected floor becomes `timestamp >= toStartOfMonth(now()) - toIntervalMonth(N)`. `now()` already carries the project timezone in HogQL.
- A shorter window takes effect on the 1st of the next month. Both writers of `event_retention_months`, the reconcile that runs on a billing change and the nightly Temporal sync, skip decreases unless the run happens on the 1st. The nightly sync runs every day, so it applies the pending decrease on the 1st. Longer windows still apply immediately.
- The retention warning in the app uses the same boundary, so the tile icon and banner agree with the query at month edges.
- Mechanical: the query cache key varies by the floor's date instead of the number of months, so a result cached on the last day of a month is not served with last month's floor.

The riskiest line is the operator and function change in `retention_floor_for_table`. Every other change follows from it.

## How did you test this code?

- `test_printer.py`: the floor assertions now check for `greaterOrEquals(events.timestamp, minus(toStartOfMonth(now`, so a return to the rolling predicate fails.
- `test_event_retention.py`: two new cases, a decrease mid-month leaves the window unchanged and an increase mid-month applies, with the class frozen on the 1st so the existing cases still write.
- `test_activities.py`: one new case where the same run skips a decrease and applies an increase. The activity tests patch the first-of-the-month helper instead of freezing time, because freezegun trips a metaclass conflict in `pydantic.v1` when the activity imports it lazily.
- `test_query_runner.py`: the cache key is stable within a month and changes on the 1st.
- `exceedsRetention.test.ts`: two rows on either side of the month boundary.

Not run: the repo-wide mypy pass and the ClickHouse-backed query snapshots, which CI covers.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The customer-facing page is [PostHog/posthog.com#19927](https://github.com/PostHog/posthog.com/pull/19927). No doc in this repo describes the floor.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, session linked below. The user asked what the app needs so data ages out on calendar months as the policy says, then asked for the PR. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iuyL4asmxXmXTab7VhcZc
