### PR TITLE
fix(logs): treat a missing body as empty in the json sniff

### DIFF
--- a/nodejs/src/logs/log-body-parse.test.ts
+++ b/nodejs/src/logs/log-body-parse.test.ts
@@ -1,8 +1,9 @@
 import { parseLogBodyForIngestion } from './log-body-parse'
 
 describe('log-body-parse', () => {
-    it('returns empty for null body', () => {
-        expect(parseLogBodyForIngestion(null)).toEqual({ kind: 'empty' })
+    // Trace records have no body field, so the value arrives as `undefined` rather than `null`.
+    it.each([[null], [undefined]])('returns empty for %p body', (body) => {
+        expect(parseLogBodyForIngestion(body)).toEqual({ kind: 'empty' })
     })
 
     it('classifies JSON object', () => {

--- a/nodejs/src/logs/log-body-parse.ts
+++ b/nodejs/src/logs/log-body-parse.ts
@@ -41,13 +41,14 @@ function canStartJsonDocument(body: string): boolean {
     return false
 }
 
-export function parseLogBodyForIngestion(body: string | null): LogBodyParseResult {
-    if (body === null) {
+export function parseLogBodyForIngestion(body: string | null | undefined): LogBodyParseResult {
+    // Trace records carry no body field at all, so `undefined` reaches here as well as `null`.
+    if (body === null || body === undefined) {
         return { kind: 'empty' }
     }
     // Plaintext log lines are a large share of the traffic and every one of them makes `parseJSON`
     // build and throw an error. The scan reaches the same result without paying for the throw.
-    if (!canStartJsonDocument(body)) {
+    if (typeof body === 'string' && !canStartJsonDocument(body)) {
         return { kind: 'invalid_json', raw: body }
     }
     try {

--- a/nodejs/src/logs/log-record-avro.test.ts
+++ b/nodejs/src/logs/log-record-avro.test.ts
@@ -406,6 +406,39 @@ describe('log-record-avro', () => {
     })
 
     describe('processLogMessageBuffer', () => {
+        // Trace records are written with a schema that has no `body` field, so the decoded record
+        // has no `body` key at all. The JSON stage must treat that like a null body, not throw.
+        it('passes a body-less trace record through with JSON parsing enabled', async () => {
+            const schemaJson = LOG_RECORD_SCHEMA.schema() as { fields: { name: string }[] }
+            const bodylessSchema = avro.parse({
+                ...schemaJson,
+                fields: schemaJson.fields.filter((field) => field.name !== 'body'),
+            })
+            const record = {
+                uuid: 'span-uuid',
+                trace_id: Buffer.from('0123456789abcdef'),
+                span_id: Buffer.from('01234567'),
+                trace_flags: null,
+                timestamp: null,
+                observed_timestamp: null,
+                severity_text: null,
+                severity_number: null,
+                service_name: 'api',
+                resource_attributes: null,
+                instrumentation_scope: null,
+                event_name: null,
+                attributes: { 'http.method': 'GET' },
+                bytes_uncompressed: null,
+            } as unknown as LogRecord
+
+            const inputBuffer = await encodeLogRecords(bodylessSchema, 'zstandard', [record])
+            const { value: outputBuffer } = await processLogMessageBuffer(inputBuffer, { json_parse_logs: true })
+            const [_, __, decoded] = await decodeLogRecords(outputBuffer!)
+
+            expect(decoded).toHaveLength(1)
+            expect(decoded[0]?.attributes).toEqual({ 'http.method': 'GET' })
+        })
+
         it('processes buffer with JSON parsing enabled', async () => {
             const records: LogRecord[] = [
                 {


### PR DESCRIPTION
## Problem

- Trace spans for a team with JSON parsing enabled fail ingestion and land on the dead-letter topic instead of ClickHouse.
- Trace records have no `body` field, so the value is `undefined`.
- `parseLogBodyForIngestion` only guards `null`. The JSON start scan added in #92714 reads `body.length` before the `try`, so `undefined` throws a TypeError.
- Before #92714 the same input threw inside the `try` and the record went through.

## Changes

- A trace record with no body passes the JSON stage untouched, as it did before #92714.
- `parseLogBodyForIngestion` treats `undefined` like `null` and only scans string bodies. That covers all four callers with one guard.

## How did you test this code?

- Added an `undefined` row to the null-body case in `log-body-parse.test.ts`.
- Added a `processLogMessageBuffer` case that encodes a record with a schema that has no body field and runs it with JSON parsing on. No existing test used a body-less schema.
- Both new cases fail on master with the same TypeError and pass with this change.
- Not run: the rest of the nodejs suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code. Skills invoked: /writing-tests, /writing-pr-descriptions.
- The guard sits in the one shared function rather than at each of the four call sites.
