### PR TITLE
fix(mcp-store): allow oauth reconnection

### DIFF
--- a/products/mcp_store/frontend/gateway/GatewayServerScene.tsx
+++ b/products/mcp_store/frontend/gateway/GatewayServerScene.tsx
@@ -92,6 +92,7 @@ export function GatewayServerScene({
         removingServerIds.has(server.id) ||
         Boolean(connection && disconnectingInstallationIds.has(connection.installation_id))
     const needsReconnect = Boolean(connection?.pending_oauth || connection?.needs_reauth)
+    const canReconnect = Boolean(connection && (server.auth_type === 'oauth' || needsReconnect))
     const confirmRemoval = (): void => {
         if (!connection && removalAction !== 'delete_for_everyone') {
             return
@@ -183,7 +184,7 @@ export function GatewayServerScene({
                                     }
                                 />
                             </div>
-                            {needsReconnect && (
+                            {canReconnect && (
                                 <LemonButton
                                     type="primary"
                                     size="small"
@@ -195,6 +196,7 @@ export function GatewayServerScene({
                                               : undefined
                                     }
                                     onClick={() => reconnectServer(connection.installation_id)}
+                                    data-attr="mcp-server-reconnect"
                                 >
                                     Reconnect your account
                                 </LemonButton>

--- a/products/mcp_store/frontend/gateway/GatewayServersHome.test.tsx
+++ b/products/mcp_store/frontend/gateway/GatewayServersHome.test.tsx
@@ -120,4 +120,26 @@ describe('GatewayServersHome', () => {
         expect(connectServer).toHaveBeenCalledWith('server-id')
         expect(openServer).toHaveBeenCalledTimes(1)
     })
+
+    it('lets a user reconnect a healthy OAuth connection', () => {
+        render(
+            <GatewayServerCard
+                server={{
+                    ...gatewayServer(),
+                    auth_type: 'oauth',
+                    your_connection: {
+                        installation_id: 'installation-id',
+                        is_enabled: true,
+                        pending_oauth: false,
+                        needs_reauth: false,
+                        last_used_at: null,
+                    },
+                }}
+            />
+        )
+
+        fireEvent.click(screen.getByText('Reconnect'))
+
+        expect(reconnectServer).toHaveBeenCalledWith('installation-id')
+    })
 })

--- a/products/mcp_store/frontend/gateway/GatewayServersHome.tsx
+++ b/products/mcp_store/frontend/gateway/GatewayServersHome.tsx
@@ -153,6 +153,7 @@ export function GatewayServerCard({
     const connection = server.your_connection
     const connected = Boolean(connection?.is_enabled && !connection.pending_oauth && !connection.needs_reauth)
     const needsReconnect = Boolean(connection?.pending_oauth || connection?.needs_reauth)
+    const canReconnect = Boolean(connection && (server.auth_type === 'oauth' || needsReconnect))
     const connecting = connectingServerId === server.id
     const disabled = !server.is_team_enabled
     const canConnectIndividual = !connection
@@ -217,13 +218,14 @@ export function GatewayServerCard({
                 {isAdmin && !recommended && <PeopleRow server={server} />}
             </div>
             <div className="shrink-0">
-                {needsReconnect && connection ? (
+                {canReconnect && connection ? (
                     <LemonButton
                         size="small"
                         type="primary"
                         disabledReason={connectionDisabledReason}
                         onClick={() => reconnectServer(connection.installation_id)}
                         stopPropagation
+                        data-attr="mcp-server-reconnect"
                     >
                         Reconnect
                     </LemonButton>


### PR DESCRIPTION
## Problem

- People with a healthy OAuth MCP connection cannot reconnect it to change the connected account.

## Changes

- MCP server cards and details now show Reconnect for personal OAuth connections, even when credentials remain valid.
- API-key connections remain unchanged.
- Screenshot unavailable: a pre-existing ngrok endpoint blocked the local app startup.

## How did you test this code?

- `hogli test products/mcp_store/frontend/gateway/GatewayServersHome.test.tsx` verifies that a healthy OAuth connection starts reauthorization.
- `pnpm --filter=@posthog/frontend typescript:check` passed after building local workspace dependencies.
- Visual verification was not run because the local stack stopped at the existing ngrok endpoint.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. The MCP Store README already documents reconnection.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex updated the existing gateway controls and added a focused regression test. Skills used: Conductor, adding-mcp-store-servers, writing-ui-components, writing-tests, and writing-pr-descriptions.
