### PR TITLE
feat(experiments): add enroll mode to the precompute enrollment census

### DIFF
--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -290,3 +290,7 @@ SIGNALS_INBOX_PR_NOTIFICATION_POLL_SECONDS: int = get_from_env(
 
 # Incoming webhook for experiment precompute canary divergence alerts. Unset: Slack alerting is skipped.
 EXPERIMENT_CANARY_SLACK_WEBHOOK_URL: str = os.getenv("EXPERIMENT_CANARY_SLACK_WEBHOOK_URL", "")
+
+# "report_only": the enrollment census logs candidates and writes nothing (default).
+# "enroll": the census also enables precomputation for qualifying teams, capped per run.
+EXPERIMENT_PRECOMPUTE_ENROLLMENT_MODE: str = os.getenv("EXPERIMENT_PRECOMPUTE_ENROLLMENT_MODE", "report_only")

--- a/products/experiments/backend/temporal/enrollment_census_logic.py
+++ b/products/experiments/backend/temporal/enrollment_census_logic.py
@@ -253,9 +253,19 @@ def enroll_candidates(report: EnrollmentCensusReport) -> list[int]:
                 team_id=candidate.stats.team_id,
             )
             continue
-        config.experiment_precomputation_enabled = True
-        config.precomputation_enabled_set_by = TeamExperimentsConfig.PrecomputationEnabledSetBy.AUTO
-        config.save(update_fields=["experiment_precomputation_enabled", "precomputation_enabled_set_by"])
+        # Conditional UPDATE, not a save of the read row: a human toggling the team between
+        # our read and this write must win, in either direction.
+        updated = (
+            TeamExperimentsConfig.objects.filter(team_id=candidate.stats.team_id)
+            .filter(experiment_precomputation_enabled=False)
+            .exclude(precomputation_enabled_set_by=TeamExperimentsConfig.PrecomputationEnabledSetBy.MANUAL)
+            .update(
+                experiment_precomputation_enabled=True,
+                precomputation_enabled_set_by=TeamExperimentsConfig.PrecomputationEnabledSetBy.AUTO,
+            )
+        )
+        if not updated:
+            continue
         enrolled.append(candidate.stats.team_id)
         logger.info(
             "experiment_precompute_enrollment_enrolled",

--- a/products/experiments/backend/temporal/enrollment_census_logic.py
+++ b/products/experiments/backend/temporal/enrollment_census_logic.py
@@ -230,7 +230,20 @@ def enroll_candidates(report: EnrollmentCensusReport) -> list[int]:
 
     Additive only: the single write is False to True with set_by="auto". Teams a human
     touched (set_by="manual", in either direction) and already-enabled teams are skipped.
+
+    The wave commits atomically: a mid-loop failure enrolls nobody, so an activity retry
+    starts from a clean slate instead of topping up a partial wave with a fresh counter.
+    A worker crash in the gap after commit but before the activity completes can still
+    replay one full wave; that enrolls the next-worst qualifying teams a day early, which
+    is acceptable.
     """
+    enrolled: list[int] = []
+    with transaction.atomic():
+        enrolled = _enroll_candidates_locked(report)
+    return enrolled
+
+
+def _enroll_candidates_locked(report: EnrollmentCensusReport) -> list[int]:
     enrolled: list[int] = []
     for candidate in report.candidates:
         if len(enrolled) >= MAX_ENROLLMENTS_PER_RUN:

--- a/products/experiments/backend/temporal/enrollment_census_logic.py
+++ b/products/experiments/backend/temporal/enrollment_census_logic.py
@@ -9,12 +9,14 @@ anywhere in this module is False to True, and teams a human touched are never mo
 """
 
 from django.conf import settings
+from django.db import IntegrityError, transaction
 from django.db.models import Count
 
 import structlog
 
 from posthog.clickhouse.client import sync_execute
 from posthog.dataclasses import frozen
+from posthog.models.team import Team
 
 from products.experiments.backend.models.experiment import Experiment
 from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
@@ -233,7 +235,16 @@ def enroll_candidates(report: EnrollmentCensusReport) -> list[int]:
     for candidate in report.candidates:
         if len(enrolled) >= MAX_ENROLLMENTS_PER_RUN:
             break
-        config, _ = TeamExperimentsConfig.objects.get_or_create(team_id=candidate.stats.team_id)
+        # query_log_archive outlives team deletion: a deleted team's scans still qualify it,
+        # and creating a config for it would raise and abort the rest of the wave.
+        if not Team.objects.filter(id=candidate.stats.team_id).exists():
+            logger.info("experiment_precompute_enrollment_skipped_deleted_team", team_id=candidate.stats.team_id)
+            continue
+        try:
+            with transaction.atomic():
+                config, _ = TeamExperimentsConfig.objects.get_or_create(team_id=candidate.stats.team_id)
+        except IntegrityError:
+            continue
         if config.experiment_precomputation_enabled:
             continue
         if config.precomputation_enabled_set_by == TeamExperimentsConfig.PrecomputationEnabledSetBy.MANUAL:

--- a/products/experiments/backend/temporal/enrollment_census_logic.py
+++ b/products/experiments/backend/temporal/enrollment_census_logic.py
@@ -3,9 +3,12 @@
 Finds teams whose experiment metric reads run as direct event scans only because the
 team is not enrolled in precomputation (`experiment_precompute_skip_reason = 'team_disabled'`),
 measures their pain over a trailing window, and reports the ones crossing the enrollment
-criteria. Report-only: this module never writes to `TeamExperimentsConfig`.
+criteria. In "enroll" mode (`EXPERIMENT_PRECOMPUTE_ENROLLMENT_MODE`) it also enables
+precomputation for a capped number of candidates per run. Additive only: the single write
+anywhere in this module is False to True, and teams a human touched are never modified.
 """
 
+from django.conf import settings
 from django.db.models import Count
 
 import structlog
@@ -14,6 +17,7 @@ from posthog.clickhouse.client import sync_execute
 from posthog.dataclasses import frozen
 
 from products.experiments.backend.models.experiment import Experiment
+from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
 
 logger = structlog.get_logger(__name__)
 
@@ -38,6 +42,13 @@ HARD_FAILURES_THRESHOLD = 5
 BUILD_CAP_EXCLUSION_BYTES = int(2.5 * 10**12)
 
 EXCLUSION_BUILD_BYTE_CAP = "build_byte_cap"
+
+ENROLLMENT_MODE_ENROLL = "enroll"
+
+# Enroll at most this many teams per daily run, worst (most bytes rescanned) first. Makes
+# the rollout gradual by construction: each wave gets a day of canary and query-perf
+# scrutiny before the next.
+MAX_ENROLLMENTS_PER_RUN = 5
 
 # Reads query_log_archive, not system.query_log: the archive outlives query_log's short
 # retention and stores log_comment as a typed JSON column. The lc_product prefilter keeps
@@ -212,6 +223,40 @@ def build_census_report(stats: list[TeamDirectScanStats], window_days: int) -> E
     )
 
 
+def enroll_candidates(report: EnrollmentCensusReport) -> list[int]:
+    """Enable precomputation for up to MAX_ENROLLMENTS_PER_RUN candidates, worst first.
+
+    Additive only: the single write is False to True with set_by="auto". Teams a human
+    touched (set_by="manual", in either direction) and already-enabled teams are skipped.
+    """
+    enrolled: list[int] = []
+    for candidate in report.candidates:
+        if len(enrolled) >= MAX_ENROLLMENTS_PER_RUN:
+            break
+        config, _ = TeamExperimentsConfig.objects.get_or_create(team_id=candidate.stats.team_id)
+        if config.experiment_precomputation_enabled:
+            continue
+        if config.precomputation_enabled_set_by == TeamExperimentsConfig.PrecomputationEnabledSetBy.MANUAL:
+            logger.info(
+                "experiment_precompute_enrollment_skipped_manual",
+                team_id=candidate.stats.team_id,
+            )
+            continue
+        config.experiment_precomputation_enabled = True
+        config.precomputation_enabled_set_by = TeamExperimentsConfig.PrecomputationEnabledSetBy.AUTO
+        config.save(update_fields=["experiment_precomputation_enabled", "precomputation_enabled_set_by"])
+        enrolled.append(candidate.stats.team_id)
+        logger.info(
+            "experiment_precompute_enrollment_enrolled",
+            team_id=candidate.stats.team_id,
+            reasons=list(candidate.reasons),
+            total_read_bytes=candidate.stats.total_read_bytes,
+            running_experiments=candidate.running_experiments,
+            running_metrics=candidate.running_metrics,
+        )
+    return enrolled
+
+
 def run_enrollment_census_sync(window_days: int = CENSUS_WINDOW_DAYS) -> EnrollmentCensusReport:
     stats = fetch_direct_scan_stats(window_days)
     report = build_census_report(stats, window_days)
@@ -238,11 +283,17 @@ def run_enrollment_census_sync(window_days: int = CENSUS_WINDOW_DAYS) -> Enrollm
             max_read_bytes=excluded_team.stats.max_read_bytes,
             total_read_bytes=excluded_team.stats.total_read_bytes,
         )
+    enrolled: list[int] = []
+    if settings.EXPERIMENT_PRECOMPUTE_ENROLLMENT_MODE == ENROLLMENT_MODE_ENROLL:
+        enrolled = enroll_candidates(report)
+
     logger.info(
         "experiment_precompute_enrollment_census_finished",
         window_days=report.window_days,
         evaluated_teams=report.evaluated_teams,
         candidates=len(report.candidates),
         excluded=len(report.excluded),
+        mode=settings.EXPERIMENT_PRECOMPUTE_ENROLLMENT_MODE,
+        enrolled=enrolled,
     )
     return report

--- a/products/experiments/backend/temporal/test_enrollment_census_logic.py
+++ b/products/experiments/backend/temporal/test_enrollment_census_logic.py
@@ -173,3 +173,13 @@ class TestEnrollmentWrites(BaseTest):
 
         enabled = TeamExperimentsConfig.objects.filter(team=team, experiment_precomputation_enabled=True).exists()
         assert enabled == expect_write
+
+    def test_deleted_team_is_skipped_and_later_candidates_still_enroll(self):
+        fresh = self._team()
+        deleted_team_stats = _stats(team_id=999_999_999, total_read_bytes=9 * 10**12)
+        fresh_stats = _stats(team_id=fresh.id, total_read_bytes=6 * 10**12)
+        report = build_census_report([deleted_team_stats, fresh_stats], window_days=14)
+
+        enrolled = enroll_candidates(report)
+
+        assert enrolled == [fresh.id]

--- a/products/experiments/backend/temporal/test_enrollment_census_logic.py
+++ b/products/experiments/backend/temporal/test_enrollment_census_logic.py
@@ -4,18 +4,27 @@ from typing import Any
 
 from freezegun import freeze_time
 from posthog.test.base import BaseTest
+from unittest.mock import patch
 
+from django.test import override_settings
 from django.utils import timezone
 
 from parameterized import parameterized
 
+from posthog.models.team import Team
+
 from products.experiments.backend.models.experiment import Experiment, ExperimentSavedMetric, ExperimentToSavedMetric
+from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
 from products.experiments.backend.temporal.enrollment_census_logic import (
     BUILD_CAP_EXCLUSION_BYTES,
     EXCLUSION_BUILD_BYTE_CAP,
+    MAX_ENROLLMENTS_PER_RUN,
+    EnrollmentCensusReport,
     TeamDirectScanStats,
     TeamRunningLoad,
     build_census_report,
+    enroll_candidates,
+    run_enrollment_census_sync,
     running_experiment_load,
 )
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
@@ -97,3 +106,70 @@ class TestEnrollmentCensusCriteria(BaseTest):
         assert running_experiment_load([self.team.id]) == {
             self.team.id: TeamRunningLoad(running_experiments=1, running_metrics=4)
         }
+
+
+class TestEnrollmentWrites(BaseTest):
+    def _team(self) -> Team:
+        return Team.objects.create(organization=self.organization, name=f"team-{uuid.uuid4().hex[:8]}")
+
+    def _report_for(self, teams: list[Team]) -> EnrollmentCensusReport:
+        # Descending bytes in list order, matching the census sort.
+        stats = [
+            _stats(team_id=team.id, total_read_bytes=(len(teams) - i + 5) * 10**12) for i, team in enumerate(teams)
+        ]
+        return build_census_report(stats, window_days=14)
+
+    def test_enrolls_worst_first_up_to_cap(self):
+        teams = [self._team() for _ in range(MAX_ENROLLMENTS_PER_RUN + 2)]
+        report = self._report_for(teams)
+
+        enrolled = enroll_candidates(report)
+
+        assert enrolled == [team.id for team in teams[:MAX_ENROLLMENTS_PER_RUN]]
+        for team in teams[:MAX_ENROLLMENTS_PER_RUN]:
+            config = TeamExperimentsConfig.objects.get(team=team)
+            assert config.experiment_precomputation_enabled
+            assert config.precomputation_enabled_set_by == TeamExperimentsConfig.PrecomputationEnabledSetBy.AUTO
+        for team in teams[MAX_ENROLLMENTS_PER_RUN:]:
+            assert not TeamExperimentsConfig.objects.filter(team=team, experiment_precomputation_enabled=True).exists()
+
+    def test_never_overrides_a_human_and_skips_enabled_without_burning_cap(self):
+        manually_disabled, already_enabled, fresh = self._team(), self._team(), self._team()
+        TeamExperimentsConfig.objects.update_or_create(
+            team=manually_disabled,
+            defaults={
+                "experiment_precomputation_enabled": False,
+                "precomputation_enabled_set_by": TeamExperimentsConfig.PrecomputationEnabledSetBy.MANUAL,
+            },
+        )
+        TeamExperimentsConfig.objects.update_or_create(
+            team=already_enabled,
+            defaults={
+                "experiment_precomputation_enabled": True,
+                "precomputation_enabled_set_by": TeamExperimentsConfig.PrecomputationEnabledSetBy.MANUAL,
+            },
+        )
+        report = self._report_for([manually_disabled, already_enabled, fresh])
+
+        enrolled = enroll_candidates(report)
+
+        assert enrolled == [fresh.id]
+        config = TeamExperimentsConfig.objects.get(team=manually_disabled)
+        assert not config.experiment_precomputation_enabled
+        assert config.precomputation_enabled_set_by == TeamExperimentsConfig.PrecomputationEnabledSetBy.MANUAL
+
+    @parameterized.expand([("report_only", "report_only", False), ("enroll", "enroll", True)])
+    def test_mode_gates_the_write(self, _name: str, mode: str, expect_write: bool):
+        team = self._team()
+        row = (team.id, 100, 0, 10**9, 6 * 10**12, 0, 3)
+        with (
+            override_settings(EXPERIMENT_PRECOMPUTE_ENROLLMENT_MODE=mode),
+            patch(
+                "products.experiments.backend.temporal.enrollment_census_logic.sync_execute",
+                return_value=[row],
+            ),
+        ):
+            run_enrollment_census_sync()
+
+        enabled = TeamExperimentsConfig.objects.filter(team=team, experiment_precomputation_enabled=True).exists()
+        assert enabled == expect_write

--- a/products/experiments/backend/temporal/test_enrollment_census_logic.py
+++ b/products/experiments/backend/temporal/test_enrollment_census_logic.py
@@ -134,7 +134,7 @@ class TestEnrollmentWrites(BaseTest):
             assert not TeamExperimentsConfig.objects.filter(team=team, experiment_precomputation_enabled=True).exists()
 
     def test_never_overrides_a_human_and_skips_enabled_without_burning_cap(self):
-        manually_disabled, already_enabled, fresh = self._team(), self._team(), self._team()
+        manually_disabled, already_enabled = self._team(), self._team()
         TeamExperimentsConfig.objects.update_or_create(
             team=manually_disabled,
             defaults={
@@ -149,11 +149,14 @@ class TestEnrollmentWrites(BaseTest):
                 "precomputation_enabled_set_by": TeamExperimentsConfig.PrecomputationEnabledSetBy.MANUAL,
             },
         )
-        report = self._report_for([manually_disabled, already_enabled, fresh])
+        # More fresh teams than cap slots: if the two skipped teams burned slots,
+        # fewer than a full capful would enroll.
+        fresh_teams = [self._team() for _ in range(MAX_ENROLLMENTS_PER_RUN)]
+        report = self._report_for([manually_disabled, already_enabled, *fresh_teams])
 
         enrolled = enroll_candidates(report)
 
-        assert enrolled == [fresh.id]
+        assert enrolled == [team.id for team in fresh_teams]
         config = TeamExperimentsConfig.objects.get(team=manually_disabled)
         assert not config.experiment_precomputation_enabled
         assert config.precomputation_enabled_set_by == TeamExperimentsConfig.PrecomputationEnabledSetBy.MANUAL


### PR DESCRIPTION
## Problem

The enrollment census (#88455, #93449) reports teams that need precomputation, but enabling them is still a manual staff-endpoint action per team. Yesterday's reports list 27 US and 14 EU candidates waiting.

## Changes

- New setting `EXPERIMENT_PRECOMPUTE_ENROLLMENT_MODE`, default `report_only` (today's behavior, unchanged).
- Set to `enroll`, the daily census also enables precomputation for up to 5 candidates per run, worst first by bytes rescanned. Each wave gets a day of canary scrutiny before the next.
- Enrollment writes `set_by=auto`. Teams a human touched (#89176) are never modified, and the only write in the module is False to True, so a manual disable sticks and enabled teams are unreachable.
- Each enrollment logs one line (`experiment_precompute_enrollment_enrolled`), queryable in Loki next to the candidate reports.

Flipping the mode is a deploy-time env change, not part of this PR.

## How did you test this code?

- New tests: cap and worst-first ordering, a manually disabled team is never re-enabled (the regression the provenance field exists to prevent), already-enabled teams are skipped without burning cap slots, and the mode setting gates the write end to end (report_only writes nothing).
- Not tested: a live enroll-mode run against production data; the first real run is the rollout step and is watched via the canary and the enrollment logs.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None, internal setting.
