### PR TITLE
feat(posthog_ai): clarify the model default settings and link to them

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1997,9 +1997,9 @@ snapshots:
     components-search--product-recents-and-starred--light:
         hash: v1.k794b7964.f2c75682469c037327f94f22550286ed866d4883e03ef7c66a3f234a31b1017b.1gKkr-42m5_F8qJMq6ahElSjOFRERpPTay3A0__UOo0
     components-search--searching--dark:
-        hash: v1.k794b7964.b5b6392f03b88199976388751bd330e913a0bacaa169cfbd7556e31d938b031b.WojPbjfmz4xLp10A6oORUyfgggXE27MbiDetkbVfVtU
+        hash: v1.k794b7964.7b5de739918a3105f14ef1b5c831b8ddc13f3e33cbf3f2d99f45b74e1bdb5212.Vml_l6q1RdulTgTpPJtHtfW26V4T71fyXmdz1e8eakk
     components-search--searching--light:
-        hash: v1.k794b7964.89872c07596f30d630ef8416102ea447a1ded4e66c0edca46017095620a090ab.UkIcBzbQDZt16dnO-Xph7b06JgK7nDAP3o0AP-1ra1E
+        hash: v1.k794b7964.749679cdf00b2d0892c9132e603542b4eab245e0ec4ac480e4cde730173e8fb3.nU303Ca0l5AQaU3QJBLpStoi54YwzrVTwJSrD5ggQL4
     components-sentencelist--full-sentence--dark:
         hash: v1.k794b7964.7e8e5dd2e09d246cc3668f362f2391fe67618bd1143aa393832297f5dc30e558.yptEWKc5RAUY613Fwd5cQ0VIinMvpdoI6cuKgagAGxk
     components-sentencelist--full-sentence--light:
@@ -8351,7 +8351,7 @@ snapshots:
     scenes-app-settings-environment--settings-environment-access-control--dark:
         hash: v1.k794b7964.c9ccaaba4bf03f6923b41fe85e387d17139a6d7d69a6e06913a37cb5dd019532.bpCeuesKb9InCkdPuMqRPNFckeU7o1u6QcQfQf5ogSE
     scenes-app-settings-environment--settings-environment-access-control--light:
-        hash: v1.k794b7964.e2a2721a0bbfca9bb459d0b991cedd912f1af81eff8ff15996bcc73984417aee.j7jFwv6YnpcoUKYfoXaZaluFS2_lDIFHE7TtSSvBOlI
+        hash: v1.k794b7964.9ea484177cb94c831f0508e3482b1a876fc2b69db66c95b8f69fe73586909a3b._EvRaax5KzNHywyiNOpnbtVEPebu79kfKuX5zFMrXj0
     scenes-app-settings-environment--settings-environment-autocapture--dark:
         hash: v1.k794b7964.8defefc8ee81d152212ad970ee03afd0170e149183c700875620b83c94041edb.1GgekWHSuFhNxSx6MSUDbX9I0RjLB_eJK_x9Y356OXU
     scenes-app-settings-environment--settings-environment-autocapture--light:
@@ -8423,7 +8423,7 @@ snapshots:
     scenes-app-settings-environment--settings-environment-web-analytics--dark:
         hash: v1.k794b7964.eb79f313f1c5dbf00e0689c0146e5116234b52f8835fd7d5c3fe2f9b41cf1bbb.2ixJGP2YQe4fQy9SW5hHOT5Kwam27dvHJgJps1yZ3h8
     scenes-app-settings-environment--settings-environment-web-analytics--light:
