### PR TITLE
fix(subscriptions): hide Slack gallery option for prompt reports

### DIFF
--- a/products/subscriptions/frontend/components/Subscriptions/views/EditSubscription.tsx
+++ b/products/subscriptions/frontend/components/Subscriptions/views/EditSubscription.tsx
@@ -572,8 +572,9 @@ function EditSubscriptionForm({
                                             </LemonField>
                                         )}
 
-                                        {(slackGalleryEnabled ||
-                                            subscription.delivery_config?.post_all_insights_in_main_message) &&
+                                        {!isAiPrompt &&
+                                            (slackGalleryEnabled ||
+                                                subscription.delivery_config?.post_all_insights_in_main_message) &&
                                             subscription.integration_id &&
                                             subscription.target_value &&
                                             (() => {


### PR DESCRIPTION
## Problem

People editing an AI prompt subscription see a Slack image-layout option that only applies to dashboard and insight subscriptions.

## Changes

- AI prompt subscriptions no longer show the “Post all insights in the main message” control.
- Dashboard and insight subscription behavior stays unchanged.

### Before

![Prompt subscription before](https://raw.githubusercontent.com/PostHog/pr-assets/c7afd4452fdf7ce06ad9fb17549432f0a413252a/2026/09/d6733bd2-5e90-4faa-8801-c307494d3eb9.jpg)

### After

![Prompt subscription after](https://raw.githubusercontent.com/PostHog/pr-assets/29fd8a1594f5fe864f9406034d1b9c354a576cf4/2026/09/fe70519f-16fc-4567-9b66-4f8db1a5bc86.jpg)

## How did you test this code?

- `pnpm --filter=@posthog/frontend fix`
- `pnpm --filter=@posthog/frontend typescript:check`
- Browser-driven Storybook verification used a synthetic AI prompt Slack subscription.
- No focused regression test was added for this narrow visibility guard, as directed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex authored the change using shell, Git, GitHub CLI, and the in-app Browser.
- Skills: brainstorming, systematic debugging, test-driven development, using git worktrees, verification before completion, browser control, and writing PR descriptions.
- Public artifact check: the screenshots contain synthetic report content and a generic `#general` channel.