### PR TITLE
feat(desktop): add costs tile to inbox report detail

### DIFF
--- a/products/desktop/packages/ui/src/features/inbox/components/ReportCostsSection.stories.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportCostsSection.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { ReactNode } from "react";
+import { ReportCostsSectionView } from "./ReportCostsSection";
+
+const asideWidth = (Story: () => ReactNode) => (
+  <div style={{ width: 320 }}>
+    <Story />
+  </div>
+);
+
+const meta: Meta<typeof ReportCostsSectionView> = {
+  title: "Inbox/ReportCostsSection",
+  component: ReportCostsSectionView,
+  args: {
+    usage: {
+      token_cost_usd: 42.53,
+      compute_cost_usd: 7.44,
+      total_cost_usd: 49.97,
+    },
+  },
+  decorators: [asideWidth],
+};
+export default meta;
+
+type Story = StoryObj<typeof ReportCostsSectionView>;
+
+/** The breakdown a click on the header reveals. */
+export const Expanded: Story = {
+  args: { defaultCollapsed: false },
+};
+
+/** Resting state: the visible flag puts the total on the collapsed header. */
+export const CollapsedWithTotal: Story = {
+  args: { showHeaderTotal: true },
+};
+
+/** Sub-cent spend collapses to <$0.01 so a non-zero cost never reads as free. */
+export const SubCent: Story = {
+  args: {
+    usage: {
+      token_cost_usd: 0.004,
+      compute_cost_usd: 0,
+      total_cost_usd: 0.004,
+    },
+    defaultCollapsed: false,
+  },
+};

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportCostsSection.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportCostsSection.tsx
@@ -1,0 +1,104 @@
+import { CoinsIcon } from "@phosphor-icons/react";
+import type { TaskUsage } from "@posthog/api-client/posthog-client";
+import { cn } from "@posthog/quill";
+import { TASK_COST_FLAG, TASK_COST_VISIBLE_FLAG } from "@posthog/shared";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
+import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
+import { formatCostUsd } from "@posthog/ui/features/sessions/contextColors";
+
+// Reports have no backend cost rollup yet, so the section shows placeholder
+// figures, shaped like `TaskUsage` so real data is a drop-in swap.
+const PLACEHOLDER_USAGE: TaskUsage = {
+  token_cost_usd: 42.53,
+  compute_cost_usd: 7.44,
+  total_cost_usd: 49.97,
+};
+
+/**
+ * Cost of the agent work behind a report, following the session composer's
+ * estimated-cost breakdown: the total, split into tokens and cloud compute.
+ * Gated like the session cost: the task-cost flag reveals the section, and
+ * the visible flag additionally puts the total on the collapsed header.
+ */
+export function ReportCostsSection() {
+  const costEnabled = useFeatureFlag(TASK_COST_FLAG) || import.meta.env.DEV;
+  const costVisible = useFeatureFlag(TASK_COST_VISIBLE_FLAG);
+
+  if (!costEnabled) return null;
+
+  return (
+    <ReportCostsSectionView
+      usage={PLACEHOLDER_USAGE}
+      showHeaderTotal={costVisible}
+    />
+  );
+}
+
+export function ReportCostsSectionView({
+  usage,
+  showHeaderTotal = false,
+  defaultCollapsed = true,
+}: {
+  usage: TaskUsage;
+  showHeaderTotal?: boolean;
+  defaultCollapsed?: boolean;
+}) {
+  return (
+    <DetailSection
+      Icon={CoinsIcon}
+      title="Costs"
+      collapsible
+      defaultCollapsed={defaultCollapsed}
+      rightSlot={
+        showHeaderTotal ? (
+          <span className="text-[12px] text-gray-10 tabular-nums">
+            {formatCostUsd(usage.total_cost_usd)}
+          </span>
+        ) : undefined
+      }
+    >
+      <div className="overflow-hidden rounded-(--radius-1) border border-(--gray-4)">
+        <div className="flex items-center justify-between gap-6 bg-(--gray-2) px-2.5 py-1.5">
+          <span className="font-medium text-[11px] text-gray-10">
+            Estimated cost
+          </span>
+          <span className="font-semibold text-[15px] text-gray-12 tabular-nums leading-none">
+            {formatCostUsd(usage.total_cost_usd)}
+          </span>
+        </div>
+        <div className="grid grid-cols-2 border-(--gray-4) border-t">
+          <CostDetail label="Tokens" value={usage.token_cost_usd} />
+          <CostDetail
+            label="Cloud compute"
+            value={usage.compute_cost_usd}
+            divided
+          />
+        </div>
+      </div>
+    </DetailSection>
+  );
+}
+
+function CostDetail({
+  label,
+  value,
+  divided = false,
+}: {
+  label: string;
+  value: number;
+  divided?: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex min-w-0 flex-col px-2.5 py-1.5",
+        divided && "border-(--gray-4) border-l",
+      )}
+    >
+      <span className="truncate text-[10px] text-gray-10">{label}</span>
+      <span className="font-medium text-[12px] text-gray-12 tabular-nums">
+        {formatCostUsd(value)}
+      </span>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.tsx
@@ -9,6 +9,7 @@ import { ReportFeedbackFooter } from "@posthog/ui/features/inbox/components/deta
 import { InboxDetailFrame } from "@posthog/ui/features/inbox/components/InboxDetailFrame";
 import { InboxReportDetailGate } from "@posthog/ui/features/inbox/components/InboxReportDetailGate";
 import { ReportChatSidebar } from "@posthog/ui/features/inbox/components/ReportChatSidebar";
