### PR TITLE
fix(desktop): match inbox badge to filters

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/NavRail.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/NavRail.tsx
@@ -213,7 +213,6 @@ function NavRailImpl() {
   const inboxVisible = destinations.some(({ pane }) => pane === "inbox");
   const inboxDecisionCount = useInboxDecisionCount({
     enabled: inboxVisible,
-    ignoreFilters: true,
   });
   const { unreadCount: unseenActivity } = useTaskActivity({
     enabled: mentionsEnabled,

--- a/products/desktop/packages/ui/src/features/inbox/AGENTS.md
+++ b/products/desktop/packages/ui/src/features/inbox/AGENTS.md
@@ -87,6 +87,8 @@ The detail components share the same shape: load the report, render a common hea
 
 `useInboxAllReports` is the list source of truth. It reads UI scope/filter state, calls the paginated report list hook, returns filtered reports, and computes counts used by the tabs. Multiple tab bodies can call it because React Query dedupes the underlying request.
 
+The sidebar badge counts only the active `Review and merge` and `Needs decision` groups selected by the persisted status filter. Its count-only queries also apply the current priority and reviewer-scope filters, so the badge matches the report list.
+
 Tab membership and counts live in `utils/reportMembership.ts`. Keep that file as the canonical place for report partitioning rules so the tab bodies, counts, and tests stay aligned.
 
 Detail screens layer additional data on top of the base report:

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxDecisionCount.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxDecisionCount.test.tsx
@@ -5,6 +5,10 @@ import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetSignalReports = vi.hoisted(() => vi.fn());
+const filterMocks = vi.hoisted(() => ({
+  priorityFilter: ["P1"] as string[],
+  reportStateFilter: ["review_and_merge", "needs_decision"] as string[],
+}));
 
 vi.mock("@posthog/ui/features/auth/authClient", () => ({
   useOptionalAuthenticatedClient: () => ({
@@ -23,9 +27,8 @@ vi.mock("@posthog/ui/features/inbox/stores/inboxReviewerScopeStore", () => ({
 vi.mock("@posthog/ui/features/inbox/stores/inboxSignalsFilterStore", () => ({
   useInboxSignalsFilterStore: (selector: (state: unknown) => unknown) =>
     selector({
-      sourceProductFilter: ["github"],
-      priorityFilter: ["P1"],
-      prFilter: "all",
+      priorityFilter: filterMocks.priorityFilter,
+      reportStateFilter: filterMocks.reportStateFilter,
     }),
 }));
 
@@ -38,31 +41,49 @@ function renderCount(enabled: boolean) {
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
-  return renderHook(
-    () => useInboxDecisionCount({ enabled, ignoreFilters: true }),
-    { wrapper },
-  );
+  return renderHook(() => useInboxDecisionCount({ enabled }), { wrapper });
 }
 
 describe("useInboxDecisionCount", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetSignalReports.mockResolvedValue({ count: 7, results: [] });
+    filterMocks.priorityFilter = ["P1"];
+    filterMocks.reportStateFilter = ["review_and_merge", "needs_decision"];
+    mockGetSignalReports.mockImplementation(async (params) => ({
+      count: params.has_implementation_pr ? 2 : 3,
+      results: [],
+    }));
   });
 
-  it("loads only a one-row server count for the navigation badge", async () => {
+  it("counts the active report groups with the configured priority filter", async () => {
     const { result } = renderCount(true);
 
-    await waitFor(() => expect(result.current).toBe(7));
-    expect(mockGetSignalReports).toHaveBeenCalledOnce();
-    expect(mockGetSignalReports).toHaveBeenCalledWith(
-      expect.objectContaining({
-        count_only: true,
-        priority: undefined,
-        source_product: undefined,
-        status: "ready",
-      }),
+    await waitFor(() => expect(result.current).toBe(5));
+    expect(mockGetSignalReports).toHaveBeenCalledTimes(2);
+    expect(mockGetSignalReports.mock.calls.map(([params]) => params)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          count_only: true,
+          has_implementation_pr: true,
+          priority: "P1",
+          status: "ready",
+        }),
+        expect.objectContaining({
+          actionability: "immediately_actionable,requires_human_input",
+          count_only: true,
+          has_implementation_pr: false,
+          priority: "P1",
+          status: "ready,pending_input",
+        }),
+      ]),
     );
+  });
+
+  it("shows no badge when the status filter hides active reports", () => {
+    filterMocks.reportStateFilter = ["resolved", "dismissed"];
+
+    expect(renderCount(true).result.current).toBe(0);
+    expect(mockGetSignalReports).not.toHaveBeenCalled();
   });
 
   it("does not request a count when the navigation item is unavailable", () => {

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxDecisionCount.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxDecisionCount.ts
@@ -1,6 +1,8 @@
 import {
   buildPriorityFilterParam,
   buildSuggestedReviewerFilterParam,
+  INBOX_ACTIONABLE_ACTIONABILITY_FILTER,
+  INBOX_ACTIONABLE_REPORT_STATUS_FILTER,
 } from "@posthog/core/inbox/reportFiltering";
 import {
   INBOX_SCOPE_FOR_YOU,
@@ -12,55 +14,74 @@ import { useInboxReports } from "@posthog/ui/features/inbox/hooks/useInboxReport
 import { useInboxReviewerScopeStore } from "@posthog/ui/features/inbox/stores/inboxReviewerScopeStore";
 import { useInboxSignalsFilterStore } from "@posthog/ui/features/inbox/stores/inboxSignalsFilterStore";
 
-const EMPTY_FILTER_ARRAY: never[] = [];
-
 /**
- * The navigation badge needs only the ready-report count. Keeping it separate
- * from `useInboxSectionCounts` avoids polling the other two section counts on
- * every route.
+ * The navigation badge counts the active report groups selected in the Inbox.
+ * Keeping it separate from `useInboxSectionCounts` avoids polling terminal
+ * section counts on every route.
  */
-export function useInboxDecisionCount(options?: {
-  enabled?: boolean;
-  ignoreFilters?: boolean;
-}): number {
+export function useInboxDecisionCount(options?: { enabled?: boolean }): number {
   const enabled = options?.enabled ?? true;
-  const ignoreFilters = options?.ignoreFilters ?? false;
   const scope = useInboxReviewerScopeStore((state) => state.scope);
-  const sourceProductFilter = useInboxSignalsFilterStore((state) =>
-    ignoreFilters ? EMPTY_FILTER_ARRAY : state.sourceProductFilter,
+  const priorityFilter = useInboxSignalsFilterStore(
+    (state) => state.priorityFilter,
   );
-  const priorityFilter = useInboxSignalsFilterStore((state) =>
-    ignoreFilters ? EMPTY_FILTER_ARRAY : state.priorityFilter,
+  const reportStateFilter = useInboxSignalsFilterStore(
+    (state) => state.reportStateFilter,
   );
+  const showAllStates = reportStateFilter.length === 0;
+  const showReviewAndMerge =
+    showAllStates || reportStateFilter.includes("review_and_merge");
+  const showNeedsDecision =
+    showAllStates || reportStateFilter.includes("needs_decision");
+  const shouldCount = enabled && (showReviewAndMerge || showNeedsDecision);
   const isForYou = scope === INBOX_SCOPE_FOR_YOU;
   const teammateUuid = parseTeammateInboxScope(scope);
   const client = useOptionalAuthenticatedClient();
   const { data: currentUser } = useCurrentUser({
     client,
-    enabled: enabled && isForYou && teammateUuid === null,
+    enabled: shouldCount && isForYou && teammateUuid === null,
   });
   const reviewerUuid =
     teammateUuid ?? (isForYou ? (currentUser?.uuid ?? null) : null);
   const scopeReady = !isForYou || reviewerUuid !== null;
-  const query = useInboxReports(
+  const sharedFilters = {
+    priority: buildPriorityFilterParam(priorityFilter),
+    suggested_reviewers: reviewerUuid
+      ? buildSuggestedReviewerFilterParam([reviewerUuid])
+      : undefined,
+    count_only: true,
+  };
+  const queryOptions = {
+    refetchInterval: 60_000,
+    refetchIntervalInBackground: false,
+  };
+  const reviewAndMergeQuery = useInboxReports(
     {
+      ...sharedFilters,
       status: "ready",
-      source_product:
-        sourceProductFilter.length > 0
-          ? sourceProductFilter.join(",")
-          : undefined,
-      priority: buildPriorityFilterParam(priorityFilter),
-      suggested_reviewers: reviewerUuid
-        ? buildSuggestedReviewerFilterParam([reviewerUuid])
-        : undefined,
-      count_only: true,
+      has_implementation_pr: true,
     },
     {
-      enabled: enabled && scopeReady,
-      refetchInterval: 60_000,
-      refetchIntervalInBackground: false,
+      ...queryOptions,
+      enabled: shouldCount && showReviewAndMerge && scopeReady,
+    },
+  );
+  const needsDecisionQuery = useInboxReports(
+    {
+      ...sharedFilters,
+      status: INBOX_ACTIONABLE_REPORT_STATUS_FILTER,
+      actionability: INBOX_ACTIONABLE_ACTIONABILITY_FILTER,
+      has_implementation_pr: false,
+    },
+    {
+      ...queryOptions,
+      enabled: shouldCount && showNeedsDecision && scopeReady,
     },
   );
 
-  return enabled ? (query.data?.count ?? 0) : 0;
+  if (!shouldCount) return 0;
+  return (
+    (reviewAndMergeQuery.data?.count ?? 0) +
+    (needsDecisionQuery.data?.count ?? 0)
+  );
 }

--- a/products/desktop/packages/ui/src/features/inbox/stores/inboxSignalsFilterStore.test.ts
+++ b/products/desktop/packages/ui/src/features/inbox/stores/inboxSignalsFilterStore.test.ts
@@ -127,6 +127,29 @@ describe("inboxSignalsFilterStore", () => {
     expect(persisted.state.priorityFilter).toEqual(["P0", "P1"]);
   });
 
+  it("restores filter and sort preferences after a restart", async () => {
+    const store = useInboxSignalsFilterStore.getState();
+    store.setSort("created_at", "asc");
+    store.setPriorityFilter(["P0", "P1"]);
+    store.setReportStateFilter(["dismissed"]);
+    const persisted = localStorage.getItem("inbox-signals-filter-storage");
+
+    useInboxSignalsFilterStore.setState({
+      sortField: "total_weight",
+      sortDirection: "desc",
+      priorityFilter: [],
+      reportStateFilter: ["review_and_merge", "needs_decision"],
+    });
+    localStorage.setItem("inbox-signals-filter-storage", persisted as string);
+    await useInboxSignalsFilterStore.persist.rehydrate();
+
+    const restored = useInboxSignalsFilterStore.getState();
+    expect(restored.sortField).toBe("created_at");
+    expect(restored.sortDirection).toBe("asc");
+    expect(restored.priorityFilter).toEqual(["P0", "P1"]);
+    expect(restored.reportStateFilter).toEqual(["dismissed"]);
+  });
+
   it("resetFilters restores defaults across surviving filter fields", () => {
     const store = useInboxSignalsFilterStore.getState();
     store.setSearchQuery("hello");


### PR DESCRIPTION
## Problem

Desktop users can see an Inbox badge after their active filters hide every report that needs action.

The compact nav rail ignored saved filters, and the badge counted one broad ready status instead of the filtered report groups.

## Changes

- The badge now counts selected Review and merge and Needs decision groups under the current priority and reviewer filters.
- Terminal-only status filters now remove the badge and skip unnecessary count requests.
- The filter store now has a restart rehydration regression test.
- No screenshot: the layout and styling are unchanged; only the badge value changes.

## How did you test this code?

- `pnpm --filter @posthog/ui test -- src/features/inbox/hooks/useInboxDecisionCount.test.tsx src/features/inbox/stores/inboxSignalsFilterStore.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `uv run hogli ci:preflight --fix`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the desktop Inbox architecture note. No public documentation change is required.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The PostHog Slack app implemented and tested this change from the linked Slack thread.

Skills: `/posthog-desktop`, `/writing-tests`, and `/writing-pr-descriptions`. `/writing-kea-logics` was inspected, then excluded because Desktop uses Zustand.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1788424377470369?thread_ts=1788424377.470369&cid=C0ACRAMJUAG)*