### PR TITLE
fix(tasks): drop nonexistent harness package from local sandbox image build

### DIFF
--- a/products/tasks/backend/logic/services/docker_sandbox.py
+++ b/products/tasks/backend/logic/services/docker_sandbox.py
@@ -79,6 +79,11 @@ SLIM_IMAGE_NAME = "posthog-sandbox-slim"
 _DOCKERFILE_SHA_LABEL = "com.posthog.sandbox.dockerfile-sha"
 _AGENT_VERSION_LABEL = "com.posthog.sandbox.agent-version"
 AGENT_SERVER_PORT = 47821  # Arbitrary high port unlikely to conflict with dev servers
+
+# posthog-code workspace packages staged into a local sandbox image build. @posthog/agent
+# needs shared, git and enricher; git needs shared. Both the path check and the copy read
+# this tuple, so a package named here but absent from the checkout fails the build outright.
+_LOCAL_SANDBOX_PACKAGES = ("agent", "shared", "git", "enricher")
 # Streamlit sandboxes expose their auth proxy (not the agent-server) on this port; the
 # host-published port maps to it so connect_info can reach the app across processes.
 
@@ -262,7 +267,7 @@ class DockerSandbox(SandboxBase):
             os.path.join(monorepo_root, "scripts", "rimraf.mjs"),
             *[
                 os.path.join(monorepo_root, "packages", package_name, "package.json")
-                for package_name in ("agent", "harness", "shared", "git", "enricher")
+                for package_name in _LOCAL_SANDBOX_PACKAGES
             ],
         ]
         missing = [path for path in required_paths if not os.path.exists(path)]
@@ -345,7 +350,7 @@ class DockerSandbox(SandboxBase):
             shutil.copytree(os.path.join(monorepo_root, "patches"), os.path.join(workspace_path, "patches"))
             shutil.copy2(os.path.join(monorepo_root, "scripts", "rimraf.mjs"), scripts_path)
 
-            for package_name in ("agent", "harness", "shared", "git", "enricher"):
+            for package_name in _LOCAL_SANDBOX_PACKAGES:
                 shutil.copytree(
                     os.path.join(monorepo_root, "packages", package_name),
                     os.path.join(packages_path, package_name),

--- a/products/tasks/backend/logic/services/test_docker_sandbox.py
+++ b/products/tasks/backend/logic/services/test_docker_sandbox.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 from parameterized import parameterized
 
 from products.tasks.backend.exceptions import SandboxExecutionError, SandboxProvisionError
-from products.tasks.backend.logic.services.docker_sandbox import DockerSandbox
+from products.tasks.backend.logic.services.docker_sandbox import _LOCAL_SANDBOX_PACKAGES, DockerSandbox
 from products.tasks.backend.logic.services.sandbox import (
     ExecutionResult,
     SandboxConfig,
@@ -153,7 +153,7 @@ class TestDockerSandboxUnit:
         (tmp_path / "patches").mkdir()
         (tmp_path / "scripts").mkdir()
         (tmp_path / "scripts" / "rimraf.mjs").touch()
-        for package_name in ("agent", "harness", "shared", "git", "enricher"):
+        for package_name in _LOCAL_SANDBOX_PACKAGES:
             package_path = tmp_path / "packages" / package_name
             package_path.mkdir(parents=True)
             (package_path / "package.json").touch()
@@ -170,7 +170,7 @@ class TestDockerSandboxUnit:
         (monorepo_path / "patches").mkdir()
         (monorepo_path / "scripts").mkdir()
         (monorepo_path / "scripts" / "rimraf.mjs").touch()
-        for package_name in ("agent", "harness", "shared", "git", "enricher"):
+        for package_name in _LOCAL_SANDBOX_PACKAGES:
             package_path = monorepo_path / "packages" / package_name
             package_path.mkdir(parents=True)
             (package_path / "package.json").touch()
@@ -185,7 +185,8 @@ class TestDockerSandboxUnit:
         workspace_path = context_path / "local-workspace"
         assert (workspace_path / "pnpm-workspace.yaml").is_file()
         assert (workspace_path / "scripts" / "rimraf.mjs").is_file()
-        assert (workspace_path / "packages" / "harness" / "package.json").is_file()
+        for package_name in _LOCAL_SANDBOX_PACKAGES:
+            assert (workspace_path / "packages" / package_name / "package.json").is_file()
         command = run.call_args.args[0]
         assert command[0:2] == ["docker", "build"]
         assert command[-1] == str(context_path)

--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-local
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-local
@@ -11,7 +11,6 @@ COPY local-workspace/patches /local-workspace/patches
 COPY local-workspace/packages/agent/package.json /local-workspace/packages/agent/package.json
 COPY local-workspace/packages/enricher/package.json /local-workspace/packages/enricher/package.json
 COPY local-workspace/packages/git/package.json /local-workspace/packages/git/package.json
-COPY local-workspace/packages/harness/package.json /local-workspace/packages/harness/package.json
 COPY local-workspace/packages/shared/package.json /local-workspace/packages/shared/package.json
 
 RUN --mount=type=cache,id=posthog-sandbox-local-pnpm,target=/pnpm/store,sharing=locked \


### PR DESCRIPTION
## Problem

TL;DR: local Docker sandbox agent runs can start again.

A developer who sets `LOCAL_POSTHOG_CODE_MONOREPO_ROOT` to run tasks against a local posthog-code checkout got a `SandboxProvisionError` before any container started. The path validator demanded `packages/harness/package.json`, and the posthog-code repo has no `harness` package: it ships `agent`, `electron-trpc`, `enricher`, `git`, `platform`, `shared`. `@posthog/agent` depends only on `shared`, `git`, and `enricher`, so the fix drops `harness` rather than renaming it to `platform`.

The package tuple lived in two hardcoded copies, with nothing binding either to the other repo's layout, which is how it drifted.

## Changes

- Local sandbox agent runs start again with `LOCAL_POSTHOG_CODE_MONOREPO_ROOT` set, against a real posthog-code checkout.
- Both hardcoded tuples now read one module-level `_LOCAL_SANDBOX_PACKAGES` constant, so the two copies cannot drift apart again.
- `Dockerfile.sandbox-local` drops its `COPY` of the harness package.json. The install filters on `@posthog/agent...`, so the line was dead weight and would fail the build next.
- Mechanical: test fixtures build their package list from the same constant instead of a third hardcoded copy.

## How did you test this code?

- Ran the `TestDockerSandboxUnit` suite: the two edited tests pass. They now catch a drift regression: a package added to `_LOCAL_SANDBOX_PACKAGES` without updating the staging or validator logic fails the copy assertion.
- Verified the validator against a real posthog-code checkout via `python manage.py shell`: `_get_local_posthog_code_root()` returned the path instead of raising.
- Not run: a full `docker build` of the local image, because the base image build takes minutes. The Dockerfile change only removes a COPY of a directory the build context no longer contains, and the install filter never referenced the package.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: Claude Code (kimi-k3), PostHog Desktop task.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- The task specified the constant consolidation. The agent found and fixed two things beyond the prompt: the harness COPY in Dockerfile.sandbox-local (the next failure after the Python fix), and the test fixtures' third hardcoded copy of the tuple, now bound to the constant.
- Public artifact: nothing in this PR draws on session-only material. The package list is verifiable from the public posthog-code repo.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*