### PR TITLE
fix(desktop): hide SDK API errors from agent output

### DIFF
--- a/products/desktop/packages/agent/src/adapters/claude/conversion/sdk-to-acp.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/conversion/sdk-to-acp.test.ts
@@ -109,7 +109,7 @@ function assistantMessage(
   apiId: string,
   content: Array<Record<string, unknown>>,
   parentToolUseId: string | null = null,
-  model?: string,
+  isApiErrorMessage?: boolean,
 ): SDKAssistantMessage {
   return {
     type: "assistant",
@@ -120,8 +120,8 @@ function assistantMessage(
       id: apiId,
       role: "assistant",
       content,
-      model,
     },
+    isApiErrorMessage,
   } as unknown as SDKAssistantMessage;
 }
 
@@ -164,14 +164,14 @@ describe("assembled assistant text fallback", () => {
   });
 
   it.each([
-    { model: "<synthetic>", expected: [] },
+    { isApiErrorMessage: true, expected: [] },
     {
-      model: "zai-org/glm-5.3-flash",
+      isApiErrorMessage: false,
       expected: ["API Error: Content block is not a thinking block"],
     },
   ])(
-    "filters content-block errors from $model assistant messages",
-    async ({ model, expected }) => {
+    "filters SDK API error messages when marked $isApiErrorMessage",
+    async ({ isApiErrorMessage, expected }) => {
       const { context, updates } = createHandlerContext();
       await handleUserAssistantMessage(
         assistantMessage(
@@ -183,7 +183,7 @@ describe("assembled assistant text fallback", () => {
             },
           ],
           null,
-          model,
+          isApiErrorMessage,
         ),
         context,
       );

--- a/products/desktop/packages/agent/src/adapters/claude/conversion/sdk-to-acp.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/conversion/sdk-to-acp.test.ts
@@ -109,6 +109,7 @@ function assistantMessage(
   apiId: string,
   content: Array<Record<string, unknown>>,
   parentToolUseId: string | null = null,
+  model?: string,
 ): SDKAssistantMessage {
   return {
     type: "assistant",
@@ -119,6 +120,7 @@ function assistantMessage(
       id: apiId,
       role: "assistant",
       content,
+      model,
     },
   } as unknown as SDKAssistantMessage;
 }
@@ -160,6 +162,34 @@ describe("assembled assistant text fallback", () => {
     );
     expect(chunkTexts(updates, "agent_message_chunk")).toEqual(["full answer"]);
   });
+
+  it.each([
+    { model: "<synthetic>", expected: [] },
+    {
+      model: "zai-org/glm-5.3-flash",
+      expected: ["API Error: Content block is not a thinking block"],
+    },
+  ])(
+    "filters content-block errors from $model assistant messages",
+    async ({ model, expected }) => {
+      const { context, updates } = createHandlerContext();
+      await handleUserAssistantMessage(
+        assistantMessage(
+          "msg_1",
+          [
+            {
+              type: "text",
+              text: "API Error: Content block is not a thinking block",
+            },
+          ],
+          null,
+          model,
+        ),
+        context,
+      );
+      expect(chunkTexts(updates, "agent_message_chunk")).toEqual(expected);
+    },
+  );
 
   it("drops assembled text that already streamed live", async () => {
     const { context, updates } = createHandlerContext();

--- a/products/desktop/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
@@ -61,6 +61,7 @@ interface AnthropicMessageWithContent {
     content: AnthropicMessageContent;
     model?: string;
   };
+  isApiErrorMessage?: boolean;
 }
 
 type ChunkHandlerContext = {
@@ -1180,22 +1181,7 @@ function shouldSkipUserAssistantMessage(
   return (
     isSdkLocalCommandMessage(message.message.content) ||
     isLoginRequiredMessage(message) ||
-    isSyntheticContentBlockErrorMessage(message)
-  );
-}
-
-function isSyntheticContentBlockErrorMessage(
-  message: AnthropicMessageWithContent,
-): boolean {
-  const content = message.message.content;
-  return (
-    message.type === "assistant" &&
-    message.message.model === "<synthetic>" &&
-    Array.isArray(content) &&
-    content.length === 1 &&
-    content[0].type === "text" &&
-    typeof content[0].text === "string" &&
-    classifyAgentError(content[0].text) === "content_block_rejection"
+    message.isApiErrorMessage === true
   );
 }
 

--- a/products/desktop/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
@@ -1179,7 +1179,23 @@ function shouldSkipUserAssistantMessage(
 ): boolean {
   return (
     isSdkLocalCommandMessage(message.message.content) ||
-    isLoginRequiredMessage(message)
+    isLoginRequiredMessage(message) ||
+    isSyntheticContentBlockErrorMessage(message)
+  );
+}
+
+function isSyntheticContentBlockErrorMessage(
+  message: AnthropicMessageWithContent,
+): boolean {
+  const content = message.message.content;
+  return (
+    message.type === "assistant" &&
+    message.message.model === "<synthetic>" &&
+    Array.isArray(content) &&
+    content.length === 1 &&
+    content[0].type === "text" &&
+    typeof content[0].text === "string" &&
+    classifyAgentError(content[0].text) === "content_block_rejection"
   );
 }
 


### PR DESCRIPTION
## Problem

People can see a provider API error as if the agent wrote it.

## Changes

- Messages marked as API errors by the Claude SDK no longer render as agent output.
- Real agent responses that discuss the same error still render normally.
- No screenshot: this change removes an erroneous message without changing the layout.

## How did you test this code?

- Added adapter cases that distinguish SDK API errors from real agent text.
- Ran the focused adapter test, the agent package typecheck, the desktop workspace typecheck, and CI preflight.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not needed. This fixes internal error presentation without changing a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Desktop implemented this fix with `/posthog-desktop`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, and `/running-ci-preflight`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
