### PR TITLE
fix(projects): show saved project tags after a page reload

### DIFF
--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -552,11 +552,19 @@ def team_evaluation_context_suggestions_view(team: Team, request: request.Reques
     return response.Response({"success": True, "name": context_name, "hidden_from_suggestions": hidden})
 
 
-class ProjectSerializer(serializers.ModelSerializer):
+class ProjectSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer):
+    """The project as the app context serves it, which is where the frontend reads it on page load.
+
+    projectLogic bootstraps `currentProject` from the app context and only calls the API when that
+    is missing, so a field left out here is invisible to the app until something refetches.
+    """
+
+    tags = project_tags.tags_field()
+
     class Meta:
         model = Project
         # Keep this serializer narrow; legacy Team-compatible fields live on ProjectBackwardCompatSerializer.
-        fields = ["id", "organization_id", "name", "product_description", "created_at", "is_pending_deletion"]
+        fields = ["id", "organization_id", "name", "product_description", "created_at", "is_pending_deletion", "tags"]
         read_only_fields = ["id", "organization_id", "created_at", "is_pending_deletion"]
 
 

--- a/posthog/test/test_get_context_for_template.py
+++ b/posthog/test/test_get_context_for_template.py
@@ -12,6 +12,7 @@ from django.test import RequestFactory
 
 from parameterized import parameterized
 
+from posthog.api.tagged_item import set_tags_on_object
 from posthog.models import UserHomeSettings
 from posthog.utils import get_context_for_template
 
@@ -71,6 +72,20 @@ class TestGetContextForTemplate(APIBaseTest):
 
         app_context = json.loads(actual["posthog_app_context"])
         assert app_context["homepage"] == (stored_homepage or None)
+
+    def test_bootstraps_project_tags_into_app_context(self):
+        # projectLogic reads currentProject from the app context and only calls the API when it is
+        # absent, so tags missing here render an empty Tags field until something refetches.
+        set_tags_on_object(["production", "eu-region"], self.team.project)
+
+        request = RequestFactory().get("/")
+        SessionMiddleware(lambda _request: HttpResponse()).process_request(request)
+        request.user = self.user
+
+        actual = get_context_for_template("layout", request)
+
+        app_context = json.loads(actual["posthog_app_context"])
+        assert sorted(app_context["current_project"]["tags"]) == ["eu-region", "production"]
 
     @parameterized.expand(
         [

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -201,7 +201,9 @@ class TestAutoProjectMiddleware(APIBaseTest):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        cls.base_app_num_queries = 54
+        # 55, not 54: the app context serializes the project's tags, which costs one
+        # indexed lookup on posthog_taggeditem per page load.
+        cls.base_app_num_queries = 55
         # Create another team that the user does have access to
         cls.second_team = create_team(organization=cls.organization, name="Second Life")
 


### PR DESCRIPTION
## Problem

Someone who tags a project sees the Tags field empty on the next page load. The tag saved correctly and the API returns it, so the field looks broken while the data is fine.

The app context carries the project that the frontend renders on page load. It builds that project with its own serializer, which had no `tags` field. `projectLogic` reads `currentProject` from the app context and calls the API only when the context has no project, so nothing ever refetched the missing field.

Follow-up to #92307, which added tags to the two API serializers but not to this third one.

## Changes

- Project settings now shows the saved tags after a page reload.
- The app context project serializer gains a `tags` field, through the same `TaggedItemSerializerMixin` the other two project serializers already use.

> [!NOTE]
> This adds one indexed query per page load on the app context path — `posthog_taggeditem` by `project_id`, using the index that #93351 created.

No visual change: the Tags field already looked like this, it just rendered empty.

## How did you test this code?

Added one case to the app context test suite. It catches exactly this regression — a project in the app context payload that carries no `tags` key. No existing test asserted anything about the app context project payload, which is why the feature PR shipped with this gap.

Not verified in a browser. The local dev database sits behind master and does not carry the tag migrations, so the running stack cannot serve this feature.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 5), directed by the assignee after they hit the bug on a live project.

Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-pr-descriptions`, `/creating-pull-requests`.

The first instinct was to make `projectLogic` always refetch from the API. That was rejected: it would add a request to every page load to paper over a payload that should have been complete, and it would leave the app context wrong for any other reader. Fixing the serializer keeps one source of truth for what a project looks like.

The test went into the app context suite rather than next to the serializer. A serializer-level assertion would pass even if the app context switched to a different serializer, which is the shape of the bug being fixed.
