### PR TITLE
fix(frontend): show a network error screen when the app shell chunk fails to load

### DIFF
--- a/frontend/src/layout/AppLoadError.tsx
+++ b/frontend/src/layout/AppLoadError.tsx
@@ -1,0 +1,59 @@
+import { useActions, useValues } from 'kea'
+import posthog from 'posthog-js'
+import { useEffect, useState } from 'react'
+
+import { IconRefresh } from '@posthog/icons'
+
+import { SupportTicketExceptionEvent, supportLogic } from 'lib/components/Support/supportLogic'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { teamLogic } from 'scenes/teamLogic'
+
+interface AppLoadErrorProps {
+    error: unknown
+}
+
+/**
+ * Shown when the app shell chunk still fails to download after the automatic retries and reload.
+ * The generic ErrorBoundary never sees this error, so the exception is captured here to keep it
+ * visible in error tracking.
+ */
+export function AppLoadError({ error }: AppLoadErrorProps): JSX.Element {
+    const { openSupportForm } = useActions(supportLogic)
+    const { currentTeamId } = useValues(teamLogic)
+    const [exceptionEvent, setExceptionEvent] = useState<SupportTicketExceptionEvent | undefined>()
+
+    // Capture once per mount. A re-render must not send the same failure again.
+    useEffect(() => {
+        setExceptionEvent(posthog.captureException(error, { chunk_load_error: true, team_id: currentTeamId }))
+    }, []) // oxlint-disable-line react-hooks/exhaustive-deps
+
+    return (
+        <div className="p-4">
+            <h1 className="mb-1 text-2xl font-bold">PostHog could not load</h1>
+            <p>
+                Your browser could not download part of the app. This is usually a network problem. Reload the page to
+                try again. If it happens again, try a different network, or turn off browser extensions and proxies.
+            </p>
+            <div className="flex gap-2 flex-wrap">
+                <LemonButton
+                    type="primary"
+                    icon={<IconRefresh />}
+                    onClick={() => window.location.reload()}
+                    data-attr="app-load-error-reload"
+                >
+                    Reload the page
+                </LemonButton>
+                <LemonButton
+                    type="secondary"
+                    onClick={() =>
+                        openSupportForm({ kind: 'bug', isEmailFormOpen: true, exception_event: exceptionEvent })
+                    }
+                    data-attr="app-load-error-email-engineer"
+                >
+                    Email an engineer
+                </LemonButton>
+            </div>
+            {exceptionEvent?.uuid && <div className="text-muted text-xs mt-2">Exception ID: {exceptionEvent.uuid}</div>}
+        </div>
+    )
+}

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -22,6 +22,7 @@ import { appScenes } from 'scenes/appScenes'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { userLogic } from 'scenes/userLogic'
 
+import { AppLoadError } from '~/layout/AppLoadError'
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 
@@ -199,7 +200,7 @@ function AppScene(): JSX.Element | null {
     }
 
     return (
-        <ChunkLoadErrorBoundary>
+        <ChunkLoadErrorBoundary fallback={(error) => <AppLoadError error={error} />}>
             <Suspense
                 fallback={
                     // SpinnerOverlay is already imported here — no new lazy deps vs skeleton.

--- a/frontend/src/scenes/ChunkLoadErrorBoundary.test.tsx
+++ b/frontend/src/scenes/ChunkLoadErrorBoundary.test.tsx
@@ -81,6 +81,30 @@ describe('ChunkLoadErrorBoundary', () => {
         ).toBeInTheDocument()
     })
 
+    it('renders the fallback for repeated chunk errors when one is provided', () => {
+        const reload = jest.fn()
+        window.localStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()))
+
+        render(
+            <TestErrorBoundary>
+                <ChunkLoadErrorBoundary
+                    reload={reload}
+                    fallback={(error) => <div>fallback: {(error as Error).message}</div>}
+                >
+                    <ThrowChunkError />
+                </ChunkLoadErrorBoundary>
+            </TestErrorBoundary>
+        )
+
+        expect(reload).not.toHaveBeenCalled()
+        expect(
+            screen.getByText('fallback: Failed to fetch dynamically imported module: /static/react-json-view.js')
+        ).toBeInTheDocument()
+        expect(
+            screen.queryByText('Failed to fetch dynamically imported module: /static/react-json-view.js')
+        ).not.toBeInTheDocument()
+    })
+
     it('lets non-chunk errors bubble to the parent error boundary', () => {
         const reload = jest.fn()
 

--- a/frontend/src/scenes/ChunkLoadErrorBoundary.tsx
+++ b/frontend/src/scenes/ChunkLoadErrorBoundary.tsx
@@ -13,13 +13,14 @@ interface State {
 /**
  * Catches chunk-load failures from `React.lazy(() => import(...))` boundaries.
  * On a stale-deploy chunk-hash mismatch we reload once; if a reload was already
- * attempted in the last 20s we let the error bubble to the outer ErrorBoundary
- * rather than spinning forever. Non-chunk errors are re-thrown so the regular
- * error UI still renders.
+ * attempted in the last 20s we render `fallback` when given, or else let the error
+ * bubble to the outer ErrorBoundary rather than spinning forever. Non-chunk errors
+ * are re-thrown so the regular error UI still renders.
  */
 interface ChunkLoadErrorBoundaryProps {
     children: ReactNode
     reload?: () => void
+    fallback?: (error: unknown) => ReactNode
 }
 
 export class ChunkLoadErrorBoundary extends Component<ChunkLoadErrorBoundaryProps, State> {
@@ -61,6 +62,9 @@ export class ChunkLoadErrorBoundary extends Component<ChunkLoadErrorBoundaryProp
 
     override render(): ReactNode {
         const { error, surface } = this.state
+        if (error && surface && isChunkLoadError(error) && this.props.fallback) {
+            return this.props.fallback(error)
+        }
         if (error && (!isChunkLoadError(error) || surface)) {
             throw error
         }


### PR DESCRIPTION
## Problem

- A user whose browser cannot download the app shell chunk sees "An error has occurred" with a raw stack trace, after the automatic retries and the one reload.
- That screen reads like an app crash and sends the user to support for what is usually a network problem. Ticket 70720 is an example.
- Scene chunks and boot chunks already get a network error screen. The shell boundary was the only one without.

## Changes

- The user now sees "PostHog could not load" with the next steps, a "Reload the page" button, and an "Email an engineer" button. The support form still gets the exception attached.
- `ChunkLoadErrorBoundary` gets an optional `fallback`. The shell boundary in `App.tsx` passes the new `AppLoadError` screen. Without a `fallback` the boundary rethrows as before, so the boot boundaries in `index.tsx` are unchanged.
- The new screen captures the exception itself, once per mount, with `team_id`, because the generic `ErrorBoundary` no longer sees the error.
- The retries and the one reload are unchanged.

## How did you test this code?

- Added one case to `ChunkLoadErrorBoundary.test.tsx`: a repeated chunk error renders the `fallback` and does not reach the parent boundary. It catches the boundary rethrowing instead of using the fallback.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
