### PR TITLE
fix(desktop): report token usage and cost for pi cloud runs

### DIFF
--- a/products/desktop/packages/agent/src/pi/conversation/translatePiConversation.test.ts
+++ b/products/desktop/packages/agent/src/pi/conversation/translatePiConversation.test.ts
@@ -66,17 +66,35 @@ describe("createPiConversationTranslator", () => {
     expect(ended).toEqual([]);
   });
 
-  it("records assistant token usage on the completed turn", () => {
+  it("bills every model call in a turn and reads context from the last valid one", () => {
     vi.useFakeTimers();
     vi.setSystemTime(20);
-    const translator = createPiConversationTranslator();
+    const translator = createPiConversationTranslator(() => 200_000);
     const first = assistant([{ type: "text", text: "first" }]);
-    first.usage.totalTokens = 1_200;
+    Object.assign(first.usage, {
+      input: 1_000,
+      output: 100,
+      cacheRead: 60,
+      cacheWrite: 20,
+      totalTokens: 1_200,
+    });
     const second = assistant([{ type: "text", text: "second" }]);
-    second.usage.totalTokens = 900;
+    Object.assign(second.usage, {
+      input: 800,
+      output: 40,
+      cacheRead: 50,
+      cacheWrite: 10,
+      reasoning: 25,
+      totalTokens: 900,
+    });
 
     translator.translateEvent({ type: "message_end", message: first });
     translator.translateEvent({ type: "message_end", message: second });
+    translator.translateEvent({
+      type: "agent_end",
+      messages: [first, second],
+      willRetry: false,
+    });
 
     expect(translator.translateEvent({ type: "agent_settled" })).toEqual([
       {
@@ -84,6 +102,119 @@ describe("createPiConversationTranslator", () => {
         timestamp: 20,
         stopReason: "stop",
         totalTokens: 2_100,
+        usage: {
+          inputTokens: 1_800,
+          outputTokens: 140,
+          cachedReadTokens: 110,
+          cachedWriteTokens: 30,
+          thoughtTokens: 25,
+          totalTokens: 2_100,
+          contextTokens: 900,
+          contextWindow: 200_000,
+        },
+      },
+    ]);
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ["error" as const, 1_000],
+    ["aborted" as const, 1_000],
+  ])(
+    "bills a %s final response but keeps it out of the context reading",
+    (stopReason, expectedContextTokens) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(20);
+      const translator = createPiConversationTranslator();
+      const answered = assistant([{ type: "text", text: "answer" }]);
+      answered.usage.input = 1_000;
+      answered.usage.totalTokens = 1_000;
+      const failed = assistant([{ type: "text", text: "boom" }], stopReason);
+      failed.usage.input = 30;
+      failed.usage.totalTokens = 30;
+
+      translator.translateEvent({ type: "message_end", message: answered });
+      translator.translateEvent({ type: "message_end", message: failed });
+      translator.translateEvent({
+        type: "agent_end",
+        messages: [answered, failed],
+        willRetry: false,
+      });
+
+      expect(translator.translateEvent({ type: "agent_settled" })).toEqual([
+        {
+          type: "turn_completed",
+          timestamp: 20,
+          stopReason,
+          totalTokens: 1_030,
+          usage: {
+            inputTokens: 1_030,
+            outputTokens: 0,
+            cachedReadTokens: 0,
+            cachedWriteTokens: 0,
+            totalTokens: 1_030,
+            contextTokens: expectedContextTokens,
+          },
+        },
+      ]);
+      vi.useRealTimers();
+    },
+  );
+
+  it("bills the compaction summarization call and marks the context unknown", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(20);
+    const translator = createPiConversationTranslator();
+    const answered = assistant([{ type: "text", text: "answer" }]);
+    answered.usage.input = 1_000;
+    answered.usage.totalTokens = 1_000;
+
+    translator.translateEvent({ type: "message_end", message: answered });
+    translator.translateEvent({
+      type: "agent_end",
+      messages: [answered],
+      willRetry: false,
+    });
+    translator.translateEvent({
+      type: "compaction_end",
+      reason: "threshold",
+      aborted: false,
+      willRetry: false,
+      result: {
+        summary: "summary",
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 180_000,
+        usage: {
+          input: 5_000,
+          output: 200,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 5_200,
+          cost: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            total: 0,
+          },
+        },
+      },
+    });
+
+    expect(translator.translateEvent({ type: "agent_settled" })).toEqual([
+      {
+        type: "turn_completed",
+        timestamp: 20,
+        stopReason: "stop",
+        totalTokens: 6_200,
+        usage: {
+          inputTokens: 6_000,
+          outputTokens: 200,
+          cachedReadTokens: 0,
+          cachedWriteTokens: 0,
+          totalTokens: 6_200,
+          contextTokens: null,
+        },
       },
     ]);
     vi.useRealTimers();
@@ -107,9 +238,15 @@ describe("createPiConversationTranslator", () => {
       messages: [failedTurnMessage],
       willRetry: false,
     });
+    translator.translateEvent({ type: "agent_settled" });
     translator.translateEvent({
       type: "message_end",
       message: nextTurnMessage,
+    });
+    translator.translateEvent({
+      type: "agent_end",
+      messages: [nextTurnMessage],
+      willRetry: false,
     });
 
     expect(translator.translateEvent({ type: "agent_settled" })).toEqual([
@@ -118,6 +255,14 @@ describe("createPiConversationTranslator", () => {
         timestamp: 20,
         stopReason: "stop",
         totalTokens: 900,
+        usage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          cachedReadTokens: 0,
+          cachedWriteTokens: 0,
+          totalTokens: 900,
+          contextTokens: 900,
+        },
       },
     ]);
     vi.useRealTimers();

--- a/products/desktop/packages/agent/src/pi/conversation/translatePiConversation.ts
+++ b/products/desktop/packages/agent/src/pi/conversation/translatePiConversation.ts
@@ -1,6 +1,6 @@
-import type { AssistantMessage, Message } from "@earendil-works/pi-ai";
+import type { AssistantMessage, Message, Usage } from "@earendil-works/pi-ai";
 import type { JsonAgentSessionEvent } from "@earendil-works/pi-coding-agent";
-import type { AgentConversationEvent } from "@posthog/shared";
+import type { AgentConversationEvent, AgentTurnUsage } from "@posthog/shared";
 import { createPiMessageTranslator } from "./translatePiMessage";
 
 type AgentMessage = Extract<
@@ -9,6 +9,65 @@ type AgentMessage = Extract<
 >["message"];
 
 const utf8Encoder = new TextEncoder();
+
+interface TurnUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  reasoningTokens: number | undefined;
+  totalTokens: number;
+}
+
+function emptyTurnUsage(): TurnUsage {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    reasoningTokens: undefined,
+    totalTokens: 0,
+  };
+}
+
+function addBilledUsage(totals: TurnUsage, usage: Usage): void {
+  totals.inputTokens += usage.input;
+  totals.outputTokens += usage.output;
+  totals.cacheReadTokens += usage.cacheRead;
+  totals.cacheWriteTokens += usage.cacheWrite;
+  totals.totalTokens += usage.totalTokens;
+  if (usage.reasoning !== undefined) {
+    totals.reasoningTokens = (totals.reasoningTokens ?? 0) + usage.reasoning;
+  }
+}
+
+function contextTokensOf(message: AssistantMessage): number | null {
+  if (message.stopReason === "error" || message.stopReason === "aborted") {
+    return null;
+  }
+  const { usage } = message;
+  const tokens =
+    usage.totalTokens ||
+    usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
+  return tokens > 0 ? tokens : null;
+}
+
+function toAgentTurnUsage(
+  totals: TurnUsage,
+  contextTokens: number | null,
+  contextWindow: number | undefined,
+): AgentTurnUsage {
+  return {
+    inputTokens: totals.inputTokens,
+    outputTokens: totals.outputTokens,
+    cachedReadTokens: totals.cacheReadTokens,
+    cachedWriteTokens: totals.cacheWriteTokens,
+    thoughtTokens: totals.reasoningTokens,
+    totalTokens: totals.totalTokens,
+    contextTokens,
+    contextWindow,
+  };
+}
 
 function isMessage(message: AgentMessage): message is Message {
   return (
@@ -114,13 +173,16 @@ export interface PiConversationTranslator {
   translateEvent(event: JsonAgentSessionEvent): AgentConversationEvent[];
 }
 
-export function createPiConversationTranslator(): PiConversationTranslator {
+export function createPiConversationTranslator(
+  getContextWindow?: () => number | undefined,
+): PiConversationTranslator {
   const messageTranslator = createPiMessageTranslator();
   let historyTurnActive = false;
   let activeAssistantStream: ActiveAssistantStream | undefined;
   let latestRuntimeTimestamp = 0;
   let latestConversationTimestamp = 0;
-  let turnTotalTokens = 0;
+  let turnUsage = emptyTurnUsage();
+  let contextTokens: number | null = null;
   let pendingRuntimeError: AgentConversationEvent | undefined;
   let settledStopReason: string | undefined;
   let retrying = false;
@@ -514,7 +576,11 @@ export function createPiConversationTranslator(): PiConversationTranslator {
         );
       }
 
-      turnTotalTokens += event.message.usage.totalTokens;
+      addBilledUsage(turnUsage, event.message.usage);
+      const messageContextTokens = contextTokensOf(event.message);
+      if (messageContextTokens !== null) {
+        contextTokens = messageContextTokens;
+      }
 
       return visibleEvents;
     }
@@ -523,10 +589,6 @@ export function createPiConversationTranslator(): PiConversationTranslator {
       activeAssistantStream = undefined;
       const runtimeError = pendingRuntimeError;
       pendingRuntimeError = undefined;
-
-      if (!event.willRetry) {
-        turnTotalTokens = 0;
-      }
 
       if (!event.willRetry && runtimeError) {
         return [runtimeError];
@@ -594,6 +656,11 @@ export function createPiConversationTranslator(): PiConversationTranslator {
         ];
       }
 
+      if (event.result?.usage) {
+        addBilledUsage(turnUsage, event.result.usage);
+      }
+      contextTokens = null;
+
       const timestamp = event.result?.summary
         ? Math.max(Date.now(), latestConversationTimestamp + 1)
         : latestConversationTimestamp;
@@ -628,8 +695,13 @@ export function createPiConversationTranslator(): PiConversationTranslator {
       const stopReason = settledStopReason;
       latestRuntimeTimestamp = 0;
       settledStopReason = undefined;
-      const totalTokens = turnTotalTokens;
-      turnTotalTokens = 0;
+      const billed = turnUsage;
+      turnUsage = emptyTurnUsage();
+      const totalTokens = billed.totalTokens;
+      const usage =
+        billed.totalTokens > 0
+          ? toAgentTurnUsage(billed, contextTokens, getContextWindow?.())
+          : undefined;
 
       return hadRuntimeActivity
         ? [
@@ -638,6 +710,7 @@ export function createPiConversationTranslator(): PiConversationTranslator {
               timestamp,
               stopReason,
               ...(totalTokens > 0 ? { totalTokens } : {}),
+              ...(usage ? { usage } : {}),
             },
           ]
         : [];

--- a/products/desktop/packages/agent/src/pi/runtime.ts
+++ b/products/desktop/packages/agent/src/pi/runtime.ts
@@ -33,9 +33,12 @@ export class PiRuntime {
   }> = [];
   private directBashActive = false;
 
-  constructor(client: PiRpcClient) {
+  constructor(
+    client: PiRpcClient,
+    getContextWindow?: () => number | undefined,
+  ) {
     this.client = client;
-    this.translator = createPiConversationTranslator();
+    this.translator = createPiConversationTranslator(getContextWindow);
     client.onEvent((event) => this.handleEvent(event));
   }
 

--- a/products/desktop/packages/agent/src/pi/types.ts
+++ b/products/desktop/packages/agent/src/pi/types.ts
@@ -190,3 +190,5 @@ export const piExtensionSessionEventSchema = z.union([
 ]);
 
 export type PiSessionStats = Awaited<ReturnType<RpcClient["getSessionStats"]>>;
+
+export type PiUsageStats = Pick<PiSessionStats, "contextUsage">;

--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -974,7 +974,7 @@ describe("AgentServer HTTP Mode", () => {
       return testServer;
     }
 
-    it("reports cumulative run token usage into TaskRun.state after each settled turn", () => {
+    it("reports cumulative run token usage into TaskRun.state after each settled turn", async () => {
       const testServer = createUsageTestServer();
       const turnUsage = {
         inputTokens: 100,
@@ -987,7 +987,9 @@ describe("AgentServer HTTP Mode", () => {
       testServer.recordTurnUsage(turnUsage);
       testServer.recordTurnUsage(turnUsage);
 
-      expect(testServer.posthogAPI.updateTaskRun).toHaveBeenCalledTimes(2);
+      await vi.waitFor(() =>
+        expect(testServer.posthogAPI.updateTaskRun).toHaveBeenCalledTimes(2),
+      );
       expect(testServer.posthogAPI.updateTaskRun).toHaveBeenNthCalledWith(
         1,
         "task-1",

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -134,7 +134,7 @@ import {
   type ExistingPrCheckoutResult,
 } from "./pr-checkout";
 import { createRtkSavingsNotification } from "./rtk-savings";
-import { RunUsageAccumulator } from "./run-usage";
+import { RunUsageAccumulator, reportRunUsage, seedRunUsage } from "./run-usage";
 import { jsonRpcRequestSchema, validateCommandParams } from "./schemas";
 import type { AgentServerConfig, ClaudeCodeConfig } from "./types";
 import { waitForFile } from "./wait-for-file";
@@ -1847,6 +1847,7 @@ export class AgentServer {
       preTask?.repositories ??
       (preTask?.repository ? [preTask.repository] : []);
 
+    seedRunUsage(this.runUsage, preTaskRun?.state.token_usage);
     this.prewarmedRun = preTaskRun?.state.prewarmed === true;
     this.prewarmedStartupTurnPending = this.prewarmedRun;
 
@@ -5500,13 +5501,13 @@ ${commonInstructions}
     if (!this.runUsage.add(usage)) return;
     const payload = this.session?.payload;
     if (!payload) return;
-    void this.posthogAPI
-      .updateTaskRun(payload.task_id, payload.run_id, {
-        state: { token_usage: this.runUsage.snapshot() },
-      })
-      .catch((error) => {
-        this.logger.warn("Failed to report run token usage", error);
-      });
+    reportRunUsage(
+      this.runUsage,
+      this.posthogAPI,
+      payload.task_id,
+      payload.run_id,
+      this.logger,
+    );
   }
 
   private handleAcpTransportMessage(message: unknown): void {

--- a/products/desktop/packages/agent/src/server/pi-agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/pi-agent-server.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { AgentConversationEvent } from "@posthog/shared";
 import { describe, expect, it, vi } from "vitest";
 import { PiAgentServer } from "./pi-agent-server";
 import type { AgentServerConfig } from "./types";
@@ -962,4 +963,78 @@ describe("PiAgentServer", () => {
       }),
     );
   });
+
+  it("reports cumulative run token usage after each settled Pi turn", async () => {
+    const updateTaskRun = vi.fn(async () => ({}));
+    const handled: AgentConversationEvent[] = [];
+    const server = new PiAgentServer(config()) as unknown as {
+      posthogAPI: { updateTaskRun: typeof updateTaskRun };
+      handleEvent(event: AgentConversationEvent): void;
+      handleConversationEvent(event: AgentConversationEvent): void;
+    };
+    server.posthogAPI = { updateTaskRun };
+    server.handleEvent = (event) => {
+      handled.push(event);
+    };
+    const turn: AgentConversationEvent = {
+      type: "turn_completed",
+      timestamp: 1,
+      stopReason: "stop",
+      totalTokens: 165,
+      usage: {
+        inputTokens: 100,
+        outputTokens: 50,
+        cachedReadTokens: 10,
+        cachedWriteTokens: 5,
+        totalTokens: 165,
+      },
+    };
+
+    server.handleConversationEvent(turn);
+    server.handleConversationEvent(turn);
+
+    expect(handled).toHaveLength(2);
+    await vi.waitFor(() => expect(updateTaskRun).toHaveBeenCalledTimes(2));
+    expect(updateTaskRun).toHaveBeenLastCalledWith("task-1", "run-1", {
+      state: {
+        token_usage: {
+          input_tokens: 200,
+          output_tokens: 100,
+          cache_read_tokens: 20,
+          cache_write_tokens: 10,
+          thought_tokens: 0,
+          total_tokens: 330,
+          turns: 2,
+        },
+      },
+    });
+  });
+
+  it.each([
+    [{ type: "set_model", provider: "anthropic", modelId: "big" }, 1_000_000],
+    [{ type: "prompt", message: "hello" }, 200_000],
+  ])(
+    "keeps the stamped context window in step with the live model after %o",
+    async (command, expectedContextWindow) => {
+      const getState = vi.fn(async () => ({
+        model: { contextWindow: 1_000_000 },
+      }));
+      const sendCommand = vi.fn(async () => ({ ok: true }));
+      const server = new PiAgentServer(config()) as unknown as {
+        session: unknown;
+        modelContextWindow: number | null;
+        executeCommand(
+          method: string,
+          params: Record<string, unknown>,
+        ): Promise<unknown>;
+      };
+      server.session = { runtime: { client: { getState }, sendCommand } };
+      server.modelContextWindow = 200_000;
+
+      await server.executeCommand("pi/rpc", { command });
+
+      expect(sendCommand).toHaveBeenCalledWith(command);
+      expect(server.modelContextWindow).toBe(expectedContextWindow);
+    },
+  );
 });

--- a/products/desktop/packages/agent/src/server/pi-agent-server.ts
+++ b/products/desktop/packages/agent/src/server/pi-agent-server.ts
@@ -1,10 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
+import type { RpcSessionState } from "@earendil-works/pi-coding-agent";
 import type { ServerType } from "@hono/node-server";
 import { serve } from "@hono/node-server";
 import {
   type AgentConversationEvent,
+  type AgentTurnUsage,
   MCP_TOOL_PERMISSION_OPTIONS,
   type McpToolPermissionDecision,
   type McpToolPermissionRequest,
@@ -42,8 +44,14 @@ import { Logger } from "../utils/logger";
 import { TaskRunEventStreamSender } from "./event-stream-sender";
 import { type JwtPayload, JwtValidationError, validateJwt } from "./jwt";
 import { createRtkSavingsNotification } from "./rtk-savings";
+import { RunUsageAccumulator, reportRunUsage, seedRunUsage } from "./run-usage";
 import { jsonRpcRequestSchema } from "./schemas";
 import type { AgentServerConfig } from "./types";
+
+const MODEL_CHANGING_RPC_COMMANDS: ReadonlySet<string> = new Set([
+  "set_model",
+  "cycle_model",
+]);
 
 interface SseController {
   send(data: unknown): void;
@@ -143,6 +151,8 @@ export class PiAgentServer {
     McpToolPermissionRequest
   >();
   private rtkSavingsAttempted = false;
+  private runUsage = new RunUsageAccumulator();
+  private modelContextWindow: number | null = null;
 
   constructor(private readonly config: AgentServerConfig) {
     this.posthogAPI = new PostHogAPIClient({
@@ -250,6 +260,7 @@ export class PiAgentServer {
         );
     }
     this.session = null;
+    this.runUsage = new RunUsageAccumulator();
     this.pendingMcpPermissions.clear();
     await this.flushConversationLog().catch((error) =>
       this.logger.error("Failed to persist Pi events during shutdown", error),
@@ -582,6 +593,7 @@ export class PiAgentServer {
         }),
     ]);
     const runState = taskRun?.state;
+    seedRunUsage(this.runUsage, runState?.token_usage);
     const taskSnapshotKind = taskRun
       ? typeof runState?.snapshot_kind === "string"
         ? runState.snapshot_kind
@@ -655,9 +667,12 @@ export class PiAgentServer {
       extensions,
       contextWikiPath: resolveContextWikiPath(),
     });
-    const runtime = new PiRuntime(client);
+    const runtime = new PiRuntime(
+      client,
+      () => this.modelContextWindow ?? undefined,
+    );
     const unsubscribeConversation = runtime.onConversationEvent((event) =>
-      this.handleEvent(event),
+      this.handleConversationEvent(event),
     );
     const unsubscribeRuntime = runtime.onRuntimeEvent((event) => {
       if (event.type === "agent_settled") {
@@ -684,6 +699,7 @@ export class PiAgentServer {
       );
     }
     const runtimeState = await client.getState();
+    this.applyModelContextWindow(runtimeState);
     this.sessionFile = runtimeState.sessionFile ?? restoredSessionFile ?? null;
     const unsubscribe = () => {
       unsubscribeConversation();
@@ -704,6 +720,24 @@ export class PiAgentServer {
       taskId: payload.task_id,
       runId: payload.run_id,
     });
+  }
+
+  private handleConversationEvent(event: AgentConversationEvent): void {
+    if (event.type === "turn_completed" && event.usage) {
+      this.recordTurnUsage(event.usage);
+    }
+    this.handleEvent(event);
+  }
+
+  private recordTurnUsage(usage: AgentTurnUsage): void {
+    if (!this.runUsage.add(usage)) return;
+    reportRunUsage(
+      this.runUsage,
+      this.posthogAPI,
+      this.config.taskId,
+      this.config.runId,
+      this.logger,
+    );
   }
 
   private handleEvent(event: AgentConversationEvent): void {
@@ -823,8 +857,27 @@ export class PiAgentServer {
           const response = piExtensionUIResponseSchema.parse(command);
           return this.respondExtensionUI(response);
         }
-        return runtime.sendCommand(command);
+        const result = await runtime.sendCommand(command);
+        if (MODEL_CHANGING_RPC_COMMANDS.has(command.type)) {
+          await this.refreshModelContextWindow(client);
+        }
+        return result;
       }
+    }
+  }
+
+  private applyModelContextWindow(state: RpcSessionState): void {
+    this.modelContextWindow =
+      typeof state.model?.contextWindow === "number"
+        ? state.model.contextWindow
+        : null;
+  }
+
+  private async refreshModelContextWindow(client: PiRpcClient): Promise<void> {
+    try {
+      this.applyModelContextWindow(await client.getState());
+    } catch (error) {
+      this.logger.debug("Failed to refresh Pi model context window", error);
     }
   }
 

--- a/products/desktop/packages/agent/src/server/run-usage.test.ts
+++ b/products/desktop/packages/agent/src/server/run-usage.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, test } from "vitest";
-import { RunUsageAccumulator } from "./run-usage";
+import { describe, expect, test, vi } from "vitest";
+import type { PostHogAPIClient } from "../posthog-api";
+import type { Logger } from "../utils/logger";
+import { RunUsageAccumulator, reportRunUsage, seedRunUsage } from "./run-usage";
 
 describe("RunUsageAccumulator", () => {
   test("accumulates across turns and defaults nullable ACP fields to 0", () => {
@@ -47,6 +49,64 @@ describe("RunUsageAccumulator", () => {
     },
   );
 
+  test("continues stored totals so a same-run resume does not lose them", () => {
+    const acc = new RunUsageAccumulator();
+
+    expect(
+      seedRunUsage(acc, {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_tokens: 10,
+        cache_write_tokens: 5,
+        thought_tokens: 0,
+        total_tokens: 165,
+        turns: 1,
+      }),
+    ).toBe(true);
+    acc.add({
+      inputTokens: 200,
+      outputTokens: 80,
+      totalTokens: 280,
+    });
+
+    expect(acc.snapshot()).toEqual({
+      input_tokens: 300,
+      output_tokens: 130,
+      cache_read_tokens: 10,
+      cache_write_tokens: 5,
+      thought_tokens: 0,
+      total_tokens: 445,
+      turns: 2,
+    });
+  });
+
+  test.each([
+    ["missing state", undefined],
+    ["a non-object value", 42],
+  ])("leaves the totals alone when the stored usage is %s", (_label, value) => {
+    const acc = new RunUsageAccumulator();
+    expect(seedRunUsage(acc, value)).toBe(false);
+    expect(acc.snapshot().turns).toBe(0);
+  });
+
+  test("does not seed once a turn of its own has been counted", () => {
+    const acc = new RunUsageAccumulator();
+    acc.add({ inputTokens: 1, outputTokens: 1, totalTokens: 2 });
+
+    expect(
+      seedRunUsage(acc, {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        thought_tokens: 0,
+        total_tokens: 150,
+        turns: 1,
+      }),
+    ).toBe(false);
+    expect(acc.snapshot().total_tokens).toBe(2);
+  });
+
   test("snapshot is a copy — later turns don't mutate earlier snapshots", () => {
     const acc = new RunUsageAccumulator();
     acc.add({ inputTokens: 1, outputTokens: 1, totalTokens: 2 });
@@ -54,5 +114,33 @@ describe("RunUsageAccumulator", () => {
     acc.add({ inputTokens: 1, outputTokens: 1, totalTokens: 2 });
     expect(first.turns).toBe(1);
     expect(acc.snapshot().turns).toBe(2);
+  });
+
+  test("sends run usage reports one at a time so an older snapshot never lands last", async () => {
+    const acc = new RunUsageAccumulator();
+    const settle: Array<() => void> = [];
+    const updateTaskRun = vi.fn(
+      (_taskId: string, _runId: string, body: unknown) =>
+        new Promise<unknown>((resolve) => {
+          settle.push(() => resolve(body));
+        }),
+    );
+    const api = { updateTaskRun } as unknown as PostHogAPIClient;
+    const logger = { warn: vi.fn() } as unknown as Logger;
+
+    acc.add({ inputTokens: 1, outputTokens: 1, totalTokens: 2 });
+    const first = reportRunUsage(acc, api, "task-1", "run-1", logger);
+    acc.add({ inputTokens: 1, outputTokens: 1, totalTokens: 2 });
+    const second = reportRunUsage(acc, api, "task-1", "run-1", logger);
+
+    expect(updateTaskRun).toHaveBeenCalledTimes(1);
+    settle[0]();
+    await first;
+    expect(updateTaskRun).toHaveBeenCalledTimes(2);
+    expect(updateTaskRun.mock.calls[1][2]).toEqual({
+      state: { token_usage: expect.objectContaining({ turns: 2 }) },
+    });
+    settle[1]();
+    await second;
   });
 });

--- a/products/desktop/packages/agent/src/server/run-usage.ts
+++ b/products/desktop/packages/agent/src/server/run-usage.ts
@@ -1,4 +1,7 @@
 import type { Usage } from "@agentclientprotocol/sdk";
+import { z } from "zod/v4";
+import type { PostHogAPIClient } from "../posthog-api";
+import type { Logger } from "../utils/logger";
 
 /**
  * Cumulative token usage for a task run, shaped for `TaskRun.state.token_usage`
@@ -45,7 +48,65 @@ export class RunUsageAccumulator {
     return true;
   }
 
+  seed(totals: RunTokenUsage): boolean {
+    if (this.totals.turns > 0 || this.totals.total_tokens > 0) return false;
+    this.totals = { ...totals };
+    return true;
+  }
+
   snapshot(): RunTokenUsage {
     return { ...this.totals };
   }
+}
+
+const storedTokenCount = z.number().int().nonnegative().catch(0);
+
+const storedRunTokenUsageSchema = z.object({
+  input_tokens: storedTokenCount,
+  output_tokens: storedTokenCount,
+  cache_read_tokens: storedTokenCount,
+  cache_write_tokens: storedTokenCount,
+  thought_tokens: storedTokenCount,
+  total_tokens: storedTokenCount,
+  turns: storedTokenCount,
+});
+
+export function seedRunUsage(
+  accumulator: RunUsageAccumulator,
+  storedTokenUsage: unknown,
+): boolean {
+  const parsed = storedRunTokenUsageSchema.safeParse(storedTokenUsage);
+  if (!parsed.success) return false;
+  return accumulator.seed(parsed.data);
+}
+
+const inflightReports = new WeakMap<RunUsageAccumulator, Promise<void>>();
+
+export function reportRunUsage(
+  accumulator: RunUsageAccumulator,
+  api: PostHogAPIClient,
+  taskId: string,
+  runId: string,
+  logger: Logger,
+): Promise<void> {
+  const send = (): Promise<void> =>
+    api
+      .updateTaskRun(taskId, runId, {
+        state: { token_usage: accumulator.snapshot() },
+      })
+      .then(
+        () => undefined,
+        (error: unknown) => {
+          logger.warn("Failed to report run token usage", error);
+        },
+      );
+  const previous = inflightReports.get(accumulator);
+  const next = previous ? previous.then(send) : send();
+  inflightReports.set(accumulator, next);
+  void next.then(() => {
+    if (inflightReports.get(accumulator) === next) {
+      inflightReports.delete(accumulator);
+    }
+  });
+  return next;
 }

--- a/products/desktop/packages/core/src/pi-runtime/cloudPiSessionClient.test.ts
+++ b/products/desktop/packages/core/src/pi-runtime/cloudPiSessionClient.test.ts
@@ -66,6 +66,27 @@ function context(status: "queued" | "in_progress" | "completed") {
   };
 }
 
+function turnCompleted(
+  totalTokens: number,
+  contextWindow: number | null = 200_000,
+): AgentConversationEvent {
+  return {
+    type: "turn_completed",
+    timestamp: 1,
+    stopReason: "stop",
+    totalTokens,
+    usage: {
+      inputTokens: totalTokens,
+      outputTokens: 0,
+      cachedReadTokens: 0,
+      cachedWriteTokens: 0,
+      totalTokens,
+      contextTokens: totalTokens,
+      contextWindow: contextWindow ?? undefined,
+    },
+  };
+}
+
 const snapshotEvent: AgentConversationEvent = {
   type: "assistant_message_chunk",
   timestamp: 1,
@@ -853,5 +874,102 @@ describe("CloudPiSessionClient", () => {
       "Cloud task run run-1 is failed",
     );
     expect(cloud.client.sendCommand).not.toHaveBeenCalled();
+  });
+  it("derives context usage from stored turn usage on a terminal run", () => {
+    const cloud = createCloudTaskClient();
+    const session = new CloudPiSessionClient(
+      cloud.client,
+      context("completed"),
+    );
+    session.onConversationEvent(vi.fn(), vi.fn());
+
+    cloud.sendUpdate({
+      taskId: "task-1",
+      runId: "run-1",
+      kind: "snapshot",
+      status: "completed",
+      newEntries: [
+        { type: "pi_event", event: turnCompleted(1_000) },
+        { type: "pi_event", event: turnCompleted(50_000) },
+      ],
+      totalEntryCount: 2,
+    });
+
+    expect(session.usageStats()).toEqual({
+      contextUsage: {
+        tokens: 50_000,
+        contextWindow: 200_000,
+        percent: null,
+      },
+    });
+  });
+
+  it.each([
+    ["no earlier window", [turnCompleted(1_000, null)], undefined],
+    [
+      "an earlier window",
+      [turnCompleted(1_000), turnCompleted(50_000, null)],
+      {
+        contextUsage: { tokens: 50_000, contextWindow: 200_000, percent: null },
+      },
+    ],
+  ])(
+    "keeps the last known context window when a turn reports none, with %s",
+    (_label, events, expected) => {
+      const cloud = createCloudTaskClient();
+      const session = new CloudPiSessionClient(
+        cloud.client,
+        context("completed"),
+      );
+      session.onConversationEvent(vi.fn(), vi.fn());
+
+      cloud.sendUpdate({
+        taskId: "task-1",
+        runId: "run-1",
+        kind: "snapshot",
+        status: "completed",
+        newEntries: events.map((event) => ({ type: "pi_event", event })),
+        totalEntryCount: events.length,
+      });
+
+      expect(session.usageStats()).toEqual(expected);
+    },
+  );
+
+  it("marks the context unknown after a completed compaction", () => {
+    const cloud = createCloudTaskClient();
+    const session = new CloudPiSessionClient(
+      cloud.client,
+      context("completed"),
+    );
+    session.onConversationEvent(vi.fn(), vi.fn());
+
+    cloud.sendUpdate({
+      taskId: "task-1",
+      runId: "run-1",
+      kind: "snapshot",
+      status: "completed",
+      newEntries: [
+        { type: "pi_event", event: turnCompleted(50_000) },
+        {
+          type: "pi_event",
+          event: {
+            type: "runtime_status",
+            timestamp: 2,
+            status: "compacting",
+            isComplete: true,
+          },
+        },
+      ],
+      totalEntryCount: 2,
+    });
+
+    expect(session.usageStats()).toEqual({
+      contextUsage: {
+        tokens: null,
+        contextWindow: 200_000,
+        percent: null,
+      },
+    });
   });
 });

--- a/products/desktop/packages/core/src/pi-runtime/cloudPiSessionClient.ts
+++ b/products/desktop/packages/core/src/pi-runtime/cloudPiSessionClient.ts
@@ -10,6 +10,7 @@ import {
   type PiExtensionSessionEvent,
   type PiPersistedSessionConfig,
   type PiQueueSnapshot,
+  type PiUsageStats,
   piExtensionSessionEventSchema,
   piExtensionUIResponseSchema,
   type RpcExtensionUIResponse,
@@ -105,6 +106,26 @@ function permissionDescription(
   return undefined;
 }
 
+interface CloudTurnUsage {
+  contextTokens: number | null;
+  contextWindow: number | null;
+}
+
+function emptyTurnUsage(): CloudTurnUsage {
+  return {
+    contextTokens: null,
+    contextWindow: null,
+  };
+}
+
+function isCompletedCompaction(event: AgentConversationEvent): boolean {
+  return (
+    event.type === "runtime_status" &&
+    event.status === "compacting" &&
+    event.isComplete === true
+  );
+}
+
 export interface CloudPiSessionContext {
   taskId: string;
   runId: string;
@@ -119,6 +140,7 @@ export class CloudPiSessionClient implements PiSession {
   private readonly terminalClient: PiRemoteRpcClient;
   private runStatus: TaskRunStatus;
   private snapshotEvents: AgentConversationEvent[] = [];
+  private turnUsage: CloudTurnUsage = emptyTurnUsage();
   private snapshotReady = false;
   private resolveSnapshot: () => void = () => {};
   private rejectSnapshot: (error: unknown) => void = () => {};
@@ -229,6 +251,36 @@ export class CloudPiSessionClient implements PiSession {
     });
     if (!result.success) {
       throw new Error(result.error ?? `Pi RPC command failed: ${type}`);
+    }
+  }
+
+  usageStats(): PiUsageStats | undefined {
+    const { contextTokens, contextWindow } = this.turnUsage;
+    if (contextWindow === null) {
+      return undefined;
+    }
+
+    return {
+      contextUsage: {
+        tokens: contextTokens,
+        contextWindow,
+        percent: null,
+      },
+    };
+  }
+
+  private accumulateTurnUsage(events: AgentConversationEvent[]): void {
+    for (const event of events) {
+      if (isCompletedCompaction(event)) {
+        this.turnUsage.contextTokens = null;
+        continue;
+      }
+      if (event.type !== "turn_completed" || !event.usage) {
+        continue;
+      }
+      this.turnUsage.contextTokens = event.usage.contextTokens ?? null;
+      this.turnUsage.contextWindow =
+        event.usage.contextWindow ?? this.turnUsage.contextWindow;
     }
   }
 
@@ -469,6 +521,8 @@ export class CloudPiSessionClient implements PiSession {
       );
 
       this.snapshotEvents = events;
+      this.turnUsage = emptyTurnUsage();
+      this.accumulateTurnUsage(events);
       this.markSnapshotReady();
       for (const event of events) {
         if (!event.sourceId || !previousSourceIds.has(event.sourceId)) {
@@ -490,6 +544,7 @@ export class CloudPiSessionClient implements PiSession {
         (event) => !event.sourceId || !existingSourceIds.has(event.sourceId),
       );
       this.snapshotEvents = [...this.snapshotEvents, ...newEvents];
+      this.accumulateTurnUsage(newEvents);
       this.markSnapshotReady();
       for (const event of newEvents) {
         onEvent(event, { isLive: true });

--- a/products/desktop/packages/core/src/pi-runtime/piSessionController.test.ts
+++ b/products/desktop/packages/core/src/pi-runtime/piSessionController.test.ts
@@ -1582,6 +1582,25 @@ describe("PiSessionController", () => {
     ]);
   });
 
+  it("falls back to stored turn usage when the live stats RPC is unavailable", async () => {
+    const session = createSession();
+    vi.mocked(session.client.getSessionStats).mockRejectedValue(
+      new Error("Cloud task run run-1 is completed"),
+    );
+    session.usageStats = vi.fn(() => ({
+      contextUsage: { tokens: 50_000, contextWindow: 200_000, percent: 25 },
+    }));
+    const controller = createController(session);
+
+    await controller.connect("task-1");
+
+    await vi.waitFor(() => {
+      expect(controller.store.getState().sessions["task-1"].stats).toEqual({
+        contextUsage: { tokens: 50_000, contextWindow: 200_000, percent: 25 },
+      });
+    });
+  });
+
   it("loads session state and appends normalized runtime events", async () => {
     const initialEvent: AgentConversationEvent = {
       type: "assistant_message_chunk",

--- a/products/desktop/packages/core/src/pi-runtime/piSessionController.ts
+++ b/products/desktop/packages/core/src/pi-runtime/piSessionController.ts
@@ -5,6 +5,7 @@ import type {
   PiPersistedSessionConfig,
   PiQueueSnapshot,
   PiThinkingLevel,
+  PiUsageStats,
   RpcExtensionUIResponse,
 } from "@posthog/agent/pi/types";
 import {
@@ -78,6 +79,7 @@ export interface PiSession {
     id: string,
   ): Promise<void>;
   health(): Promise<PiRuntimeHealth>;
+  usageStats?(): PiUsageStats | undefined;
   getConversation(): Promise<AgentConversationEvent[]>;
   onConversationEvent(
     onEvent: (
@@ -723,7 +725,7 @@ export class PiSessionController {
         session.getConversation(),
         session.client.getState(),
         session.getQueue(),
-        session.client.getSessionStats().catch(() => retainedStats),
+        this.loadStats(session, retainedStats),
       ]);
       if (this.getSessionVersion(taskId) !== connectedSessionVersion) {
         return;
@@ -1045,12 +1047,22 @@ export class PiSessionController {
     this.updateSession(taskId, { cloudStatus });
   }
 
+  private async loadStats(
+    session: PiSession,
+    retained?: PiUsageStats,
+  ): Promise<PiUsageStats | undefined> {
+    const liveStats = await session.client
+      .getSessionStats()
+      .catch(() => undefined);
+    return liveStats ?? session.usageStats?.() ?? retained;
+  }
+
   private async refreshStats(taskId: string): Promise<void> {
     const sessionVersion = this.getSessionVersion(taskId);
     try {
       const session = await this.getPiSession(taskId);
-      const stats = await session.client.getSessionStats();
-      if (this.getSessionVersion(taskId) === sessionVersion) {
+      const stats = await this.loadStats(session);
+      if (stats && this.getSessionVersion(taskId) === sessionVersion) {
         this.updateSession(taskId, { stats });
       }
     } catch {

--- a/products/desktop/packages/core/src/pi-runtime/piSessionStore.ts
+++ b/products/desktop/packages/core/src/pi-runtime/piSessionStore.ts
@@ -2,9 +2,9 @@ import type {
   PiCommand,
   PiNativeModelInfo,
   PiQueueSnapshot,
-  PiSessionStats,
   PiSessionStatus,
   PiThinkingLevel,
+  PiUsageStats,
 } from "@posthog/agent/pi/types";
 import type {
   AgentConversationEvent,
@@ -37,7 +37,7 @@ export interface PiControllerSessionState {
   commands: PiCommand[];
   queue: PiQueueSnapshot;
   status?: PiSessionStatus;
-  stats?: PiSessionStats;
+  stats?: PiUsageStats;
   cloudStatus?: TaskRunStatus;
   error?: PiSessionError;
   authRestoring: boolean;

--- a/products/desktop/packages/core/src/pi-runtime/piSessionUsage.ts
+++ b/products/desktop/packages/core/src/pi-runtime/piSessionUsage.ts
@@ -1,8 +1,8 @@
-import type { PiSessionStats } from "@posthog/agent/pi/types";
+import type { PiUsageStats } from "@posthog/agent/pi/types";
 import type { ContextUsage } from "../sessions/contextUsage";
 
 export function toPiContextUsage(
-  stats: PiSessionStats | undefined,
+  stats: PiUsageStats | undefined,
 ): ContextUsage | null {
   const usage = stats?.contextUsage;
   if (!usage || usage.tokens === null) {

--- a/products/desktop/packages/shared/src/agent-conversation.ts
+++ b/products/desktop/packages/shared/src/agent-conversation.ts
@@ -20,6 +20,17 @@ export type AgentToolCallStatus =
 
 export type AgentProgressStatus = "in_progress" | "completed" | "failed";
 
+export interface AgentTurnUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cachedReadTokens: number;
+  cachedWriteTokens: number;
+  thoughtTokens?: number;
+  totalTokens: number;
+  contextTokens?: number | null;
+  contextWindow?: number;
+}
+
 export interface AgentTextContent {
   type: "text";
   text: string;
@@ -181,6 +192,7 @@ export type AgentConversationEvent = (
       timestamp: number;
       stopReason?: string;
       totalTokens?: number;
+      usage?: AgentTurnUsage;
     }
 ) &
   AgentConversationEventIdentity;

--- a/products/desktop/packages/shared/src/index.ts
+++ b/products/desktop/packages/shared/src/index.ts
@@ -15,6 +15,7 @@ export type {
   AgentToolCallLocation,
   AgentToolCallStatus,
   AgentToolKind,
+  AgentTurnUsage,
 } from "./agent-conversation";
 export * from "./agent-runtime";
 export * from "./analytics-events";


### PR DESCRIPTION
## Problem

- A PostHog Code cloud run on the Pi runtime shows no context ring and no cost in the desktop, on any model, while the same run on the default runtime shows both.
- The Pi conversation translator zeroed the turn's token total on `agent_end`, which pi emits before `agent_settled`, so every finished turn reported no tokens.
- The Pi agent-server never persisted run-level usage, so `TaskRun.state.token_usage` stayed empty and run analytics had no token figures.
- For a finished run the desktop's cloud Pi client has no live stats RPC, so it had no source for context usage, and the indicator hides the backend cost when it has no context usage.

## Changes

- A Pi cloud run now shows the context ring, the token popover, and the cost, during the run and after it finishes.

![ui-pi-popover](https://raw.githubusercontent.com/PostHog/pr-assets/ae761ab6ff1a6b99440cd5145608df53404cc446/2026/09/86b39750-3ddb-4e23-8c26-a0c3361058ac.png)

