### PR TITLE
fix(desktop): render mermaid diagrams in chat

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatMarkdown.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatMarkdown.test.tsx
@@ -1,7 +1,22 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { renderToStaticMarkup as renderMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
+
+vi.mock("mermaid", () => ({
+  default: {
+    initialize: vi.fn(),
+    render: vi.fn(async () => ({
+      svg: '<svg data-testid="mermaid-svg"></svg>',
+    })),
+  },
+}));
+
+vi.mock("@posthog/ui/shell/themeStore", () => ({
+  useThemeStore: (selector: (state: { isDarkMode: boolean }) => unknown) =>
+    selector({ isDarkMode: false }),
+}));
 
 const queryClient = new QueryClient();
 function renderStatic(node: ReactNode) {
@@ -46,7 +61,16 @@ vi.mock("@posthog/ui/features/pr-review/usePrChecks", () => ({
 
 import { ChatMarkdown, ChatStreamingMarkdown } from "./ChatMarkdown";
 
+const MERMAID_FENCE = "```mermaid\ngraph TD; A-->B\n```";
+
 describe("ChatMarkdown", () => {
+  it("renders mermaid fences as diagrams", async () => {
+    render(<ChatMarkdown content={MERMAID_FENCE} />);
+
+    expect(await screen.findByTestId("mermaid-svg")).toBeInTheDocument();
+    expect(screen.queryByText("graph TD; A-->B")).toBeNull();
+  });
+
   it("preserves ordered-list numbering across intervening prose", () => {
     const content = `1. First review comment
 

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatMarkdown.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatMarkdown.tsx
@@ -26,6 +26,7 @@ import {
   looksLikeBareFilename,
 } from "@posthog/ui/features/sessions/components/session-update/fileLinkChips";
 import { HighlightedCode } from "@posthog/ui/primitives/HighlightedCode";
+import { MermaidDiagram } from "@posthog/ui/primitives/MermaidDiagram";
 import { Spin } from "@posthog/ui/primitives/Spinner";
 import { useCopy } from "@posthog/ui/primitives/useCopy";
 import { parseArtifactLink } from "@posthog/ui/utils/artifactLinks";
@@ -36,6 +37,7 @@ import {
   parseChartBlock,
 } from "@posthog/ui/utils/chartBlocks";
 import { parseEvidenceLink } from "@posthog/ui/utils/evidenceLinks";
+import { MERMAID_LANGUAGE } from "@posthog/ui/utils/mermaidBlocks";
 import { remarkObjectTags } from "@posthog/ui/utils/remarkObjectTags";
 import { IconButton } from "@radix-ui/themes";
 import { memo, type ReactNode, useMemo } from "react";
@@ -150,6 +152,9 @@ const components: Components = {
       const spec = parseChartBlock(text);
       if (!spec) return null;
       return <MessageChartCard spec={spec} blockKey={chartBlockKey(text)} />;
+    }
+    if (match?.[1].toLowerCase() === MERMAID_LANGUAGE) {
+      return <MermaidDiagram code={text} />;
     }
     // Fenced blocks (carry a language, or span multiple lines) render as a boxed, copyable
     // block; short inline spans stay inline. `pre` below is a passthrough so the box lives here,

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/AgentMessage.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/AgentMessage.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("mermaid", () => ({
+  default: {
+    initialize: vi.fn(),
+    render: vi.fn(async () => ({
+      svg: '<svg data-testid="mermaid-svg"></svg>',
+    })),
+  },
+}));
+
+vi.mock("@posthog/ui/shell/themeStore", () => ({
+  useThemeStore: (selector: (state: { isDarkMode: boolean }) => unknown) =>
+    selector({ isDarkMode: false }),
+}));
+
+import { AgentMessage } from "./AgentMessage";
+
+const MERMAID_FENCE = "```mermaid\ngraph TD; A-->B\n```";
+
+describe("AgentMessage", () => {
+  it("renders mermaid fences as diagrams after streaming completes", async () => {
+    render(<AgentMessage content={MERMAID_FENCE} />);
+
+    expect(await screen.findByTestId("mermaid-svg")).toBeInTheDocument();
+    expect(screen.queryByText("graph TD; A-->B")).toBeNull();
+  });
+});

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/AgentMessage.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/AgentMessage.tsx
@@ -1,9 +1,11 @@
 import { Check, Copy } from "@phosphor-icons/react";
-import { Box, Code, IconButton } from "@radix-ui/themes";
+import { IconButton } from "@radix-ui/themes";
 import { memo, useCallback, useState } from "react";
 import type { Components } from "react-markdown";
 import { HighlightedCode } from "../../../../primitives/HighlightedCode";
+import { MermaidDiagram } from "../../../../primitives/MermaidDiagram";
 import { Tooltip } from "../../../../primitives/Tooltip";
+import { MERMAID_LANGUAGE } from "../../../../utils/mermaidBlocks";
 import { MarkdownRenderer } from "../../../editor/components/MarkdownRenderer";
 import { StreamingMarkdown } from "../../../editor/components/StreamingMarkdown";
 import { useSmoothedText } from "../../../editor/components/useSmoothedText";
@@ -18,12 +20,11 @@ const agentComponents: Partial<Components> = {
   code: ({ children, className }) => {
     const langMatch = className?.match(/language-(\w+)/);
     if (langMatch) {
-      return (
-        <HighlightedCode
-          code={String(children).replace(/\n$/, "")}
-          language={langMatch[1]}
-        />
-      );
+      const code = String(children).replace(/\n$/, "");
+      if (langMatch[1].toLowerCase() === MERMAID_LANGUAGE) {
+        return <MermaidDiagram code={code} />;
+      }
+      return <HighlightedCode code={code} language={langMatch[1]} />;
     }
 
     const text = String(children).replace(/\n$/, "");
@@ -32,12 +33,9 @@ const agentComponents: Partial<Components> = {
     }
 
     const fallback = (
-      <Code
-        variant="ghost"
-        className="border border-border bg-gray-3 text-[13px]"
-      >
+      <code className="rounded border border-border bg-gray-3 px-1 text-[13px]">
         {children}
-      </Code>
+      </code>
     );
 
     if (looksLikeBareFilename(text)) {
@@ -70,7 +68,7 @@ export const AgentMessage = memo(function AgentMessage({
   }, [content]);
 
   return (
-    <Box className="group/msg relative pl-3 text-[13px] [&>*:last-child]:mb-0 [&_p]:leading-[1.9]">
+    <div className="group/msg relative pl-3 text-[13px] [&>*:last-child]:mb-0 [&_p]:leading-[1.9]">
       {isStreaming ? (
         <StreamingMarkdown
           content={smoothed}
@@ -84,7 +82,7 @@ export const AgentMessage = memo(function AgentMessage({
           componentsOverride={agentComponents}
         />
       )}
-      <Box className="absolute top-1 left-full ml-2 opacity-0 transition-opacity group-hover/msg:opacity-100">
+      <div className="absolute top-1 left-full ml-2 opacity-0 transition-opacity group-hover/msg:opacity-100">
         <Tooltip content={copied ? "Copied!" : "Copy message"}>
           <IconButton
             size="1"
@@ -96,7 +94,7 @@ export const AgentMessage = memo(function AgentMessage({
             {copied ? <Check size={14} /> : <Copy size={14} />}
           </IconButton>
         </Tooltip>
-      </Box>
-    </Box>
+      </div>
+    </div>
   );
 });


### PR DESCRIPTION
## Problem

Desktop chat users see Mermaid definitions as code instead of diagrams.

**Why:** Diagrams make agent explanations easier to understand.

## Changes

- Chat messages render closed `mermaid` fences as diagrams.
- Existing strict Mermaid safety checks apply in chat messages.
- Tests lock the agent-message and chat-thread rendering behavior.

## How did you test this code?

- Automated: focused Vitest coverage for the agent-message and chat-thread Mermaid fences.
- Automated: `pnpm lint` and `pnpm exec tsgo --noEmit`.
- Not run: live Electron inspection. This VM lacks the required `agent-browser` helper.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Existing documentation has no Desktop chat Markdown feature page.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used `/posthog-desktop`, `/writing-tests`, `/writing-pr-descriptions`, and `/test-electron-app`. The change reuses the existing Mermaid renderer in both chat paths.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*