### PR TITLE
chore(experiments): document the flag cleanup PR option in the lifecycle skill

### DIFF
--- a/products/experiments/skills/managing-experiment-lifecycle/SKILL.md
+++ b/products/experiments/skills/managing-experiment-lifecycle/SKILL.md
@@ -142,6 +142,16 @@ Required: `variant_key` (e.g. "test"). Optional: `conclusion`, `conclusion_comme
 
 Returns 409 if an approval policy requires review before the flag change.
 
+### Flag cleanup PR (option on end and ship variant)
+
+Both `experiment-end` and `experiment-ship-variant` accept `open_cleanup_pr: true`.
+A background PostHog Code task then removes the experiment's feature flag code and opens a draft pull request in the team's connected GitHub repository.
+
+- Only set this when the user asks for it or confirms it.
+- Requires the team to have the flag cleanup feature enabled and the key to carry the `task:write` scope; silently skipped otherwise.
+- `repository` ("organization/repository") picks the target when several repositories are connected. Omit it to fall back to the experiment's saved repository, the team default, or the only connected repository. With several candidates and no default, the cleanup is skipped unless provided.
+- Track progress with `experiment-cleanup-task` — the PR URL appears there once opened; a cleanup typically takes several minutes.
+
 ### Archive (`experiment-archive`)
 
 Hides a stopped experiment from the default list view.

--- a/products/experiments/skills/managing-experiment-lifecycle/SKILL.md
+++ b/products/experiments/skills/managing-experiment-lifecycle/SKILL.md
@@ -148,7 +148,8 @@ Both `experiment-end` and `experiment-ship-variant` accept `open_cleanup_pr: tru
 A background PostHog Code task then removes the experiment's feature flag code and opens a draft pull request in the team's connected GitHub repository.
 
 - Only set this when the user asks for it or confirms it.
-- Requires the team to have the flag cleanup feature enabled and the key to carry the `task:write` scope; silently skipped otherwise.
+- The key must carry the `task:write` scope, or the whole request is rejected with a 403 and the experiment is not ended or shipped.
+- The cleanup runs only when the call actually ends the experiment and a `conclusion` is set — shipping an already-stopped experiment, or ending without a conclusion, skips it. It also requires the team to have the flag cleanup feature enabled; silently skipped when it isn't.
 - `repository` ("organization/repository") picks the target when several repositories are connected. Omit it to fall back to the experiment's saved repository, the team default, or the only connected repository. With several candidates and no default, the cleanup is skipped unless provided.
 - Track progress with `experiment-cleanup-task` — the PR URL appears there once opened; a cleanup typically takes several minutes.
 


### PR DESCRIPTION
## Problem

Agents loading the managing-experiment-lifecycle skill don't learn that ending or shipping can open a flag cleanup PR, so they never offer it and can't fill the repository parameters correctly.

## Changes

- Adds a "Flag cleanup PR" section to the skill: `open_cleanup_pr` on end and ship variant, the repository fallback order, and tracking via `experiment-cleanup-task`.
- Wording follows the existing parameter descriptions in `products/experiments/mcp/tools.yaml`.

## How did you test this code?

Docs-only change. Claims checked against the tools.yaml descriptions and the end/ship serializer help text on master.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None needed, this is the docs update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session: a docs-gap sweep over the last 3 months of experiments PRs found the skill never mentions the cleanup option shipped in #86946. Skills invoked: /writing-pr-descriptions. Earlier drafts also touched the staff query-performance skill and an exposure-criteria validation note; both were dropped as not worth documenting.