### PR TITLE
fix(usage-ingestion): preserve trusted capture timestamps

### DIFF
--- a/nodejs/src/common/usage-ingestion/usage-record-batch.ts
+++ b/nodejs/src/common/usage-ingestion/usage-record-batch.ts
@@ -13,6 +13,7 @@ interface PendingRecord {
     recordId: string
     quantity: number
     unit?: string
+    timestampMs?: number
 }
 
 /**
@@ -43,13 +44,13 @@ export class UsageRecordBatch {
         return this.client !== null && this.config.isTeamEnabled(teamId)
     }
 
-    add(teamId: number, usageKey: string, recordId: string, quantity = 1, unit?: string): void {
+    add(teamId: number, usageKey: string, recordId: string, quantity = 1, unit?: string, timestampMs?: number): void {
         if (quantity <= 0 || !this.accepts(teamId)) {
             return
         }
         const key = `${teamId}:${usageKey}:${recordId}`
         if (!this.records.has(key)) {
-            this.records.set(key, { teamId, usageKey, recordId, quantity, unit })
+            this.records.set(key, { teamId, usageKey, recordId, quantity, unit, timestampMs })
         }
     }
 
@@ -62,7 +63,8 @@ export class UsageRecordBatch {
         acknowledgements: Promise<unknown | null>[],
         teamId: number,
         usageKey: string,
-        recordId: string
+        recordId: string,
+        timestampMs?: number
     ): void {
         // A record that would be dropped must not put the flush behind its Kafka writes.
         if (!this.accepts(teamId)) {
@@ -72,7 +74,7 @@ export class UsageRecordBatch {
             Promise.all(acknowledgements)
                 .then((results) => {
                     if (results.every((result) => result !== null)) {
-                        this.add(teamId, usageKey, recordId)
+                        this.add(teamId, usageKey, recordId, 1, undefined, timestampMs)
                     }
                 })
                 // Kafka errors are handled by the producer side effect. They must
@@ -94,17 +96,15 @@ export class UsageRecordBatch {
         if (!this.client || this.records.size === 0) {
             return
         }
-        // Flush time, never anything off the event. toDate of this lands in the storage
-        // sorting key, so a customer-supplied value would let a customer decide whether
-        // their own records deduplicate.
-        const timestampMs = Date.now()
+        // Aggregate producers have no per-record capture time, so retain their flush-time clock.
+        const flushedAtMs = Date.now()
         const records: UsageRecordInput[] = [...this.records.values()].map((record) => ({
             recordId: record.recordId,
             teamId: record.teamId,
             usageKey: record.usageKey,
             unit: record.unit ?? this.config.unit,
             quantity: record.quantity,
-            timestampMs,
+            timestampMs: record.timestampMs ?? flushedAtMs,
         }))
         this.records.clear()
         await this.client.ingest(records)

--- a/nodejs/src/ingestion/common/steps/usage-records-steps.test.ts
+++ b/nodejs/src/ingestion/common/steps/usage-records-steps.test.ts
@@ -42,7 +42,8 @@ describe('usage-records-steps', () => {
     async function queueEventUsage(
         ingested: Promise<IngestedEventInfo | null>[],
         event: Partial<{ event: string; eventUuid: string; distinctId: string }> = {},
-        personProcessing: { processPerson?: boolean; person?: Person } = {}
+        personProcessing: { processPerson?: boolean; person?: Person } = {},
+        headers: { now?: Date } = {}
     ): Promise<void> {
         const prepare = createRecordEventUsageStep(() => 'events')
         const prepared = await prepare({
@@ -54,6 +55,7 @@ describe('usage-records-steps', () => {
                 timestamp: '2026-06-15T23:55:00.000Z',
                 ...event,
             },
+            headers,
             eventUsageBatch,
             ...personProcessing,
         })
@@ -142,6 +144,22 @@ describe('usage-records-steps', () => {
                 timestampMs: FLUSH_TIMESTAMP_MS,
             },
         ])
+    })
+
+    it('uses trusted capture time when an event flushes six hours later', async () => {
+        const capturedAtMs = FLUSH_TIMESTAMP_MS
+        jest.setSystemTime(capturedAtMs)
+        await queueEventUsage(
+            [Promise.resolve({ topic: 'events', partition: 0 })],
+            {},
+            {},
+            { now: new Date(capturedAtMs) }
+        )
+
+        jest.advanceTimersByTime(6 * 60 * 60 * 1000)
+        await eventUsageBatch.flush()
+
+        expect(ingestedUsage[0]).toEqual(expect.objectContaining({ timestampMs: capturedAtMs }))
     })
 
     // The meters have to match `person_mode` in the nightly report's two billable-event queries,

--- a/nodejs/src/ingestion/common/steps/usage-records-steps.ts
+++ b/nodejs/src/ingestion/common/steps/usage-records-steps.ts
@@ -7,7 +7,7 @@ import { EVENTS_USAGE_KEY, UsageKeyResolver } from '~/ingestion/common/usage-rec
 import { BeforeBatchStep } from '~/ingestion/framework/batching-pipeline'
 import { PipelineResult, ok } from '~/ingestion/framework/results'
 import { ProcessingStep } from '~/ingestion/framework/steps'
-import { Person } from '~/types'
+import { EventHeaders, Person } from '~/types'
 
 export interface EventUsageBatchContext {
     eventUsageBatch: UsageRecordBatch
@@ -28,6 +28,7 @@ export function createEventUsageBeforeBatchStep<TInput, CInput, CBatch>(
 
 export interface RecordEventUsageInput {
     preparedEvent: { teamId: number; event: string; eventUuid: string; distinctId: string; timestamp: string }
+    headers: Pick<EventHeaders, 'now'>
     eventUsageBatch: UsageRecordBatch
     processPerson?: boolean
     person?: Person
@@ -58,6 +59,7 @@ export interface EventUsageRecord {
     teamId: number
     usageKey: string
     recordId: string
+    timestampMs?: number
 }
 
 export interface EventUsageRecordContext {
@@ -96,7 +98,9 @@ export function createRecordEventUsageStep<T extends RecordEventUsageInput>(
         }
         const { teamId } = input.preparedEvent
         const recordId = analyticsRecordId(input.preparedEvent)
-        const eventUsageRecords: EventUsageRecord[] = [{ teamId, usageKey, recordId }]
+        const captureTimestampMs = input.headers.now?.getTime()
+        const timestampMs = Number.isFinite(captureTimestampMs) ? captureTimestampMs : undefined
+        const eventUsageRecords: EventUsageRecord[] = [{ teamId, usageKey, recordId, timestampMs }]
         // Mirrors the report's enhanced-persons query: the plain billable count plus a `person_mode`
         // filter, so an event billed under its own key is outside both. Reading the mode stored on
         // the event rather than `processPerson` keeps force upgrades counted.
@@ -104,7 +108,7 @@ export function createRecordEventUsageStep<T extends RecordEventUsageInput>(
             usageKey === EVENTS_USAGE_KEY &&
             resolvePersonMode(input.person, input.processPerson ?? false) !== 'propertyless'
         ) {
-            eventUsageRecords.push({ teamId, usageKey: 'enhanced_person_events', recordId })
+            eventUsageRecords.push({ teamId, usageKey: 'enhanced_person_events', recordId, timestampMs })
         }
         return Promise.resolve(ok({ ...input, eventUsageRecords }))
     }
@@ -127,7 +131,8 @@ export function createRecordEventUsageAfterIngestStep<T extends RecordEventUsage
                     input.ingested,
                     record.teamId,
                     record.usageKey,
-                    record.recordId
+                    record.recordId,
+                    record.timestampMs
                 )
             }
         }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/pipeline-types.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/pipeline-types.ts
@@ -23,6 +23,7 @@ export interface SessionReplayHeaders {
     token: string
     session_id: string
     distinct_id: string
+    now?: Date
 }
 
 /** Tags an element with whether its session is being seen for the first time in this batch. */

