### PR TITLE
fix(tasks): seed sandbox OAuth apps during local setup

### DIFF
--- a/bin/ensure-local-setup
+++ b/bin/ensure-local-setup
@@ -86,10 +86,7 @@ def ensure_wizard_oauth_app() -> None:
 STEPS = [
     ("dev personal API key", lambda: call_command("setup_local_api_key")),
     ("wizard cloud-run OAuth app", ensure_wizard_oauth_app),
-    # Sandbox agent OAuth apps (Array / PostHog AI / Signals). `hogli start`'s migrate-postgres
-    # unit runs `bin/migrate --scope=postgres`, which skips the `tasks-oauth` scope that calls this
-    # command, so a fresh local setup that restores the pre-migrated schema never seeds them. The
-    # command is idempotent and no-ops in the US/EU regions, so running it here is safe.
+    # Local migrate runs use --scope=postgres, which skips bin/migrate's tasks-oauth scope, so seed the sandbox agent OAuth apps here.
     ("task sandbox OAuth apps", lambda: call_command("setup_tasks_oauth")),
 ]
 

--- a/bin/ensure-local-setup
+++ b/bin/ensure-local-setup
@@ -86,6 +86,11 @@ def ensure_wizard_oauth_app() -> None:
 STEPS = [
     ("dev personal API key", lambda: call_command("setup_local_api_key")),
     ("wizard cloud-run OAuth app", ensure_wizard_oauth_app),
+    # Sandbox agent OAuth apps (Array / PostHog AI / Signals). `hogli start`'s migrate-postgres
+    # unit runs `bin/migrate --scope=postgres`, which skips the `tasks-oauth` scope that calls this
+    # command, so a fresh local setup that restores the pre-migrated schema never seeds them. The
+    # command is idempotent and no-ops in the US/EU regions, so running it here is safe.
+    ("task sandbox OAuth apps", lambda: call_command("setup_tasks_oauth")),
 ]
 
 


### PR DESCRIPTION
## Problem

A PostHog AI sandbox run on a fresh local setup fails immediately with `OAuthApplication.DoesNotExist`, rewrapped as the opaque "Failed to create OAuth access token for task <uuid>". The AI side panel cannot start an agent at all.

`setup_tasks_oauth` seeds the PostHog AI dev OAuth app, but `hogli start` runs `bin/migrate --scope=postgres`, which skips the `tasks-oauth` scope that calls it. A fresh setup that restores the pre-migrated schema therefore never creates the row. Nothing else seeds it: demo-data generation only creates the Array app, and `bin/ensure-local-setup` did not cover it either.

## Changes

- PostHog AI (and Array/Signals) sandbox OAuth apps are now seeded on every `hogli start`, so a fresh local setup can run AI sandbox agents.
- The change adds `setup_tasks_oauth` as a step in `bin/ensure-local-setup`, which runs on every start and already provisions the wizard OAuth app. The command is idempotent (`get_or_create`) and no-ops in the US/EU regions, so rerunning it each start is safe.

All of the change is wiring an existing management command into the local bootstrap; no app fields or behavior change.

Chose `bin/ensure-local-setup` over extending the demo-data `_set_up_demo_oauth_application`: an AI-agent prerequisite does not belong to demo-data generation, and the bootstrap script is the seam that already owns local-only OAuth provisioning.

## How did you test this code?

- `hogli test products/tasks/backend/management/commands/test/test_setup_tasks_oauth.py` (8 passed) — covers app creation, idempotent rerun, and the US/EU region guard (no-op outside local dev).
- Not run: the full dev stack was not up, so `create_oauth_access_token_for_user(..., application="posthog_ai")` was not exercised live in a shell. The seeded row satisfies the `get_posthog_ai_app()` lookup by client_id, which the existing test's creation assertions cover.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`docs/internal/sandboxes-setup-guide.md` already documents `setup_tasks_oauth` for the "PostHog AI app not found" case; no change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools: Claude Code (PostHog Desktop). Session: this task.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- The task brief predated the existing `setup_tasks_oauth` command, so the shipped fix wires that command into `bin/ensure-local-setup` rather than adding a new seeder. The optional error-message legibility change was skipped: `_get_oauth_app_for_client_id` already names the app and client_id, and the wrap preserves it via `str(e)`.