+import { ReportCostsSection } from "@posthog/ui/features/inbox/components/ReportCostsSection";
 import { ReportDetailActions } from "@posthog/ui/features/inbox/components/ReportDetailActions";
 import { ReportReviewersSection } from "@posthog/ui/features/inbox/components/ReportReviewersSection";
 import { ReportRunsSection } from "@posthog/ui/features/inbox/components/ReportRunsSection";
@@ -117,6 +118,7 @@ function ReportDetailContent({
         >
           <ReportReviewersSection report={report} />
           <ReportRunsSection report={report} />
+          <ReportCostsSection />
           <ReportActivitySection reportId={report.id} />
         </InboxDetailFrame>
       </div>


### PR DESCRIPTION
## Problem

A reader of a desktop inbox report cannot see what the agent work behind it cost. A session already shows this in its composer cost popover: estimated total, tokens, cloud compute.

## Changes

- Report detail gains a Costs tile after Runs. It expands to the session-style breakdown: estimated total, then tokens and cloud compute.
- The figures are placeholders shaped like `TaskUsage`. No per-report cost rollup exists yet, so wiring real data later is a data swap.
- The same flags gate it as the session cost: `posthog-code-task-cost` reveals the tile, `posthog-code-task-cost-visible` adds the total to the collapsed header.
- Mechanical: a Storybook story covers the expanded, collapsed, and sub-cent states.

| Expanded (light) | Expanded (dark) | Collapsed with total |
| --- | --- | --- |
| ![expanded-light](https://raw.githubusercontent.com/PostHog/pr-assets/cde163acf4d66300588a3c257ec173c6685cf881/2026/09/670dd7e5-354f-40b2-91ec-49942247defd.png) | ![expanded-dark](https://raw.githubusercontent.com/PostHog/pr-assets/4b36798b6f77262ede183f9ab0cf920d15260b69/2026/09/3c21f1e3-51a5-4a81-8a14-81fe783f64ec.png) | ![collapsed-light](https://raw.githubusercontent.com/PostHog/pr-assets/f6b3cc8168fa6b0a7a4048d2e12c8b681feeb169/2026/09/4bb6166a-8927-4eb3-af86-71986c269736.png) |

## How did you test this code?

- `pnpm --filter @posthog/ui typecheck` and Biome pass on the touched files.
- The screenshots come from the new stories, rendered in headless Chromium in light and dark themes.
- Not run: the desktop app itself. The tile composes the existing `DetailSection` chrome with static data.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: the tile is flag-gated placeholder UI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code in a PostHog Desktop cloud task, from a screenshot of the session cost popover as the reference design.
- Skills invoked: `/writing-user-facing-copy`, `storybook-stories` (desktop), `/writing-pr-descriptions`.
- The tile mirrors the cost block in `ContextBreakdownPopover`. Only the desktop inbox changes; the web inbox mirror is untouched.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
