### PR TITLE
feat(slack_app): resolve the agent design gate against the acting user

### DIFF
--- a/products/slack_app/backend/feature_flags.py
+++ b/products/slack_app/backend/feature_flags.py
@@ -13,12 +13,23 @@ surfaces:
 - **Remote evaluation** (``only_evaluate_locally=False``) — no deployment needs a
   local-evaluation personal API key for these to work; evaluation goes through
   PostHog's flags endpoint with the project token.
+- **Organization targeting** — the PostHog organization rides along as a group, so a
+  rule like ``$group_key equals <org uuid>`` targets one customer.
 - **Region targeting** — the deployment region rides along as the ``region``
   person property (via ``_region_properties``) so a flag rule like
   ``region equals DEV`` can target a single Cloud region.
+- **Person targeting** — a gate told which PostHog user it is deciding for is keyed
+  on that user, so the person's own record answers the rule. That makes the usual
+  internal rollout rules work unchanged: ``email ends_with @posthog.com``, a cohort,
+  any person property. Nothing here forwards those properties; the person already
+  carries them.
 - ``send_feature_flag_events=False`` — these are control checks, not analytics.
 - **Fail-closed** — any error returns ``False`` so a flaky flag call never
   silently enables a feature for everyone.
+
+The identity a gate is keyed on is also the identity it buckets on. So give a gate
+either a user on every call or on none, and read a rollout percentage on a
+user-keyed gate as a share of people rather than of workspaces.
 """
 
 from __future__ import annotations
@@ -53,18 +64,30 @@ def _region_properties() -> dict[str, str]:
     return {"region": get_instance_region() or "dev"}
 
 
-def _workspace_flag_enabled(flag: str, integration: Integration, *, failure_log_key: str) -> bool:
-    """Evaluate one workspace-keyed gate under the settings this module documents.
+def _workspace_flag_enabled(
+    flag: str,
+    integration: Integration,
+    *,
+    failure_log_key: str,
+    distinct_id: str | None = None,
+) -> bool:
+    """Evaluate one gate under the settings this module documents.
 
     The uniformity the docstring above promises is only real if there is one place that
     spells it out. A gate that needs more than a flag — scopes, say — checks that itself
     and calls this for the flag half.
+
+    ``distinct_id`` identifies the PostHog user the check is being made for, and becomes
+    the identity the flag resolves against. It is a distinct ID rather than a user id so
+    a caller can pass what it already holds, and so deciding a gate costs no query here.
+    Without one the gate falls back to the Slack workspace, which no person rule can
+    match.
     """
     try:
         return bool(
             posthoganalytics.feature_enabled(
                 flag,
-                f"slack_workspace:{integration.integration_id}",
+                distinct_id or f"slack_workspace:{integration.integration_id}",
                 groups={"organization": str(integration.team.organization_id)},
                 person_properties=_region_properties(),
                 only_evaluate_locally=False,
@@ -85,14 +108,20 @@ def is_slack_app_oauth_enabled(integration: Integration) -> bool:
     return has_scopes(integration, OAUTH_REQUIRED_SCOPES)
 
 
-def is_slack_app_agent_design_enabled(integration: Integration) -> bool:
+def is_slack_app_agent_design_enabled(integration: Integration, distinct_id: str | None = None) -> bool:
     """Gate for the agent-design plan-block streaming surface on Slack task runs.
     Posts through the ``chat:write`` the mention flow already requires, so this is the
-    flag alone. Keyed on the Slack workspace + PostHog org."""
+    flag alone.
+
+    ``distinct_id`` identifies the PostHog user whose run this is. The decision is about
+    that person's run, so the flag resolves against them and an internal rollout can name
+    them the way every other one does. Without it the gate falls back to the workspace.
+    """
     return _workspace_flag_enabled(
         SLACK_APP_AGENT_DESIGN_FLAG,
         integration,
         failure_log_key="slack_app_agent_design_feature_flag_check_failed",
+        distinct_id=distinct_id,
     )
 
 

--- a/products/slack_app/backend/tests/test_feature_flags.py
+++ b/products/slack_app/backend/tests/test_feature_flags.py
@@ -1,6 +1,8 @@
 import pytest
+from unittest.mock import patch
 
 from products.slack_app.backend import feature_flags
+from products.slack_app.backend.tests.conftest import SLACK_TEAM_ID
 
 # (gate, scopes the feature calls)
 SCOPED_GATES = [
@@ -28,3 +30,28 @@ def test_gate_stays_closed_when_a_required_scope_is_missing(workspace_integratio
     _grant(workspace_integration, required - {min(required)})
 
     assert gate(workspace_integration) is False
+
+
+@pytest.mark.parametrize(
+    ("distinct_id", "expected_identity"),
+    [
+        ("user-1", "user-1"),
+        (None, f"slack_workspace:{SLACK_TEAM_ID}"),
+    ],
+    ids=["known user", "no user"],
+)
+def test_agent_design_gate_resolves_against_the_acting_user(
+    settings, workspace_integration, org_team_user, distinct_id, expected_identity
+):
+    # The identity decides which rules can match at all. Resolving a known user against the
+    # workspace instead would silently stop every person rule, `email ends_with
+    # @posthog.com` included, from matching anyone.
+    settings.CLOUD_DEPLOYMENT = "DEV"
+    org, _, _ = org_team_user
+
+    with patch("posthoganalytics.feature_enabled", return_value=True) as feature_enabled:
+        feature_flags.is_slack_app_agent_design_enabled(workspace_integration, distinct_id)
+
+    assert feature_enabled.call_args.args[1] == expected_identity
+    assert feature_enabled.call_args.kwargs["person_properties"] == {"region": "DEV"}
+    assert feature_enabled.call_args.kwargs["groups"] == {"organization": str(org.id)}

--- a/products/tasks/backend/temporal/process_task/activities/feature_flags.py
+++ b/products/tasks/backend/temporal/process_task/activities/feature_flags.py
@@ -36,7 +36,13 @@ def is_slack_app_agent_design_enabled_for_task_activity(
         logger.warning("slack_app_agent_design_integration_missing", integration_id=input.integration_id)
         enabled = False
     else:
-        enabled = is_slack_app_agent_design_enabled(integration)
+        # The run's creator is the person the decision is about, so the gate resolves the
+        # flag against them and an internal rollout can name people by email or cohort the
+        # way every other one does. None when the run has no creator on record.
+        creator_distinct_id = (
+            TaskRun.objects.filter(id=input.run_id).values_list("task__created_by__distinct_id", flat=True).first()
+        )
+        enabled = is_slack_app_agent_design_enabled(integration, creator_distinct_id)
 
     def _persist(state: dict[str, Any]) -> None:
         state[AGENT_DESIGN_STATE_KEY] = enabled


### PR DESCRIPTION
## Problem

A Slack app rollout cannot name one person. `slack-app-agent-design` resolves against the Slack workspace, so a condition covers a whole org or region.

## Changes

The gate now resolves against the PostHog user whose run it is, so `email ends_with @posthog.com`, cohorts, and any person property work here like they do everywhere else.

- The activity passes the run's creator, so a thread renders one way for its whole life.
- No user falls back to the workspace. Forking and turn feedback are unchanged.

> [!NOTE]
> A percentage rollout is now a share of people, not of workspaces. No effect at 100%.

## How did you test this code?

Two cases in `test_feature_flags.py` over the identity the gate resolves against, catching a silent miss where a known user resolves against the workspace and no person rule matches.

Ruff and mypy clean. Tests not re-run after the final rename.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). Skills: `/writing-tests`, `/writing-pr-descriptions`.

Earlier drafts forwarded the user's email as a person property. `products/tasks/backend/feature_flags.py` showed the house pattern keys the flag on the person instead, which needs no forwarding.
