### PR TITLE
fix(desktop): align model switch cost with task usage

### DIFF
--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
@@ -1274,10 +1274,6 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
                   sessionUpdate: "usage_update",
                   used: lastAssistantTotalUsage,
                   size: windowSize(),
-                  cost: {
-                    amount: message.total_cost_usd,
-                    currency: "USD",
-                  },
                 },
               });
             }
@@ -1566,7 +1562,6 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
                     sessionUpdate: "usage_update",
                     used: nextTotal,
                     size: windowSize(),
-                    cost: null,
                   },
                 });
               }

--- a/products/desktop/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
@@ -895,7 +895,6 @@ export type ResultMessageHandlerResult = {
     outputTokens: number;
     cachedReadTokens: number;
     cachedWriteTokens: number;
-    costUsd?: number;
     contextWindowSize?: number;
   };
 };
@@ -989,8 +988,6 @@ function extractUsageFromResult(
     outputTokens: msgUsage.output_tokens ?? 0,
     cachedReadTokens: msgUsage.cache_read_input_tokens ?? 0,
     cachedWriteTokens: msgUsage.cache_creation_input_tokens ?? 0,
-    costUsd:
-      typeof msg.total_cost_usd === "number" ? msg.total_cost_usd : undefined,
     contextWindowSize,
   };
 }

--- a/products/desktop/packages/core/src/pi-runtime/piSessionUsage.test.ts
+++ b/products/desktop/packages/core/src/pi-runtime/piSessionUsage.test.ts
@@ -2,10 +2,7 @@ import type { PiSessionStats } from "@posthog/agent/pi/types";
 import { describe, expect, it } from "vitest";
 import { toPiContextUsage } from "./piSessionUsage";
 