-        hash: v1.k794b7964.e319bd2edb8a9c629f2e8c6c01900ac1d603faf2e751ec10bcaa9021305c71f3.92jZVjrbRQ_R17e0vaR0uRtzu6t6ss_cuAWyg9-1md8
+        hash: v1.k794b7964.71f6b9c1343a9bb2d8ec78dfebae8d7d9845882353fd2f03f63d45c5ce238431.gnx48GKk7hyfbiZTB-hdcMC4K5dpCekR-NpE7kD7sVY
     scenes-app-settings-identity-provider-configuration--saml--dark:
         hash: v1.k794b7964.cf436ecd8d8529a7ba3eac50b1b359bf7c7ac7086e75ccbc7b5490608df007a5.aymaHq_BYkFfw3IZlHK3NWvUBkda_1BaIDMDUNKDyNs
     scenes-app-settings-identity-provider-configuration--saml--light:

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -364,7 +364,7 @@ export const SETTINGS_MAP: SettingSection[] = [
                 id: 'task-agent-project-default',
                 title: 'Project default model',
                 description:
-                    'The model agent runs launch with when nobody picks one. Everyone on this project inherits it, in PostHog AI, Slack, and PostHog Desktop.',
+                    'The model agent runs launch with when nobody picks one. Everyone on this project inherits it in the new PostHog AI view, in Slack, and in Quick Ask on PostHog Desktop.',
                 component: <TaskAgentProjectDefaultSettings />,
                 keywords: ['ai', 'model', 'claude', 'codex', 'agent', 'tasks', 'default', 'slack', 'desktop'],
             },
@@ -372,7 +372,7 @@ export const SETTINGS_MAP: SettingSection[] = [
                 id: 'task-agent-my-preference',
                 title: 'My default model',
                 description:
-                    'The model your own runs launch with, overriding the project default. Applies in PostHog AI, Slack, and PostHog Desktop.',
+                    'The model your own runs launch with, overriding the project default. Applies in the new PostHog AI view, in Slack, and in Quick Ask on PostHog Desktop.',
                 component: <TaskAgentMyPreferenceSettings />,
                 keywords: ['ai', 'model', 'claude', 'codex', 'agent', 'tasks', 'preference', 'slack', 'desktop'],
             },

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -364,7 +364,7 @@ export const SETTINGS_MAP: SettingSection[] = [
                 id: 'task-agent-project-default',
                 title: 'Project default model',
                 description:
-                    'The model agent runs launch with when nobody picks one. Everyone on this project inherits it in the new PostHog AI view, in Slack, and in Quick Ask on PostHog Desktop.',
+                    'The model agent runs launch with when nobody picks one. Everyone on this project inherits it in the new PostHog AI view, in Slack, and in PostHog Desktop.',
                 component: <TaskAgentProjectDefaultSettings />,
                 keywords: ['ai', 'model', 'claude', 'codex', 'agent', 'tasks', 'default', 'slack', 'desktop'],
             },
@@ -372,7 +372,7 @@ export const SETTINGS_MAP: SettingSection[] = [
                 id: 'task-agent-my-preference',
                 title: 'My default model',
                 description:
-                    'The model your own runs launch with, overriding the project default. Applies in the new PostHog AI view, in Slack, and in Quick Ask on PostHog Desktop.',
+                    'The model your own runs launch with, overriding the project default. Applies in the new PostHog AI view, in Slack, and in PostHog Desktop.',
                 component: <TaskAgentMyPreferenceSettings />,
                 keywords: ['ai', 'model', 'claude', 'codex', 'agent', 'tasks', 'preference', 'slack', 'desktop'],
             },

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -364,7 +364,7 @@ export const SETTINGS_MAP: SettingSection[] = [
                 id: 'task-agent-project-default',
                 title: 'Project default model',
                 description:
-                    'The model agent runs launch with when nobody picks one. Everyone on this project inherits it, in PostHog AI 2.0, Slack, and PostHog Desktop.',
+                    'The model agent runs launch with when nobody picks one. Everyone on this project inherits it, in PostHog AI, Slack, and PostHog Desktop.',
                 component: <TaskAgentProjectDefaultSettings />,
                 keywords: ['ai', 'model', 'claude', 'codex', 'agent', 'tasks', 'default', 'slack', 'desktop'],
             },
