### PR TITLE
fix(desktop): show archive progress in every sidebar

### DIFF
--- a/products/desktop/packages/ui/src/features/archive/useArchiveTask.test.ts
+++ b/products/desktop/packages/ui/src/features/archive/useArchiveTask.test.ts
@@ -1,12 +1,58 @@
 import type { Schemas } from "@posthog/api-client";
-import { QueryClient } from "@tanstack/react-query";
-import { describe, expect, it } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useArchivingTasksStore } from "../sidebar/archivingTasksStore";
 import { taskKeys } from "../tasks/taskKeys";
-import { getCachedArchiveTask } from "./useArchiveTask";
 
-describe("getCachedArchiveTask", () => {
+const mocks = vi.hoisted(() => ({
+  archiveTask: vi.fn(),
+}));
+
+vi.mock(
+  "@posthog/core/archive/archiveOrchestration",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@posthog/core/archive/archiveOrchestration")
+    >()),
+    archiveTask: mocks.archiveTask,
+  }),
+);
+vi.mock("@posthog/di/container", () => ({
+  resolveService: () => ({}),
+}));
+vi.mock("@posthog/host-router/react", () => ({
+  useHostTRPC: () => ({
+    archive: {
+      archivedTaskIds: { queryKey: () => ["archived-task-ids"] },
+      list: { queryKey: () => ["archive-list"] },
+      pathFilter: () => ({ queryKey: ["archive-path-filter"] }),
+    },
+  }),
+}));
+vi.mock("./useUnarchiveTask", () => ({
+  useUnarchiveTask: () => ({ restore: vi.fn() }),
+}));
+vi.mock("@posthog/ui/primitives/toast", () => ({
+  toast: { success: vi.fn(), dismiss: vi.fn() },
+}));
+
+import { getCachedArchiveTask, useArchiveTask } from "./useArchiveTask";
+
+let queryClient: QueryClient;
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useArchiveTask", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient();
+    useArchivingTasksStore.setState({ archivingTaskIds: new Set() });
+  });
+
   it("reads metadata from a task summary when no full list is cached", () => {
-    const queryClient = new QueryClient();
     const summary = {
       id: "task-1",
       title: "Archived from sidebar",
@@ -20,4 +66,38 @@ describe("getCachedArchiveTask", () => {
 
     expect(getCachedArchiveTask(queryClient, summary.id)).toEqual(summary);
   });
+
+  it.each(["success", "failure"] as const)(
+    "marks a task as archiving before slow work and clears it after %s",
+    async (outcome) => {
+      let settle: () => void = () => undefined;
+      mocks.archiveTask.mockImplementation(
+        () =>
+          new Promise<void>((resolve, reject) => {
+            settle = () =>
+              outcome === "success" ? resolve() : reject(new Error("failed"));
+          }),
+      );
+      const { result } = renderHook(() => useArchiveTask(), { wrapper });
+
+      const archivePromise = result.current.archiveTask({ taskId: "task-1" });
+
+      expect(useArchivingTasksStore.getState().isArchiving("task-1")).toBe(
+        true,
+      );
+      expect(mocks.archiveTask).toHaveBeenCalledWith(
+        "task-1",
+        expect.any(Object),
+        expect.objectContaining({ optimistic: false }),
+      );
+      settle();
+      await act(async () => {
+        if (outcome === "success") await archivePromise;
+        else await expect(archivePromise).rejects.toThrow("failed");
+      });
+      expect(useArchivingTasksStore.getState().isArchiving("task-1")).toBe(
+        false,
+      );
+    },
+  );
 });

--- a/products/desktop/packages/ui/src/features/archive/useArchiveTask.test.ts
+++ b/products/desktop/packages/ui/src/features/archive/useArchiveTask.test.ts
@@ -49,7 +49,10 @@ describe("useArchiveTask", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     queryClient = new QueryClient();
-    useArchivingTasksStore.setState({ archivingTaskIds: new Set() });
+    useArchivingTasksStore.setState({
+      archivingTaskIds: new Set(),
+      hiddenArchivingTaskIds: new Set(),
+    });
   });
 
   it("reads metadata from a task summary when no full list is cached", () => {

--- a/products/desktop/packages/ui/src/features/archive/useArchiveTask.ts
+++ b/products/desktop/packages/ui/src/features/archive/useArchiveTask.ts
@@ -22,6 +22,7 @@ import type { Task } from "@posthog/shared/domain-types";
 import { useReviewViewedStore } from "@posthog/ui/features/code-review/reviewViewedStore";
 import { useCommandCenterStore } from "@posthog/ui/features/command-center/commandCenterStore";
 import { useFocusStore } from "@posthog/ui/features/focus/focusStore";
+import { useArchivingTasksStore } from "@posthog/ui/features/sidebar/archivingTasksStore";
 import { pinnedTasksApi } from "@posthog/ui/features/sidebar/taskMetaApi";
 import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
 import { destroyTaskTerminals } from "@posthog/ui/features/terminal/destroyTaskTerminals";
@@ -227,21 +228,30 @@ export function useArchiveTask(options?: {
   const { restore } = useUnarchiveTask();
 
   const archiveTask = async ({ taskId }: { taskId: string }) => {
-    await archiveTaskImperative(taskId, queryClient, keys, {
-      navigateUnscoped: options?.navigateUnscoped,
-    });
-    const toastId = `archive-undo-${taskId}`;
-    toast.success("Task archived", {
-      id: toastId,
-      duration: UNDO_TOAST_DURATION_MS,
-      action: {
-        label: "Undo",
-        onClick: () => {
-          toast.dismiss(toastId);
-          void undoArchive(taskId, restore);
+    const store = useArchivingTasksStore.getState();
+    if (store.isArchiving(taskId)) return;
+
+    store.startArchiving(taskId);
+    try {
+      await archiveTaskImperative(taskId, queryClient, keys, {
+        optimistic: false,
+        navigateUnscoped: options?.navigateUnscoped,
+      });
+      const toastId = `archive-undo-${taskId}`;
+      toast.success("Task archived", {
+        id: toastId,
+        duration: UNDO_TOAST_DURATION_MS,
+        action: {
+          label: "Undo",
+          onClick: () => {
+            toast.dismiss(toastId);
+            void undoArchive(taskId, restore);
+          },
         },
-      },
-    });
+      });
+    } finally {
+      useArchivingTasksStore.getState().stopArchiving(taskId);
+    }
   };
 
   return { archiveTask };

--- a/products/desktop/packages/ui/src/features/archive/useTaskArchive.tsx
+++ b/products/desktop/packages/ui/src/features/archive/useTaskArchive.tsx
@@ -92,18 +92,14 @@ export function useTaskArchive(
 
   const runArchive = useCallback(async () => {
     if (!taskId) return;
-    const store = useArchivingTasksStore.getState();
-    if (store.isArchiving(taskId)) return;
+    if (useArchivingTasksStore.getState().isArchiving(taskId)) return;
 
-    store.startArchiving(taskId);
     try {
       await archiveTask({ taskId });
     } catch (error) {
       log.error("Failed to archive task", error);
       toast.error("Failed to archive task");
       throw error;
-    } finally {
-      useArchivingTasksStore.getState().stopArchiving(taskId);
     }
   }, [archiveTask, taskId]);
 

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -140,7 +140,10 @@ beforeEach(() => {
   mocks.openBrowserTab.mockClear();
   useSidebarStore.setState({ listItemMetadataFields: [] });
   usePendingCanvasDeleteStore.setState({ pending: {} });
-  useArchivingTasksStore.setState({ archivingTaskIds: new Set() });
+  useArchivingTasksStore.setState({
+    archivingTaskIds: new Set(),
+    hiddenArchivingTaskIds: new Set(),
+  });
   useTaskSelectionStore.setState({
     selectedTaskIds: [],
     lastClickedId: null,
@@ -160,6 +163,7 @@ describe("ChannelItemRow", () => {
       <ChannelItemRow
         actions={pendingActions}
         isActive={false}
+        isEditing
         item={item()}
       />,
     );
@@ -167,6 +171,9 @@ describe("ChannelItemRow", () => {
     const row = screen.getByRole("button");
     expect(row.className).toContain("opacity-50");
     expect(row.draggable).toBe(false);
+    expect(row).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByText("Archiving")).toHaveClass("sr-only");
+    expect(screen.queryByRole("textbox")).toBeNull();
 
     fireEvent.click(row);
     fireEvent.contextMenu(row);

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -2,6 +2,7 @@ import type { ChannelItemModel } from "@posthog/core/canvas/channelItems";
 import { formatRelativeTimeShort } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { CANVAS_DRAG_TYPE } from "@posthog/ui/features/canvas/canvasDrag";
+import { useArchivingTasksStore } from "@posthog/ui/features/sidebar/archivingTasksStore";
 import type { TaskStatusInput } from "@posthog/ui/features/sidebar/components/items/taskStatusVocabulary";
 import {
   beginSidebarPeek,
@@ -139,6 +140,7 @@ beforeEach(() => {
   mocks.openBrowserTab.mockClear();
   useSidebarStore.setState({ listItemMetadataFields: [] });
   usePendingCanvasDeleteStore.setState({ pending: {} });
+  useArchivingTasksStore.setState({ archivingTaskIds: new Set() });
   useTaskSelectionStore.setState({
     selectedTaskIds: [],
     lastClickedId: null,
@@ -146,7 +148,32 @@ beforeEach(() => {
 });
 
 describe("ChannelItemRow", () => {
-  // This table keeps task state labels consistent across all task rows.
+  it("dims an archiving task and blocks its row actions", () => {
+    const pendingActions = {
+      ...actions,
+      open: vi.fn(),
+      togglePin: vi.fn(),
+      archive: vi.fn(),
+    };
+    useArchivingTasksStore.getState().startArchiving("task-1");
+    renderInList(
+      <ChannelItemRow
+        actions={pendingActions}
+        isActive={false}
+        item={item()}
+      />,
+    );
+
+    const row = screen.getByRole("button");
+    expect(row.className).toContain("opacity-50");
+    expect(row.draggable).toBe(false);
+
+    fireEvent.click(row);
+    fireEvent.contextMenu(row);
+    expect(pendingActions.open).not.toHaveBeenCalled();
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
   it.each([
     ["a permission prompt", { needsPermission: true }, "Needs your input"],
     [

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
@@ -295,11 +295,14 @@ export function ChannelItemRowView({
       // The space's lists follow web conventions — every clickable row shows a
       // pointer, like the feed and activity rows — unlike the Code sidebar,
       // which keeps SidebarItem's native cursor-default.
-      className="cursor-pointer"
+      className={isArchiving ? "cursor-default" : "cursor-pointer"}
       depth={0}
       icon={
         isArchiving ? (
-          <DotsCircleSpinner size={12} className="text-muted-foreground" />
+          <>
+            <DotsCircleSpinner size={12} className="text-muted-foreground" />
+            <span className="sr-only">Archiving</span>
+          </>
         ) : (
           <ChannelItemDot item={item} status={status} />
         )
@@ -309,7 +312,9 @@ export function ChannelItemRowView({
       subtitle={subtitle}
       isActive={isActive}
       isSelected={isSelected}
+      aria-busy={isArchiving || undefined}
       isDimmed={isArchiving}
+      disabled={isArchiving}
       // Lets a drag-selection find the row and its session; canvases are not
       // selectable, so they stay unmarked and the marquee passes over them.
       {...(item.kind === "task" ? { [SESSION_ROW_ATTRIBUTE]: item.id } : {})}
@@ -396,9 +401,16 @@ export function ChannelItemRow({
 }) {
   const status = useChannelTaskStatus(item);
   const subtitle = useChannelItemMetadata(item);
-  const isArchiving = useArchivingTasksStore(
-    (state) => item.kind === "task" && state.archivingTaskIds.has(item.id),
+  const archivePresentation = useArchivingTasksStore((state) =>
+    item.kind !== "task"
+      ? null
+      : state.hiddenArchivingTaskIds.has(item.id)
+        ? "hidden"
+        : state.archivingTaskIds.has(item.id)
+          ? "progress"
+          : null,
   );
+  const isArchiving = archivePresentation === "progress";
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const [handoffOpen, setHandoffOpen] = useState(false);
   const handoffMounted = useMountedOnceOpened(handoffOpen);
@@ -483,7 +495,9 @@ export function ChannelItemRow({
     ],
   );
 
-  if (isEditing) {
+  if (archivePresentation === "hidden") return null;
+
+  if (isEditing && !isArchiving) {
     return (
       <InlineEditInput
         depth={0}

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
@@ -32,6 +32,7 @@ import { useChannelItemMetadata } from "@posthog/ui/features/canvas/hooks/useCha
 import { useChannelTaskStatus } from "@posthog/ui/features/canvas/hooks/useChannelTaskStatus";
 import { useIsCanvasPendingDelete } from "@posthog/ui/features/canvas/stores/pendingCanvasDeleteStore";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
+import { useArchivingTasksStore } from "@posthog/ui/features/sidebar/archivingTasksStore";
 import { InlineEditInput } from "@posthog/ui/features/sidebar/components/items/TaskItem";
 import {
   PinnedBadge,
@@ -50,6 +51,7 @@ import { SESSION_ROW_ATTRIBUTE } from "@posthog/ui/features/sidebar/useMarqueeSe
 import { HandoffTaskDialog } from "@posthog/ui/features/task-detail/components/HandoffTaskDialog";
 import { useMountedOnceOpened } from "@posthog/ui/hooks/useMountedOnceOpened";
 import { useNow } from "@posthog/ui/hooks/useNow";
+import { DotsCircleSpinner } from "@posthog/ui/primitives/DotsCircleSpinner";
 import {
   type DragEvent,
   type ReactNode,
@@ -265,6 +267,7 @@ export function ChannelItemRowView({
   subtitle,
   isActive,
   isSelected = false,
+  isArchiving = false,
   showPinBadge = true,
   draggable = false,
   currentUserUuid,
@@ -278,6 +281,7 @@ export function ChannelItemRowView({
   subtitle?: ReactNode;
   isActive: boolean;
   isSelected?: boolean;
+  isArchiving?: boolean;
   showPinBadge?: boolean;
   draggable?: boolean;
   currentUserUuid?: string;
@@ -293,16 +297,23 @@ export function ChannelItemRowView({
       // which keeps SidebarItem's native cursor-default.
       className="cursor-pointer"
       depth={0}
-      icon={<ChannelItemDot item={item} status={status} />}
+      icon={
+        isArchiving ? (
+          <DotsCircleSpinner size={12} className="text-muted-foreground" />
+        ) : (
+          <ChannelItemDot item={item} status={status} />
+        )
+      }
       // A non-string label opts out of SidebarItem's truncation tooltip.
       label={<span>{item.title}</span>}
       subtitle={subtitle}
       isActive={isActive}
       isSelected={isSelected}
+      isDimmed={isArchiving}
       // Lets a drag-selection find the row and its session; canvases are not
       // selectable, so they stay unmarked and the marquee passes over them.
       {...(item.kind === "task" ? { [SESSION_ROW_ATTRIBUTE]: item.id } : {})}
-      draggable={draggable}
+      draggable={draggable && !isArchiving}
       onDragStart={onDragStart}
       onDragEnd={onDragEnd}
       onClick={onClick}
@@ -385,6 +396,9 @@ export function ChannelItemRow({
 }) {
   const status = useChannelTaskStatus(item);
   const subtitle = useChannelItemMetadata(item);
+  const isArchiving = useArchivingTasksStore(
+    (state) => item.kind === "task" && state.archivingTaskIds.has(item.id),
+  );
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const [handoffOpen, setHandoffOpen] = useState(false);
   const handoffMounted = useMountedOnceOpened(handoffOpen);
@@ -484,25 +498,36 @@ export function ChannelItemRow({
 
   // One tooltip provider per task row, shared by its dot and badges so moving
   // between them doesn't re-wait the open delay. Canvas rows have neither.
-  const row = (
+  const rowView = (
+    <ChannelItemRowView
+      item={item}
+      status={status}
+      subtitle={subtitle}
+      isActive={isActive}
+      isSelected={isSelected}
+      isArchiving={isArchiving}
+      showPinBadge={showPinBadge}
+      draggable
+      currentUserUuid={currentUser.data?.uuid}
+      onDragStart={handleDragStart}
+      onDragEnd={onDragEnd}
+      onClick={
+        isArchiving
+          ? undefined
+          : (e) => (onClick ? onClick(e) : actions.open(item))
+      }
+    />
+  );
+  const row = isArchiving ? (
+    rowView
+  ) : (
     <ChannelItemHoverCard item={item} menu={menu}>
-      <ChannelItemRowView
-        item={item}
-        status={status}
-        subtitle={subtitle}
-        isActive={isActive}
-        isSelected={isSelected}
-        showPinBadge={showPinBadge}
-        draggable
-        currentUserUuid={currentUser.data?.uuid}
-        onDragStart={handleDragStart}
-        onDragEnd={onDragEnd}
-        onClick={(e) => (onClick ? onClick(e) : actions.open(item))}
-      />
+      {rowView}
     </ChannelItemHoverCard>
   );
 
   const tipped = <TaskStatusTooltips>{row}</TaskStatusTooltips>;
+  if (isArchiving) return tipped;
   // Right-click opens the same actions the hover card lists, from the same
   // definition, so the two can't drift.
   return (

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.test.tsx
@@ -170,6 +170,7 @@ import {
   useSidebarSearchStore,
 } from "@posthog/ui/features/canvas/stores/sidebarSearchStore";
 import { useSpaceTreeStore } from "@posthog/ui/features/canvas/stores/spaceTreeStore";
+import { useArchivingTasksStore } from "@posthog/ui/features/sidebar/archivingTasksStore";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { ChannelsList } from "./ChannelsList";
 
@@ -222,6 +223,10 @@ describe("ChannelsList", () => {
     useSpaceTreeStore.setState({
       expandedSpaceIds: new Set(),
       highlightedValue: undefined,
+    });
+    useArchivingTasksStore.setState({
+      archivingTaskIds: new Set(),
+      hiddenArchivingTaskIds: new Set(),
     });
     useSidebarSearchStore.setState({
       focusRequest: 0,
@@ -552,6 +557,26 @@ describe("ChannelsList", () => {
       // Still scoped, so whatever asks for the channel pane next opens on the
       // space the session came from.
       expect(useCurrentChannelStore.getState().currentChannelId).toBe(ENG.id);
+    });
+
+    it("shows inert archive progress for a session in the expanded tree", async () => {
+      const user = userEvent.setup();
+      renderList();
+
+      await user.click(screen.getByLabelText("Expand engineering"));
+      act(() => useArchivingTasksStore.getState().startArchiving("task-new"));
+
+      const row = screen.getByText("Ship the tree").closest("button");
+      expect(row).toHaveAttribute("aria-busy", "true");
+      expect(row).toBeDisabled();
+      expect(screen.getByText("Archiving")).toHaveClass("sr-only");
+
+      if (row) {
+        fireEvent.click(row);
+        fireEvent.contextMenu(row);
+      }
+      expect(mocks.navigate).not.toHaveBeenCalled();
+      expect(screen.queryByRole("menu")).toBeNull();
     });
 
     // The row after the last session: the keyboard has to know about it, or the

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.test.tsx
@@ -568,7 +568,7 @@ describe("ChannelsList", () => {
 
       const row = screen.getByText("Ship the tree").closest("button");
       expect(row).toHaveAttribute("aria-busy", "true");
-      expect(row).toBeDisabled();
+      expect(row).toHaveAttribute("aria-disabled", "true");
       expect(screen.getByText("Archiving")).toHaveClass("sr-only");
 
       if (row) {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -108,6 +108,7 @@ import { requestSidebarSearchFocus } from "@posthog/ui/features/canvas/stores/si
 import { useSpaceTreeStore } from "@posthog/ui/features/canvas/stores/spaceTreeStore";
 import { copyChannelLink } from "@posthog/ui/features/canvas/utils/copyChannelLink";
 import { formatHotkey } from "@posthog/ui/features/command/keyboard-shortcuts";
+import { useArchivingTasksStore } from "@posthog/ui/features/sidebar/archivingTasksStore";
 import {
   TaskBadgeStack,
   TaskStatusDot,
@@ -120,6 +121,7 @@ import {
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { HandoffTaskDialog } from "@posthog/ui/features/task-detail/components/HandoffTaskDialog";
 import { useMountedOnceOpened } from "@posthog/ui/hooks/useMountedOnceOpened";
+import { DotsCircleSpinner } from "@posthog/ui/primitives/DotsCircleSpinner";
 import {
   OverflowTickerText,
   useOverflowTickerReveal,
@@ -453,6 +455,14 @@ const SpaceTaskRow = memo(function SpaceTaskRow({
   // a dozen spaces' worth of rows at once.
   const status = useChannelTaskStatus(item, { withPrStatus: false });
   const actions = useSpaceTaskActionsContext();
+  const archivePresentation = useArchivingTasksStore((state) =>
+    state.hiddenArchivingTaskIds.has(item.id)
+      ? "hidden"
+      : state.archivingTaskIds.has(item.id)
+        ? "progress"
+        : null,
+  );
+  const isArchiving = archivePresentation === "progress";
   // A boolean rather than the value itself, so a keypress re-renders only the
   // two rows whose answer changed.
   const isHighlighted = useSpaceTreeStore(
@@ -495,20 +505,31 @@ const SpaceTaskRow = memo(function SpaceTaskRow({
     [item, spaceId, actions, canHandoff],
   );
 
+  if (archivePresentation === "hidden") return null;
+
   const row = (
     <SpaceRowSurface
       asOption={asOption}
       optionValue={item.key}
       data-selected={isActive || undefined}
-      onClick={() => openTask(spaceId, item.id)}
+      aria-busy={isArchiving || undefined}
+      disabled={isArchiving}
+      onClick={isArchiving ? undefined : () => openTask(spaceId, item.id)}
       // A step in from its space's name, clear of the guide that runs between
       // the two columns.
-      className="pl-8"
+      className={cn("pl-8", isArchiving && "opacity-50")}
     >
       {/* The dot belongs to the title, not to the row: its own tighter gap
           keeps them one mark rather than two columns. */}
       <span className="flex min-w-0 items-center gap-1.5">
-        <TaskStatusDot dot={taskDot(status ?? {})} />
+        {isArchiving ? (
+          <>
+            <DotsCircleSpinner size={12} className="text-muted-foreground" />
+            <span className="sr-only">Archiving</span>
+          </>
+        ) : (
+          <TaskStatusDot dot={taskDot(status ?? {})} />
+        )}
         <span
           className={cn(
             "truncate text-[13px]",
@@ -525,6 +546,9 @@ const SpaceTaskRow = memo(function SpaceTaskRow({
       )}
     </SpaceRowSurface>
   );
+
+  const tipped = <TaskStatusTooltips>{row}</TaskStatusTooltips>;
+  if (isArchiving) return tipped;
 
   return (
     <TaskRowContextMenu menu={menu}>

--- a/products/desktop/packages/ui/src/features/sidebar/archivingTasksStore.test.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/archivingTasksStore.test.ts
@@ -3,7 +3,10 @@ import { useArchivingTasksStore } from "./archivingTasksStore";
 
 describe("archivingTasksStore", () => {
   beforeEach(() => {
-    useArchivingTasksStore.setState({ archivingTaskIds: new Set() });
+    useArchivingTasksStore.setState({
+      archivingTaskIds: new Set(),
+      hiddenArchivingTaskIds: new Set(),
+    });
   });
 
   it("marks a task as archiving and back", () => {
@@ -26,6 +29,17 @@ describe("archivingTasksStore", () => {
     expect(state.isArchiving("task-1")).toBe(true);
     expect(state.isArchiving("task-2")).toBe(true);
     expect(state.isArchiving("task-3")).toBe(false);
+  });
+
+  it("distinguishes bulk rows that disappear from single-task progress", () => {
+    const { startArchiving } = useArchivingTasksStore.getState();
+
+    startArchiving("single-task");
+    startArchiving("bulk-task", "hidden");
+
+    const state = useArchivingTasksStore.getState();
+    expect(state.shouldHideWhileArchiving("single-task")).toBe(false);
+    expect(state.shouldHideWhileArchiving("bulk-task")).toBe(true);
   });
 
   it("is idempotent and keeps a stable reference when nothing changes", () => {

--- a/products/desktop/packages/ui/src/features/sidebar/archivingTasksStore.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/archivingTasksStore.ts
@@ -3,41 +3,53 @@ import { create } from "zustand";
 interface ArchivingTasksState {
   /** Task IDs with an archive request currently in flight. */
   archivingTaskIds: Set<string>;
+  hiddenArchivingTaskIds: Set<string>;
 }
 
 interface ArchivingTasksActions {
   isArchiving: (taskId: string) => boolean;
-  startArchiving: (taskId: string) => void;
+  shouldHideWhileArchiving: (taskId: string) => boolean;
+  startArchiving: (
+    taskId: string,
+    presentation?: "progress" | "hidden",
+  ) => void;
   stopArchiving: (taskId: string) => void;
 }
 
 type ArchivingTasksStore = ArchivingTasksState & ArchivingTasksActions;
 
 /**
- * Tracks which tasks are mid-archive so the sidebar can show a per-row spinner
- * and treat clicks, pin toggles, and right-clicks on those rows as no-ops until
- * the archive resolves.
+ * Tracks which tasks are mid-archive so single-task actions can render progress
+ * while bulk actions remove rows immediately. Pending rows ignore interactions
+ * until the archive resolves.
  */
 export const useArchivingTasksStore = create<ArchivingTasksStore>(
   (set, get) => ({
     archivingTaskIds: new Set(),
+    hiddenArchivingTaskIds: new Set(),
 
     isArchiving: (taskId) => get().archivingTaskIds.has(taskId),
+    shouldHideWhileArchiving: (taskId) =>
+      get().hiddenArchivingTaskIds.has(taskId),
 
-    startArchiving: (taskId) =>
+    startArchiving: (taskId, presentation = "progress") =>
       set((state) => {
         if (state.archivingTaskIds.has(taskId)) return state;
-        const next = new Set(state.archivingTaskIds);
-        next.add(taskId);
-        return { archivingTaskIds: next };
+        const archivingTaskIds = new Set(state.archivingTaskIds);
+        archivingTaskIds.add(taskId);
+        const hiddenArchivingTaskIds = new Set(state.hiddenArchivingTaskIds);
+        if (presentation === "hidden") hiddenArchivingTaskIds.add(taskId);
+        return { archivingTaskIds, hiddenArchivingTaskIds };
       }),
 
     stopArchiving: (taskId) =>
       set((state) => {
         if (!state.archivingTaskIds.has(taskId)) return state;
-        const next = new Set(state.archivingTaskIds);
-        next.delete(taskId);
-        return { archivingTaskIds: next };
+        const archivingTaskIds = new Set(state.archivingTaskIds);
+        archivingTaskIds.delete(taskId);
+        const hiddenArchivingTaskIds = new Set(state.hiddenArchivingTaskIds);
+        hiddenArchivingTaskIds.delete(taskId);
+        return { archivingTaskIds, hiddenArchivingTaskIds };
       }),
   }),
 );

--- a/products/desktop/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
@@ -358,7 +358,6 @@ function SidebarMenuComponent() {
           error: new Error("Task is already archiving"),
         };
       }
-      store.startArchiving(taskId);
       try {
         await archiveTask({ taskId });
         return { success: true as const };
@@ -366,8 +365,6 @@ function SidebarMenuComponent() {
         log.error("Failed to archive task", error);
         toast.error("Failed to archive task");
         return { success: false as const, error };
-      } finally {
-        useArchivingTasksStore.getState().stopArchiving(taskId);
       }
     },
     [archiveTask],

--- a/products/desktop/packages/ui/src/features/sidebar/components/TaskListView.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/TaskListView.stories.tsx
@@ -1,7 +1,8 @@
 import type { TaskData } from "@posthog/core/sidebar/sidebarData.types";
+import { useArchivingTasksStore } from "@posthog/ui/features/sidebar/archivingTasksStore";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { fn } from "storybook/test";
 import { TaskListView } from "./TaskListView";
 
@@ -68,6 +69,15 @@ function StatefulTaskList(args: React.ComponentProps<typeof TaskListView>) {
   );
 }
 
+function ArchivingTaskList(args: React.ComponentProps<typeof TaskListView>) {
+  useEffect(() => {
+    useArchivingTasksStore.getState().startArchiving("task-2");
+    return () => useArchivingTasksStore.getState().stopArchiving("task-2");
+  }, []);
+
+  return <StatefulTaskList {...args} />;
+}
+
 const meta = {
   title: "Sidebar/Task list drag and drop",
   component: TaskListView,
@@ -112,3 +122,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const Archiving: Story = {
+  render: (args) => <ArchivingTaskList {...args} />,
+};

--- a/products/desktop/packages/ui/src/features/sidebar/components/TaskRow.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/TaskRow.tsx
@@ -67,8 +67,6 @@ export function TaskRow({
     state.archivingTaskIds.has(task.id),
   );
 
-  if (isArchiving) return null;
-
   return (
     <TaskItem
       depth={depth}
@@ -77,6 +75,7 @@ export function TaskRow({
       subtitle={subtitle}
       isActive={isActive}
       isSelected={isSelected}
+      isArchiving={isArchiving}
       hideHoverActions={hideHoverActions}
       isEditing={isEditing}
       workspaceMode={effectiveMode}

--- a/products/desktop/packages/ui/src/features/sidebar/components/TaskRow.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/TaskRow.tsx
@@ -63,9 +63,14 @@ export function TaskRow({
     cloudPrUrl: task.cloudPrUrl,
     taskRunEnvironment: task.taskRunEnvironment,
   });
-  const isArchiving = useArchivingTasksStore((state) =>
-    state.archivingTaskIds.has(task.id),
+  const archivePresentation = useArchivingTasksStore((state) =>
+    state.hiddenArchivingTaskIds.has(task.id)
+      ? "hidden"
+      : state.archivingTaskIds.has(task.id)
+        ? "progress"
+        : null,
   );
+  if (archivePresentation === "hidden") return null;
 
   return (
     <TaskItem
@@ -75,7 +80,7 @@ export function TaskRow({
       subtitle={subtitle}
       isActive={isActive}
       isSelected={isSelected}
-      isArchiving={isArchiving}
+      isArchiving={archivePresentation === "progress"}
       hideHoverActions={hideHoverActions}
       isEditing={isEditing}
       workspaceMode={effectiveMode}

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/TaskItem.test.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/TaskItem.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { InlineEditInput } from "./TaskItem";
+import { InlineEditInput, TaskItem } from "./TaskItem";
 
 describe("InlineEditInput", () => {
   afterEach(() => {
@@ -30,5 +30,43 @@ describe("InlineEditInput", () => {
     await waitFor(() => expect(input).toHaveFocus());
     expect(input).toHaveProperty("selectionStart", 0);
     expect(input).toHaveProperty("selectionEnd", "Original title".length);
+  });
+});
+
+describe("TaskItem", () => {
+  it("renders inert archive progress instead of edit or pull request actions", () => {
+    const onClick = vi.fn();
+    const onDoubleClick = vi.fn();
+    const onContextMenu = vi.fn();
+    const { container } = render(
+      <TaskItem
+        taskId="task-1"
+        label="Archive me"
+        isActive={false}
+        isArchiving
+        isEditing
+        prUrl="https://github.com/PostHog/posthog/pull/123"
+        onClick={onClick}
+        onDoubleClick={onDoubleClick}
+        onContextMenu={onContextMenu}
+      />,
+    );
+
+    const row = screen.getByText("Archive me").closest("button");
+    expect(row).toHaveAttribute("aria-busy", "true");
+    expect(row).toBeDisabled();
+    expect(screen.getByText("Archiving")).toHaveClass("sr-only");
+    expect(container.querySelector("[aria-hidden='true']")).not.toBeNull();
+    expect(screen.queryByRole("textbox")).toBeNull();
+    expect(screen.queryByLabelText("Open pull request #123")).toBeNull();
+
+    if (row) {
+      fireEvent.click(row);
+      fireEvent.doubleClick(row);
+      fireEvent.contextMenu(row);
+    }
+    expect(onClick).not.toHaveBeenCalled();
+    expect(onDoubleClick).not.toHaveBeenCalled();
+    expect(onContextMenu).not.toHaveBeenCalled();
   });
 });

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/TaskItem.test.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/TaskItem.test.tsx
@@ -54,7 +54,7 @@ describe("TaskItem", () => {
 
     const row = screen.getByText("Archive me").closest("button");
     expect(row).toHaveAttribute("aria-busy", "true");
-    expect(row).toBeDisabled();
+    expect(row).toHaveAttribute("aria-disabled", "true");
     expect(screen.getByText("Archiving")).toHaveClass("sr-only");
     expect(container.querySelector("[aria-hidden='true']")).not.toBeNull();
     expect(screen.queryByRole("textbox")).toBeNull();

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
@@ -144,7 +144,10 @@ export function TaskItem({
   onEditCancel,
 }: TaskItemProps) {
   const icon = isArchiving ? (
-    <DotsCircleSpinner size={ICON_SIZE} className="text-gray-10" />
+    <>
+      <DotsCircleSpinner size={ICON_SIZE} className="text-gray-10" />
+      <span className="sr-only">Archiving</span>
+    </>
   ) : (
     <TaskIcon
       workspaceMode={workspaceMode}
@@ -164,7 +167,7 @@ export function TaskItem({
 
   const prRef = useMemo(() => (prUrl ? parseGithubUrl(prUrl) : null), [prUrl]);
   const prBadge =
-    prUrl && prRef?.kind === "pr" ? (
+    !isArchiving && prUrl && prRef?.kind === "pr" ? (
       <PrBadge url={prUrl} number={prRef.number} />
     ) : null;
 
@@ -206,7 +209,7 @@ export function TaskItem({
     [onDragStart, taskId],
   );
 
-  if (isEditing) {
+  if (isEditing && !isArchiving) {
     return (
       <InlineEditInput
         depth={depth}
@@ -227,15 +230,17 @@ export function TaskItem({
       subtitle={subtitle}
       isActive={isActive}
       isSelected={isSelected}
+      aria-busy={isArchiving || undefined}
       // Lets a drag-selection find the row and the session it stands for.
       {...{ [SESSION_ROW_ATTRIBUTE]: taskId }}
       isDimmed={isArchiving}
+      disabled={isArchiving}
       draggable={!isArchiving}
       onDragStart={handleDragStart}
       onDragEnd={onDragEnd}
-      onClick={onClick}
-      onDoubleClick={onDoubleClick}
-      onContextMenu={onContextMenu}
+      onClick={isArchiving ? undefined : onClick}
+      onDoubleClick={isArchiving ? undefined : onDoubleClick}
+      onContextMenu={isArchiving ? undefined : onContextMenu}
       endContent={endContent}
     />
   );

--- a/products/desktop/packages/ui/src/features/sidebar/useSidebarBulkActions.test.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/useSidebarBulkActions.test.tsx
@@ -300,7 +300,7 @@ describe("useSidebarBulkActions", () => {
 
   describe("archiveSelected", () => {
     it("hides bulk rows while their archive is pending", async () => {
-      let settle = () => undefined;
+      let settle: () => void = () => undefined;
       hoisted.archiveTasksImperative.mockImplementation(
         () =>
           new Promise((resolve) => {

--- a/products/desktop/packages/ui/src/features/sidebar/useSidebarBulkActions.test.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/useSidebarBulkActions.test.tsx
@@ -1,6 +1,7 @@
 import type { TaskData } from "@posthog/core/sidebar/sidebarData.types";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useArchivingTasksStore } from "./archivingTasksStore";
 import { useTaskSelectionStore } from "./taskSelectionStore";
 import { useSidebarBulkActions } from "./useSidebarBulkActions";
 
@@ -112,6 +113,10 @@ describe("useSidebarBulkActions", () => {
     useTaskSelectionStore.setState({
       selectedTaskIds: ["t1", "t2"],
       lastClickedId: null,
+    });
+    useArchivingTasksStore.setState({
+      archivingTaskIds: new Set(),
+      hiddenArchivingTaskIds: new Set(),
     });
   });
 
@@ -294,6 +299,30 @@ describe("useSidebarBulkActions", () => {
   );
 
   describe("archiveSelected", () => {
+    it("hides bulk rows while their archive is pending", async () => {
+      let settle = () => undefined;
+      hoisted.archiveTasksImperative.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            settle = () => resolve({ archived: 2, failed: 0 });
+          }),
+      );
+      const { result } = render();
+
+      let archivePromise: Promise<void> | undefined;
+      act(() => {
+        archivePromise = result.current.archiveSelected();
+      });
+
+      const pending = useArchivingTasksStore.getState();
+      expect(pending.shouldHideWhileArchiving("t1")).toBe(true);
+      expect(pending.shouldHideWhileArchiving("t2")).toBe(true);
+
+      settle();
+      await act(async () => archivePromise);
+      expect(useArchivingTasksStore.getState().isArchiving("t1")).toBe(false);
+    });
+
     it("clears the selection when every session was archived", async () => {
       const { result } = render();
 

--- a/products/desktop/packages/ui/src/features/sidebar/useSidebarBulkActions.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/useSidebarBulkActions.ts
@@ -137,7 +137,7 @@ export function useSidebarBulkActions(
     if (selectedCount === 0 || isArchiving) return;
     setIsArchiving(true);
     const store = useArchivingTasksStore.getState();
-    for (const id of taskIds) store.startArchiving(id);
+    for (const id of taskIds) store.startArchiving(id, "hidden");
     try {
       const { archived, failed } = await archiveTasksImperative(
         taskIds,


### PR DESCRIPTION
## Problem

Desktop users who archive a task with a worktree can wait through cleanup without visible progress.

**Why:** Some archive entry points skipped the shared pending state. Optimistic removal also happened only after slow preflight work.

## Changes

- Every single-task archive now enters one shared pending state before slow work starts.
- Both sidebar types keep the task visible, dim it, show a spinner, and block interactions until cleanup succeeds.
- Bulk archives remain optimistic and parallel.

Before:

```mermaid
flowchart LR
    A{{Archive}} --> B[Workspace and API preflight]
    B --> C[Remove row]
    C --> D[Worktree cleanup]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B,C,D phGray;
```

After:

```mermaid
flowchart LR
    A{{Archive}} --> B[Set shared pending state]
    B --> C[Dim row and show spinner]
    C --> D[Worktree cleanup]
    D --> E[Remove row]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B,C phBlue;
    class D,E phGray;
```

Before:

![posthog-desktop-archive-before](https://raw.githubusercontent.com/PostHog/pr-assets/90d0368fce35a351ee98ac63815941e3dcbe3316/2026/09/5e8b2ce3-1d97-4171-871b-1ed361f6f644.png)

After:

![posthog-desktop-archiving-state](https://raw.githubusercontent.com/PostHog/pr-assets/d652f7326bf38809885fc04cf8e2263912c3abde/2026/09/1129d315-912b-44a8-b698-9d5ee4d87b1d.png)

## How did you test this code?

- The UI unit suite covers pending state before slow work, cleanup after both outcomes, and the dimmed, inactive Space row.
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter code build-storybook`
- `uv run hogli ci:preflight --fix`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation update. This restores progress feedback without changing archive controls or automatic archive behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The PostHog Slack app implemented this change. It used `posthog-desktop`, `checking-deploy-timing`, `querying-posthog-data`, `writing-ui-components`, `writing-tests`, `storybook-stories`, and `writing-pr-descriptions`.

The investigation used private support context. The committed fixtures are invented and contain no source material.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1788424649874699?thread_ts=1788424649.874699&cid=C0ACRAMJUAG)*
