### PR TITLE
chore(replay-vision): drop the legacy vision action tables

### DIFF
--- a/products/replay_vision/backend/migrations/0089_drop_vision_action_tables.py
+++ b/products/replay_vision/backend/migrations/0089_drop_vision_action_tables.py
@@ -1,0 +1,22 @@
+# Generated manually - drops the legacy vision action tables.
+# Second step after 0086 removed both models from Django state.
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("replay_vision", "0088_remap_scanner_models_gemini_3_8"),
+    ]
+
+    # Runs first: the run table's foreign key references the action table.
+    operations = [
+        migrations.RunSQL(
+            sql="DROP TABLE IF EXISTS replay_vision_visionactionrun;",
+            reverse_sql="",  # No reverse - the rows are gone with the table.
+        ),
+        migrations.RunSQL(
+            sql="DROP TABLE IF EXISTS replay_vision_visionaction;",
+            reverse_sql="",
+        ),
+    ]

--- a/products/replay_vision/backend/migrations/0089_drop_vision_action_tables.py
+++ b/products/replay_vision/backend/migrations/0089_drop_vision_action_tables.py
@@ -9,14 +9,17 @@ class Migration(migrations.Migration):
         ("replay_vision", "0088_remap_scanner_models_gemini_3_8"),
     ]
 
-    # Runs first: the run table's foreign key references the action table.
+    # Both tables carry foreign keys to posthog_team and posthog_user, so dropping them takes a
+    # brief ACCESS EXCLUSIVE lock on those hot tables to remove the referential triggers. The local
+    # timeout keeps a lost lock race from queueing behind in-flight traffic; bin/migrate retries.
     operations = [
+        # The run table goes first: its foreign key references the action table.
         migrations.RunSQL(
-            sql="DROP TABLE IF EXISTS replay_vision_visionactionrun;",
+            sql="SET LOCAL lock_timeout = '2s'; DROP TABLE IF EXISTS replay_vision_visionactionrun;",
             reverse_sql="",  # No reverse - the rows are gone with the table.
         ),
         migrations.RunSQL(
-            sql="DROP TABLE IF EXISTS replay_vision_visionaction;",
+            sql="SET LOCAL lock_timeout = '2s'; DROP TABLE IF EXISTS replay_vision_visionaction;",
             reverse_sql="",
         ),
     ]

--- a/products/replay_vision/backend/migrations/max_migration.txt
+++ b/products/replay_vision/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0088_remap_scanner_models_gemini_3_8
+0089_drop_vision_action_tables


### PR DESCRIPTION
## Problem

Nobody sees a difference. `replay_vision_visionaction` and `replay_vision_visionactionrun` have held no live data since the vision actions migration ran in both regions, and #92983 removed their models from Django state. The tables have outlived the code that read them.

## Changes

- One migration, `0089`, drops both tables with `RunSQL`. It is the second step of the retirement that `0086` started, per `safe-django-migrations.md` "Dropping Tables".
- The run table drops first, because its foreign key references the action table. The other order fails outright, since Postgres refuses to drop a table another one still references.
- Each statement sets a 2 second local `lock_timeout`. Both tables carry foreign keys to `posthog_team` and `posthog_user`, so the drop briefly takes `ACCESS EXCLUSIVE` on those hot tables to remove the referential triggers. The work is metadata-only, but a lost lock race would otherwise queue behind live traffic for the default 20 seconds. `bin/migrate` retries.
- Both statements use `IF EXISTS`, so a retried `bin/migrate` is a no-op rather than a failure.
- No reverse SQL: recreating an empty table would not bring the rows back, so the migration is honestly irreversible.

> [!WARNING]
> This deletes the migration's audit trail. Each row carried a `migrated_to` or `retired` stamp naming the scout or alert that replaced it, and that mapping exists nowhere else. Shipping this is a deliberate decision to keep the outcome and drop the provenance.

**Safety window:** #92983 merged on 2026-09-02, and its state removal is live in prod US and EU, confirmed on 2026-09-03 by checking that the model module is absent from the running image in both regions.

## How did you test this code?

- `analyze_migration_risk` reports "Validated staged drop: Found prior SeparateDatabaseAndState that removed model from state" for both operations.
- `sqlmigrate` emits both statements, run table first, inside one transaction.
- `makemigrations --check` reports no state drift; `hogli ci:preflight` clean; ruff clean.
- Not verified: that prod carries no unexpected inbound foreign key beyond the run-to-action one the app defines. That check needs a live session I lost. `DROP TABLE` without `CASCADE` fails loudly rather than cascading, so the failure mode is a blocked deploy, not silent data loss. Worth running before this merges.

## Automatic notifications

- [ ] Publish changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code in Tue's session, the last database step of the #92983 cleanup, on Tue's explicit go for the audit-trail tradeoff above.
- Skills invoked: `/django-migrations`.
- Follows `posthog/migrations/0958_drop_teamcoreeventsconfig_table.py`, the house precedent for a second-step table drop.
- A review pass caught the incidental hot-table lock, which is why the `lock_timeout` is there. The analyzer's staged-drop detection uses a substring search, so the added `SET LOCAL` does not hide the drop from it, and that was checked rather than assumed.