### PR TITLE
fix(aio): remove the summarization model env lever

### DIFF
--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -25,9 +25,6 @@ MAX_CONCURRENT_WORKFLOW_TASKS: int | None = get_from_env(
     "MAX_CONCURRENT_WORKFLOW_TASKS", None, optional=True, type_cast=int
 )
 MAX_CONCURRENT_ACTIVITIES: int | None = get_from_env("MAX_CONCURRENT_ACTIVITIES", None, optional=True, type_cast=int)
-# Batch trace summarization model; overridable so a fleet-wide model rollback is a config change
-# plus a worker restart, not a deploy.
-LLMA_SUMMARIZATION_MODEL: str = get_from_env("LLMA_SUMMARIZATION_MODEL", "gpt-5-nano")
 TARGET_MEMORY_USAGE: float | None = get_from_env("TARGET_MEMORY_USAGE", None, optional=True, type_cast=float)
 TARGET_CPU_USAGE: float | None = get_from_env("TARGET_CPU_USAGE", None, optional=True, type_cast=float)
 

--- a/posthog/temporal/ai_observability/trace_summarization/constants.py
+++ b/posthog/temporal/ai_observability/trace_summarization/constants.py
@@ -2,8 +2,6 @@
 
 from datetime import timedelta
 
-from django.conf import settings
-
 from temporalio.common import RetryPolicy
 
 from products.ai_observability.backend.summarization.models import OpenAIModel, SummarizationMode
@@ -17,11 +15,12 @@ DEFAULT_TRACE_BATCH_SIZE = 6  # Traces processed in small parallel batches
 DEFAULT_MODE = SummarizationMode.DETAILED
 DEFAULT_WINDOW_MINUTES = 60  # Process traces from last N minutes (matches schedule frequency)
 DEFAULT_WINDOW_OFFSET_MINUTES = 30  # Offset window into the past so traces have time to fully complete
-# parse() fails the worker at boot on a value outside OpenAIModel, naming the valid models,
-# instead of failing every summary at runtime. It cannot check the other constraint: the value
-# must also be on the Python gateway's llma_summarization allowlist
-# (services/llm-gateway/src/llm_gateway/products/config.py), or the fallback path 403s.
-DEFAULT_MODEL = OpenAIModel.parse(settings.LLMA_SUMMARIZATION_MODEL)
+# Not env-configurable: the coordinator schedule bakes this value into its stored input in
+# whatever process re-creates it, so an env override would govern only part of the traffic.
+# Changing the model is a deploy, and the value must also be on the Python gateway's
+# llma_summarization allowlist (services/llm-gateway/src/llm_gateway/products/config.py),
+# or the fallback path 403s.
+DEFAULT_MODEL = OpenAIModel.GPT_5_NANO
 
 # Max estimated raw trace size (in characters) before formatting.
 # Traces exceeding this are skipped — formatting huge traces is CPU-intensive


### PR DESCRIPTION
## Problem

- `LLMA_SUMMARIZATION_MODEL` was advertised as the no-deploy rollback lever for the gpt-5-nano rollout, and it half-works: the coordinator schedule bakes a concrete model into its stored input whenever `schedule_temporal_workflows` re-creates it, in a process that does not carry the worker's env.
- Observed during the #91639 rollout: the re-baked schedule sent gpt-5-nano for part of the traffic while the env-pinned workers sent gpt-4.1-nano. Pulling the lever in an incident would silently roll back only half the traffic.
- A lever that half-works is worse than none, and making it whole costs more machinery than the product needs: summaries degrading for the ~30 minutes a revert-and-deploy takes is acceptable.

## Changes

- Removes the `LLMA_SUMMARIZATION_MODEL` setting; `DEFAULT_MODEL` is a hardcoded constant, so the code is the single source of truth and the schedule bake can no longer disagree with the workers.
- Model changes (and rollbacks) are deploys. The constant's comment records why it must not become env-configurable again and the gateway-allowlist constraint on its value.
- The companion charts change removes the now-dead env var from the worker deployment.

## How did you test this code?

- No behavior change: the removed env resolves to the same gpt-5-nano the constant now hardcodes, in every environment (the charts pin was flipped to gpt-5-nano before this PR). Existing coordinator/state tests pass; repo-wide `mypy --cache-fine-grained .` is clean.
- Considered and rejected: making inputs carry `model=None` and resolving on the worker to keep the lever honest (~104 lines). The lever's value does not justify the machinery for a self-healing hourly batch.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code, directed by the assignee, after the mixed-model finding during the #91639 rollout. The assignee chose deleting the lever over repairing it.
- Skills invoked: /writing-pr-descriptions, /writing-code-comments.