--- a/nodejs/src/ingestion/pipelines/sessionreplay/session-usage-step.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/session-usage-step.test.ts
@@ -91,6 +91,17 @@ describe('createRecordSessionUsageStep', () => {
         expect(await record('web', 'posthog-js', false)).toEqual([])
     })
 
+    it('uses trusted capture time from replay headers', async () => {
+        const capturedAtMs = 1_700_000_000_000
+        const value = buildValue('web', 'posthog-js', true)
+        value.headers.now = new Date(capturedAtMs)
+
+        await createRecordSessionUsageStep(usageBatch)(value)
+        await usageBatch.flush()
+
+        expect(ingested[0]).toEqual(expect.objectContaining({ timestampMs: capturedAtMs }))
+    })
+
     describe('trackUnbilledNewSessions', () => {
         async function unbilledCount(): Promise<number> {
             const metric = register.getSingleMetric('recording_blob_ingestion_v2_unbilled_new_session')!

--- a/nodejs/src/ingestion/pipelines/sessionreplay/session-usage-step.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/session-usage-step.ts
@@ -37,7 +37,15 @@ export function createRecordSessionUsageStep<T extends SessionUsageInput>(
     return function recordSessionUsage(value): Promise<PipelineResult<Recordable<T>>> {
         if (value.isNewSession) {
             const meter = billableMeter(value.parsedMessage.snapshot_source)
-            usageBatch?.add(value.team.teamId, meter, value.headers.session_id)
+            const captureTimestampMs = value.headers.now?.getTime()
+            usageBatch?.add(
+                value.team.teamId,
+                meter,
+                value.headers.session_id,
+                1,
+                undefined,
+                Number.isFinite(captureTimestampMs) ? captureTimestampMs : undefined
+            )
         }
         return Promise.resolve(ok(value))
     }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/validate-headers-step.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/validate-headers-step.test.ts
@@ -7,11 +7,12 @@ import { createValidateSessionReplayHeadersStep } from './validate-headers-step'
 describe('createValidateSessionReplayHeadersStep', () => {
     const step = createValidateSessionReplayHeadersStep()
 
-    it('narrows headers to the guaranteed fields and drops the rest, preserving other input', async () => {
+    it('narrows headers while preserving trusted capture time and other input', async () => {
         const step = createValidateSessionReplayHeadersStep<{ marker: string; headers: EventHeaders }>()
+        const now = new Date('2026-09-03T10:00:00.000Z')
         const input = {
             marker: 'preserved',
-            headers: createTestEventHeaders({ token: 'tok', session_id: 'sess-1', distinct_id: 'user-1' }),
+            headers: createTestEventHeaders({ token: 'tok', session_id: 'sess-1', distinct_id: 'user-1', now }),
         }
 
         const result = await step(input)
@@ -19,8 +20,7 @@ describe('createValidateSessionReplayHeadersStep', () => {
         expect(isOkResult(result)).toBe(true)
         if (isOkResult(result)) {
             expect(result.value.marker).toBe('preserved')
-            // Only the guaranteed replay headers survive — the wide EventHeaders fields are dropped.
-            expect(result.value.headers).toEqual({ token: 'tok', session_id: 'sess-1', distinct_id: 'user-1' })
+            expect(result.value.headers).toEqual({ token: 'tok', session_id: 'sess-1', distinct_id: 'user-1', now })
         }
     })
 

--- a/nodejs/src/ingestion/pipelines/sessionreplay/validate-headers-step.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/validate-headers-step.ts
@@ -21,7 +21,7 @@ export function createValidateSessionReplayHeadersStep<
     T extends ValidateSessionReplayHeadersStepInput,
 >(): ProcessingStep<T, Omit<T, 'headers'> & { headers: SessionReplayHeaders }> {
     return async function validateReplayHeadersStep(input) {
-        const { token, session_id, distinct_id } = input.headers
+        const { token, session_id, distinct_id, now } = input.headers
 
         if (!token) {
             return dlq('no_token_in_header')
@@ -34,7 +34,7 @@ export function createValidateSessionReplayHeadersStep<
         }
 
         return Promise.resolve(
-            ok({ ...input, headers: { token, session_id: normalizeSessionId(session_id), distinct_id } })
+            ok({ ...input, headers: { token, session_id: normalizeSessionId(session_id), distinct_id, now } })
         )
     }
 }

--- a/posthog/models/usage_ingestion/billing_usage_records.py
+++ b/posthog/models/usage_ingestion/billing_usage_records.py
@@ -27,9 +27,9 @@ def billing_usage_records_data_table_engine() -> ReplacingMergeTree:
     )
 
 
-# Every producer stamps `timestamp` from its own clock when it flushes, never from anything a
-# customer sends, which is what lets toDate(timestamp) sit in the sorting key. Sourcing it from
-# event data would hand a customer control over whether their records deduplicate.
+# Event-derived producers use trusted server capture time when available; aggregate producers use
+# their emission clock. Never use customer-supplied timestamps, which would let a customer control
+# whether their records deduplicate.
 BASE_BILLING_USAGE_RECORDS_COLUMNS = """
     schema_version UInt8,
     record_id String,

--- a/proto/usage_ingestion/v1/service.proto
+++ b/proto/usage_ingestion/v1/service.proto
@@ -21,7 +21,8 @@ message BillingUsageRecord {
   // so producers cannot supply one.
   int64 team_id = 1;
 
-  // Stamp this from the producer's own clock when it emits, never from a customer payload.
+  // Stamp this from trusted server capture time when available; otherwise use the producer's
+  // emission clock. Never use a customer payload.
   // It is part of the identity, so a value a customer controls would let them decide
   // whether their own records deduplicate.
   int64 timestamp_ms = 2;

--- a/rust/batch-import-worker/src/parse/content/amplitude.rs
+++ b/rust/batch-import-worker/src/parse/content/amplitude.rs
@@ -320,7 +320,7 @@ fn create_group_identify_event(
         session_id: None,
         ip: "".to_string(),
         data: serde_json::to_string(&raw_event)?,
-        now: timestamp.format("%Y-%m-%d %H:%M:%S%.3f").to_string(),
+        now: Utc::now().to_rfc3339(),
         sent_at: None,
         token: context.token.clone(),
         event: "$groupidentify".to_string(),
@@ -1907,9 +1907,8 @@ mod tests {
         assert_eq!(group_identify_data["event"], "$groupidentify");
         assert_eq!(group_identify_data["timestamp"], specific_timestamp);
 
-        // Verify the timestamp is not a "now" timestamp
-        let now = chrono::Utc::now();
-        assert_ne!(group_identify_data["timestamp"], now.to_rfc3339());
+        // The event timestamp is customer-supplied; `now` is the trusted server capture time.
+        assert_ne!(group_identify_event.inner.now, "2023-10-15 14:30:00.000");
 
         // Check original event also has the same timestamp
         let original_event = &result[1];

--- a/rust/usage-ingestion/src/counters.rs
+++ b/rust/usage-ingestion/src/counters.rs
@@ -113,8 +113,6 @@ pub struct CounterAccumulator {
 
 impl CounterAccumulator {
     pub fn add_record(&self, record: &KafkaBillingUsageRecord) -> Result<(), CounterAddError> {
-        // TODO: Pass trusted capture time from event-derived producers into `usage_timestamp`.
-        // Batch-flush time rebuckets lagged records into wrong quota windows; customer event timestamps must not be used.
         self.add(
             record.team_id,
             record.organization_id,


### PR DESCRIPTION
## Problem

- Billing readers can see delayed event work in the wrong quota window.

## Changes

- Event-derived records retain trusted capture time through acknowledgement and flush.
- Aggregate records retain flush timestamps when no item capture time exists.
- Session replay retains trusted header time after validation.
- This internal change has no UI surface.

Before:

```mermaid
flowchart LR
    Capture{{Capture}} --> Worker[Delayed worker]
    Worker --> Flush[Flush clock]
    Flush --> Counter[Usage counter]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Capture phYellow;
    class Worker,Flush phBlue;
    class Counter phGray;
```

After:

```mermaid
flowchart LR
    Capture{{Capture}} --> Header[Trusted header]
    Header --> Worker[Delayed worker]
    Worker --> Timestamp[Usage timestamp]
    Timestamp --> Counter[Usage counter]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Capture phYellow;
    class Header,Worker,Timestamp phBlue;
    class Counter phGray;
```

## How did you test this code?

- `hogli test nodejs/src/ingestion/common/steps/usage-records-steps.test.ts` covers a six-hour delayed flush.
- `hogli test nodejs/src/ingestion/pipelines/sessionreplay/session-usage-step.test.ts` covers replay capture time.
- `hogli test nodejs/src/ingestion/pipelines/sessionreplay/validate-headers-step.test.ts` covers replay header preservation.
- `hogli test nodejs/src/common/usage-ingestion/usage-record-batch.test.ts` covers deduplication and acknowledgements.
- Not run: the full Node test suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- Updated internal producer documentation and gRPC timestamp guidance.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Created with Codex. Skills: `/ponytail`, `/writing-tests`, `/writing-pr-descriptions`, `/stacking-prs`, and Conductor guidance.
- Focused tests cover timestamp propagation and existing batch behavior.
- No sensitive session material was added.