-function stats(
-  contextUsage: PiSessionStats["contextUsage"],
-  cost = 0,
-): PiSessionStats {
+function stats(contextUsage: PiSessionStats["contextUsage"]): PiSessionStats {
   return {
     sessionFile: undefined,
     sessionId: "session-1",
@@ -21,25 +18,21 @@ function stats(
       cacheWrite: 50,
       total: 1_650,
     },
-    cost,
+    cost: 0,
     contextUsage,
   };
 }
 
 describe("toPiContextUsage", () => {
-  it("maps native Pi context and cost statistics to shared context usage", () => {
+  it("maps native Pi context statistics to shared context usage", () => {
     expect(
       toPiContextUsage(
-        stats(
-          { tokens: 38_323, contextWindow: 1_000_000, percent: 3.8323 },
-          0.42,
-        ),
+        stats({ tokens: 38_323, contextWindow: 1_000_000, percent: 3.8323 }),
       ),
     ).toEqual({
       used: 38_323,
       size: 1_000_000,
       percentage: 4,
-      cost: { amount: 0.42, currency: "USD" },
       breakdown: null,
       breakdownAvailable: false,
     });

--- a/products/desktop/packages/core/src/pi-runtime/piSessionUsage.ts
+++ b/products/desktop/packages/core/src/pi-runtime/piSessionUsage.ts
@@ -18,7 +18,6 @@ export function toPiContextUsage(
           ? (usage.tokens / usage.contextWindow) * 100
           : 0),
     ),
-    cost: stats.cost > 0 ? { amount: stats.cost, currency: "USD" } : null,
     breakdown: null,
     breakdownAvailable: false,
   };

--- a/products/desktop/packages/core/src/sessions/contextUsage.test.ts
+++ b/products/desktop/packages/core/src/sessions/contextUsage.test.ts
@@ -17,31 +17,6 @@ function usageUpdateEvent(used: number, size: number): AcpMessage {
   };
 }
 
-function costUsageUpdateEvent(
-  used: number,
-  size: number,
-  amount: number,
-  currency = "USD",
-): AcpMessage {
-  return {
-    type: "acp_message",
-    ts: 1,
-    message: {
-      jsonrpc: "2.0",
-      method: "session/update",
-      params: {
-        sessionId: "s1",
-        update: {
-          sessionUpdate: "usage_update",
-          used,
-          size,
-          cost: { amount, currency },
-        },
-      },
-    },
-  };
-}
-
 function sizelessUsageUpdateEvent(used: number): AcpMessage {
   return {
     type: "acp_message",
@@ -144,30 +119,6 @@ describe("extractContextUsage", () => {
     expect(result?.breakdown?.conversation).toBe(45_500);
   });
 
-  it("reports null cost when no update carries a cost", () => {
-    const result = extractContextUsage([usageUpdateEvent(50_000, 200_000)]);
-    expect(result?.cost).toBeNull();
-  });
-
-  it("surfaces the cost from a single turn", () => {
-    const result = extractContextUsage([
-      costUsageUpdateEvent(50_000, 200_000, 0.42),
-    ]);
-    expect(result?.cost).toEqual({ amount: 0.42, currency: "USD" });
-  });
-
-  it("sums cost across turns since each result reports only its own spend", () => {
-    const result = extractContextUsage([
-      costUsageUpdateEvent(40_000, 200_000, 0.4),
-      costUsageUpdateEvent(90_000, 200_000, 0.35),
-      costUsageUpdateEvent(120_000, 200_000, 0.25),
-    ]);
-    // Context occupancy tracks the newest turn; cost accrues across all of them.
-    expect(result?.used).toBe(120_000);
-    expect(result?.cost?.amount).toBeCloseTo(1.0, 10);
-    expect(result?.cost?.currency).toBe("USD");
-  });
-
   it("tolerates the double-underscore method prefix from extNotification", () => {
     const result = extractContextUsage([
       usageUpdateEvent(50_000, 200_000),
@@ -227,28 +178,6 @@ describe("createContextUsageTracker", () => {
     // Dropping the latest usage event must lower the reported value, not keep
     // the stale append-path total.
     expect(tracker.update([earlier])?.used).toBe(50_000);
-  });
-
-  it("accumulates cost only over newly appended turns", () => {
-    const tracker = createContextUsageTracker();
-    const first = costUsageUpdateEvent(40_000, 200_000, 0.4);
-
-    expect(tracker.update([first])?.cost?.amount).toBeCloseTo(0.4, 10);
-
-    const result = tracker.update([
-      first,
-      costUsageUpdateEvent(90_000, 200_000, 0.35),
-    ]);
-    expect(result?.cost?.amount).toBeCloseTo(0.75, 10);
-  });
-
-  it("matches the batch extractor for a cost-bearing log", () => {
-    const tracker = createContextUsageTracker();
-    const events = [
-      costUsageUpdateEvent(40_000, 200_000, 0.4),
-      costUsageUpdateEvent(90_000, 200_000, 0.35),
-    ];
-    expect(tracker.update(events)).toEqual(extractContextUsage(events));
   });
 
   it("rebuilds when the tail changes at the same length", () => {

--- a/products/desktop/packages/core/src/sessions/contextUsage.ts
+++ b/products/desktop/packages/core/src/sessions/contextUsage.ts
@@ -15,29 +15,18 @@ export interface ContextUsage {
   used: number;
   size: number;
   percentage: number;
-  /** Cumulative estimated session cost, summed across turns; `null` if none reported (e.g. codex). */
-  cost: { amount: number; currency: string } | null;
   breakdown: ContextBreakdown | null;
   breakdownAvailable?: boolean;
 }
 
-type ContextUsageAggregate = Omit<ContextUsage, "breakdown" | "cost">;
+type ContextUsageAggregate = Omit<ContextUsage, "breakdown">;
 
 export function extractContextUsage(events: AcpMessage[]): ContextUsage | null {
   let aggregate: ContextUsageAggregate | null = null;
   let breakdown: ContextBreakdown | null = null;
-  let costAmount: number | null = null;
-  let costCurrency = "USD";
 
-  // Cost sums over every turn, so this can't early-break once the newest
-  // aggregate/breakdown is found — it walks the full log.
   for (let i = events.length - 1; i >= 0; i--) {
     const msg = events[i].message;
-    const cost = extractCost(msg);
-    if (cost) {
-      costAmount = (costAmount ?? 0) + cost.amount;
-      costCurrency = cost.currency;
-    }
     if (!aggregate) {
       aggregate = extractAggregate(msg);
     } else if (aggregate.size <= 0) {
@@ -51,13 +40,11 @@ export function extractContextUsage(events: AcpMessage[]): ContextUsage | null {
   }
 
   if (!aggregate) return null;
-  return { ...aggregate, cost: toCost(costAmount, costCurrency), breakdown };
+  return { ...aggregate, breakdown };
 }
 
 interface ContextUsageState {
   aggregate: ContextUsageAggregate | null;
-  costAmount: number | null;
-  costCurrency: string;
   breakdown: ContextBreakdown | null;
 }
 
@@ -65,8 +52,6 @@ export function createContextUsageTracker() {
   return createAppendOnlyTracker<ContextUsageState, ContextUsage | null>({
     init: () => ({
       aggregate: null,
-      costAmount: null,
-      costCurrency: "USD",
       breakdown: null,
     }),
     processEvent: (state, event) => {
@@ -75,26 +60,16 @@ export function createContextUsageTracker() {
       if (next) {
         state.aggregate = withCarriedSize(next, state.aggregate);
       }
-      const cost = extractCost(msg);
-      if (cost) {
-        state.costAmount = (state.costAmount ?? 0) + cost.amount;
-        state.costCurrency = cost.currency;
-      }
       state.breakdown = extractBreakdown(msg) ?? state.breakdown;
     },
     getResult: (state) =>
       state.aggregate
         ? {
             ...state.aggregate,
-            cost: toCost(state.costAmount, state.costCurrency),
             breakdown: state.breakdown,
           }
         : null,
   });
-}
-
-function toCost(amount: number | null, currency: string): ContextUsage["cost"] {
-  return amount != null ? { amount, currency } : null;
 }
 
 /**
@@ -130,7 +105,6 @@ function extractAggregate(
             sessionUpdate?: string;
             used?: number;
             size?: number;
-            cost?: { amount: number; currency: string } | null;
           };
         }
       | undefined;
@@ -147,38 +121,6 @@ function extractAggregate(
       const percentage =
         size > 0 ? Math.min(100, Math.round((update.used / size) * 100)) : 0;
       return { used: update.used, size, percentage };
-    }
-  }
-  return null;
-}
-
-function extractCost(
-  msg: AcpMessage["message"],
-): { amount: number; currency: string } | null {
-  if (
-    "method" in msg &&
-    msg.method === "session/update" &&
-    !("id" in msg) &&
-    "params" in msg
-  ) {
-    const params = msg.params as
-      | {
-          update?: {
-            sessionUpdate?: string;
-            cost?: { amount: number; currency: string } | null;
-          };
-        }
-      | undefined;
-    const update = params?.update;
-    if (
-      update?.sessionUpdate === "usage_update" &&
-      update.cost &&
-      typeof update.cost.amount === "number"
-    ) {
-      return {
-        amount: update.cost.amount,
-        currency: update.cost.currency ?? "USD",
-      };
     }
   }
   return null;

--- a/products/desktop/packages/ui/src/features/autoresearch/AutoresearchFullDashboard.stories.tsx
+++ b/products/desktop/packages/ui/src/features/autoresearch/AutoresearchFullDashboard.stories.tsx
@@ -52,7 +52,6 @@ function FullDashboardStory(props: FullDashboardStoryProps) {
           props.contextSize > 0
             ? Math.round((props.contextUsed / props.contextSize) * 100)
             : 0,
-        cost: null,
         breakdown: null,
       }
     : null;

--- a/products/desktop/packages/ui/src/features/autoresearch/AutoresearchRuntimeStats.test.tsx
+++ b/products/desktop/packages/ui/src/features/autoresearch/AutoresearchRuntimeStats.test.tsx
@@ -56,7 +56,6 @@ describe("AutoresearchRuntimeStats", () => {
       used: 42_800,
       size: 200_000,
       percentage: 21,
-      cost: { amount: 1.284, currency: "USD" },
       breakdown: null,
     });
 

--- a/products/desktop/packages/ui/src/features/message-editor/components/PromptInput.stories.tsx
+++ b/products/desktop/packages/ui/src/features/message-editor/components/PromptInput.stories.tsx
@@ -75,7 +75,6 @@ const mockUsage: ContextUsage = {
   used: 24_000,
   size: 353_000,
   percentage: 7,
-  cost: { amount: 0.42, currency: "USD" },
   breakdown: {
     systemPrompt: 14_000,
     tools: 0,

--- a/products/desktop/packages/ui/src/features/sessions/components/ContextBreakdownPopover.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ContextBreakdownPopover.test.tsx
@@ -12,7 +12,6 @@ function usageWith(
     used: 74_000,
     size: 200_000,
     percentage: 37,
-    cost: null,
     breakdown,
     ...overrides,
   };

--- a/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.test.tsx
@@ -44,7 +44,6 @@ function usage(overrides?: Partial<ContextUsage>): ContextUsage {
     used: 50_000,
     size: 200_000,
     percentage: 25,
-    cost: null,
     breakdown: null,
     ...overrides,
   };

--- a/products/desktop/packages/ui/src/features/sessions/components/ModelSwitchCacheDialog.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ModelSwitchCacheDialog.test.tsx
@@ -3,9 +3,46 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ModelSwitchCacheDialog } from "./ModelSwitchCacheDialog";
 
+const taskUsageState = vi.hoisted(() => ({
+  data: undefined as
+    | {
+        token_cost_usd: number;
+        compute_cost_usd: number;
+        total_cost_usd: number;
+      }
+    | undefined,
+}));
+vi.mock("@posthog/ui/features/sessions/hooks/useTaskUsage", () => ({
+  useTaskUsage: () => taskUsageState,
+}));
+
 describe("ModelSwitchCacheDialog", () => {
   beforeEach(() => {
     useSettingsStore.setState({ warnOnMidSessionModelSwitch: true });
+    taskUsageState.data = undefined;
+  });
+
+  it("shows the same task cost used by the context indicator", () => {
+    taskUsageState.data = {
+      token_cost_usd: 12.5,
+      compute_cost_usd: 0.4,
+      total_cost_usd: 12.9,
+    };
+
+    render(
+      <ModelSwitchCacheDialog
+        open
+        fromModelLabel="Claude Sonnet 5"
+        toModelId="claude-opus-5"
+        toModelLabel="Claude Opus 5"
+        taskId="task-1"
+        onConfirm={vi.fn().mockResolvedValue(true)}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Task cost so far")).toBeInTheDocument();
+    expect(screen.getByText("$12.90")).toBeInTheDocument();
   });
 
   it("keeps future warnings enabled when the user selects do not show again and cancels", () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/ModelSwitchCacheDialog.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ModelSwitchCacheDialog.test.tsx
@@ -41,7 +41,7 @@ describe("ModelSwitchCacheDialog", () => {
       />,
     );
 
-    expect(screen.getByText("Task cost so far")).toBeInTheDocument();
+    expect(screen.getByText("Session cost so far")).toBeInTheDocument();
     expect(screen.getByText("$12.90")).toBeInTheDocument();
   });
 

--- a/products/desktop/packages/ui/src/features/sessions/components/ModelSwitchCacheDialog.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ModelSwitchCacheDialog.test.tsx
@@ -41,7 +41,7 @@ describe("ModelSwitchCacheDialog", () => {
       />,
     );
 
-    expect(screen.getByText("Session cost so far")).toBeInTheDocument();
+    expect(screen.getByText("Estimated task cost so far")).toBeInTheDocument();
     expect(screen.getByText("$12.90")).toBeInTheDocument();
   });
 

--- a/products/desktop/packages/ui/src/features/sessions/components/ModelSwitchCacheDialog.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ModelSwitchCacheDialog.tsx
@@ -13,6 +13,7 @@ import {
   Text,
 } from "@posthog/quill";
 import { formatCostUsd } from "@posthog/ui/features/sessions/contextColors";
+import { useTaskUsage } from "@posthog/ui/features/sessions/hooks/useTaskUsage";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { type ReactElement, useEffect, useId, useRef, useState } from "react";
 
@@ -21,8 +22,8 @@ interface ModelSwitchCacheDialogProps {
   fromModelLabel: string;
   toModelId: string;
   toModelLabel: string;
+  taskId?: string;
   contextTokens?: number;
-  sessionCostUsd?: number;
   onConfirm: () => Promise<boolean>;
   onCopyHandoffSummary?: () => Promise<void>;
   onCancel: () => void;
@@ -35,8 +36,8 @@ export function ModelSwitchCacheDialog({
   fromModelLabel,
   toModelId,
   toModelLabel,
+  taskId,
   contextTokens = 0,
-  sessionCostUsd,
   onConfirm,
   onCopyHandoffSummary,
   onCancel,
@@ -46,6 +47,7 @@ export function ModelSwitchCacheDialog({
   );
   const [dontShowAgain, setDontShowAgain] = useState(false);
   const [activeAction, setActiveAction] = useState<ActiveAction>(null);
+  const { data: taskUsage } = useTaskUsage(taskId, open);
   const checkboxId = useId();
   const cancelButtonRef = useRef<HTMLButtonElement>(null);
   const requestTokenRef = useRef(0);
@@ -53,8 +55,7 @@ export function ModelSwitchCacheDialog({
     toModelId,
     contextTokens,
   );
-  const hasCostInfo =
-    estimatedInputCost !== null || sessionCostUsd !== undefined;
+  const hasCostInfo = estimatedInputCost !== null || taskUsage !== undefined;
   const busy = activeAction !== null;
 
   useEffect(() => {
@@ -131,13 +132,13 @@ export function ModelSwitchCacheDialog({
                     </Text>
                   </div>
                 )}
-                {sessionCostUsd !== undefined && (
+                {taskUsage !== undefined && (
                   <div className="flex items-center justify-between gap-4">
                     <Text className="text-[12px] text-muted-foreground">
-                      Session cost so far
+                      Task cost so far
                     </Text>
                     <Text className="shrink-0 font-medium text-[12px] text-foreground tabular-nums">
-                      {formatCostUsd(sessionCostUsd)}
+                      {formatCostUsd(taskUsage.total_cost_usd)}
                     </Text>
                   </div>
                 )}

--- a/products/desktop/packages/ui/src/features/sessions/components/ModelSwitchCacheDialog.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ModelSwitchCacheDialog.tsx
@@ -33,6 +33,15 @@ type ActiveAction = "copy_summary" | "switch" | null;
 
 export function ModelSwitchCacheDialog({
   open,
+  ...props
+}: ModelSwitchCacheDialogProps): ReactElement | null {
+  if (!open) return null;
+
+  return <OpenModelSwitchCacheDialog open {...props} />;
+}
+
+function OpenModelSwitchCacheDialog({
+  open,
   fromModelLabel,
   toModelId,
   toModelLabel,
@@ -135,7 +144,7 @@ export function ModelSwitchCacheDialog({
                 {taskUsage !== undefined && (
                   <div className="flex items-center justify-between gap-4">
                     <Text className="text-[12px] text-muted-foreground">
-                      Session cost so far
+                      Estimated task cost so far
                     </Text>
                     <Text className="shrink-0 font-medium text-[12px] text-foreground tabular-nums">
                       {formatCostUsd(taskUsage.total_cost_usd)}

--- a/products/desktop/packages/ui/src/features/sessions/components/ModelSwitchCacheDialog.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ModelSwitchCacheDialog.tsx
@@ -135,7 +135,7 @@ export function ModelSwitchCacheDialog({
                 {taskUsage !== undefined && (
                   <div className="flex items-center justify-between gap-4">
                     <Text className="text-[12px] text-muted-foreground">
-                      Task cost so far
+                      Session cost so far
                     </Text>
                     <Text className="shrink-0 font-medium text-[12px] text-foreground tabular-nums">
                       {formatCostUsd(taskUsage.total_cost_usd)}

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.stories.tsx
@@ -17,7 +17,6 @@ const usage: ContextUsage = {
   used: 788_000,
   size: 1_000_000,
   percentage: 79,
-  cost: null,
   breakdown: null,
 };
 

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -961,12 +961,8 @@ export function SessionView({
         fromModelLabel={pendingModelSwitch?.fromLabel ?? ""}
         toModelId={pendingModelSwitch?.value ?? ""}
         toModelLabel={pendingModelSwitch?.label ?? ""}
+        taskId={taskId}
         contextTokens={contextUsage?.used}
-        sessionCostUsd={
-          olderHistoryCursor === 0 && contextUsage?.cost?.currency === "USD"
-            ? contextUsage.cost.amount
-            : undefined
-        }
         onConfirm={confirmModelSwitch}
         onCopyHandoffSummary={
           canCopyHandoffSummary && !hasPendingSideQuestion

--- a/products/desktop/packages/ui/src/features/sessions/hooks/useAutoCompact.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/hooks/useAutoCompact.test.tsx
@@ -13,7 +13,6 @@ function usageAt(percentage: number): ContextUsage {
     used: percentage,
     size: 100,
     percentage,
-    cost: null,
     breakdown: null,
   };
 }


### PR DESCRIPTION
## Problem

People can see conflicting cost totals in the model switch warning and the context indicator.

**Why:** The warning used live agent-reported costs, while the indicator used the task total from the usage API.

## Changes

- The model switch warning now shows the same task usage total as the context indicator.
- Opening the warning enables the existing usage query, so both surfaces share one cached value.
- Context usage now tracks tokens and breakdowns only. The redundant live cost field and session update payload are removed.
- No screenshot: the dialog layout does not change, and the copy update is text-only.

## How did you test this code?

- Added a modal assertion that guards the task usage total shown by both surfaces.
- Removed cost-only tests after removing the old behavior.
- Ran focused tests for context tracking, the modal, auto-compact, runtime stats, and Claude usage updates.
- Ran desktop lint, core boundary lint, full desktop typecheck, and CI preflight.
- Not run: manual desktop verification because this change does not alter layout or interactions.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The cost source changes without changing the documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Slack app used repository search and terminal tools. Skills: `/posthog-desktop`, `/writing-tests`, `/writing-user-facing-copy`, `/announcing-behavior-changes`, and `/writing-pr-descriptions`.

The final change reuses the task usage query and removes the unused context cost path. No private session material appears in committed code or test data.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1788433275060669?thread_ts=1788433275.060669&cid=C09G8Q32R6F)*