### PR TITLE
fix(replay): tidy the scanner overview and configuration layout

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -8325,9 +8325,9 @@ snapshots:
     scenes-app-replay-vision--scanner-on-demand--light:
         hash: v1.k794b7964.d6b1a876ab50b940e9bcbe27164922f5c564a01c25c56bbc8955255a2d47173f.DOdeCbLwHWJmW1H1uAYkxdvHS2rpSR6froY4FXuOW7s
     scenes-app-replay-vision--scanner-scan-drought--dark:
-        hash: v1.k794b7964.72a30b649581a8ddfab3938d808745ec59c8835be0d09b2ba9ebc36e0ec3ccb2.tdSNB9Z9hc5xRYFhCZXGJq8bjVsIL0eaMeMpUWNoRWU
+        hash: v1.k794b7964.47963d3ee2fc2934b80cfd51b0db411baf326710d528c8995ed7eecbae4d6faa.zV2CxUwodEqwEiQT5_Tr3XAFLhkhAGTY3z8LUm97USo
     scenes-app-replay-vision--scanner-scan-drought--light:
-        hash: v1.k794b7964.3fc8ddca236998f0b042cd1539adbbfd027b231ad1d931fbd374829173190ec9.79G-dm1PKe4P6CJnsTKI9t0y8ddXYPZQV-DtsJqpwk0
+        hash: v1.k794b7964.d3e3119d983ea105adcd26771cfdfbe14e082892971e48cb4000de6ca48e44df.pfdBzR5cE9sN8GjQF_54zIi5OvM-4nGsvyzsZd9TLSk
     scenes-app-replay-vision--scanner-scouts--dark:
         hash: v1.k794b7964.174b7e25770bf4078971ec6b27ede47c0e76f7b08d54ae2744b1df565358a306.j4XgQXlEtlJH60fRmBnJhujHhRN2iVkocBhPgNkOwgE
     scenes-app-replay-vision--scanner-scouts--light:
@@ -8353,9 +8353,9 @@ snapshots:
     scenes-app-replay-vision--startup-program-cap--light:
         hash: v1.k794b7964.1f2fc262b5c742019e78b9fd8a13820c73291ee4c8086a34b01e8cdd47e31248.WubeGDNAdkP-6NxslVXFGWzr-pHvVfeYQQfEBk4LGj0
     scenes-app-replay-vision--summarizer-overview--dark:
-        hash: v1.k794b7964.308f2be72bf5de78256b32b4b66e9145939dad4198830c210fb2e227ac72ef2e.370AqRlsMg1JflYllw0ar6uTnzGb0hGM-Nr_9LcQ1xc
+        hash: v1.k794b7964.e42cf686d09f2f56d8c71ee727daa188b9035845f140039d1fcf97d1a6015bd8.n5bkjIKQiygb6-ZU2bU4zvxctlG1ydVjGgj-8NNcMlo
     scenes-app-replay-vision--summarizer-overview--light:
-        hash: v1.k794b7964.099cc1596e288a869426dec004e0d3e6ae35de1ca2ec7f0264f775911010b0d9.eTbr9P9h5LFG5AtPxCE0tZn7Hxp4GvNnGI9zYmMI86o
+        hash: v1.k794b7964.170aad973eff971cc58688cabbd435de4bb7427078c256504cbbdcc62ecd91ae.LQ4Rpyb8e8Hp-gd3XvRvpLBx3CS_qA6LisevEJdAm3I
     scenes-app-replay-vision--usage-tab--dark:
         hash: v1.k794b7964.adcd33918c09bfe0779ee7a51b77ee173de0cdd74d66300ea01d173280068d48.ib0BfEMTsMIEACC9iavsKKP4h8jNle7YTt9dvkkw4-o
     scenes-app-replay-vision--usage-tab--light:

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerConfigReadonly.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerConfigReadonly.tsx
@@ -465,7 +465,7 @@ export function ScannerConfigReadonly({ scanner }: { scanner: ReplayScanner }): 
                             {scanner.enabled ? 'Runs automatically on a schedule' : 'Runs on-demand only'}
                         </span>
                     </div>
