### PR TITLE
feat(desktop): readable flag audience card and edit-in-task on the flag page

### DIFF
--- a/products/desktop/apps/web/src/web-container.ts
+++ b/products/desktop/apps/web/src/web-container.ts
@@ -119,6 +119,10 @@ import {
   SESSION_SERVICE,
   type SessionService,
 } from "@posthog/core/sessions/sessionService";
+import {
+  AGENT_PROMPT_SENDER,
+  type AgentPromptSender,
+} from "@posthog/ui/features/sessions/agentPromptSender";
 import { sessionsModule } from "@posthog/core/sessions/sessions.module";
 import {
   type GithubPrTitleClient,
@@ -166,7 +170,7 @@ import {
 } from "@posthog/core/tasks/identifiers";
 import type { TaskDeletionService } from "@posthog/core/tasks/taskDeletionService";
 import { tasksModule } from "@posthog/core/tasks/tasks.module";
-import { setRootContainer } from "@posthog/di/container";
+import { resolveService, setRootContainer } from "@posthog/di/container";
 import { assertHostCapabilities } from "@posthog/di/hostCapabilities";
 import { ROOT_LOGGER, type RootLogger } from "@posthog/di/logger";
 import {
@@ -358,6 +362,7 @@ interface WebBindings {
   [CLOUD_TASK_SERVICE]: CloudTaskService;
   [CLOUD_TASK_AUTH]: ICloudTaskAuth;
   [SESSION_SERVICE]: SessionService;
+  [AGENT_PROMPT_SENDER]: AgentPromptSender;
   [SETUP_STORE]: ISetupStore;
   [GITHUB_ISSUE_CLIENT]: GitHubIssueClient;
   [HEDGEHOG_MODE_HOST]: HedgehogModeHost;
@@ -504,6 +509,18 @@ container
   .bind(SESSION_SERVICE)
   .toDynamicValue(() => getSessionService())
   .inSingletonScope();
+
+// Shared UI resolves AGENT_PROMPT_SENDER for send-to-agent actions
+// (sendPromptToAgent, the flag edit popover); route it through SessionService
+// like the desktop renderer does.
+container
+  .bind<AgentPromptSender>(AGENT_PROMPT_SENDER)
+  .toConstantValue(async (taskId, prompt) => {
+    await resolveService<SessionService>(SESSION_SERVICE).sendPrompt(
+      taskId,
+      prompt,
+    );
+  });
 
 // ── Feature flags (real posthog-js) ──
 // When posthog isn't initialized (no real VITE_POSTHOG_API_KEY), isEnabled

--- a/products/desktop/apps/web/src/web-container.ts
+++ b/products/desktop/apps/web/src/web-container.ts
@@ -119,10 +119,6 @@ import {
   SESSION_SERVICE,
   type SessionService,
 } from "@posthog/core/sessions/sessionService";
-import {
-  AGENT_PROMPT_SENDER,
-  type AgentPromptSender,
-} from "@posthog/ui/features/sessions/agentPromptSender";
 import { sessionsModule } from "@posthog/core/sessions/sessions.module";
 import {
   type GithubPrTitleClient,
@@ -256,6 +252,10 @@ import {
 } from "@posthog/ui/features/notifications/identifiers";
 import { notificationsUiModule } from "@posthog/ui/features/notifications/notifications.module";
 import { OnboardingGithubConnectClient } from "@posthog/ui/features/onboarding/githubConnectClientImpl";
+import {
+  AGENT_PROMPT_SENDER,
+  type AgentPromptSender,
+} from "@posthog/ui/features/sessions/agentPromptSender";
 import { getSessionService } from "@posthog/ui/features/sessions/sessionServiceHost";
 import { setupUiModule } from "@posthog/ui/features/setup/setup.module";
 import { taskCreationEffects } from "@posthog/ui/features/task-detail/taskCreationEffectsImpl";

--- a/products/desktop/packages/api-client/endpoint-allowlist.json
+++ b/products/desktop/packages/api-client/endpoint-allowlist.json
@@ -26,6 +26,7 @@
     "/api/projects/{project_id}/integrations/{id}/",
     "/api/projects/{project_id}/persons/",
     "/api/projects/{project_id}/persons/{id}/",
+    "/api/projects/{project_id}/persons/batch_by_distinct_ids/",
     "/api/projects/{project_id}/session_recordings/{id}/",
     "/api/projects/{project_id}/surveys/{id}/",
     "/api/projects/{project_id}/surveys/{id}/stats/",

--- a/products/desktop/packages/api-client/src/evidence-previews.test.ts
+++ b/products/desktop/packages/api-client/src/evidence-previews.test.ts
@@ -303,7 +303,6 @@ describe("evidence preview shaping", () => {
       title: "Configuration",
       fields: expect.arrayContaining([
         { label: "Type", value: "Multivariate" },
-        { label: "Release conditions", value: "1 condition" },
       ]),
     });
   });
@@ -330,15 +329,19 @@ describe("evidence preview shaping", () => {
       },
     } as unknown as Schemas.FeatureFlag);
 
-    expect(preview.sections).toContainEqual({
-      title: "Release conditions",
-      fields: [
-        {
-          label: "Set 1",
-          value: "plan exact pro · 25% rollout · Variant: test",
-        },
-      ],
-    });
+    expect(preview.flagAudience?.rules).toEqual([
+      {
+        conditions: [
+          {
+            subject: "plan",
+            operator: "is",
+            values: [{ label: "pro", literal: true }],
+          },
+        ],
+        share: 25,
+        result: { kind: "variant", key: "test" },
+      },
+    ]);
   });
 
   it("shows a disabled flag without a name as just the state", () => {

--- a/products/desktop/packages/api-client/src/evidence-previews.test.ts
+++ b/products/desktop/packages/api-client/src/evidence-previews.test.ts
@@ -330,7 +330,7 @@ describe("evidence preview shaping", () => {
     } as unknown as Schemas.FeatureFlag);
 
     expect(preview.flagAudience?.rules).toEqual([
-      {
+      expect.objectContaining({
         conditions: [
           {
             subject: "plan",
@@ -340,7 +340,7 @@ describe("evidence preview shaping", () => {
         ],
         share: 25,
         result: { kind: "variant", key: "test" },
-      },
+      }),
     ]);
   });
 

--- a/products/desktop/packages/api-client/src/evidence-previews.test.ts
+++ b/products/desktop/packages/api-client/src/evidence-previews.test.ts
@@ -335,7 +335,7 @@ describe("evidence preview shaping", () => {
           {
             subject: "plan",
             operator: "is",
-            values: [{ label: "pro", literal: true }],
+            values: [{ label: "pro" }],
           },
         ],
         share: 25,

--- a/products/desktop/packages/api-client/src/evidence-previews.ts
+++ b/products/desktop/packages/api-client/src/evidence-previews.ts
@@ -7,6 +7,13 @@
 // stays a thin "fetch by kind, shape result" dispatch.
 
 import type { SignalReport } from "@posthog/shared/domain-types";
+import {
+  type FlagAudience,
+  flagReachLabel,
+  type ResolvedPerson,
+  shapeFlagAudience,
+  targetedDistinctIds,
+} from "./flag-audience";
 import type { Schemas } from "./generated";
 
 export interface EvidenceDetailField {
@@ -108,6 +115,8 @@ export interface EvidencePreview {
   };
   sections?: EvidenceDetailSection[];
   experimentResults?: ExperimentResultsPresentation;
+  /** Who a feature flag reaches, as a readable rules table. */
+  flagAudience?: FlagAudience;
   /**
    * A dashboard's tiles, each resolvable to a live insight chart, so a full
    * page can render the metrics themselves rather than describe them.
@@ -269,8 +278,12 @@ function surveyQuestionSummary(question: unknown): string | null {
   return type ? `${prompt} (${humanizeStatus(type)})` : prompt;
 }
 
-export function shapeFlagPreview(flag: Schemas.FeatureFlag): EvidencePreview {
+export function shapeFlagPreview(
+  flag: Schemas.FeatureFlag,
+  people: Map<string, ResolvedPerson> = new Map(),
+): EvidencePreview {
   const name = flag.name?.trim();
+  const audience = shapeFlagAudience(flag, people);
 
   const facts: string[] = [];
   const filters = isRecord(flag.filters) ? flag.filters : {};
@@ -298,19 +311,12 @@ export function shapeFlagPreview(flag: Schemas.FeatureFlag): EvidencePreview {
     : isMultivariate
       ? "Multivariate"
       : "Boolean";
-  const singleRollout =
-    groups.length === 1 && isRecord(groups[0])
-      ? groups[0].rollout_percentage
-      : null;
   const stats: Array<{ label: string; value: string }> = [
-    ...(typeof singleRollout === "number"
-      ? [{ label: "Rollout", value: `${singleRollout}%` }]
-      : groups.length > 1
-        ? [{ label: "Release conditions", value: String(groups.length) }]
-        : []),
+    { label: "Reach", value: flagReachLabel(audience) },
     ...(variants > 0 ? [{ label: "Variants", value: String(variants) }] : []),
     { label: "Type", value: flagType },
   ];
+  const distinctIds = targetedDistinctIds(flag);
   return {
     title: flag.key,
     detail: name || undefined,
@@ -319,13 +325,10 @@ export function shapeFlagPreview(flag: Schemas.FeatureFlag): EvidencePreview {
       : { label: "Disabled", tone: "neutral" },
     facts,
     stats,
+    flagAudience: audience,
     sections: [
       ...detailSection("Configuration", [
         ["Type", flagType],
-        [
-          "Release conditions",
-          groups.length ? count(groups.length, "condition") : "All users",
-        ],
         [
           "Evaluation runtime",
           flag.evaluation_runtime === "all"
@@ -344,17 +347,22 @@ export function shapeFlagPreview(flag: Schemas.FeatureFlag): EvidencePreview {
               : "Disabled",
         ],
         [
+          "Used by",
+          flag.experiment_set?.length
+            ? count(flag.experiment_set.length, "experiment")
+            : null,
+        ],
+        [
           "Last called",
           flag.last_called_at ? formatDay(flag.last_called_at) : null,
         ],
+        [
+          distinctIds.length === 1
+            ? "Targeted distinct ID"
+            : "Targeted distinct IDs",
+          distinctIds.length > 0 ? distinctIds.join(", ") : null,
+        ],
       ]),
-      ...detailSection(
-        "Release conditions",
-        groups.map((group, index) => [
-          `Set ${index + 1}`,
-          flagConditionSummary(group),
-        ]),
-      ),
     ],
     resolvedId: String(flag.id),
   };

--- a/products/desktop/packages/api-client/src/evidence-previews.ts
+++ b/products/desktop/packages/api-client/src/evidence-previews.ts
@@ -10,9 +10,9 @@ import type { SignalReport } from "@posthog/shared/domain-types";
 import {
   type FlagAudience,
   flagReachLabel,
+  positivelyTargetedDistinctIds,
   type ResolvedPerson,
   shapeFlagAudience,
-  targetedDistinctIds,
 } from "./flag-audience";
 import type { Schemas } from "./generated";
 
@@ -316,7 +316,7 @@ export function shapeFlagPreview(
     ...(variants > 0 ? [{ label: "Variants", value: String(variants) }] : []),
     { label: "Type", value: flagType },
   ];
-  const distinctIds = targetedDistinctIds(flag);
+  const distinctIds = positivelyTargetedDistinctIds(flag);
   return {
     title: flag.key,
     detail: name || undefined,

--- a/products/desktop/packages/api-client/src/evidence-previews.ts
+++ b/products/desktop/packages/api-client/src/evidence-previews.ts
@@ -10,9 +10,9 @@ import type { SignalReport } from "@posthog/shared/domain-types";
 import {
   type FlagAudience,
   flagReachLabel,
-  positivelyTargetedDistinctIds,
   type ResolvedPerson,
   shapeFlagAudience,
+  targetedDistinctIds,
 } from "./flag-audience";
 import type { Schemas } from "./generated";
 
@@ -316,7 +316,7 @@ export function shapeFlagPreview(
     ...(variants > 0 ? [{ label: "Variants", value: String(variants) }] : []),
     { label: "Type", value: flagType },
   ];
-  const distinctIds = positivelyTargetedDistinctIds(flag);
+  const distinctIds = targetedDistinctIds(flag, true);
   return {
     title: flag.key,
     detail: name || undefined,

--- a/products/desktop/packages/api-client/src/flag-audience.test.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.test.ts
@@ -28,6 +28,16 @@ describe("flag audience shaping", () => {
     expect(audience.rules[0].conditions[0].subject).toBe("Person");
   });
 
+  it("reports nobody for a flag with no release conditions", () => {
+    const audience = shapeFlagAudience(flagWith({ groups: [] }));
+
+    expect(audience.rules).toEqual([]);
+    expect(audience.headline).toBe("On for nobody.");
+    expect(audience.summary).toBe(
+      "The flag has no release conditions, so every check returns false.",
+    );
+  });
+
   it("renders a readable label for operators that only reach flags through the API", () => {
     const audience = shapeFlagAudience(
       flagWith({

--- a/products/desktop/packages/api-client/src/flag-audience.test.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.test.ts
@@ -38,6 +38,29 @@ describe("flag audience shaping", () => {
     );
   });
 
+  it("marks rules after a 100% catch-all as unreachable", () => {
+    const audience = shapeFlagAudience(
+      flagWith({
+        multivariate: { variants: [{ key: "a" }, { key: "b" }] },
+        groups: [
+          { rollout_percentage: 100 },
+          {
+            properties: [{ key: "plan", operator: "exact", value: "pro" }],
+            rollout_percentage: 50,
+            variant: "b",
+          },
+        ],
+      }),
+    );
+
+    expect(audience.rules.map((rule) => rule.reachable)).toEqual([
+      true,
+      false,
+    ]);
+    // The shadowed rule must not promise its variant in the summary.
+    expect(audience.summary).not.toContain("b");
+  });
+
   it("renders a readable label for operators that only reach flags through the API", () => {
     const audience = shapeFlagAudience(
       flagWith({

--- a/products/desktop/packages/api-client/src/flag-audience.test.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.test.ts
@@ -43,9 +43,6 @@ describe("flag audience shaping", () => {
 
     expect(audience.rules).toEqual([]);
     expect(audience.headline).toBe("On for nobody.");
-    expect(audience.summary).toBe(
-      "The flag has no release conditions, so every check returns false.",
-    );
   });
 
   it("marks rules after a 100% catch-all as unreachable", () => {
@@ -64,17 +61,9 @@ describe("flag audience shaping", () => {
     );
 
     expect(audience.rules.map((rule) => rule.reachable)).toEqual([true, false]);
-    // The shadowed rule must not promise its variant in the summary.
-    expect(audience.summary).not.toContain("b");
-  });
-
-  it("keeps the summary consistent with the hidden fallback row on a catch-all", () => {
-    const audience = shapeFlagAudience(
-      flagWith({ groups: [{ rollout_percentage: 100 }] }),
-    );
-
     expect(audience.fallbackReachable).toBe(false);
-    expect(audience.summary).not.toContain("Everyone else gets false.");
+    // The shadowed rule must not appear in the headline.
+    expect(audience.headline).toBe("Split into 2 variants for everyone.");
   });
 
   it("keeps group-scope rules out of the guaranteed catch-all", () => {
@@ -104,7 +93,7 @@ describe("flag audience shaping", () => {
     expect(audience.bucketing).toBe("device");
   });
 
-  it("states the enrollment override for early access flags", () => {
+  it("surfaces the enrollment key for early access flags", () => {
     const audience = shapeFlagAudience(
       flagWith({
         feature_enrollment: true,
@@ -113,12 +102,9 @@ describe("flag audience shaping", () => {
     );
 
     expect(audience.enrollmentKey).toBe("$feature_enrollment/test-flag");
-    expect(audience.summary).toContain(
-      "$feature_enrollment/test-flag overrides these rules",
-    );
   });
 
-  it("states the holdout result before the rules", () => {
+  it("surfaces the experiment holdout", () => {
     const audience = shapeFlagAudience(
       flagWith({
         holdout: { id: 3, exclusion_percentage: 20 },
@@ -127,9 +113,6 @@ describe("flag audience shaping", () => {
     );
 
     expect(audience.holdout).toEqual({ id: "3", exclusionPercentage: 20 });
-    expect(audience.summary).toMatch(
-      /^20% of people are held out for experiment 3 and get holdout-3\./,
-    );
   });
 
   it("does not describe a fraction of a named person at partial rollout", () => {
@@ -156,9 +139,6 @@ describe("flag audience shaping", () => {
     );
 
     expect(audience.headline).toBe("On for Alex.");
-    expect(audience.summary).toBe(
-      "Alex is targeted, and the 25% rollout hash decides. Everyone else gets false.",
-    );
   });
 
   it("does not label excluded distinct IDs as targeted", () => {

--- a/products/desktop/packages/api-client/src/flag-audience.test.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.test.ts
@@ -27,4 +27,23 @@ describe("flag audience shaping", () => {
     expect(audience.headline).toBe("On for 25% of Power users.");
     expect(audience.rules[0].conditions[0].subject).toBe("Person");
   });
+
+  it("renders a readable label for operators that only reach flags through the API", () => {
+    const audience = shapeFlagAudience(
+      flagWith({
+        groups: [
+          {
+            properties: [
+              { key: "app_version", operator: "semver_caret", value: "2.1.0" },
+            ],
+            rollout_percentage: 100,
+          },
+        ],
+      }),
+    );
+
+    expect(audience.rules[0].conditions[0].operator).toBe(
+      "is version in caret range",
+    );
+  });
 });

--- a/products/desktop/packages/api-client/src/flag-audience.test.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.test.ts
@@ -61,6 +61,15 @@ describe("flag audience shaping", () => {
     expect(audience.summary).not.toContain("b");
   });
 
+  it("keeps the summary consistent with the hidden fallback row on a catch-all", () => {
+    const audience = shapeFlagAudience(
+      flagWith({ groups: [{ rollout_percentage: 100 }] }),
+    );
+
+    expect(audience.fallbackReachable).toBe(false);
+    expect(audience.summary).not.toContain("Everyone else gets false.");
+  });
+
   it("renders a readable label for operators that only reach flags through the API", () => {
     const audience = shapeFlagAudience(
       flagWith({

--- a/products/desktop/packages/api-client/src/flag-audience.test.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { shapeFlagAudience } from "./flag-audience";
+import type { Schemas } from "./generated";
+
+// The shaper only reads the fields it shows; build minimal inputs and cast.
+function flagWith(filters: unknown): Schemas.FeatureFlag {
+  return { id: 1, key: "test-flag", active: true, filters } as unknown as Schemas.FeatureFlag;
+}
+
+describe("flag audience shaping", () => {
+  it("treats an explicit null aggregation as person targeting", () => {
+    const audience = shapeFlagAudience(
+      flagWith({
+        aggregation_group_type_index: 0,
+        groups: [
+          {
+            properties: [
+              { type: "cohort", key: "id", value: 7, cohort_name: "Power users" },
+            ],
+            rollout_percentage: 25,
+            aggregation_group_type_index: null,
+          },
+        ],
+      }),
+    );
+
+    expect(audience.headline).toBe("On for 25% of Power users.");
+    expect(audience.rules[0].conditions[0].subject).toBe("Person");
+  });
+});

--- a/products/desktop/packages/api-client/src/flag-audience.test.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.test.ts
@@ -70,6 +70,27 @@ describe("flag audience shaping", () => {
     expect(audience.summary).not.toContain("Everyone else gets false.");
   });
 
+  it("keeps group-scope rules out of the guaranteed catch-all", () => {
+    const audience = shapeFlagAudience(
+      flagWith({ aggregation_group_type_index: 0, groups: [{ rollout_percentage: 100 }] }),
+    );
+
+    expect(audience.rules[0].isGroup).toBe(true);
+    expect(audience.fallbackReachable).toBe(true);
+    expect(audience.headline).toBe("On for every group.");
+    expect(audience.stability).toBe("the group key");
+  });
+
+  it("describes device bucketing and keeps its fallback reachable", () => {
+    const audience = shapeFlagAudience(
+      flagWith({ bucketing_identifier: "device_id", groups: [{ rollout_percentage: 100 }] }),
+    );
+
+    expect(audience.fallbackReachable).toBe(true);
+    expect(audience.headline).toBe("On for every device.");
+    expect(audience.stability).toBe("the device ID");
+  });
+
   it("renders a readable label for operators that only reach flags through the API", () => {
     const audience = shapeFlagAudience(
       flagWith({

--- a/products/desktop/packages/api-client/src/flag-audience.test.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { shapeFlagAudience } from "./flag-audience";
+import {
+  positivelyTargetedDistinctIds,
+  shapeFlagAudience,
+  targetedDistinctIds,
+} from "./flag-audience";
 import type { Schemas } from "./generated";
 
 // The shaper only reads the fields it shows; build minimal inputs and cast.
@@ -146,6 +150,29 @@ describe("flag audience shaping", () => {
     expect(audience.summary).toBe(
       "Alex is targeted, and the 25% rollout hash decides. Everyone else gets false.",
     );
+  });
+
+  it("does not label excluded distinct IDs as targeted", () => {
+    const flag = flagWith({
+      groups: [
+        {
+          properties: [
+            {
+              type: "person",
+              key: "distinct_id",
+              operator: "is_not",
+              value: "bot-1",
+            },
+          ],
+          rollout_percentage: 100,
+        },
+      ],
+    });
+
+    // Person-name resolution still collects the excluded id, but the
+    // targeted-ids field must not claim the rule targets it.
+    expect(targetedDistinctIds(flag)).toEqual(["bot-1"]);
+    expect(positivelyTargetedDistinctIds(flag)).toEqual([]);
   });
 
   it("renders a readable label for operators that only reach flags through the API", () => {

--- a/products/desktop/packages/api-client/src/flag-audience.test.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.test.ts
@@ -119,6 +119,35 @@ describe("flag audience shaping", () => {
     );
   });
 
+  it("does not describe a fraction of a named person at partial rollout", () => {
+    const people = new Map([
+      ["u-1", { uuid: "p-1", name: "Alex", email: null }],
+    ]);
+    const audience = shapeFlagAudience(
+      flagWith({
+        groups: [
+          {
+            properties: [
+              {
+                type: "person",
+                key: "distinct_id",
+                operator: "exact",
+                value: "u-1",
+              },
+            ],
+            rollout_percentage: 25,
+          },
+        ],
+      }),
+      people,
+    );
+
+    expect(audience.headline).toBe("On for Alex.");
+    expect(audience.summary).toBe(
+      "Alex is targeted, and the 25% rollout hash decides. Everyone else gets false.",
+    );
+  });
+
   it("renders a readable label for operators that only reach flags through the API", () => {
     const audience = shapeFlagAudience(
       flagWith({

--- a/products/desktop/packages/api-client/src/flag-audience.test.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.test.ts
@@ -105,6 +105,20 @@ describe("flag audience shaping", () => {
     );
   });
 
+  it("states the holdout result before the rules", () => {
+    const audience = shapeFlagAudience(
+      flagWith({
+        holdout: { id: 3, exclusion_percentage: 20 },
+        groups: [{ rollout_percentage: 100 }],
+      }),
+    );
+
+    expect(audience.holdout).toEqual({ id: "3", exclusionPercentage: 20 });
+    expect(audience.summary).toMatch(
+      /^20% of people are held out for experiment 3 and get holdout-3\./,
+    );
+  });
+
   it("renders a readable label for operators that only reach flags through the API", () => {
     const audience = shapeFlagAudience(
       flagWith({

--- a/products/desktop/packages/api-client/src/flag-audience.test.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  positivelyTargetedDistinctIds,
-  shapeFlagAudience,
-  targetedDistinctIds,
-} from "./flag-audience";
+import { shapeFlagAudience, targetedDistinctIds } from "./flag-audience";
 import type { Schemas } from "./generated";
 
 // The shaper only reads the fields it shows; build minimal inputs and cast.
@@ -92,7 +88,7 @@ describe("flag audience shaping", () => {
     expect(audience.rules[0].isGroup).toBe(true);
     expect(audience.fallbackReachable).toBe(true);
     expect(audience.headline).toBe("On for every group.");
-    expect(audience.stability).toBe("the group key");
+    expect(audience.bucketing).toBe("group");
   });
 
   it("describes device bucketing and keeps its fallback reachable", () => {
@@ -105,7 +101,7 @@ describe("flag audience shaping", () => {
 
     expect(audience.fallbackReachable).toBe(true);
     expect(audience.headline).toBe("On for every device.");
-    expect(audience.stability).toBe("the device ID");
+    expect(audience.bucketing).toBe("device");
   });
 
   it("states the enrollment override for early access flags", () => {
@@ -185,7 +181,7 @@ describe("flag audience shaping", () => {
     // Person-name resolution still collects the excluded id, but the
     // targeted-ids field must not claim the rule targets it.
     expect(targetedDistinctIds(flag)).toEqual(["bot-1"]);
-    expect(positivelyTargetedDistinctIds(flag)).toEqual([]);
+    expect(targetedDistinctIds(flag, true)).toEqual([]);
   });
 
   it("renders a readable label for operators that only reach flags through the API", () => {

--- a/products/desktop/packages/api-client/src/flag-audience.test.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.test.ts
@@ -8,7 +8,12 @@ import type { Schemas } from "./generated";
 
 // The shaper only reads the fields it shows; build minimal inputs and cast.
 function flagWith(filters: unknown): Schemas.FeatureFlag {
-  return { id: 1, key: "test-flag", active: true, filters } as unknown as Schemas.FeatureFlag;
+  return {
+    id: 1,
+    key: "test-flag",
+    active: true,
+    filters,
+  } as unknown as Schemas.FeatureFlag;
 }
 
 describe("flag audience shaping", () => {
@@ -19,7 +24,12 @@ describe("flag audience shaping", () => {
         groups: [
           {
             properties: [
-              { type: "cohort", key: "id", value: 7, cohort_name: "Power users" },
+              {
+                type: "cohort",
+                key: "id",
+                value: 7,
+                cohort_name: "Power users",
+              },
             ],
             rollout_percentage: 25,
             aggregation_group_type_index: null,
@@ -57,10 +67,7 @@ describe("flag audience shaping", () => {
       }),
     );
 
-    expect(audience.rules.map((rule) => rule.reachable)).toEqual([
-      true,
-      false,
-    ]);
+    expect(audience.rules.map((rule) => rule.reachable)).toEqual([true, false]);
     // The shadowed rule must not promise its variant in the summary.
     expect(audience.summary).not.toContain("b");
   });
@@ -76,7 +83,10 @@ describe("flag audience shaping", () => {
 
   it("keeps group-scope rules out of the guaranteed catch-all", () => {
     const audience = shapeFlagAudience(
-      flagWith({ aggregation_group_type_index: 0, groups: [{ rollout_percentage: 100 }] }),
+      flagWith({
+        aggregation_group_type_index: 0,
+        groups: [{ rollout_percentage: 100 }],
+      }),
     );
 
     expect(audience.rules[0].isGroup).toBe(true);
@@ -87,7 +97,10 @@ describe("flag audience shaping", () => {
 
   it("describes device bucketing and keeps its fallback reachable", () => {
     const audience = shapeFlagAudience(
-      flagWith({ bucketing_identifier: "device_id", groups: [{ rollout_percentage: 100 }] }),
+      flagWith({
+        bucketing_identifier: "device_id",
+        groups: [{ rollout_percentage: 100 }],
+      }),
     );
 
     expect(audience.fallbackReachable).toBe(true);

--- a/products/desktop/packages/api-client/src/flag-audience.test.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.test.ts
@@ -91,6 +91,20 @@ describe("flag audience shaping", () => {
     expect(audience.stability).toBe("the device ID");
   });
 
+  it("states the enrollment override for early access flags", () => {
+    const audience = shapeFlagAudience(
+      flagWith({
+        feature_enrollment: true,
+        groups: [{ rollout_percentage: 100 }],
+      }),
+    );
+
+    expect(audience.enrollmentKey).toBe("$feature_enrollment/test-flag");
+    expect(audience.summary).toContain(
+      "$feature_enrollment/test-flag overrides these rules",
+    );
+  });
+
   it("renders a readable label for operators that only reach flags through the API", () => {
     const audience = shapeFlagAudience(
       flagWith({

--- a/products/desktop/packages/api-client/src/flag-audience.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.ts
@@ -1,0 +1,453 @@
+import type { Schemas } from "./generated";
+
+/**
+ * Who a feature flag reaches, shaped for reading rather than editing: a
+ * headline sentence, the rules as a first-match-wins table where every row
+ * ends in its result, and the variant split when the flag has one.
+ */
+export interface FlagAudience {
+  /** "On for one person." */
+  headline: string;
+  /** "Alex gets true. Everyone else gets false." */
+  summary: string;
+  disabled: boolean;
+  rules: FlagRule[];
+  /** What a check returns when no rule matches. */
+  fallback: FlagResult;
+  variants: FlagVariant[];
+}
+
+export interface FlagRule {
+  /** Empty when the rule matches everyone. */
+  conditions: FlagCondition[];
+  /** Rollout percentage within the matched audience. */
+  share: number;
+  result: FlagResult;
+}
+
+export type FlagResult =
+  | { kind: "true" }
+  | { kind: "false" }
+  | { kind: "variant"; key: string }
+  | { kind: "split" }
+  | { kind: "payload" };
+
+export interface FlagCondition {
+  /** "Person", "Group", "email", "Cohort", "Flag" */
+  subject: string;
+  /** "is", "in cohort", "ends with" */
+  operator: string;
+  values: FlagValue[];
+}
+
+export interface FlagValue {
+  label: string;
+  /** Email under a resolved person, for example. */
+  secondary?: string;
+  /** The raw id behind a resolved label. */
+  raw?: string;
+  link?: { kind: "person" | "cohort"; id: string };
+  literal: boolean;
+}
+
+export interface FlagVariant {
+  key: string;
+  percentage: number;
+  payload: string | null;
+}
+
+export interface ResolvedPerson {
+  uuid: string;
+  name: string;
+  email: string | null;
+}
+
+const OPERATORS: Record<string, string> = {
+  exact: "is",
+  is_not: "is not",
+  icontains: "contains",
+  not_icontains: "does not contain",
+  regex: "matches",
+  not_regex: "does not match",
+  starts_with: "starts with",
+  not_starts_with: "does not start with",
+  ends_with: "ends with",
+  not_ends_with: "does not end with",
+  gt: ">",
+  gte: "≥",
+  lt: "<",
+  lte: "≤",
+  is_set: "is set",
+  is_not_set: "is not set",
+  in: "in cohort",
+  not_in: "not in cohort",
+  flag_evaluates_to: "evaluates to",
+  is_date_before: "before",
+  is_date_after: "after",
+  is_date_exact: "on",
+  semver_eq: "is version",
+  semver_neq: "is not version",
+  semver_gt: "newer than",
+  semver_gte: "at least version",
+  semver_lt: "older than",
+  semver_lte: "at most version",
+};
+
+type Property = Record<string, unknown>;
+
+function isRecord(value: unknown): value is Property {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value === "string" && value) return value;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  if (typeof value === "boolean") return String(value);
+  return null;
+}
+
+function isDistinctIdFilter(property: Property): boolean {
+  return property.type === "person" && property.key === "distinct_id";
+}
+
+/** Distinct ids a flag targets directly, so the caller can resolve them to people. */
+export function targetedDistinctIds(flag: Schemas.FeatureFlag): string[] {
+  const groups = conditionGroups(flag);
+  const ids = new Set<string>();
+  for (const group of groups) {
+    for (const property of group.properties) {
+      if (!isDistinctIdFilter(property)) continue;
+      const values = Array.isArray(property.value)
+        ? property.value
+        : [property.value];
+      for (const value of values) {
+        const id = asString(value);
+        if (id) ids.add(id);
+      }
+    }
+  }
+  return [...ids];
+}
+
+interface ConditionGroup {
+  properties: Property[];
+  rollout: number;
+  variant: string | null;
+  isGroup: boolean;
+}
+
+function conditionGroups(flag: Schemas.FeatureFlag): ConditionGroup[] {
+  const filters = isRecord(flag.filters) ? flag.filters : {};
+  const groups = Array.isArray(filters.groups) ? filters.groups : [];
+  const flagLevelGroupIndex = filters.aggregation_group_type_index;
+  return groups.filter(isRecord).map((group) => {
+    const rollout =
+      typeof group.rollout_percentage === "number"
+        ? group.rollout_percentage
+        : 100;
+    const groupIndex =
+      group.aggregation_group_type_index ?? flagLevelGroupIndex;
+    return {
+      properties: Array.isArray(group.properties)
+        ? group.properties.filter(isRecord)
+        : [],
+      rollout,
+      variant: asString(group.variant),
+      isGroup: typeof groupIndex === "number",
+    };
+  });
+}
+
+function shapeValues(
+  property: Property,
+  people: Map<string, ResolvedPerson>,
+): FlagValue[] {
+  if (property.type === "cohort") {
+    const id = asString(property.value) ?? "";
+    const name = asString(property.cohort_name);
+    return [
+      {
+        label: name ?? `Cohort ${id}`,
+        raw: name ? id : undefined,
+        link: id ? { kind: "cohort", id } : undefined,
+        literal: false,
+      },
+    ];
+  }
+  const raw = Array.isArray(property.value)
+    ? property.value
+    : property.value === undefined || property.value === null
+      ? []
+      : [property.value];
+  const distinctId = isDistinctIdFilter(property);
+  return raw.flatMap((entry): FlagValue[] => {
+    const value = asString(entry);
+    if (!value) return [];
+    if (distinctId) {
+      const person = people.get(value);
+      if (person) {
+        return [
+          {
+            label: person.name,
+            secondary:
+              person.email && person.email !== person.name
+                ? person.email
+                : undefined,
+            raw: value,
+            link: { kind: "person", id: person.uuid },
+            literal: false,
+          },
+        ];
+      }
+      return [{ label: value, literal: true }];
+    }
+    return [{ label: value, literal: true }];
+  });
+}
+
+function shapeCondition(
+  property: Property,
+  isGroup: boolean,
+  people: Map<string, ResolvedPerson>,
+): FlagCondition | null {
+  const operatorKey = asString(property.operator);
+  const values = shapeValues(property, people);
+  if (property.type === "cohort") {
+    return {
+      subject: isGroup ? "Group" : "Person",
+      operator: OPERATORS[operatorKey ?? "in"] ?? "in cohort",
+      values,
+    };
+  }
+  if (property.type === "flag") {
+    return {
+      subject: "Flag",
+      operator: OPERATORS.flag_evaluates_to,
+      values: [
+        { label: asString(property.key) ?? "", literal: true },
+        ...values,
+      ],
+    };
+  }
+  if (isDistinctIdFilter(property)) {
+    return {
+      subject: "Person",
+      operator: OPERATORS[operatorKey ?? "exact"] ?? "is",
+      values,
+    };
+  }
+  const key = asString(property.key);
+  if (!key) return null;
+  return {
+    subject: key,
+    operator: OPERATORS[operatorKey ?? "exact"] ?? operatorKey ?? "is",
+    values,
+  };
+}
+
+interface Audience {
+  /** "one person", "25% of Power users" */
+  label: string;
+  plural: boolean;
+}
+
+function describeAudience(
+  rule: FlagRule,
+  group: ConditionGroup,
+  people: Map<string, ResolvedPerson>,
+): Audience {
+  const noun = group.isGroup ? "groups" : "people";
+  const share = rule.share < 100 ? `${rule.share}% of ` : "";
+  if (rule.conditions.length === 0) {
+    return rule.share < 100
+      ? { label: `${rule.share}% of ${noun}`, plural: true }
+      : { label: "everyone", plural: true };
+  }
+  if (rule.conditions.length === 1 && group.properties.length === 1) {
+    const [condition] = rule.conditions;
+    const [property] = group.properties;
+    if (
+      property &&
+      isDistinctIdFilter(property) &&
+      condition.operator === "is"
+    ) {
+      const n = condition.values.length;
+      if (n === 1) {
+        const person = people.get(condition.values[0].raw ?? "");
+        return {
+          label: `${share}${person ? person.name : "one person"}`,
+          plural: false,
+        };
+      }
+      return { label: `${share}${n} people`, plural: true };
+    }
+    if (property?.type === "cohort" && condition.operator === "in cohort") {
+      return {
+        label: `${share}${condition.values[0]?.label ?? "a cohort"}`,
+        plural: true,
+      };
+    }
+  }
+  const conditions =
+    rule.conditions.length === 1
+      ? "one condition"
+      : `${rule.conditions.length} conditions`;
+  return { label: `${share}${noun} matching ${conditions}`, plural: true };
+}
+
+function describeResult(result: FlagResult): string {
+  switch (result.kind) {
+    case "true":
+      return "true";
+    case "false":
+      return "false";
+    case "variant":
+      return result.key;
+    case "split":
+      return "a variant";
+    case "payload":
+      return "the payload";
+  }
+}
+
+function capitalize(text: string): string {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+function joinAudiences(labels: string[]): string {
+  if (labels.length <= 1) return labels[0] ?? "everyone";
+  if (labels.length === 2) return `${labels[0]} and ${labels[1]}`;
+  return `${labels.length} audiences`;
+}
+
+export function shapeFlagAudience(
+  flag: Schemas.FeatureFlag,
+  people: Map<string, ResolvedPerson> = new Map(),
+): FlagAudience {
+  const filters = isRecord(flag.filters) ? flag.filters : {};
+  const multivariate = isRecord(filters.multivariate)
+    ? filters.multivariate
+    : null;
+  const payloads = isRecord(filters.payloads) ? filters.payloads : {};
+  const variants: FlagVariant[] = Array.isArray(multivariate?.variants)
+    ? multivariate.variants.filter(isRecord).flatMap((variant) => {
+        const key = asString(variant.key);
+        if (!key) return [];
+        return [
+          {
+            key,
+            percentage:
+              typeof variant.rollout_percentage === "number"
+                ? variant.rollout_percentage
+                : 0,
+            payload: asString(payloads[key]),
+          },
+        ];
+      })
+    : [];
+  const isRemoteConfig = flag.is_remote_configuration === true;
+  const disabled = flag.active === false;
+  const groups = conditionGroups(flag);
+
+  const matchResult = (variant: string | null): FlagResult => {
+    if (isRemoteConfig) return { kind: "payload" };
+    if (variant) return { kind: "variant", key: variant };
+    if (variants.length > 0) return { kind: "split" };
+    return { kind: "true" };
+  };
+
+  const rules: FlagRule[] = groups.map((group) => ({
+    conditions: group.properties.flatMap((property) => {
+      const condition = shapeCondition(property, group.isGroup, people);
+      return condition ? [condition] : [];
+    }),
+    share: group.rollout,
+    result: matchResult(group.variant),
+  }));
+  const fallback: FlagResult = { kind: "false" };
+
+  if (disabled) {
+    return {
+      headline: "Off for everyone.",
+      summary: "The flag is disabled, so every check returns false.",
+      disabled,
+      rules,
+      fallback,
+      variants,
+    };
+  }
+
+  if (rules.length === 0) {
+    // No condition sets means every check matches; show that as one rule so
+    // the table still reads top to bottom.
+    rules.push({ conditions: [], share: 100, result: matchResult(null) });
+    return {
+      headline: isRemoteConfig
+        ? "Sends a payload to everyone."
+        : variants.length > 0
+          ? `Split into ${variants.length} variants for everyone.`
+          : "On for everyone.",
+      summary: isRemoteConfig
+        ? "Every check returns the configured payload."
+        : variants.length > 0
+          ? "Every check returns a variant, picked by a stable hash of the distinct ID."
+          : "Every check returns true.",
+      disabled,
+      rules,
+      fallback,
+      variants,
+    };
+  }
+
+  const live = rules.filter((rule) => rule.share > 0);
+  if (live.length === 0) {
+    return {
+      headline: "On for nobody yet.",
+      summary:
+        "Rules are defined, but rollout is 0%, so every check returns false.",
+      disabled,
+      rules,
+      fallback,
+      variants,
+    };
+  }
+
+  const audiences = live.map((rule) =>
+    describeAudience(rule, groups[rules.indexOf(rule)], people),
+  );
+  const who = joinAudiences(audiences.map((audience) => audience.label));
+  const headline = isRemoteConfig
+    ? `Sends a payload to ${who}.`
+    : variants.length > 0
+      ? `Split into ${variants.length} variants for ${who}.`
+      : `On for ${who}.`;
+
+  const sentences = live.slice(0, 2).map((rule, index) => {
+    const audience = audiences[index];
+    return `${capitalize(audience.label)} ${audience.plural ? "get" : "gets"} ${describeResult(rule.result)}.`;
+  });
+  if (live.length > 2) {
+    const more = live.length - 2;
+    sentences.push(
+      `${more} more ${more === 1 ? "rule applies" : "rules apply"}.`,
+    );
+  }
+  sentences.push("Everyone else gets false.");
+
+  return {
+    headline,
+    summary: sentences.join(" "),
+    disabled,
+    rules,
+    fallback,
+    variants,
+  };
+}
+
+/** Short "Reach" label for the stat strip: "1 person", "25% of a cohort", "Everyone". */
+export function flagReachLabel(audience: FlagAudience): string {
+  if (audience.disabled) return "Nobody";
+  const match = audience.headline.match(/(?:for|to) (.+)\.$/);
+  if (!match) return "Everyone";
+  return capitalize(match[1]);
+}

--- a/products/desktop/packages/api-client/src/flag-audience.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.ts
@@ -2,7 +2,7 @@ import type { Schemas } from "./generated";
 
 /**
  * Who a feature flag reaches, shaped for reading rather than editing: a
- * headline sentence, the rules as a first-match-wins table where every row
+ * headline sentence, the rules as a first-match-wins list where every row
  * ends in its result, and the variant split when the flag has one.
  */
 export interface FlagAudience {
@@ -12,15 +12,11 @@ export interface FlagAudience {
   summary: string;
   disabled: boolean;
   rules: FlagRule[];
-  /** What a check returns when no rule matches. */
-  fallback: FlagResult;
-  /** False when a reachable rule already matches everyone, so the fallback row is hidden. */
+  /** False when a reachable rule already matches everyone, so the "Everyone else" row is hidden. */
   fallbackReachable: boolean;
   variants: FlagVariant[];
-  /** What a check buckets on, which decides the variant-assignment hash key. */
-  bucketing: "distinct_id" | "device_id";
-  /** The bucketing key as display text: "the distinct ID", "the device ID", "the group key". */
-  stability: string;
+  /** What the evaluator hashes on for rollouts and variant assignment. */
+  bucketing: "person" | "device" | "group";
   /** Person property checked before the rules for early access flags; null when off. */
   enrollmentKey: string | null;
   /** Experiment holdout checked before the rules; null when the flag has none. */
@@ -60,8 +56,8 @@ export interface FlagValue {
   secondary?: string;
   /** The raw id behind a resolved label. */
   raw?: string;
+  /** Set when the value is a person or cohort the card can open; absent for literals. */
   link?: { kind: "person" | "cohort"; id: string };
-  literal: boolean;
 }
 
 export interface FlagVariant {
@@ -120,56 +116,88 @@ const OPERATORS: Record<Schemas.PropertyOperator, string> = {
 };
 
 type Property = Record<string, unknown>;
+type People = Map<string, ResolvedPerson>;
 
 function isRecord(value: unknown): value is Property {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function asString(value: unknown): string | null {
-  if (typeof value === "string" && value) return value;
+  if (typeof value === "string") return value || null;
   if (typeof value === "number" && Number.isFinite(value)) return String(value);
   if (typeof value === "boolean") return String(value);
   return null;
+}
+
+function asList(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  return value === undefined || value === null ? [] : [value];
 }
 
 function isDistinctIdFilter(property: Property): boolean {
   return property.type === "person" && property.key === "distinct_id";
 }
 
-/** Distinct ids a flag targets directly, so the caller can resolve them to people. */
-export function targetedDistinctIds(flag: Schemas.FeatureFlag): string[] {
-  return collectDistinctIds(flag, () => true);
+function operatorLabel(
+  operator: unknown,
+  fallback: Schemas.PropertyOperator,
+): string {
+  const key = asString(operator);
+  return OPERATORS[(key ?? fallback) as Schemas.PropertyOperator] ?? key ?? "";
+}
+
+interface ConditionGroup {
+  properties: Property[];
+  rollout: number;
+  variant: string | null;
+  isGroup: boolean;
+  /** "person" or "group:<index>"; rules only shadow later rules of the same aggregation. */
+  aggregation: string;
+}
+
+function conditionGroups(flag: Schemas.FeatureFlag): ConditionGroup[] {
+  const filters = isRecord(flag.filters) ? flag.filters : {};
+  return asList(filters.groups)
+    .filter(isRecord)
+    .map((group) => {
+      // An explicit null means person-level aggregation; only an absent field
+      // inherits the flag-level group index.
+      const index =
+        group.aggregation_group_type_index !== undefined
+          ? group.aggregation_group_type_index
+          : filters.aggregation_group_type_index;
+      const isGroup = typeof index === "number";
+      return {
+        properties: asList(group.properties).filter(isRecord),
+        rollout:
+          typeof group.rollout_percentage === "number"
+            ? group.rollout_percentage
+            : 100,
+        variant: asString(group.variant),
+        isGroup,
+        aggregation: isGroup ? `group:${index}` : "person",
+      };
+    });
 }
 
 /**
- * Distinct ids a flag positively targets, so the caller can label them as
- * targeted. Excludes negative conditions such as `is not`, whose ids the rule
- * rejects; person-name resolution still uses the full list.
+ * Distinct ids a flag targets, so the caller can resolve them to people.
+ * `positiveOnly` drops negative operators such as `is not`, whose ids the
+ * rule rejects rather than targets.
  */
-export function positivelyTargetedDistinctIds(
+export function targetedDistinctIds(
   flag: Schemas.FeatureFlag,
+  positiveOnly = false,
 ): string[] {
-  return collectDistinctIds(
-    flag,
-    (operator) => operator === undefined || operator === "exact",
-  );
-}
-
-function collectDistinctIds(
-  flag: Schemas.FeatureFlag,
-  include: (operator: string | undefined) => boolean,
-): string[] {
-  const groups = conditionGroups(flag);
   const ids = new Set<string>();
-  for (const group of groups) {
+  for (const group of conditionGroups(flag)) {
     for (const property of group.properties) {
       if (!isDistinctIdFilter(property)) continue;
-      const operator = asString(property.operator) ?? undefined;
-      if (!include(operator)) continue;
-      const values = Array.isArray(property.value)
-        ? property.value
-        : [property.value];
-      for (const value of values) {
+      const operator = property.operator;
+      if (positiveOnly && operator !== undefined && operator !== "exact") {
+        continue;
+      }
+      for (const value of asList(property.value)) {
         const id = asString(value);
         if (id) ids.add(id);
       }
@@ -178,134 +206,55 @@ function collectDistinctIds(
   return [...ids];
 }
 
-interface ConditionGroup {
-  properties: Property[];
-  rollout: number;
-  variant: string | null;
-  isGroup: boolean;
-  /** The resolved aggregation index: a number for group targeting, null for person. */
-  aggregationIndex: number | null;
-}
-
-function conditionGroups(flag: Schemas.FeatureFlag): ConditionGroup[] {
-  const filters = isRecord(flag.filters) ? flag.filters : {};
-  const groups = Array.isArray(filters.groups) ? filters.groups : [];
-  const flagLevelGroupIndex = filters.aggregation_group_type_index;
-  return groups.filter(isRecord).map((group) => {
-    const rollout =
-      typeof group.rollout_percentage === "number"
-        ? group.rollout_percentage
-        : 100;
-    // An explicit null means person-level aggregation; only an absent field
-    // inherits the flag-level group index. `??` would collapse that null into
-    // the flag-level value and mislabel person rules as group rules.
-    const groupIndex =
-      group.aggregation_group_type_index !== undefined
-        ? group.aggregation_group_type_index
-        : flagLevelGroupIndex;
-    return {
-      properties: Array.isArray(group.properties)
-        ? group.properties.filter(isRecord)
-        : [],
-      rollout,
-      variant: asString(group.variant),
-      isGroup: typeof groupIndex === "number",
-      aggregationIndex: typeof groupIndex === "number" ? groupIndex : null,
-    };
-  });
-}
-
-function shapeValues(
-  property: Property,
-  people: Map<string, ResolvedPerson>,
-): FlagValue[] {
-  if (property.type === "cohort") {
-    const id = asString(property.value) ?? "";
-    const name = asString(property.cohort_name);
-    return [
-      {
-        label: name ?? `Cohort ${id}`,
-        raw: name ? id : undefined,
-        link: id ? { kind: "cohort", id } : undefined,
-        literal: false,
-      },
-    ];
-  }
-  const raw = Array.isArray(property.value)
-    ? property.value
-    : property.value === undefined || property.value === null
-      ? []
-      : [property.value];
-  const distinctId = isDistinctIdFilter(property);
-  return raw.flatMap((entry): FlagValue[] => {
-    const value = asString(entry);
-    if (!value) return [];
-    if (distinctId) {
-      const person = people.get(value);
-      if (person) {
-        return [
-          {
-            label: person.name,
-            secondary:
-              person.email && person.email !== person.name
-                ? person.email
-                : undefined,
-            raw: value,
-            link: { kind: "person", id: person.uuid },
-            literal: false,
-          },
-        ];
-      }
-      return [{ label: value, literal: true }];
-    }
-    return [{ label: value, literal: true }];
-  });
-}
-
 function shapeCondition(
   property: Property,
   isGroup: boolean,
-  people: Map<string, ResolvedPerson>,
+  people: People,
 ): FlagCondition | null {
-  const operatorKey = asString(property.operator);
-  const values = shapeValues(property, people);
   if (property.type === "cohort") {
+    const id = asString(property.value) ?? "";
+    const name = asString(property.cohort_name);
     return {
       subject: isGroup ? "Group" : "Person",
-      operator:
-        OPERATORS[(operatorKey ?? "in") as Schemas.PropertyOperator] ??
-        "in cohort",
-      values,
+      operator: operatorLabel(property.operator, "in"),
+      values: [
+        {
+          label: name ?? `Cohort ${id}`,
+          raw: id,
+          link: id ? { kind: "cohort", id } : undefined,
+        },
+      ],
     };
   }
+  const distinctId = isDistinctIdFilter(property);
+  const values = asList(property.value).flatMap((entry): FlagValue[] => {
+    const value = asString(entry);
+    if (!value) return [];
+    const person = distinctId ? people.get(value) : undefined;
+    if (!person) return [{ label: value }];
+    return [
+      {
+        label: person.name,
+        secondary:
+          person.email && person.email !== person.name
+            ? person.email
+            : undefined,
+        raw: value,
+        link: { kind: "person", id: person.uuid },
+      },
+    ];
+  });
   if (property.type === "flag") {
     return {
       subject: "Flag",
       operator: OPERATORS.flag_evaluates_to,
-      values: [
-        { label: asString(property.key) ?? "", literal: true },
-        ...values,
-      ],
+      values: [{ label: asString(property.key) ?? "" }, ...values],
     };
   }
-  if (isDistinctIdFilter(property)) {
-    return {
-      subject: "Person",
-      operator:
-        OPERATORS[(operatorKey ?? "exact") as Schemas.PropertyOperator] ?? "is",
-      values,
-    };
-  }
+  const operator = operatorLabel(property.operator, "exact");
+  if (distinctId) return { subject: "Person", operator, values };
   const key = asString(property.key);
-  if (!key) return null;
-  return {
-    subject: key,
-    operator:
-      OPERATORS[(operatorKey ?? "exact") as Schemas.PropertyOperator] ??
-      operatorKey ??
-      "is",
-    values,
-  };
+  return key ? { subject: key, operator, values } : null;
 }
 
 interface Audience {
@@ -319,276 +268,137 @@ interface Audience {
 function describeAudience(
   rule: FlagRule,
   group: ConditionGroup,
-  people: Map<string, ResolvedPerson>,
-  deviceBucketed: boolean,
+  people: People,
+  bucketing: FlagAudience["bucketing"],
 ): Audience {
-  const noun = group.isGroup ? "groups" : "people";
   const share = rule.share < 100 ? `${rule.share}% of ` : "";
+  const noun = group.isGroup ? "groups" : "people";
   if (rule.conditions.length === 0) {
-    if (rule.share < 100) {
-      return { label: `${rule.share}% of ${noun}`, plural: true };
-    }
+    if (share) return { label: `${share}${noun}`, plural: true };
     // A group rule still needs a group key, and a device-bucketed rule still
     // needs a device ID, so "everyone" would overstate who matches.
-    if (rule.isGroup) {
-      return { label: "every group", plural: true };
-    }
-    if (deviceBucketed) {
-      return { label: "every device", plural: true };
-    }
-    // "everyone" takes a singular verb in the summary sentence.
+    if (group.isGroup) return { label: "every group", plural: true };
+    if (bucketing === "device") return { label: "every device", plural: true };
     return { label: "everyone", plural: false };
   }
+  const [condition] = rule.conditions;
+  const [property] = group.properties;
   if (rule.conditions.length === 1 && group.properties.length === 1) {
-    const [condition] = rule.conditions;
-    const [property] = group.properties;
-    if (
-      property &&
-      isDistinctIdFilter(property) &&
-      condition.operator === "is"
-    ) {
-      const n = condition.values.length;
-      if (n === 1) {
-        const person = people.get(condition.values[0].raw ?? "");
-        const who = person ? person.name : "one person";
-        // The rollout is a per-identifier hash: a named person is either in
-        // or out, never a fraction, so the share stays on the rule row.
-        return {
-          label: who,
-          plural: false,
-          sentence:
-            rule.share < 100
-              ? `${who} is targeted, and the ${rule.share}% rollout hash decides.`
-              : undefined,
-        };
-      }
-      return { label: `${share}${n} people`, plural: true };
+    if (isDistinctIdFilter(property) && condition.operator === "is") {
+      const count = condition.values.length;
+      if (count > 1) return { label: `${share}${count} people`, plural: true };
+      const who =
+        people.get(condition.values[0]?.raw ?? "")?.name ?? "one person";
+      // The rollout hashes the identifier: a named person is either in or
+      // out, never a fraction, so the share stays on the rule row.
+      return {
+        label: who,
+        plural: false,
+        sentence: share
+          ? `${who} is targeted, and the ${rule.share}% rollout hash decides.`
+          : undefined,
+      };
     }
-    if (property?.type === "cohort" && condition.operator === "in cohort") {
+    if (property.type === "cohort" && condition.operator === "in cohort") {
       return {
         label: `${share}${condition.values[0]?.label ?? "a cohort"}`,
         plural: true,
       };
     }
   }
-  const conditions =
+  const count =
     rule.conditions.length === 1
       ? "one condition"
       : `${rule.conditions.length} conditions`;
-  return { label: `${share}${noun} matching ${conditions}`, plural: true };
+  return { label: `${share}${noun} matching ${count}`, plural: true };
 }
 
+const RESULT_WORDS = {
+  true: "true",
+  false: "false",
+  split: "a variant",
+  payload: "the payload",
+};
+
 function describeResult(result: FlagResult): string {
-  switch (result.kind) {
-    case "true":
-      return "true";
-    case "false":
-      return "false";
-    case "variant":
-      return result.key;
-    case "split":
-      return "a variant";
-    case "payload":
-      return "the payload";
-  }
+  return result.kind === "variant" ? result.key : RESULT_WORDS[result.kind];
 }
 
 function capitalize(text: string): string {
   return text.charAt(0).toUpperCase() + text.slice(1);
 }
 
-function joinAudiences(labels: string[]): string {
-  if (labels.length <= 1) return labels[0] ?? "everyone";
-  if (labels.length === 2) return `${labels[0]} and ${labels[1]}`;
-  return `${labels.length} audiences`;
-}
+type Shape = Omit<FlagAudience, "headline" | "summary">;
 
-/**
- * A reachable rule with no conditions at 100% matches every evaluable check,
- * leaving nobody for the fallback. Group rules still need a group key and
- * device-bucketed rules still need a device ID, so those keep the fallback.
- */
-function catchAllRule(rule: FlagRule, deviceBucketed: boolean): boolean {
-  return (
-    rule.reachable &&
-    rule.conditions.length === 0 &&
-    rule.share === 100 &&
-    !rule.isGroup &&
-    !deviceBucketed
-  );
-}
-
-export function shapeFlagAudience(
-  flag: Schemas.FeatureFlag,
-  people: Map<string, ResolvedPerson> = new Map(),
-): FlagAudience {
-  const filters = isRecord(flag.filters) ? flag.filters : {};
-  const multivariate = isRecord(filters.multivariate)
-    ? filters.multivariate
-    : null;
-  const payloads = isRecord(filters.payloads) ? filters.payloads : {};
-  const variants: FlagVariant[] = Array.isArray(multivariate?.variants)
-    ? multivariate.variants.filter(isRecord).flatMap((variant) => {
-        const key = asString(variant.key);
-        if (!key) return [];
-        return [
-          {
-            key,
-            percentage:
-              typeof variant.rollout_percentage === "number"
-                ? variant.rollout_percentage
-                : 0,
-            payload: asString(payloads[key]),
-          },
-        ];
-      })
-    : [];
-  const isRemoteConfig = flag.is_remote_configuration === true;
-  const disabled = flag.active === false;
-  const groups = conditionGroups(flag);
-  const deviceBucketed = filters.bucketing_identifier === "device_id";
-  // The variant hash key follows the bucketing identifier: device id when set,
-  // the group key for group-aggregated rules, otherwise the distinct ID.
-  const stability = deviceBucketed
-    ? "the device ID"
-    : groups.some((group) => group.isGroup)
-      ? "the group key"
-      : "the distinct ID";
-  const bucketing: FlagAudience["bucketing"] = deviceBucketed
-    ? "device_id"
-    : "distinct_id";
-
-  const matchResult = (variant: string | null): FlagResult => {
-    if (isRemoteConfig) return { kind: "payload" };
-    if (variant) return { kind: "variant", key: variant };
-    if (variants.length > 0) return { kind: "split" };
-    return { kind: "true" };
-  };
-
-  const holdoutRecord = isRecord(filters.holdout) ? filters.holdout : null;
-  const holdout: FlagAudience["holdout"] = holdoutRecord
-    ? {
-        id: asString(holdoutRecord.id) ?? "",
-        exclusionPercentage: Math.min(
-          Math.max(
-            typeof holdoutRecord.exclusion_percentage === "number"
-              ? holdoutRecord.exclusion_percentage
-              : 0,
-            0,
-          ),
-          100,
-        ),
-      }
-    : null;
-
-  // Early access flags check the enrollment person property before any rule:
-  // a true value returns true immediately, any other present value returns
-  // false, and an absent value falls through to the rules below.
-  const enrollmentKey =
-    filters.feature_enrollment === true
-      ? `$feature_enrollment/${flag.key}`
-      : null;
-
-  const rules: FlagRule[] = groups.map((group) => ({
-    conditions: group.properties.flatMap((property) => {
-      const condition = shapeCondition(property, group.isGroup, people);
-      return condition ? [condition] : [];
-    }),
-    share: group.rollout,
-    result: matchResult(group.variant),
-    reachable: true,
-    isGroup: group.isGroup,
-  }));
-  // The evaluator checks condition sets in declaration order and returns on
-  // the first match, so an empty condition set at 100% shadows every later
-  // set of the same aggregation. Mirrors the web flag page's own warning.
-  const shadowedAggregations = new Set<string>();
-  groups.forEach((group, index) => {
-    const aggregation =
-      typeof group.aggregationIndex === "number"
-        ? `group:${group.aggregationIndex}`
-        : "person";
-    if (shadowedAggregations.has(aggregation)) {
-      rules[index].reachable = false;
-      return;
-    }
-    if (rules[index].conditions.length === 0 && group.rollout >= 100) {
-      shadowedAggregations.add(aggregation);
-    }
-  });
-  const fallback: FlagResult = { kind: "false" };
-
-  if (disabled) {
+function describeFlag(
+  shape: Shape,
+  groups: ConditionGroup[],
+  people: People,
+  remoteConfig: boolean,
+): Pick<FlagAudience, "headline" | "summary"> {
+  if (shape.disabled) {
     return {
       headline: "Off for everyone.",
       summary: "The flag is disabled, so every check returns false.",
-      disabled,
-      rules,
-      fallback,
-      fallbackReachable: !rules.some((rule) =>
-        catchAllRule(rule, deviceBucketed),
-      ),
-      variants,
-      bucketing,
-      stability,
-      enrollmentKey,
-      holdout,
     };
   }
-
-  if (rules.length === 0) {
-    // The evaluator skips the condition loop on empty groups and returns
-    // false, so clearing targeting turns the flag off for everybody.
+  // The evaluator skips the condition loop on empty groups and returns false,
+  // so clearing targeting turns the flag off for everybody.
+  if (shape.rules.length === 0) {
     return {
-      headline: isRemoteConfig
-        ? "Sends a payload to nobody."
-        : "On for nobody.",
+      headline: remoteConfig ? "Sends a payload to nobody." : "On for nobody.",
       summary:
         "The flag has no release conditions, so every check returns false.",
-      disabled,
-      rules,
-      fallback,
-      fallbackReachable: true,
-      variants,
-      bucketing,
-      stability,
-      enrollmentKey,
-      holdout,
     };
   }
-
-  const live = rules.filter((rule) => rule.share > 0 && rule.reachable);
+  const live = shape.rules.filter((rule) => rule.share > 0 && rule.reachable);
   if (live.length === 0) {
     return {
       headline: "On for nobody yet.",
       summary:
         "Rules are defined, but rollout is 0%, so every check returns false.",
-      disabled,
-      rules,
-      fallback,
-      fallbackReachable: true,
-      variants,
-      bucketing,
-      stability,
-      enrollmentKey,
-      holdout,
     };
   }
 
   const audiences = live.map((rule) =>
-    describeAudience(rule, groups[rules.indexOf(rule)], people, deviceBucketed),
+    describeAudience(
+      rule,
+      groups[shape.rules.indexOf(rule)],
+      people,
+      shape.bucketing,
+    ),
   );
-  const who = joinAudiences(audiences.map((audience) => audience.label));
-  const headline = isRemoteConfig
+  const labels = audiences.map((audience) => audience.label);
+  const who =
+    labels.length === 1
+      ? labels[0]
+      : labels.length === 2
+        ? `${labels[0]} and ${labels[1]}`
+        : `${labels.length} audiences`;
+  const headline = remoteConfig
     ? `Sends a payload to ${who}.`
-    : variants.length > 0
-      ? `Split into ${variants.length} variants for ${who}.`
+    : shape.variants.length > 0
+      ? `Split into ${shape.variants.length} variants for ${who}.`
       : `On for ${who}.`;
 
-  const sentences = live.slice(0, 2).map((rule, index) => {
-    const audience = audiences[index];
-    if (audience.sentence) return audience.sentence;
-    return `${capitalize(audience.label)} ${audience.plural ? "get" : "gets"} ${describeResult(rule.result)}.`;
+  // The evaluator resolves enrollment and the holdout before the rules, so
+  // those sentences come first.
+  const sentences: string[] = [];
+  if (shape.enrollmentKey) {
+    sentences.push(
+      `${shape.enrollmentKey} overrides these rules: a true value always gets true, and any other value gets false.`,
+    );
+  } else if (shape.holdout) {
+    sentences.push(
+      `${shape.holdout.exclusionPercentage}% of people are held out for experiment ${shape.holdout.id} and get holdout-${shape.holdout.id}.`,
+    );
+  }
+  live.slice(0, 2).forEach((rule, index) => {
+    const { label, plural, sentence } = audiences[index];
+    sentences.push(
+      sentence ??
+        `${capitalize(label)} ${plural ? "get" : "gets"} ${describeResult(rule.result)}.`,
+    );
   });
   if (live.length > 2) {
     const more = live.length - 2;
@@ -596,49 +406,115 @@ export function shapeFlagAudience(
       `${more} more ${more === 1 ? "rule applies" : "rules apply"}.`,
     );
   }
-  const fallbackReachable = !rules.some((rule) =>
-    catchAllRule(rule, deviceBucketed),
-  );
-  // The evaluator resolves enrollment and the holdout before the rules, so
-  // those sentences come first.
-  const overrideSentences: string[] = [];
-  if (enrollmentKey) {
-    overrideSentences.push(
-      `${enrollmentKey} overrides these rules: a true value always gets true, and any other value gets false.`,
-    );
-  } else if (holdout) {
-    overrideSentences.push(
-      `${holdout.exclusionPercentage}% of people are held out for experiment ${holdout.id} and get holdout-${holdout.id}.`,
+  if (shape.fallbackReachable && !shape.enrollmentKey) {
+    sentences.push(
+      shape.bucketing === "person"
+        ? "Everyone else gets false."
+        : "A check without its bucketing key still gets false.",
     );
   }
-  const allSentences = [...overrideSentences, ...sentences];
-  if (fallbackReachable && !enrollmentKey) {
-    allSentences.push(
-      deviceBucketed || rules.some((rule) => rule.isGroup)
-        ? "A check without its bucketing key still gets false."
-        : "Everyone else gets false.",
-    );
-  }
+  return { headline, summary: sentences.join(" ") };
+}
 
-  return {
-    headline,
-    summary: allSentences.join(" "),
-    disabled,
+export function shapeFlagAudience(
+  flag: Schemas.FeatureFlag,
+  people: People = new Map(),
+): FlagAudience {
+  const filters = isRecord(flag.filters) ? flag.filters : {};
+  const payloads = isRecord(filters.payloads) ? filters.payloads : {};
+  const multivariate = isRecord(filters.multivariate)
+    ? filters.multivariate
+    : {};
+  const variants = asList(multivariate.variants)
+    .filter(isRecord)
+    .flatMap((variant): FlagVariant[] => {
+      const key = asString(variant.key);
+      if (!key) return [];
+      const percentage = variant.rollout_percentage;
+      return [
+        {
+          key,
+          percentage: typeof percentage === "number" ? percentage : 0,
+          payload: asString(payloads[key]),
+        },
+      ];
+    });
+  const remoteConfig = flag.is_remote_configuration === true;
+  const groups = conditionGroups(flag);
+  const deviceBucketed = filters.bucketing_identifier === "device_id";
+  const bucketing: FlagAudience["bucketing"] = deviceBucketed
+    ? "device"
+    : groups.some((group) => group.isGroup)
+      ? "group"
+      : "person";
+  const resultFor = (variant: string | null): FlagResult => {
+    if (remoteConfig) return { kind: "payload" };
+    if (variant) return { kind: "variant", key: variant };
+    return variants.length > 0 ? { kind: "split" } : { kind: "true" };
+  };
+
+  // The evaluator checks condition sets in order and returns on the first
+  // match, so an empty set at 100% shadows every later set of the same
+  // aggregation. Mirrors the web flag page's own warning.
+  const shadowed = new Set<string>();
+  const rules = groups.map((group): FlagRule => {
+    const reachable = !shadowed.has(group.aggregation);
+    const conditions = group.properties.flatMap(
+      (property) => shapeCondition(property, group.isGroup, people) ?? [],
+    );
+    if (conditions.length === 0 && group.rollout >= 100) {
+      shadowed.add(group.aggregation);
+    }
+    return {
+      conditions,
+      share: group.rollout,
+      result: resultFor(group.variant),
+      reachable,
+      isGroup: group.isGroup,
+    };
+  });
+  // A reachable catch-all leaves nobody for the fallback. Group rules still
+  // need a group key and device-bucketed rules a device ID, so those keep it.
+  const catchAll =
+    !deviceBucketed &&
+    rules.some(
+      (rule) =>
+        rule.reachable &&
+        !rule.isGroup &&
+        rule.conditions.length === 0 &&
+        rule.share === 100,
+    );
+
+  const holdoutRecord = isRecord(filters.holdout) ? filters.holdout : null;
+  const exclusion = holdoutRecord?.exclusion_percentage;
+  const shape: Shape = {
+    disabled: flag.active === false,
     rules,
-    fallback,
-    fallbackReachable,
+    fallbackReachable: !catchAll,
     variants,
     bucketing,
-    stability,
-    enrollmentKey,
-    holdout,
+    // Early access flags check the enrollment person property before any
+    // rule: true returns true, any other present value returns false.
+    enrollmentKey:
+      filters.feature_enrollment === true
+        ? `$feature_enrollment/${flag.key}`
+        : null,
+    holdout: holdoutRecord
+      ? {
+          id: asString(holdoutRecord.id) ?? "",
+          exclusionPercentage: Math.min(
+            Math.max(typeof exclusion === "number" ? exclusion : 0, 0),
+            100,
+          ),
+        }
+      : null,
   };
+  return { ...shape, ...describeFlag(shape, groups, people, remoteConfig) };
 }
 
 /** Short "Reach" label for the stat strip: "1 person", "25% of a cohort", "Everyone". */
 export function flagReachLabel(audience: FlagAudience): string {
   if (audience.disabled) return "Nobody";
   const match = audience.headline.match(/(?:for|to) (.+)\.$/);
-  if (!match) return "Everyone";
-  return capitalize(match[1]);
+  return match ? capitalize(match[1]) : "Everyone";
 }

--- a/products/desktop/packages/api-client/src/flag-audience.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.ts
@@ -62,11 +62,17 @@ export interface ResolvedPerson {
   email: string | null;
 }
 
-const OPERATORS: Record<string, string> = {
+// Typed against the generated operator union so a new schema operator fails
+// the typecheck here instead of leaking its raw token into the card.
+const OPERATORS: Record<Schemas.PropertyOperator, string> = {
   exact: "is",
   is_not: "is not",
   icontains: "contains",
   not_icontains: "does not contain",
+  icontains_multi: "contains any of",
+  not_icontains_multi: "does not contain any of",
+  between: "is between",
+  not_between: "is not between",
   regex: "matches",
   not_regex: "does not match",
   starts_with: "starts with",
@@ -91,6 +97,12 @@ const OPERATORS: Record<string, string> = {
   semver_gte: "at least version",
   semver_lt: "older than",
   semver_lte: "at most version",
+  semver_tilde: "is version in tilde range",
+  semver_caret: "is version in caret range",
+  semver_wildcard: "matches version wildcard",
+  is_cleaned_path_exact: "is cleaned path",
+  min: "at least once ≥",
+  max: "at most once ≤",
 };
 
 type Property = Record<string, unknown>;
@@ -220,7 +232,7 @@ function shapeCondition(
   if (property.type === "cohort") {
     return {
       subject: isGroup ? "Group" : "Person",
-      operator: OPERATORS[operatorKey ?? "in"] ?? "in cohort",
+      operator: OPERATORS[(operatorKey ?? "in") as Schemas.PropertyOperator] ?? "in cohort",
       values,
     };
   }
@@ -237,7 +249,7 @@ function shapeCondition(
   if (isDistinctIdFilter(property)) {
     return {
       subject: "Person",
-      operator: OPERATORS[operatorKey ?? "exact"] ?? "is",
+      operator: OPERATORS[(operatorKey ?? "exact") as Schemas.PropertyOperator] ?? "is",
       values,
     };
   }
@@ -245,7 +257,10 @@ function shapeCondition(
   if (!key) return null;
   return {
     subject: key,
-    operator: OPERATORS[operatorKey ?? "exact"] ?? operatorKey ?? "is",
+    operator:
+      OPERATORS[(operatorKey ?? "exact") as Schemas.PropertyOperator] ??
+      operatorKey ??
+      "is",
     values,
   };
 }

--- a/products/desktop/packages/api-client/src/flag-audience.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.ts
@@ -23,6 +23,8 @@ export interface FlagAudience {
   stability: string;
   /** Person property checked before the rules for early access flags; null when off. */
   enrollmentKey: string | null;
+  /** Experiment holdout checked before the rules; null when the flag has none. */
+  holdout: { id: string; exclusionPercentage: number } | null;
 }
 
 export interface FlagRule {
@@ -428,6 +430,22 @@ export function shapeFlagAudience(
     return { kind: "true" };
   };
 
+  const holdoutRecord = isRecord(filters.holdout) ? filters.holdout : null;
+  const holdout: FlagAudience["holdout"] = holdoutRecord
+    ? {
+        id: asString(holdoutRecord.id) ?? "",
+        exclusionPercentage: Math.min(
+          Math.max(
+            typeof holdoutRecord.exclusion_percentage === "number"
+              ? holdoutRecord.exclusion_percentage
+              : 0,
+            0,
+          ),
+          100,
+        ),
+      }
+    : null;
+
   // Early access flags check the enrollment person property before any rule:
   // a true value returns true immediately, any other present value returns
   // false, and an absent value falls through to the rules below.
@@ -477,6 +495,7 @@ export function shapeFlagAudience(
       bucketing,
       stability,
       enrollmentKey,
+      holdout,
     };
   }
 
@@ -497,6 +516,7 @@ export function shapeFlagAudience(
       bucketing,
       stability,
       enrollmentKey,
+      holdout,
     };
   }
 
@@ -514,6 +534,7 @@ export function shapeFlagAudience(
       bucketing,
       stability,
       enrollmentKey,
+      holdout,
     };
   }
 
@@ -545,12 +566,21 @@ export function shapeFlagAudience(
   const fallbackReachable = !rules.some((rule) =>
     catchAllRule(rule, deviceBucketed),
   );
+  // The evaluator resolves enrollment and the holdout before the rules, so
+  // those sentences come first.
+  const overrideSentences: string[] = [];
   if (enrollmentKey) {
-    sentences.push(
+    overrideSentences.push(
       `${enrollmentKey} overrides these rules: a true value always gets true, and any other value gets false.`,
     );
-  } else if (fallbackReachable) {
-    sentences.push(
+  } else if (holdout) {
+    overrideSentences.push(
+      `${holdout.exclusionPercentage}% of people are held out for experiment ${holdout.id} and get holdout-${holdout.id}.`,
+    );
+  }
+  const allSentences = [...overrideSentences, ...sentences];
+  if (fallbackReachable && !enrollmentKey) {
+    allSentences.push(
       deviceBucketed || rules.some((rule) => rule.isGroup)
         ? "A check without its bucketing key still gets false."
         : "Everyone else gets false.",
@@ -559,7 +589,7 @@ export function shapeFlagAudience(
 
   return {
     headline,
-    summary: sentences.join(" "),
+    summary: allSentences.join(" "),
     disabled,
     rules,
     fallback,
@@ -568,6 +598,7 @@ export function shapeFlagAudience(
     bucketing,
     stability,
     enrollmentKey,
+    holdout,
   };
 }
 

--- a/products/desktop/packages/api-client/src/flag-audience.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.ts
@@ -138,11 +138,34 @@ function isDistinctIdFilter(property: Property): boolean {
 
 /** Distinct ids a flag targets directly, so the caller can resolve them to people. */
 export function targetedDistinctIds(flag: Schemas.FeatureFlag): string[] {
+  return collectDistinctIds(flag, () => true);
+}
+
+/**
+ * Distinct ids a flag positively targets, so the caller can label them as
+ * targeted. Excludes negative conditions such as `is not`, whose ids the rule
+ * rejects; person-name resolution still uses the full list.
+ */
+export function positivelyTargetedDistinctIds(
+  flag: Schemas.FeatureFlag,
+): string[] {
+  return collectDistinctIds(
+    flag,
+    (operator) => operator === undefined || operator === "exact",
+  );
+}
+
+function collectDistinctIds(
+  flag: Schemas.FeatureFlag,
+  include: (operator: string | undefined) => boolean,
+): string[] {
   const groups = conditionGroups(flag);
   const ids = new Set<string>();
   for (const group of groups) {
     for (const property of group.properties) {
       if (!isDistinctIdFilter(property)) continue;
+      const operator = asString(property.operator) ?? undefined;
+      if (!include(operator)) continue;
       const values = Array.isArray(property.value)
         ? property.value
         : [property.value];

--- a/products/desktop/packages/api-client/src/flag-audience.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.ts
@@ -23,6 +23,8 @@ export interface FlagRule {
   /** Rollout percentage within the matched audience. */
   share: number;
   result: FlagResult;
+  /** False when an earlier catch-all for the same aggregation shadows this rule. */
+  reachable: boolean;
 }
 
 export type FlagResult =
@@ -146,6 +148,8 @@ interface ConditionGroup {
   rollout: number;
   variant: string | null;
   isGroup: boolean;
+  /** The resolved aggregation index: a number for group targeting, null for person. */
+  aggregationIndex: number | null;
 }
 
 function conditionGroups(flag: Schemas.FeatureFlag): ConditionGroup[] {
@@ -171,6 +175,7 @@ function conditionGroups(flag: Schemas.FeatureFlag): ConditionGroup[] {
       rollout,
       variant: asString(group.variant),
       isGroup: typeof groupIndex === "number",
+      aggregationIndex: typeof groupIndex === "number" ? groupIndex : null,
     };
   });
 }
@@ -281,7 +286,8 @@ function describeAudience(
   if (rule.conditions.length === 0) {
     return rule.share < 100
       ? { label: `${rule.share}% of ${noun}`, plural: true }
-      : { label: "everyone", plural: true };
+      : // "everyone" takes a singular verb in the summary sentence.
+        { label: "everyone", plural: false };
   }
   if (rule.conditions.length === 1 && group.properties.length === 1) {
     const [condition] = rule.conditions;
@@ -383,7 +389,25 @@ export function shapeFlagAudience(
     }),
     share: group.rollout,
     result: matchResult(group.variant),
+    reachable: true,
   }));
+  // The evaluator checks condition sets in declaration order and returns on
+  // the first match, so an empty condition set at 100% shadows every later
+  // set of the same aggregation. Mirrors the web flag page's own warning.
+  const shadowedAggregations = new Set<string>();
+  groups.forEach((group, index) => {
+    const aggregation =
+      typeof group.aggregationIndex === "number"
+        ? `group:${group.aggregationIndex}`
+        : "person";
+    if (shadowedAggregations.has(aggregation)) {
+      rules[index].reachable = false;
+      return;
+    }
+    if (rules[index].conditions.length === 0 && group.rollout >= 100) {
+      shadowedAggregations.add(aggregation);
+    }
+  });
   const fallback: FlagResult = { kind: "false" };
 
   if (disabled) {
@@ -413,7 +437,7 @@ export function shapeFlagAudience(
     };
   }
 
-  const live = rules.filter((rule) => rule.share > 0);
+  const live = rules.filter((rule) => rule.share > 0 && rule.reachable);
   if (live.length === 0) {
     return {
       headline: "On for nobody yet.",

--- a/products/desktop/packages/api-client/src/flag-audience.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.ts
@@ -14,6 +14,8 @@ export interface FlagAudience {
   rules: FlagRule[];
   /** What a check returns when no rule matches. */
   fallback: FlagResult;
+  /** False when a reachable rule already matches everyone, so the fallback row is hidden. */
+  fallbackReachable: boolean;
   variants: FlagVariant[];
 }
 
@@ -346,6 +348,11 @@ function joinAudiences(labels: string[]): string {
   return `${labels.length} audiences`;
 }
 
+/** A reachable rule with no conditions at 100% matches everyone, leaving nobody for the fallback. */
+function catchAllRule(rule: FlagRule): boolean {
+  return rule.reachable && rule.conditions.length === 0 && rule.share === 100;
+}
+
 export function shapeFlagAudience(
   flag: Schemas.FeatureFlag,
   people: Map<string, ResolvedPerson> = new Map(),
@@ -417,6 +424,7 @@ export function shapeFlagAudience(
       disabled,
       rules,
       fallback,
+      fallbackReachable: !rules.some(catchAllRule),
       variants,
     };
   }
@@ -433,6 +441,7 @@ export function shapeFlagAudience(
       disabled,
       rules,
       fallback,
+      fallbackReachable: true,
       variants,
     };
   }
@@ -446,6 +455,7 @@ export function shapeFlagAudience(
       disabled,
       rules,
       fallback,
+      fallbackReachable: true,
       variants,
     };
   }
@@ -470,7 +480,10 @@ export function shapeFlagAudience(
       `${more} more ${more === 1 ? "rule applies" : "rules apply"}.`,
     );
   }
-  sentences.push("Everyone else gets false.");
+  const fallbackReachable = !rules.some(catchAllRule);
+  if (fallbackReachable) {
+    sentences.push("Everyone else gets false.");
+  }
 
   return {
     headline,
@@ -478,6 +491,7 @@ export function shapeFlagAudience(
     disabled,
     rules,
     fallback,
+    fallbackReachable,
     variants,
   };
 }

--- a/products/desktop/packages/api-client/src/flag-audience.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.ts
@@ -21,6 +21,8 @@ export interface FlagAudience {
   bucketing: "distinct_id" | "device_id";
   /** The bucketing key as display text: "the distinct ID", "the device ID", "the group key". */
   stability: string;
+  /** Person property checked before the rules for early access flags; null when off. */
+  enrollmentKey: string | null;
 }
 
 export interface FlagRule {
@@ -426,6 +428,14 @@ export function shapeFlagAudience(
     return { kind: "true" };
   };
 
+  // Early access flags check the enrollment person property before any rule:
+  // a true value returns true immediately, any other present value returns
+  // false, and an absent value falls through to the rules below.
+  const enrollmentKey =
+    filters.feature_enrollment === true
+      ? `$feature_enrollment/${flag.key}`
+      : null;
+
   const rules: FlagRule[] = groups.map((group) => ({
     conditions: group.properties.flatMap((property) => {
       const condition = shapeCondition(property, group.isGroup, people);
@@ -466,6 +476,7 @@ export function shapeFlagAudience(
       variants,
       bucketing,
       stability,
+      enrollmentKey,
     };
   }
 
@@ -485,6 +496,7 @@ export function shapeFlagAudience(
       variants,
       bucketing,
       stability,
+      enrollmentKey,
     };
   }
 
@@ -501,6 +513,7 @@ export function shapeFlagAudience(
       variants,
       bucketing,
       stability,
+      enrollmentKey,
     };
   }
 
@@ -532,7 +545,11 @@ export function shapeFlagAudience(
   const fallbackReachable = !rules.some((rule) =>
     catchAllRule(rule, deviceBucketed),
   );
-  if (fallbackReachable) {
+  if (enrollmentKey) {
+    sentences.push(
+      `${enrollmentKey} overrides these rules: a true value always gets true, and any other value gets false.`,
+    );
+  } else if (fallbackReachable) {
     sentences.push(
       deviceBucketed || rules.some((rule) => rule.isGroup)
         ? "A check without its bucketing key still gets false."
@@ -550,6 +567,7 @@ export function shapeFlagAudience(
     variants,
     bucketing,
     stability,
+    enrollmentKey,
   };
 }
 

--- a/products/desktop/packages/api-client/src/flag-audience.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.ts
@@ -272,7 +272,9 @@ function shapeCondition(
   if (property.type === "cohort") {
     return {
       subject: isGroup ? "Group" : "Person",
-      operator: OPERATORS[(operatorKey ?? "in") as Schemas.PropertyOperator] ?? "in cohort",
+      operator:
+        OPERATORS[(operatorKey ?? "in") as Schemas.PropertyOperator] ??
+        "in cohort",
       values,
     };
   }
@@ -289,7 +291,8 @@ function shapeCondition(
   if (isDistinctIdFilter(property)) {
     return {
       subject: "Person",
-      operator: OPERATORS[(operatorKey ?? "exact") as Schemas.PropertyOperator] ?? "is",
+      operator:
+        OPERATORS[(operatorKey ?? "exact") as Schemas.PropertyOperator] ?? "is",
       values,
     };
   }
@@ -522,7 +525,9 @@ export function shapeFlagAudience(
       disabled,
       rules,
       fallback,
-      fallbackReachable: !rules.some((rule) => catchAllRule(rule, deviceBucketed)),
+      fallbackReachable: !rules.some((rule) =>
+        catchAllRule(rule, deviceBucketed),
+      ),
       variants,
       bucketing,
       stability,
@@ -571,12 +576,7 @@ export function shapeFlagAudience(
   }
 
   const audiences = live.map((rule) =>
-    describeAudience(
-      rule,
-      groups[rules.indexOf(rule)],
-      people,
-      deviceBucketed,
-    ),
+    describeAudience(rule, groups[rules.indexOf(rule)], people, deviceBucketed),
   );
   const who = joinAudiences(audiences.map((audience) => audience.label));
   const headline = isRemoteConfig

--- a/products/desktop/packages/api-client/src/flag-audience.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.ts
@@ -398,20 +398,14 @@ export function shapeFlagAudience(
   }
 
   if (rules.length === 0) {
-    // No condition sets means every check matches; show that as one rule so
-    // the table still reads top to bottom.
-    rules.push({ conditions: [], share: 100, result: matchResult(null) });
+    // The evaluator skips the condition loop on empty groups and returns
+    // false, so clearing targeting turns the flag off for everybody.
     return {
       headline: isRemoteConfig
-        ? "Sends a payload to everyone."
-        : variants.length > 0
-          ? `Split into ${variants.length} variants for everyone.`
-          : "On for everyone.",
-      summary: isRemoteConfig
-        ? "Every check returns the configured payload."
-        : variants.length > 0
-          ? "Every check returns a variant, picked by a stable hash of the distinct ID."
-          : "Every check returns true.",
+        ? "Sends a payload to nobody."
+        : "On for nobody.",
+      summary:
+        "The flag has no release conditions, so every check returns false.",
       disabled,
       rules,
       fallback,

--- a/products/desktop/packages/api-client/src/flag-audience.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.ts
@@ -2,14 +2,12 @@ import type { Schemas } from "./generated";
 
 /**
  * Who a feature flag reaches, shaped for reading rather than editing: a
- * headline sentence, the rules as a first-match-wins list where every row
- * ends in its result, and the variant split when the flag has one.
+ * headline, the rules as a first-match-wins list where every row ends in
+ * its result, and the variant split when the flag has one.
  */
 export interface FlagAudience {
   /** "On for one person." */
   headline: string;
-  /** "Alex gets true. Everyone else gets false." */
-  summary: string;
   disabled: boolean;
   rules: FlagRule[];
   /** False when a reachable rule already matches everyone, so the "Everyone else" row is hidden. */
@@ -257,110 +255,63 @@ function shapeCondition(
   return key ? { subject: key, operator, values } : null;
 }
 
-interface Audience {
-  /** "one person", "25% of Power users" */
-  label: string;
-  plural: boolean;
-  /** Replaces the default "<label> gets <result>." sentence when the label alone misreads. */
-  sentence?: string;
-}
-
 function describeAudience(
   rule: FlagRule,
   group: ConditionGroup,
   people: People,
   bucketing: FlagAudience["bucketing"],
-): Audience {
+): string {
   const share = rule.share < 100 ? `${rule.share}% of ` : "";
   const noun = group.isGroup ? "groups" : "people";
   if (rule.conditions.length === 0) {
-    if (share) return { label: `${share}${noun}`, plural: true };
+    if (share) return `${share}${noun}`;
     // A group rule still needs a group key, and a device-bucketed rule still
     // needs a device ID, so "everyone" would overstate who matches.
-    if (group.isGroup) return { label: "every group", plural: true };
-    if (bucketing === "device") return { label: "every device", plural: true };
-    return { label: "everyone", plural: false };
+    if (group.isGroup) return "every group";
+    return bucketing === "device" ? "every device" : "everyone";
   }
   const [condition] = rule.conditions;
   const [property] = group.properties;
   if (rule.conditions.length === 1 && group.properties.length === 1) {
     if (isDistinctIdFilter(property) && condition.operator === "is") {
       const count = condition.values.length;
-      if (count > 1) return { label: `${share}${count} people`, plural: true };
-      const who =
-        people.get(condition.values[0]?.raw ?? "")?.name ?? "one person";
+      if (count > 1) return `${share}${count} people`;
       // The rollout hashes the identifier: a named person is either in or
       // out, never a fraction, so the share stays on the rule row.
-      return {
-        label: who,
-        plural: false,
-        sentence: share
-          ? `${who} is targeted, and the ${rule.share}% rollout hash decides.`
-          : undefined,
-      };
+      return people.get(condition.values[0]?.raw ?? "")?.name ?? "one person";
     }
     if (property.type === "cohort" && condition.operator === "in cohort") {
-      return {
-        label: `${share}${condition.values[0]?.label ?? "a cohort"}`,
-        plural: true,
-      };
+      return `${share}${condition.values[0]?.label ?? "a cohort"}`;
     }
   }
   const count =
     rule.conditions.length === 1
       ? "one condition"
       : `${rule.conditions.length} conditions`;
-  return { label: `${share}${noun} matching ${count}`, plural: true };
-}
-
-const RESULT_WORDS = {
-  true: "true",
-  false: "false",
-  split: "a variant",
-  payload: "the payload",
-};
-
-function describeResult(result: FlagResult): string {
-  return result.kind === "variant" ? result.key : RESULT_WORDS[result.kind];
+  return `${share}${noun} matching ${count}`;
 }
 
 function capitalize(text: string): string {
   return text.charAt(0).toUpperCase() + text.slice(1);
 }
 
-type Shape = Omit<FlagAudience, "headline" | "summary">;
+type Shape = Omit<FlagAudience, "headline">;
 
-function describeFlag(
+function headlineFor(
   shape: Shape,
   groups: ConditionGroup[],
   people: People,
   remoteConfig: boolean,
-): Pick<FlagAudience, "headline" | "summary"> {
-  if (shape.disabled) {
-    return {
-      headline: "Off for everyone.",
-      summary: "The flag is disabled, so every check returns false.",
-    };
-  }
+): string {
+  if (shape.disabled) return "Off for everyone.";
   // The evaluator skips the condition loop on empty groups and returns false,
   // so clearing targeting turns the flag off for everybody.
   if (shape.rules.length === 0) {
-    return {
-      headline: remoteConfig ? "Sends a payload to nobody." : "On for nobody.",
-      summary:
-        "The flag has no release conditions, so every check returns false.",
-    };
+    return remoteConfig ? "Sends a payload to nobody." : "On for nobody.";
   }
   const live = shape.rules.filter((rule) => rule.share > 0 && rule.reachable);
-  if (live.length === 0) {
-    return {
-      headline: "On for nobody yet.",
-      summary:
-        "Rules are defined, but rollout is 0%, so every check returns false.",
-    };
-  }
-
-  const audiences = live.map((rule) =>
+  if (live.length === 0) return "On for nobody yet.";
+  const labels = live.map((rule) =>
     describeAudience(
       rule,
       groups[shape.rules.indexOf(rule)],
@@ -368,52 +319,17 @@ function describeFlag(
       shape.bucketing,
     ),
   );
-  const labels = audiences.map((audience) => audience.label);
   const who =
     labels.length === 1
       ? labels[0]
       : labels.length === 2
         ? `${labels[0]} and ${labels[1]}`
         : `${labels.length} audiences`;
-  const headline = remoteConfig
-    ? `Sends a payload to ${who}.`
-    : shape.variants.length > 0
-      ? `Split into ${shape.variants.length} variants for ${who}.`
-      : `On for ${who}.`;
-
-  // The evaluator resolves enrollment and the holdout before the rules, so
-  // those sentences come first.
-  const sentences: string[] = [];
-  if (shape.enrollmentKey) {
-    sentences.push(
-      `${shape.enrollmentKey} overrides these rules: a true value always gets true, and any other value gets false.`,
-    );
-  } else if (shape.holdout) {
-    sentences.push(
-      `${shape.holdout.exclusionPercentage}% of people are held out for experiment ${shape.holdout.id} and get holdout-${shape.holdout.id}.`,
-    );
+  if (remoteConfig) return `Sends a payload to ${who}.`;
+  if (shape.variants.length > 0) {
+    return `Split into ${shape.variants.length} variants for ${who}.`;
   }
-  live.slice(0, 2).forEach((rule, index) => {
-    const { label, plural, sentence } = audiences[index];
-    sentences.push(
-      sentence ??
-        `${capitalize(label)} ${plural ? "get" : "gets"} ${describeResult(rule.result)}.`,
-    );
-  });
-  if (live.length > 2) {
-    const more = live.length - 2;
-    sentences.push(
-      `${more} more ${more === 1 ? "rule applies" : "rules apply"}.`,
-    );
-  }
-  if (shape.fallbackReachable && !shape.enrollmentKey) {
-    sentences.push(
-      shape.bucketing === "person"
-        ? "Everyone else gets false."
-        : "A check without its bucketing key still gets false.",
-    );
-  }
-  return { headline, summary: sentences.join(" ") };
+  return `On for ${who}.`;
 }
 
 export function shapeFlagAudience(
@@ -509,7 +425,10 @@ export function shapeFlagAudience(
         }
       : null,
   };
-  return { ...shape, ...describeFlag(shape, groups, people, remoteConfig) };
+  return {
+    ...shape,
+    headline: headlineFor(shape, groups, people, remoteConfig),
+  };
 }
 
 /** Short "Reach" label for the stat strip: "1 person", "25% of a cohort", "Everyone". */

--- a/products/desktop/packages/api-client/src/flag-audience.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.ts
@@ -17,6 +17,10 @@ export interface FlagAudience {
   /** False when a reachable rule already matches everyone, so the fallback row is hidden. */
   fallbackReachable: boolean;
   variants: FlagVariant[];
+  /** What a check buckets on, which decides the variant-assignment hash key. */
+  bucketing: "distinct_id" | "device_id";
+  /** The bucketing key as display text: "the distinct ID", "the device ID", "the group key". */
+  stability: string;
 }
 
 export interface FlagRule {
@@ -27,6 +31,8 @@ export interface FlagRule {
   result: FlagResult;
   /** False when an earlier catch-all for the same aggregation shadows this rule. */
   reachable: boolean;
+  /** True when the rule aggregates over groups instead of persons. */
+  isGroup: boolean;
 }
 
 export type FlagResult =
@@ -282,14 +288,24 @@ function describeAudience(
   rule: FlagRule,
   group: ConditionGroup,
   people: Map<string, ResolvedPerson>,
+  deviceBucketed: boolean,
 ): Audience {
   const noun = group.isGroup ? "groups" : "people";
   const share = rule.share < 100 ? `${rule.share}% of ` : "";
   if (rule.conditions.length === 0) {
-    return rule.share < 100
-      ? { label: `${rule.share}% of ${noun}`, plural: true }
-      : // "everyone" takes a singular verb in the summary sentence.
-        { label: "everyone", plural: false };
+    if (rule.share < 100) {
+      return { label: `${rule.share}% of ${noun}`, plural: true };
+    }
+    // A group rule still needs a group key, and a device-bucketed rule still
+    // needs a device ID, so "everyone" would overstate who matches.
+    if (rule.isGroup) {
+      return { label: "every group", plural: true };
+    }
+    if (deviceBucketed) {
+      return { label: "every device", plural: true };
+    }
+    // "everyone" takes a singular verb in the summary sentence.
+    return { label: "everyone", plural: false };
   }
   if (rule.conditions.length === 1 && group.properties.length === 1) {
     const [condition] = rule.conditions;
@@ -348,9 +364,19 @@ function joinAudiences(labels: string[]): string {
   return `${labels.length} audiences`;
 }
 
-/** A reachable rule with no conditions at 100% matches everyone, leaving nobody for the fallback. */
-function catchAllRule(rule: FlagRule): boolean {
-  return rule.reachable && rule.conditions.length === 0 && rule.share === 100;
+/**
+ * A reachable rule with no conditions at 100% matches every evaluable check,
+ * leaving nobody for the fallback. Group rules still need a group key and
+ * device-bucketed rules still need a device ID, so those keep the fallback.
+ */
+function catchAllRule(rule: FlagRule, deviceBucketed: boolean): boolean {
+  return (
+    rule.reachable &&
+    rule.conditions.length === 0 &&
+    rule.share === 100 &&
+    !rule.isGroup &&
+    !deviceBucketed
+  );
 }
 
 export function shapeFlagAudience(
@@ -381,6 +407,17 @@ export function shapeFlagAudience(
   const isRemoteConfig = flag.is_remote_configuration === true;
   const disabled = flag.active === false;
   const groups = conditionGroups(flag);
+  const deviceBucketed = filters.bucketing_identifier === "device_id";
+  // The variant hash key follows the bucketing identifier: device id when set,
+  // the group key for group-aggregated rules, otherwise the distinct ID.
+  const stability = deviceBucketed
+    ? "the device ID"
+    : groups.some((group) => group.isGroup)
+      ? "the group key"
+      : "the distinct ID";
+  const bucketing: FlagAudience["bucketing"] = deviceBucketed
+    ? "device_id"
+    : "distinct_id";
 
   const matchResult = (variant: string | null): FlagResult => {
     if (isRemoteConfig) return { kind: "payload" };
@@ -397,6 +434,7 @@ export function shapeFlagAudience(
     share: group.rollout,
     result: matchResult(group.variant),
     reachable: true,
+    isGroup: group.isGroup,
   }));
   // The evaluator checks condition sets in declaration order and returns on
   // the first match, so an empty condition set at 100% shadows every later
@@ -424,8 +462,10 @@ export function shapeFlagAudience(
       disabled,
       rules,
       fallback,
-      fallbackReachable: !rules.some(catchAllRule),
+      fallbackReachable: !rules.some((rule) => catchAllRule(rule, deviceBucketed)),
       variants,
+      bucketing,
+      stability,
     };
   }
 
@@ -443,6 +483,8 @@ export function shapeFlagAudience(
       fallback,
       fallbackReachable: true,
       variants,
+      bucketing,
+      stability,
     };
   }
 
@@ -457,11 +499,18 @@ export function shapeFlagAudience(
       fallback,
       fallbackReachable: true,
       variants,
+      bucketing,
+      stability,
     };
   }
 
   const audiences = live.map((rule) =>
-    describeAudience(rule, groups[rules.indexOf(rule)], people),
+    describeAudience(
+      rule,
+      groups[rules.indexOf(rule)],
+      people,
+      deviceBucketed,
+    ),
   );
   const who = joinAudiences(audiences.map((audience) => audience.label));
   const headline = isRemoteConfig
@@ -480,9 +529,15 @@ export function shapeFlagAudience(
       `${more} more ${more === 1 ? "rule applies" : "rules apply"}.`,
     );
   }
-  const fallbackReachable = !rules.some(catchAllRule);
+  const fallbackReachable = !rules.some((rule) =>
+    catchAllRule(rule, deviceBucketed),
+  );
   if (fallbackReachable) {
-    sentences.push("Everyone else gets false.");
+    sentences.push(
+      deviceBucketed || rules.some((rule) => rule.isGroup)
+        ? "A check without its bucketing key still gets false."
+        : "Everyone else gets false.",
+    );
   }
 
   return {
@@ -493,6 +548,8 @@ export function shapeFlagAudience(
     fallback,
     fallbackReachable,
     variants,
+    bucketing,
+    stability,
   };
 }
 

--- a/products/desktop/packages/api-client/src/flag-audience.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.ts
@@ -145,8 +145,13 @@ function conditionGroups(flag: Schemas.FeatureFlag): ConditionGroup[] {
       typeof group.rollout_percentage === "number"
         ? group.rollout_percentage
         : 100;
+    // An explicit null means person-level aggregation; only an absent field
+    // inherits the flag-level group index. `??` would collapse that null into
+    // the flag-level value and mislabel person rules as group rules.
     const groupIndex =
-      group.aggregation_group_type_index ?? flagLevelGroupIndex;
+      group.aggregation_group_type_index !== undefined
+        ? group.aggregation_group_type_index
+        : flagLevelGroupIndex;
     return {
       properties: Array.isArray(group.properties)
         ? group.properties.filter(isRecord)

--- a/products/desktop/packages/api-client/src/flag-audience.ts
+++ b/products/desktop/packages/api-client/src/flag-audience.ts
@@ -286,6 +286,8 @@ interface Audience {
   /** "one person", "25% of Power users" */
   label: string;
   plural: boolean;
+  /** Replaces the default "<label> gets <result>." sentence when the label alone misreads. */
+  sentence?: string;
 }
 
 function describeAudience(
@@ -322,9 +324,16 @@ function describeAudience(
       const n = condition.values.length;
       if (n === 1) {
         const person = people.get(condition.values[0].raw ?? "");
+        const who = person ? person.name : "one person";
+        // The rollout is a per-identifier hash: a named person is either in
+        // or out, never a fraction, so the share stays on the rule row.
         return {
-          label: `${share}${person ? person.name : "one person"}`,
+          label: who,
           plural: false,
+          sentence:
+            rule.share < 100
+              ? `${who} is targeted, and the ${rule.share}% rollout hash decides.`
+              : undefined,
         };
       }
       return { label: `${share}${n} people`, plural: true };
@@ -555,6 +564,7 @@ export function shapeFlagAudience(
 
   const sentences = live.slice(0, 2).map((rule, index) => {
     const audience = audiences[index];
+    if (audience.sentence) return audience.sentence;
     return `${capitalize(audience.label)} ${audience.plural ? "get" : "gets"} ${describeResult(rule.result)}.`;
   });
   if (live.length > 2) {

--- a/products/desktop/packages/api-client/src/generated.ts
+++ b/products/desktop/packages/api-client/src/generated.ts
@@ -20235,6 +20235,21 @@ export namespace Endpoints {
         };
         responses: { 200: Schemas.PersonRecord };
     };
+    /**
+     * This endpoint is meant for reading and deleting persons. To create or update persons, we recommend using the [capture API](https://posthog.com/docs/api/capture), the `$set` and `$unset` [properties](https://posthog.com/docs/product-analytics/user-properties), or one of our SDKs.
+     */
+    export type post_Persons_batch_by_distinct_ids_create = {
+        method: "POST";
+        path: "/api/projects/{project_id}/persons/batch_by_distinct_ids/";
+        requestFormat: "json";
+        parameters: {
+            query: Partial<{ format: "csv" | "json" }>;
+            path: { project_id: string };
+
+            body: Schemas.PersonRecord;
+        };
+        responses: { 200: unknown };
+    };
     export type get_Session_recordings_retrieve = {
         method: "GET";
         path: "/api/projects/{project_id}/session_recordings/{id}/";
@@ -20720,6 +20735,7 @@ export type EndpointByMethod = {
         "/api/projects/{project_id}/hog_flows/": Endpoints.post_Hog_flows_create;
         "/api/projects/{project_id}/hog_flows/{id}/run/": Endpoints.post_Hog_flows_run_create;
         "/api/projects/{project_id}/hog_flows/{id}/schedules/": Endpoints.post_Hog_flows_schedules_create;
+        "/api/projects/{project_id}/persons/batch_by_distinct_ids/": Endpoints.post_Persons_batch_by_distinct_ids_create;
         "/api/projects/{project_id}/tasks/": Endpoints.post_Tasks_create;
         "/api/projects/{project_id}/tasks/{id}/run/": Endpoints.post_Tasks_run_create;
         "/api/projects/{project_id}/tasks/{task_id}/runs/{id}/analyze/": Endpoints.post_Tasks_runs_analyze_create;

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -1152,6 +1152,10 @@ const DRF_GENERIC_NOT_FOUND_DETAIL = "Not found.";
 /** One request per targeted distinct id; flags listing more stay raw past this. */
 const MAX_RESOLVED_FLAG_PEOPLE = 10;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 function isPropertyRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -6939,39 +6943,48 @@ export class PostHogAPIClient {
     flag: Schemas.FeatureFlag,
   ): Promise<Map<string, ResolvedPerson>> {
     const ids = targetedDistinctIds(flag).slice(0, MAX_RESOLVED_FLAG_PEOPLE);
-    const entries = await Promise.all(
-      ids.map(async (distinctId): Promise<[string, ResolvedPerson] | null> => {
-        try {
-          const page = await this.api.get(
-            "/api/projects/{project_id}/persons/",
-            {
-              path: { project_id: projectId },
-              query: { distinct_id: distinctId, limit: 1 },
-            },
-          );
-          const person = page.results?.[0];
-          if (!person) return null;
-          const properties = isPropertyRecord(person.properties)
-            ? person.properties
-            : {};
-          const email =
-            typeof properties.email === "string" ? properties.email : null;
-          return [
-            distinctId,
-            {
-              uuid: person.uuid,
-              name: person.name || email || distinctId,
-              email,
-            },
-          ];
-        } catch {
-          return null;
-        }
-      }),
-    );
-    return new Map(
-      entries.filter((entry): entry is [string, ResolvedPerson] => !!entry),
-    );
+    if (ids.length === 0) return new Map();
+    try {
+      // One batched call instead of one request per id: the persons list
+      // endpoint hydrates an actors query per call and shares a per-user
+      // throttle with every other person preview.
+      const response = await this.api.post(
+        "/api/projects/{project_id}/persons/batch_by_distinct_ids/",
+        {
+          path: { project_id: projectId },
+          query: {},
+          // The spec mislabels the body as a full person record; the endpoint
+          // reads a distinct_ids array.
+          body: { distinct_ids: ids } as unknown as Schemas.PersonRecord,
+        },
+      );
+      const results =
+        response && typeof response === "object" && "results" in response
+          ? (response as { results: Record<string, unknown> }).results
+          : {};
+      const people = new Map<string, ResolvedPerson>();
+      for (const distinctId of ids) {
+        const person = results[distinctId];
+        if (!isRecord(person)) continue;
+        const uuid = typeof person.uuid === "string" ? person.uuid : null;
+        if (!uuid) continue;
+        const properties = isPropertyRecord(person.properties)
+          ? person.properties
+          : {};
+        const email =
+          typeof properties.email === "string" ? properties.email : null;
+        const name =
+          typeof person.name === "string" ? person.name : null;
+        people.set(distinctId, {
+          uuid,
+          name: name || email || distinctId,
+          email,
+        });
+      }
+      return people;
+    } catch {
+      return new Map();
+    }
   }
 
   async getEvidencePreview(

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -111,6 +111,7 @@ import {
   type FetchImplementation,
   requestErrorStatus,
 } from "./fetcher";
+import { type ResolvedPerson, targetedDistinctIds } from "./flag-audience";
 import { createApiClient, type Schemas } from "./generated";
 import type {
   McpAgentGrantScope,
@@ -1148,6 +1149,12 @@ function optionalString(value: unknown): string | null {
 // alike — never a business-specific message, so it's less actionable than the
 // endpoint's own fallback plus status code.
 const DRF_GENERIC_NOT_FOUND_DETAIL = "Not found.";
+/** One request per targeted distinct id; flags listing more stay raw past this. */
+const MAX_RESOLVED_FLAG_PEOPLE = 10;
+
+function isPropertyRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 /** Unwrap the shared fetcher's `Failed request: [<status>] <json>` into the endpoint's clean message. */
 function extractRequestErrorMessage(error: unknown, fallback: string): string {
@@ -6923,6 +6930,50 @@ export class PostHogAPIClient {
    * back to a static reference. Query-backed kinds (hogql, insight) resolve
    * in the UI instead, where chart shaping lives.
    */
+  /**
+   * People behind the distinct ids a flag targets, keyed by distinct id. A
+   * lookup that fails leaves its id unresolved so the raw id still renders.
+   */
+  private async resolveFlagPeople(
+    projectId: string,
+    flag: Schemas.FeatureFlag,
+  ): Promise<Map<string, ResolvedPerson>> {
+    const ids = targetedDistinctIds(flag).slice(0, MAX_RESOLVED_FLAG_PEOPLE);
+    const entries = await Promise.all(
+      ids.map(async (distinctId): Promise<[string, ResolvedPerson] | null> => {
+        try {
+          const page = await this.api.get(
+            "/api/projects/{project_id}/persons/",
+            {
+              path: { project_id: projectId },
+              query: { distinct_id: distinctId, limit: 1 },
+            },
+          );
+          const person = page.results?.[0];
+          if (!person) return null;
+          const properties = isPropertyRecord(person.properties)
+            ? person.properties
+            : {};
+          const email =
+            typeof properties.email === "string" ? properties.email : null;
+          return [
+            distinctId,
+            {
+              uuid: person.uuid,
+              name: person.name || email || distinctId,
+              email,
+            },
+          ];
+        } catch {
+          return null;
+        }
+      }),
+    );
+    return new Map(
+      entries.filter((entry): entry is [string, ResolvedPerson] => !!entry),
+    );
+  }
+
   async getEvidencePreview(
     kind: string,
     id: string,
@@ -6948,9 +6999,10 @@ export class PostHogAPIClient {
           flag = page.results.find((entry) => entry.key === id);
         }
         if (!flag) return null;
-        // Depth: PostHog's own staleness verdict, and whether anything still
-        // evaluates the flag (7-day call volume).
-        const [status, volume] = await Promise.all([
+        // Depth: PostHog's own staleness verdict, whether anything still
+        // evaluates the flag (7-day call volume), and the people behind any
+        // distinct ids the flag targets directly, so the page can name them.
+        const [status, volume, people] = await Promise.all([
           this.api
             .get("/api/projects/{project_id}/feature_flags/{id}/status/", {
               path: { project_id: projectId, id: flag.id },
@@ -6960,9 +7012,10 @@ export class PostHogAPIClient {
             kind: "HogQLQuery",
             query: `SELECT toDate(timestamp) AS day, count() FROM events WHERE event = '$feature_flag_called' AND properties.$feature_flag = '${hogqlEscape(flag.key)}' AND timestamp >= now() - INTERVAL 7 DAY GROUP BY day ORDER BY day`,
           }).catch(() => ({})),
+          this.resolveFlagPeople(projectId, flag),
         ]);
         return decorateFlagPreview(
-          shapeFlagPreview(flag),
+          shapeFlagPreview(flag, people),
           status,
           gridRows(volume),
         );

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -6973,8 +6973,7 @@ export class PostHogAPIClient {
           : {};
         const email =
           typeof properties.email === "string" ? properties.email : null;
-        const name =
-          typeof person.name === "string" ? person.name : null;
+        const name = typeof person.name === "string" ? person.name : null;
         people.set(distinctId, {
           uuid,
           name: name || email || distinctId,

--- a/products/desktop/packages/ui/src/features/editor/evidencePreview.ts
+++ b/products/desktop/packages/ui/src/features/editor/evidencePreview.ts
@@ -2,6 +2,7 @@ import type {
   EvidenceDetailSection,
   ExperimentResultsPresentation,
 } from "@posthog/api-client/evidence-previews";
+import type { FlagAudience } from "@posthog/api-client/flag-audience";
 import type { PostHogAPIClient } from "@posthog/api-client/posthog-client";
 import {
   type ChartHeadlineStat,
@@ -51,6 +52,8 @@ export interface EvidenceCardData {
   };
   sections?: EvidenceDetailSection[];
   experimentResults?: ExperimentResultsPresentation;
+  /** Who a feature flag reaches, as a readable rules table. */
+  flagAudience?: FlagAudience;
   /** A dashboard's tiles, each resolvable to a live insight chart. */
   tiles?: Array<{ shortId: string; name: string | null }>;
   /** Canonical id when it differs from the cited one (a flag cited by key). */

--- a/products/desktop/packages/ui/src/features/posthog-objects/EditFlagInTaskPopover.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/EditFlagInTaskPopover.tsx
@@ -1,0 +1,119 @@
+import { FlagIcon, ShieldCheckIcon } from "@phosphor-icons/react";
+import {
+  Button,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Text,
+  Textarea,
+} from "@posthog/quill";
+import { sendPromptToAgent } from "@posthog/ui/features/sessions/sendPromptToAgent";
+import { isSendMessageSubmitKey } from "@posthog/ui/utils/sendMessageKey";
+import { useCallback, useState } from "react";
+
+/** Appended to every edit so the agent shows the outcome before it writes. */
+export const FLAG_EDIT_GUARD =
+  "First do a dry run and ask for approval before you change anything.";
+
+export function buildFlagEditPrompt(flagKey: string, request: string): string {
+  return `Edit the feature flag \`${flagKey}\`: ${request.trim()}\n\n${FLAG_EDIT_GUARD}`;
+}
+
+/**
+ * Sends a plain-language change request for a flag back into the task the
+ * flag appears in. The agent dry-runs and asks before it applies anything.
+ */
+export function EditFlagInTaskPopover({
+  taskId,
+  flagKey,
+}: {
+  taskId: string;
+  flagKey: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [request, setRequest] = useState("");
+  const [sending, setSending] = useState(false);
+  const canSend = request.trim().length > 0 && !sending;
+
+  const send = useCallback(async () => {
+    if (!canSend) return;
+    setSending(true);
+    try {
+      const sent = await sendPromptToAgent(
+        taskId,
+        buildFlagEditPrompt(flagKey, request),
+      );
+      if (sent) {
+        setRequest("");
+        setOpen(false);
+      }
+    } finally {
+      setSending(false);
+    }
+  }, [canSend, taskId, flagKey, request]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <Button
+            variant="primary"
+            size="sm"
+            data-attr="posthog-object-edit-flag-in-task"
+          />
+        }
+      >
+        Edit in task
+      </PopoverTrigger>
+      <PopoverContent align="end" sideOffset={6} className="w-[420px] p-3.5">
+        <Text className="block font-semibold text-[13px]">
+          Edit this flag in the task
+        </Text>
+        <Text variant="muted" className="mt-0.5 block text-xs">
+          Describe the change the way you would tell a teammate: who should get
+          the flag, and what they should get. The agent works out the rules.
+        </Text>
+
+        <div className="mt-3 rounded-lg border border-border bg-card">
+          <Textarea
+            value={request}
+            onChange={(event) => setRequest(event.target.value)}
+            onKeyDown={(event) => {
+              if (isSendMessageSubmitKey(event)) {
+                event.preventDefault();
+                void send();
+              }
+            }}
+            placeholder='For example: "Turn this on for the Beta testers cohort too, keep the current person" or "Roll out to 50% of everyone"'
+            className="min-h-16 resize-none border-0 bg-transparent px-3 py-2.5 text-[13px] shadow-none focus-visible:ring-0"
+            disabled={sending}
+          />
+          <div className="flex items-center justify-between gap-2 border-border border-t px-2.5 py-2">
+            <span className="inline-flex items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-0.5 text-[11.5px] text-foreground">
+              <FlagIcon size={11} color="var(--primary)" />
+              {flagKey}
+            </span>
+            <Button
+              variant="primary"
+              size="sm"
+              disabled={!canSend}
+              onClick={() => void send()}
+            >
+              {sending ? "Sending…" : "Send to task"}
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-3 flex items-start gap-2 rounded-lg border border-border bg-muted px-2.5 py-2 text-muted-foreground text-xs">
+          <ShieldCheckIcon size={12} className="mt-0.5 shrink-0" />
+          <span>
+            Sent with every edit:{" "}
+            <span className="font-medium text-foreground">
+              “{FLAG_EDIT_GUARD}”
+            </span>
+          </span>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/products/desktop/packages/ui/src/features/posthog-objects/EditFlagInTaskPopover.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/EditFlagInTaskPopover.tsx
@@ -1,6 +1,12 @@
-import { FlagIcon, ShieldCheckIcon } from "@phosphor-icons/react";
+import {
+  FlagIcon,
+  PencilSimpleIcon,
+  ShieldCheckIcon,
+} from "@phosphor-icons/react";
 import {
   Button,
+  Kbd,
+  KbdGroup,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -8,6 +14,8 @@ import {
   Textarea,
 } from "@posthog/quill";
 import { sendPromptToAgent } from "@posthog/ui/features/sessions/sendPromptToAgent";
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import { toast } from "@posthog/ui/primitives/toast";
 import { isSendMessageSubmitKey } from "@posthog/ui/utils/sendMessageKey";
 import { useCallback, useState } from "react";
 
@@ -18,6 +26,9 @@ export const FLAG_EDIT_GUARD =
 export function buildFlagEditPrompt(flagKey: string, request: string): string {
   return `Edit the feature flag \`${flagKey}\`: ${request.trim()}\n\n${FLAG_EDIT_GUARD}`;
 }
+
+const EXAMPLE_REQUEST =
+  "Turn this on for the Beta testers cohort as well, and keep the current person.";
 
 /**
  * Sends a plain-language change request for a flag back into the task the
@@ -33,6 +44,7 @@ export function EditFlagInTaskPopover({
   const [open, setOpen] = useState(false);
   const [request, setRequest] = useState("");
   const [sending, setSending] = useState(false);
+  const sendMessagesWith = useSettingsStore((state) => state.sendMessagesWith);
   const canSend = request.trim().length > 0 && !sending;
 
   const send = useCallback(async () => {
@@ -46,6 +58,10 @@ export function EditFlagInTaskPopover({
       if (sent) {
         setRequest("");
         setOpen(false);
+        toast.success("Sent to the task", {
+          description:
+            "The agent will show a dry run before it changes the flag.",
+        });
       }
     } finally {
       setSending(false);
@@ -63,55 +79,73 @@ export function EditFlagInTaskPopover({
           />
         }
       >
+        <PencilSimpleIcon size={13} weight="bold" />
         Edit in task
       </PopoverTrigger>
-      <PopoverContent align="end" sideOffset={6} className="w-[420px] p-3.5">
-        <Text className="block font-semibold text-[13px]">
-          Edit this flag in the task
-        </Text>
-        <Text variant="muted" className="mt-0.5 block text-xs">
-          Describe the change the way you would tell a teammate: who should get
-          the flag, and what they should get. The agent works out the rules.
-        </Text>
-
-        <div className="mt-3 rounded-lg border border-border bg-card">
-          <Textarea
-            value={request}
-            onChange={(event) => setRequest(event.target.value)}
-            onKeyDown={(event) => {
-              if (isSendMessageSubmitKey(event)) {
-                event.preventDefault();
-                void send();
-              }
-            }}
-            placeholder='For example: "Turn this on for the Beta testers cohort too, keep the current person" or "Roll out to 50% of everyone"'
-            className="min-h-16 resize-none border-0 bg-transparent px-3 py-2.5 text-[13px] shadow-none focus-visible:ring-0"
-            disabled={sending}
-          />
-          <div className="flex items-center justify-between gap-2 border-border border-t px-2.5 py-2">
-            <span className="inline-flex items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-0.5 text-[11.5px] text-foreground">
-              <FlagIcon size={11} color="var(--primary)" />
+      <PopoverContent align="end" sideOffset={8} className="w-[440px] p-0">
+        <div className="px-4 pt-3.5 pb-3">
+          <div className="flex items-center gap-2">
+            <Text className="font-semibold text-[13px]">
+              Describe the change
+            </Text>
+            <span className="inline-flex items-center gap-1 rounded-md border border-border bg-muted px-1.5 py-px font-mono text-[11px] text-foreground">
+              <FlagIcon size={10} weight="fill" color="var(--primary)" />
               {flagKey}
             </span>
-            <Button
-              variant="primary"
-              size="sm"
-              disabled={!canSend}
-              onClick={() => void send()}
-            >
-              {sending ? "Sending…" : "Send to task"}
-            </Button>
+          </div>
+          <Text variant="muted" className="mt-1 block text-xs leading-relaxed">
+            Say who should get the flag and what they should get. The agent
+            turns that into release conditions in the task this flag came from.
+          </Text>
+        </div>
+
+        <div className="px-4">
+          <div className="rounded-lg border border-border bg-card shadow-xs transition-shadow focus-within:border-(--primary) focus-within:shadow-[0_0_0_3px_var(--primary-a4,rgba(0,0,0,0.06))]">
+            <Textarea
+              autoFocus
+              value={request}
+              onChange={(event) => setRequest(event.target.value)}
+              onKeyDown={(event) => {
+                if (isSendMessageSubmitKey(event)) {
+                  event.preventDefault();
+                  void send();
+                }
+              }}
+              placeholder={`For example: "${EXAMPLE_REQUEST}"`}
+              className="min-h-20 resize-none border-0 bg-transparent px-3 py-2.5 text-[13px] shadow-none focus-visible:ring-0"
+              disabled={sending}
+            />
+            <div className="flex items-center justify-between gap-2 border-border border-t px-2.5 py-2">
+              <KbdGroup className="text-[11px] text-muted-foreground">
+                {sendMessagesWith === "cmd+enter" && <Kbd>⌘</Kbd>}
+                <Kbd>↵</Kbd>
+                <span className="ml-1">to send</span>
+              </KbdGroup>
+              <Button
+                variant="primary"
+                size="sm"
+                loading={sending}
+                disabled={!canSend}
+                onClick={() => void send()}
+              >
+                Send to task
+              </Button>
+            </div>
           </div>
         </div>
 
-        <div className="mt-3 flex items-start gap-2 rounded-lg border border-border bg-muted px-2.5 py-2 text-muted-foreground text-xs">
-          <ShieldCheckIcon size={12} className="mt-0.5 shrink-0" />
-          <span>
-            Sent with every edit:{" "}
-            <span className="font-medium text-foreground">
-              “{FLAG_EDIT_GUARD}”
+        <div className="mt-3 border-border border-t bg-muted px-4 py-2.5">
+          <div className="flex items-start gap-2 text-muted-foreground text-xs leading-relaxed">
+            <ShieldCheckIcon
+              size={13}
+              weight="fill"
+              className="mt-px shrink-0 text-(--green-9)"
+            />
+            <span>
+              Nothing changes without your approval. Every request ends with:{" "}
+              <span className="text-foreground">“{FLAG_EDIT_GUARD}”</span>
             </span>
-          </span>
+          </div>
         </div>
       </PopoverContent>
     </Popover>

--- a/products/desktop/packages/ui/src/features/posthog-objects/EditFlagInTaskPopover.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/EditFlagInTaskPopover.tsx
@@ -1,12 +1,5 @@
 import {
-  FlagIcon,
-  PencilSimpleIcon,
-  ShieldCheckIcon,
-} from "@phosphor-icons/react";
-import {
   Button,
-  Kbd,
-  KbdGroup,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -14,7 +7,6 @@ import {
   Textarea,
 } from "@posthog/quill";
 import { sendPromptToAgent } from "@posthog/ui/features/sessions/sendPromptToAgent";
-import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { toast } from "@posthog/ui/primitives/toast";
 import { isSendMessageSubmitKey } from "@posthog/ui/utils/sendMessageKey";
 import { useCallback, useState } from "react";
@@ -26,9 +18,6 @@ export const FLAG_EDIT_GUARD =
 export function buildFlagEditPrompt(flagKey: string, request: string): string {
   return `Edit the feature flag \`${flagKey}\`: ${request.trim()}\n\n${FLAG_EDIT_GUARD}`;
 }
-
-const EXAMPLE_REQUEST =
-  "Turn this on for the Beta testers cohort as well, and keep the current person.";
 
 /**
  * Sends a plain-language change request for a flag back into the task the
@@ -44,7 +33,6 @@ export function EditFlagInTaskPopover({
   const [open, setOpen] = useState(false);
   const [request, setRequest] = useState("");
   const [sending, setSending] = useState(false);
-  const sendMessagesWith = useSettingsStore((state) => state.sendMessagesWith);
   const canSend = request.trim().length > 0 && !sending;
 
   const send = useCallback(async () => {
@@ -58,10 +46,7 @@ export function EditFlagInTaskPopover({
       if (sent) {
         setRequest("");
         setOpen(false);
-        toast.success("Sent to the task", {
-          description:
-            "The agent will show a dry run before it changes the flag.",
-        });
+        toast.success("Sent to the task");
       }
     } finally {
       setSending(false);
@@ -79,73 +64,40 @@ export function EditFlagInTaskPopover({
           />
         }
       >
-        <PencilSimpleIcon size={13} weight="bold" />
         Edit in task
       </PopoverTrigger>
-      <PopoverContent align="end" sideOffset={8} className="w-[440px] p-0">
-        <div className="px-4 pt-3.5 pb-3">
-          <div className="flex items-center gap-2">
-            <Text className="font-semibold text-[13px]">
-              Describe the change
-            </Text>
-            <span className="inline-flex items-center gap-1 rounded-md border border-border bg-muted px-1.5 py-px font-mono text-[11px] text-foreground">
-              <FlagIcon size={10} weight="fill" color="var(--primary)" />
-              {flagKey}
-            </span>
-          </div>
-          <Text variant="muted" className="mt-1 block text-xs leading-relaxed">
-            Say who should get the flag and what they should get. The agent
-            turns that into release conditions in the task this flag came from.
-          </Text>
-        </div>
-
-        <div className="px-4">
-          <div className="rounded-lg border border-border bg-card shadow-xs transition-shadow focus-within:border-(--primary) focus-within:shadow-[0_0_0_3px_var(--primary-a4,rgba(0,0,0,0.06))]">
-            <Textarea
-              autoFocus
-              value={request}
-              onChange={(event) => setRequest(event.target.value)}
-              onKeyDown={(event) => {
-                if (isSendMessageSubmitKey(event)) {
-                  event.preventDefault();
-                  void send();
-                }
-              }}
-              placeholder={`For example: "${EXAMPLE_REQUEST}"`}
-              className="min-h-20 resize-none border-0 bg-transparent px-3 py-2.5 text-[13px] shadow-none focus-visible:ring-0"
-              disabled={sending}
-            />
-            <div className="flex items-center justify-between gap-2 border-border border-t px-2.5 py-2">
-              <KbdGroup className="text-[11px] text-muted-foreground">
-                {sendMessagesWith === "cmd+enter" && <Kbd>⌘</Kbd>}
-                <Kbd>↵</Kbd>
-                <span className="ml-1">to send</span>
-              </KbdGroup>
-              <Button
-                variant="primary"
-                size="sm"
-                loading={sending}
-                disabled={!canSend}
-                onClick={() => void send()}
-              >
-                Send to task
-              </Button>
-            </div>
-          </div>
-        </div>
-
-        <div className="mt-3 border-border border-t bg-muted px-4 py-2.5">
-          <div className="flex items-start gap-2 text-muted-foreground text-xs leading-relaxed">
-            <ShieldCheckIcon
-              size={13}
-              weight="fill"
-              className="mt-px shrink-0 text-(--green-9)"
-            />
-            <span>
-              Nothing changes without your approval. Every request ends with:{" "}
-              <span className="text-foreground">“{FLAG_EDIT_GUARD}”</span>
-            </span>
-          </div>
+      <PopoverContent align="end" sideOffset={8} className="w-[400px] p-4">
+        <Text className="block font-semibold text-[13px]">
+          Describe the change
+        </Text>
+        <Text variant="muted" className="mt-0.5 block text-xs">
+          Say who gets the flag and what they get.
+        </Text>
+        <Textarea
+          autoFocus
+          rows={3}
+          value={request}
+          onChange={(event) => setRequest(event.target.value)}
+          onKeyDown={(event) => {
+            if (isSendMessageSubmitKey(event)) {
+              event.preventDefault();
+              void send();
+            }
+          }}
+          placeholder="For example: Turn this on for the Beta testers cohort too."
+          className="mt-3 resize-none text-[13px]"
+          disabled={sending}
+        />
+        <div className="mt-3 flex justify-end">
+          <Button
+            variant="primary"
+            size="sm"
+            loading={sending}
+            disabled={!canSend}
+            onClick={() => void send()}
+          >
+            Send to task
+          </Button>
         </div>
       </PopoverContent>
     </Popover>

--- a/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
@@ -1,0 +1,322 @@
+import type {
+  FlagAudience,
+  FlagCondition,
+  FlagResult,
+  FlagRule,
+  FlagValue,
+  FlagVariant,
+} from "@posthog/api-client/flag-audience";
+import { Card, CardContent, Text } from "@posthog/quill";
+import { useEvidenceUrl } from "@posthog/ui/features/editor/components/EvidenceRefChip";
+import { openExternalUrl } from "@posthog/ui/shell/openExternal";
+
+const VARIANT_COLORS = [
+  "var(--primary)",
+  "var(--blue-9)",
+  "var(--teal-9)",
+  "var(--purple-9)",
+  "var(--amber-9)",
+  "var(--pink-9)",
+];
+
+function variantColor(variants: FlagVariant[], key: string): string {
+  const index = variants.findIndex((variant) => variant.key === key);
+  return VARIANT_COLORS[Math.max(index, 0) % VARIANT_COLORS.length];
+}
+
+function EntityChip({ value }: { value: FlagValue }) {
+  const link = value.link;
+  const url = useEvidenceUrl(link?.kind ?? "person", link?.id ?? "");
+  const body = (
+    <>
+      <span>{value.label}</span>
+      {value.secondary && (
+        <span className="font-normal text-muted-foreground">
+          {value.secondary}
+        </span>
+      )}
+      {url && <span className="text-[10px] opacity-70">↗</span>}
+    </>
+  );
+  const className =
+    "inline-flex items-center gap-1.5 rounded-md border border-(--blue-6) bg-(--blue-2) px-2 py-px font-medium text-(--blue-11) text-xs leading-5";
+  if (!url) {
+    return (
+      <span className={className} title={value.raw}>
+        {body}
+      </span>
+    );
+  }
+  return (
+    <button
+      type="button"
+      className={`${className} cursor-pointer hover:bg-(--blue-3)`}
+      title={value.raw}
+      onClick={() => openExternalUrl(url)}
+    >
+      {body}
+    </button>
+  );
+}
+
+function ValueChip({ value }: { value: FlagValue }) {
+  if (value.link) return <EntityChip value={value} />;
+  return (
+    <span
+      className={`inline-flex items-center rounded-md border border-border bg-muted px-2 py-px text-xs leading-5 ${value.literal ? "font-mono" : "font-medium"}`}
+    >
+      {value.label}
+    </span>
+  );
+}
+
+function ConditionLine({
+  condition,
+  first,
+}: {
+  condition: FlagCondition;
+  first: boolean;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {!first && (
+        <span className="font-semibold text-[10.5px] text-muted-foreground uppercase tracking-wide">
+          and
+        </span>
+      )}
+      <span className="text-muted-foreground">
+        {condition.subject} {condition.operator}
+      </span>
+      {condition.values.map((value, index) => (
+        <ValueChip key={`${value.label}:${index}`} value={value} />
+      ))}
+    </div>
+  );
+}
+
+function ResultPill({
+  result,
+  variants,
+}: {
+  result: FlagResult;
+  variants: FlagVariant[];
+}) {
+  const base =
+    "inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 font-semibold text-xs";
+  switch (result.kind) {
+    case "true":
+      return (
+        <span
+          className={`${base} border-(--green-6) bg-(--green-2) font-mono text-(--green-11)`}
+        >
+          true
+        </span>
+      );
+    case "false":
+      return (
+        <span
+          className={`${base} border-border bg-muted font-mono text-muted-foreground`}
+        >
+          false
+        </span>
+      );
+    case "payload":
+      return (
+        <span className={`${base} border-border bg-card text-foreground`}>
+          payload
+        </span>
+      );
+    case "variant":
+      return (
+        <span className={`${base} border-border bg-card text-foreground`}>
+          <span
+            className="size-2 rounded-full"
+            style={{ background: variantColor(variants, result.key) }}
+          />
+          {result.key}
+        </span>
+      );
+    case "split":
+      return (
+        <span
+          className={`${base} border-border bg-card text-foreground`}
+          title={variants
+            .map((variant) => `${variant.key} ${variant.percentage}%`)
+            .join(" · ")}
+        >
+          <span className="flex gap-0.5">
+            {variants.map((variant) => (
+              <span
+                key={variant.key}
+                className="size-2 rounded-full"
+                style={{ background: variantColor(variants, variant.key) }}
+              />
+            ))}
+          </span>
+          a variant
+        </span>
+      );
+  }
+}
+
+function RuleRow({
+  index,
+  rule,
+  variants,
+}: {
+  index: number;
+  rule: FlagRule;
+  variants: FlagVariant[];
+}) {
+  return (
+    <div className="grid grid-cols-[22px_1fr_auto] items-center gap-x-3 border-border border-b px-3 py-2.5 last:border-b-0">
+      <span className="flex size-5 items-center justify-center rounded-md border border-border bg-muted font-semibold text-[11px] text-foreground">
+        {index + 1}
+      </span>
+      <div className="flex min-w-0 flex-col gap-1 text-[13px]">
+        {rule.conditions.length === 0 ? (
+          <span>Everyone</span>
+        ) : (
+          rule.conditions.map((condition, conditionIndex) => (
+            <ConditionLine
+              key={`${condition.subject}:${conditionIndex}`}
+              condition={condition}
+              first={conditionIndex === 0}
+            />
+          ))
+        )}
+      </div>
+      <div className="flex items-center justify-end gap-2.5 whitespace-nowrap">
+        {rule.share < 100 && (
+          <span className="text-[11px] text-muted-foreground tabular-nums">
+            {rule.share}% of matches
+          </span>
+        )}
+        <ResultPill result={rule.result} variants={variants} />
+      </div>
+    </div>
+  );
+}
+
+function VariantsList({ variants }: { variants: FlagVariant[] }) {
+  return (
+    <div className="mt-4">
+      <div className="flex items-baseline justify-between gap-2">
+        <Text
+          variant="muted"
+          className="block text-[11px] uppercase tracking-wider"
+        >
+          Variants
+        </Text>
+        <Text variant="muted" className="text-xs">
+          Assigned by a stable hash, so a person keeps their variant
+        </Text>
+      </div>
+      <div className="mt-2 flex h-2 gap-0.5 overflow-hidden rounded">
+        {variants.map((variant) => (
+          <span
+            key={variant.key}
+            className="h-full"
+            style={{
+              width: `${variant.percentage}%`,
+              background: variantColor(variants, variant.key),
+            }}
+          />
+        ))}
+      </div>
+      {variants.map((variant) => (
+        <div
+          key={variant.key}
+          className="grid grid-cols-[auto_1fr_auto] items-center gap-3 border-border border-b py-1.5 text-[13px] last:border-b-0"
+        >
+          <span className="flex items-center gap-2">
+            <span
+              className="size-2 rounded-full"
+              style={{ background: variantColor(variants, variant.key) }}
+            />
+            <span className="font-mono font-semibold text-xs">
+              {variant.key}
+            </span>
+          </span>
+          <span
+            className={`truncate font-mono text-xs ${variant.payload ? "text-foreground" : "text-muted-foreground"}`}
+          >
+            {variant.payload ?? "No payload"}
+          </span>
+          <span className="font-semibold tabular-nums">
+            {variant.percentage}%
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Rules have no id; conditions plus position keep keys stable across refetches. */
+function ruleKey(rule: FlagRule, index: number): string {
+  const conditions = rule.conditions
+    .map((condition) => `${condition.subject} ${condition.operator}`)
+    .join("|");
+  return `${index}:${conditions}`;
+}
+
+/**
+ * Answers "who gets this flag, and what do they get?" before showing any
+ * structure: a headline, one outcome sentence, then the rules as a
+ * first-match-wins table where every row ends in its result.
+ */
+export function FlagAudienceCard({ audience }: { audience: FlagAudience }) {
+  // A rule with no conditions at 100% matches everyone, so nobody reaches the fallback.
+  const fallbackReachable = !audience.rules.some(
+    (rule) => rule.conditions.length === 0 && rule.share === 100,
+  );
+  return (
+    <Card size="sm">
+      <CardContent>
+        <Text
+          variant="muted"
+          className="block text-[11px] uppercase tracking-wider"
+        >
+          Who gets this
+        </Text>
+        <div className="mt-2 font-semibold text-base text-foreground tracking-tight">
+          {audience.headline}
+        </div>
+        <Text className="mt-0.5 block text-[13px] text-muted-foreground">
+          {audience.summary}
+        </Text>
+
+        <div
+          className={`mt-3.5 overflow-hidden rounded-lg border border-border ${audience.disabled ? "opacity-60" : ""}`}
+        >
+          <div className="flex justify-between border-border border-b bg-muted px-3 py-1.5 text-[11px] text-muted-foreground">
+            <span>Rules, checked in order. First match wins.</span>
+            <span>Result</span>
+          </div>
+          {audience.rules.map((rule, index) => (
+            <RuleRow
+              key={ruleKey(rule, index)}
+              index={index}
+              rule={rule}
+              variants={audience.variants}
+            />
+          ))}
+          {fallbackReachable && (
+            <div className="grid grid-cols-[22px_1fr_auto] items-center gap-x-3 px-3 py-2.5 text-[13px] text-muted-foreground">
+              <span />
+              <span>Everyone else</span>
+              <ResultPill
+                result={audience.fallback}
+                variants={audience.variants}
+              />
+            </div>
+          )}
+        </div>
+
+        {audience.variants.length > 0 && (
+          <VariantsList variants={audience.variants} />
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
@@ -163,10 +163,12 @@ function RuleRow({
   index,
   rule,
   variants,
+  bucketing,
 }: {
   index: number;
   rule: FlagRule;
   variants: FlagVariant[];
+  bucketing: FlagAudience["bucketing"];
 }) {
   return (
     <div
@@ -182,7 +184,13 @@ function RuleRow({
           </span>
         )}
         {rule.conditions.length === 0 ? (
-          <span>Everyone</span>
+          <span>
+            {rule.isGroup
+              ? "Every group"
+              : bucketing === "device_id"
+                ? "Every device"
+                : "Everyone"}
+          </span>
         ) : (
           rule.conditions.map((condition, conditionIndex) => (
             <ConditionLine
@@ -205,7 +213,13 @@ function RuleRow({
   );
 }
 
-function VariantsList({ variants }: { variants: FlagVariant[] }) {
+function VariantsList({
+  variants,
+  stability,
+}: {
+  variants: FlagVariant[];
+  stability: FlagAudience["stability"];
+}) {
   return (
     <div className="mt-4">
       <div className="flex items-baseline justify-between gap-2">
@@ -216,7 +230,8 @@ function VariantsList({ variants }: { variants: FlagVariant[] }) {
           Variants
         </Text>
         <Text variant="muted" className="text-xs">
-          Assigned by a stable hash, so a person keeps their variant
+          Assigned by a stable hash of {stability}, so the assignment keeps
+          holding
         </Text>
       </div>
       <div className="mt-2 flex h-2 gap-0.5 overflow-hidden rounded">
@@ -304,6 +319,7 @@ export function FlagAudienceCard({ audience }: { audience: FlagAudience }) {
               index={index}
               rule={rule}
               variants={audience.variants}
+              bucketing={audience.bucketing}
             />
           ))}
           {audience.fallbackReachable && (
@@ -319,7 +335,10 @@ export function FlagAudienceCard({ audience }: { audience: FlagAudience }) {
         </div>
 
         {audience.variants.length > 0 && (
-          <VariantsList variants={audience.variants} />
+          <VariantsList
+            variants={audience.variants}
+            stability={audience.stability}
+          />
         )}
       </CardContent>
     </Card>

--- a/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
@@ -216,9 +216,11 @@ function RuleRow({
 function VariantsList({
   variants,
   stability,
+  holdout,
 }: {
   variants: FlagVariant[];
   stability: FlagAudience["stability"];
+  holdout: FlagAudience["holdout"];
 }) {
   return (
     <div className="mt-4">
@@ -246,6 +248,13 @@ function VariantsList({
           />
         ))}
       </div>
+      {holdout && (
+        <Text variant="muted" className="mt-1 block text-xs">
+          {holdout.exclusionPercentage}% of people receive{" "}
+          <span className="font-mono">holdout-{holdout.id}</span> instead of a
+          variant.
+        </Text>
+      )}
       {variants.map((variant) => (
         <div
           key={variant.key}
@@ -323,6 +332,16 @@ export function FlagAudienceCard({ audience }: { audience: FlagAudience }) {
               true; any other value gets false.
             </div>
           )}
+          {audience.holdout && (
+            <div className="border-border border-b bg-(--amber-2) px-3 py-2 text-[12px] text-muted-foreground">
+              Holdout: {audience.holdout.exclusionPercentage}% of people are
+              held out for experiment {audience.holdout.id} and get{" "}
+              <span className="font-mono text-foreground">
+                holdout-{audience.holdout.id}
+              </span>{" "}
+              before these rules.
+            </div>
+          )}
           {audience.rules.map((rule, index) => (
             <RuleRow
               key={ruleKey(rule, index)}
@@ -348,6 +367,7 @@ export function FlagAudienceCard({ audience }: { audience: FlagAudience }) {
           <VariantsList
             variants={audience.variants}
             stability={audience.stability}
+            holdout={audience.holdout}
           />
         )}
       </CardContent>

--- a/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
@@ -313,6 +313,16 @@ export function FlagAudienceCard({ audience }: { audience: FlagAudience }) {
             <span>Rules, checked in order. First match wins.</span>
             <span>Result</span>
           </div>
+          {audience.enrollmentKey && (
+            <div className="border-border border-b bg-(--blue-2) px-3 py-2 text-[12px] text-muted-foreground">
+              Early access: the{" "}
+              <span className="font-mono text-foreground">
+                {audience.enrollmentKey}
+              </span>{" "}
+              person property is checked before these rules. A true value gets
+              true; any other value gets false.
+            </div>
+          )}
           {audience.rules.map((rule, index) => (
             <RuleRow
               key={ruleKey(rule, index)}

--- a/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
@@ -29,9 +29,7 @@ function EntityChip({ value }: { value: FlagValue }) {
   const url = useEvidenceUrl(link?.kind ?? "person", link?.id ?? "");
   // Narrow panels clip the row, so the chip shrinks with an ellipsis and the
   // hover title carries the full label plus the secondary value.
-  const title = [value.label, value.secondary]
-    .filter(Boolean)
-    .join(" · ");
+  const title = [value.label, value.secondary].filter(Boolean).join(" · ");
   const body = (
     <>
       <span className="min-w-0 truncate">{value.label}</span>
@@ -177,7 +175,7 @@ function RuleRow({
 }) {
   return (
     <div
-      className={`@container grid grid-cols-[22px_1fr_auto] items-center gap-x-3 border-border border-b px-3 py-2.5 last:border-b-0 @max-[420px]:grid-cols-[22px_1fr] ${rule.reachable === false ? "opacity-50" : ""}`}
+      className={`@container grid @max-[420px]:grid-cols-[22px_1fr] grid-cols-[22px_1fr_auto] items-center gap-x-3 border-border border-b px-3 py-2.5 last:border-b-0 ${rule.reachable === false ? "opacity-50" : ""}`}
     >
       <span className="flex size-5 items-center justify-center rounded-md border border-border bg-muted font-semibold text-[11px] text-foreground">
         {index + 1}
@@ -206,7 +204,7 @@ function RuleRow({
           ))
         )}
       </div>
-      <div className="flex items-center justify-end gap-2.5 whitespace-nowrap @max-[420px]:col-start-2 @max-[420px]:justify-start">
+      <div className="@max-[420px]:col-start-2 flex items-center @max-[420px]:justify-start justify-end gap-2.5 whitespace-nowrap">
         {rule.share < 100 && (
           <span className="text-[11px] text-muted-foreground tabular-nums">
             {rule.share}% of matches

--- a/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
@@ -293,8 +293,8 @@ function RuleStep({
 
 /**
  * Answers "who gets this flag, and what do they get?" before showing any
- * structure: a headline, one outcome sentence, then the rules as a
- * first-match-wins flow where every step ends in its result.
+ * structure: a headline, then the rules as a first-match-wins flow where
+ * every step ends in its result.
  */
 export function FlagAudienceCard({
   audience,
@@ -320,9 +320,6 @@ export function FlagAudienceCard({
                 {audience.headline}
               </h2>
             </div>
-            <Text className="mt-1.5 block max-w-prose text-[13px] text-muted-foreground leading-relaxed">
-              {audience.summary}
-            </Text>
           </div>
           {action && <div className="shrink-0">{action}</div>}
         </div>

--- a/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
@@ -1,3 +1,12 @@
+import {
+  ArrowElbowDownRightIcon,
+  ArrowSquareOutIcon,
+  FlaskIcon,
+  KeyIcon,
+  PowerIcon,
+  UserIcon,
+  UsersThreeIcon,
+} from "@phosphor-icons/react";
 import type {
   FlagAudience,
   FlagCondition,
@@ -9,6 +18,7 @@ import type {
 import { Card, CardContent, Text } from "@posthog/quill";
 import { useEvidenceUrl } from "@posthog/ui/features/editor/components/EvidenceRefChip";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
+import type { ReactNode } from "react";
 
 const VARIANT_COLORS = [
   "var(--primary)",
@@ -24,25 +34,32 @@ function variantColor(variants: FlagVariant[], key: string): string {
   return VARIANT_COLORS[Math.max(index, 0) % VARIANT_COLORS.length];
 }
 
+/** The width of the step gutter; the connector line is centered in it. */
+const GUTTER = "grid-cols-[28px_minmax(0,1fr)_auto]";
+
 function EntityChip({ value }: { value: FlagValue }) {
   const link = value.link;
   const url = useEvidenceUrl(link?.kind ?? "person", link?.id ?? "");
+  const Icon = link?.kind === "cohort" ? UsersThreeIcon : UserIcon;
   // Narrow panels clip the row, so the chip shrinks with an ellipsis and the
   // hover title carries the full label plus the secondary value.
   const title = [value.label, value.secondary].filter(Boolean).join(" · ");
   const body = (
     <>
+      <span className="flex size-4 shrink-0 items-center justify-center rounded-full bg-(--blue-4) text-(--blue-11)">
+        <Icon size={10} weight="bold" />
+      </span>
       <span className="min-w-0 truncate">{value.label}</span>
       {value.secondary && (
-        <span className="min-w-0 truncate font-normal text-muted-foreground">
+        <span className="min-w-0 truncate font-normal opacity-70">
           {value.secondary}
         </span>
       )}
-      {url && <span className="text-[10px] opacity-70">↗</span>}
+      {url && <ArrowSquareOutIcon size={11} className="shrink-0 opacity-70" />}
     </>
   );
   const className =
-    "inline-flex items-center gap-1.5 rounded-md border border-(--blue-6) bg-(--blue-2) px-2 py-px font-medium text-(--blue-11) text-xs leading-5";
+    "inline-flex max-w-full items-center gap-1.5 rounded-full border border-(--blue-6) bg-(--blue-2) py-px pr-2 pl-1 font-medium text-(--blue-11) text-xs leading-5";
   if (!url) {
     return (
       <span className={className} title={title || value.raw}>
@@ -53,7 +70,7 @@ function EntityChip({ value }: { value: FlagValue }) {
   return (
     <button
       type="button"
-      className={`${className} cursor-pointer hover:bg-(--blue-3)`}
+      className={`${className} cursor-pointer transition-colors hover:bg-(--blue-3)`}
       title={title || value.raw}
       onClick={() => openExternalUrl(url)}
     >
@@ -66,7 +83,8 @@ function ValueChip({ value }: { value: FlagValue }) {
   if (value.link) return <EntityChip value={value} />;
   return (
     <span
-      className={`inline-flex items-center rounded-md border border-border bg-muted px-2 py-px text-xs leading-5 ${value.literal ? "font-mono" : "font-medium"}`}
+      className={`inline-flex max-w-full items-center truncate rounded-md border border-border bg-muted px-1.5 py-px text-xs leading-5 ${value.literal ? "font-mono text-foreground" : "font-medium"}`}
+      title={value.label}
     >
       {value.label}
     </span>
@@ -81,15 +99,14 @@ function ConditionLine({
   first: boolean;
 }) {
   return (
-    <div className="flex flex-wrap items-center gap-1.5">
+    <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
       {!first && (
-        <span className="font-semibold text-[10.5px] text-muted-foreground uppercase tracking-wide">
+        <span className="rounded border border-border px-1 font-semibold text-[10px] text-muted-foreground uppercase leading-4 tracking-wide">
           and
         </span>
       )}
-      <span className="text-muted-foreground">
-        {condition.subject} {condition.operator}
-      </span>
+      <span className="font-medium text-foreground">{condition.subject}</span>
+      <span className="text-muted-foreground">{condition.operator}</span>
       {condition.values.map((value, index) => (
         <ValueChip key={`${value.label}:${index}`} value={value} />
       ))}
@@ -105,12 +122,12 @@ function ResultPill({
   variants: FlagVariant[];
 }) {
   const base =
-    "inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 font-semibold text-xs";
+    "inline-flex h-6 items-center gap-1.5 rounded-md border px-2 font-semibold text-xs";
   switch (result.kind) {
     case "true":
       return (
         <span
-          className={`${base} border-(--green-6) bg-(--green-2) font-mono text-(--green-11)`}
+          className={`${base} border-(--green-6) bg-(--green-3) font-mono text-(--green-11)`}
         >
           true
         </span>
@@ -131,9 +148,11 @@ function ResultPill({
       );
     case "variant":
       return (
-        <span className={`${base} border-border bg-card text-foreground`}>
+        <span
+          className={`${base} border-border bg-card font-mono text-foreground`}
+        >
           <span
-            className="size-2 rounded-full"
+            className="size-2 shrink-0 rounded-full"
             style={{ background: variantColor(variants, result.key) }}
           />
           {result.key}
@@ -147,19 +166,104 @@ function ResultPill({
             .map((variant) => `${variant.key} ${variant.percentage}%`)
             .join(" · ")}
         >
-          <span className="flex gap-0.5">
+          <span className="flex h-2 w-7 gap-px overflow-hidden rounded-full">
             {variants.map((variant) => (
               <span
                 key={variant.key}
-                className="size-2 rounded-full"
-                style={{ background: variantColor(variants, variant.key) }}
+                className="h-full"
+                style={{
+                  width: `${variant.percentage}%`,
+                  background: variantColor(variants, variant.key),
+                }}
               />
             ))}
           </span>
-          a variant
+          {variants.length} variants
         </span>
       );
   }
+}
+
+/** A tiny meter next to a partial rollout, so the share is read at a glance. */
+function ShareMeter({ share }: { share: number }) {
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 text-[11px] text-muted-foreground tabular-nums"
+      title={`${share}% of the people who match this rule`}
+    >
+      <span className="flex h-1.5 w-10 overflow-hidden rounded-full bg-(--gray-5)">
+        <span
+          className="h-full rounded-full bg-(--gray-9)"
+          style={{ width: `${share}%` }}
+        />
+      </span>
+      {share}% of matches
+    </span>
+  );
+}
+
+/**
+ * One row of the evaluation flow. The gutter draws the connector line and a
+ * marker; `position` trims the line at the top and bottom of the flow.
+ */
+function FlowRow({
+  marker,
+  position,
+  muted,
+  children,
+  result,
+}: {
+  marker: ReactNode;
+  position: "first" | "middle" | "last" | "only";
+  muted?: boolean;
+  children: ReactNode;
+  result?: ReactNode;
+}) {
+  const lineTop =
+    position === "first" || position === "only" ? "top-1/2" : "top-0";
+  const lineBottom =
+    position === "last" || position === "only" ? "bottom-1/2" : "bottom-0";
+  return (
+    <div
+      className={`@container relative grid ${GUTTER} @max-[560px]:grid-cols-[28px_minmax(0,1fr)] items-center gap-x-3 gap-y-2 px-3 py-3 ${muted ? "text-muted-foreground" : ""}`}
+    >
+      <span
+        aria-hidden
+        className={`absolute left-[25px] ${lineTop} ${lineBottom} w-px bg-border`}
+      />
+      <span className="relative z-10 flex justify-center">{marker}</span>
+      <div className="flex min-w-0 flex-col gap-1.5 text-[13px]">
+        {children}
+      </div>
+      {result && (
+        <div className="@max-[560px]:col-start-2 flex items-center @max-[560px]:justify-start justify-end gap-3 whitespace-nowrap">
+          {result}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StepMarker({
+  children,
+  tone = "default",
+}: {
+  children: ReactNode;
+  tone?: "default" | "muted" | "info" | "warning";
+}) {
+  const tones = {
+    default: "border-border bg-card text-foreground",
+    muted: "border-dashed border-border bg-card text-muted-foreground",
+    info: "border-(--blue-6) bg-(--blue-3) text-(--blue-11)",
+    warning: "border-(--amber-6) bg-(--amber-3) text-(--amber-11)",
+  };
+  return (
+    <span
+      className={`flex size-6 items-center justify-center rounded-full border font-semibold text-[11px] tabular-nums shadow-xs ${tones[tone]}`}
+    >
+      {children}
+    </span>
+  );
 }
 
 function RuleRow({
@@ -167,56 +271,61 @@ function RuleRow({
   rule,
   variants,
   bucketing,
+  position,
 }: {
   index: number;
   rule: FlagRule;
   variants: FlagVariant[];
   bucketing: FlagAudience["bucketing"];
+  position: "first" | "middle" | "last" | "only";
 }) {
+  const unreachable = rule.reachable === false;
+  const everyone = rule.isGroup
+    ? "Every group"
+    : bucketing === "device_id"
+      ? "Every device"
+      : "Everyone";
   return (
-    <div
-      className={`@container grid @max-[420px]:grid-cols-[22px_1fr] grid-cols-[22px_1fr_auto] items-center gap-x-3 border-border border-b px-3 py-2.5 last:border-b-0 ${rule.reachable === false ? "opacity-50" : ""}`}
+    <FlowRow
+      marker={
+        <StepMarker tone={unreachable ? "muted" : "default"}>
+          {index + 1}
+        </StepMarker>
+      }
+      position={position}
+      muted={unreachable}
+      result={
+        <>
+          {rule.share < 100 && !unreachable && (
+            <ShareMeter share={rule.share} />
+          )}
+          <span className={unreachable ? "opacity-50" : ""}>
+            <ResultPill result={rule.result} variants={variants} />
+          </span>
+        </>
+      }
     >
-      <span className="flex size-5 items-center justify-center rounded-md border border-border bg-muted font-semibold text-[11px] text-foreground">
-        {index + 1}
-      </span>
-      <div className="flex min-w-0 flex-col gap-1 text-[13px]">
-        {rule.reachable === false && (
-          <span className="text-[11px] text-muted-foreground italic">
-            Unreachable — an earlier condition matches everyone at 100%
-          </span>
-        )}
-        {rule.conditions.length === 0 ? (
-          <span>
-            {rule.isGroup
-              ? "Every group"
-              : bucketing === "device_id"
-                ? "Every device"
-                : "Everyone"}
-          </span>
-        ) : (
-          rule.conditions.map((condition, conditionIndex) => (
-            <ConditionLine
-              key={`${condition.subject}:${conditionIndex}`}
-              condition={condition}
-              first={conditionIndex === 0}
-            />
-          ))
-        )}
-      </div>
-      <div className="@max-[420px]:col-start-2 flex items-center @max-[420px]:justify-start justify-end gap-2.5 whitespace-nowrap">
-        {rule.share < 100 && (
-          <span className="text-[11px] text-muted-foreground tabular-nums">
-            {rule.share}% of matches
-          </span>
-        )}
-        <ResultPill result={rule.result} variants={variants} />
-      </div>
-    </div>
+      {unreachable && (
+        <span className="inline-flex w-fit items-center gap-1 rounded border border-border bg-muted px-1.5 text-[10.5px] text-muted-foreground leading-4">
+          Never reached. An earlier rule already matches everyone.
+        </span>
+      )}
+      {rule.conditions.length === 0 ? (
+        <span className="font-medium">{everyone}</span>
+      ) : (
+        rule.conditions.map((condition, conditionIndex) => (
+          <ConditionLine
+            key={`${condition.subject}:${conditionIndex}`}
+            condition={condition}
+            first={conditionIndex === 0}
+          />
+        ))
+      )}
+    </FlowRow>
   );
 }
 
-function VariantsList({
+function VariantsSection({
   variants,
   stability,
   holdout,
@@ -226,24 +335,24 @@ function VariantsList({
   holdout: FlagAudience["holdout"];
 }) {
   return (
-    <div className="mt-4">
-      <div className="flex items-baseline justify-between gap-2">
+    <div className="mt-5">
+      <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
         <Text
           variant="muted"
-          className="block text-[11px] uppercase tracking-wider"
+          className="block font-semibold text-[11px] uppercase tracking-wider"
         >
-          Variants
+          Variant split
         </Text>
         <Text variant="muted" className="text-xs">
-          Assigned by a stable hash of {stability}, so the assignment keeps
-          holding
+          Assigned by a stable hash of {stability}
         </Text>
       </div>
-      <div className="mt-2 flex h-2 gap-0.5 overflow-hidden rounded">
+      <div className="mt-2.5 flex h-2.5 gap-0.5 overflow-hidden rounded-full">
         {variants.map((variant) => (
           <span
             key={variant.key}
-            className="h-full"
+            className="h-full first:rounded-l-full last:rounded-r-full"
+            title={`${variant.key} · ${variant.percentage}%`}
             style={{
               width: `${variant.percentage}%`,
               background: variantColor(variants, variant.key),
@@ -251,38 +360,42 @@ function VariantsList({
           />
         ))}
       </div>
+      <div className="mt-3 grid @[560px]:grid-cols-2 gap-x-6 gap-y-2">
+        {variants.map((variant) => (
+          <div
+            key={variant.key}
+            className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-x-2.5 text-[13px]"
+          >
+            <span
+              className="size-2.5 rounded-full"
+              style={{ background: variantColor(variants, variant.key) }}
+            />
+            <span className="flex min-w-0 items-baseline gap-2">
+              <span className="font-mono font-semibold text-xs">
+                {variant.key}
+              </span>
+              {variant.payload && (
+                <code
+                  title={variant.payload}
+                  className="min-w-0 truncate rounded bg-muted px-1 font-mono text-[11px] text-muted-foreground"
+                >
+                  {variant.payload}
+                </code>
+              )}
+            </span>
+            <span className="font-semibold tabular-nums">
+              {variant.percentage}%
+            </span>
+          </div>
+        ))}
+      </div>
       {holdout && (
-        <Text variant="muted" className="mt-1 block text-xs">
+        <Text variant="muted" className="mt-2.5 block text-xs">
           {holdout.exclusionPercentage}% of people receive{" "}
           <span className="font-mono">holdout-{holdout.id}</span> instead of a
           variant.
         </Text>
       )}
-      {variants.map((variant) => (
-        <div
-          key={variant.key}
-          className="grid grid-cols-[auto_1fr_auto] items-center gap-3 border-border border-b py-1.5 text-[13px] last:border-b-0"
-        >
-          <span className="flex items-center gap-2">
-            <span
-              className="size-2 rounded-full"
-              style={{ background: variantColor(variants, variant.key) }}
-            />
-            <span className="font-mono font-semibold text-xs">
-              {variant.key}
-            </span>
-          </span>
-          <span
-            title={variant.payload ?? undefined}
-            className={`truncate font-mono text-xs ${variant.payload ? "text-foreground" : "text-muted-foreground"}`}
-          >
-            {variant.payload ?? "No payload"}
-          </span>
-          <span className="font-semibold tabular-nums">
-            {variant.percentage}%
-          </span>
-        </div>
-      ))}
     </div>
   );
 }
@@ -295,84 +408,198 @@ function ruleKey(rule: FlagRule, index: number): string {
   return `${index}:${conditions}`;
 }
 
+function flowPosition(
+  index: number,
+  total: number,
+): "first" | "middle" | "last" | "only" {
+  if (total === 1) return "only";
+  if (index === 0) return "first";
+  if (index === total - 1) return "last";
+  return "middle";
+}
+
 /**
  * Answers "who gets this flag, and what do they get?" before showing any
  * structure: a headline, one outcome sentence, then the rules as a
- * first-match-wins table where every row ends in its result.
+ * first-match-wins flow where every step ends in its result.
  */
-export function FlagAudienceCard({ audience }: { audience: FlagAudience }) {
-  // The shaper computes reachability once: a reachable rule with no
-  // conditions at 100% already matches everyone, so the fallback never runs.
+export function FlagAudienceCard({
+  audience,
+  action,
+}: {
+  audience: FlagAudience;
+  /** Rendered beside the eyebrow; the page passes the edit-in-task control. */
+  action?: ReactNode;
+}) {
+  // Pre-checks and the fallback are steps in the same flow as the rules, so
+  // they share one index space for the connector line.
+  const preChecks = [
+    audience.enrollmentKey ? "enrollment" : null,
+    audience.holdout ? "holdout" : null,
+  ].filter((step): step is "enrollment" | "holdout" => step !== null);
+  const stepCount =
+    preChecks.length +
+    audience.rules.length +
+    (audience.fallbackReachable ? 1 : 0);
+  let step = 0;
+  const nextPosition = () => flowPosition(step++, stepCount);
+
   return (
-    <Card size="sm">
-      <CardContent>
-        <Text
-          variant="muted"
-          className="block text-[11px] uppercase tracking-wider"
-        >
-          Who gets this
-        </Text>
-        <div className="mt-2 font-semibold text-base text-foreground tracking-tight">
-          {audience.headline}
+    <Card size="sm" className="overflow-hidden">
+      <CardContent className="p-0">
+        <div className="flex flex-wrap items-start justify-between gap-x-6 gap-y-3 px-5 pt-4 pb-4">
+          <div className="min-w-0 flex-1 basis-64">
+            <Text
+              variant="muted"
+              className="block font-semibold text-[11px] uppercase tracking-wider"
+            >
+              Who gets this
+            </Text>
+            <div className="mt-1.5 flex items-start gap-2.5">
+              <span
+                aria-hidden
+                className={`mt-2 size-2.5 shrink-0 rounded-full ${
+                  audience.disabled
+                    ? "bg-(--gray-8)"
+                    : "bg-(--green-9) shadow-[0_0_0_3px_var(--green-4)]"
+                }`}
+              />
+              <h2 className="font-semibold text-foreground text-xl leading-tight tracking-tight">
+                {audience.headline}
+              </h2>
+            </div>
+            <Text className="mt-1.5 block max-w-prose text-[13px] text-muted-foreground leading-relaxed">
+              {audience.summary}
+            </Text>
+          </div>
+          {action && <div className="shrink-0">{action}</div>}
         </div>
-        <Text className="mt-0.5 block text-[13px] text-muted-foreground">
-          {audience.summary}
-        </Text>
+
+        {audience.disabled && (
+          <div className="flex items-center gap-2.5 border-border border-t bg-muted px-5 py-2.5 text-[12.5px] text-muted-foreground">
+            <PowerIcon size={14} className="shrink-0" />
+            <span>
+              The flag is off. The rules below apply when the flag is turned on.
+            </span>
+          </div>
+        )}
 
         <div
-          className={`mt-3.5 overflow-hidden rounded-lg border border-border ${audience.disabled ? "opacity-60" : ""}`}
+          className={`border-border border-t ${audience.disabled ? "opacity-70" : ""}`}
         >
-          <div className="flex justify-between border-border border-b bg-muted px-3 py-1.5 text-[11px] text-muted-foreground">
-            <span>Rules, checked in order. First match wins.</span>
+          <div
+            className={`grid ${GUTTER} gap-x-3 bg-muted px-3 py-1.5 font-medium text-[11px] text-muted-foreground`}
+          >
+            <span />
+            <span>Rules, checked in order. The first match decides.</span>
             <span>Result</span>
           </div>
-          {audience.enrollmentKey && (
-            <div className="border-border border-b bg-(--blue-2) px-3 py-2 text-[12px] text-muted-foreground">
-              Early access: the{" "}
-              <span className="font-mono text-foreground">
-                {audience.enrollmentKey}
-              </span>{" "}
-              person property is checked before these rules. A true value gets
-              true; any other value gets false.
-            </div>
-          )}
-          {audience.holdout && (
-            <div className="border-border border-b bg-(--amber-2) px-3 py-2 text-[12px] text-muted-foreground">
-              Holdout: {audience.holdout.exclusionPercentage}% of people are
-              held out for experiment {audience.holdout.id} and get{" "}
-              <span className="font-mono text-foreground">
-                holdout-{audience.holdout.id}
-              </span>{" "}
-              before these rules.
-            </div>
-          )}
-          {audience.rules.map((rule, index) => (
-            <RuleRow
-              key={ruleKey(rule, index)}
-              index={index}
-              rule={rule}
-              variants={audience.variants}
-              bucketing={audience.bucketing}
-            />
-          ))}
-          {audience.fallbackReachable && (
-            <div className="grid grid-cols-[22px_1fr_auto] items-center gap-x-3 px-3 py-2.5 text-[13px] text-muted-foreground">
-              <span />
-              <span>Everyone else</span>
-              <ResultPill
-                result={audience.fallback}
+          <div className="divide-y divide-border">
+            {audience.enrollmentKey && (
+              <FlowRow
+                marker={
+                  <StepMarker tone="info">
+                    <KeyIcon size={12} weight="bold" />
+                  </StepMarker>
+                }
+                position={nextPosition()}
+                result={
+                  <span className="text-[11px] text-muted-foreground">
+                    true → true, anything else → false
+                  </span>
+                }
+              >
+                <span>
+                  <span className="font-medium">Early access</span>
+                  <span className="text-muted-foreground">
+                    {" "}
+                    checks the{" "}
+                    <code className="rounded bg-muted px-1 font-mono text-[12px] text-foreground">
+                      {audience.enrollmentKey}
+                    </code>{" "}
+                    person property first
+                  </span>
+                </span>
+              </FlowRow>
+            )}
+            {audience.holdout && (
+              <FlowRow
+                marker={
+                  <StepMarker tone="warning">
+                    <FlaskIcon size={12} weight="bold" />
+                  </StepMarker>
+                }
+                position={nextPosition()}
+                result={
+                  <>
+                    <ShareMeter share={audience.holdout.exclusionPercentage} />
+                    <span className="inline-flex h-6 items-center rounded-md border border-(--amber-6) bg-(--amber-3) px-2 font-mono font-semibold text-(--amber-11) text-xs">
+                      holdout-{audience.holdout.id}
+                    </span>
+                  </>
+                }
+              >
+                <span>
+                  <span className="font-medium">Holdout</span>
+                  <span className="text-muted-foreground">
+                    {" "}
+                    for experiment {audience.holdout.id}, decided before the
+                    rules
+                  </span>
+                </span>
+              </FlowRow>
+            )}
+            {audience.rules.map((rule, index) => (
+              <RuleRow
+                key={ruleKey(rule, index)}
+                index={index}
+                rule={rule}
                 variants={audience.variants}
+                bucketing={audience.bucketing}
+                position={nextPosition()}
               />
-            </div>
-          )}
+            ))}
+            {audience.rules.length === 0 && (
+              <div
+                className={`grid ${GUTTER} gap-x-3 px-3 py-3 text-[13px] text-muted-foreground`}
+              >
+                <span />
+                <span>
+                  No rules yet. Add a release condition to turn the flag on for
+                  someone.
+                </span>
+              </div>
+            )}
+            {audience.fallbackReachable && (
+              <FlowRow
+                marker={
+                  <StepMarker tone="muted">
+                    <ArrowElbowDownRightIcon size={12} weight="bold" />
+                  </StepMarker>
+                }
+                position={nextPosition()}
+                muted
+                result={
+                  <ResultPill
+                    result={audience.fallback}
+                    variants={audience.variants}
+                  />
+                }
+              >
+                <span>Everyone else</span>
+              </FlowRow>
+            )}
+          </div>
         </div>
 
         {audience.variants.length > 0 && (
-          <VariantsList
-            variants={audience.variants}
-            stability={audience.stability}
-            holdout={audience.holdout}
-          />
+          <div className="@container border-border border-t px-5 pb-5">
+            <VariantsSection
+              variants={audience.variants}
+              stability={audience.stability}
+              holdout={audience.holdout}
+            />
+          </div>
         )}
       </CardContent>
     </Card>

--- a/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
@@ -273,10 +273,8 @@ function ruleKey(rule: FlagRule, index: number): string {
  * first-match-wins table where every row ends in its result.
  */
 export function FlagAudienceCard({ audience }: { audience: FlagAudience }) {
-  // A rule with no conditions at 100% matches everyone, so nobody reaches the fallback.
-  const fallbackReachable = !audience.rules.some(
-    (rule) => rule.conditions.length === 0 && rule.share === 100,
-  );
+  // The shaper computes reachability once: a reachable rule with no
+  // conditions at 100% already matches everyone, so the fallback never runs.
   return (
     <Card size="sm">
       <CardContent>
@@ -308,7 +306,7 @@ export function FlagAudienceCard({ audience }: { audience: FlagAudience }) {
               variants={audience.variants}
             />
           ))}
-          {fallbackReachable && (
+          {audience.fallbackReachable && (
             <div className="grid grid-cols-[22px_1fr_auto] items-center gap-x-3 px-3 py-2.5 text-[13px] text-muted-foreground">
               <span />
               <span>Everyone else</span>

--- a/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
@@ -27,11 +27,16 @@ function variantColor(variants: FlagVariant[], key: string): string {
 function EntityChip({ value }: { value: FlagValue }) {
   const link = value.link;
   const url = useEvidenceUrl(link?.kind ?? "person", link?.id ?? "");
+  // Narrow panels clip the row, so the chip shrinks with an ellipsis and the
+  // hover title carries the full label plus the secondary value.
+  const title = [value.label, value.secondary]
+    .filter(Boolean)
+    .join(" · ");
   const body = (
     <>
-      <span>{value.label}</span>
+      <span className="min-w-0 truncate">{value.label}</span>
       {value.secondary && (
-        <span className="font-normal text-muted-foreground">
+        <span className="min-w-0 truncate font-normal text-muted-foreground">
           {value.secondary}
         </span>
       )}
@@ -42,7 +47,7 @@ function EntityChip({ value }: { value: FlagValue }) {
     "inline-flex items-center gap-1.5 rounded-md border border-(--blue-6) bg-(--blue-2) px-2 py-px font-medium text-(--blue-11) text-xs leading-5";
   if (!url) {
     return (
-      <span className={className} title={value.raw}>
+      <span className={className} title={title || value.raw}>
         {body}
       </span>
     );
@@ -51,7 +56,7 @@ function EntityChip({ value }: { value: FlagValue }) {
     <button
       type="button"
       className={`${className} cursor-pointer hover:bg-(--blue-3)`}
-      title={value.raw}
+      title={title || value.raw}
       onClick={() => openExternalUrl(url)}
     >
       {body}
@@ -172,7 +177,7 @@ function RuleRow({
 }) {
   return (
     <div
-      className={`grid grid-cols-[22px_1fr_auto] items-center gap-x-3 border-border border-b px-3 py-2.5 last:border-b-0 ${rule.reachable === false ? "opacity-50" : ""}`}
+      className={`@container grid grid-cols-[22px_1fr_auto] items-center gap-x-3 border-border border-b px-3 py-2.5 last:border-b-0 @max-[420px]:grid-cols-[22px_1fr] ${rule.reachable === false ? "opacity-50" : ""}`}
     >
       <span className="flex size-5 items-center justify-center rounded-md border border-border bg-muted font-semibold text-[11px] text-foreground">
         {index + 1}
@@ -201,7 +206,7 @@ function RuleRow({
           ))
         )}
       </div>
-      <div className="flex items-center justify-end gap-2.5 whitespace-nowrap">
+      <div className="flex items-center justify-end gap-2.5 whitespace-nowrap @max-[420px]:col-start-2 @max-[420px]:justify-start">
         {rule.share < 100 && (
           <span className="text-[11px] text-muted-foreground tabular-nums">
             {rule.share}% of matches
@@ -270,6 +275,7 @@ function VariantsList({
             </span>
           </span>
           <span
+            title={variant.payload ?? undefined}
             className={`truncate font-mono text-xs ${variant.payload ? "text-foreground" : "text-muted-foreground"}`}
           >
             {variant.payload ?? "No payload"}

--- a/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
@@ -169,11 +169,18 @@ function RuleRow({
   variants: FlagVariant[];
 }) {
   return (
-    <div className="grid grid-cols-[22px_1fr_auto] items-center gap-x-3 border-border border-b px-3 py-2.5 last:border-b-0">
+    <div
+      className={`grid grid-cols-[22px_1fr_auto] items-center gap-x-3 border-border border-b px-3 py-2.5 last:border-b-0 ${rule.reachable === false ? "opacity-50" : ""}`}
+    >
       <span className="flex size-5 items-center justify-center rounded-md border border-border bg-muted font-semibold text-[11px] text-foreground">
         {index + 1}
       </span>
       <div className="flex min-w-0 flex-col gap-1 text-[13px]">
+        {rule.reachable === false && (
+          <span className="text-[11px] text-muted-foreground italic">
+            Unreachable — an earlier condition matches everyone at 100%
+          </span>
+        )}
         {rule.conditions.length === 0 ? (
           <span>Everyone</span>
         ) : (

--- a/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
@@ -46,20 +46,23 @@ function EntityChip({ value }: { value: FlagValue }) {
   const title = [value.label, value.secondary].filter(Boolean).join(" · ");
   const body = (
     <>
-      <span className="flex size-4 shrink-0 items-center justify-center rounded-full bg-(--blue-4) text-(--blue-11)">
-        <Icon size={10} weight="bold" />
-      </span>
+      <Icon size={12} className="shrink-0 text-muted-foreground" />
       <span className="min-w-0 truncate">{value.label}</span>
       {value.secondary && (
-        <span className="min-w-0 truncate font-normal opacity-70">
+        <span className="min-w-0 truncate font-normal text-muted-foreground">
           {value.secondary}
         </span>
       )}
-      {url && <ArrowSquareOutIcon size={11} className="shrink-0 opacity-70" />}
+      {url && (
+        <ArrowSquareOutIcon
+          size={11}
+          className="shrink-0 text-muted-foreground"
+        />
+      )}
     </>
   );
   const className =
-    "inline-flex max-w-full items-center gap-1.5 rounded-full border border-(--blue-6) bg-(--blue-2) py-px pr-2 pl-1 font-medium text-(--blue-11) text-xs leading-5";
+    "inline-flex max-w-full items-center gap-1.5 rounded-md border border-border bg-card px-1.5 py-px font-medium text-foreground text-xs leading-5";
   if (!url) {
     return (
       <span className={className} title={title || value.raw}>
@@ -70,7 +73,7 @@ function EntityChip({ value }: { value: FlagValue }) {
   return (
     <button
       type="button"
-      className={`${className} cursor-pointer transition-colors hover:bg-(--blue-3)`}
+      className={`${className} cursor-pointer transition-colors hover:bg-muted`}
       title={title || value.raw}
       onClick={() => openExternalUrl(url)}
     >
@@ -83,7 +86,7 @@ function ValueChip({ value }: { value: FlagValue }) {
   if (value.link) return <EntityChip value={value} />;
   return (
     <span
-      className={`inline-flex max-w-full items-center truncate rounded-md border border-border bg-muted px-1.5 py-px text-xs leading-5 ${value.literal ? "font-mono text-foreground" : "font-medium"}`}
+      className={`inline-flex max-w-full items-center truncate rounded-md border border-border bg-card px-1.5 py-px text-xs leading-5 ${value.literal ? "font-mono" : "font-medium"}`}
       title={value.label}
     >
       {value.label}
@@ -100,11 +103,7 @@ function ConditionLine({
 }) {
   return (
     <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
-      {!first && (
-        <span className="rounded border border-border px-1 font-semibold text-[10px] text-muted-foreground uppercase leading-4 tracking-wide">
-          and
-        </span>
-      )}
+      {!first && <span className="text-muted-foreground">and</span>}
       <span className="font-medium text-foreground">{condition.subject}</span>
       <span className="text-muted-foreground">{condition.operator}</span>
       {condition.values.map((value, index) => (
@@ -127,7 +126,7 @@ function ResultPill({
     case "true":
       return (
         <span
-          className={`${base} border-(--green-6) bg-(--green-3) font-mono text-(--green-11)`}
+          className={`${base} border-border bg-card font-mono text-(--green-11)`}
         >
           true
         </span>
@@ -135,7 +134,7 @@ function ResultPill({
     case "false":
       return (
         <span
-          className={`${base} border-border bg-muted font-mono text-muted-foreground`}
+          className={`${base} border-border bg-card font-mono text-muted-foreground`}
         >
           false
         </span>
@@ -191,9 +190,9 @@ function ShareMeter({ share }: { share: number }) {
       className="inline-flex items-center gap-1.5 text-[11px] text-muted-foreground tabular-nums"
       title={`${share}% of the people who match this rule`}
     >
-      <span className="flex h-1.5 w-10 overflow-hidden rounded-full bg-(--gray-5)">
+      <span className="flex h-1.5 w-10 overflow-hidden rounded-full bg-border">
         <span
-          className="h-full rounded-full bg-(--gray-9)"
+          className="h-full rounded-full bg-muted-foreground"
           style={{ width: `${share}%` }}
         />
       </span>
@@ -249,13 +248,11 @@ function StepMarker({
   tone = "default",
 }: {
   children: ReactNode;
-  tone?: "default" | "muted" | "info" | "warning";
+  tone?: "default" | "muted";
 }) {
   const tones = {
     default: "border-border bg-card text-foreground",
     muted: "border-dashed border-border bg-card text-muted-foreground",
-    info: "border-(--blue-6) bg-(--blue-3) text-(--blue-11)",
-    warning: "border-(--amber-6) bg-(--amber-3) text-(--amber-11)",
   };
   return (
     <span
@@ -306,7 +303,7 @@ function RuleRow({
       }
     >
       {unreachable && (
-        <span className="inline-flex w-fit items-center gap-1 rounded border border-border bg-muted px-1.5 text-[10.5px] text-muted-foreground leading-4">
+        <span className="text-[11px] text-muted-foreground">
           Never reached. An earlier rule already matches everyone.
         </span>
       )}
@@ -459,9 +456,7 @@ export function FlagAudienceCard({
               <span
                 aria-hidden
                 className={`mt-2 size-2.5 shrink-0 rounded-full ${
-                  audience.disabled
-                    ? "bg-(--gray-8)"
-                    : "bg-(--green-9) shadow-[0_0_0_3px_var(--green-4)]"
+                  audience.disabled ? "bg-(--gray-8)" : "bg-(--green-9)"
                 }`}
               />
               <h2 className="font-semibold text-foreground text-xl leading-tight tracking-tight">
@@ -498,8 +493,8 @@ export function FlagAudienceCard({
             {audience.enrollmentKey && (
               <FlowRow
                 marker={
-                  <StepMarker tone="info">
-                    <KeyIcon size={12} weight="bold" />
+                  <StepMarker>
+                    <KeyIcon size={12} />
                   </StepMarker>
                 }
                 position={nextPosition()}
@@ -525,15 +520,15 @@ export function FlagAudienceCard({
             {audience.holdout && (
               <FlowRow
                 marker={
-                  <StepMarker tone="warning">
-                    <FlaskIcon size={12} weight="bold" />
+                  <StepMarker>
+                    <FlaskIcon size={12} />
                   </StepMarker>
                 }
                 position={nextPosition()}
                 result={
                   <>
                     <ShareMeter share={audience.holdout.exclusionPercentage} />
-                    <span className="inline-flex h-6 items-center rounded-md border border-(--amber-6) bg-(--amber-3) px-2 font-mono font-semibold text-(--amber-11) text-xs">
+                    <span className="inline-flex h-6 items-center rounded-md border border-border bg-card px-2 font-mono font-semibold text-xs">
                       holdout-{audience.holdout.id}
                     </span>
                   </>
@@ -574,7 +569,7 @@ export function FlagAudienceCard({
               <FlowRow
                 marker={
                   <StepMarker tone="muted">
-                    <ArrowElbowDownRightIcon size={12} weight="bold" />
+                    <ArrowElbowDownRightIcon size={12} />
                   </StepMarker>
                 }
                 position={nextPosition()}

--- a/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
@@ -46,7 +46,7 @@ function EntityChip({ value }: { value: FlagValue }) {
   const title = [value.label, value.secondary].filter(Boolean).join(" · ");
   const body = (
     <>
-      <Icon size={12} className="shrink-0 text-muted-foreground" />
+      <Icon size={11} className="shrink-0 text-muted-foreground" />
       <span className="min-w-0 truncate">{value.label}</span>
       {value.secondary && (
         <span className="min-w-0 truncate font-normal text-muted-foreground">
@@ -62,7 +62,7 @@ function EntityChip({ value }: { value: FlagValue }) {
     </>
   );
   const className =
-    "inline-flex max-w-full items-center gap-1.5 rounded-md border border-border bg-card px-1.5 py-px font-medium text-foreground text-xs leading-5";
+    "inline-flex max-w-full items-center gap-1 rounded border border-border bg-card px-1.5 font-medium text-foreground text-xs leading-[18px]";
   if (!url) {
     return (
       <span className={className} title={title || value.raw}>
@@ -86,7 +86,7 @@ function ValueChip({ value }: { value: FlagValue }) {
   if (value.link) return <EntityChip value={value} />;
   return (
     <span
-      className={`inline-flex max-w-full items-center truncate rounded-md border border-border bg-card px-1.5 py-px text-xs leading-5 ${value.literal ? "font-mono" : "font-medium"}`}
+      className={`inline-flex max-w-full items-center truncate rounded border border-border bg-card px-1.5 text-xs leading-[18px] ${value.literal ? "font-mono" : "font-medium"}`}
       title={value.label}
     >
       {value.label}
@@ -121,7 +121,7 @@ function ResultPill({
   variants: FlagVariant[];
 }) {
   const base =
-    "inline-flex h-6 items-center gap-1.5 rounded-md border px-2 font-semibold text-xs";
+    "inline-flex h-5 items-center gap-1.5 rounded border px-1.5 font-semibold text-xs";
   switch (result.kind) {
     case "true":
       return (
@@ -528,7 +528,7 @@ export function FlagAudienceCard({
                 result={
                   <>
                     <ShareMeter share={audience.holdout.exclusionPercentage} />
-                    <span className="inline-flex h-6 items-center rounded-md border border-border bg-card px-2 font-mono font-semibold text-xs">
+                    <span className="inline-flex h-5 items-center rounded border border-border bg-card px-1.5 font-mono font-semibold text-xs">
                       holdout-{audience.holdout.id}
                     </span>
                   </>

--- a/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/FlagAudienceCard.tsx
@@ -9,7 +9,6 @@ import {
 } from "@phosphor-icons/react";
 import type {
   FlagAudience,
-  FlagCondition,
   FlagResult,
   FlagRule,
   FlagValue,
@@ -34,19 +33,81 @@ function variantColor(variants: FlagVariant[], key: string): string {
   return VARIANT_COLORS[Math.max(index, 0) % VARIANT_COLORS.length];
 }
 
-/** The width of the step gutter; the connector line is centered in it. */
-const GUTTER = "grid-cols-[28px_minmax(0,1fr)_auto]";
+const HASH_KEY: Record<FlagAudience["bucketing"], string> = {
+  person: "the distinct ID",
+  device: "the device ID",
+  group: "the group key",
+};
 
-function EntityChip({ value }: { value: FlagValue }) {
+/** Gutter, conditions, result. The connector line is centered in the gutter. */
+const COLUMNS = "grid-cols-[28px_minmax(0,1fr)_auto]";
+const CHIP =
+  "inline-flex max-w-full items-center gap-1 rounded border border-border bg-card px-1.5 text-xs leading-[18px]";
+const PILL =
+  "inline-flex h-5 items-center gap-1.5 rounded border border-border bg-card px-1.5 font-semibold text-xs";
+
+function Eyebrow({ children }: { children: ReactNode }) {
+  return (
+    <Text
+      variant="muted"
+      className="block font-semibold text-[11px] uppercase tracking-wider"
+    >
+      {children}
+    </Text>
+  );
+}
+
+function Dot({
+  color,
+  className = "size-2",
+}: {
+  color: string;
+  className?: string;
+}) {
+  return (
+    <span
+      className={`shrink-0 rounded-full ${className}`}
+      style={{ background: color }}
+    />
+  );
+}
+
+function SplitBar({
+  variants,
+  className,
+}: {
+  variants: FlagVariant[];
+  className: string;
+}) {
+  return (
+    <span className={`flex gap-px overflow-hidden rounded-full ${className}`}>
+      {variants.map((variant) => (
+        <span
+          key={variant.key}
+          className="h-full"
+          title={`${variant.key} · ${variant.percentage}%`}
+          style={{
+            width: `${variant.percentage}%`,
+            background: variantColor(variants, variant.key),
+          }}
+        />
+      ))}
+    </span>
+  );
+}
+
+function ValueChip({ value }: { value: FlagValue }) {
   const link = value.link;
-  const url = useEvidenceUrl(link?.kind ?? "person", link?.id ?? "");
+  const evidenceUrl = useEvidenceUrl(link?.kind ?? "person", link?.id ?? "");
+  const url = link ? evidenceUrl : null;
   const Icon = link?.kind === "cohort" ? UsersThreeIcon : UserIcon;
   // Narrow panels clip the row, so the chip shrinks with an ellipsis and the
   // hover title carries the full label plus the secondary value.
   const title = [value.label, value.secondary].filter(Boolean).join(" · ");
+  const className = `${CHIP} ${link ? "font-medium" : "font-mono"}`;
   const body = (
     <>
-      <Icon size={11} className="shrink-0 text-muted-foreground" />
+      {link && <Icon size={11} className="shrink-0 text-muted-foreground" />}
       <span className="min-w-0 truncate">{value.label}</span>
       {value.secondary && (
         <span className="min-w-0 truncate font-normal text-muted-foreground">
@@ -61,11 +122,9 @@ function EntityChip({ value }: { value: FlagValue }) {
       )}
     </>
   );
-  const className =
-    "inline-flex max-w-full items-center gap-1 rounded border border-border bg-card px-1.5 font-medium text-foreground text-xs leading-[18px]";
   if (!url) {
     return (
-      <span className={className} title={title || value.raw}>
+      <span className={className} title={title}>
         {body}
       </span>
     );
@@ -74,42 +133,11 @@ function EntityChip({ value }: { value: FlagValue }) {
     <button
       type="button"
       className={`${className} cursor-pointer transition-colors hover:bg-muted`}
-      title={title || value.raw}
+      title={title}
       onClick={() => openExternalUrl(url)}
     >
       {body}
     </button>
-  );
-}
-
-function ValueChip({ value }: { value: FlagValue }) {
-  if (value.link) return <EntityChip value={value} />;
-  return (
-    <span
-      className={`inline-flex max-w-full items-center truncate rounded border border-border bg-card px-1.5 text-xs leading-[18px] ${value.literal ? "font-mono" : "font-medium"}`}
-      title={value.label}
-    >
-      {value.label}
-    </span>
-  );
-}
-
-function ConditionLine({
-  condition,
-  first,
-}: {
-  condition: FlagCondition;
-  first: boolean;
-}) {
-  return (
-    <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
-      {!first && <span className="text-muted-foreground">and</span>}
-      <span className="font-medium text-foreground">{condition.subject}</span>
-      <span className="text-muted-foreground">{condition.operator}</span>
-      {condition.values.map((value, index) => (
-        <ValueChip key={`${value.label}:${index}`} value={value} />
-      ))}
-    </div>
   );
 }
 
@@ -120,67 +148,31 @@ function ResultPill({
   result: FlagResult;
   variants: FlagVariant[];
 }) {
-  const base =
-    "inline-flex h-5 items-center gap-1.5 rounded border px-1.5 font-semibold text-xs";
-  switch (result.kind) {
-    case "true":
-      return (
-        <span
-          className={`${base} border-border bg-card font-mono text-(--green-11)`}
-        >
-          true
-        </span>
-      );
-    case "false":
-      return (
-        <span
-          className={`${base} border-border bg-card font-mono text-muted-foreground`}
-        >
-          false
-        </span>
-      );
-    case "payload":
-      return (
-        <span className={`${base} border-border bg-card text-foreground`}>
-          payload
-        </span>
-      );
-    case "variant":
-      return (
-        <span
-          className={`${base} border-border bg-card font-mono text-foreground`}
-        >
-          <span
-            className="size-2 shrink-0 rounded-full"
-            style={{ background: variantColor(variants, result.key) }}
-          />
-          {result.key}
-        </span>
-      );
-    case "split":
-      return (
-        <span
-          className={`${base} border-border bg-card text-foreground`}
-          title={variants
-            .map((variant) => `${variant.key} ${variant.percentage}%`)
-            .join(" · ")}
-        >
-          <span className="flex h-2 w-7 gap-px overflow-hidden rounded-full">
-            {variants.map((variant) => (
-              <span
-                key={variant.key}
-                className="h-full"
-                style={{
-                  width: `${variant.percentage}%`,
-                  background: variantColor(variants, variant.key),
-                }}
-              />
-            ))}
-          </span>
-          {variants.length} variants
-        </span>
-      );
+  if (result.kind === "split") {
+    return (
+      <span
+        className={PILL}
+        title={variants.map((v) => `${v.key} ${v.percentage}%`).join(" · ")}
+      >
+        <SplitBar variants={variants} className="h-2 w-7" />
+        {variants.length} variants
+      </span>
+    );
   }
+  const tone = {
+    true: "font-mono text-(--green-11)",
+    false: "font-mono text-muted-foreground",
+    variant: "font-mono",
+    payload: "",
+  }[result.kind];
+  return (
+    <span className={`${PILL} ${tone}`}>
+      {result.kind === "variant" && (
+        <Dot color={variantColor(variants, result.key)} />
+      )}
+      {result.kind === "variant" ? result.key : result.kind}
+    </span>
+  );
 }
 
 /** A tiny meter next to a partial rollout, so the share is read at a glance. */
@@ -202,35 +194,33 @@ function ShareMeter({ share }: { share: number }) {
 }
 
 /**
- * One row of the evaluation flow. The gutter draws the connector line and a
- * marker; `position` trims the line at the top and bottom of the flow.
+ * One step of the evaluation flow. Steps are siblings in one list, so CSS
+ * trims the connector line at the first and last step.
  */
-function FlowRow({
+function Step({
   marker,
-  position,
   muted,
-  children,
   result,
+  children,
 }: {
   marker: ReactNode;
-  position: "first" | "middle" | "last" | "only";
   muted?: boolean;
-  children: ReactNode;
   result?: ReactNode;
+  children: ReactNode;
 }) {
-  const lineTop =
-    position === "first" || position === "only" ? "top-1/2" : "top-0";
-  const lineBottom =
-    position === "last" || position === "only" ? "bottom-1/2" : "bottom-0";
   return (
     <div
-      className={`@container relative grid ${GUTTER} @max-[560px]:grid-cols-[28px_minmax(0,1fr)] items-center gap-x-3 gap-y-2 px-3 py-3 ${muted ? "text-muted-foreground" : ""}`}
+      className={`group @container relative grid ${COLUMNS} @max-[560px]:grid-cols-[28px_minmax(0,1fr)] items-center gap-x-3 gap-y-2 px-3 py-3 ${muted ? "text-muted-foreground" : ""}`}
     >
       <span
         aria-hidden
-        className={`absolute left-[25px] ${lineTop} ${lineBottom} w-px bg-border`}
+        className="absolute top-0 bottom-0 left-[25px] w-px bg-border group-first:top-1/2 group-last:bottom-1/2"
       />
-      <span className="relative z-10 flex justify-center">{marker}</span>
+      <span
+        className={`relative z-10 flex size-6 items-center justify-center justify-self-center rounded-full border border-border bg-card font-semibold text-[11px] tabular-nums shadow-xs ${muted ? "border-dashed" : ""}`}
+      >
+        {marker}
+      </span>
       <div className="flex min-w-0 flex-col gap-1.5 text-[13px]">
         {children}
       </div>
@@ -243,176 +233,62 @@ function FlowRow({
   );
 }
 
-function StepMarker({
-  children,
-  tone = "default",
-}: {
-  children: ReactNode;
-  tone?: "default" | "muted";
-}) {
-  const tones = {
-    default: "border-border bg-card text-foreground",
-    muted: "border-dashed border-border bg-card text-muted-foreground",
-  };
-  return (
-    <span
-      className={`flex size-6 items-center justify-center rounded-full border font-semibold text-[11px] tabular-nums shadow-xs ${tones[tone]}`}
-    >
-      {children}
-    </span>
-  );
-}
-
-function RuleRow({
+function RuleStep({
   index,
   rule,
-  variants,
-  bucketing,
-  position,
+  audience,
 }: {
   index: number;
   rule: FlagRule;
-  variants: FlagVariant[];
-  bucketing: FlagAudience["bucketing"];
-  position: "first" | "middle" | "last" | "only";
+  audience: FlagAudience;
 }) {
-  const unreachable = rule.reachable === false;
   const everyone = rule.isGroup
     ? "Every group"
-    : bucketing === "device_id"
+    : audience.bucketing === "device"
       ? "Every device"
       : "Everyone";
   return (
-    <FlowRow
-      marker={
-        <StepMarker tone={unreachable ? "muted" : "default"}>
-          {index + 1}
-        </StepMarker>
-      }
-      position={position}
-      muted={unreachable}
+    <Step
+      marker={index + 1}
+      muted={!rule.reachable}
       result={
         <>
-          {rule.share < 100 && !unreachable && (
+          {rule.share < 100 && rule.reachable && (
             <ShareMeter share={rule.share} />
           )}
-          <span className={unreachable ? "opacity-50" : ""}>
-            <ResultPill result={rule.result} variants={variants} />
+          <span className={rule.reachable ? "" : "opacity-50"}>
+            <ResultPill result={rule.result} variants={audience.variants} />
           </span>
         </>
       }
     >
-      {unreachable && (
-        <span className="text-[11px] text-muted-foreground">
+      {!rule.reachable && (
+        <span className="text-[11px]">
           Never reached. An earlier rule already matches everyone.
         </span>
       )}
-      {rule.conditions.length === 0 ? (
+      {rule.conditions.length === 0 && (
         <span className="font-medium">{everyone}</span>
-      ) : (
-        rule.conditions.map((condition, conditionIndex) => (
-          <ConditionLine
-            key={`${condition.subject}:${conditionIndex}`}
-            condition={condition}
-            first={conditionIndex === 0}
-          />
-        ))
       )}
-    </FlowRow>
-  );
-}
-
-function VariantsSection({
-  variants,
-  stability,
-  holdout,
-}: {
-  variants: FlagVariant[];
-  stability: FlagAudience["stability"];
-  holdout: FlagAudience["holdout"];
-}) {
-  return (
-    <div className="mt-5">
-      <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
-        <Text
-          variant="muted"
-          className="block font-semibold text-[11px] uppercase tracking-wider"
+      {rule.conditions.map((condition, conditionIndex) => (
+        <div
+          key={`${condition.subject}:${conditionIndex}`}
+          className="flex flex-wrap items-center gap-x-1.5 gap-y-1"
         >
-          Variant split
-        </Text>
-        <Text variant="muted" className="text-xs">
-          Assigned by a stable hash of {stability}
-        </Text>
-      </div>
-      <div className="mt-2.5 flex h-2.5 gap-0.5 overflow-hidden rounded-full">
-        {variants.map((variant) => (
-          <span
-            key={variant.key}
-            className="h-full first:rounded-l-full last:rounded-r-full"
-            title={`${variant.key} · ${variant.percentage}%`}
-            style={{
-              width: `${variant.percentage}%`,
-              background: variantColor(variants, variant.key),
-            }}
-          />
-        ))}
-      </div>
-      <div className="mt-3 grid @[560px]:grid-cols-2 gap-x-6 gap-y-2">
-        {variants.map((variant) => (
-          <div
-            key={variant.key}
-            className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-x-2.5 text-[13px]"
-          >
-            <span
-              className="size-2.5 rounded-full"
-              style={{ background: variantColor(variants, variant.key) }}
-            />
-            <span className="flex min-w-0 items-baseline gap-2">
-              <span className="font-mono font-semibold text-xs">
-                {variant.key}
-              </span>
-              {variant.payload && (
-                <code
-                  title={variant.payload}
-                  className="min-w-0 truncate rounded bg-muted px-1 font-mono text-[11px] text-muted-foreground"
-                >
-                  {variant.payload}
-                </code>
-              )}
-            </span>
-            <span className="font-semibold tabular-nums">
-              {variant.percentage}%
-            </span>
-          </div>
-        ))}
-      </div>
-      {holdout && (
-        <Text variant="muted" className="mt-2.5 block text-xs">
-          {holdout.exclusionPercentage}% of people receive{" "}
-          <span className="font-mono">holdout-{holdout.id}</span> instead of a
-          variant.
-        </Text>
-      )}
-    </div>
+          {conditionIndex > 0 && (
+            <span className="text-muted-foreground">and</span>
+          )}
+          <span className="font-medium text-foreground">
+            {condition.subject}
+          </span>
+          <span className="text-muted-foreground">{condition.operator}</span>
+          {condition.values.map((value, valueIndex) => (
+            <ValueChip key={`${value.label}:${valueIndex}`} value={value} />
+          ))}
+        </div>
+      ))}
+    </Step>
   );
-}
-
-/** Rules have no id; conditions plus position keep keys stable across refetches. */
-function ruleKey(rule: FlagRule, index: number): string {
-  const conditions = rule.conditions
-    .map((condition) => `${condition.subject} ${condition.operator}`)
-    .join("|");
-  return `${index}:${conditions}`;
-}
-
-function flowPosition(
-  index: number,
-  total: number,
-): "first" | "middle" | "last" | "only" {
-  if (total === 1) return "only";
-  if (index === 0) return "first";
-  if (index === total - 1) return "last";
-  return "middle";
 }
 
 /**
@@ -428,36 +304,17 @@ export function FlagAudienceCard({
   /** Rendered beside the eyebrow; the page passes the edit-in-task control. */
   action?: ReactNode;
 }) {
-  // Pre-checks and the fallback are steps in the same flow as the rules, so
-  // they share one index space for the connector line.
-  const preChecks = [
-    audience.enrollmentKey ? "enrollment" : null,
-    audience.holdout ? "holdout" : null,
-  ].filter((step): step is "enrollment" | "holdout" => step !== null);
-  const stepCount =
-    preChecks.length +
-    audience.rules.length +
-    (audience.fallbackReachable ? 1 : 0);
-  let step = 0;
-  const nextPosition = () => flowPosition(step++, stepCount);
-
+  const { holdout, variants } = audience;
   return (
     <Card size="sm" className="overflow-hidden">
       <CardContent className="p-0">
-        <div className="flex flex-wrap items-start justify-between gap-x-6 gap-y-3 px-5 pt-4 pb-4">
+        <div className="flex flex-wrap items-start justify-between gap-x-6 gap-y-3 px-5 py-4">
           <div className="min-w-0 flex-1 basis-64">
-            <Text
-              variant="muted"
-              className="block font-semibold text-[11px] uppercase tracking-wider"
-            >
-              Who gets this
-            </Text>
+            <Eyebrow>Who gets this</Eyebrow>
             <div className="mt-1.5 flex items-start gap-2.5">
-              <span
-                aria-hidden
-                className={`mt-2 size-2.5 shrink-0 rounded-full ${
-                  audience.disabled ? "bg-(--gray-8)" : "bg-(--green-9)"
-                }`}
+              <Dot
+                color={audience.disabled ? "var(--gray-8)" : "var(--green-9)"}
+                className="mt-2 size-2.5"
               />
               <h2 className="font-semibold text-foreground text-xl leading-tight tracking-tight">
                 {audience.headline}
@@ -473,9 +330,7 @@ export function FlagAudienceCard({
         {audience.disabled && (
           <div className="flex items-center gap-2.5 border-border border-t bg-muted px-5 py-2.5 text-[12.5px] text-muted-foreground">
             <PowerIcon size={14} className="shrink-0" />
-            <span>
-              The flag is off. The rules below apply when the flag is turned on.
-            </span>
+            The flag is off. The rules below apply when the flag is turned on.
           </div>
         )}
 
@@ -483,7 +338,7 @@ export function FlagAudienceCard({
           className={`border-border border-t ${audience.disabled ? "opacity-70" : ""}`}
         >
           <div
-            className={`grid ${GUTTER} gap-x-3 bg-muted px-3 py-1.5 font-medium text-[11px] text-muted-foreground`}
+            className={`grid ${COLUMNS} gap-x-3 bg-muted px-3 py-1.5 font-medium text-[11px] text-muted-foreground`}
           >
             <span />
             <span>Rules, checked in order. The first match decides.</span>
@@ -491,13 +346,8 @@ export function FlagAudienceCard({
           </div>
           <div className="divide-y divide-border">
             {audience.enrollmentKey && (
-              <FlowRow
-                marker={
-                  <StepMarker>
-                    <KeyIcon size={12} />
-                  </StepMarker>
-                }
-                position={nextPosition()}
+              <Step
+                marker={<KeyIcon size={12} />}
                 result={
                   <span className="text-[11px] text-muted-foreground">
                     true → true, anything else → false
@@ -515,21 +365,16 @@ export function FlagAudienceCard({
                     person property first
                   </span>
                 </span>
-              </FlowRow>
+              </Step>
             )}
-            {audience.holdout && (
-              <FlowRow
-                marker={
-                  <StepMarker>
-                    <FlaskIcon size={12} />
-                  </StepMarker>
-                }
-                position={nextPosition()}
+            {holdout && (
+              <Step
+                marker={<FlaskIcon size={12} />}
                 result={
                   <>
-                    <ShareMeter share={audience.holdout.exclusionPercentage} />
-                    <span className="inline-flex h-5 items-center rounded border border-border bg-card px-1.5 font-mono font-semibold text-xs">
-                      holdout-{audience.holdout.id}
+                    <ShareMeter share={holdout.exclusionPercentage} />
+                    <span className={`${PILL} font-mono`}>
+                      holdout-{holdout.id}
                     </span>
                   </>
                 }
@@ -538,62 +383,84 @@ export function FlagAudienceCard({
                   <span className="font-medium">Holdout</span>
                   <span className="text-muted-foreground">
                     {" "}
-                    for experiment {audience.holdout.id}, decided before the
-                    rules
+                    for experiment {holdout.id}, decided before the rules
                   </span>
                 </span>
-              </FlowRow>
+              </Step>
             )}
             {audience.rules.map((rule, index) => (
-              <RuleRow
-                key={ruleKey(rule, index)}
+              <RuleStep
+                key={`${index}:${rule.conditions.map((c) => c.subject).join("|")}`}
                 index={index}
                 rule={rule}
-                variants={audience.variants}
-                bucketing={audience.bucketing}
-                position={nextPosition()}
+                audience={audience}
               />
             ))}
             {audience.rules.length === 0 && (
-              <div
-                className={`grid ${GUTTER} gap-x-3 px-3 py-3 text-[13px] text-muted-foreground`}
-              >
-                <span />
-                <span>
-                  No rules yet. Add a release condition to turn the flag on for
-                  someone.
-                </span>
-              </div>
+              <Step marker={null} muted>
+                No rules yet. Add a release condition to turn the flag on for
+                someone.
+              </Step>
             )}
             {audience.fallbackReachable && (
-              <FlowRow
-                marker={
-                  <StepMarker tone="muted">
-                    <ArrowElbowDownRightIcon size={12} />
-                  </StepMarker>
-                }
-                position={nextPosition()}
+              <Step
+                marker={<ArrowElbowDownRightIcon size={12} />}
                 muted
                 result={
-                  <ResultPill
-                    result={audience.fallback}
-                    variants={audience.variants}
-                  />
+                  <ResultPill result={{ kind: "false" }} variants={variants} />
                 }
               >
-                <span>Everyone else</span>
-              </FlowRow>
+                Everyone else
+              </Step>
             )}
           </div>
         </div>
 
-        {audience.variants.length > 0 && (
-          <div className="@container border-border border-t px-5 pb-5">
-            <VariantsSection
-              variants={audience.variants}
-              stability={audience.stability}
-              holdout={audience.holdout}
-            />
+        {variants.length > 0 && (
+          <div className="@container border-border border-t px-5 py-5">
+            <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+              <Eyebrow>Variant split</Eyebrow>
+              <Text variant="muted" className="text-xs">
+                Assigned by a stable hash of {HASH_KEY[audience.bucketing]}
+              </Text>
+            </div>
+            <SplitBar variants={variants} className="mt-2.5 h-2.5" />
+            <div className="mt-3 grid @[560px]:grid-cols-2 gap-x-6 gap-y-2">
+              {variants.map((variant) => (
+                <div
+                  key={variant.key}
+                  className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-x-2.5 text-[13px]"
+                >
+                  <Dot
+                    color={variantColor(variants, variant.key)}
+                    className="size-2.5"
+                  />
+                  <span className="flex min-w-0 items-baseline gap-2">
+                    <span className="font-mono font-semibold text-xs">
+                      {variant.key}
+                    </span>
+                    {variant.payload && (
+                      <code
+                        title={variant.payload}
+                        className="min-w-0 truncate rounded bg-muted px-1 font-mono text-[11px] text-muted-foreground"
+                      >
+                        {variant.payload}
+                      </code>
+                    )}
+                  </span>
+                  <span className="font-semibold tabular-nums">
+                    {variant.percentage}%
+                  </span>
+                </div>
+              ))}
+            </div>
+            {holdout && (
+              <Text variant="muted" className="mt-2.5 block text-xs">
+                {holdout.exclusionPercentage}% of people receive{" "}
+                <span className="font-mono">holdout-{holdout.id}</span> instead
+                of a variant.
+              </Text>
+            )}
           </div>
         )}
       </CardContent>

--- a/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.tsx
@@ -38,7 +38,9 @@ import {
   getObjectKind,
   POSTHOG_OBJECT_ICON_COLOR,
 } from "@posthog/ui/utils/objectKinds";
+import { EditFlagInTaskPopover } from "./EditFlagInTaskPopover";
 import { ExperimentResultsSummary } from "./ExperimentResultsSummary";
+import { FlagAudienceCard } from "./FlagAudienceCard";
 import { PostHogObjectDetails } from "./PostHogObjectDetails";
 
 const CHART_ERROR_MESSAGE =
@@ -174,6 +176,9 @@ function ObjectContent({ preview }: { preview: EvidenceCardData }) {
   const stats = (preview.stats ?? []).filter((stat) => stat.value);
   return (
     <div className="flex flex-col gap-3">
+      {preview.flagAudience && (
+        <FlagAudienceCard audience={preview.flagAudience} />
+      )}
       {stats.length > 0 ? (
         <StatStrip stats={stats} />
       ) : preview.facts && preview.facts.length > 0 ? (
@@ -218,6 +223,8 @@ export interface PostHogObjectViewProps {
   objectId: string;
   /** Shown while the preview loads or when the object has no live name. */
   fallbackName: string;
+  /** The task this object appears in; enables sending edits back to it. */
+  taskId?: string;
   url: string | null;
   /** Omitted when the page isn't backed by a run artifact (chip-opened). */
   occurrenceCount?: number;
@@ -230,6 +237,7 @@ export function PostHogObjectPageView({
   objectKind,
   objectId,
   fallbackName,
+  taskId,
   url,
   occurrenceCount,
   state,
@@ -300,6 +308,9 @@ export function PostHogObjectPageView({
               >
                 Open in PostHog ↗
               </Button>
+            )}
+            {objectKind === "flag" && taskId && preview?.title && (
+              <EditFlagInTaskPopover taskId={taskId} flagKey={preview.title} />
             )}
           </div>
         </header>
@@ -385,11 +396,13 @@ export function PostHogObjectPageView({
 export function PostHogObjectPage({
   metadata,
   fallbackName,
+  taskId,
 }: {
   /** Only kind + id when opened from an inline reference chip. */
   metadata: Pick<PostHogObjectArtifactMetadata, "object_kind" | "object_id"> &
     Partial<Omit<PostHogObjectArtifactMetadata, "object_kind" | "object_id">>;
   fallbackName: string;
+  taskId?: string;
 }) {
   const query = useAuthenticatedQuery(
     evidencePreviewQueryKey({
@@ -424,6 +437,7 @@ export function PostHogObjectPage({
       objectKind={metadata.object_kind}
       objectId={metadata.object_id}
       fallbackName={fallbackName}
+      taskId={taskId}
       url={url}
       occurrenceCount={metadata.occurrence_count}
       state={state}

--- a/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.tsx
@@ -417,6 +417,10 @@ export function PostHogObjectPage({
     {
       staleTime: EVIDENCE_PREVIEW_STALE_TIME,
       refetchOnWindowFocus: false,
+      // The flag page now offers an edit action, so a cached preview can
+      // outlive the object: always refetch on remount so a read after the
+      // agent applies a change shows the new state.
+      refetchOnMount: "always",
       retry: 1,
     },
   );

--- a/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.tsx
@@ -157,7 +157,13 @@ function FactChips({ facts }: { facts: string[] }) {
   );
 }
 
-function ObjectContent({ preview }: { preview: EvidenceCardData }) {
+function ObjectContent({
+  preview,
+  taskId,
+}: {
+  preview: EvidenceCardData;
+  taskId?: string;
+}) {
   // A dashboard is its metrics: render each tile's insight as a live chart
   // and skip the descriptive cards, which only restate what the charts show.
   if (preview.tiles && preview.tiles.length > 0) {
@@ -174,11 +180,25 @@ function ObjectContent({ preview }: { preview: EvidenceCardData }) {
     );
   }
   const stats = (preview.stats ?? []).filter((stat) => stat.value);
+  // The audience card already states reach, type, and variants, so the flag
+  // page skips the stat strip instead of repeating them in tiles.
+  if (preview.flagAudience) {
+    return (
+      <div className="flex flex-col gap-3">
+        <FlagAudienceCard
+          audience={preview.flagAudience}
+          action={
+            taskId && preview.title ? (
+              <EditFlagInTaskPopover taskId={taskId} flagKey={preview.title} />
+            ) : null
+          }
+        />
+        <PostHogObjectDetails preview={preview} />
+      </div>
+    );
+  }
   return (
     <div className="flex flex-col gap-3">
-      {preview.flagAudience && (
-        <FlagAudienceCard audience={preview.flagAudience} />
-      )}
       {stats.length > 0 ? (
         <StatStrip stats={stats} />
       ) : preview.facts && preview.facts.length > 0 ? (
@@ -309,9 +329,6 @@ export function PostHogObjectPageView({
                 Open in PostHog ↗
               </Button>
             )}
-            {objectKind === "flag" && taskId && preview?.title && (
-              <EditFlagInTaskPopover taskId={taskId} flagKey={preview.title} />
-            )}
           </div>
         </header>
 
@@ -373,7 +390,7 @@ export function PostHogObjectPageView({
               <Skeleton className="h-40 w-full rounded-lg" />
             </div>
           ) : preview ? (
-            <ObjectContent preview={preview} />
+            <ObjectContent preview={preview} taskId={taskId} />
           ) : (
             <UnavailableObject
               isError={state === "error"}

--- a/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPageView.stories.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPageView.stories.tsx
@@ -1,3 +1,4 @@
+import type { FlagAudience } from "@posthog/api-client/flag-audience";
 import type { EvidenceCardData } from "@posthog/ui/features/editor/evidencePreview";
 import { PostHogObjectPageView } from "@posthog/ui/features/posthog-objects/PostHogObjectPage";
 import type { Meta, StoryObj } from "@storybook/react-vite";
@@ -12,35 +13,159 @@ const DAYS = [
   "2026-08-16",
 ];
 
+const alex = {
+  label: "Alex Rivera",
+  secondary: "alex@example.com",
+  raw: "4dc8564d-1f2e-4b7a-9c3d-2a1b0c9d8e7f",
+  link: { kind: "person" as const, id: "4dc8564d-1f2e-4b7a-9c3d-2a1b0c9d8e7f" },
+  literal: false,
+};
+
+const betaTesters = {
+  label: "Beta testers",
+  raw: "142",
+  link: { kind: "cohort" as const, id: "142" },
+  literal: false,
+};
+
+const multivariateAudience: FlagAudience = {
+  headline: "Split into 3 variants for Alex Rivera and Pro plan users.",
+  summary:
+    "Alex Rivera gets test. 25% of people whose plan is pro get a variant, decided by the rollout hash. Everyone else gets false.",
+  disabled: false,
+  rules: [
+    {
+      conditions: [{ subject: "Person", operator: "is", values: [alex] }],
+      share: 100,
+      result: { kind: "variant", key: "test" },
+      reachable: true,
+      isGroup: false,
+    },
+    {
+      conditions: [
+        {
+          subject: "plan",
+          operator: "is",
+          values: [{ label: "pro", literal: true }],
+        },
+        {
+          subject: "Cohort",
+          operator: "in cohort",
+          values: [betaTesters],
+        },
+      ],
+      share: 25,
+      result: { kind: "split" },
+      reachable: true,
+      isGroup: false,
+    },
+    {
+      conditions: [
+        {
+          subject: "email",
+          operator: "ends with",
+          values: [{ label: "@example.com", literal: true }],
+        },
+      ],
+      share: 100,
+      result: { kind: "variant", key: "control" },
+      reachable: true,
+      isGroup: false,
+    },
+  ],
+  fallback: { kind: "false" },
+  fallbackReachable: true,
+  variants: [
+    { key: "control", percentage: 34, payload: null },
+    { key: "test", percentage: 33, payload: '{"prompt":"soft"}' },
+    { key: "aggressive", percentage: 33, payload: '{"prompt":"hard"}' },
+  ],
+  bucketing: "distinct_id",
+  stability: "the distinct ID",
+  enrollmentKey: null,
+  holdout: null,
+};
+
+const booleanAudience: FlagAudience = {
+  headline: "On for Alex Rivera.",
+  summary:
+    "Alex Rivera is targeted, and the 25% rollout hash decides. Everyone else gets false.",
+  disabled: false,
+  rules: [
+    {
+      conditions: [{ subject: "Person", operator: "is", values: [alex] }],
+      share: 25,
+      result: { kind: "true" },
+      reachable: true,
+      isGroup: false,
+    },
+  ],
+  fallback: { kind: "false" },
+  fallbackReachable: true,
+  variants: [],
+  bucketing: "distinct_id",
+  stability: "the distinct ID",
+  enrollmentKey: null,
+  holdout: null,
+};
+
+const shadowedAudience: FlagAudience = {
+  headline: "On for everyone.",
+  summary: "Everyone gets true.",
+  disabled: false,
+  rules: [
+    {
+      conditions: [],
+      share: 100,
+      result: { kind: "true" },
+      reachable: true,
+      isGroup: false,
+    },
+    {
+      conditions: [
+        { subject: "Cohort", operator: "in cohort", values: [betaTesters] },
+      ],
+      share: 50,
+      result: { kind: "true" },
+      reachable: false,
+      isGroup: false,
+    },
+  ],
+  fallback: { kind: "false" },
+  fallbackReachable: false,
+  variants: [],
+  bucketing: "distinct_id",
+  stability: "the distinct ID",
+  enrollmentKey: null,
+  holdout: null,
+};
+
+const configuration = {
+  title: "Configuration",
+  fields: [
+    { label: "Type", value: "Multivariate" },
+    { label: "Evaluation runtime", value: "All runtimes" },
+    { label: "Experience continuity", value: "On" },
+    { label: "Last called", value: "Aug 16" },
+    {
+      label: "Targeted IDs",
+      value: "4dc8564d-1f2e-4b7a-9c3d-2a1b0c9d8e7f",
+    },
+  ],
+};
+
 const flagPreview: EvidenceCardData = {
   title: "pi-harness",
   detail: "Cloud task harness rollout",
   status: { label: "Enabled", tone: "positive" },
   stats: [
-    { label: "Rollout", value: "100%" },
+    { label: "Reach", value: "Alex Rivera and Pro plan users" },
     { label: "Variants", value: "3" },
     { label: "Type", value: "Multivariate" },
-    { label: "Calls in 7 days", value: "1.2K" },
   ],
   spark: { points: [24, 32, 28, 46, 51, 63, 58], labels: DAYS, render: "line" },
-  sections: [
-    {
-      title: "Configuration",
-      fields: [
-        { label: "Type", value: "Multivariate" },
-        { label: "Release conditions", value: "2 conditions" },
-        { label: "Evaluation runtime", value: "Both client and server" },
-        { label: "Last called", value: "Aug 16" },
-      ],
-    },
-    {
-      title: "Release conditions",
-      fields: [
-        { label: "Set 1", value: "plan is pro · 25% rollout · Variant: test" },
-        { label: "Set 2", value: "75% rollout" },
-      ],
-    },
-  ],
+  flagAudience: multivariateAudience,
+  sections: [configuration],
 };
 
 const experimentPreview: EvidenceCardData = {
@@ -178,11 +303,65 @@ export const FeatureFlag: Story = {
     objectKind: "flag",
     objectId: "390",
     fallbackName: "pi-harness",
+    taskId: "task-1",
     url: "https://us.posthog.com/project/2/feature_flags/390",
     occurrenceCount: 4,
     state: "ready",
     preview: flagPreview,
   },
+};
+
+export const BooleanFlagForOnePerson: Story = {
+  args: {
+    ...FeatureFlag.args,
+    preview: {
+      ...flagPreview,
+      title: "new-onboarding",
+      detail: "Guided onboarding flow",
+      flagAudience: booleanAudience,
+      sections: [{ ...configuration, fields: configuration.fields.slice(1) }],
+    },
+  },
+};
+
+export const ShadowedRule: Story = {
+  args: {
+    ...FeatureFlag.args,
+    preview: {
+      ...flagPreview,
+      title: "dark-mode",
+      detail: "Dark theme for the app shell",
+      flagAudience: shadowedAudience,
+    },
+  },
+};
+
+export const DisabledFlag: Story = {
+  args: {
+    ...FeatureFlag.args,
+    preview: {
+      ...flagPreview,
+      status: { label: "Disabled", tone: "neutral" },
+      flagAudience: {
+        ...multivariateAudience,
+        headline: "Off for everyone.",
+        summary: "The flag is disabled, so every check returns false.",
+        disabled: true,
+      },
+    },
+  },
+};
+
+/** The nav sidebar and an open side panel leave a 1280px window about 520px. */
+export const NarrowPanel: Story = {
+  args: FeatureFlag.args,
+  decorators: [
+    (Story) => (
+      <div style={{ width: 520, borderRight: "1px solid var(--border)" }}>
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export const Experiment: Story = {

--- a/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPageView.stories.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPageView.stories.tsx
@@ -37,7 +37,6 @@ const rule = (overrides: Partial<FlagRule>): FlagRule => ({
 
 const audience = (overrides: Partial<FlagAudience>): FlagAudience => ({
   headline: "On for everyone.",
-  summary: "Everyone gets true.",
   disabled: false,
   rules: [],
   fallbackReachable: true,
@@ -50,8 +49,6 @@ const audience = (overrides: Partial<FlagAudience>): FlagAudience => ({
 
 const multivariateAudience = audience({
   headline: "Split into 3 variants for Alex Rivera and Pro plan users.",
-  summary:
-    "Alex Rivera gets test. 25% of people whose plan is pro get a variant, decided by the rollout hash. Everyone else gets false.",
   rules: [
     rule({
       conditions: [{ subject: "Person", operator: "is", values: [alex] }],
@@ -81,32 +78,6 @@ const multivariateAudience = audience({
     { key: "test", percentage: 33, payload: '{"prompt":"soft"}' },
     { key: "aggressive", percentage: 33, payload: '{"prompt":"hard"}' },
   ],
-});
-
-const booleanAudience = audience({
-  headline: "On for Alex Rivera.",
-  summary:
-    "Alex Rivera is targeted, and the 25% rollout hash decides. Everyone else gets false.",
-  rules: [
-    rule({
-      conditions: [{ subject: "Person", operator: "is", values: [alex] }],
-      share: 25,
-    }),
-  ],
-});
-
-const shadowedAudience = audience({
-  rules: [
-    rule({}),
-    rule({
-      conditions: [
-        { subject: "Cohort", operator: "in cohort", values: [betaTesters] },
-      ],
-      share: 50,
-      reachable: false,
-    }),
-  ],
-  fallbackReachable: false,
 });
 
 const configuration = {
@@ -278,59 +249,6 @@ export const FeatureFlag: Story = {
     state: "ready",
     preview: flagPreview,
   },
-};
-
-export const BooleanFlagForOnePerson: Story = {
-  args: {
-    ...FeatureFlag.args,
-    preview: {
-      ...flagPreview,
-      title: "new-onboarding",
-      detail: "Guided onboarding flow",
-      flagAudience: booleanAudience,
-      sections: [{ ...configuration, fields: configuration.fields.slice(1) }],
-    },
-  },
-};
-
-export const ShadowedRule: Story = {
-  args: {
-    ...FeatureFlag.args,
-    preview: {
-      ...flagPreview,
-      title: "dark-mode",
-      detail: "Dark theme for the app shell",
-      flagAudience: shadowedAudience,
-    },
-  },
-};
-
-export const DisabledFlag: Story = {
-  args: {
-    ...FeatureFlag.args,
-    preview: {
-      ...flagPreview,
-      status: { label: "Disabled", tone: "neutral" },
-      flagAudience: {
-        ...multivariateAudience,
-        headline: "Off for everyone.",
-        summary: "The flag is disabled, so every check returns false.",
-        disabled: true,
-      },
-    },
-  },
-};
-
-/** The nav sidebar and an open side panel leave a 1280px window about 520px. */
-export const NarrowPanel: Story = {
-  args: FeatureFlag.args,
-  decorators: [
-    (Story) => (
-      <div style={{ width: 520, borderRight: "1px solid var(--border)" }}>
-        <Story />
-      </div>
-    ),
-  ],
 };
 
 export const Experiment: Story = {

--- a/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPageView.stories.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPageView.stories.tsx
@@ -1,4 +1,4 @@
-import type { FlagAudience } from "@posthog/api-client/flag-audience";
+import type { FlagAudience, FlagRule } from "@posthog/api-client/flag-audience";
 import type { EvidenceCardData } from "@posthog/ui/features/editor/evidencePreview";
 import { PostHogObjectPageView } from "@posthog/ui/features/posthog-objects/PostHogObjectPage";
 import type { Meta, StoryObj } from "@storybook/react-vite";
@@ -18,127 +18,96 @@ const alex = {
   secondary: "alex@example.com",
   raw: "4dc8564d-1f2e-4b7a-9c3d-2a1b0c9d8e7f",
   link: { kind: "person" as const, id: "4dc8564d-1f2e-4b7a-9c3d-2a1b0c9d8e7f" },
-  literal: false,
 };
 
 const betaTesters = {
   label: "Beta testers",
   raw: "142",
   link: { kind: "cohort" as const, id: "142" },
-  literal: false,
 };
 
-const multivariateAudience: FlagAudience = {
+const rule = (overrides: Partial<FlagRule>): FlagRule => ({
+  conditions: [],
+  share: 100,
+  result: { kind: "true" },
+  reachable: true,
+  isGroup: false,
+  ...overrides,
+});
+
+const audience = (overrides: Partial<FlagAudience>): FlagAudience => ({
+  headline: "On for everyone.",
+  summary: "Everyone gets true.",
+  disabled: false,
+  rules: [],
+  fallbackReachable: true,
+  variants: [],
+  bucketing: "person",
+  enrollmentKey: null,
+  holdout: null,
+  ...overrides,
+});
+
+const multivariateAudience = audience({
   headline: "Split into 3 variants for Alex Rivera and Pro plan users.",
   summary:
     "Alex Rivera gets test. 25% of people whose plan is pro get a variant, decided by the rollout hash. Everyone else gets false.",
-  disabled: false,
   rules: [
-    {
+    rule({
       conditions: [{ subject: "Person", operator: "is", values: [alex] }],
-      share: 100,
       result: { kind: "variant", key: "test" },
-      reachable: true,
-      isGroup: false,
-    },
-    {
+    }),
+    rule({
       conditions: [
-        {
-          subject: "plan",
-          operator: "is",
-          values: [{ label: "pro", literal: true }],
-        },
-        {
-          subject: "Cohort",
-          operator: "in cohort",
-          values: [betaTesters],
-        },
+        { subject: "plan", operator: "is", values: [{ label: "pro" }] },
+        { subject: "Cohort", operator: "in cohort", values: [betaTesters] },
       ],
       share: 25,
       result: { kind: "split" },
-      reachable: true,
-      isGroup: false,
-    },
-    {
+    }),
+    rule({
       conditions: [
         {
           subject: "email",
           operator: "ends with",
-          values: [{ label: "@example.com", literal: true }],
+          values: [{ label: "@example.com" }],
         },
       ],
-      share: 100,
       result: { kind: "variant", key: "control" },
-      reachable: true,
-      isGroup: false,
-    },
+    }),
   ],
-  fallback: { kind: "false" },
-  fallbackReachable: true,
   variants: [
     { key: "control", percentage: 34, payload: null },
     { key: "test", percentage: 33, payload: '{"prompt":"soft"}' },
     { key: "aggressive", percentage: 33, payload: '{"prompt":"hard"}' },
   ],
-  bucketing: "distinct_id",
-  stability: "the distinct ID",
-  enrollmentKey: null,
-  holdout: null,
-};
+});
 
-const booleanAudience: FlagAudience = {
+const booleanAudience = audience({
   headline: "On for Alex Rivera.",
   summary:
     "Alex Rivera is targeted, and the 25% rollout hash decides. Everyone else gets false.",
-  disabled: false,
   rules: [
-    {
+    rule({
       conditions: [{ subject: "Person", operator: "is", values: [alex] }],
       share: 25,
-      result: { kind: "true" },
-      reachable: true,
-      isGroup: false,
-    },
+    }),
   ],
-  fallback: { kind: "false" },
-  fallbackReachable: true,
-  variants: [],
-  bucketing: "distinct_id",
-  stability: "the distinct ID",
-  enrollmentKey: null,
-  holdout: null,
-};
+});
 
-const shadowedAudience: FlagAudience = {
-  headline: "On for everyone.",
-  summary: "Everyone gets true.",
-  disabled: false,
+const shadowedAudience = audience({
   rules: [
-    {
-      conditions: [],
-      share: 100,
-      result: { kind: "true" },
-      reachable: true,
-      isGroup: false,
-    },
-    {
+    rule({}),
+    rule({
       conditions: [
         { subject: "Cohort", operator: "in cohort", values: [betaTesters] },
       ],
       share: 50,
-      result: { kind: "true" },
       reachable: false,
-      isGroup: false,
-    },
+    }),
   ],
-  fallback: { kind: "false" },
   fallbackReachable: false,
-  variants: [],
-  bucketing: "distinct_id",
-  stability: "the distinct ID",
-  enrollmentKey: null,
-  holdout: null,
-};
+});
 
 const configuration = {
   title: "Configuration",

--- a/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreview.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreview.tsx
@@ -346,6 +346,7 @@ export function ArtifactPreview({
       <PostHogObjectPage
         metadata={liveReferenceMetadata ?? previewData.metadata}
         fallbackName={name}
+        taskId={taskId}
       />
     );
   }

--- a/products/desktop/packages/ui/src/features/task-detail/components/TabContentRenderer.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TabContentRenderer.tsx
@@ -101,6 +101,7 @@ export function TabContentRenderer({
             object_id: data.objectId,
           }}
           fallbackName={tab.label}
+          taskId={taskId}
         />
       );
 

--- a/products/desktop/packages/ui/src/shell/requiredHostCapabilities.ts
+++ b/products/desktop/packages/ui/src/shell/requiredHostCapabilities.ts
@@ -8,11 +8,11 @@ import { HOST_CAPABILITIES } from "@posthog/platform/host-capabilities";
 import { SPEECH_SERVICE } from "@posthog/platform/speech";
 import { AUTH_SIDE_EFFECTS } from "@posthog/ui/features/auth/identifiers";
 import { REVIEW_HOST } from "@posthog/ui/features/code-review/reviewHost";
-import { AGENT_PROMPT_SENDER } from "@posthog/ui/features/sessions/agentPromptSender";
 import { CONNECTIVITY_CLIENT } from "@posthog/ui/features/connectivity/connectivityClient";
 import { FEATURE_FLAGS } from "@posthog/ui/features/feature-flags/identifiers";
 import { GIT_CACHE_KEY_PROVIDER } from "@posthog/ui/features/git-interaction/gitCacheProvider";
 import { SPEECH_NOTIFY_SETTINGS } from "@posthog/ui/features/notifications/identifiers";
+import { AGENT_PROMPT_SENDER } from "@posthog/ui/features/sessions/agentPromptSender";
 import { UPDATES_CLIENT } from "@posthog/ui/features/updates/updatesClient";
 import { DIFF_WORKER_FACTORY } from "@posthog/ui/shell/diffWorkerHost";
 

--- a/products/desktop/packages/ui/src/shell/requiredHostCapabilities.ts
+++ b/products/desktop/packages/ui/src/shell/requiredHostCapabilities.ts
@@ -8,6 +8,7 @@ import { HOST_CAPABILITIES } from "@posthog/platform/host-capabilities";
 import { SPEECH_SERVICE } from "@posthog/platform/speech";
 import { AUTH_SIDE_EFFECTS } from "@posthog/ui/features/auth/identifiers";
 import { REVIEW_HOST } from "@posthog/ui/features/code-review/reviewHost";
+import { AGENT_PROMPT_SENDER } from "@posthog/ui/features/sessions/agentPromptSender";
 import { CONNECTIVITY_CLIENT } from "@posthog/ui/features/connectivity/connectivityClient";
 import { FEATURE_FLAGS } from "@posthog/ui/features/feature-flags/identifiers";
 import { GIT_CACHE_KEY_PROVIDER } from "@posthog/ui/features/git-interaction/gitCacheProvider";
@@ -66,6 +67,11 @@ export const REQUIRED_HOST_CAPABILITIES: readonly HostCapabilityRequirement[] =
     {
       token: REVIEW_HOST,
       description: "code-review page host wiring",
+    },
+    {
+      token: AGENT_PROMPT_SENDER,
+      description:
+        "send-a-prompt-to-the-agent actions (sendPromptToAgent, edit flag in task)",
     },
     {
       token: DIFF_WORKER_FACTORY,


### PR DESCRIPTION
## Problem

On the desktop app's feature flag page, the release conditions sit at the bottom and read as raw data, for example `id exact 4dc8564d-…`. A person cannot tell who gets the flag without opening the web UI. There is also no way to ask for a change from the page.

## Changes

- The flag page opens with a **Who gets this** card. It leads with a status dot and a headline such as "On for one person.".
- The release conditions render as a connected flow of numbered steps. Each step ends in its result: `true`, `false`, a variant, or the variant split. A final "Everyone else" step makes the default explicit. A step an earlier rule shadows shows "Never reached".
- Distinct IDs resolve to person chips with the name and email. Cohort IDs resolve to cohort chips. Both open in PostHog. Raw IDs stay in the Configuration card.
- A partial rollout shows as a small meter next to the result it applies to ("25% of matches"), so it is not read as a share of all users.
- Multivariate flags show the split bar and each variant's percentage with its payload inline.
- Early access and experiment holdouts appear as steps before the rules, because the evaluator checks them first.
- The stat strip is gone on the flag page. The card already states reach, type, and variants.
- **Edit in task** sits in the card header. It opens a short text box that takes focus and confirms with a toast. The message goes to the task the flag appears in, with the flag key and a fixed dry-run line appended.
- Mechanical: `taskId` passes through `PostHogObjectPage` from both mount sites; the flag fetch path looks up the people behind targeted distinct IDs (capped at 10).

![flag-page-light](https://raw.githubusercontent.com/PostHog/pr-assets/9848bb6f8d8bf72336d5033704d55dc424868f9e/2026/09/02f501f9-3a4f-4ccf-8d4f-97d4598de3ff.png)

![flag-edit-popover](https://raw.githubusercontent.com/PostHog/pr-assets/ac7b349981acf19a370fcebba49991f0cdcc2a88/2026/09/140bb28e-2efa-4591-bc8e-a96372ff3e99.png)

## How did you test this code?

- One Storybook story covers the multivariate flag page. The screenshots above come from it.
- The existing `posthog-objects` Vitest suite passes. Biome and the `@posthog/ui` typecheck are clean for the touched files.
- Not run: the app against a live backend. The stories use invented fixture data.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

Built in a PostHog Desktop task with auto-publish. The first version rendered condition structure and asked the reader to compute the meaning. This version leads with the answer and renders the conditions as a first-match flow with a result column. Edit-in-task has no quick actions and does not create a new task. Skills invoked: storybook-stories, writing-user-facing-copy, writing-pr-descriptions.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*


