### PR TITLE
feat(tasks): expose team and user tasks config in Django admin

### DIFF
--- a/products/tasks/backend/admin.py
+++ b/products/tasks/backend/admin.py
@@ -1,6 +1,7 @@
 import logging
 from typing import cast
 
+from django import forms
 from django.contrib import admin, messages
 from django.db.models import QuerySet
 from django.http import Http404, HttpRequest, HttpResponse, HttpResponseRedirect
@@ -8,12 +9,14 @@ from django.shortcuts import redirect
 from django.urls import path, reverse
 from django.utils.html import format_html
 
+from posthog.models.scoping import team_scope
 from posthog.models.user import User
 from posthog.storage import object_storage
 
 from . import loop_service
+from .logic.services.ai_run_defaults import validate_ai_run_preferences
 from .loop_lifecycle import DISABLED_REASON_ADMIN_PAUSED, pause_loop
-from .models import Loop, LoopTrigger, SandboxSnapshot, Task, TaskRun
+from .models import Loop, LoopTrigger, SandboxSnapshot, Task, TaskRun, TeamTasksConfig, UserTasksConfig
 from .visibility import task_run_visibility_q, task_visibility_q
 
 logger = logging.getLogger(__name__)
@@ -230,3 +233,76 @@ class LoopTriggerAdmin(admin.ModelAdmin):
         for trigger in queryset:
             loop_service.delete_loop_trigger_schedule(trigger)
         super().delete_queryset(request, queryset)
+
+
+_AI_RUN_PREFERENCE_KEYS = ("runtime_adapter", "model", "reasoning_effort")
+
+
+class _TasksConfigAdminForm(forms.ModelForm):
+    """Shared form for the two tasks-config admins. Runs the same checks as the API
+    write path (`update_team_ai_run_preferences` / `update_user_ai_run_preferences`),
+    so an admin edit cannot store a payload the resolver would reject or skip."""
+
+    def clean_team(self):
+        team = self.cleaned_data["team"]
+        # Preference rows are keyed on the canonical (project root) team; a row keyed on an
+        # environment team is never read by the resolver.
+        if team is not None and team.parent_team_id is not None:
+            raise forms.ValidationError(
+                "Preferences are keyed on the project root team. "
+                f"Pick the parent team (id {team.parent_team_id}) instead of this environment team."
+            )
+        return team
+
+    def clean_ai_run_preferences(self):
+        prefs = self.cleaned_data.get("ai_run_preferences")
+        if not prefs:
+            return prefs
+        if not isinstance(prefs, dict):
+            raise forms.ValidationError("Must be a JSON object.")
+        unknown = sorted(set(prefs) - set(_AI_RUN_PREFERENCE_KEYS))
+        if unknown:
+            raise forms.ValidationError(
+                f"Unknown keys: {', '.join(unknown)}. Allowed: {', '.join(_AI_RUN_PREFERENCE_KEYS)}."
+            )
+        non_strings = sorted(key for key, value in prefs.items() if not isinstance(value, str))
+        if non_strings:
+            raise forms.ValidationError(f"Values must be strings: {', '.join(non_strings)}.")
+        validate_ai_run_preferences(prefs.get("runtime_adapter"), prefs.get("model"), prefs.get("reasoning_effort"))
+        return prefs
+
+    def _post_clean(self) -> None:
+        # Unique-constraint validation queries through the model's default manager, which for
+        # UserTasksConfig is fail-closed and raises without a team context. Admin requests have
+        # none, so scope model validation to the team picked in the form.
+        team = self.cleaned_data.get("team")
+        if team is None:
+            super()._post_clean()
+            return
+        with team_scope(team.id):
+            super()._post_clean()
+
+
+@admin.register(TeamTasksConfig)
+class TeamTasksConfigAdmin(admin.ModelAdmin):
+    form = _TasksConfigAdminForm
+    list_display = ("team", "ai_run_preferences", "created_at", "updated_at")
+    search_fields = ("team__name", "team__organization__name")
+    readonly_fields = ("created_at", "updated_at")
+    autocomplete_fields = ("team",)
+    list_select_related = ("team",)
+    show_full_result_count = False
+
+
+@admin.register(UserTasksConfig)
+class UserTasksConfigAdmin(admin.ModelAdmin):
+    form = _TasksConfigAdminForm
+    list_display = ("id", "team", "user", "ai_run_preferences", "created_at", "updated_at")
+    search_fields = ("team__name", "user__email")
+    readonly_fields = ("id", "created_at", "updated_at")
+    autocomplete_fields = ("team", "user")
+    show_full_result_count = False
+
+    def get_queryset(self, request: HttpRequest):
+        # Admin has no team context; UserTasksConfig's default manager is fail-closed.
+        return UserTasksConfig.objects.unscoped().select_related("team", "user")

