### PR TITLE
chore(desktop): drop the retired is_pro seat flag

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -308,17 +308,11 @@ export interface CreateResourceCommentRequest {
 export class CloudUsageLimitError extends Error {
   limitType: UsageLimitType;
   resetAt: string | null;
-  isPro: boolean;
-  constructor(params: {
-    limitType: UsageLimitType;
-    resetAt: string | null;
-    isPro: boolean;
-  }) {
+  constructor(params: { limitType: UsageLimitType; resetAt: string | null }) {
     super(CLOUD_USAGE_LIMIT_ERROR_MESSAGE);
     this.name = "CloudUsageLimitError";
     this.limitType = params.limitType;
     this.resetAt = params.resetAt;
-    this.isPro = params.isPro;
   }
 }
 
@@ -6133,7 +6127,6 @@ export class PostHogAPIClient {
           typeof parsed.body.reset_at === "string"
             ? parsed.body.reset_at
             : null,
-        isPro: parsed.body.is_pro === true,
       });
     }
   }

--- a/products/desktop/packages/core/src/billing/usageDisplay.test.ts
+++ b/products/desktop/packages/core/src/billing/usageDisplay.test.ts
@@ -32,7 +32,6 @@ function makeUsage(
       exceeded: overrides.burst ?? false,
     },
     is_rate_limited: overrides.isRateLimited ?? false,
-    is_pro: false,
   };
 }
 

