### PR TITLE
fix(settings): don't load org API keys behind the paywall

### DIFF
--- a/frontend/src/scenes/settings/organization/OrganizationPersonalAPIKeys.tsx
+++ b/frontend/src/scenes/settings/organization/OrganizationPersonalAPIKeys.tsx
@@ -30,14 +30,10 @@ function ownerLabel(owner: OrganizationPersonalAPIKeyApi['owner']): string {
     return fullName(owner) || owner.email
 }
 
-export function OrganizationPersonalAPIKeys(): JSX.Element {
+// Mounted only behind the paywall and the admin check, so we never request keys the page cannot show.
+function OrganizationPersonalAPIKeysTable(): JSX.Element {
     const { filteredKeys, keysLoading, search } = useValues(organizationPersonalAPIKeysLogic)
     const { setSearch } = useActions(organizationPersonalAPIKeysLogic)
-    const restrictionReason = useRestrictedArea({ minimumAccessLevel: OrganizationMembershipLevel.Admin })
-
-    if (restrictionReason) {
-        return <p className="text-muted">{restrictionReason}</p>
-    }
 
     const columns: LemonTableColumns<OrganizationPersonalAPIKeyApi> = [
         {
@@ -83,10 +79,7 @@ export function OrganizationPersonalAPIKeys(): JSX.Element {
     ]
 
     return (
-        <PayGateMini
-            feature={AvailableFeature.ORGANIZATION_SECURITY_SETTINGS}
-            featureDetail="organization-personal-api-keys"
-        >
+        <>
             <div className="mb-2">
                 <LemonInput
                     type="search"
@@ -108,6 +101,23 @@ export function OrganizationPersonalAPIKeys(): JSX.Element {
                         : 'No personal API keys have access to this organization.'
                 }
             />
+        </>
+    )
+}
+
+export function OrganizationPersonalAPIKeys(): JSX.Element {
+    const restrictionReason = useRestrictedArea({ minimumAccessLevel: OrganizationMembershipLevel.Admin })
+
+    if (restrictionReason) {
+        return <p className="text-muted">{restrictionReason}</p>
+    }
+
+    return (
+        <PayGateMini
+            feature={AvailableFeature.ORGANIZATION_SECURITY_SETTINGS}
+            featureDetail="organization-personal-api-keys"
+        >
+            <OrganizationPersonalAPIKeysTable />
         </PayGateMini>
     )
 }

--- a/frontend/src/scenes/settings/organization/OrganizationPersonalAPIKeys.tsx
+++ b/frontend/src/scenes/settings/organization/OrganizationPersonalAPIKeys.tsx
@@ -1,110 +1,13 @@
-import { useActions, useValues } from 'kea'
-
-import { LemonInput } from '@posthog/lemon-ui'
+import { useValues } from 'kea'
 
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
 import { useRestrictedArea } from 'lib/components/RestrictedArea'
-import { TZLabel } from 'lib/components/TZLabel'
 import { OrganizationMembershipLevel } from 'lib/constants'
-import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
-import { fullName } from 'lib/utils/strings'
-import { TagList } from 'scenes/settings/user/PersonalAPIKeys'
 import { userLogic } from 'scenes/userLogic'
 
 import { AvailableFeature } from '~/types'
 
-import type { OrganizationPersonalAPIKeyApi } from 'products/platform_features/frontend/generated/api.schemas'
-
-import { organizationPersonalAPIKeysLogic } from './organizationPersonalAPIKeysLogic'
-
-function AccessScope({ accessScope }: { accessScope: OrganizationPersonalAPIKeyApi['access_scope'] }): JSX.Element {
-    if (accessScope.type === 'all') {
-        return <span className="text-muted">All projects (unscoped)</span>
-    }
-    if (accessScope.type === 'organization') {
-        return <span>Organization-wide</span>
-    }
-    return <TagList tags={(accessScope.projects ?? []).map((project) => project.name)} />
-}
-
-function ownerLabel(owner: OrganizationPersonalAPIKeyApi['owner']): string {
-    return fullName(owner) || owner.email
-}
-
-// Mounted only when the page can show the keys, so we never request them otherwise.
-function OrganizationPersonalAPIKeysTable(): JSX.Element {
-    const { filteredKeys, keysLoading, search } = useValues(organizationPersonalAPIKeysLogic)
-    const { setSearch } = useActions(organizationPersonalAPIKeysLogic)
-
-    const columns: LemonTableColumns<OrganizationPersonalAPIKeyApi> = [
-        {
-            title: 'Owner',
-            key: 'owner',
-            sorter: (a, b) => ownerLabel(a.owner).localeCompare(ownerLabel(b.owner)),
-            render: (_, key) => (
-                <div className="flex flex-col">
-                    <span>{ownerLabel(key.owner)}</span>
-                    <span className="text-muted text-xs">{key.owner.email}</span>
-                </div>
-            ),
-        },
-        {
-            title: 'Masked value',
-            key: 'mask_value',
-            sorter: (a, b) => a.mask_value.localeCompare(b.mask_value),
-            render: (_, key) => <span className="font-mono">{key.mask_value}</span>,
-        },
-        {
-            title: 'Scopes',
-            key: 'scopes',
-            render: (_, key) => <TagList tags={[...key.scopes]} />,
-        },
-        {
-            title: 'Access scope',
-            key: 'access_scope',
-            render: (_, key) => <AccessScope accessScope={key.access_scope} />,
-        },
-        {
-            title: 'Last used',
-            key: 'last_used_at',
-            sorter: (a, b) => new Date(a.last_used_at ?? 0).getTime() - new Date(b.last_used_at ?? 0).getTime(),
-            render: (_, key) =>
-                key.last_used_at ? <TZLabel time={key.last_used_at} /> : <span className="text-muted">Never</span>,
-        },
-        {
-            title: 'Created',
-            key: 'created_at',
-            sorter: (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
-            render: (_, key) => <TZLabel time={key.created_at} />,
-        },
-    ]
-
-    return (
-        <>
-            <div className="mb-2">
-                <LemonInput
-                    type="search"
-                    placeholder="Search by name, email, or scope"
-                    value={search}
-                    onChange={setSearch}
-                    className="max-w-80"
-                />
-            </div>
-            <LemonTable
-                dataSource={filteredKeys}
-                loading={keysLoading}
-                columns={columns}
-                rowKey={(key) => `${key.owner.email}-${key.mask_value}-${key.created_at}`}
-                pagination={{ pageSize: 25 }}
-                emptyState={
-                    search.trim()
-                        ? 'No personal API keys match your search.'
-                        : 'No personal API keys have access to this organization.'
-                }
-            />
-        </>
-    )
-}
+import { OrganizationPersonalAPIKeysTable } from './OrganizationPersonalAPIKeysTable'
 
 export function OrganizationPersonalAPIKeys(): JSX.Element {
     const { hasAvailableFeature } = useValues(userLogic)

--- a/frontend/src/scenes/settings/organization/OrganizationPersonalAPIKeys.tsx
+++ b/frontend/src/scenes/settings/organization/OrganizationPersonalAPIKeys.tsx
@@ -9,6 +9,7 @@ import { OrganizationMembershipLevel } from 'lib/constants'
 import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { fullName } from 'lib/utils/strings'
 import { TagList } from 'scenes/settings/user/PersonalAPIKeys'
+import { userLogic } from 'scenes/userLogic'
 
 import { AvailableFeature } from '~/types'
 
@@ -30,7 +31,7 @@ function ownerLabel(owner: OrganizationPersonalAPIKeyApi['owner']): string {
     return fullName(owner) || owner.email
 }
 
-// Mounted only behind the paywall and the admin check, so we never request keys the page cannot show.
+// Mounted only when the page can show the keys, so we never request them otherwise.
 function OrganizationPersonalAPIKeysTable(): JSX.Element {
     const { filteredKeys, keysLoading, search } = useValues(organizationPersonalAPIKeysLogic)
     const { setSearch } = useActions(organizationPersonalAPIKeysLogic)
@@ -106,7 +107,13 @@ function OrganizationPersonalAPIKeysTable(): JSX.Element {
 }
 
 export function OrganizationPersonalAPIKeys(): JSX.Element {
+    const { hasAvailableFeature } = useValues(userLogic)
     const restrictionReason = useRestrictedArea({ minimumAccessLevel: OrganizationMembershipLevel.Admin })
+
+    // PayGateMini falls through to its children when billing carries no metadata for the feature,
+    // so the entitlement is checked here too. Otherwise the table below mounts and its first
+    // request comes back as a payment prompt.
+    const entitled = hasAvailableFeature(AvailableFeature.ORGANIZATION_SECURITY_SETTINGS)
 
     if (restrictionReason) {
         return <p className="text-muted">{restrictionReason}</p>
@@ -117,7 +124,7 @@ export function OrganizationPersonalAPIKeys(): JSX.Element {
             feature={AvailableFeature.ORGANIZATION_SECURITY_SETTINGS}
             featureDetail="organization-personal-api-keys"
         >
-            <OrganizationPersonalAPIKeysTable />
+            {entitled ? <OrganizationPersonalAPIKeysTable /> : null}
         </PayGateMini>
     )
 }

--- a/frontend/src/scenes/settings/organization/OrganizationPersonalAPIKeysTable.tsx
+++ b/frontend/src/scenes/settings/organization/OrganizationPersonalAPIKeysTable.tsx
@@ -1,0 +1,100 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonInput } from '@posthog/lemon-ui'
+
+import { TZLabel } from 'lib/components/TZLabel'
+import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
+import { fullName } from 'lib/utils/strings'
+import { TagList } from 'scenes/settings/user/PersonalAPIKeys'
+
+import type { OrganizationPersonalAPIKeyApi } from 'products/platform_features/frontend/generated/api.schemas'
+
+import { organizationPersonalAPIKeysLogic } from './organizationPersonalAPIKeysLogic'
+
+function AccessScope({ accessScope }: { accessScope: OrganizationPersonalAPIKeyApi['access_scope'] }): JSX.Element {
+    if (accessScope.type === 'all') {
+        return <span className="text-muted">All projects (unscoped)</span>
+    }
+    if (accessScope.type === 'organization') {
+        return <span>Organization-wide</span>
+    }
+    return <TagList tags={(accessScope.projects ?? []).map((project) => project.name)} />
+}
+
+function ownerLabel(owner: OrganizationPersonalAPIKeyApi['owner']): string {
+    return fullName(owner) || owner.email
+}
+
+export function OrganizationPersonalAPIKeysTable(): JSX.Element {
+    const { filteredKeys, keysLoading, search } = useValues(organizationPersonalAPIKeysLogic)
+    const { setSearch } = useActions(organizationPersonalAPIKeysLogic)
+
+    const columns: LemonTableColumns<OrganizationPersonalAPIKeyApi> = [
+        {
+            title: 'Owner',
+            key: 'owner',
+            sorter: (a, b) => ownerLabel(a.owner).localeCompare(ownerLabel(b.owner)),
+            render: (_, key) => (
+                <div className="flex flex-col">
+                    <span>{ownerLabel(key.owner)}</span>
+                    <span className="text-muted text-xs">{key.owner.email}</span>
+                </div>
+            ),
+        },
+        {
+            title: 'Masked value',
+            key: 'mask_value',
+            sorter: (a, b) => a.mask_value.localeCompare(b.mask_value),
+            render: (_, key) => <span className="font-mono">{key.mask_value}</span>,
+        },
+        {
+            title: 'Scopes',
+            key: 'scopes',
+            render: (_, key) => <TagList tags={[...key.scopes]} />,
+        },
+        {
+            title: 'Access scope',
+            key: 'access_scope',
+            render: (_, key) => <AccessScope accessScope={key.access_scope} />,
+        },
+        {
+            title: 'Last used',
+            key: 'last_used_at',
+            sorter: (a, b) => new Date(a.last_used_at ?? 0).getTime() - new Date(b.last_used_at ?? 0).getTime(),
+            render: (_, key) =>
+                key.last_used_at ? <TZLabel time={key.last_used_at} /> : <span className="text-muted">Never</span>,
+        },
+        {
+            title: 'Created',
+            key: 'created_at',
+            sorter: (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+            render: (_, key) => <TZLabel time={key.created_at} />,
+        },
+    ]
+
+    return (
+        <>
+            <div className="mb-2">
+                <LemonInput
+                    type="search"
+                    placeholder="Search by name, email, or scope"
+                    value={search}
+                    onChange={setSearch}
+                    className="max-w-80"
+                />
+            </div>
+            <LemonTable
+                dataSource={filteredKeys}
+                loading={keysLoading}
+                columns={columns}
+                rowKey={(key) => `${key.owner.email}-${key.mask_value}-${key.created_at}`}
+                pagination={{ pageSize: 25 }}
+                emptyState={
+                    search.trim()
+                        ? 'No personal API keys match your search.'
+                        : 'No personal API keys have access to this organization.'
+                }
+            />
+        </>
+    )
+}


### PR DESCRIPTION
## Problem

Admins who open Settings > Organization > Security get an error toast, and the failed request loaded personal API keys that the page never showed. The keys table sits behind `PayGateMini`, so on an organization without the security-settings feature the table is hidden but the request still ran and the API rejected it.

## Changes

- The security settings page no longer shows an error toast, and it no longer requests personal API keys that it cannot display.
- The table is also hidden when the organization is not entitled to the feature but billing carries no metadata for it. `PayGateMini` renders its children in that case, which is why the paywall alone did not stop the request. The sibling notification setting in the same section already guards this way.
- Mechanical: the keys table moved into a child component, so the kea logic (and its `afterMount` load) mounts only when both guards pass.

## How did you test this code?

No manual testing — the dev stack was not started for this change.

Automated checks run in the sandbox: `pnpm --filter=@posthog/frontend fix`, and the existing `organizationPersonalAPIKeysLogic` Jest suite, which passes. The whole-repo `tsgo` typecheck is the gate for this change and it cannot complete in this sandbox: it is killed for memory after the workspace packages are built. The `Frontend typechecking` CI job runs that same command and is the check to read for it.

No new test: the existing logic test still covers loading and filtering, and asserting "the request does not fire" needs billing, user, and paywall state stubbed around a rendered component. The sibling setting with the same guard has no such test either.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Reported in Slack: the security settings page hits the personal API keys endpoint for data it does not show. Written by the PostHog Slack app (Claude Code), then shepherded through a review and CI loop with the `pr-shepherd` skill (`qa-swarm` router review, `ci-shepherd`). No other repo skills were invoked.

The first commit moved the table behind `PayGateMini` only. The review pass pointed at `NotificationGovernanceSetting`, which documents that the paywall falls through when billing has no metadata for a feature — the second commit adds the same entitlement check, since that fall-through is the likely shape of the reported case.

Public artifact: the diff and this description contain no material from the session that is not already public.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1788386816340789?thread_ts=1788386816.340789&cid=C0ACRAMJUAG)*