--- a/products/tasks/backend/admin.py
+++ b/products/tasks/backend/admin.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import nullcontext
 from typing import cast
 
 from django import forms
@@ -265,11 +266,8 @@ class _TasksConfigAdminForm(forms.ModelForm):
         # UserTasksConfig is fail-closed and raises without a team context. Admin requests have
         # none, so scope model validation to the team picked in the form.
         team = self.cleaned_data.get("team")
-        if team is None:
-            super()._post_clean()
-            return
-        with team_scope(team.id):
-            super()._post_clean()
+        with team_scope(team.id) if team is not None else nullcontext():
+            super()._post_clean()  # type: ignore[misc]  # django-stubs does not declare _post_clean
 
 
 @admin.register(TeamTasksConfig)

--- a/products/tasks/backend/admin.py
+++ b/products/tasks/backend/admin.py
@@ -14,7 +14,7 @@ from posthog.models.user import User
 from posthog.storage import object_storage
 
 from . import loop_service
-from .logic.services.ai_run_defaults import validate_ai_run_preferences
+from .logic.services.ai_run_defaults import validate_ai_run_preferences_payload
 from .loop_lifecycle import DISABLED_REASON_ADMIN_PAUSED, pause_loop
 from .models import Loop, LoopTrigger, SandboxSnapshot, Task, TaskRun, TeamTasksConfig, UserTasksConfig
 from .visibility import task_run_visibility_q, task_visibility_q
@@ -235,9 +235,6 @@ class LoopTriggerAdmin(admin.ModelAdmin):
         super().delete_queryset(request, queryset)
 
 
