### PR TITLE
fix(desktop): hide raw logs in pi threads

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -363,6 +363,7 @@ function formatTimestamp(ts: number): string {
  * tab stop a keyboard reader needs to reach the thumbs at all.
  */
 const FooterRevealContext = createContext(false);
+const RawLogsToggleContext = createContext(false);
 
 function TurnFooter({
   turnId,
@@ -736,10 +737,6 @@ function UserBubble({
  * message's right rail — the turn footer covers the common case, so a single message's copy lives
  * here instead of costing every row a hover affordance.
  *
- * This menu sits inside `SessionView`'s own context menu and wins the event over it, so it also
- * carries that menu's raw-logs toggle; without it, right-clicking a message would be the one spot
- * in the session where the toggle went missing.
- *
  * Highlighted text wins over the message: right-clicking a selection copies just that, as it does
  * outside the app. The whole message is the fallback for a right-click with nothing selected, and
  * stays reachable without the menu through the footer's copy button.
@@ -755,6 +752,7 @@ function MessageContextMenu({
   value: string;
   children: ReactElement;
 }) {
+  const showRawLogsToggle = useContext(RawLogsToggleContext);
   const showRawLogs = useShowRawLogs();
   const { setShowRawLogs } = useSessionViewActions();
   const [selection, setSelection] = useState<string | null>(null);
@@ -779,11 +777,15 @@ function MessageContextMenu({
           <Copy size={14} />
           {selection ? "Copy selection" : "Copy message"}
         </ContextMenuItem>
-        <ContextMenuSeparator />
-        <ContextMenuItem onClick={() => setShowRawLogs(!showRawLogs)}>
-          <Scroll size={14} />
-          {showRawLogs ? "Back to conversation" : "Show raw logs"}
-        </ContextMenuItem>
+        {showRawLogsToggle && (
+          <>
+            <ContextMenuSeparator />
+            <ContextMenuItem onClick={() => setShowRawLogs(!showRawLogs)}>
+              <Scroll size={14} />
+              {showRawLogs ? "Back to conversation" : "Show raw logs"}
+            </ContextMenuItem>
+          </>
+        )}
       </ContextMenuContent>
     </ContextMenu>
   );
@@ -1432,13 +1434,15 @@ export function ChatThread({ events, ...props }: ChatThreadProps) {
   );
 
   return (
-    <ChatThreadRenderer
-      key={props.taskId}
-      {...props}
-      conversationItems={items}
-      footerEvents={[]}
-      footerState={footerState}
-    />
+    <RawLogsToggleContext.Provider value={false}>
+      <ChatThreadRenderer
+        key={props.taskId}
+        {...props}
+        conversationItems={items}
+        footerEvents={[]}
+        footerState={footerState}
+      />
+    </RawLogsToggleContext.Provider>
   );
 }
 
@@ -1449,12 +1453,14 @@ export function AcpChatThread({ events, ...props }: AcpChatThreadProps) {
   });
 
   return (
-    <ChatThreadRenderer
-      key={props.taskId}
-      {...props}
-      conversationItems={items}
-      footerEvents={events}
-    />
+    <RawLogsToggleContext.Provider value={true}>
+      <ChatThreadRenderer
+        key={props.taskId}
+        {...props}
+        conversationItems={items}
+        footerEvents={events}
+      />
+    </RawLogsToggleContext.Provider>
   );
 }
 


### PR DESCRIPTION
## Problem

- Pi conversation context menus offered raw logs, but Pi does not render a raw logs view.

## Changes

- Pi conversation context menus now show copy actions without the raw logs option.
- ACP conversation context menus retain the raw logs option.
- No screenshot: this change removes one context menu item from Pi conversations.

## How did you test this code?

- Ran `pnpm typecheck`, `pnpm lint`, and `pnpm --filter @posthog/ui test` in `products/desktop`.
- No manual test ran.
- No test was added because this only hides an existing menu item by conversation type.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No docs update: this undocumented context menu option is removed only from Pi conversations.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: PostHog Desktop coding agent.
- Skills: `/posthog-desktop`, `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-tests`, and `/writing-pr-descriptions`.
- The raw logs option remains available in ACP conversations, where the legacy raw logs view exists.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*