-                    <LemonCard className="p-4" hoverEffect={false}>
+                    <LemonCard className="p-4 flex-1" hoverEffect={false}>
                         <CardHeader icon={<IconInfo />} title="Overview" />
                         <div className="flex flex-col gap-3">
                             <LabeledRow label="Type">

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
@@ -213,7 +213,7 @@ function SelfDrivingOverview({ scannerId }: { scannerId: string }): JSX.Element 
     // Unresolved data renders as loading, never as the off-state nudge or the empty state.
     if (!scanner || (selfDrivingStatsLoading && !selfDrivingStats)) {
         return (
-            <OverviewPanel title="Self-driving">
+            <OverviewPanel title="Self-driving" fill>
                 <PanelEmpty loading message="" />
             </OverviewPanel>
         )
@@ -222,7 +222,7 @@ function SelfDrivingOverview({ scannerId }: { scannerId: string }): JSX.Element 
     // nudge only replaces the funnel when there is nothing to show.
     if (!scanner.emits_signals && (!selfDrivingStats || selfDrivingStats.signals_emitted === 0)) {
         return (
-            <OverviewPanel title="Self-driving" disabled>
+            <OverviewPanel title="Self-driving" disabled fill>
                 <div className="text-muted text-sm">
                     This scanner doesn't emit signals. Turn on self-driving in the{' '}
                     <Link to={urls.replayVisionScannerConfigure(scannerId)}>scanner's configuration</Link> to feed its
@@ -233,7 +233,7 @@ function SelfDrivingOverview({ scannerId }: { scannerId: string }): JSX.Element 
     }
     if (!selfDrivingStats || selfDrivingStats.signals_emitted === 0) {
         return (
-            <OverviewPanel title="Self-driving">
+            <OverviewPanel title="Self-driving" fill>
                 <PanelEmpty
                     loading={selfDrivingStatsLoading}
                     message={
@@ -246,9 +246,12 @@ function SelfDrivingOverview({ scannerId }: { scannerId: string }): JSX.Element 
         )
     }
     return (
-        <OverviewPanel title="Self-driving" subtitle="all time">
-            {/* Capped so the four stages read as one row on wide screens instead of drifting apart. */}
-            <div className="grid grid-cols-4 gap-4 max-w-3xl" data-attr="vision-self-driving-funnel">
+        <OverviewPanel title="Self-driving" subtitle="all time" fill>
+            {/* Two up in a narrow panel, four across once there is room. */}
+            <div
+                className="@container/funnel grid grid-cols-2 @sm/funnel:grid-cols-4 gap-4"
+                data-attr="vision-self-driving-funnel"
+            >
                 <SelfDrivingStage
                     count={selfDrivingStats.signals_emitted}
                     label={pluralize(selfDrivingStats.signals_emitted, 'signal emitted', 'signals emitted', false)}
@@ -404,35 +407,39 @@ function ClassifierOverview({ scannerId }: { scannerId: string }): JSX.Element |
     )
 }
 
-function CreditLimitOverview({ scannerId }: { scannerId: string }): JSX.Element | null {
+function CreditLimitOverview({ scannerId }: { scannerId: string }): JSX.Element {
     const { creditLimitStats } = useValues(scannerOverviewLogic({ scannerId }))
     if (!creditLimitStats) {
-        return null
+        return (
+            <OverviewPanel title="Spend against limit" disabled fill>
+                <div className="text-muted text-sm">
+                    This scanner has no spending limit. Set one in the{' '}
+                    <Link to={urls.replayVisionScannerConfigure(scannerId)}>scanner's configuration</Link> to cap what
+                    it can spend each billing period.
+                </div>
+            </OverviewPanel>
+        )
     }
     const { used, limit, usedPct, limitReached } = creditLimitStats
     return (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-            <div className="min-w-0">
-                <OverviewPanel
-                    title="Spend against limit"
-                    subtitle={limitReached ? <LemonTag type="danger">Limit reached</LemonTag> : `${usedPct}%`}
-                    fill
-                >
-                    <LemonProgress percent={usedPct} strokeColor={limitReached ? 'var(--danger)' : undefined} />
-                    <div className="text-sm tabular-nums">
-                        {formatCreditsRange(used, limit)} (≈ {creditsToUsd(limit)} per period)
-                    </div>
-                    {limitReached && (
-                        // The tag can appear below 100%: a scanner stops as soon as what's left can't cover a whole
-                        // scan, so the copy has to explain that rather than claim the budget is fully spent.
-                        <div className="text-xs text-muted">
-                            What's left won't cover another scan, so this scanner has stopped until its limit resets at
-                            the start of the next billing period. Sessions skipped while capped are not scanned later.
-                        </div>
-                    )}
-                </OverviewPanel>
+        <OverviewPanel
+            title="Spend against limit"
+            subtitle={limitReached ? <LemonTag type="danger">Limit reached</LemonTag> : `${usedPct}%`}
+            fill
+        >
+            <LemonProgress percent={usedPct} strokeColor={limitReached ? 'var(--danger)' : undefined} />
+            <div className="text-sm tabular-nums">
+                {formatCreditsRange(used, limit)} (≈ {creditsToUsd(limit)} per period)
             </div>
-        </div>
+            {limitReached && (
+                // The tag can appear below 100%: a scanner stops as soon as what's left can't cover a whole
+                // scan, so the copy has to explain that rather than claim the budget is fully spent.
+                <div className="text-xs text-muted">
+                    What's left won't cover another scan, so this scanner has stopped until its limit resets at the
+                    start of the next billing period. Sessions skipped while capped are not scanned later.
+                </div>
+            )}
+        </OverviewPanel>
     )
 }
 
@@ -625,8 +632,10 @@ export function ScannerOverview({ scannerId }: { scannerId: string }): JSX.Eleme
         <div className="flex flex-col gap-4">
             <ScannerOverviewFilters scannerId={scannerId} />
             {body}
-            <SelfDrivingOverview scannerId={scannerId} />
-            <CreditLimitOverview scannerId={scannerId} />
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                <SelfDrivingOverview scannerId={scannerId} />
+                <CreditLimitOverview scannerId={scannerId} />
+            </div>
         </div>
     )
 }

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
@@ -370,7 +370,7 @@ function ClassifierOverview({ scannerId }: { scannerId: string }): JSX.Element |
     )
 
     return (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 @2xl:grid-cols-2 gap-4">
             <OverviewPanel title="Top configured categories" subtitle="from the categories you defined" fill>
                 <RankedTermList
                     ranked={fixedRanked}
@@ -408,7 +408,16 @@ function ClassifierOverview({ scannerId }: { scannerId: string }): JSX.Element |
 }
 
 function CreditLimitOverview({ scannerId }: { scannerId: string }): JSX.Element {
+    const { scanner } = useValues(replayScannerLogic({ id: scannerId }))
     const { creditLimitStats } = useValues(scannerOverviewLogic({ scannerId }))
+    // An unloaded scanner is not a scanner without a limit, so it waits rather than claiming one way.
+    if (!scanner) {
+        return (
+            <OverviewPanel title="Spend against limit" fill>
+                <PanelEmpty loading message="" />
+            </OverviewPanel>
+        )
+    }
     if (!creditLimitStats) {
         return (
             <OverviewPanel title="Spend against limit" disabled fill>
@@ -508,7 +517,7 @@ function SummarizerOverview({ scannerId }: { scannerId: string }): JSX.Element |
             : undefined
     const keywordSubtitle = totalSucceeded > 0 ? `from ${summaries(totalSucceeded)}` : undefined
     return (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 @2xl:grid-cols-2 gap-4">
             <OverviewPanel title="Top friction points" subtitle={frictionSubtitle} fill>
                 <RankedTermList
                     ranked={frictionRanked}
@@ -597,7 +606,7 @@ export function ScannerOverview({ scannerId }: { scannerId: string }): JSX.Eleme
     let body: JSX.Element
     if (scannerType === 'scorer') {
         body = (
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 @2xl:grid-cols-2 gap-4">
                 {/* min-w-0 lets the canvas charts shrink inside their grid tracks instead of overflowing */}
                 <div className="min-w-0">
                     <ScannerInsightsChart scannerId={scannerId} scannerType={scannerType} />
@@ -618,7 +627,7 @@ export function ScannerOverview({ scannerId }: { scannerId: string }): JSX.Eleme
         body = (
             <div className="space-y-4">
                 <ScannerInsightsChart scannerId={scannerId} scannerType={scannerType} />
-                <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 @2xl:grid-cols-2 gap-4">
                     {typeOverview && <div className="min-w-0">{typeOverview}</div>}
                     <div className="min-w-0">
                         <ImpactOverview scannerId={scannerId} />
@@ -629,10 +638,10 @@ export function ScannerOverview({ scannerId }: { scannerId: string }): JSX.Eleme
     }
 
     return (
-        <div className="flex flex-col gap-4">
+        <div className="@container flex flex-col gap-4">
             <ScannerOverviewFilters scannerId={scannerId} />
             {body}
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 @2xl:grid-cols-2 gap-4">
                 <SelfDrivingOverview scannerId={scannerId} />
                 <CreditLimitOverview scannerId={scannerId} />
             </div>


### PR DESCRIPTION
## Problem

The bottom of a scanner's Overview tab looks unfinished. Self-driving sits alone at full width, and the spend panel below it wraps itself in a two-column grid with a single child, so it claims a whole row and leaves the right half empty. Directly above them, Top friction points and Common keywords already sit side by side, so the page changes layout rule halfway down.

The spend panel also disappears entirely when a scanner has no spending limit, which is the default. Self-driving in the same situation greys itself out and explains how to turn it on, so two panels answering the same kind of question behave differently.

The Configuration tab has the same shape of problem. Behavior stretches to the row height, so a long prompt leaves bare page under Overview instead of the card growing with it.

## Changes

- Self-driving and Spend against limit now share one row, using the same two-column grid as the friction and keywords pair above them, and both fill their half so the cards match height.
- The spend panel always renders. With no limit set it greys out and points at the scanner's configuration, matching how self-driving already handles being switched off.
- The self-driving stat row goes two up in a narrow panel and four across once there is room, since it now lives in half the width.
- On the Configuration tab, the Overview card grows into whatever height Behavior leaves, so a long prompt no longer opens a gap beside it.

Before. Self-driving alone at full width, no spend panel at all for this scanner.

![before](https://raw.githubusercontent.com/PostHog/pr-assets/81c45e24806b1126d4b8fbd702362f26fbe08883/2026/09/a7286d22-7bf9-474b-a5d9-90973b7bb14c.png)

After. Both panels on one row, each greyed out with a nudge because this scanner has neither feature on.

![after](https://raw.githubusercontent.com/PostHog/pr-assets/c3cb96a715016c5d25721695b3dcbe420326f2b4/2026/09/76a93ef9-f479-41a8-9616-fb71fe2d20b6.png)

Configuration tab, before and after, with a long prompt. Overview used to stop short; now it meets Behavior.

![config before](https://raw.githubusercontent.com/PostHog/pr-assets/46d4feb99ffaec90f7a8315d098977cfe65c3395/2026/09/eb67de58-c8e9-4a12-b30c-e44e79a055d4.png)

![config after](https://raw.githubusercontent.com/PostHog/pr-assets/b7af839d6f35edb7398f7b61b0ae0e6113313a1d/2026/09/801851a7-2bec-4f71-b55d-4e02652fb5b2.png)

## How did you test this code?

- Rendered the Overview and Configuration stories in Storybook, before and after, shown above. The Configuration pair uses a temporarily lengthened prompt to force the case; that edit was reverted.
- `pnpm --filter=@posthog/frontend exec jest products/replay_vision/frontend/`: 622 pass.
- Not covered: the case where both features are on. The local fixtures have no scanner with a spending limit, so the populated side-by-side state is unverified beyond the layout rule it shares with the row above.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session. Skills invoked: /writing-ui-components, /writing-user-facing-copy, /writing-pr-descriptions.
- Spotted by a human looking at a real scanner's Overview tab. Layout and empty-state only; no data or logic changed.

