### PR TITLE
feat(workflows): add simple linear workflow editor

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -578,6 +578,7 @@ export const FEATURE_FLAGS = {
     WORKFLOWS_EMAIL_REPUTATION: 'workflows-email-reputation', // owner: #team-workflows
     WORKFLOWS_EMAIL_SENDER_ROTATION: 'workflows-email-sender-rotation', // owner: @arthurdedeus #team-workflows
     WORKFLOWS_INTERNAL_EVENT_FILTERS: 'workflows-internal-event-filters', // owner: @haven #team-workflows
+    WORKFLOWS_LINEAR_VIEW: 'workflows-linear-view', // owner: #team-workflows
     WORKFLOWS_PUSH_NOTIFICATIONS: 'workflows-push-notifications', // owner: #team-workflows
     XAA_AUTHENTICATION: 'xaa-authentication', // owner: @reecejones #team-platform-features
 } as const

--- a/products/workflows/frontend/Workflows/Workflow.tsx
+++ b/products/workflows/frontend/Workflows/Workflow.tsx
@@ -1,20 +1,30 @@
 import { useActions, useValues } from 'kea'
+import { useState } from 'react'
 
 import { LemonBanner, LemonButton, SpinnerOverlay } from '@posthog/lemon-ui'
 
 import { HogFlowEditor } from './hogflows/HogFlowEditor'
