### PR TITLE
fix(insights): keep click and drag selection in scene title fields

### DIFF
--- a/frontend/src/layout/scenes/components/SceneTitleSection.test.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, createEvent, fireEvent, render, screen } from '@testing-library/react'
 
 import { SceneName } from './SceneTitleSection'
 
@@ -36,5 +36,33 @@ describe('SceneName', () => {
 
         rerender(<SceneName name="Generated name" canEdit onChange={jest.fn()} />)
         expect(screen.getByText('Generated name')).toBeInTheDocument()
+    })
+
+    // Guards click and drag text selection: the edit row is wider and taller than the field
+    // inside it, so a press that misses the glyphs by a few pixels lands on the row. Left
+    // unclaimed, some browsers read that press as their own gesture rather than a selection.
+    test('a press on the edit row beside the field focuses the field and is consumed', () => {
+        render(<SceneName name="Paying users" canEdit forceEdit onChange={jest.fn()} />)
+
+        const row = screen.getByTestId('scene-name-edit-row')
+        const textarea = screen.getByRole('textbox')
+        expect(textarea).not.toHaveFocus()
+
+        const press = createEvent.mouseDown(row)
+        fireEvent(row, press)
+
+        expect(textarea).toHaveFocus()
+        expect(press.defaultPrevented).toBe(true)
+    })
+
+    // The counterpart: a press on the field itself must reach the browser untouched,
+    // or it would never start a selection.
+    test('a press on the field itself is left alone', () => {
+        render(<SceneName name="Paying users" canEdit forceEdit onChange={jest.fn()} />)
+
+        const press = createEvent.mouseDown(screen.getByRole('textbox'))
+        fireEvent(screen.getByRole('textbox'), press)
+
+        expect(press.defaultPrevented).toBe(false)
     })
 })

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -523,6 +523,7 @@ export function SceneName({
                     <div
                         ref={containerRef}
                         className="flex items-center gap-1 w-full"
+                        data-attr="scene-name-edit-row"
                         onMouseDown={(e) => {
                             // A press on the row around the field leaves the gesture unclaimed by the page,
                             // which some browsers read as a window drag instead of a text selection.

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -469,6 +469,7 @@ export function SceneName({
 
     const [isEditing, setIsEditing] = useState(forceEdit)
     const containerRef = useRef<HTMLDivElement>(null)
+    const nameInputRef = useRef<HTMLTextAreaElement>(null)
 
     const textClasses =
         'text-lg font-semibold my-0 pl-[var(--button-padding-x-sm)] min-h-[var(--button-height-sm)] leading-[1.4] select-auto'
@@ -519,8 +520,20 @@ export function SceneName({
         onChange && canEdit ? (
             <>
                 {isEditing ? (
-                    <div ref={containerRef} className="flex items-center gap-1 w-full">
+                    <div
+                        ref={containerRef}
+                        className="flex items-center gap-1 w-full"
+                        onMouseDown={(e) => {
+                            // A press on the row around the field leaves the gesture unclaimed by the page,
+                            // which some browsers read as a window drag instead of a text selection.
+                            if (e.target === e.currentTarget) {
+                                e.preventDefault()
+                                nameInputRef.current?.focus()
+                            }
+                        }}
+                    >
                         <TextareaPrimitive
+                            ref={nameInputRef}
                             variant="default"
                             name="name"
                             value={name || ''}

--- a/frontend/src/lib/ui/TextareaPrimitive/TextareaPrimitive.test.tsx
+++ b/frontend/src/lib/ui/TextareaPrimitive/TextareaPrimitive.test.tsx
@@ -30,4 +30,21 @@ describe('TextareaPrimitive', () => {
 
         expect(textarea.selectionStart).toBe('a title to select'.length)
     })
+    // The caret rule is layered on top of the caller's own handlers rather than replacing
+    // them: SceneName saves its pending rename on blur, and that must still run.
+    it('still calls the handlers a caller supplies', () => {
+        const onFocus = jest.fn()
+        const onBlur = jest.fn()
+        const onPointerDown = jest.fn()
+        render(<TextareaPrimitive onFocus={onFocus} onBlur={onBlur} onPointerDown={onPointerDown} />)
+        const textarea = screen.getByRole('textbox')
+
+        fireEvent.pointerDown(textarea)
+        fireEvent.focus(textarea)
+        fireEvent.blur(textarea)
+
+        expect(onPointerDown).toHaveBeenCalledTimes(1)
+        expect(onFocus).toHaveBeenCalledTimes(1)
+        expect(onBlur).toHaveBeenCalledTimes(1)
+    })
 })

--- a/frontend/src/lib/ui/TextareaPrimitive/TextareaPrimitive.test.tsx
+++ b/frontend/src/lib/ui/TextareaPrimitive/TextareaPrimitive.test.tsx
@@ -1,0 +1,33 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { TextareaPrimitive } from './TextareaPrimitive'
+
+describe('TextareaPrimitive', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    // Guards click and drag text selection: moving the caret to the end on a focus that
+    // came from a pointer press collapses the selection the press started, so a drag
+    // selects nothing and the gesture is left for the browser to interpret.
+    it('keeps the caret where a pointer press put it', () => {
+        render(<TextareaPrimitive defaultValue="a title to select" />)
+        const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+
+        fireEvent.pointerDown(textarea)
+        fireEvent.focus(textarea)
+
+        expect(textarea.selectionStart).toBe(0)
+    })
+
+    it('moves the caret to the end when focus arrives without a pointer press', () => {
+        render(<TextareaPrimitive defaultValue="a title to select" />)
+        const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+
+        fireEvent.focus(textarea)
+
+        expect(textarea.selectionStart).toBe('a title to select'.length)
+    })
+})

--- a/frontend/src/lib/ui/TextareaPrimitive/TextareaPrimitive.tsx
+++ b/frontend/src/lib/ui/TextareaPrimitive/TextareaPrimitive.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react'
+import { forwardRef, useRef } from 'react'
 import TextareaAutosize, { TextareaAutosizeProps } from 'react-textarea-autosize'
 
 import { IconMarkdownFilled } from '@posthog/icons'
@@ -17,18 +17,37 @@ type TextareaPrimitiveProps = TextareaAutosizeProps &
 
 export const TextareaPrimitive = forwardRef<HTMLTextAreaElement, TextareaPrimitiveProps>(
     ({ className, variant, error, markdown = false, wrapperClassName, ...rest }, ref): JSX.Element => {
-        // Ensure cursor is at the end of the textarea when it is focused
+        const focusFollowsPointerRef = useRef(false)
+
+        // Put the cursor at the end when focus arrives without a pointer press, e.g. autofocus or tab.
+        // After a pointer press the caret must stay where it landed, so that click and drag selects text.
         function onFocus(e: React.FocusEvent<HTMLTextAreaElement>): void {
-            e.currentTarget.setSelectionRange(e.currentTarget.value.length, e.currentTarget.value.length)
+            if (!focusFollowsPointerRef.current) {
+                e.currentTarget.setSelectionRange(e.currentTarget.value.length, e.currentTarget.value.length)
+            }
+            focusFollowsPointerRef.current = false
+            rest.onFocus?.(e)
+        }
+
+        function onPointerDown(e: React.PointerEvent<HTMLTextAreaElement>): void {
+            focusFollowsPointerRef.current = true
+            rest.onPointerDown?.(e)
+        }
+
+        function onBlur(e: React.FocusEvent<HTMLTextAreaElement>): void {
+            focusFollowsPointerRef.current = false
+            rest.onBlur?.(e)
         }
 
         return (
             <div className={cn('relative flex flex-col gap-0', wrapperClassName)}>
                 <TextareaAutosize
                     ref={ref}
-                    onFocus={onFocus}
                     aria-label={markdown ? 'Markdown supported' : undefined}
                     {...rest}
+                    onFocus={onFocus}
+                    onPointerDown={onPointerDown}
+                    onBlur={onBlur}
                     className={cn(
                         textInputVariants({ variant, error: !!error, size: 'auto' }),
                         'resize-y show-scrollbar-on-hover px-[var(--button-padding-x-base)] py-[var(--button-padding-y-base)]',

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -2157,3 +2157,11 @@
         transform: translateY(0);
     }
 }
+
+// `-webkit-app-region` is an inherited property in Chromium, and a region marked as a drag
+// handle swallows click and drag text selection. Text entry must never become a drag handle.
+input,
+textarea,
+[contenteditable='true'] {
+    -webkit-app-region: no-drag;
+}


### PR DESCRIPTION
## Problem

Someone renaming an insight cannot reliably select the text they are editing. Click and drag over the title sometimes selects nothing, and in at least one Chromium browser the unclaimed gesture moves the browser window instead. It is intermittent, and it happens while the field is already in edit mode.

Three separate causes sit behind it:

1. `TextareaPrimitive` moved the caret to the end of the value on **every** focus. Any focus that the field loses and regains mid-edit — a debounced save re-render, a tooltip, a side panel — collapses the selection a press just started.
2. `SceneName`'s edit row is a flex row with a gap, so a press a few pixels off the glyphs lands on the row, not on the field. The page claims nothing, and the browser is free to read the gesture as its own.
3. `-webkit-app-region` is an inherited property in Chromium. A region marked as a drag handle swallows text selection, and nothing marked our text entry as exempt.

## Changes

- The title field now keeps the caret where a press put it, so click and drag selects the text under the pointer. Focus that arrives without a pointer press — autofocus, tab — still puts the caret at the end.
- A press on the title row beside the field now focuses the field instead of being discarded.
- Every `input`, `textarea`, and `contenteditable` is now `-webkit-app-region: no-drag`. Mechanical, no visual change.

The description field shares the component, so it gets the caret fix too.

Cause 3 is defence in depth rather than a confirmed cause: nothing in the web frontend marks a drag region today, so this guards against one being introduced above a field.

## How did you test this code?

Automated only, seven tests across two suites.

`TextareaPrimitive.test.tsx` is new and covers the caret rule in both directions — a pointer press must leave the caret alone, a bare focus must move it to the end — plus a check that handlers a caller supplies still run alongside the composed ones.

`SceneTitleSection.test.tsx` gains the row behaviour: a press beside the field focuses the field and is consumed, and a press on the field itself is left alone. The row carries a `scene-name-edit-row` data-attr so it is addressable.

None of these behaviours was covered before. The two that matter were checked against a locally reverted component and both fail without the fix, so they are not vacuous.

Also run: `src/layout/scenes`, `src/lib/components/Scenes`, and `src/lib/ui` all pass. Oxlint and Oxfmt are clean on the touched files, and Stylelint is clean on `base.scss`.

Not done: no manual check in a browser. The reported symptom is browser-specific and was not reproduced here, so whether these changes remove it in practice still needs confirmation from someone who can reproduce it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing docs cover this behaviour.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude Code) from a report in Slack. No repo skills were invoked.

The first diagnosis was wrong and is worth recording: the title renders as a `<button>` until a completed click, so a press-and-drag before edit mode never reaches a text field. The reporter pointed out the symptom also occurs mid-edit, which ruled that out and led to the three causes above. The view-mode button was left alone as a result — changing it would not have fixed what was reported.

Cause 1 is the strongest candidate, cause 2 the most likely near-miss, and cause 3 insurance. None is confirmed against a live repro, so treat this as narrowing rather than a proven fix.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1788378460952759?thread_ts=1788378460.952759&cid=C0ACRAMJUAG)*

