### PR TITLE
fix(desktop): stop background auth calls bypassing the scope-reauth gate

### DIFF
--- a/products/desktop/packages/core/src/auth/auth.test.ts
+++ b/products/desktop/packages/core/src/auth/auth.test.ts
@@ -476,6 +476,28 @@ describe("AuthService", () => {
     });
   });
 
+  it("does not let a caller silently refresh past a stale scope version", async () => {
+    seedStoredSession({
+      refreshToken: "refresh-token",
+      selectedProjectId: 123,
+      scopeVersion: OAUTH_SCOPE_VERSION - 1,
+    });
+    oauthFlow.refreshToken.mockResolvedValue(mockTokenResponse());
+    stubAuthFetch();
+
+    await service.initialize();
+    expect(service.getState().needsScopeReauth).toBe(true);
+
+    // A caller that only wants a token (e.g. a background usage/telemetry
+    // fetch) must not resurrect the session on the old scope grant behind
+    // the reauth prompt's back.
+    await expect(service.getValidAccessToken()).rejects.toThrow(
+      NotAuthenticatedError,
+    );
+    expect(oauthFlow.refreshToken).not.toHaveBeenCalled();
+    expect(service.getState().needsScopeReauth).toBe(true);
+  });
+
   it.each(["us", "dev", "dev-cloud"] as const)(
     "restores an authenticated stored %s session",
     async (cloudRegion) => {

--- a/products/desktop/packages/core/src/auth/auth.ts
+++ b/products/desktop/packages/core/src/auth/auth.ts
@@ -1514,6 +1514,13 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
   private async resolveStoredSession(): Promise<StoredSessionInput | null> {
     const stored = this.authSession.getCurrent();
     if (!stored) return null;
+    // A stale scope version means the stored refresh token was granted under
+    // permissions the app no longer requests. Refusing it here, at the one
+    // place every session-refresh path resolves the stored token, stops a
+    // caller that skips the explicit reauth checks (doInitialize,
+    // attemptSessionRecovery) from resurrecting the old-scope session behind
+    // the reauth prompt's back.
+    if (stored.scopeVersion < OAUTH_SCOPE_VERSION) return null;
 
     const refreshToken = await this.cipher.decrypt(
       stored.refreshTokenEncrypted,


### PR DESCRIPTION
## Problem

Restarting PostHog Desktop after a scope-version bump briefly shows the "Re-authentication required" dialog, then loads normally without the user ever signing back in.

On boot, a stored session on an old OAuth scope version is correctly flagged as needing reauthentication and the app goes anonymous. But that check only lived in two call sites (`doInitialize`, `attemptSessionRecovery`). Any other code that asks for a token - background usage polling, MCP proxy requests, the LLM gateway, canvas data fetches - calls `getValidAccessToken()`/`authenticatedFetch()`, which resolves the stored session through a different path with no scope check, and happily refreshes the old-scope refresh token. That flips the state back to authenticated behind the dialog, closing it, while the app is still running on the pre-bump scope grant it was supposed to have re-consented to.

## Changes

- Moves the scope-version check into `resolveStoredSession()`, the single place every session-refresh path (including `getValidAccessToken`) resolves the stored token from disk.
- A caller that hits a stale-scope session now gets `NotAuthenticatedError` instead of a silently resurrected session, so the reauth prompt stays up until the user actually signs in.
- No user-visible change to the intended flow: a session on the current scope version is unaffected.

## How did you test this code?

Added a test to `auth.test.ts`: after `initialize()` sets `needsScopeReauth: true` for a stale-scope stored session, calling `getValidAccessToken()` must reject with `NotAuthenticatedError` and must not call `oauthFlow.refreshToken`. This reproduced the bug before the fix (the call resolved successfully instead of rejecting) and passes after it.

Ran the full `@posthog/core` suite (`pnpm --filter @posthog/core test`, 294 files / 4015 tests) and `pnpm --filter @posthog/core typecheck` - both pass. Not run: the Electron app itself, since this sandbox has no display to drive it manually.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal auth service behavior, no documented workflow changed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated with Claude Code by reading the desktop auth service (`packages/core/src/auth/auth.ts`) and tracing every caller of `ensureValidSession`/`getValidAccessToken` to find where the scope-reauth check was skipped. No skills were invoked for the investigation; `/writing-tests` and `/writing-pr-descriptions` were invoked before writing the test and this description, per repo convention.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