@@ -372,7 +372,7 @@ export const SETTINGS_MAP: SettingSection[] = [
                 id: 'task-agent-my-preference',
                 title: 'My default model',
                 description:
-                    'The model your own runs launch with, overriding the project default. Applies in PostHog AI 2.0, Slack, and PostHog Desktop.',
+                    'The model your own runs launch with, overriding the project default. Applies in PostHog AI, Slack, and PostHog Desktop.',
                 component: <TaskAgentMyPreferenceSettings />,
                 keywords: ['ai', 'model', 'claude', 'codex', 'agent', 'tasks', 'preference', 'slack', 'desktop'],
             },

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -357,24 +357,24 @@ export const SETTINGS_MAP: SettingSection[] = [
     {
         level: 'environment',
         id: 'environment-task-agents',
-        title: 'Task agents',
+        title: 'Model preferences',
         group: 'AI',
         settings: [
             {
                 id: 'task-agent-project-default',
                 title: 'Project default model',
                 description:
-                    'The model agent runs launch with when nobody picks one. Everyone on this project inherits it, for runs started from the task composer, Slack, and PostHog Desktop.',
+                    'The model agent runs launch with when nobody picks one. Everyone on this project inherits it, in PostHog AI 2.0, Slack, and PostHog Desktop.',
                 component: <TaskAgentProjectDefaultSettings />,
-                keywords: ['ai', 'model', 'claude', 'codex', 'agent', 'tasks', 'default'],
+                keywords: ['ai', 'model', 'claude', 'codex', 'agent', 'tasks', 'default', 'slack', 'desktop'],
             },
             {
                 id: 'task-agent-my-preference',
                 title: 'My default model',
                 description:
-                    'The model your own runs launch with, overriding the project default. Applies everywhere in PostHog: the task composer, Slack, and PostHog Desktop.',
+                    'The model your own runs launch with, overriding the project default. Applies in PostHog AI 2.0, Slack, and PostHog Desktop.',
                 component: <TaskAgentMyPreferenceSettings />,
-                keywords: ['ai', 'model', 'claude', 'codex', 'agent', 'tasks', 'preference'],
+                keywords: ['ai', 'model', 'claude', 'codex', 'agent', 'tasks', 'preference', 'slack', 'desktop'],
             },
         ],
     },

--- a/frontend/src/scenes/settings/environment/TaskAgentDefaultsSettings.tsx
+++ b/frontend/src/scenes/settings/environment/TaskAgentDefaultsSettings.tsx
@@ -179,7 +179,7 @@ export function TaskAgentMyPreferenceSettings(): JSX.Element {
                         from {resolvedDefaults.source === 'user' ? 'your default above' : 'the project default'}.
                     </>
                 ) : (
-                    <>No default is set — runs use each surface's built-in model.</>
+                    <>No default is set. Runs use each surface's built-in model.</>
                 )}
             </p>
         </div>

--- a/products/posthog_ai/frontend/components/composer/ComposerModelEffortPickers.test.tsx
+++ b/products/posthog_ai/frontend/components/composer/ComposerModelEffortPickers.test.tsx
@@ -1,0 +1,63 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import {
+    ModelChoiceApi,
+    ReasoningEffortEnumApi,
+    RuntimeAdapterEnumApi,
+} from 'products/tasks/frontend/generated/api.schemas'
+
+import { ComposerModelEffortPickers } from './ComposerModelEffortPickers'
+
+const CATALOGUE: ModelChoiceApi[] = [
+    {
+        runtime_adapter: RuntimeAdapterEnumApi.Claude,
+        model: 'claude-sonnet-5',
+        display_name: 'Claude Sonnet 5',
+        supported_efforts: [ReasoningEffortEnumApi.Low, ReasoningEffortEnumApi.Medium, ReasoningEffortEnumApi.High],
+    },
+    {
+        runtime_adapter: RuntimeAdapterEnumApi.Claude,
+        model: 'claude-opus-5',
+        display_name: 'Claude Opus 5',
+        supported_efforts: [ReasoningEffortEnumApi.Low, ReasoningEffortEnumApi.Medium, ReasoningEffortEnumApi.High],
+    },
+]
+
+function renderPickers(overrides: Partial<React.ComponentProps<typeof ComposerModelEffortPickers>> = {}): void {
+    render(
+        <ComposerModelEffortPickers
+            models={CATALOGUE}
+            selectedModel="claude-opus-5"
+            selectedEffort={ReasoningEffortEnumApi.High}
+            onModelChange={jest.fn()}
+            onEffortChange={jest.fn()}
+            {...overrides}
+        />
+    )
+    fireEvent.click(screen.getByRole('button'))
+}
+
+describe('ComposerModelEffortPickers', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('offers no way to change the default on a surface that has none to change', () => {
+        renderPickers()
+
+        expect(screen.getByText('Reset to default')).toBeInTheDocument()
+        expect(screen.queryByText('Change default')).not.toBeInTheDocument()
+    })
+
+    it('sends the user to where the default is configured', async () => {
+        const onOpenDefaultSettings = jest.fn()
+        renderPickers({ onOpenDefaultSettings })
+
+        fireEvent.click(screen.getByText('Change default'))
+
+        // Applied once the menu has finished closing, not on the click itself.
+        await waitFor(() => expect(onOpenDefaultSettings).toHaveBeenCalledTimes(1))
+    })
+})

