### PR TITLE
chore(replay-vision): retire the vision action temporal patches

### DIFF
--- a/products/replay_vision/backend/temporal/reconciler.py
+++ b/products/replay_vision/backend/temporal/reconciler.py
@@ -86,8 +86,7 @@ class ReconcileScannerSchedulesWorkflow(PostHogWorkflow):
         except Exception:
             workflow.logger.exception("replay_vision.reap_orphaned_observations_failed")
 
-        # The stuck-run reaper went with vision actions. Both markers stay deprecated until no
-        # history carrying either can replay.
+        # Declared until no history carrying either marker can replay.
         workflow.deprecate_patch("reap-stuck-vision-action-runs-2026-07")
         workflow.deprecate_patch("drop-stuck-vision-action-run-reaper-2026-09")
 
@@ -180,7 +179,7 @@ class ReconcileScannerSchedulesWorkflow(PostHogWorkflow):
 
     async def _run_reaper(
         self,
-        reaper_activity: Callable[[], Any] | str,
+        reaper_activity: Callable[[], Any],
         *,
         heartbeat_timeout: dt.timedelta | None = None,
         start_to_close_timeout: dt.timedelta = REAPER_OP_TIMEOUT,

--- a/products/replay_vision/backend/temporal/reconciler.py
+++ b/products/replay_vision/backend/temporal/reconciler.py
@@ -86,15 +86,10 @@ class ReconcileScannerSchedulesWorkflow(PostHogWorkflow):
         except Exception:
             workflow.logger.exception("replay_vision.reap_orphaned_observations_failed")
 
-        # The stuck-run reaper is removed with vision actions; pre-patch in-flight executions
-        # recorded its schedule and must replay it, so it stays behind the patch by name.
-        if workflow.patched("reap-stuck-vision-action-runs-2026-07") and not workflow.patched(
-            "drop-stuck-vision-action-run-reaper-2026-09"
-        ):
-            try:
-                await self._run_reaper("reap_stuck_vision_action_runs_activity")
-            except Exception:
-                workflow.logger.exception("replay_vision.reap_stuck_vision_action_runs_failed")
+        # The stuck-run reaper went with vision actions. Both markers stay deprecated until no
+        # history carrying either can replay.
+        workflow.deprecate_patch("reap-stuck-vision-action-runs-2026-07")
+        workflow.deprecate_patch("drop-stuck-vision-action-run-reaper-2026-09")
 
         if workflow.patched("reap-childless-inline-scanners-2026-08"):
             try:

--- a/products/replay_vision/backend/temporal/sweep_workflow.py
+++ b/products/replay_vision/backend/temporal/sweep_workflow.py
@@ -61,8 +61,7 @@ class SweepScannerWorkflow(PostHogWorkflow):
 
     @wf.run
     async def run(self, inputs: SweepScannerInputs) -> None:
-        # Every sweep that recorded the vision-action dispatch has long closed, so the legacy path
-        # is gone. The marker stays deprecated until no history carrying it can replay.
+        # Declared until no history carrying the marker can replay.
         wf.deprecate_patch("drop-vision-action-dispatch-2026-09")
 
         # Same heartbeat keeps the prompt recommendation fresh. The activity self-gates to at most one

--- a/products/replay_vision/backend/temporal/sweep_workflow.py
+++ b/products/replay_vision/backend/temporal/sweep_workflow.py
@@ -61,10 +61,9 @@ class SweepScannerWorkflow(PostHogWorkflow):
 
     @wf.run
     async def run(self, inputs: SweepScannerInputs) -> None:
-        # Vision actions are removed; pre-patch in-flight sweeps recorded this dispatch and must
-        # replay the same commands, so the legacy path stays behind the patch until they drain.
-        if not wf.patched("drop-vision-action-dispatch-2026-09"):
-            await self._dispatch_due_vision_actions_legacy(inputs)
+        # Every sweep that recorded the vision-action dispatch has long closed, so the legacy path
+        # is gone. The marker stays deprecated until no history carrying it can replay.
+        wf.deprecate_patch("drop-vision-action-dispatch-2026-09")
 
         # Same heartbeat keeps the prompt recommendation fresh. The activity self-gates to at most one
         # regeneration per day and only when ratings changed, so the 5-minute sweep cadence is fine.
@@ -216,33 +215,6 @@ class SweepScannerWorkflow(PostHogWorkflow):
             start_to_close_timeout=dt.timedelta(seconds=30),
             retry_policy=common.RetryPolicy(maximum_attempts=3),
         )