--- a/products/desktop/packages/core/src/llm-gateway/llm-gateway.test.ts
+++ b/products/desktop/packages/core/src/llm-gateway/llm-gateway.test.ts
@@ -340,7 +340,6 @@ describe("LlmGatewayService.fetchUsage", () => {
       exceeded: false,
     },
     is_rate_limited: false,
-    is_pro: true,
   };
 
   it("returns the schema-parsed usage payload", async () => {
@@ -350,7 +349,6 @@ describe("LlmGatewayService.fetchUsage", () => {
     const usage = await service.fetchUsage();
 
     expect(usage.product).toBe("code");
-    expect(usage.is_pro).toBe(true);
     expect(usage.sustained.used_percent).toBe(10);
     expect(fetchMock).toHaveBeenCalledWith(`${API_HOST}/gateway/usage`, {
       headers: { "X-PostHog-Project-Id": "42" },

--- a/products/desktop/packages/core/src/usage/monitor-schemas.ts
+++ b/products/desktop/packages/core/src/usage/monitor-schemas.ts
@@ -14,7 +14,6 @@ const thresholdCrossedEvent = z.object({
   ]),
   usedPercent: z.number(),
   resetAt: z.string().datetime(),
-  isPro: z.boolean(),
   userIsActive: z.boolean(),
 });
 

--- a/products/desktop/packages/core/src/usage/schemas.ts
+++ b/products/desktop/packages/core/src/usage/schemas.ts
@@ -27,7 +27,6 @@ export const usageOutput = z.object({
     })
     .optional(),
   is_rate_limited: z.boolean(),
-  is_pro: z.boolean(),
   code_usage_subscribed: z.boolean().optional(),
   billing_period_end: z.string().datetime().nullable().optional(),
 });

--- a/products/desktop/packages/core/src/usage/usage-monitor.test.ts
+++ b/products/desktop/packages/core/src/usage/usage-monitor.test.ts
@@ -105,13 +105,11 @@ function makeUsage(overrides?: {
   billingPeriodEnd?: string | null;
   burstResetAt?: string;
   sustainedResetAt?: string;
-  isPro?: boolean;
 }): UsageOutput {
   return {
     product: "posthog_code",
     user_id: 42,
     is_rate_limited: false,
-    is_pro: overrides?.isPro ?? false,
     code_usage_subscribed: false,
     billing_period_end:
       overrides?.billingPeriodEnd === undefined
@@ -213,24 +211,6 @@ describe("UsageMonitorService", () => {
       "burst",
       "sustained",
     ]);
-  });
-
-  it("marks events with isPro from the gateway", async () => {
-    const events: { isPro: boolean }[] = [];
-    const gateway = mockGateway(
-      makeUsage({
-        sustainedPercent: 60,
-        isPro: true,
-        billingPeriodEnd: "2026-06-01T00:00:00.000Z",
-      }),
-    );
-    service = makeService(gateway, makeActivityMonitor());
-    service.on(UsageMonitorEvent.ThresholdCrossed, (e) =>
-      events.push(e as { isPro: boolean }),
-    );
-
-    await service.fetchOnce();
-    expect(events[0]?.isPro).toBe(true);
   });
 
   it("marks events with userIsActive from the agent service", async () => {

--- a/products/desktop/packages/core/src/usage/usage-monitor.ts
+++ b/products/desktop/packages/core/src/usage/usage-monitor.ts
@@ -194,15 +194,8 @@ export class UsageMonitorService extends TypedEventEmitter<UsageMonitorEvents> {
     if (!isCodeUsageFreeTier(usage)) return;
     const userId = usage.user_id.toString();
     const product = usage.product;
-    this.maybeEmit(usage, "burst", usage.burst, userId, product, usage.is_pro);
-    this.maybeEmit(
-      usage,
-      "sustained",
-      usage.sustained,
-      userId,
-      product,
-      usage.is_pro,
-    );
+    this.maybeEmit(usage, "burst", usage.burst, userId, product);
+    this.maybeEmit(usage, "sustained", usage.sustained, userId, product);
   }
 
   private maybeEmit(
@@ -211,7 +204,6 @@ export class UsageMonitorService extends TypedEventEmitter<UsageMonitorEvents> {
     status: UsageBucket,
     userId: string,
     product: string,
-    isPro: boolean,
   ): void {
     const anchor = this.anchorFor(bucket, status, usage);
     if (!anchor) return;
@@ -236,7 +228,6 @@ export class UsageMonitorService extends TypedEventEmitter<UsageMonitorEvents> {
       threshold,
       usedPercent: status.used_percent,
       resetAt: status.reset_at,
-      isPro,
       userIsActive: this.host.hasActiveSessions(),
     });
   }

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -818,7 +818,6 @@ export interface InboxReportScrolledProperties {
 }
 
 export interface UsageViewedProperties {
-  is_pro: boolean;
   /** Monthly bucket percent (0-100), null when usage is unavailable. */
   sustained_used_percent: number | null;
   /** Daily bucket percent (0-100), null when usage is unavailable. */
@@ -1276,7 +1275,6 @@ export interface UpgradePromptClickedProperties {
 
 export interface CloudTaskUsageBlockedProperties {
   bucket: "burst" | "sustained" | null;
-  is_pro: boolean;
 }
 
 // Claude Code session import events

--- a/products/desktop/packages/ui/src/features/billing/preflightCloudUsage.test.ts
+++ b/products/desktop/packages/ui/src/features/billing/preflightCloudUsage.test.ts
@@ -38,7 +38,6 @@ function makeUsage(
     sustained: boolean;
     burst: boolean;
     isRateLimited: boolean;
-    isPro: boolean;
   }> = {},
 ): UsageOutput {
   return {
@@ -55,7 +54,6 @@ function makeUsage(
       exceeded: overrides.burst ?? false,
     },
     is_rate_limited: overrides.isRateLimited ?? false,
-    is_pro: overrides.isPro ?? false,
   };
 }
 
@@ -68,7 +66,7 @@ interface Case {
     cause?: "model_gate" | "org_limit" | null;
     resetAt?: string | null;
   };
-  trackPayload?: { bucket: "burst" | "sustained" | null; is_pro: boolean };
+  trackPayload?: { bucket: "burst" | "sustained" | null };
 }
 
 const cases: Case[] = [
@@ -82,7 +80,7 @@ const cases: Case[] = [
     name: "blocks with the daily reset hint when the burst bucket is exceeded",
     arrange: () =>
       refresh.mockResolvedValue(
-        makeUsage({ burst: true, isRateLimited: true, isPro: true }),
+        makeUsage({ burst: true, isRateLimited: true }),
       ),
     available: false,
     modal: {
@@ -90,7 +88,7 @@ const cases: Case[] = [
       cause: "org_limit",
       resetAt: "2026-05-01T12:10:00.000Z",
     },
-    trackPayload: { bucket: "burst", is_pro: true },
+    trackPayload: { bucket: "burst" },
   },
   {
     name: "falls back to the latest snapshot when refresh fails",
@@ -100,7 +98,7 @@ const cases: Case[] = [
     },
     available: false,
     modal: { isOpen: true, cause: "org_limit" },
-    trackPayload: { bucket: "sustained", is_pro: false },
+    trackPayload: { bucket: "sustained" },
   },
   {
     name: "falls back to the monthly reset hint when only is_rate_limited is set",
@@ -112,7 +110,7 @@ const cases: Case[] = [
       cause: "org_limit",
       resetAt: "2026-05-01T13:00:00.000Z",
     },
-    trackPayload: { bucket: null, is_pro: false },
+    trackPayload: { bucket: null },
   },
   {
     name: "fails open (allows creation) when usage cannot be fetched",

--- a/products/desktop/packages/ui/src/features/billing/preflightCloudUsage.ts
+++ b/products/desktop/packages/ui/src/features/billing/preflightCloudUsage.ts
@@ -52,7 +52,6 @@ export async function assertCloudUsageAvailable(): Promise<boolean> {
         : usage.sustained.exceeded
           ? "sustained"
           : null,
-      is_pro: usage.is_pro,
     });
     useUsageLimitStore.getState().show(usageLimitArgs(usage));
     return false;

--- a/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.stories.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.stories.tsx
@@ -27,7 +27,6 @@ const usage = {
     },
   },
   is_rate_limited: false,
-  is_pro: true,
   code_usage_subscribed: true,
   billing_period_end: "2026-09-01T00:00:00.000Z",
 } satisfies UsageOutput;

--- a/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
@@ -57,7 +57,6 @@ export function PlanUsageSettings() {
 
   useTrackUsageViewed({
     isLoading: billingEnabled && usageLoading,
-    isPro: usage?.is_pro ?? false,
     sustainedUsedPercent: usage?.sustained.used_percent ?? null,
     burstUsedPercent: usage?.burst.used_percent ?? null,
   });

--- a/products/desktop/packages/ui/src/features/usage/useTrackUsageViewed.ts
+++ b/products/desktop/packages/ui/src/features/usage/useTrackUsageViewed.ts
@@ -4,13 +4,12 @@ import { useEffect, useRef } from "react";
 
 export interface TrackUsageViewedInput {
   isLoading: boolean;
-  isPro: boolean;
   sustainedUsedPercent: number | null;
   burstUsedPercent: number | null;
 }
 
 export function useTrackUsageViewed(input: TrackUsageViewedInput): void {
-  const { isLoading, isPro, sustainedUsedPercent, burstUsedPercent } = input;
+  const { isLoading, sustainedUsedPercent, burstUsedPercent } = input;
 
   const firedRef = useRef(false);
   useEffect(() => {
@@ -19,9 +18,8 @@ export function useTrackUsageViewed(input: TrackUsageViewedInput): void {
     if (isLoading) return;
     firedRef.current = true;
     track(ANALYTICS_EVENTS.USAGE_VIEWED, {
-      is_pro: isPro,
       sustained_used_percent: sustainedUsedPercent,
       burst_used_percent: burstUsedPercent,
     });
-  }, [isLoading, isPro, sustainedUsedPercent, burstUsedPercent]);
+  }, [isLoading, sustainedUsedPercent, burstUsedPercent]);
 }


### PR DESCRIPTION
`is_pro` said whether a user held a Pro PostHog Desktop seat. Seat billing was retired on 2026-07-16, so the gateway has reported `false` for everyone since.

The field renders nothing. Every place that reads it puts it into an analytics event: `USAGE_VIEWED`, `CLOUD_TASK_USAGE_BLOCKED`, and the usage threshold events. The one exception is a field on `CloudUsageLimitError` that gets set and never read. The usage limit modal builds its message from `resetAt` and `cause` only.

Removing it here is safe for builds people already have installed. The gateway keeps sending `is_pro` for them. These schemas are plain `z.object`, which drops unknown keys, so a newer build ignores the field rather than failing to parse the response.

Two analytics events lose the property from this build onward. Old data keeps it. One thing to know: the insight ["Usage health - free vs pro active users"](https://us.posthog.com/project/2/insights/pvU2R0a8) has shown a single `false` bar since 16 July, and it will go empty.

`api-client/src/generated.ts` keeps `is_pro`. That file is generated from the tasks API, which still returns the field.

Typecheck passes on all 27 workspace tasks. `@posthog/core` runs 4007 tests and `@posthog/ui` runs 4268, all passing.

Companion to #94055.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZzR5vLj7Fxm9raypB1PSU