+import { getLinearWorkflowActionIds } from './hogflows/linearWorkflow'
 import { WorkflowLogicProps, workflowLogic } from './workflowLogic'
 import { WorkflowStatusBar } from './WorkflowStatusBar'
 
 export function Workflow(props: WorkflowLogicProps): JSX.Element {
-    const { originalWorkflow, workflowLoading, externallyEdited, isSyncingExternalEdit } = useValues(
+    const { originalWorkflow, workflow, workflowLoading, externallyEdited, isSyncingExternalEdit } = useValues(
         workflowLogic(props)
     )
     const { loadWorkflow, keepMyWorkflowVersion } = useActions(workflowLogic(props))
+    const [editorLayout, setEditorLayout] = useState<'simple' | 'advanced'>('simple')
+    const canUseSimpleLayout = !!getLinearWorkflowActionIds(workflow)
+    const effectiveEditorLayout = editorLayout === 'simple' && canUseSimpleLayout ? 'simple' : 'advanced'
 
     return (
-        <div className="flex flex-col grow relative border rounded-md">
-            <WorkflowStatusBar {...props} />
+        <div className="relative flex h-[calc(100vh-13rem)] max-h-full min-h-[25rem] grow flex-col overflow-hidden rounded-md border">
+            <WorkflowStatusBar
+                {...props}
+                editorLayout={effectiveEditorLayout}
+                canUseSimpleLayout={canUseSimpleLayout}
+                onEditorLayoutChange={setEditorLayout}
+            />
             {/* Brief working/disabled overlay while we reconcile to an edit made elsewhere (clean state). */}
             {isSyncingExternalEdit && <SpinnerOverlay />}
             {externallyEdited && (
@@ -36,7 +46,11 @@ export function Workflow(props: WorkflowLogicProps): JSX.Element {
                     </div>
                 </LemonBanner>
             )}
-            {!originalWorkflow && workflowLoading ? <SpinnerOverlay /> : <HogFlowEditor />}
+            {!originalWorkflow && workflowLoading ? (
+                <SpinnerOverlay />
+            ) : (
+                <HogFlowEditor isSimpleLayout={effectiveEditorLayout === 'simple'} />
+            )}
         </div>
     )
 }

--- a/products/workflows/frontend/Workflows/Workflow.tsx
+++ b/products/workflows/frontend/Workflows/Workflow.tsx
@@ -1,9 +1,11 @@
 import { useActions, useValues } from 'kea'
-import { useState } from 'react'
 
 import { LemonBanner, LemonButton, SpinnerOverlay } from '@posthog/lemon-ui'
 
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+
 import { HogFlowEditor } from './hogflows/HogFlowEditor'
+import { hogFlowEditorLogic } from './hogflows/hogFlowEditorLogic'
 import { getLinearWorkflowActionIds } from './hogflows/linearWorkflow'
 import { WorkflowLogicProps, workflowLogic } from './workflowLogic'
 import { WorkflowStatusBar } from './WorkflowStatusBar'
@@ -13,8 +15,10 @@ export function Workflow(props: WorkflowLogicProps): JSX.Element {
         workflowLogic(props)
     )
     const { loadWorkflow, keepMyWorkflowVersion } = useActions(workflowLogic(props))
-    const [editorLayout, setEditorLayout] = useState<'simple' | 'advanced'>('simple')
-    const canUseSimpleLayout = !!getLinearWorkflowActionIds(workflow)
+    const { editorLayout } = useValues(hogFlowEditorLogic(props))
+    const { setEditorLayout } = useActions(hogFlowEditorLogic(props))
+    const linearViewEnabled = useFeatureFlag('WORKFLOWS_LINEAR_VIEW')
+    const canUseSimpleLayout = linearViewEnabled && !!getLinearWorkflowActionIds(workflow)
     const effectiveEditorLayout = editorLayout === 'simple' && canUseSimpleLayout ? 'simple' : 'advanced'
 
     return (
@@ -23,6 +27,7 @@ export function Workflow(props: WorkflowLogicProps): JSX.Element {
                 {...props}
                 editorLayout={effectiveEditorLayout}
                 canUseSimpleLayout={canUseSimpleLayout}
+                showEditorLayoutToggle={linearViewEnabled}
                 onEditorLayoutChange={setEditorLayout}
             />
             {/* Brief working/disabled overlay while we reconcile to an edit made elsewhere (clean state). */}

--- a/products/workflows/frontend/Workflows/WorkflowScene.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowScene.tsx
@@ -29,7 +29,7 @@ import {
 } from './workflowAgentContext'
 import { WorkflowAssets } from './WorkflowAssets'
 import { WorkflowInvocations } from './WorkflowInvocations'
-import { workflowLogic } from './workflowLogic'
+import { WorkflowLogicProps, workflowLogic } from './workflowLogic'
 import { WorkflowMetrics } from './WorkflowMetrics'
 import { WorkflowRevisions } from './WorkflowRevisions'
 import { WorkflowSceneHeader } from './WorkflowSceneHeader'
@@ -55,10 +55,11 @@ export function WorkflowScene(props: WorkflowSceneLogicProps): JSX.Element {
     const { searchParams } = useValues(router)
     const templateId = searchParams.templateId as string | undefined
     const editTemplateId = searchParams.editTemplateId as string | undefined
+    const workflowProps: WorkflowLogicProps = { id: workflowSceneProps.id, templateId, editTemplateId }
 
     const batchJobsLogic = batchWorkflowJobsLogic({ id: workflowSceneProps.id })
 
-    const logic = workflowLogic({ id: props.id, templateId, editTemplateId })
+    const logic = workflowLogic(workflowProps)
     // The save/auto-save indicators moved into the WorkflowStatusBar; the scene only needs the
     // workflow itself (for the agent context) and the load state.
     const { workflow, workflowLoading, originalWorkflow, hogFunctionTemplatesById } = useValues(logic)
@@ -115,7 +116,7 @@ export function WorkflowScene(props: WorkflowSceneLogicProps): JSX.Element {
         {
             label: 'Workflow',
             key: 'workflow',
-            content: <Workflow {...workflowSceneProps} />,
+            content: <Workflow {...workflowProps} />,
         },
 
         {
@@ -164,11 +165,11 @@ export function WorkflowScene(props: WorkflowSceneLogicProps): JSX.Element {
 
     return (
         <SceneContent className="h-full flex flex-col grow" data-attr="workflow-scene">
-            <BindLogic logic={workflowLogic} props={{ id: props.id, templateId, editTemplateId }}>
+            <BindLogic logic={workflowLogic} props={workflowProps}>
                 <WorkflowSceneHeader {...props} />
                 {/* Only show Logs and Metrics tabs if the workflow has already been created */}
                 {!props.id || props.id === 'new' ? (
-                    <Workflow {...props} />
+                    <Workflow {...workflowProps} />
                 ) : (
                     <LemonTabs
                         activeKey={currentTab}

--- a/products/workflows/frontend/Workflows/WorkflowStatusBar.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowStatusBar.tsx
@@ -7,17 +7,20 @@ import { LastSavedIndicator } from 'lib/components/LastSavedIndicator'
 import { useDebouncedValue } from 'lib/hooks/useDebouncedValue'
 import { urls } from 'scenes/urls'
 
+import type { HogFlowEditorLayout } from './hogflows/hogFlowEditorLogic'
 import { WorkflowLogicProps, workflowLogic } from './workflowLogic'
 
 type WorkflowStatusBarProps = WorkflowLogicProps & {
-    editorLayout: 'simple' | 'advanced'
+    editorLayout: HogFlowEditorLayout
     canUseSimpleLayout: boolean
-    onEditorLayoutChange: (layout: 'simple' | 'advanced') => void
+    showEditorLayoutToggle: boolean
+    onEditorLayoutChange: (layout: HogFlowEditorLayout) => void
 }
 
 export function WorkflowStatusBar({
     editorLayout,
     canUseSimpleLayout,
+    showEditorLayoutToggle,
     onEditorLayoutChange,
     ...props
 }: WorkflowStatusBarProps): JSX.Element | null {
@@ -46,28 +49,30 @@ export function WorkflowStatusBar({
     return (
         <div className="flex items-center justify-between gap-2 px-2 py-1.5 border-b bg-surface-secondary rounded-t-md flex-wrap">
             <div className="flex items-center gap-3 min-w-0">
-                <LemonSegmentedButton
-                    value={editorLayout}
-                    onChange={onEditorLayoutChange}
-                    size="small"
-                    options={[
-                        {
-                            value: 'simple',
-                            icon: <IconList />,
-                            tooltip: 'Simple view',
-                            disabledReason: canUseSimpleLayout
-                                ? undefined
-                                : 'Simple view is only available for linear workflows',
-                            'data-attr': 'workflow-switch-to-simple-view',
-                        },
-                        {
-                            value: 'advanced',
-                            icon: <IconDecisionTree />,
-                            tooltip: 'Advanced view',
-                            'data-attr': 'workflow-switch-to-advanced-view',
-                        },
-                    ]}
-                />
+                {showEditorLayoutToggle && (
+                    <LemonSegmentedButton
+                        value={editorLayout}
+                        onChange={onEditorLayoutChange}
+                        size="small"
+                        options={[
+                            {
+                                value: 'simple',
+                                icon: <IconList />,
+                                tooltip: 'Simple view',
+                                disabledReason: canUseSimpleLayout
+                                    ? undefined
+                                    : 'Simple view is only available for linear workflows',
+                                'data-attr': 'workflow-switch-to-simple-view',
+                            },
+                            {
+                                value: 'advanced',
+                                icon: <IconDecisionTree />,
+                                tooltip: 'Advanced view',
+                                'data-attr': 'workflow-switch-to-advanced-view',
+                            },
+                        ]}
+                    />
+                )}
                 {showWorkflowStatus &&
                     (isEditingDraftOfLive ? (
                         <LemonTag type="warning">Editing draft</LemonTag>

--- a/products/workflows/frontend/Workflows/WorkflowStatusBar.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowStatusBar.tsx
@@ -1,7 +1,7 @@
 import { useValues, useActions } from 'kea'
 
-import { IconClock, IconInfo } from '@posthog/icons'
-import { LemonButton, LemonSwitch, LemonTag, Spinner, Tooltip } from '@posthog/lemon-ui'
+import { IconClock, IconDecisionTree, IconInfo, IconList } from '@posthog/icons'
+import { LemonButton, LemonSegmentedButton, LemonSwitch, LemonTag, Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import { LastSavedIndicator } from 'lib/components/LastSavedIndicator'
 import { useDebouncedValue } from 'lib/hooks/useDebouncedValue'
@@ -9,12 +9,18 @@ import { urls } from 'scenes/urls'
 
 import { WorkflowLogicProps, workflowLogic } from './workflowLogic'
 
-/**
- * State narration for a saved workflow: what you're editing (live config vs staged draft), save
- * state, and the auto-save toggle. Deliberately no write actions here - save/publish/discard live
- * in the scene header with every other scene's primary actions, and in the scene menu bar.
- */
-export function WorkflowStatusBar(props: WorkflowLogicProps): JSX.Element | null {
+type WorkflowStatusBarProps = WorkflowLogicProps & {
+    editorLayout: 'simple' | 'advanced'
+    canUseSimpleLayout: boolean
+    onEditorLayoutChange: (layout: 'simple' | 'advanced') => void
+}
+
+export function WorkflowStatusBar({
+    editorLayout,
+    canUseSimpleLayout,
+    onEditorLayoutChange,
+    ...props
+}: WorkflowStatusBarProps): JSX.Element | null {
     const logic = workflowLogic(props)
     const {
         originalWorkflow,
@@ -28,24 +34,49 @@ export function WorkflowStatusBar(props: WorkflowLogicProps): JSX.Element | null
     const { setAutoSaveEnabled } = useActions(logic)
     const showSaving = useDebouncedValue(isAutoSavePending || workflowLoading, 1000)
 
-    if (!props.id || props.id === 'new' || props.editTemplateId || !originalWorkflow) {
+    if (!originalWorkflow) {
         return null
     }
 
+    const showWorkflowStatus = !props.editTemplateId
+    const historyWorkflowId = props.id && props.id !== 'new' ? props.id : null
     const isActive = originalWorkflow.status === 'active'
     const isEditingDraftOfLive = isActive && (hasStagedDraft || hasUnsavedChanges)
 
     return (
         <div className="flex items-center justify-between gap-2 px-2 py-1.5 border-b bg-surface-secondary rounded-t-md flex-wrap">
             <div className="flex items-center gap-3 min-w-0">
-                {isEditingDraftOfLive ? (
-                    <LemonTag type="warning">Editing draft</LemonTag>
-                ) : isActive ? (
-                    <LemonTag type="success">Live</LemonTag>
-                ) : (
-                    <LemonTag>Draft</LemonTag>
-                )}
-                {isActive && (
+                <LemonSegmentedButton
+                    value={editorLayout}
+                    onChange={onEditorLayoutChange}
+                    size="small"
+                    options={[
+                        {
+                            value: 'simple',
+                            icon: <IconList />,
+                            tooltip: 'Simple view',
+                            disabledReason: canUseSimpleLayout
+                                ? undefined
+                                : 'Simple view is only available for linear workflows',
+                            'data-attr': 'workflow-switch-to-simple-view',
+                        },
+                        {
+                            value: 'advanced',
+                            icon: <IconDecisionTree />,
+                            tooltip: 'Advanced view',
+                            'data-attr': 'workflow-switch-to-advanced-view',
+                        },
+                    ]}
+                />
+                {showWorkflowStatus &&
+                    (isEditingDraftOfLive ? (
+                        <LemonTag type="warning">Editing draft</LemonTag>
+                    ) : isActive ? (
+                        <LemonTag type="success">Live</LemonTag>
+                    ) : (
+                        <LemonTag>Draft</LemonTag>
+                    ))}
+                {showWorkflowStatus && isActive && (
                     <span className="text-xs text-secondary truncate">
                         {isEditingDraftOfLive
                             ? 'The live version keeps running until you publish.'
@@ -55,42 +86,46 @@ export function WorkflowStatusBar(props: WorkflowLogicProps): JSX.Element | null
             </div>
             {/* Interactive controls sit right-anchored with variable-width text leftmost, so the
                 toggle and History never shift as the narration or the timestamp changes. */}
-            <div className="flex items-center gap-3 shrink-0">
-                {autoSaveEnabled && showSaving ? (
-                    <span className="text-xs text-tertiary flex items-center gap-1">
-                        <Spinner textColored /> Saving…
+            {showWorkflowStatus && (
+                <div className="flex items-center gap-3 shrink-0">
+                    {autoSaveEnabled && showSaving ? (
+                        <span className="text-xs text-tertiary flex items-center gap-1">
+                            <Spinner textColored /> Saving…
+                        </span>
+                    ) : lastSavedAt ? (
+                        <LastSavedIndicator timestamp={lastSavedAt} />
+                    ) : null}
+                    <span className="flex items-center gap-1">
+                        <LemonSwitch
+                            checked={autoSaveEnabled}
+                            onChange={setAutoSaveEnabled}
+                            label="Auto-save"
+                            size="small"
+                        />
+                        <Tooltip
+                            title={
+                                isActive
+                                    ? 'Auto-save stores your changes as a draft. Nothing goes live until you publish.'
+                                    : 'Draft workflows auto-save as you edit.'
+                            }
+                            placement="bottom"
+                        >
+                            <IconInfo className="text-tertiary size-4" />
+                        </Tooltip>
                     </span>
-                ) : lastSavedAt ? (
-                    <LastSavedIndicator timestamp={lastSavedAt} />
-                ) : null}
-                <span className="flex items-center gap-1">
-                    <LemonSwitch
-                        checked={autoSaveEnabled}
-                        onChange={setAutoSaveEnabled}
-                        label="Auto-save"
-                        size="small"
-                    />
-                    <Tooltip
-                        title={
-                            isActive
-                                ? 'Auto-save stores your changes as a draft. Nothing goes live until you publish.'
-                                : 'Draft workflows auto-save as you edit.'
-                        }
-                        placement="bottom"
-                    >
-                        <IconInfo className="text-tertiary size-4" />
-                    </Tooltip>
-                </span>
-                <LemonButton
-                    type="tertiary"
-                    size="small"
-                    icon={<IconClock />}
-                    to={urls.workflow(props.id, 'history')}
-                    tooltip="See and restore previous versions"
-                >
-                    History
-                </LemonButton>
-            </div>
+                    {historyWorkflowId && (
+                        <LemonButton
+                            type="tertiary"
+                            size="small"
+                            icon={<IconClock />}
+                            to={urls.workflow(historyWorkflowId, 'history')}
+                            tooltip="See and restore previous versions"
+                        >
+                            History
+                        </LemonButton>
+                    )}
+                </div>
+            )}
         </div>
     )
 }

--- a/products/workflows/frontend/Workflows/WorkflowStatusBar.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowStatusBar.tsx
@@ -91,7 +91,7 @@ export function WorkflowStatusBar({
             </div>
             {/* Interactive controls sit right-anchored with variable-width text leftmost, so the
                 toggle and History never shift as the narration or the timestamp changes. */}
-            {showWorkflowStatus && (
+            {showWorkflowStatus && historyWorkflowId && (
                 <div className="flex items-center gap-3 shrink-0">
                     {autoSaveEnabled && showSaving ? (
                         <span className="text-xs text-tertiary flex items-center gap-1">
@@ -118,17 +118,15 @@ export function WorkflowStatusBar({
                             <IconInfo className="text-tertiary size-4" />
                         </Tooltip>
                     </span>
-                    {historyWorkflowId && (
-                        <LemonButton
-                            type="tertiary"
-                            size="small"
-                            icon={<IconClock />}
-                            to={urls.workflow(historyWorkflowId, 'history')}
-                            tooltip="See and restore previous versions"
-                        >
-                            History
-                        </LemonButton>
-                    )}
+                    <LemonButton
+                        type="tertiary"
+                        size="small"
+                        icon={<IconClock />}
+                        to={urls.workflow(historyWorkflowId, 'history')}
+                        tooltip="See and restore previous versions"
+                    >
+                        History
+                    </LemonButton>
                 </div>
             )}
         </div>

--- a/products/workflows/frontend/Workflows/hogflows/HogFlowEditor.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/HogFlowEditor.tsx
@@ -12,6 +12,7 @@ import {
     useNodesInitialized,
     useReactFlow,
 } from '@xyflow/react'
+import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
 import { useEffect, useMemo, useRef } from 'react'
 
@@ -21,6 +22,7 @@ import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 
 import { workflowLogic } from '../workflowLogic'
 import { hogFlowEditorLogic } from './hogFlowEditorLogic'
+import { HogFlowLinearEditor } from './HogFlowLinearEditor'
 import { HogFlowEditorPanel } from './panel/HogFlowEditorPanel'
 import { LOW_DETAIL_ZOOM, MIN_ZOOM } from './react_flow_utils/constants'
 import { REACT_FLOW_EDGE_TYPES } from './react_flow_utils/SmartEdge'
@@ -28,7 +30,7 @@ import { REACT_FLOW_NODE_TYPES } from './steps/Nodes'
 import { HogFlowActionEdge, HogFlowActionNode } from './types'
 
 // Inner component that encapsulates React Flow
-function HogFlowEditorContent(): JSX.Element {
+function HogFlowEditorContent({ isSimpleLayout }: { isSimpleLayout: boolean }): JSX.Element {
     const { isDarkModeOn } = useValues(themeLogic)
 
     const { nodes, edges, dropzoneNodes, isMovingNode, isCopyingNode, isZoomedOutFar } = useValues(hogFlowEditorLogic)
@@ -38,7 +40,6 @@ function HogFlowEditorContent(): JSX.Element {
         setSelectedNodeId,
         setReactFlowInstance,
         onNodesDelete,
-        showDropzones,
         onDragOver,
         onDrop,
         setReactFlowWrapper,
@@ -73,61 +74,74 @@ function HogFlowEditorContent(): JSX.Element {
     )
 
     return (
-        <div ref={reactFlowWrapper} className="flex flex-col grow w-full" data-attr="workflow-editor">
-            <ReactFlow<HogFlowActionNode, HogFlowActionEdge>
-                className="grow"
-                fitView
-                minZoom={MIN_ZOOM}
-                // Only dispatched when the detail tier flips, so panning and zooming don't put a
-                // Redux action on every animation frame.
-                onMove={(_, viewport) => {
-                    const zoomedOutFar = viewport.zoom < LOW_DETAIL_ZOOM
-                    if (zoomedOutFar !== isZoomedOutFar) {
-                        setIsZoomedOutFar(zoomedOutFar)
-                    }
-                }}
-                nodes={nodesWithDropzones}
-                edges={edges}
-                onNodesChange={onNodesChange}
-                onEdgesChange={onEdgesChange}
-                onNodesDelete={onNodesDelete}
-                onDragStart={showDropzones}
-                onDragOver={onDragOver}
-                onDrop={onDrop}
-                onNodeClick={(_, node) => node.selectable && setSelectedNodeId(node.id)}
-                nodeTypes={REACT_FLOW_NODE_TYPES as NodeTypes}
-                edgeTypes={REACT_FLOW_EDGE_TYPES as EdgeTypes}
-                nodesDraggable={false}
-                colorMode={isDarkModeOn ? 'dark' : 'light'}
-                onPaneClick={handlePaneClick}
-            >
-                <Background gap={36} variant={BackgroundVariant.Dots} />
-
-                {(isMovingNode || isCopyingNode) && (
-                    <Panel position="bottom-left">
-                        {/* Offset right of the zoom controls so the hint sits beside them */}
-                        <div className="flex items-center gap-1.5 ml-12 px-3 py-1.5 rounded border shadow-sm bg-surface-primary text-sm">
-                            <IconInfo className="text-base text-muted shrink-0" />
-                            <span>Click a highlighted spot to {isMovingNode ? 'move' : 'copy'} this step</span>
-                            <span className="text-muted">· press Esc to cancel</span>
-                        </div>
-                    </Panel>
+        <div
+            ref={reactFlowWrapper}
+            className="relative flex min-h-0 flex-1 overflow-hidden"
+            data-attr="workflow-editor"
+        >
+            <div
+                className={clsx(
+                    'flex min-h-0 min-w-0 grow',
+                    isSimpleLayout && 'absolute inset-0 pointer-events-none opacity-0'
                 )}
+                aria-hidden={isSimpleLayout}
+                {...(isSimpleLayout ? { inert: '' } : {})}
+            >
+                <ReactFlow<HogFlowActionNode, HogFlowActionEdge>
+                    className="grow"
+                    fitView
+                    minZoom={MIN_ZOOM}
+                    // Only dispatched when the detail tier flips, so panning and zooming don't put a
+                    // Redux action on every animation frame.
+                    onMove={(_, viewport) => {
+                        const zoomedOutFar = viewport.zoom < LOW_DETAIL_ZOOM
+                        if (zoomedOutFar !== isZoomedOutFar) {
+                            setIsZoomedOutFar(zoomedOutFar)
+                        }
+                    }}
+                    nodes={nodesWithDropzones}
+                    edges={edges}
+                    onNodesChange={onNodesChange}
+                    onEdgesChange={onEdgesChange}
+                    onNodesDelete={onNodesDelete}
+                    onDragOver={onDragOver}
+                    onDrop={onDrop}
+                    onNodeClick={(_, node) => node.selectable && setSelectedNodeId(node.id)}
+                    nodeTypes={REACT_FLOW_NODE_TYPES as NodeTypes}
+                    edgeTypes={REACT_FLOW_EDGE_TYPES as EdgeTypes}
+                    nodesDraggable={false}
+                    colorMode={isDarkModeOn ? 'dark' : 'light'}
+                    onPaneClick={handlePaneClick}
+                >
+                    <Background gap={36} variant={BackgroundVariant.Dots} />
 
-                <Controls showInteractive={false} />
+                    {(isMovingNode || isCopyingNode) && (
+                        <Panel position="bottom-left">
+                            {/* Offset right of the zoom controls so the hint sits beside them */}
+                            <div className="flex items-center gap-1.5 ml-12 px-3 py-1.5 rounded border shadow-sm bg-surface-primary text-sm">
+                                <IconInfo className="text-base text-muted shrink-0" />
+                                <span>Click a highlighted spot to {isMovingNode ? 'move' : 'copy'} this step</span>
+                                <span className="text-muted">· press Esc to cancel</span>
+                            </div>
+                        </Panel>
+                    )}
 
-                <HogFlowEditorPanel />
-            </ReactFlow>
+                    <Controls showInteractive={false} />
+                </ReactFlow>
+            </div>
+
+            {isSimpleLayout && <HogFlowLinearEditor />}
+            <HogFlowEditorPanel layout={isSimpleLayout ? 'panel' : 'floating'} />
         </div>
     )
 }
 
-export function HogFlowEditor(): JSX.Element {
+export function HogFlowEditor({ isSimpleLayout }: { isSimpleLayout: boolean }): JSX.Element {
     const { logicProps } = useValues(workflowLogic)
     return (
         <ReactFlowProvider>
             <BindLogic logic={hogFlowEditorLogic} props={logicProps}>
-                <HogFlowEditorContent />
+                <HogFlowEditorContent isSimpleLayout={isSimpleLayout} />
             </BindLogic>
         </ReactFlowProvider>
     )

--- a/products/workflows/frontend/Workflows/hogflows/HogFlowLinearEditor.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/HogFlowLinearEditor.tsx
@@ -36,7 +36,6 @@ function HogFlowLinearDropzone({ active, edge }: { active: boolean; edge?: HogFl
             }}
             data-attr="workflow-linear-dropzone"
         >
-            <div className="pointer-events-none absolute inset-y-0 left-1/2 border-l-2 border-primary" />
             <div className="pointer-events-none relative flex size-8 items-center justify-center rounded-full border-2 bg-surface-primary">
                 <IconPlus className="text-lg text-primary" />
             </div>

--- a/products/workflows/frontend/Workflows/hogflows/HogFlowLinearEditor.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/HogFlowLinearEditor.tsx
@@ -20,42 +20,43 @@ function HogFlowLinearDropzone({
     const { moveNodeToEdge, onDragOver, onDrop } = useActions(hogFlowEditorLogic)
     const [isHighlighted, setIsHighlighted] = useState(false)
 
-    if (!active || !edge) {
-        return (
-            <div className="relative my-2 flex h-7 justify-center" aria-hidden="true">
-                <div className="absolute inset-y-0 border-l-2 border-primary" />
-            </div>
-        )
-    }
+    // A step dropped next to where it already is does not move, so that gap is not a target.
+    const isNoOpTarget = !!draggedActionId && (edge?.from === draggedActionId || edge?.to === draggedActionId)
 
+    // The gap keeps the same height in both states. A drag that resizes the list under the
+    // pointer moves every step away from where the person aimed.
     return (
-        <div
-            className={`group relative my-2 flex h-16 w-full cursor-pointer items-center justify-center rounded border-2 border-dashed transition-colors ${
-                isHighlighted ? 'border-primary bg-surface-primary' : 'border-primary/50'
-            }`}
-            onDragOver={(event) => {
-                setIsHighlighted(true)
-                onDragOver(event)
-            }}
-            onDragLeave={() => setIsHighlighted(false)}
-            onDrop={(event) => {
-                setIsHighlighted(false)
-                if (draggedActionId) {
-                    if (edge.from !== draggedActionId && edge.to !== draggedActionId) {
-                        moveNodeToEdge(draggedActionId, edge, false)
-                    }
-                } else {
-                    onDrop(event, edge)
-                }
-            }}
-            data-attr="workflow-linear-dropzone"
-        >
-            <div className="pointer-events-none relative flex size-8 items-center justify-center rounded-full border-2 bg-surface-primary">
-                <IconPlus className="text-lg text-primary" />
-            </div>
-            <span className="pointer-events-none absolute left-[calc(50%+2rem)] whitespace-nowrap rounded border bg-surface-primary px-2 py-1 text-xs text-secondary opacity-0 transition-opacity group-hover:opacity-100 motion-reduce:transition-none">
-                Drop step here
-            </span>
+        <div className="relative my-2 flex h-7 justify-center">
+            {!active || !edge || isNoOpTarget ? (
+                <div className="absolute inset-y-0 border-l-2 border-primary" aria-hidden="true" />
+            ) : (
+                <div
+                    className={`group absolute inset-x-0 -inset-y-2 flex cursor-pointer items-center justify-center rounded border-2 border-dashed transition-colors ${
+                        isHighlighted ? 'border-primary bg-surface-primary' : 'border-primary/50'
+                    }`}
+                    onDragOver={(event) => {
+                        setIsHighlighted(true)
+                        onDragOver(event)
+                    }}
+                    onDragLeave={() => setIsHighlighted(false)}
+                    onDrop={(event) => {
+                        setIsHighlighted(false)
+                        if (draggedActionId) {
+                            moveNodeToEdge(draggedActionId, edge, false)
+                        } else {
+                            onDrop(event, edge)
+                        }
+                    }}
+                    data-attr="workflow-linear-dropzone"
+                >
+                    <div className="pointer-events-none relative flex size-8 items-center justify-center rounded-full border-2 bg-surface-primary">
+                        <IconPlus className="text-lg text-primary" />
+                    </div>
+                    <span className="pointer-events-none absolute left-[calc(50%+2rem)] whitespace-nowrap rounded border bg-surface-primary px-2 py-1 text-xs text-secondary opacity-0 transition-opacity group-hover:opacity-100 motion-reduce:transition-none">
+                        Drop step here
+                    </span>
+                </div>
+            )}
         </div>
     )
 }

--- a/products/workflows/frontend/Workflows/hogflows/HogFlowLinearEditor.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/HogFlowLinearEditor.tsx
@@ -8,8 +8,16 @@ import { getLinearWorkflowActionIds } from './linearWorkflow'
 import { StepView } from './steps/components/StepView'
 import type { HogFlowAction, HogFlowEdge } from './types'
 
-function HogFlowLinearDropzone({ active, edge }: { active: boolean; edge?: HogFlowEdge }): JSX.Element {
-    const { onDragOver, onDrop } = useActions(hogFlowEditorLogic)
+function HogFlowLinearDropzone({
+    active,
+    edge,
+    draggedActionId,
+}: {
+    active: boolean
+    edge?: HogFlowEdge
+    draggedActionId: string | null
+}): JSX.Element {
+    const { moveNodeToEdge, onDragOver, onDrop } = useActions(hogFlowEditorLogic)
     const [isHighlighted, setIsHighlighted] = useState(false)
 
     if (!active || !edge) {
@@ -32,7 +40,13 @@ function HogFlowLinearDropzone({ active, edge }: { active: boolean; edge?: HogFl
             onDragLeave={() => setIsHighlighted(false)}
             onDrop={(event) => {
                 setIsHighlighted(false)
-                onDrop(event, edge)
+                if (draggedActionId) {
+                    if (edge.from !== draggedActionId && edge.to !== draggedActionId) {
+                        moveNodeToEdge(draggedActionId, edge, false)
+                    }
+                } else {
+                    onDrop(event, edge)
+                }
             }}
             data-attr="workflow-linear-dropzone"
         >
@@ -48,6 +62,7 @@ function HogFlowLinearDropzone({ active, edge }: { active: boolean; edge?: HogFl
 
 export function HogFlowLinearEditor(): JSX.Element {
     const { workflow, nodeToBeAdded } = useValues(hogFlowEditorLogic)
+    const [draggedActionId, setDraggedActionId] = useState<string | null>(null)
     const actionIds = getLinearWorkflowActionIds(workflow)
 
     const actionsById = new Map(workflow.actions.map((action) => [action.id, action]))
@@ -63,9 +78,29 @@ export function HogFlowLinearEditor(): JSX.Element {
             <div className="mx-auto flex w-full max-w-3xl flex-col">
                 {linearActions.map((action, index) => (
                     <div key={action.id} className="flex flex-col">
-                        <StepView action={action} layout="list" />
+                        <div
+                            draggable={action.type !== 'trigger' && action.type !== 'exit'}
+                            onDragStart={(event) => {
+                                setDraggedActionId(action.id)
+                                event.dataTransfer.effectAllowed = 'move'
+                                event.dataTransfer.setData('text/plain', action.id)
+                            }}
+                            onDragEnd={() => setDraggedActionId(null)}
+                            className={`${
+                                action.type !== 'trigger' && action.type !== 'exit'
+                                    ? 'cursor-grab active:cursor-grabbing'
+                                    : ''
+                            } ${draggedActionId === action.id ? 'opacity-50' : ''}`}
+                            data-attr="workflow-linear-step-drag"
+                        >
+                            <StepView action={action} layout="list" />
+                        </div>
                         {index < linearActions.length - 1 && (
-                            <HogFlowLinearDropzone active={!!nodeToBeAdded} edge={linearEdges[index]} />
+                            <HogFlowLinearDropzone
+                                active={!!nodeToBeAdded || !!draggedActionId}
+                                edge={linearEdges[index]}
+                                draggedActionId={draggedActionId}
+                            />
                         )}
                     </div>
                 ))}

--- a/products/workflows/frontend/Workflows/hogflows/HogFlowLinearEditor.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/HogFlowLinearEditor.tsx
@@ -1,0 +1,76 @@
+import { useActions, useValues } from 'kea'
+import { useState } from 'react'
+
+import { IconPlus } from '@posthog/icons'
+
+import { hogFlowEditorLogic } from './hogFlowEditorLogic'
+import { getLinearWorkflowActionIds } from './linearWorkflow'
+import { StepView } from './steps/components/StepView'
+import type { HogFlowAction, HogFlowEdge } from './types'
+
+function HogFlowLinearDropzone({ active, edge }: { active: boolean; edge?: HogFlowEdge }): JSX.Element {
+    const { onDragOver, onDrop } = useActions(hogFlowEditorLogic)
+    const [isHighlighted, setIsHighlighted] = useState(false)
+
+    if (!active || !edge) {
+        return (
+            <div className="relative my-2 flex h-7 justify-center" aria-hidden="true">
+                <div className="absolute inset-y-0 border-l-2 border-primary" />
+            </div>
+        )
+    }
+
+    return (
+        <div
+            className={`group relative my-2 flex h-16 w-full cursor-pointer items-center justify-center rounded border-2 border-dashed transition-colors ${
+                isHighlighted ? 'border-primary bg-surface-primary' : 'border-primary/50'
+            }`}
+            onDragOver={(event) => {
+                setIsHighlighted(true)
+                onDragOver(event)
+            }}
+            onDragLeave={() => setIsHighlighted(false)}
+            onDrop={(event) => {
+                setIsHighlighted(false)
+                onDrop(event, edge)
+            }}
+            data-attr="workflow-linear-dropzone"
+        >
+            <div className="pointer-events-none absolute inset-y-0 left-1/2 border-l-2 border-primary" />
+            <div className="pointer-events-none relative flex size-8 items-center justify-center rounded-full border-2 bg-surface-primary">
+                <IconPlus className="text-lg text-primary" />
+            </div>
+            <span className="pointer-events-none absolute left-[calc(50%+2rem)] whitespace-nowrap rounded border bg-surface-primary px-2 py-1 text-xs text-secondary opacity-0 transition-opacity group-hover:opacity-100 motion-reduce:transition-none">
+                Drop step here
+            </span>
+        </div>
+    )
+}
+
+export function HogFlowLinearEditor(): JSX.Element {
+    const { workflow, nodeToBeAdded } = useValues(hogFlowEditorLogic)
+    const actionIds = getLinearWorkflowActionIds(workflow)
+
+    const actionsById = new Map(workflow.actions.map((action) => [action.id, action]))
+    const linearActions =
+        actionIds?.map((actionId) => actionsById.get(actionId)).filter((action): action is HogFlowAction => !!action) ??
+        []
+
+    const edgesBySource = new Map(workflow.edges.map((edge) => [edge.from, edge]))
+    const linearEdges = actionIds?.slice(0, -1).map((actionId) => edgesBySource.get(actionId)) ?? []
+
+    return (
+        <div className="flex min-h-0 min-w-0 flex-1 overflow-y-auto p-4" data-attr="workflow-linear-editor">
+            <div className="mx-auto flex w-full max-w-3xl flex-col">
+                {linearActions.map((action, index) => (
+                    <div key={action.id} className="flex flex-col">
+                        <StepView action={action} layout="list" />
+                        {index < linearActions.length - 1 && (
+                            <HogFlowLinearDropzone active={!!nodeToBeAdded} edge={linearEdges[index]} />
+                        )}
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/products/workflows/frontend/Workflows/hogflows/HogFlowLinearEditor.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/HogFlowLinearEditor.tsx
@@ -60,7 +60,7 @@ export function HogFlowLinearEditor(): JSX.Element {
     const linearEdges = actionIds?.slice(0, -1).map((actionId) => edgesBySource.get(actionId)) ?? []
 
     return (
-        <div className="flex min-h-0 min-w-0 flex-1 overflow-y-auto p-4" data-attr="workflow-linear-editor">
+        <div className="flex min-h-0 min-w-0 flex-1 overflow-y-auto p-2" data-attr="workflow-linear-editor">
             <div className="mx-auto flex w-full max-w-3xl flex-col">
                 {linearActions.map((action, index) => (
                     <div key={action.id} className="flex flex-col">

--- a/products/workflows/frontend/Workflows/hogflows/HogFlowLinearEditor.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/HogFlowLinearEditor.tsx
@@ -60,7 +60,7 @@ export function HogFlowLinearEditor(): JSX.Element {
     const linearEdges = actionIds?.slice(0, -1).map((actionId) => edgesBySource.get(actionId)) ?? []
 
     return (
-        <div className="flex min-h-0 min-w-0 flex-1 overflow-y-auto p-2" data-attr="workflow-linear-editor">
+        <div className="flex min-h-0 min-w-0 flex-1 overflow-y-auto p-4" data-attr="workflow-linear-editor">
             <div className="mx-auto flex w-full max-w-3xl flex-col">
                 {linearActions.map((action, index) => (
                     <div key={action.id} className="flex flex-col">

--- a/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.test.ts
@@ -97,6 +97,14 @@ describe('hogFlowEditorLogic', () => {
         logic.mount()
     })
 
+    it('resolves the selected action while React Flow nodes are still laying out', () => {
+        const action = logic.values.workflow.actions[0]
+        logic.actions.setNodesRaw([])
+        logic.actions.setSelectedNodeId(action.id)
+
+        expect(logic.values.selectedNode).toMatchObject({ id: action.id, data: action })
+    })
+
     describe('conditional branch naming', () => {
         const createMockHogFlow = (conditionNames?: (string | undefined)[]): HogFlow => ({
             id: 'test-flow',

--- a/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.test.ts
@@ -2,6 +2,7 @@ import { expectLogic } from 'kea-test-utils'
 
 import { initKeaTests } from '~/test/init'
 
+import { EXIT_NODE_ID, NEW_WORKFLOW, TRIGGER_NODE_ID, workflowLogic } from '../workflowLogic'
 import { computeMoveEdges, hogFlowEditorLogic } from './hogFlowEditorLogic'
 import { HogFlow, HogFlowAction, HogFlowActionEdge, HogFlowActionNode } from './types'
 
@@ -103,6 +104,34 @@ describe('hogFlowEditorLogic', () => {
         logic.actions.setSelectedNodeId(action.id)
 
         expect(logic.values.selectedNode).toMatchObject({ id: action.id, data: action })
+    })
+
+    it('duplicates a linear step below itself', () => {
+        const delay: HogFlowAction = {
+            id: 'delay',
+            name: 'Delay',
+            description: '',
+            type: 'delay',
+            created_at: 0,
+            updated_at: 0,
+            config: { delay_duration: '1d' },
+        }
+        workflowLogic().actions.setWorkflowInfo({
+            actions: [NEW_WORKFLOW.actions[0], delay, NEW_WORKFLOW.actions[1]],
+            edges: [edge(TRIGGER_NODE_ID, delay.id, 'continue'), edge(delay.id, EXIT_NODE_ID, 'continue')],
+        })
+
+        logic.actions.duplicateNodeBelow(delay.id)
+
+        const duplicatedAction = logic.values.workflow.actions.find(
+            (action) => action.id !== delay.id && action.type === delay.type
+        )
+        expect(duplicatedAction).toMatchObject({ name: delay.name, config: delay.config })
+        expect(logic.values.workflow.edges).toEqual([
+            edge(TRIGGER_NODE_ID, delay.id, 'continue'),
+            edge(delay.id, duplicatedAction!.id, 'continue'),
+            edge(duplicatedAction!.id, EXIT_NODE_ID, 'continue'),
+        ])
     })
 
     describe('conditional branch naming', () => {

--- a/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
@@ -170,11 +170,11 @@ export interface hogFlowEditorLogicValues {
     animatingEdgePair: string | null
     dropzoneNodes: DropzoneNode[]
     edges: HogFlowActionEdge[]
+    editorLayout: HogFlowEditorLayout
     highlightedDropzoneNodeId: string | null
     isCopyingNode: boolean
     isMovingNode: boolean
     isZoomedOutFar: boolean
-    editorLayout: HogFlowEditorLayout
     mode: HogFlowEditorMode
     movingNodeId: string | null
     nodeToBeAdded: CreateActionType | HogFlowActionNode | null
@@ -2012,14 +2012,14 @@ export interface hogFlowEditorLogicActions {
     setEdges: (edges: HogFlowActionEdge[]) => {
         edges: HogFlowActionEdge[]
     }
+    setEditorLayout: (editorLayout: HogFlowEditorLayout) => {
+        editorLayout: HogFlowEditorLayout
+    }
     setHighlightedDropzoneNodeId: (highlightedDropzoneNodeId: string | null) => {
         highlightedDropzoneNodeId: string | null
     }
     setIsZoomedOutFar: (isZoomedOutFar: boolean) => {
         isZoomedOutFar: boolean
-    }
-    setEditorLayout: (editorLayout: HogFlowEditorLayout) => {
-        editorLayout: HogFlowEditorLayout
     }
     setMode: (mode: HogFlowEditorMode) => {
         mode: 'build' | 'logs' | 'metrics' | 'test' | 'variables'

--- a/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
@@ -137,6 +137,7 @@ export function computeMoveEdges(
 
 export const HOG_FLOW_EDITOR_MODES = ['build', 'variables', 'test', 'metrics', 'logs'] as const
 export type HogFlowEditorMode = (typeof HOG_FLOW_EDITOR_MODES)[number]
+export type HogFlowEditorLayout = 'simple' | 'advanced'
 export type HogFlowEditorActionMetrics = {
     actionId: string
     succeeded: number
@@ -173,6 +174,7 @@ export interface hogFlowEditorLogicValues {
     isCopyingNode: boolean
     isMovingNode: boolean
     isZoomedOutFar: boolean
+    editorLayout: HogFlowEditorLayout
     mode: HogFlowEditorMode
     movingNodeId: string | null
     nodeToBeAdded: CreateActionType | HogFlowActionNode | null
@@ -2016,6 +2018,9 @@ export interface hogFlowEditorLogicActions {
     setIsZoomedOutFar: (isZoomedOutFar: boolean) => {
         isZoomedOutFar: boolean
     }
+    setEditorLayout: (editorLayout: HogFlowEditorLayout) => {
+        editorLayout: HogFlowEditorLayout
+    }
     setMode: (mode: HogFlowEditorMode) => {
         mode: 'build' | 'logs' | 'metrics' | 'test' | 'variables'
     }
@@ -2123,6 +2128,7 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
         onDrop: (event?: DragEvent, targetEdge?: HogFlowEdge) => ({ event, targetEdge }),
         setNodeToBeAdded: (nodeToBeAdded: CreateActionType | HogFlowActionNode | null) => ({ nodeToBeAdded }),
         setHighlightedDropzoneNodeId: (highlightedDropzoneNodeId: string | null) => ({ highlightedDropzoneNodeId }),
+        setEditorLayout: (editorLayout: HogFlowEditorLayout) => ({ editorLayout }),
         setMode: (mode: HogFlowEditorMode) => ({ mode }),
         setAnimatingEdgePair: (from: string, to: string) => ({ from, to }),
         clearAnimatingEdgePair: true,
@@ -2141,6 +2147,12 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
         setIsZoomedOutFar: (isZoomedOutFar: boolean) => ({ isZoomedOutFar }),
     }),
     reducers(() => ({
+        editorLayout: [
+            'simple' as HogFlowEditorLayout,
+            {
+                setEditorLayout: (_, { editorLayout }) => editorLayout,
+            },
+        ],
         mode: [
             'build' as HogFlowEditorMode,
             {
@@ -2960,16 +2972,21 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
         return {
             setSelectedNodeId: () => syncProperty('node', values.selectedNodeId ?? null),
             setMode: () => syncProperty('mode', values.mode),
+            setEditorLayout: () => syncProperty('view', values.editorLayout === 'simple' ? 'linear' : 'graph'),
         }
     }),
     urlToAction(({ actions, values }) => {
         const reactToTabChange = (_: any, search: Record<string, string>): void => {
-            const { node = null, mode } = search
+            const { node = null, mode, view } = search
             if (node !== values.selectedNodeId) {
                 actions.setSelectedNodeId(node ?? null)
             }
             if (mode && HOG_FLOW_EDITOR_MODES.includes(mode as HogFlowEditorMode) && mode !== values.mode) {
                 actions.setMode(mode as HogFlowEditorMode)
+            }
+            const editorLayout = view === 'graph' ? 'advanced' : 'simple'
+            if (editorLayout !== values.editorLayout) {
+                actions.setEditorLayout(editorLayout)
             }
         }
 

--- a/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
@@ -29,6 +29,7 @@ import type { HogFunctionTemplateType, UserBasicType } from '../../../../../fron
 import { optOutCategoriesLogic } from '../../OptOuts/optOutCategoriesLogic'
 import type { MessageCategory } from '../../OptOuts/optOutCategoriesLogic'
 import { EXIT_NODE_ID, TRIGGER_NODE_ID, WorkflowLogicProps, workflowLogic } from '../workflowLogic'
+import { getLinearWorkflowActionIds } from './linearWorkflow'
 import { getFormattedNodes } from './react_flow_utils/autolayout'
 import { BOTTOM_HANDLE_POSITION, NODE_HEIGHT, NODE_WIDTH, TOP_HANDLE_POSITION } from './react_flow_utils/constants'
 import { getSmartStepPath } from './react_flow_utils/SmartEdge'
@@ -2091,7 +2092,7 @@ export type hogFlowEditorLogicType = MakeLogicType<
 export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
     props({} as WorkflowLogicProps),
     path((key) => ['scenes', 'hogflows', 'hogFlowEditorLogic', key]),
-    key((props) => `hog-flow-editor-${props.id}`),
+    key((props) => `hog-flow-editor-${props.id}-${props.templateId || 'default'}-${props.editTemplateId || 'default'}`),
     connect(() => ({
         values: [
             workflowLogic,
@@ -2944,11 +2945,14 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
         }
     }),
 
-    subscriptions(({ actions }) => ({
+    subscriptions(({ actions, values }) => ({
         workflow: (hogFlow?: HogFlow, oldHogFlow?: HogFlow) => {
             // Auto-save round-trips can emit a deep-equal workflow; skipping the rebuild avoids
             // re-deriving every node and edge (including the async layout pass) for no change.
             if (hogFlow && !objectsEqual(hogFlow, oldHogFlow)) {
+                if (values.editorLayout === 'simple' && !getLinearWorkflowActionIds(hogFlow)) {
+                    actions.setEditorLayout('advanced')
+                }
                 actions.resetFlowFromHogFlow(hogFlow)
             }
         },
@@ -2984,7 +2988,11 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
             if (mode && HOG_FLOW_EDITOR_MODES.includes(mode as HogFlowEditorMode) && mode !== values.mode) {
                 actions.setMode(mode as HogFlowEditorMode)
             }
-            const editorLayout = view === 'graph' ? 'advanced' : 'simple'
+            const requestedEditorLayout = view === 'graph' ? 'advanced' : 'simple'
+            const editorLayout =
+                requestedEditorLayout === 'simple' && !getLinearWorkflowActionIds(values.workflow)
+                    ? 'advanced'
+                    : requestedEditorLayout
             if (editorLayout !== values.editorLayout) {
                 actions.setEditorLayout(editorLayout)
             }
@@ -2996,6 +3004,9 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
     }),
     events(({ actions, values }) => ({
         afterMount: () => {
+            if (values.editorLayout === 'simple' && !getLinearWorkflowActionIds(values.workflow)) {
+                actions.setEditorLayout('advanced')
+            }
             actions.resetFlowFromHogFlow(values.workflow)
 
             const handleKeyDown = (e: KeyboardEvent): void => {

--- a/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
@@ -1938,6 +1938,9 @@ export interface hogFlowEditorLogicActions {
     copyNodeToHighlightedDropzone: () => {
         value: true
     }
+    duplicateNodeBelow: (actionId: string) => {
+        actionId: string
+    }
     fitView: (options?: { duration?: number; noZoom?: boolean }) => {
         duration?: number | undefined
         noZoom?: boolean | undefined
@@ -1974,6 +1977,11 @@ export interface hogFlowEditorLogicActions {
             params: Pick<AppMetricsTotalsRequest, 'appSource' | 'appSourceId' | 'dateFrom' | 'dateTo'>
             timezone: string
         }
+    }
+    moveNodeToEdge: (movingNodeId: string, targetEdge: HogFlowEdge, isBranchJoinDropzone: boolean) => {
+        movingNodeId: string
+        targetEdge: HogFlowEdge
+        isBranchJoinDropzone: boolean
     }
     moveNodeToHighlightedDropzone: () => {
         value: true
@@ -2139,6 +2147,12 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
         startMovingNode: (node: HogFlowActionNode) => ({ node }),
         stopMovingNode: true,
         moveNodeToHighlightedDropzone: true,
+        moveNodeToEdge: (movingNodeId: string, targetEdge: HogFlowEdge, isBranchJoinDropzone: boolean) => ({
+            movingNodeId,
+            targetEdge,
+            isBranchJoinDropzone,
+        }),
+        duplicateNodeBelow: (actionId: string) => ({ actionId }),
         loadActionMetricsById: (
             params: Pick<AppMetricsTotalsRequest, 'appSource' | 'appSourceId' | 'dateFrom' | 'dateTo'>,
             timezone: string
@@ -2915,23 +2929,33 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
                 }
 
                 const isBranchJoinDropzone = dropzoneNode.data.isBranchJoinDropzone ?? false
-                const newEdges = computeMoveEdges(
-                    values.workflow.edges,
-                    movingNodeId,
-                    targetHogFlowEdge,
-                    isBranchJoinDropzone
-                )
+                actions.moveNodeToEdge(movingNodeId, targetHogFlowEdge, isBranchJoinDropzone)
+                actions.hideDropzones()
+                actions.stopMovingNode()
+            },
+            moveNodeToEdge: ({ movingNodeId, targetEdge, isBranchJoinDropzone }) => {
+                // Uses computeMoveEdges (pure function) to manipulate edges in a single
+                // setWorkflowInfo call. This preserves node identity while moving a step.
+                const newEdges = computeMoveEdges(values.workflow.edges, movingNodeId, targetEdge, isBranchJoinDropzone)
 
                 if (!newEdges) {
                     lemonToast.error("Couldn't move this step there. Try a different spot.")
-                    actions.stopMovingNode()
                     return
                 }
 
                 actions.setWorkflowInfo({ actions: values.workflow.actions, edges: newEdges })
                 actions.setSelectedNodeId(movingNodeId)
-                actions.hideDropzones()
-                actions.stopMovingNode()
+            },
+            duplicateNodeBelow: ({ actionId }) => {
+                const action = values.workflow.actions.find((action) => action.id === actionId)
+                const targetEdge = values.workflow.edges.find((edge) => edge.from === actionId)
+
+                if (!action || action.type === 'trigger' || action.type === 'exit' || !targetEdge) {
+                    return
+                }
+
+                actions.setNodeToBeAdded(action)
+                actions.onDrop(undefined, targetEdge)
             },
             handlePaneClick: () => {
                 actions.setSelectedNodeId(null)

--- a/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
@@ -1978,8 +1978,12 @@ export interface hogFlowEditorLogicActions {
     onDragOver: (event: DragEvent) => {
         event: DragEvent<Element>
     }
-    onDrop: (event?: DragEvent) => {
+    onDrop: (
+        event?: DragEvent,
+        targetEdge?: HogFlowEdge
+    ) => {
         event: DragEvent<Element> | undefined
+        targetEdge: HogFlowEdge | undefined
     }
     onEdgesChange: (edges: EdgeChange<HogFlowActionEdge>[]) => {
         edges: EdgeChange<HogFlowActionEdge>[]
@@ -2055,7 +2059,11 @@ export interface hogFlowEditorLogicMeta {
     key: string
     __keaTypeGenInternalSelectorTypes: {
         nodesById: (nodes: HogFlowActionNode[]) => Record<string, HogFlowActionNode>
-        selectedNode: (nodes: HogFlowActionNode[], selectedNodeId: string | null) => HogFlowActionNode | null
+        selectedNode: (
+            nodes: HogFlowActionNode[],
+            selectedNodeId: string | null,
+            workflow: HogFlow
+        ) => HogFlowActionNode | null
         selectedNodeCanBeDeleted: (
             selectedNode: HogFlowActionNode | null,
             nodes: HogFlowActionNode[],
@@ -2112,7 +2120,7 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
         }),
         setReactFlowWrapper: (reactFlowWrapper: RefObject<HTMLDivElement>) => ({ reactFlowWrapper }),
         onDragOver: (event: DragEvent) => ({ event }),
-        onDrop: (event?: DragEvent) => ({ event }),
+        onDrop: (event?: DragEvent, targetEdge?: HogFlowEdge) => ({ event, targetEdge }),
         setNodeToBeAdded: (nodeToBeAdded: CreateActionType | HogFlowActionNode | null) => ({ nodeToBeAdded }),
         setHighlightedDropzoneNodeId: (highlightedDropzoneNodeId: string | null) => ({ highlightedDropzoneNodeId }),
         setMode: (mode: HogFlowEditorMode) => ({ mode }),
@@ -2240,9 +2248,30 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
             },
         ],
         selectedNode: [
-            (s) => [s.nodes, s.selectedNodeId],
-            (nodes: HogFlowActionNode[], selectedNodeId: string | null) => {
-                return nodes.find((node) => node.id === selectedNodeId) ?? null
+            (s) => [s.nodes, s.selectedNodeId, s.workflow],
+            (
+                nodes: HogFlowActionNode[],
+                selectedNodeId: string | null,
+                workflow: HogFlow
+            ): HogFlowActionNode | null => {
+                const node = nodes.find((node) => node.id === selectedNodeId)
+                if (node || !selectedNodeId) {
+                    return node ?? null
+                }
+
+                const action = workflow.actions.find((action) => action.id === selectedNodeId)
+                return action
+                    ? ({
+                          id: action.id,
+                          type: 'action',
+                          data: action,
+                          position: { x: 0, y: 0 },
+                          deletable: !['trigger', 'exit'].includes(action.type),
+                          selectable: true,
+                          draggable: false,
+                          connectable: false,
+                      } satisfies HogFlowActionNode)
+                    : null
             },
         ],
         selectedNodeCanBeDeleted: [
@@ -2583,12 +2612,18 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
                 event.dataTransfer.dropEffect = 'move'
             },
 
-            onDrop: ({ event }) => {
+            onDrop: ({ event, targetEdge }) => {
                 event?.preventDefault()
                 const dropzoneNode = values.dropzoneNodes.find((x) => x.id === values.highlightedDropzoneNodeId)
 
-                if (values.nodeToBeAdded && dropzoneNode) {
-                    const edgeToInsertNodeInto = dropzoneNode?.data.edge
+                if (values.nodeToBeAdded && (dropzoneNode || targetEdge)) {
+                    const edgeToInsertNodeInto = targetEdge
+                        ? ({
+                              id: getEdgeId(targetEdge),
+                              source: targetEdge.from,
+                              target: targetEdge.to,
+                          } as HogFlowActionEdge)
+                        : dropzoneNode!.data.edge
 
                     // Check if nodeToBeAdded is a HogFlowActionNode (has 'data' property) or CreateActionType
                     const isHogFlowActionNode = 'data' in values.nodeToBeAdded
@@ -2636,7 +2671,7 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
                     const branchEdges = isHogFlowActionNode
                         ? 0
                         : ((partialNewAction as CreateActionType).branchEdges ?? 0)
-                    const isBranchJoinDropzone = dropzoneNode?.data.isBranchJoinDropzone ?? false
+                    const isBranchJoinDropzone = !targetEdge && (dropzoneNode?.data.isBranchJoinDropzone ?? false)
 
                     if (!step) {
                         throw new Error(`Step not found for action type: ${newAction}`)
@@ -2944,6 +2979,8 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
     }),
     events(({ actions, values }) => ({
         afterMount: () => {
+            actions.resetFlowFromHogFlow(values.workflow)
+
             const handleKeyDown = (e: KeyboardEvent): void => {
                 if (e.key === 'Escape') {
                     if (values.isCopyingNode) {

--- a/products/workflows/frontend/Workflows/hogflows/linearWorkflow.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/linearWorkflow.test.ts
@@ -1,0 +1,52 @@
+import { getLinearWorkflowActionIds } from './linearWorkflow'
+import type { HogFlow, HogFlowAction } from './types'
+
+const action = (id: string, type: HogFlowAction['type']): HogFlowAction => ({ id, type }) as HogFlowAction
+
+const workflow = (actions: HogFlowAction[], edges: HogFlow['edges']): Pick<HogFlow, 'actions' | 'edges'> => ({
+    actions,
+    edges,
+})
+
+describe('getLinearWorkflowActionIds', () => {
+    it('orders a trigger-to-exit sequence', () => {
+        expect(
+            getLinearWorkflowActionIds(
+                workflow(
+                    [action('trigger', 'trigger'), action('slack', 'function'), action('exit', 'exit')],
+                    [
+                        { from: 'trigger', to: 'slack', type: 'continue' },
+                        { from: 'slack', to: 'exit', type: 'continue' },
+                    ]
+                )
+            )
+        ).toEqual(['trigger', 'slack', 'exit'])
+    })
+
+    it.each([
+        {
+            name: 'a conditional step',
+            actions: [action('trigger', 'trigger'), action('condition', 'conditional_branch'), action('exit', 'exit')],
+            edges: [
+                { from: 'trigger', to: 'condition', type: 'continue' as const },
+                { from: 'condition', to: 'exit', type: 'continue' as const },
+            ],
+        },
+        {
+            name: 'a graph with converging paths',
+            actions: [
+                action('trigger', 'trigger'),
+                action('first', 'function'),
+                action('second', 'function'),
+                action('exit', 'exit'),
+            ],
+            edges: [
+                { from: 'trigger', to: 'first', type: 'continue' as const },
+                { from: 'trigger', to: 'second', type: 'continue' as const },
+                { from: 'first', to: 'exit', type: 'continue' as const },
+            ],
+        },
+    ])('rejects $name', ({ actions, edges }) => {
+        expect(getLinearWorkflowActionIds(workflow(actions, edges))).toBeNull()
+    })
+})

--- a/products/workflows/frontend/Workflows/hogflows/linearWorkflow.ts
+++ b/products/workflows/frontend/Workflows/hogflows/linearWorkflow.ts
@@ -1,0 +1,62 @@
+import type { HogFlow, HogFlowAction } from './types'
+
+export const BRANCHING_ACTION_TYPES = ['conditional_branch', 'random_cohort_branch', 'wait_until_condition'] as const
+
+export function isBranchingAction(action: Pick<HogFlowAction, 'type'>): boolean {
+    return BRANCHING_ACTION_TYPES.includes(action.type as (typeof BRANCHING_ACTION_TYPES)[number])
+}
+
+export function getLinearWorkflowActionIds(workflow: Pick<HogFlow, 'actions' | 'edges'>): string[] | null {
+    const { actions, edges } = workflow
+    const actionsById = new Map(actions.map((action) => [action.id, action]))
+    const trigger = actions.filter((action) => action.type === 'trigger')
+    const exit = actions.filter((action) => action.type === 'exit')
+
+    if (
+        trigger.length !== 1 ||
+        exit.length !== 1 ||
+        edges.length !== actions.length - 1 ||
+        actions.some(isBranchingAction) ||
+        edges.some((edge) => edge.type !== 'continue')
+    ) {
+        return null
+    }
+
+    const incomingById = new Map<string, number>()
+    const outgoingById = new Map<string, string>()
+
+    for (const edge of edges) {
+        if (!actionsById.has(edge.from) || !actionsById.has(edge.to) || outgoingById.has(edge.from)) {
+            return null
+        }
+        incomingById.set(edge.to, (incomingById.get(edge.to) ?? 0) + 1)
+        outgoingById.set(edge.from, edge.to)
+    }
+
+    for (const action of actions) {
+        const incoming = incomingById.get(action.id) ?? 0
+        const outgoing = outgoingById.has(action.id)
+        if (
+            (action.type === 'trigger' && incoming !== 0) ||
+            (action.type !== 'trigger' && incoming !== 1) ||
+            (action.type === 'exit' && outgoing) ||
+            (action.type !== 'exit' && !outgoing)
+        ) {
+            return null
+        }
+    }
+
+    const actionIds: string[] = []
+    let actionId: string | undefined = trigger[0].id
+    while (actionId) {
+        if (actionIds.includes(actionId)) {
+            return null
+        }
+        actionIds.push(actionId)
+        actionId = outgoingById.get(actionId)
+    }
+
+    return actionIds.length === actions.length && actionsById.get(actionIds.at(-1) ?? '')?.type === 'exit'
+        ? actionIds
+        : null
+}

--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanel.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanel.tsx
@@ -1,27 +1,39 @@
-import { useReactFlow } from '@xyflow/react'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
+import { useRef } from 'react'
 
-import { IconArrowLeft, IconTrash } from '@posthog/icons'
-import { LemonBadge, LemonButton, LemonTab, LemonTabs, Tooltip } from '@posthog/lemon-ui'
+import { IconArrowLeft } from '@posthog/icons'
+import { LemonButton, LemonTab, LemonTabs } from '@posthog/lemon-ui'
 
+import { Resizer } from 'lib/components/Resizer/Resizer'
+import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
 import { capitalizeFirstLetter } from 'lib/utils/strings'
 
-import { workflowLogic } from '../../workflowLogic'
 import { HOG_FLOW_EDITOR_MODES, HogFlowEditorMode, hogFlowEditorLogic } from '../hogFlowEditorLogic'
-import { useHogFlowStep } from '../steps/HogFlowSteps'
 import { HogFlowEditorPanelBuild } from './HogFlowEditorPanelBuild'
 import { HogFlowEditorPanelBuildDetail } from './HogFlowEditorPanelBuildDetail'
 import { HogFlowEditorPanelLogs } from './HogFlowEditorPanelLogs'
 import { HogFlowEditorPanelMetrics } from './HogFlowEditorPanelMetrics'
+import { HogFlowEditorPanelSelectedStep } from './HogFlowEditorPanelSelectedStep'
 import { HogFlowEditorPanelVariables } from './HogFlowEditorPanelVariables'
 import { EmailActionTestContent } from './testing/HogFlowEditorNotificationPanelTest'
 import { HogFlowEditorPanelTest } from './testing/HogFlowEditorPanelTest'
 
-export function HogFlowEditorPanel(): JSX.Element | null {
-    const { selectedNode, mode, selectedNodeCanBeDeleted, workflow } = useValues(hogFlowEditorLogic)
+export function HogFlowEditorPanel({
+    layout = 'floating',
+}: {
+    layout?: 'floating' | 'panel'
+} = {}): JSX.Element | null {
+    const { selectedNode, mode, workflow } = useValues(hogFlowEditorLogic)
     const { setMode, setSelectedNodeId } = useActions(hogFlowEditorLogic)
-    const { deleteElements } = useReactFlow()
+    const panelRef = useRef<HTMLDivElement>(null)
+    const resizerProps: ResizerLogicProps = {
+        logicKey: 'hog-flow-simple-panel',
+        containerRef: panelRef,
+        placement: 'left',
+        persistent: true,
+    }
+    const { desiredSize: panelWidth } = useValues(resizerLogic(resizerProps))
 
     const variablesCount = workflow?.variables?.length || 0
 
@@ -39,23 +51,35 @@ export function HogFlowEditorPanel(): JSX.Element | null {
 
     const width = mode !== 'build' ? '37rem' : selectedNode ? '37rem' : '25rem'
 
-    const Step = useHogFlowStep(selectedNode?.data)
-    const { actionValidationErrorsById } = useValues(workflowLogic)
-    const validationResult = actionValidationErrorsById[selectedNode?.id ?? '']
-
     return (
         <div
-            className="absolute flex flex-col m-0 p-2 overflow-hidden transition-[width] max-h-full right-0 justify-end"
-            style={{ width }}
+            ref={panelRef}
+            className={clsx(
+                'flex min-h-0 flex-col m-0 overflow-hidden max-h-full justify-end',
+                layout === 'floating'
+                    ? 'absolute right-0 p-2 transition-[width]'
+                    : 'relative h-full shrink-0 bg-surface-primary'
+            )}
+            style={
+                layout === 'floating' ? { width } : { width: panelWidth ?? '50%', minWidth: '20rem', maxWidth: '70%' }
+            }
         >
+            {layout === 'panel' && <Resizer {...resizerProps} />}
             <div
-                className="relative flex flex-col rounded-md overflow-hidden bg-surface-primary max-h-full z-10"
-                style={{
-                    border: '1px solid var(--border)',
-                    boxShadow: '0 3px 0 var(--border)',
-                }}
+                className={clsx(
+                    'relative flex min-h-0 flex-col rounded-md overflow-hidden bg-surface-primary z-10',
+                    layout === 'floating' ? 'max-h-full' : 'h-full !rounded-none'
+                )}
+                style={
+                    layout === 'floating'
+                        ? {
+                              border: '1px solid var(--border)',
+                              boxShadow: '0 3px 0 var(--border)',
+                          }
+                        : undefined
+                }
             >
-                <div className="flex gap-2 border-b items-center">
+                <div className="flex shrink-0 gap-2 border-b items-center">
                     <div
                         className={clsx(
                             'transition-all overflow-hidden flex p-1',
@@ -67,6 +91,8 @@ export function HogFlowEditorPanel(): JSX.Element | null {
                             icon={<IconArrowLeft />}
                             onClick={() => setSelectedNodeId(null)}
                             disabled={!selectedNode}
+                            aria-label="Back to steps"
+                            data-attr="workflow-panel-back"
                         />
                     </div>
 
@@ -78,38 +104,9 @@ export function HogFlowEditorPanel(): JSX.Element | null {
                             barClassName="-mb-px "
                         />
                     </div>
-
-                    {selectedNode && (
-                        <span className="flex gap-1 items-center font-medium rounded-md mr-3 min-w-0">
-                            <span className="text-lg">{Step?.icon}</span>
-                            <Tooltip title={selectedNode.data.name}>
-                                <span className="font-semibold truncate">{selectedNode.data.name}</span>
-                            </Tooltip>
-                            {validationResult?.valid === false && (
-                                <Tooltip title="Some fields need attention">
-                                    <div>
-                                        <LemonBadge status="warning" size="small" content="!" />
-                                    </div>
-                                </Tooltip>
-                            )}
-                            {selectedNode.deletable && (
-                                <LemonButton
-                                    size="small"
-                                    status="danger"
-                                    icon={<IconTrash />}
-                                    onClick={() => {
-                                        void deleteElements({ nodes: [selectedNode] })
-                                        setSelectedNodeId(null)
-                                    }}
-                                    disabledReason={
-                                        selectedNodeCanBeDeleted ? undefined : 'Clean up branching steps first'
-                                    }
-                                />
-                            )}
-                        </span>
-                    )}
                 </div>
 
+                {selectedNode && ['build', 'metrics', 'test'].includes(mode) && <HogFlowEditorPanelSelectedStep />}
                 {mode === 'build' && (
                     <>{!selectedNode ? <HogFlowEditorPanelBuild /> : <HogFlowEditorPanelBuildDetail />}</>
                 )}

--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanel.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanel.tsx
@@ -60,7 +60,11 @@ export function HogFlowEditorPanel({
                     ? 'absolute right-0 p-2 transition-[width]'
                     : 'relative h-full shrink-0 bg-surface-primary'
             )}
-            style={layout === 'floating' ? { width } : { width: panelWidth ?? '50%', minWidth: width, maxWidth: '70%' }}
+            style={
+                layout === 'floating'
+                    ? { width }
+                    : { width: panelWidth ?? '50%', minWidth: `min(${width}, 70%)`, maxWidth: '70%' }
+            }
         >
             {layout === 'panel' && <Resizer {...resizerProps} />}
             <div

--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanel.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanel.tsx
@@ -106,7 +106,9 @@ export function HogFlowEditorPanel({
                     </div>
                 </div>
 
-                {selectedNode && ['build', 'metrics', 'test'].includes(mode) && <HogFlowEditorPanelSelectedStep />}
+                {selectedNode && ['build', 'metrics', 'test', 'logs'].includes(mode) && (
+                    <HogFlowEditorPanelSelectedStep />
+                )}
                 {mode === 'build' && (
                     <>{!selectedNode ? <HogFlowEditorPanelBuild /> : <HogFlowEditorPanelBuildDetail />}</>
                 )}

--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanel.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanel.tsx
@@ -60,9 +60,7 @@ export function HogFlowEditorPanel({
                     ? 'absolute right-0 p-2 transition-[width]'
                     : 'relative h-full shrink-0 bg-surface-primary'
             )}
-            style={
-                layout === 'floating' ? { width } : { width: panelWidth ?? '50%', minWidth: '20rem', maxWidth: '70%' }
-            }
+            style={layout === 'floating' ? { width } : { width: panelWidth ?? '50%', minWidth: width, maxWidth: '70%' }}
         >
             {layout === 'panel' && <Resizer {...resizerProps} />}
             <div

--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuild.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuild.tsx
@@ -194,13 +194,19 @@ function HogFlowEditorToolbarNode({
     onDragStart?: (event: React.DragEvent) => void
     children?: React.ReactNode
 }): JSX.Element | null {
-    const { setNodeToBeAdded } = useActions(hogFlowEditorLogic)
+    const { hideDropzones, setNodeToBeAdded, showDropzones } = useActions(hogFlowEditorLogic)
 
     const onDragStart = (event: React.DragEvent): void => {
         setNodeToBeAdded(action)
+        showDropzones()
         event.dataTransfer.setData('application/reactflow', action.type)
         event.dataTransfer.effectAllowed = 'move'
         onDragStartProp?.(event)
+    }
+
+    const onDragEnd = (): void => {
+        setNodeToBeAdded(null)
+        hideDropzones()
     }
 
     const step = useHogFlowStep(action as HogFlowAction)
@@ -210,7 +216,7 @@ function HogFlowEditorToolbarNode({
     }
 
     return (
-        <div draggable onDragStart={onDragStart}>
+        <div draggable onDragStart={onDragStart} onDragEnd={onDragEnd}>
             <LemonButton
                 icon={<span style={{ color: step.color }}>{step.icon}</span>}
                 sideIcon={<IconDrag />}

--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuildDetail.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuildDetail.tsx
@@ -75,7 +75,7 @@ export function HogFlowEditorPanelBuildDetail(): JSX.Element | null {
     const hideFiltersPanel = isBranchingStep && !hasLegacyBranchingFilters
 
     return (
-        <div className="flex flex-col h-full overflow-hidden">
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
             <ScrollableShadows
                 direction="vertical"
                 className="flex-1 min-h-0"

--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuildDetail.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuildDetail.tsx
@@ -14,7 +14,6 @@ import {
     LemonSwitch,
 } from '@posthog/lemon-ui'
 
-import { EditableField } from 'lib/components/EditableField/EditableField'
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { LemonField } from 'lib/lemon-ui/LemonField/LemonField'
 import { urls } from 'scenes/urls'
@@ -27,7 +26,7 @@ import { workflowLogic } from '../../workflowLogic'
 import { HogFlowPropertyFilters } from '../filters/HogFlowFilters'
 import { hogFlowEditorLogic } from '../hogFlowEditorLogic'
 import { useHogFlowStep } from '../steps/HogFlowSteps'
-import { isEmailAction, isOptOutEligibleAction, isScheduleTrigger } from '../steps/types'
+import { isEmailAction, isOptOutEligibleAction } from '../steps/types'
 import type { HogFlowAction } from '../types'
 import { hogFlowOutputMappingLogic } from './hogFlowOutputMappingLogic'
 import { OutputTestResultTree } from './OutputTestResultTree'
@@ -83,42 +82,6 @@ export function HogFlowEditorPanelBuildDetail(): JSX.Element | null {
                 innerClassName="flex flex-col gap-2 p-3"
                 styledScrollbars
             >
-                <div className="flex flex-col gap-1">
-                    <EditableField
-                        name="step-name"
-                        value={action.name}
-                        onSave={(value) => {
-                            const trimmed = value.trim()
-                            if (trimmed) {
-                                setWorkflowAction(action.id, { ...action, name: trimmed })
-                            }
-                        }}
-                        placeholder="Step name"
-                        minLength={1}
-                        saveOnBlur
-                        clickToEdit
-                        compactButtons
-                        compactIcon
-                        className="font-semibold text-base"
-                        data-attr="workflow-step-name"
-                    />
-                    {!isScheduleTrigger(action) && (
-                        <EditableField
-                            name="step-description"
-                            value={action.description || ''}
-                            onSave={(value) => setWorkflowAction(action.id, { ...action, description: value.trim() })}
-                            placeholder="Add a description (optional)"
-                            multiline
-                            saveOnBlur
-                            clickToEdit
-                            compactButtons
-                            compactIcon
-                            className="text-sm text-secondary"
-                            data-attr="workflow-step-description"
-                        />
-                    )}
-                </div>
-                <LemonDivider className="my-2" />
                 <ErrorBoundary exceptionProps={{ feature: 'workflow-step-config' }}>
                     {Step?.renderConfiguration(selectedNode)}
                 </ErrorBoundary>

--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelSelectedStep.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelSelectedStep.tsx
@@ -1,0 +1,86 @@
+import { useReactFlow } from '@xyflow/react'
+import { useActions, useValues } from 'kea'
+
+import { IconTrash } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { EditableField } from 'lib/components/EditableField/EditableField'
+
+import { hogFlowEditorLogic } from '../hogFlowEditorLogic'
+import { useHogFlowStep } from '../steps/HogFlowSteps'
+import { isScheduleTrigger } from '../steps/types'
+
+export function HogFlowEditorPanelSelectedStep(): JSX.Element | null {
+    const { selectedNode, selectedNodeCanBeDeleted } = useValues(hogFlowEditorLogic)
+    const { setWorkflowAction, setSelectedNodeId } = useActions(hogFlowEditorLogic)
+    const { deleteElements } = useReactFlow()
+    const Step = useHogFlowStep(selectedNode?.data)
+
+    if (!selectedNode) {
+        return null
+    }
+
+    const action = selectedNode.data
+
+    return (
+        <div className="flex shrink-0 items-start gap-3 border-b p-3">
+            <span
+                className="flex size-12 shrink-0 items-center justify-center rounded text-2xl"
+                style={{
+                    backgroundColor: Step?.color ? `${Step.color}20` : 'var(--border)',
+                    color: Step?.color || 'var(--text-secondary)',
+                }}
+            >
+                {Step?.icon}
+            </span>
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
+                <EditableField
+                    name="step-name"
+                    value={action.name}
+                    onSave={(value) => {
+                        const trimmed = value.trim()
+                        if (trimmed) {
+                            setWorkflowAction(action.id, { ...action, name: trimmed })
+                        }
+                    }}
+                    placeholder="Step name"
+                    minLength={1}
+                    saveOnBlur
+                    clickToEdit
+                    compactButtons
+                    compactIcon
+                    className="font-semibold text-base"
+                    data-attr="workflow-step-name"
+                />
+                {!isScheduleTrigger(action) && (
+                    <EditableField
+                        name="step-description"
+                        value={action.description || ''}
+                        onSave={(value) => setWorkflowAction(action.id, { ...action, description: value.trim() })}
+                        placeholder="Add a description (optional)"
+                        multiline
+                        saveOnBlur
+                        clickToEdit
+                        compactButtons
+                        compactIcon
+                        className="text-sm text-secondary"
+                        data-attr="workflow-step-description"
+                    />
+                )}
+            </div>
+            {selectedNode.deletable && (
+                <LemonButton
+                    className="shrink-0"
+                    size="small"
+                    status="danger"
+                    icon={<IconTrash />}
+                    onClick={() => {
+                        void deleteElements({ nodes: [selectedNode] })
+                        setSelectedNodeId(null)
+                    }}
+                    disabledReason={selectedNodeCanBeDeleted ? undefined : 'Clean up branching steps first'}
+                />
+            )}
+        </div>
+    )
+}

--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelSelectedStep.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelSelectedStep.tsx
@@ -23,7 +23,7 @@ export function HogFlowEditorPanelSelectedStep(): JSX.Element | null {
     const action = selectedNode.data
 
     return (
-        <div className="flex shrink-0 items-start gap-2 border-b p-2">
+        <div className="relative z-10 flex shrink-0 items-start gap-2 border-b bg-surface-primary p-2">
             <span
                 className="flex size-10 shrink-0 items-center justify-center rounded text-xl"
                 style={{

--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelSelectedStep.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelSelectedStep.tsx
@@ -2,16 +2,18 @@ import { useReactFlow } from '@xyflow/react'
 import { useActions, useValues } from 'kea'
 
 import { IconTrash } from '@posthog/icons'
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonBadge, LemonButton, Tooltip } from '@posthog/lemon-ui'
 
 import { EditableField } from 'lib/components/EditableField/EditableField'
 
+import { workflowLogic } from '../../workflowLogic'
 import { hogFlowEditorLogic } from '../hogFlowEditorLogic'
 import { useHogFlowStep } from '../steps/HogFlowSteps'
 import { isScheduleTrigger } from '../steps/types'
 
 export function HogFlowEditorPanelSelectedStep(): JSX.Element | null {
     const { selectedNode, selectedNodeCanBeDeleted } = useValues(hogFlowEditorLogic)
+    const { actionValidationErrorsById } = useValues(workflowLogic)
     const { setWorkflowAction, setSelectedNodeId } = useActions(hogFlowEditorLogic)
     const { deleteElements } = useReactFlow()
     const Step = useHogFlowStep(selectedNode?.data)
@@ -21,6 +23,9 @@ export function HogFlowEditorPanelSelectedStep(): JSX.Element | null {
     }
 
     const action = selectedNode.data
+    const validationResult = actionValidationErrorsById[action.id]
+    const hasValidationIssue =
+        validationResult?.valid === false || Object.keys(validationResult?.warnings ?? {}).length > 0
 
     return (
         <div className="relative z-10 flex shrink-0 items-start gap-2 border-b bg-surface-primary p-2">
@@ -80,6 +85,13 @@ export function HogFlowEditorPanelSelectedStep(): JSX.Element | null {
                     }}
                     disabledReason={selectedNodeCanBeDeleted ? undefined : 'Clean up branching steps first'}
                 />
+            )}
+            {hasValidationIssue && (
+                <Tooltip title="Some fields need attention">
+                    <span className={`absolute top-2 ${selectedNode.deletable ? 'right-12' : 'right-2'}`}>
+                        <LemonBadge status="warning" size="small" content="!" />
+                    </span>
+                </Tooltip>
             )}
         </div>
     )

--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelSelectedStep.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelSelectedStep.tsx
@@ -23,9 +23,9 @@ export function HogFlowEditorPanelSelectedStep(): JSX.Element | null {
     const action = selectedNode.data
 
     return (
-        <div className="flex shrink-0 items-start gap-3 border-b p-3">
+        <div className="flex shrink-0 items-start gap-2 border-b p-2">
             <span
-                className="flex size-12 shrink-0 items-center justify-center rounded text-2xl"
+                className="flex size-10 shrink-0 items-center justify-center rounded text-xl"
                 style={{
                     backgroundColor: Step?.color ? `${Step.color}20` : 'var(--border)',
                     color: Step?.color || 'var(--text-secondary)',
@@ -33,7 +33,7 @@ export function HogFlowEditorPanelSelectedStep(): JSX.Element | null {
             >
                 {Step?.icon}
             </span>
-            <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
                 <EditableField
                     name="step-name"
                     value={action.name}
@@ -49,7 +49,7 @@ export function HogFlowEditorPanelSelectedStep(): JSX.Element | null {
                     clickToEdit
                     compactButtons
                     compactIcon
-                    className="font-semibold text-base"
+                    className="text-sm font-semibold"
                     data-attr="workflow-step-name"
                 />
                 {!isScheduleTrigger(action) && (
@@ -63,7 +63,7 @@ export function HogFlowEditorPanelSelectedStep(): JSX.Element | null {
                         clickToEdit
                         compactButtons
                         compactIcon
-                        className="text-sm text-secondary"
+                        className="text-xs text-secondary"
                         data-attr="workflow-step-description"
                     />
                 )}

--- a/products/workflows/frontend/Workflows/hogflows/steps/HogFlowSteps.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/HogFlowSteps.test.ts
@@ -47,4 +47,16 @@ describe('HogFlow step previews', () => {
     ])('derives preview labels from the action config', (workflowAction, expected) => {
         expect(previewLabels(workflowAction)).toEqual(expected)
     })
+
+    it('adds the number of action conditions', () => {
+        const workflowAction = {
+            ...action('function', {
+                template_id: 'template-webhook',
+                inputs: { method: { value: 'POST' }, url: { value: 'https://hooks.example.com/path' } },
+            }),
+            filters: { properties: [{}, {}] },
+        } as HogFlowAction
+
+        expect(previewLabels(workflowAction)).toEqual(['POST hooks.example.com', '2'])
+    })
 })

--- a/products/workflows/frontend/Workflows/hogflows/steps/HogFlowSteps.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/HogFlowSteps.test.ts
@@ -1,0 +1,50 @@
+import { HogFlowAction } from '../types'
+import { getHogFlowStep } from './HogFlowSteps'
+
+const action = (type: HogFlowAction['type'], config: unknown): HogFlowAction =>
+    ({ id: type, type, name: type, description: '', config }) as HogFlowAction
+
+const previewLabels = (workflowAction: HogFlowAction): string[] =>
+    getHogFlowStep(workflowAction, {})?.previews.map(({ label }) => label) ?? []
+
+describe('HogFlow step previews', () => {
+    it.each([
+        [
+            action('trigger', {
+                type: 'event',
+                filters: { events: [{ id: '$pageview' }], properties: [{}, {}] },
+            }),
+            ['Event · $pageview · 2 filters'],
+        ],
+        [action('delay', { delay_duration: '2h' }), ['Wait for 2 hours']],
+        [action('wait_until_condition', { max_wait_duration: '1d' }), ['Up to 1d']],
+        [
+            action('wait_until_time_window', {
+                day: 'weekday',
+                time: ['09:00', '17:00'],
+                timezone: 'UTC',
+            }),
+            ['Wait until weekdays between 09:00 and 17:00 (UTC)'],
+        ],
+        [action('conditional_branch', { conditions: [{}, {}] }), ['2 conditions']],
+        [action('random_cohort_branch', { cohorts: [{}] }), ['1 cohort']],
+        [
+            action('function', {
+                template_id: 'template-webhook',
+                inputs: { method: { value: 'post' }, url: { value: 'https://hooks.example.com/path' } },
+            }),
+            ['POST hooks.example.com'],
+        ],
+        [
+            action('function_email', {
+                inputs: { email: { value: { to: { email: 'person@example.com' } } } },
+            }),
+            ['To person@example.com'],
+        ],
+        [action('function_sms', { inputs: { phoneNumber: { value: '+15555550123' } } }), ['To +15555550123']],
+        [action('function_push', { inputs: { title: { value: 'Welcome back' } } }), ['Welcome back']],
+        [action('exit', {}), ['End workflow']],
+    ])('derives preview labels from the action config', (workflowAction, expected) => {
+        expect(previewLabels(workflowAction)).toEqual(expected)
+    })
+})

--- a/products/workflows/frontend/Workflows/hogflows/steps/HogFlowSteps.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/HogFlowSteps.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react'
 
 import {
     IconBolt,
+    IconButton,
     IconClock,
     IconDay,
     IconDecisionTree,
@@ -11,11 +12,14 @@ import {
     IconLeave,
     IconLetter,
     IconNotification,
+    IconPeople,
     IconPercentage,
+    IconTarget,
     IconWebhooks,
 } from '@posthog/icons'
 
 import { IconTwilio } from 'lib/lemon-ui/icons'
+import { getNotificationDescription } from 'scenes/hog-functions/list/notificationDescription'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { HogFunctionTemplateType } from '~/types'
@@ -24,12 +28,19 @@ import { workflowLogic } from '../../workflowLogic'
 import { HogFlowAction } from '../types'
 import { StepConditionalBranchConfiguration } from './StepConditionalBranch'
 import { StepDelayConfiguration } from './StepDelay'
+import { getDelayDescription } from './stepDelayLogic'
 import { StepExitConfiguration } from './StepExit'
 import { StepFunctionConfiguration } from './StepFunction'
 import { StepRandomCohortBranchConfiguration } from './StepRandomCohortBranch'
 import { StepTriggerConfiguration } from './StepTrigger'
 import { StepWaitUntilConditionConfiguration } from './StepWaitUntilCondition'
 import { StepWaitUntilTimeWindowConfiguration } from './StepWaitUntilTimeWindow'
+import { getWaitUntilTimeWindowDescription } from './stepWaitUntilTimeWindowLogic'
+
+type HogFlowStepPreview = {
+    label: string
+    icon?: JSX.Element
+}
 
 type HogFlowStepBuilder<T extends HogFlowAction['type']> = {
     type: T
@@ -38,6 +49,10 @@ type HogFlowStepBuilder<T extends HogFlowAction['type']> = {
         hogFunctionTemplatesById: Record<string, HogFunctionTemplateType>
     ) => JSX.Element
     color: (action: Extract<HogFlowAction, { type: T }>, isDarkModeOn: boolean) => string
+    getPreviews: (
+        action: Extract<HogFlowAction, { type: T }>,
+        hogFunctionTemplatesById: Record<string, HogFunctionTemplateType>
+    ) => HogFlowStepPreview[]
     renderConfiguration: (node: Node<Extract<HogFlowAction, { type: T }>>) => JSX.Element
 }
 
@@ -45,7 +60,62 @@ type HogFlowStep<T extends HogFlowAction['type']> = {
     type: T
     icon: JSX.Element
     color: string
+    previews: HogFlowStepPreview[]
     renderConfiguration: (node: Node<Extract<HogFlowAction, { type: T }>>) => JSX.Element
+}
+
+const TRIGGER_PREVIEWS: Record<string, HogFlowStepPreview> = {
+    event: { label: 'Event', icon: <IconBolt /> },
+    webhook: { label: 'Webhook', icon: <IconWebhooks /> },
+    manual: { label: 'Manual', icon: <IconButton /> },
+    tracking_pixel: { label: 'Tracking pixel', icon: <IconTarget /> },
+    schedule: { label: 'Schedule', icon: <IconClock /> },
+    batch: { label: 'Audience', icon: <IconPeople /> },
+    'internal-event': { label: 'Internal event', icon: <IconBolt /> },
+    'data-warehouse-table': { label: 'Data warehouse table', icon: <IconBolt /> },
+    'data-warehouse-view': { label: 'Data warehouse view', icon: <IconBolt /> },
+}
+
+function getTriggerPreviews(action: Extract<HogFlowAction, { type: 'trigger' }>): HogFlowStepPreview[] {
+    const config = action.config
+    const preview = TRIGGER_PREVIEWS[config.type] ?? { label: config.type, icon: <IconBolt /> }
+    if (!('filters' in config)) {
+        return [preview]
+    }
+
+    const selectedFilter =
+        config.type === 'event' || config.type === 'internal-event'
+            ? (config.filters.events?.[0] ?? ('actions' in config.filters ? config.filters.actions?.[0] : null))
+            : null
+    const selectedName = selectedFilter?.name ?? selectedFilter?.id
+    const propertyCount = config.filters.properties?.length ?? 0
+
+    return [
+        {
+            ...preview,
+            label: [
+                preview.label,
+                selectedName,
+                propertyCount ? `${propertyCount} ${propertyCount === 1 ? 'filter' : 'filters'}` : null,
+            ]
+                .filter(Boolean)
+                .join(' · '),
+        },
+    ]
+}
+
+function getFunctionPreviews(
+    action: Extract<HogFlowAction, { type: 'function' }>,
+    hogFunctionTemplatesById: Record<string, HogFunctionTemplateType>
+): HogFlowStepPreview[] {
+    const destination = getNotificationDescription({ inputs: action.config.inputs })
+    if (action.config.template_id === 'template-webhook') {
+        const method = String(action.config.inputs.method?.value || 'POST').toUpperCase()
+        return [{ label: destination ? `${method} ${destination}` : method }]
+    }
+
+    const templateName = hogFunctionTemplatesById[action.config.template_id]?.name ?? 'Destination'
+    return [{ label: destination ? `${templateName} · ${destination}` : templateName }]
 }
 
 const HogFlowStepConfigs: Partial<{
@@ -55,18 +125,25 @@ const HogFlowStepConfigs: Partial<{
         type: 'conditional_branch',
         icon: () => <IconDecisionTree />,
         color: (_, isDarkModeOn) => (isDarkModeOn ? '#35C46F' : '#005841'),
+        getPreviews: (action) => [
+            {
+                label: `${action.config.conditions.length} ${action.config.conditions.length === 1 ? 'condition' : 'conditions'}`,
+            },
+        ],
         renderConfiguration: (node) => <StepConditionalBranchConfiguration key={node.id} node={node} />,
     },
     delay: {
         type: 'delay',
         icon: () => <IconClock />,
         color: () => '#a20031',
+        getPreviews: (action) => [{ label: getDelayDescription(action.config).replace(/\.$/, '') }],
         renderConfiguration: (node) => <StepDelayConfiguration key={node.id} node={node} />,
     },
     exit: {
         type: 'exit',
         icon: () => <IconLeave />,
         color: () => '#4b4b4b',
+        getPreviews: (action) => [{ label: action.config.reason || 'End workflow' }],
         renderConfiguration: (node) => <StepExitConfiguration key={node.id} node={node} />,
     },
 
@@ -74,24 +151,42 @@ const HogFlowStepConfigs: Partial<{
         type: 'random_cohort_branch',
         icon: () => <IconPercentage />,
         color: (_, isDarkModeOn) => (isDarkModeOn ? '#D6247B' : '#9a004d'),
+        getPreviews: (action) => [
+            {
+                label: `${action.config.cohorts.length} ${action.config.cohorts.length === 1 ? 'cohort' : 'cohorts'}`,
+            },
+        ],
         renderConfiguration: (node) => <StepRandomCohortBranchConfiguration key={node.id} node={node} />,
     },
     trigger: {
         type: 'trigger',
         icon: () => <IconBolt />,
         color: (_, isDarkModeOn) => (isDarkModeOn ? '#35C46F' : '#005841'),
+        getPreviews: getTriggerPreviews,
         renderConfiguration: (node) => <StepTriggerConfiguration key={node.id} node={node} />,
     },
     wait_until_condition: {
         type: 'wait_until_condition',
         icon: () => <IconHourglass />,
         color: () => '#ffaa00',
+        getPreviews: (action) => [{ label: `Up to ${action.config.max_wait_duration}` }],
         renderConfiguration: (node) => <StepWaitUntilConditionConfiguration key={node.id} node={node} />,
     },
     wait_until_time_window: {
         type: 'wait_until_time_window',
         icon: () => <IconDay />,
         color: () => '#FF653F',
+        getPreviews: (action) => [
+            {
+                label: getWaitUntilTimeWindowDescription(
+                    action.config.day,
+                    action.config.time,
+                    action.config.timezone,
+                    action.config.use_person_timezone,
+                    action.config.fallback_timezone
+                ).replace(/\.$/, ''),
+            },
+        ],
         renderConfiguration: (node) => <StepWaitUntilTimeWindowConfiguration key={node.id} node={node} />,
     },
 
@@ -100,18 +195,35 @@ const HogFlowStepConfigs: Partial<{
         type: 'function_email',
         icon: () => <IconLetter />,
         color: (_, isDarkModeOn) => (isDarkModeOn ? '#2F80FA' : '#2F80FA'),
+        getPreviews: (action) => [
+            {
+                label: action.config.inputs.email?.value?.to?.email
+                    ? `To ${action.config.inputs.email.value.to.email}`
+                    : 'Email',
+            },
+        ],
         renderConfiguration: (node) => <StepFunctionConfiguration key={node.id} node={node} />,
     },
     function_sms: {
         type: 'function_sms',
         icon: () => <IconTwilio />,
         color: () => '#f22f46',
+        getPreviews: (action) => [
+            { label: action.config.inputs.phoneNumber?.value ? `To ${action.config.inputs.phoneNumber.value}` : 'SMS' },
+        ],
         renderConfiguration: (node) => <StepFunctionConfiguration key={node.id} node={node} />,
     },
     function_push: {
         type: 'function_push',
         icon: () => <IconNotification />,
         color: (_, isDarkModeOn) => (isDarkModeOn ? '#F8BE2A' : '#F44D01'),
+        getPreviews: (action) => [
+            {
+                label: action.config.inputs.title?.value
+                    ? String(action.config.inputs.title.value)
+                    : 'Push notification',
+            },
+        ],
         renderConfiguration: (node) => <StepFunctionConfiguration key={node.id} node={node} />,
     },
     function: {
@@ -147,6 +259,7 @@ const HogFlowStepConfigs: Partial<{
 
             return isDarkModeOn ? '#F8BE2A' : '#F44D01'
         },
+        getPreviews: getFunctionPreviews,
         renderConfiguration: (node) => <StepFunctionConfiguration key={node.id} node={node} />,
     },
 } as const
@@ -166,6 +279,7 @@ export function getHogFlowStep<T extends HogFlowAction['type']>(
         type,
         icon: builder.icon(action, hogFunctionTemplatesById),
         color: builder.color(action, isDarkModeOn),
+        previews: builder.getPreviews(action, hogFunctionTemplatesById),
         renderConfiguration: builder.renderConfiguration,
     }
 }

--- a/products/workflows/frontend/Workflows/hogflows/steps/HogFlowSteps.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/HogFlowSteps.tsx
@@ -8,6 +8,7 @@ import {
     IconClock,
     IconDay,
     IconDecisionTree,
+    IconFilter,
     IconHourglass,
     IconLeave,
     IconLetter,
@@ -275,11 +276,20 @@ export function getHogFlowStep<T extends HogFlowAction['type']>(
     if (!builder) {
         return undefined
     }
+    const conditionCount =
+        (action.filters?.events?.length ?? 0) +
+        (action.filters?.actions?.length ?? 0) +
+        (action.filters?.properties?.length ?? 0)
+    const previews = builder.getPreviews(action, hogFunctionTemplatesById)
+    if (conditionCount) {
+        previews.push({ label: String(conditionCount), icon: <IconFilter /> })
+    }
+
     return {
         type,
         icon: builder.icon(action, hogFunctionTemplatesById),
         color: builder.color(action, isDarkModeOn),
-        previews: builder.getPreviews(action, hogFunctionTemplatesById),
+        previews,
         renderConfiguration: builder.renderConfiguration,
     }
 }

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
@@ -3,7 +3,7 @@ import { useActions, useValues } from 'kea'
 import { useMemo } from 'react'
 
 import { IconCopy, IconDrag, IconEllipsis, IconTrash } from '@posthog/icons'
-import { LemonInput, LemonTextArea, Tooltip } from '@posthog/lemon-ui'
+import { LemonInput, LemonTag, LemonTextArea, Tooltip } from '@posthog/lemon-ui'
 
 import { LemonBadge } from 'lib/lemon-ui/LemonBadge'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -18,6 +18,45 @@ import { isScheduleTrigger } from '../types'
 import { buildSummary } from './rrule-helpers'
 import { StepViewLogicProps, stepViewLogic } from './stepViewLogic'
 import { StepViewMetrics } from './StepViewMetrics'
+
+const TRIGGER_TYPE_LABELS: Record<string, string> = {
+    event: 'Event',
+    webhook: 'Webhook',
+    manual: 'Manual',
+    tracking_pixel: 'Tracking pixel',
+    schedule: 'Schedule',
+    batch: 'Audience',
+    'internal-event': 'Internal event',
+    'data-warehouse-table': 'Data warehouse table',
+    'data-warehouse-view': 'Data warehouse view',
+}
+
+function getTriggerPreview(action: HogFlowAction): string | null {
+    if (action.type !== 'trigger') {
+        return null
+    }
+
+    const config = action.config
+    const label = TRIGGER_TYPE_LABELS[config.type] ?? config.type
+    if (!('filters' in config)) {
+        return label
+    }
+
+    const selectedFilter =
+        config.type === 'event' || config.type === 'internal-event'
+            ? (config.filters.events?.[0] ?? ('actions' in config.filters ? config.filters.actions?.[0] : null))
+            : null
+    const selectedName = selectedFilter?.name ?? selectedFilter?.id
+    const propertyCount = config.filters?.properties?.length ?? 0
+
+    return [
+        label,
+        selectedName,
+        propertyCount ? `${propertyCount} ${propertyCount === 1 ? 'filter' : 'filters'}` : null,
+    ]
+        .filter(Boolean)
+        .join(' · ')
+}
 
 export function StepView({
     action,
@@ -36,7 +75,7 @@ export function StepView({
         workflow,
         isZoomedOutFar,
     } = useValues(hogFlowEditorLogic)
-    const { setMode, setSelectedNodeId, startCopyingNode, startMovingNode } = useActions(hogFlowEditorLogic)
+    const { setSelectedNodeId, startCopyingNode, startMovingNode } = useActions(hogFlowEditorLogic)
     const { actionValidationErrorsById, logicProps, scheduleState, scheduleStartsAt, isScheduleRepeating } =
         useValues(workflowLogic)
     const { deleteElements } = useReactFlow()
@@ -94,16 +133,14 @@ export function StepView({
     const hasValidationError = actionValidationErrorsById[action.id]?.valid === false
     const hasValidationWarning = Object.keys(actionValidationErrorsById[action.id]?.warnings ?? {}).length > 0
     const isAnimationTarget = mode === 'test' && animatingEdgePair?.endsWith(`->${action.id}`)
+    const triggerPreview = getTriggerPreview(action)
 
     if (layout === 'list') {
         return (
             <LemonButton
                 fullWidth
                 active={isSelected}
-                onClick={() => {
-                    setMode('build')
-                    setSelectedNodeId(action.id)
-                }}
+                onClick={() => setSelectedNodeId(action.id)}
                 data-attr="workflow-linear-step"
                 aria-pressed={isSelected}
                 className="!h-auto !items-stretch !justify-start !rounded !border-2 !bg-surface-primary !p-0 hover:!bg-surface-secondary"
@@ -112,7 +149,7 @@ export function StepView({
                     boxShadow: `0px 2px 0px 0px ${colorLight}`,
                 }}
             >
-                <div className="flex min-w-0 flex-1 items-start gap-3 p-3 text-left">
+                <div className="flex min-w-0 flex-1 items-start gap-3 p-2 text-left">
                     <span
                         className="flex size-12 shrink-0 items-center justify-center rounded text-2xl"
                         style={{ backgroundColor: colorLight, color }}
@@ -124,8 +161,13 @@ export function StepView({
                         <span className="mt-0.5 text-sm text-secondary">
                             {scheduleDescription ?? action.description ?? 'No description'}
                         </span>
-                        {shouldShowMetricsSummary && <StepViewMetrics action={action} layout="list" />}
+                        {triggerPreview && (
+                            <LemonTag type="muted" size="small" icon={icon} className="mt-1.5 w-fit">
+                                {triggerPreview}
+                            </LemonTag>
+                        )}
                     </span>
+                    {shouldShowMetricsSummary && <StepViewMetrics action={action} layout="list" />}
                     {hasValidationError || hasValidationWarning ? (
                         <LemonBadge status="warning" size="small" content="!" />
                     ) : null}

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
@@ -19,45 +19,6 @@ import { buildSummary } from './rrule-helpers'
 import { StepViewLogicProps, stepViewLogic } from './stepViewLogic'
 import { StepViewMetrics } from './StepViewMetrics'
 
-const TRIGGER_TYPE_LABELS: Record<string, string> = {
-    event: 'Event',
-    webhook: 'Webhook',
-    manual: 'Manual',
-    tracking_pixel: 'Tracking pixel',
-    schedule: 'Schedule',
-    batch: 'Audience',
-    'internal-event': 'Internal event',
-    'data-warehouse-table': 'Data warehouse table',
-    'data-warehouse-view': 'Data warehouse view',
-}
-
-function getTriggerPreview(action: HogFlowAction): string | null {
-    if (action.type !== 'trigger') {
-        return null
-    }
-
-    const config = action.config
-    const label = TRIGGER_TYPE_LABELS[config.type] ?? config.type
-    if (!('filters' in config)) {
-        return label
-    }
-
-    const selectedFilter =
-        config.type === 'event' || config.type === 'internal-event'
-            ? (config.filters.events?.[0] ?? ('actions' in config.filters ? config.filters.actions?.[0] : null))
-            : null
-    const selectedName = selectedFilter?.name ?? selectedFilter?.id
-    const propertyCount = config.filters?.properties?.length ?? 0
-
-    return [
-        label,
-        selectedName,
-        propertyCount ? `${propertyCount} ${propertyCount === 1 ? 'filter' : 'filters'}` : null,
-    ]
-        .filter(Boolean)
-        .join(' · ')
-}
-
 export function StepView({
     action,
     layout = 'node',
@@ -133,7 +94,6 @@ export function StepView({
     const hasValidationError = actionValidationErrorsById[action.id]?.valid === false
     const hasValidationWarning = Object.keys(actionValidationErrorsById[action.id]?.warnings ?? {}).length > 0
     const isAnimationTarget = mode === 'test' && animatingEdgePair?.endsWith(`->${action.id}`)
-    const triggerPreview = getTriggerPreview(action)
 
     if (layout === 'list') {
         return (
@@ -149,7 +109,7 @@ export function StepView({
                     boxShadow: `0px 2px 0px 0px ${colorLight}`,
                 }}
             >
-                <div className="flex min-w-0 flex-1 items-start gap-3 p-2 text-left">
+                <div className="flex min-w-0 flex-1 items-start gap-3 px-1 py-2 text-left">
                     <span
                         className="flex size-12 shrink-0 items-center justify-center rounded text-2xl"
                         style={{ backgroundColor: colorLight, color }}
@@ -161,10 +121,20 @@ export function StepView({
                         <span className="mt-0.5 text-sm text-secondary">
                             {scheduleDescription ?? action.description ?? 'No description'}
                         </span>
-                        {triggerPreview && (
-                            <LemonTag type="muted" size="small" icon={icon} className="mt-1.5 w-fit">
-                                {triggerPreview}
-                            </LemonTag>
+                        {!!Step?.previews.length && (
+                            <span className="mt-1.5 flex flex-wrap gap-1">
+                                {Step.previews.map((preview) => (
+                                    <LemonTag
+                                        key={preview.label}
+                                        type="muted"
+                                        size="small"
+                                        icon={preview.icon ?? icon}
+                                        className="max-w-64 truncate"
+                                    >
+                                        {preview.label}
+                                    </LemonTag>
+                                ))}
+                            </span>
                         )}
                     </span>
                     {shouldShowMetricsSummary && <StepViewMetrics action={action} layout="list" />}

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
@@ -143,7 +143,7 @@ export function StepView({
                 onClick={() => setSelectedNodeId(action.id)}
                 data-attr="workflow-linear-step"
                 aria-pressed={isSelected}
-                className="!h-auto !items-stretch !justify-start !rounded !border-2 !bg-surface-primary !p-0 hover:!bg-surface-secondary"
+                className="!relative !h-auto !items-stretch !justify-start !rounded !border-2 !bg-surface-primary !p-0 hover:!bg-surface-secondary"
                 style={{
                     borderColor: isAnimationTarget ? 'var(--success)' : selectedColor,
                     boxShadow: `0px 2px 0px 0px ${colorLight}`,
@@ -169,7 +169,9 @@ export function StepView({
                     </span>
                     {shouldShowMetricsSummary && <StepViewMetrics action={action} layout="list" />}
                     {hasValidationError || hasValidationWarning ? (
-                        <LemonBadge status="warning" size="small" content="!" />
+                        <span className="absolute right-2 top-2">
+                            <LemonBadge status="warning" size="small" content="!" />
+                        </span>
                     ) : null}
                 </div>
             </LemonButton>

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
@@ -19,7 +19,13 @@ import { buildSummary } from './rrule-helpers'
 import { StepViewLogicProps, stepViewLogic } from './stepViewLogic'
 import { StepViewMetrics } from './StepViewMetrics'
 
-export function StepView({ action }: { action: HogFlowAction }): JSX.Element {
+export function StepView({
+    action,
+    layout = 'node',
+}: {
+    action: HogFlowAction
+    layout?: 'node' | 'list'
+}): JSX.Element {
     const {
         selectedNode,
         mode,
@@ -30,7 +36,7 @@ export function StepView({ action }: { action: HogFlowAction }): JSX.Element {
         workflow,
         isZoomedOutFar,
     } = useValues(hogFlowEditorLogic)
-    const { setSelectedNodeId, startCopyingNode, startMovingNode } = useActions(hogFlowEditorLogic)
+    const { setMode, setSelectedNodeId, startCopyingNode, startMovingNode } = useActions(hogFlowEditorLogic)
     const { actionValidationErrorsById, logicProps, scheduleState, scheduleStartsAt, isScheduleRepeating } =
         useValues(workflowLogic)
     const { deleteElements } = useReactFlow()
@@ -83,11 +89,50 @@ export function StepView({ action }: { action: HogFlowAction }): JSX.Element {
             color: Step?.color || 'var(--text-secondary)',
             icon: Step?.icon,
         }
-    }, [action, isSelected, Step])
+    }, [isSelected, Step])
 
     const hasValidationError = actionValidationErrorsById[action.id]?.valid === false
     const hasValidationWarning = Object.keys(actionValidationErrorsById[action.id]?.warnings ?? {}).length > 0
     const isAnimationTarget = mode === 'test' && animatingEdgePair?.endsWith(`->${action.id}`)
+
+    if (layout === 'list') {
+        return (
+            <LemonButton
+                fullWidth
+                active={isSelected}
+                onClick={() => {
+                    setMode('build')
+                    setSelectedNodeId(action.id)
+                }}
+                data-attr="workflow-linear-step"
+                aria-pressed={isSelected}
+                className="!h-auto !items-stretch !justify-start !rounded !border-2 !bg-surface-primary !p-0 hover:!bg-surface-secondary"
+                style={{
+                    borderColor: isAnimationTarget ? 'var(--success)' : selectedColor,
+                    boxShadow: `0px 2px 0px 0px ${colorLight}`,
+                }}
+            >
+                <div className="flex min-w-0 flex-1 items-start gap-3 p-3 text-left">
+                    <span
+                        className="flex size-12 shrink-0 items-center justify-center rounded text-2xl"
+                        style={{ backgroundColor: colorLight, color }}
+                    >
+                        {icon}
+                    </span>
+                    <span className="flex min-w-0 flex-1 flex-col">
+                        <span className="font-semibold leading-5">{action.name}</span>
+                        <span className="mt-0.5 text-sm text-secondary">
+                            {scheduleDescription ?? action.description ?? 'No description'}
+                        </span>
+                        {shouldShowMetricsSummary && <StepViewMetrics action={action} layout="list" />}
+                    </span>
+                    {hasValidationError || hasValidationWarning ? (
+                        <LemonBadge status="warning" size="small" content="!" />
+                    ) : null}
+                </div>
+            </LemonButton>
+        )
+    }
 
     return (
         <div

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
@@ -118,7 +118,7 @@ export function StepView({
                     </span>
                     <span className="flex min-w-0 flex-1 flex-col">
                         <span className="font-semibold leading-5">{action.name}</span>
-                        <span className="mt-0.5 text-sm text-secondary">
+                        <span className="mt-0.5 truncate text-xs text-secondary">
                             {scheduleDescription ?? action.description ?? 'No description'}
                         </span>
                         {!!Step?.previews.length && (

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
@@ -36,7 +36,7 @@ export function StepView({
         workflow,
         isZoomedOutFar,
     } = useValues(hogFlowEditorLogic)
-    const { setSelectedNodeId, startCopyingNode, startMovingNode } = useActions(hogFlowEditorLogic)
+    const { setSelectedNodeId, startCopyingNode, startMovingNode, duplicateNodeBelow } = useActions(hogFlowEditorLogic)
     const { actionValidationErrorsById, logicProps, scheduleState, scheduleStartsAt, isScheduleRepeating } =
         useValues(workflowLogic)
     const { deleteElements } = useReactFlow()
@@ -97,54 +97,106 @@ export function StepView({
 
     if (layout === 'list') {
         return (
-            <LemonButton
-                fullWidth
-                active={isSelected}
-                onClick={() => setSelectedNodeId(action.id)}
-                data-attr="workflow-linear-step"
-                aria-pressed={isSelected}
-                className="!relative !h-auto !items-stretch !justify-start !rounded !border-2 !bg-surface-primary !p-0 hover:!bg-surface-secondary"
-                style={{
-                    borderColor: isAnimationTarget ? 'var(--success)' : selectedColor,
-                    boxShadow: `0px 2px 0px 0px ${colorLight}`,
-                }}
-            >
-                <div className="flex min-w-0 flex-1 items-start gap-3 px-1 py-2 text-left">
-                    <span
-                        className="flex size-12 shrink-0 items-center justify-center rounded text-2xl"
-                        style={{ backgroundColor: colorLight, color }}
+            <div className="relative w-full">
+                <LemonButton
+                    fullWidth
+                    active={isSelected}
+                    onClick={() => setSelectedNodeId(action.id)}
+                    data-attr="workflow-linear-step"
+                    aria-pressed={isSelected}
+                    className="!relative !h-auto !items-stretch !justify-start !rounded !border-2 !bg-surface-primary !p-0 hover:!bg-surface-secondary"
+                    style={{
+                        borderColor: isAnimationTarget ? 'var(--success)' : selectedColor,
+                        boxShadow: `0px 2px 0px 0px ${colorLight}`,
+                    }}
+                >
+                    <div
+                        className={`flex min-w-0 flex-1 items-start gap-3 px-1 py-2 text-left ${
+                            isSelected && node?.deletable ? 'pr-10' : ''
+                        }`}
                     >
-                        {icon}
-                    </span>
-                    <span className="flex min-w-0 flex-1 flex-col">
-                        <span className="font-semibold leading-5">{action.name}</span>
-                        <span className="mt-0.5 truncate text-xs text-secondary">
-                            {scheduleDescription || action.description || 'No description'}
+                        <span
+                            className="flex size-12 shrink-0 items-center justify-center rounded text-2xl"
+                            style={{ backgroundColor: colorLight, color }}
+                        >
+                            {icon}
                         </span>
-                        {!!Step?.previews.length && (
-                            <span className="mt-1.5 flex flex-wrap gap-1">
-                                {Step.previews.map((preview) => (
-                                    <LemonTag
-                                        key={preview.label}
-                                        type="muted"
-                                        size="small"
-                                        icon={preview.icon ?? icon}
-                                        className="max-w-64 truncate"
-                                    >
-                                        {preview.label}
-                                    </LemonTag>
-                                ))}
+                        <span className="flex min-w-0 flex-1 flex-col">
+                            <span className="font-semibold leading-5">{action.name}</span>
+                            <span className="mt-0.5 truncate text-xs text-secondary">
+                                {scheduleDescription || action.description || 'No description'}
                             </span>
-                        )}
-                    </span>
-                    {shouldShowMetricsSummary && <StepViewMetrics action={action} layout="list" />}
-                    {hasValidationError || hasValidationWarning ? (
-                        <span className="absolute right-2 top-2">
-                            <LemonBadge status="warning" size="small" content="!" />
+                            {!!Step?.previews.length && (
+                                <span className="mt-1.5 flex flex-wrap gap-1">
+                                    {Step.previews.map((preview) => (
+                                        <LemonTag
+                                            key={preview.label}
+                                            type="muted"
+                                            size="small"
+                                            icon={preview.icon ?? icon}
+                                            className="max-w-64 truncate"
+                                        >
+                                            {preview.label}
+                                        </LemonTag>
+                                    ))}
+                                </span>
+                            )}
                         </span>
-                    ) : null}
-                </div>
-            </LemonButton>
+                        {shouldShowMetricsSummary && <StepViewMetrics action={action} layout="list" />}
+                        {hasValidationError || hasValidationWarning ? (
+                            <span
+                                className={`absolute top-2 ${isSelected && node?.deletable ? 'right-10' : 'right-2'}`}
+                            >
+                                <LemonBadge status="warning" size="small" content="!" />
+                            </span>
+                        ) : null}
+                    </div>
+                </LemonButton>
+                {isSelected && node?.deletable && (
+                    <div className="absolute right-2 top-2" onClick={(event) => event.stopPropagation()}>
+                        <LemonMenu
+                            items={[
+                                {
+                                    items: [
+                                        {
+                                            label: 'Duplicate below',
+                                            icon: <IconCopy />,
+                                            onClick: () => duplicateNodeBelow(action.id),
+                                            'data-attr': 'workflow-linear-duplicate-step',
+                                        },
+                                        {
+                                            label: 'Delete',
+                                            status: 'danger',
+                                            icon: <IconTrash />,
+                                            onClick: () => {
+                                                void deleteElements({ nodes: [node] })
+                                                setSelectedNodeId(null)
+                                            },
+                                            disabledReason: !selectedNodeCanBeDeleted
+                                                ? 'Clean up branching steps first'
+                                                : undefined,
+                                            'data-attr': 'workflow-linear-delete-step',
+                                        },
+                                    ],
+                                    footer: (
+                                        <div className="flex items-center gap-1 px-1 text-xs text-secondary">
+                                            <IconDrag /> Drag and drop to rearrange steps.
+                                        </div>
+                                    ),
+                                },
+                            ]}
+                        >
+                            <LemonButton
+                                icon={<IconEllipsis />}
+                                size="small"
+                                tooltip="Step actions"
+                                noPadding
+                                data-attr="workflow-linear-step-actions"
+                            />
+                        </LemonMenu>
+                    </div>
+                )}
+            </div>
         )
     }
 

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
@@ -119,7 +119,7 @@ export function StepView({
                     <span className="flex min-w-0 flex-1 flex-col">
                         <span className="font-semibold leading-5">{action.name}</span>
                         <span className="mt-0.5 truncate text-xs text-secondary">
-                            {scheduleDescription ?? action.description ?? 'No description'}
+                            {scheduleDescription || action.description || 'No description'}
                         </span>
                         {!!Step?.previews.length && (
                             <span className="mt-1.5 flex flex-wrap gap-1">

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/StepViewMetrics.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/StepViewMetrics.tsx
@@ -29,7 +29,7 @@ export function StepViewMetrics({
             <div
                 className={
                     layout === 'list'
-                        ? 'ml-auto flex h-7 w-32 shrink-0 items-center gap-2 rounded border bg-fill-button-tertiary px-2'
+                        ? 'ml-auto flex h-7 w-32 shrink-0 items-center gap-2 self-center rounded border bg-fill-button-tertiary px-2'
                         : 'flex h-2 items-center gap-1 px-1'
                 }
             >

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/StepViewMetrics.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/StepViewMetrics.tsx
@@ -28,7 +28,9 @@ export function StepViewMetrics({
         return (
             <div
                 className={
-                    layout === 'list' ? 'mt-2 flex h-4 max-w-64 items-center gap-2' : 'flex h-2 items-center gap-1 px-1'
+                    layout === 'list'
+                        ? 'ml-auto flex h-7 w-32 shrink-0 items-center gap-2 rounded border bg-fill-button-tertiary px-2'
+                        : 'flex h-2 items-center gap-1 px-1'
                 }
             >
                 <LemonSkeleton className="w-full h-[6px]" />
@@ -42,7 +44,7 @@ export function StepViewMetrics({
         <div
             className={
                 layout === 'list'
-                    ? 'mt-2 flex flex-row items-center gap-4 text-xs font-mono'
+                    ? 'ml-auto flex shrink-0 flex-row items-center gap-3 self-center rounded border bg-fill-button-tertiary px-2 py-1 text-xs font-mono'
                     : 'flex flex-row items-center text-[6px] font-mono'
             }
         >

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/StepViewMetrics.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/StepViewMetrics.tsx
@@ -8,7 +8,13 @@ import { humanFriendlyLargeNumber } from 'lib/utils/numbers'
 import { HogFlowEditorActionMetrics, hogFlowEditorLogic } from '../../hogFlowEditorLogic'
 import { HogFlowAction } from '../../types'
 
-export function StepViewMetrics({ action }: { action: HogFlowAction }): JSX.Element {
+export function StepViewMetrics({
+    action,
+    layout = 'node',
+}: {
+    action: HogFlowAction
+    layout?: 'node' | 'list'
+}): JSX.Element {
     const { actionMetricsById, actionMetricsByIdLoading } = useValues(hogFlowEditorLogic)
 
     const metrics: HogFlowEditorActionMetrics = actionMetricsById?.[action.id] ?? {
@@ -20,7 +26,11 @@ export function StepViewMetrics({ action }: { action: HogFlowAction }): JSX.Elem
 
     if (actionMetricsByIdLoading) {
         return (
-            <div className="flex items-center gap-1 h-2 px-1">
+            <div
+                className={
+                    layout === 'list' ? 'mt-2 flex h-4 max-w-64 items-center gap-2' : 'flex h-2 items-center gap-1 px-1'
+                }
+            >
                 <LemonSkeleton className="w-full h-[6px]" />
                 <LemonSkeleton className="w-full h-[6px]" />
                 <LemonSkeleton className="w-full h-[6px]" />
@@ -30,24 +40,27 @@ export function StepViewMetrics({ action }: { action: HogFlowAction }): JSX.Elem
 
     return (
         <div
-            className="flex flex-row items-center font-mono"
-            style={{
-                fontSize: 6,
-            }}
+            className={
+                layout === 'list'
+                    ? 'mt-2 flex flex-row items-center gap-4 text-xs font-mono'
+                    : 'flex flex-row items-center text-[6px] font-mono'
+            }
         >
             <Tooltip title="Successful runs of this action">
-                <div className="flex-1 px-1 text-success">
+                <div
+                    className={layout === 'list' ? 'flex items-center gap-1 text-success' : 'flex-1 px-1 text-success'}
+                >
                     <IconCheck /> {humanFriendlyLargeNumber(metrics.succeeded)}
                 </div>
             </Tooltip>
 
             <Tooltip title="Failed runs of this action">
-                <div className="flex-1 px-1 text-error">
+                <div className={layout === 'list' ? 'flex items-center gap-1 text-error' : 'flex-1 px-1 text-error'}>
                     <IconX /> {humanFriendlyLargeNumber(metrics.failed)}
                 </div>
             </Tooltip>
             <Tooltip title="Filtered runs of this action">
-                <div className="flex-1 px-1 text-muted">
+                <div className={layout === 'list' ? 'flex items-center gap-1 text-muted' : 'flex-1 px-1 text-muted'}>
                     <IconFilter /> {humanFriendlyLargeNumber(metrics.filtered)}
                 </div>
             </Tooltip>


### PR DESCRIPTION
## Problem

People building linear workflows must use a large graph canvas designed for branching workflows.

Roughly 3/4 workflows are linear meaning no branching paths. The graph UI is decent and needs to exist once you get to branches but until that point it feels cumbersome.

Downside of this approach is a copy UI of sorts which means making sure both sides work well but the simplification for basic workflows feels much nicer at least to me.

## Changes

| Graph  | List |
|-----|-----|
| <img width="1475" height="1229" alt="Screenshot 2026-09-03 at 15 53 19" src="https://github.com/user-attachments/assets/d0604c90-94e3-41ab-9706-d179b84a89af" /> | <img width="1478" height="1218" alt="Screenshot 2026-09-03 at 15 52 56" src="https://github.com/user-attachments/assets/a3013ace-ad15-4a08-9325-f3516822914e" /> |

- Linear workflows open in a fixed-height list with node-styled cards and full-width insertion targets.
- The status bar switches between simple and advanced views and stays visible for new workflows.
- Conditional steps switch the editor to the graph because the workflow is no longer linear.
- The resizable configuration panel stays mounted across layouts and defaults to half the editor width.
- Build, Metrics, and Test share the selected step's icon, title, description, and actions.

## How did you test this code?

- Jest covers linear workflow detection and selected actions before graph layout completes.
- TypeScript, scoped Oxlint, Oxfmt, and `hogli ci:preflight --fix` pass.
- Manual browser verification is pending for the final draft layout.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No matching documentation describes the workflow editor layout.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the change through iterative direction using local repository tools. The session ran `/writing-ui-components`, `/writing-kea-logics`, `/writing-user-facing-copy`, `/qa-frontend`, `/run-posthog`, and `/writing-pr-descriptions`.
