### PR TITLE
fix(insights): share y-axes between trend series of similar magnitude

### DIFF
--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.test.ts
@@ -147,11 +147,16 @@ describe('stickinessChartTransforms', () => {
             expect(series.map((s) => s.key)).toEqual(['a', 'b'])
         })
 
-        it('assigns yAxisIds [left, y1, y2] across three results when showMultipleYAxes is true', () => {
-            const results = [makeResult({ id: 'a' }), makeResult({ id: 'b' }), makeResult({ id: 'c' })]
+        it('groups y-axes by the magnitude of the percent-converted values when showMultipleYAxes is true', () => {
+            // Same raw data, but b's much larger count makes its percentages ~2 orders smaller.
+            const results = [
+                makeResult({ id: 'a', count: 100 }),
+                makeResult({ id: 'b', count: 10000 }),
+                makeResult({ id: 'c', count: 100 }),
+            ]
             const series = buildStickinessSeries(results, { getColor: () => RED, showMultipleYAxes: true })
 
-            expect(series.map((s) => s.yAxisId)).toEqual([DEFAULT_Y_AXIS_ID, 'y1', 'y2'])
+            expect(series.map((s) => s.yAxisId)).toEqual([DEFAULT_Y_AXIS_ID, 'y1', DEFAULT_Y_AXIS_ID])
         })
 
         it('transforms each result independently using its own count', () => {

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.ts
@@ -9,6 +9,7 @@ import { ChartDisplayType } from '~/types'
 import { INSIGHT_TOOLTIP_CONFIG } from '../../shared/tooltipConfig'
 import { COMPARE_PREVIOUS_DIM_OPACITY, dimHexColor } from '../../trends/shared/compareDimming'
 import { humanizeSeriesLabel } from '../../trends/shared/humanizeSeriesLabel'
+import { computeMagnitudeAxisIds } from '../../trends/shared/magnitudeAxisIds'
 
 // Shape both IndexedTrendResult (kea) and StickinessResultItem (MCP) satisfy.
 export interface StickinessResultLike {
@@ -51,9 +52,9 @@ export function toPercentData(data: number[], count: number): number[] {
 export function buildStickinessMainSeries<R extends StickinessResultLike, M = unknown>(
     r: R,
     index: number,
-    opts: BuildStickinessSeriesOpts<R, M>
+    opts: BuildStickinessSeriesOpts<R, M>,
+    yAxisId: string = DEFAULT_Y_AXIS_ID
 ): Series<M> {
-    const yAxisId = opts.showMultipleYAxes && index > 0 ? `y${index}` : DEFAULT_Y_AXIS_ID
     const excluded = opts.getHidden ? opts.getHidden(r, index) : false
     const meta: M | undefined = opts.buildMeta ? opts.buildMeta(r, index) : undefined
     // Dim the compare-against-previous series so it recedes behind the current period, matching trends.
@@ -75,7 +76,11 @@ export function buildStickinessSeries<R extends StickinessResultLike, M = unknow
     results: R[],
     opts: BuildStickinessSeriesOpts<R, M>
 ): Series<M>[] {
-    return results.map((r, index) => buildStickinessMainSeries(r, index, opts))
+    // Group on the rendered (percent-converted) values, not the raw counts.
+    const yAxisIds = opts.showMultipleYAxes
+        ? computeMagnitudeAxisIds(results.map((r) => toPercentData(r.data, r.count)))
+        : undefined
+    return results.map((r, index) => buildStickinessMainSeries(r, index, opts, yAxisIds?.[index]))
 }
 
 /** Produce per-bucket labels ("Day 0", "Day 1", …). The API's own "X day(s)" labels

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -329,19 +329,10 @@ export function TrendsBarChart({
         [isAggregated, goalLines, series]
     )
 
-    const indexByResult = useMemo(() => {
-        const m = new Map<IndexedTrendResult, number>()
-        ;(indexedResults ?? []).forEach((r: IndexedTrendResult, i: number) => m.set(r, i))
-        return m
-    }, [indexedResults])
-
     // Anomaly markers must read the same axis their series is scaled against.
     const getYAxisId = useCallback(
-        (r: IndexedTrendResult) => {
-            const idx = indexByResult.get(r) ?? 0
-            return applyMultipleYAxes && idx > 0 ? `y${idx}` : DEFAULT_Y_AXIS_ID
-        },
-        [indexByResult, applyMultipleYAxes]
+        (r: IndexedTrendResult) => series.find((s) => s.key === String(r.id))?.yAxisId ?? DEFAULT_Y_AXIS_ID,
+        [series]
     )
 
     const onPointClick = useCallback(

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.test.ts
@@ -79,9 +79,13 @@ describe('buildTrendsBarTimeSeries', () => {
 
     it.each([
         { showMultipleYAxes: undefined, expected: ['left', 'left', 'left'] },
-        { showMultipleYAxes: true, expected: ['left', 'y1', 'y2'] },
-    ])('assigns yAxisId per series (showMultipleYAxes=$showMultipleYAxes)', ({ showMultipleYAxes, expected }) => {
-        const results = [makeResult({ id: 'a' }), makeResult({ id: 'b' }), makeResult({ id: 'c' })]
+        { showMultipleYAxes: true, expected: ['left', 'y1', 'left'] },
+    ])('groups yAxisIds by magnitude (showMultipleYAxes=$showMultipleYAxes)', ({ showMultipleYAxes, expected }) => {
+        const results = [
+            makeResult({ id: 'a', data: [1, 2, 3] }),
+            makeResult({ id: 'b', data: [1000, 2000, 3000] }),
+            makeResult({ id: 'c', data: [2, 4, 6] }),
+        ]
         const series = buildTrendsBarTimeSeries(results, { getColor: () => RED, showMultipleYAxes })
         expect(series.map((s) => s.yAxisId)).toEqual(expected)
     })

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.ts
@@ -4,6 +4,7 @@ import type { Series, TimeInterval, TimeSeriesBarChartConfig, TooltipContext, YA
 import { COMPARE_PREVIOUS_DIM_OPACITY, dimHexColor } from '../shared/compareDimming'
 import { schemaGoalLinesToConfigs } from '../shared/goalLinesAdapter'
 import { humanizeSeriesLabel } from '../shared/humanizeSeriesLabel'
+import { computeMagnitudeAxisIds } from '../shared/magnitudeAxisIds'
 import { buildTrendsYAxisConfig } from '../shared/trendsAxisFormat'
 import type { GoalLineLike, YFormatterFields } from '../shared/trendsChartDisplayOptions'
 
@@ -30,8 +31,9 @@ export interface BuildTrendsBarSeriesOpts<R extends TrendsBarResultLike, M = unk
     // Resolves the legend/series label (custom name + breakdown formatting). Hosts that lack the
     // breakdown/cohort deps (e.g. MCP) omit it and fall back to the raw humanized event name.
     getLabel?: (r: R) => string
-    // Scale each series past the first against its own y-axis. Grouped (unstacked) bars only —
-    // stacked layouts must share one axis, so the adapter never sets this for them.
+    // Give series of different orders of magnitude their own y-axes (similar ones share).
+    // Grouped (unstacked) bars only — stacked layouts must share one axis, so the adapter
+    // never sets this for them.
     showMultipleYAxes?: boolean
 }
 
@@ -58,12 +60,12 @@ function buildMainTrendsBarSeries<R extends TrendsBarResultLike, M = unknown>(
     r: R,
     index: number,
     opts: BuildTrendsBarSeriesOpts<R, M>,
-    data: number[]
+    data: number[],
+    yAxisId: string = DEFAULT_Y_AXIS_ID
 ): Series<M> {
     const color = resolveBarColor(r, index, opts)
     const excluded = opts.getHidden ? opts.getHidden(r, index) : false
     const meta = opts.buildMeta ? opts.buildMeta(r, index) : undefined
-    const yAxisId = opts.showMultipleYAxes && index > 0 ? `y${index}` : DEFAULT_Y_AXIS_ID
     return {
         key: String(r.id),
         label: opts.getLabel ? opts.getLabel(r) : humanizeSeriesLabel(r.label),
@@ -79,7 +81,8 @@ export function buildTrendsBarTimeSeries<R extends TrendsBarResultLike, M = unkn
     results: R[],
     opts: BuildTrendsBarSeriesOpts<R, M>
 ): Series<M>[] {
-    return results.map((r, index) => buildMainTrendsBarSeries(r, index, opts, r.data))
+    const yAxisIds = opts.showMultipleYAxes ? computeMagnitudeAxisIds(results.map((r) => r.data)) : undefined
+    return results.map((r, index) => buildMainTrendsBarSeries(r, index, opts, r.data, yAxisIds?.[index]))
 }
 
 export interface BuildTrendsBarTimeSeriesConfigOpts {

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
@@ -157,20 +157,6 @@ export function TrendsLineChart({
         [trendsFilter, isPercentStackView, baseCurrency]
     )
 
-    const indexByResult = useMemo(() => {
-        const m = new Map<IndexedTrendResult, number>()
-        ;(indexedResults ?? []).forEach((r, i) => m.set(r, i))
-        return m
-    }, [indexedResults])
-
-    const getYAxisId = useCallback(
-        (r: IndexedTrendResult) => {
-            const idx = indexByResult.get(r) ?? 0
-            return showMultipleYAxes && idx > 0 ? `y${idx}` : DEFAULT_Y_AXIS_ID
-        },
-        [indexByResult, showMultipleYAxes]
-    )
-
     const canHandleClick = !!context?.onDataPointClick || !!hasPersonsModal
     // The persons modal is intentionally unavailable for multi-series formulas (there's no
     // single series of actors behind a computed ratio). On dashboard/card tiles a click
@@ -299,6 +285,12 @@ export function TrendsLineChart({
             getTrendsColor,
             getLabel,
         ]
+    )
+
+    // Anomaly markers must read the same axis their series is scaled against.
+    const getYAxisId = useCallback(
+        (r: IndexedTrendResult) => series.find((s) => s.key === String(r.id))?.yAxisId ?? DEFAULT_Y_AXIS_ID,
+        [series]
     )
 
     const config = useChartConfig(

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.test.ts
@@ -150,11 +150,15 @@ describe('trendsChartTransforms', () => {
             expect(series.map((s) => s.key)).toEqual(['a', 'b'])
         })
 
-        it('assigns yAxisIds [left, y1, y2] across three results when showMultipleYAxes is true', () => {
-            const results = [makeResult({ id: 'a' }), makeResult({ id: 'b' }), makeResult({ id: 'c' })]
+        it('groups series onto shared y-axes by magnitude when showMultipleYAxes is true', () => {
+            const results = [
+                makeResult({ id: 'a', data: [1, 2, 3] }),
+                makeResult({ id: 'b', data: [1000, 2000, 3000] }),
+                makeResult({ id: 'c', data: [2, 4, 6] }),
+            ]
             const series = buildTrendsSeries(results, { getColor: () => RED, showMultipleYAxes: true })
 
-            expect(series.map((s) => s.yAxisId)).toEqual([DEFAULT_Y_AXIS_ID, 'y1', 'y2'])
+            expect(series.map((s) => s.yAxisId)).toEqual([DEFAULT_Y_AXIS_ID, 'y1', DEFAULT_Y_AXIS_ID])
         })
     })
 

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.ts
@@ -11,6 +11,7 @@ import type {
 
 import { schemaGoalLinesToConfigs } from '../shared/goalLinesAdapter'
 import { humanizeSeriesLabel } from '../shared/humanizeSeriesLabel'
+import { computeMagnitudeAxisIds } from '../shared/magnitudeAxisIds'
 import { buildTrendsYAxisConfig } from '../shared/trendsAxisFormat'
 import type { CiRangesFn, GoalLineLike, YFormatterFields } from '../shared/trendsChartDisplayOptions'
 
@@ -30,6 +31,7 @@ export interface TrendsResultLike {
 export interface BuildTrendsSeriesOpts<R extends TrendsResultLike, M = unknown> {
     /** Area fill under each series (web maps `display === ActionsAreaGraph`). */
     isArea?: boolean
+    /** Give series of different orders of magnitude their own y-axes (similar ones share). */
     showMultipleYAxes?: boolean
     // Negative number — index from the end where the in-progress tail begins. Omit to skip.
     incompletenessOffsetFromEnd?: number
@@ -60,10 +62,10 @@ export function computeDashedFromIndex(
 export function buildMainTrendsSeries<R extends TrendsResultLike, M = unknown>(
     r: R,
     index: number,
-    opts: BuildTrendsSeriesOpts<R, M>
+    opts: BuildTrendsSeriesOpts<R, M>,
+    yAxisId: string = DEFAULT_Y_AXIS_ID
 ): Series<M> {
     const dashedFromIndex = computeDashedFromIndex(r, opts)
-    const yAxisId = opts.showMultipleYAxes && index > 0 ? `y${index}` : DEFAULT_Y_AXIS_ID
     const excluded = opts.getHidden ? opts.getHidden(r, index) : false
     const meta: M | undefined = opts.buildMeta ? opts.buildMeta(r, index) : undefined
     return {
@@ -83,7 +85,8 @@ export function buildTrendsSeries<R extends TrendsResultLike, M = unknown>(
     results: R[],
     opts: BuildTrendsSeriesOpts<R, M>
 ): Series<M>[] {
-    return results.map((r, index) => buildMainTrendsSeries(r, index, opts))
+    const yAxisIds = opts.showMultipleYAxes ? computeMagnitudeAxisIds(results.map((r) => r.data)) : undefined
+    return results.map((r, index) => buildMainTrendsSeries(r, index, opts, yAxisIds?.[index]))
 }
 
 export interface BuildDerivedConfigsOpts<R extends TrendsResultLike> {

--- a/products/product_analytics/frontend/insights/trends/shared/magnitudeAxisIds.test.ts
+++ b/products/product_analytics/frontend/insights/trends/shared/magnitudeAxisIds.test.ts
@@ -1,0 +1,61 @@
+import { DEFAULT_Y_AXIS_ID } from '@posthog/quill-charts'
+
+import { computeMagnitudeAxisIds } from './magnitudeAxisIds'
+
+describe('computeMagnitudeAxisIds', () => {
+    it.each<{ name: string; datasets: number[][]; expected: string[] }>([
+        {
+            name: 'similar magnitudes share the default axis',
+            datasets: [
+                [1, 2, 3],
+                [4, 5, 6],
+                [2, 8, 9],
+            ],
+            expected: [DEFAULT_Y_AXIS_ID, DEFAULT_Y_AXIS_ID, DEFAULT_Y_AXIS_ID],
+        },
+        {
+            name: 'an order-of-magnitude gap splits into two axes, interleaved series regroup',
+            datasets: [
+                [1, 2, 3],
+                [1000, 2000, 3000],
+                [2, 4, 6],
+                [5000, 1000, 2000],
+            ],
+            expected: [DEFAULT_Y_AXIS_ID, 'y1', DEFAULT_Y_AXIS_ID, 'y1'],
+        },
+        {
+            name: 'the first series keeps the default axis even when its group is the largest magnitude',
+            datasets: [
+                [1000, 2000],
+                [1, 2],
+            ],
+            expected: [DEFAULT_Y_AXIS_ID, 'y1'],
+        },
+        {
+            name: 'a smooth magnitude ramp with sub-order gaps stays on one axis',
+            datasets: [[5], [20], [90], [400]],
+            expected: [DEFAULT_Y_AXIS_ID, DEFAULT_Y_AXIS_ID, DEFAULT_Y_AXIS_ID, DEFAULT_Y_AXIS_ID],
+        },
+        {
+            name: 'axes are capped at four even with more magnitude clusters',
+            datasets: [[1], [100], [10000], [1000000], [100000000]],
+            expected: [DEFAULT_Y_AXIS_ID, 'y1', 'y2', 'y3', 'y3'],
+        },
+        {
+            name: 'all-zero and empty series join the lowest-magnitude group',
+            datasets: [[1000, 2000], [1, 2], [0, 0], []],
+            expected: [DEFAULT_Y_AXIS_ID, 'y1', 'y1', 'y1'],
+        },
+        {
+            name: 'negative values group by absolute magnitude',
+            datasets: [
+                [-1000, -2000],
+                [900, 1100],
+            ],
+            expected: [DEFAULT_Y_AXIS_ID, DEFAULT_Y_AXIS_ID],
+        },
+        { name: 'empty input', datasets: [], expected: [] },
+    ])('$name', ({ datasets, expected }) => {
+        expect(computeMagnitudeAxisIds(datasets)).toEqual(expected)
+    })
+})

--- a/products/product_analytics/frontend/insights/trends/shared/magnitudeAxisIds.ts
+++ b/products/product_analytics/frontend/insights/trends/shared/magnitudeAxisIds.ts
@@ -1,0 +1,55 @@
+import { DEFAULT_Y_AXIS_ID } from '@posthog/quill-charts'
+
+const MAGNITUDE_GAP = 1
+const MAX_Y_AXES = 4
+
+/** Assign a y-axis id per series so series of similar magnitude share an axis. Series are
+ *  clustered on log10 of their max |value|, splitting at the largest gaps of at least
+ *  MAGNITUDE_GAP orders, capped at MAX_Y_AXES axes. The first series' group keeps the
+ *  default axis id; other groups get stable ids in series order. */
+export function computeMagnitudeAxisIds(datasets: readonly (readonly number[])[]): string[] {
+    const magnitudes = datasets.map((data) => {
+        let max = 0
+        for (const value of data) {
+            const abs = Math.abs(value)
+            if (Number.isFinite(abs) && abs > max) {
+                max = abs
+            }
+        }
+        return max > 0 ? Math.log10(max) : null
+    })
+
+    const measured = magnitudes
+        .flatMap((magnitude, seriesIndex) => (magnitude === null ? [] : [{ magnitude, seriesIndex }]))
+        .sort((a, b) => a.magnitude - b.magnitude)
+
+    const splitPositions = new Set(
+        measured
+            .slice(1)
+            .map((entry, k) => ({ pos: k + 1, gap: entry.magnitude - measured[k].magnitude }))
+            .filter(({ gap }) => gap >= MAGNITUDE_GAP)
+            .sort((a, b) => b.gap - a.gap)
+            .slice(0, MAX_Y_AXES - 1)
+            .map(({ pos }) => pos)
+    )
+
+    // Flat (all-zero or empty) series carry no magnitude and join the lowest group.
+    const groupOf = datasets.map(() => 0)
+    let group = 0
+    measured.forEach(({ seriesIndex }, k) => {
+        if (splitPositions.has(k)) {
+            group += 1
+        }
+        groupOf[seriesIndex] = group
+    })
+
+    const idOf = new Map<number, string>(datasets.length ? [[groupOf[0], DEFAULT_Y_AXIS_ID]] : [])
+    return groupOf.map((g) => {
+        let id = idOf.get(g)
+        if (!id) {
+            id = `y${idOf.size}`
+            idOf.set(g, id)
+        }
+        return id
+    })
+}


### PR DESCRIPTION
## Problem

- Anyone using "Show multiple Y-axes" on a trends insight gets one axis per series: 8 series draw 8 stacked axis gutters, even when 2 scales would fit them all.
- The extra gutters shrink the plot area, and matching a series to its axis becomes guesswork.

## Changes

Same insight, 4 series, before and after:

| Before (4 axes, 2 stacked per side) | After (2 axes) |
| --- | --- |
| ![multiaxis-before](https://raw.githubusercontent.com/PostHog/pr-assets/e1a1b7f72443117fd5026f5d24381dd1df850a9a/2026/09/ca586678-c92b-4d70-a231-12f0de2c4f32.png) | ![multiaxis-after](https://raw.githubusercontent.com/PostHog/pr-assets/440d94a1c02f44fc6d36fadef5e8d5aa8c2845ac/2026/09/19d72e8b-2db7-432c-bd78-a81eccb6051b.png) |

- With "Show multiple Y-axes" on, series of similar magnitude now share one axis, so many series no longer means many axes.
- The new `magnitudeAxisIds.ts` clusters series on log10 of their max value. A gap of at least one order of magnitude starts a new axis, capped at 4 axes.
- Series forming a smooth ramp, with every step under an order of magnitude, stay on one shared axis. There is no clean place to cut a continuum.
- The grouping applies to trends line, grouped bar, and stickiness charts. Stickiness groups on the percent-converted values it renders.
- Grouping counts hidden series too, so toggling a series in the legend does not reshuffle the axes.
- Mechanical: the per-series builders now take the axis id as a parameter; the axis decision moved to the list-level builders, which the MCP visualizer also uses.

> [!NOTE]
> Saved insights with this option render fewer axes than before. No numbers change, only the axis layout.

## How did you test this code?

- New parameterized tests for `computeMagnitudeAxisIds` catch regressions in the gap split, the 4-axis cap, all-zero series, and which group keeps the default axis. No existing test covered this logic.
- The transform tests that pinned one axis per series now pin magnitude grouping, so the wiring in each chart type cannot regress silently.
- The existing `TrendsLineChart` render test still proves a right axis appears with the option on.
- A local browser check on the insight above found one tick column per side after the change and two per side before.
- Not checked in a browser: the bar and stickiness displays (unit-tested only), and dark mode.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: the "Show multiple Y-axes" option is unchanged, only how axes are allocated.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code in a local session directed by the assignee.
- Skills invoked: /writing-ui-components, /writing-tests, /writing-pr-descriptions, /announcing-behavior-changes, /test (local browser verification).
- An in-app change notice was considered and skipped: no numbers move, and the chart itself shows the new axis layout.
- The gap threshold (1 order of magnitude) and the 4-axis cap are constants in `magnitudeAxisIds.ts`, easy to tune if the split feels too eager or too lazy.