-_AI_RUN_PREFERENCE_KEYS = ("runtime_adapter", "model", "reasoning_effort")
-
-
 class _TasksConfigAdminForm(forms.ModelForm):
     """Shared form for the two tasks-config admins. Runs the same checks as the API
     write path (`update_team_ai_run_preferences` / `update_user_ai_run_preferences`),
@@ -247,7 +244,7 @@ class _TasksConfigAdminForm(forms.ModelForm):
         team = self.cleaned_data["team"]
         # Preference rows are keyed on the canonical (project root) team; a row keyed on an
         # environment team is never read by the resolver.
-        if team is not None and team.parent_team_id is not None:
+        if team.parent_team_id is not None:
             raise forms.ValidationError(
                 "Preferences are keyed on the project root team. "
                 f"Pick the parent team (id {team.parent_team_id}) instead of this environment team."
@@ -260,15 +257,7 @@ class _TasksConfigAdminForm(forms.ModelForm):
             return prefs
         if not isinstance(prefs, dict):
             raise forms.ValidationError("Must be a JSON object.")
-        unknown = sorted(set(prefs) - set(_AI_RUN_PREFERENCE_KEYS))
-        if unknown:
-            raise forms.ValidationError(
-                f"Unknown keys: {', '.join(unknown)}. Allowed: {', '.join(_AI_RUN_PREFERENCE_KEYS)}."
-            )
-        non_strings = sorted(key for key, value in prefs.items() if not isinstance(value, str))
-        if non_strings:
-            raise forms.ValidationError(f"Values must be strings: {', '.join(non_strings)}.")
-        validate_ai_run_preferences(prefs.get("runtime_adapter"), prefs.get("model"), prefs.get("reasoning_effort"))
+        validate_ai_run_preferences_payload(prefs)
         return prefs
 
     def _post_clean(self) -> None:

--- a/products/tasks/backend/logic/services/ai_run_defaults.py
+++ b/products/tasks/backend/logic/services/ai_run_defaults.py
@@ -239,6 +239,24 @@ def validate_ai_run_preferences(
     validate_model_selection(runtime_adapter, model, reasoning_effort)
 
 
+def validate_ai_run_preferences_payload(prefs: dict) -> None:
+    """Validate a raw `ai_run_preferences` payload written as a whole dict (the Django
+    admin form). API writers instead validate the triple and build the payload with
+    `build_ai_run_preferences_payload`, so unknown keys cannot occur on that path.
+
+    Raises `django.core.exceptions.ValidationError` on unknown keys, non-string
+    values, or an inconsistent triple.
+    """
+    allowed_keys = ("runtime_adapter", "model", "reasoning_effort")
+    unknown = sorted(set(prefs) - set(allowed_keys))
+    if unknown:
+        raise ValidationError(f"Unknown keys: {', '.join(unknown)}. Allowed: {', '.join(allowed_keys)}.")
+    non_strings = sorted(key for key, value in prefs.items() if not isinstance(value, str))
+    if non_strings:
+        raise ValidationError(f"Values must be strings: {', '.join(non_strings)}.")
+    validate_ai_run_preferences(prefs.get("runtime_adapter"), prefs.get("model"), prefs.get("reasoning_effort"))
+
+
 def build_ai_run_preferences_payload(
     runtime_adapter: str | None,
     model: str | None,
@@ -333,4 +351,5 @@ __all__ = [
     "update_team_ai_run_preferences",
     "update_user_ai_run_preferences",
     "validate_ai_run_preferences",
+    "validate_ai_run_preferences_payload",
 ]

--- a/products/tasks/backend/tests/test_admin.py
+++ b/products/tasks/backend/tests/test_admin.py
@@ -3,12 +3,17 @@ import uuid
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from django.contrib import admin
 from django.contrib.messages import get_messages
+from django.test import RequestFactory
 from django.urls import reverse
 
-from posthog.admin import register_all_admin
+from parameterized import parameterized
 
-from products.tasks.backend.models import Channel, Loop, Task, TaskRun
+from posthog.admin import register_all_admin
+from posthog.models.team.team import Team
+
+from products.tasks.backend.models import Channel, Loop, Task, TaskRun, TeamTasksConfig, UserTasksConfig
 
 register_all_admin()
 
@@ -181,3 +186,47 @@ class TestLoopAdminPauseAction(BaseTest):
         self.assertEqual(len(notices), 2)
         self.assertEqual(notices[0], "Paused 1 of 2 selected loop(s).")
         self.assertIn(str(failing.id), notices[1])
+
+
+class TestTasksConfigAdminForms(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.user.is_staff = True
+        self.user.save()
+        request = RequestFactory().get("/")
+        request.user = self.user
+        self.team_form_class = admin.site._registry[TeamTasksConfig].get_form(request)
+        self.user_form_class = admin.site._registry[UserTasksConfig].get_form(request)
+
+    @parameterized.expand(
+        [
+            ("model_without_adapter", {"model": "claude-opus-4-8"}),
+            ("unknown_key", {"runtime_adapter": "claude", "model": "claude-opus-4-8", "profile": "max"}),
+            ("non_string_value", {"runtime_adapter": "claude", "model": 7}),
+        ]
+    )
+    def test_rejects_invalid_preference_payloads(self, _name: str, payload: dict) -> None:
+        form = self.team_form_class(data={"team": self.team.pk, "ai_run_preferences": payload})
+        assert not form.is_valid()
+        assert "ai_run_preferences" in form.errors
+
+    def test_accepts_a_valid_payload_on_both_admin_forms(self) -> None:
+        # The extension row is auto-created with the team, so the admin flow is a change form.
+        team_form = self.team_form_class(
+            instance=TeamTasksConfig.objects.get(team=self.team),
+            data={
+                "team": self.team.pk,
+                "ai_run_preferences": {"runtime_adapter": "claude", "model": "claude-opus-4-8"},
+            },
+        )
+        assert team_form.is_valid(), team_form.errors
+        user_form = self.user_form_class(data={"team": self.team.pk, "user": self.user.pk, "ai_run_preferences": {}})
+        assert user_form.is_valid(), user_form.errors
+
+    def test_rejects_a_row_keyed_on_an_environment_team(self) -> None:
+        env_team = Team.objects.create(
+            organization=self.organization, project=self.project, parent_team=self.team, name="env"
+        )
+        form = self.team_form_class(data={"team": env_team.pk, "ai_run_preferences": None})
+        assert not form.is_valid()
+        assert "project root team" in str(form.errors["team"])


### PR DESCRIPTION
## Problem

Staff cannot inspect or fix a project's stored AI run defaults. `TeamTasksConfig` and `UserTasksConfig` (added in #70683) have no Django admin, so debugging a misbehaving default means raw SQL.

## Changes

- Staff can now view and edit both config models in Django admin, searchable by team and user name.
- A shared admin form runs the same triple validation as the API write path, so an admin edit cannot store a payload the resolver would reject or silently skip.
- The form rejects rows keyed on an environment team, because the resolver only reads project-root rows.
- Model validation runs inside `team_scope` for the selected team. Without it, saving a `UserTasksConfig` crashes: unique-constraint validation queries the fail-closed default manager, and admin requests have no team context.

No user-facing product changes; the surface is staff-only Django admin.

## How did you test this code?

- New `TestTasksConfigAdminForms` cases in `test_admin.py` cover: invalid payloads (half-set triple, unknown key, non-string value) rejected with a field error, a valid payload accepted on both forms, and an environment-team row rejected.
- The valid-payload case caught the `TeamScopeError` crash that the `team_scope` wrapper now fixes; no existing test exercised these forms.
- `python manage.py check` passes, so the admin registrations satisfy Django's admin checks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None; staff-only admin surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code. Skills invoked: /writing-code-comments, /writing-tests, /writing-pr-descriptions.
- The `team_scope` wrapper in the form was added after the new valid-payload test surfaced the fail-closed manager crash.
