### PR TITLE
chore(desktop): remove posthog-code-task-cost flag gate

### DIFF
--- a/products/desktop/packages/shared/src/flags.ts
+++ b/products/desktop/packages/shared/src/flags.ts
@@ -49,11 +49,9 @@ export const LOCAL_MCP_IMPORT_FLAG = "posthog-code-local-mcp-import";
  * Owned by the backend rollout in posthog/posthog — same flag key there.
  */
 export const MCP_GATEWAY_FLAG = "mcp-gateway";
-/** Per-task estimated cost readout in the context usage indicator. */
-export const TASK_COST_FLAG = "posthog-code-task-cost";
 /**
  * Shows the task cost as text beside the context ring rather than only inside
- * the popover. Requires TASK_COST_FLAG, which is what fetches the figure.
+ * the popover.
  */
 export const TASK_COST_VISIBLE_FLAG = "posthog-code-task-cost-visible";
 /**

--- a/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.test.tsx
@@ -1,11 +1,10 @@
-import { TASK_COST_VISIBLE_FLAG } from "@posthog/shared";
 import type { ContextUsage } from "@posthog/ui/features/sessions/hooks/useContextUsage";
 import { Theme } from "@radix-ui/themes";
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ContextUsageIndicator } from "./ContextUsageIndicator";
 
-const flagState = vi.hoisted(() => ({ cost: false, costVisible: false }));
+const flagState = vi.hoisted(() => ({ costVisible: false }));
 const taskUsageState = vi.hoisted(() => ({
   data: undefined as
     | {
@@ -16,15 +15,13 @@ const taskUsageState = vi.hoisted(() => ({
     | undefined,
 }));
 vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
-  useFeatureFlag: (key: string) =>
-    key === TASK_COST_VISIBLE_FLAG ? flagState.costVisible : flagState.cost,
+  useFeatureFlag: () => flagState.costVisible,
 }));
 vi.mock("@posthog/ui/features/sessions/hooks/useTaskUsage", () => ({
   useTaskUsage: () => taskUsageState,
 }));
 
 function enableCost(costVisible = false) {
-  flagState.cost = true;
   flagState.costVisible = costVisible;
   taskUsageState.data = {
     token_cost_usd: 0.4,
@@ -34,7 +31,6 @@ function enableCost(costVisible = false) {
 }
 
 beforeEach(() => {
-  flagState.cost = false;
   flagState.costVisible = false;
   taskUsageState.data = undefined;
 });

--- a/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.tsx
@@ -5,7 +5,7 @@ import {
   PopoverTrigger,
   Text,
 } from "@posthog/quill";
-import { TASK_COST_FLAG, TASK_COST_VISIBLE_FLAG } from "@posthog/shared";
+import { TASK_COST_VISIBLE_FLAG } from "@posthog/shared";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import {
   formatCostUsd,
@@ -32,9 +32,8 @@ export function ContextUsageIndicator({
   taskId,
   focused = true,
 }: ContextUsageIndicatorProps) {
-  const costEnabled = useFeatureFlag(TASK_COST_FLAG) || import.meta.env.DEV;
   const costVisible = useFeatureFlag(TASK_COST_VISIBLE_FLAG);
-  const { data: taskUsage } = useTaskUsage(taskId, costEnabled && focused);
+  const { data: taskUsage } = useTaskUsage(taskId, focused);
 
   if (!usage) return null;
 
@@ -44,7 +43,7 @@ export function ContextUsageIndicator({
   const hasSize = size > 0;
   const strokeDashoffset = CIRCUMFERENCE - (percentage / 100) * CIRCUMFERENCE;
   const color = getOverallUsageColor(percentage);
-  const showCost = costEnabled && taskUsage !== undefined;
+  const showCost = taskUsage !== undefined;
   const showCostText = showCost && costVisible;
   // The ring carries no text, so the token figures reach a reader only through
   // the accessible name. Cost joins them only while it has no text of its own,


### PR DESCRIPTION
## Problem

Desktop users see the per-task cost in the context usage indicator only while the `posthog-code-task-cost` flag resolves true. The flag has sat at 100% rollout for a while, so the check adds nothing for anyone and stays in the code.

## Changes

- Every desktop build now shows the task cost in the context popover; the flag check is gone, including the dev-mode bypass that emulated it.
- The `posthog-code-task-cost-visible` flag still controls whether the cost appears as text beside the ring, and remains employee-gated as before.
- Removing the constant and simplifying the test's flag mock is mechanical; nothing user-visible hides in it.

## How did you test this code?

- `ContextUsageIndicator` test suite passes, covering the accessible name with and without cost, cost-as-text, and popover-only cost.
- Full `@posthog/ui` vitest suite passes (521 files, 4275 tests).
- Typecheck passes for `@posthog/shared`, `@posthog/ui`, and `@posthog/agent`.

No screenshot: the rendered output at 100% rollout is unchanged.

> [!NOTE]
> The PostHog flag itself ([project 2 flag 811282](https://us.posthog.com/project/2/feature_flags/811282)) was left enabled at 100%: older desktop builds still read it, and deleting it now would hide the cost readout for them until they auto-update. It can be archived once those versions age out.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

Agent work in a PostHog Desktop cloud task, orchestrated with pi. Repo skills invoked: /writing-pr-descriptions, /writing-tests, /writing-ui-components (consulted for the flag-key rules). The visible-cost flag was intentionally kept because its live flag notes say it is employee-only.