-
-    async def _dispatch_due_vision_actions_legacy(self, inputs: SweepScannerInputs) -> None:
-        """Replay-only: schedules the removed vision-action commands by name so old histories match."""
-        try:
-            due = await wf.execute_activity(
-                "evaluate_due_vision_actions_activity",
-                {"scanner_id": str(inputs.scanner_id), "team_id": inputs.team_id},
-                start_to_close_timeout=dt.timedelta(seconds=30),
-                # No worker registers this activity any more, so retrying only stalls the tick.
-                retry_policy=common.RetryPolicy(maximum_attempts=1),
-            )
-            for d in due or []:
-                try:
-                    await wf.start_child_workflow(
-                        "process-vision-action",
-                        d,
-                        id=f"process-vision-action-{d['vision_action_id']}",
-                        task_queue=settings.REPLAY_VISION_TASK_QUEUE,
-                        parent_close_policy=wf.ParentClosePolicy.ABANDON,
-                        execution_timeout=dt.timedelta(hours=1),
-                    )
-                except WorkflowAlreadyStartedError:
-                    pass
-                except Exception:
-                    wf.logger.exception("replay_vision.vision_action_claim_dispatch_failed")
-        except Exception:
-            wf.logger.exception("replay_vision.vision_action_dispatch_failed")
 
     async def _start_child(self, inputs: SweepScannerInputs, candidate: CandidateSessionPayload) -> None:
         try:

--- a/products/replay_vision/backend/tests/test_reconciler.py
+++ b/products/replay_vision/backend/tests/test_reconciler.py
@@ -269,6 +269,7 @@ async def _run_reconcile(mocks: _ReconcileMocks, patched: bool = True):
         patch("temporalio.workflow.execute_activity", side_effect=mocks.execute_activity),
         patch("temporalio.workflow.logger", fake_logger),
         patch("temporalio.workflow.patched", return_value=patched),
+        patch("temporalio.workflow.deprecate_patch"),
     ):
         return await ReconcileScannerSchedulesWorkflow().run(ReconcileScannerSchedulesInputs())
 

--- a/products/replay_vision/backend/tests/test_sweep.py
+++ b/products/replay_vision/backend/tests/test_sweep.py
@@ -1370,6 +1370,7 @@ async def _run_sweep(mocks: _SweepMocks, inputs: SweepScannerInputs | None = Non
         patch("temporalio.workflow.logger", fake_logger),
         # `workflow.patched` also needs the runtime; new executions take the patched branch.
         patch("temporalio.workflow.patched", return_value=patched),
+        patch("temporalio.workflow.deprecate_patch"),
         patch("temporalio.workflow.unsafe.is_replaying", return_value=False),
     ):
         await SweepScannerWorkflow().run(inputs or _sweep_inputs())


### PR DESCRIPTION
## Problem

Nobody sees a difference. #92983 removed the legacy vision actions but left two replay-only branches behind `workflow.patched` gates, so sweeps and reconciler runs that were already in flight during that deploy could finish without a non-determinism error. Those executions are long closed: a scanner sweep finishes in minutes and reruns every 5 minutes, and the reconciler ticks on its own schedule.

## Changes

- The sweep workflow drops `_dispatch_due_vision_actions_legacy` and the branch that called it, so the run body starts at the prompt-suggestion refresh.
- The reconciler drops the stuck-run reaper branch, which scheduled a `reap_stuck_vision_action_runs_activity` no worker registers any more.
- Both files keep the patch ids as `deprecate_patch` calls. A closed history never replays, but the marker has to stay declared until no history carrying it can, which is the same endgame `posthog/temporal/ai/slack_app` uses.
- 40 lines out, 7 in.

## How did you test this code?

- `ruff` clean; both modules compile; `wf.deprecate_patch` matches the SDK and the slack_app precedent.
- Not run locally: `test_sweep.py` and `test_reconciler.py`. This sandbox's test database has a stale schema (`column "estimate_attempted_at" of relation "replay_vision_replayscanner" already exists`) that fails at setup before any test runs. CI runs both suites.

## Automatic notifications

- [ ] Publish changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code in Tue's session, as the Temporal half of the #92983 cleanup.
- The patch ids stay as `deprecate_patch` rather than being deleted outright: removing a `patched()` call while any history still carries its marker is what breaks replay, and `deprecate_patch` is the documented way to hold that door open. They can go in a later pass.