--- a/products/posthog_ai/frontend/components/composer/ComposerModelEffortPickers.tsx
+++ b/products/posthog_ai/frontend/components/composer/ComposerModelEffortPickers.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useRef, useState } from 'react'
 
-import { IconChevronDown, IconChevronLeft, IconRevert } from '@posthog/icons'
+import { IconChevronDown, IconChevronLeft, IconGear, IconRevert } from '@posthog/icons'
 import {
     Button,
     DropdownMenu,
@@ -55,6 +55,10 @@ export interface ComposerModelEffortPickersProps {
     /** Clears the explicit pick so the run falls back to the resolved default. Omit on a surface with no
      * configured default and the reset row falls back to the ladder's balanced notch. */
     onResetToDefault?: () => void
+    /** Takes the user to where the default itself is configured. Passed as a callback rather than a URL so
+     * the picker stays free of the app's routing, and an embedding host can send its own audience
+     * somewhere else. Omit and the row is absent. */
+    onOpenDefaultSettings?: () => void
 }
 
 interface PickerSectionProps {
@@ -102,6 +106,7 @@ export function ComposerModelEffortPickers({
     lockedRuntimeAdapter,
     isDefaultSelection = false,
     onResetToDefault,
+    onOpenDefaultSettings,
 }: ComposerModelEffortPickersProps): JSX.Element {
     const [open, setOpen] = useState(false)
     const [advanced, setAdvanced] = useState(false)
@@ -159,6 +164,9 @@ export function ComposerModelEffortPickers({
             onEffortChange(effort as ReasoningEffortEnumApi)
         }
     }
+
+    // With neither a configured default to fall back to nor a ladder to land on, there is nothing to reset to.
+    const showReset = Boolean(onResetToDefault) || stops.length > 0
 
     // Deferred until the menu has finished closing: applying mid-animation re-renders the list the user is
     // watching disappear.
@@ -278,24 +286,32 @@ export function ComposerModelEffortPickers({
                     />
                 )}
 
+                {(showReset || onOpenDefaultSettings) && <DropdownMenuSeparator />}
+
                 {/* One reset for both meanings of "default": drop the pick so the configured project/user
                     default applies where a surface knows about one, else land on the ladder's balanced
                     notch. Two rows for the two notions read as a duplicate, since only one ever acts. */}
-                {(onResetToDefault || stops.length > 0) && (
-                    <>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem
-                            disabled={Boolean(onResetToDefault) && isDefaultSelection}
-                            onClick={() =>
-                                selectAndClose(
-                                    onResetToDefault ?? (() => selectStop(stops[Math.floor((stops.length - 1) / 2)]))
-                                )
-                            }
-                        >
-                            <IconRevert />
-                            Reset to default
-                        </DropdownMenuItem>
-                    </>
+                {showReset && (
+                    <DropdownMenuItem
+                        disabled={Boolean(onResetToDefault) && isDefaultSelection}
+                        onClick={() =>
+                            selectAndClose(
+                                onResetToDefault ?? (() => selectStop(stops[Math.floor((stops.length - 1) / 2)]))
+                            )
+                        }
+                    >
+                        <IconRevert />
+                        Reset to default
+                    </DropdownMenuItem>
+                )}
+
+                {/* Sits under the reset row because that's where the question arises: reverting to a default
+                    you disagree with is the moment you want to change it. */}
+                {onOpenDefaultSettings && (
+                    <DropdownMenuItem onClick={() => selectAndClose(onOpenDefaultSettings)}>
+                        <IconGear />
+                        Change default
+                    </DropdownMenuItem>
                 )}
             </DropdownMenuContent>
         </DropdownMenu>

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskComposer.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskComposer.tsx
@@ -3,6 +3,7 @@ import { router } from 'kea-router'
 import { useRef } from 'react'
 
 import { AIConsentPopoverWrapper } from 'scenes/settings/organization/AIConsentPopoverWrapper'
+import { urls } from 'scenes/urls'
 
 import {
     Composer,
@@ -139,6 +140,11 @@ export function TaskComposer(): JSX.Element {
                                         // Clearing both pins is what hands the choice back to the resolved
                                         // default — submit then omits the triple entirely.
                                         onResetToDefault={() => setNewTaskData({ model: null, reasoningEffort: null })}
+                                        onOpenDefaultSettings={() =>
+                                            router.actions.push(
+                                                urls.settings('environment-task-agents', 'task-agent-my-preference')
+                                            )
+                                        }
                                     />
                                 </Composer.Footer>
                             </Composer.Frame>

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunChat.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunChat.tsx
@@ -1,6 +1,8 @@
 import { BindLogic, useActions, useValues } from 'kea'
+import { router } from 'kea-router'
 
 import { AIConsentPopoverWrapper } from 'scenes/settings/organization/AIConsentPopoverWrapper'
+import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
 import { runInteractionLogic, type RunInteractionLogicProps } from 'products/posthog_ai/frontend/api/logics'
@@ -188,6 +190,11 @@ function LiveComposer({ logicProps }: { logicProps: RunInteractionLogicProps }):
                             // While the run is live its harness is fixed to whatever the sandbox booted; once
                             // terminal the next send starts a fresh run, which may pick any harness.
                             lockedRuntimeAdapter={isTerminal ? null : logicProps.currentRuntimeAdapter}
+                            onOpenDefaultSettings={() =>
+                                router.actions.push(
+                                    urls.settings('environment-task-agents', 'task-agent-my-preference')
+                                )
+                            }
                         />
                     </Composer.Footer>
                 </Composer.Frame>


### PR DESCRIPTION
## Problem

The default model for agent runs is configured under a settings section called "Task agents", which does not read as the place model preferences live. Its copy names the wrong surfaces, and the composer offers "Reset to default" with no way to see or change what that default is.

## Changes

- The settings section is now "Model preferences". The section id and URL are unchanged, so deep links keep working.
- The copy now names the surfaces the default reaches: the new PostHog AI view, Slack, and PostHog Desktop. Naming the new view tells a reader on the legacy chat that the setting does not reach it.
- The composer's model menu gains a "Change default" row that opens the setting.
- `ComposerModelEffortPickers` takes an optional `onOpenDefaultSettings` callback, not a URL: it is a public primitive that must stay free of the app's routing (`products/posthog_ai/frontend/AGENTS.md` section 2).

| | Before | After |
| --- | --- | --- |
| Settings | ![settings-before](https://raw.githubusercontent.com/PostHog/pr-assets/6ee88b3b819a4e4b27ced805cb9d7248d52d87f9/2026/09/c05ffd6a-58d4-42b3-ac9c-ebd0fcd77170.png) | ![settings-after](https://raw.githubusercontent.com/PostHog/pr-assets/bbd583a6b658605c85cdd364d629282bb3ee7f64/2026/09/7d2b53c8-e8e5-4cf9-8a1d-90197452e63f.png) |
| Menu | ![menu-before](https://raw.githubusercontent.com/PostHog/pr-assets/5c4dd169b25a4c1e884d15d468af82d71e9b0e21/2026/09/b30c25fd-e05b-4de7-9632-372dcae4c2b0.png) | ![menu-after](https://raw.githubusercontent.com/PostHog/pr-assets/59099ed66de4fb09abb13f9af8dcd07efe31c02f/2026/09/46a5b1e8-eee2-4644-864e-568c8ae9abc3.png) |

## How did you test this code?

New `ComposerModelEffortPickers.test.tsx` covers the row appearing without its callback, and the callback not firing through the deferred-until-closed apply path.

Screenshots are Storybook renders of an earlier commit on this branch, so they still show "Quick Ask on PostHog Desktop". Not checked: the live app, so the settings deep link is verified by its types, not by a click.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus 5 in Claude Code. Skills invoked: `/writing-user-facing-copy`, `/writing-pr-descriptions`.

The copy first said "PostHog AI 2.0". A sweep of user-facing strings found that name nowhere: shipped copy calls both the new surface and the legacy chat "PostHog AI", the nav says "Tasks", and the toggle says "New view" / "Legacy view". A later pass narrowed the Desktop mention to "Quick Ask on PostHog Desktop"; review called that too granular for a settings page, so the copy names the app.

