### PR TITLE
fix(web-analytics): measure overview rows before first paint to stop the layout shift

### DIFF
--- a/frontend/src/queries/nodes/WebOverview/EvenlyDistributedRows.tsx
+++ b/frontend/src/queries/nodes/WebOverview/EvenlyDistributedRows.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react'
 
 // see https://github.com/PostHog/posthog/pull/20359/files#r1490894232 for a visual example of what this is trying to
 // solve
@@ -46,7 +46,11 @@ export const EvenlyDistributedRows = ({
         })
     }, [setRowLayout, elementRef, minWidthRems, children.length, maxItemsPerRow])
 
-    useEffect(() => {
+    // Layout effect, not effect: the first commit has no children (the column count is unknown
+    // until the container is measured). Measuring before paint means the browser never paints the
+    // empty container, so the rows appearing does not count as a layout shift. With useEffect the
+    // empty frame was painted and everything below the grid moved down when the rows arrived.
+    useLayoutEffect(() => {
         const element = elementRef.current
         if (!element) {
             return


### PR DESCRIPTION
## Problem

On web analytics the metric cards at the top of the page appear a beat after everything else and push the whole dashboard down by 120px. Field data puts `/project/:id/web` at 0.19 CLS p75 (15% of loads in the "poor" band), and the same grid renders marketing analytics, the recording overview and the customer analytics account tiles.

`EvenlyDistributedRows` needs the container width to pick a column count, and it measured in a `useEffect`, so the browser painted the empty container first and the cards arrived a frame later as a layout shift.

Third layer of a stack on #94059.

## Changes

- Overview cards are in the first painted frame. Measured on the `Scenes-App/Web Analytics` stories with a `layout-shift` PerformanceObserver in headless Chromium: CLS 0.125 → 0.004 on the dashboard story and 0.054 → 0.005 on the loading story.
- The measurement moves to `useLayoutEffect`, which runs before paint, so the second render with the rows replaces the empty commit before anything is drawn. The `ResizeObserver` subscription is unchanged.

Nothing else looks different.

Production build on a devbox, network throttled to 8 Mbps, cold load of the web analytics scene (demo project, dummy data). The cards are present in the first frame that paints:

![Web analytics loading in production mode on a devbox (8 Mbps throttle): overview cards are in the first painted frame](https://raw.githubusercontent.com/PostHog/pr-assets/44f4cf31a0bc3b77cddf2237e312c29c09962868/2026/09/44a300d0-037b-4ff3-8bfa-db79150d2350.gif)

## How did you test this code?

- Playwright against local Storybook: observed layout-shift entries with source attribution before and after on `scenes-app-web-analytics--web-analytics-dashboard` and `--web-analytics-dashboard-loading`. The remaining shifts are sub-0.003 table loader rows.
- Jest: `session-recordings/components/OverviewGrid.test.tsx`, which renders the same rows component.
- Not run: the marketing analytics and customer analytics surfaces, which share the component but have no scene story.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Claude Fable 5.1). The web-vitals field data could not attribute layout shift to elements, so the shifting node was found by running the scene stories in headless Chromium and reading `LayoutShift.sources`. Saved insights, cohorts, dashboards, persons, events and the insight visualisation stories showed no meaningful shift, so this layer is scoped to the one shared component that did.

Skills invoked: `/stacking-prs`, `/writing-code-comments`, `/writing-pr-descriptions`.

