### PR TITLE
fix(signals): pin the clock in the scout roster lifecycle test

### DIFF
--- a/products/signals/frontend/inbox/logics/scoutFleetLogic.test.ts
+++ b/products/signals/frontend/inbox/logics/scoutFleetLogic.test.ts
@@ -223,65 +223,75 @@ describe('scoutFleetLogic', () => {
     })
 
     it('lists the whole roster A→Z and tags each row with its lifecycle group', () => {
-        logic.actions.setRosterEvaluatedAt(new Date('2026-08-28T12:00:00Z').valueOf())
-        logic.actions.loadScoutConfigsSuccess([
-            { ...BASE_CONFIG, id: 'quiet', skill_name: 'signals-scout-quiet' },
-            { ...BASE_CONFIG, id: 'busy', skill_name: 'signals-scout-busy' },
-            {
-                ...BASE_CONFIG,
-                id: 'off',
-                skill_name: 'signals-scout-off',
-                enabled: false,
-                status: 'paused_by_user',
-            },
-            {
-                ...BASE_CONFIG,
-                id: 'broken',
-                skill_name: 'signals-scout-broken',
-                enabled: false,
-                status: 'paused_by_system',
-                pause_reason: 'repeated_failures',
-                status_changed_at: '2026-08-27T12:00:00Z',
-            },
-            {
-                ...BASE_CONFIG,
-                id: 'stale-pause',
-                skill_name: 'signals-scout-stale-pause',
-                enabled: false,
-                status: 'paused_by_system',
-                pause_reason: 'no_output',
-                status_changed_at: '2026-08-20T12:00:00Z',
-            },
-            {
-                ...BASE_CONFIG,
-                id: 'warned',
-                skill_name: 'signals-scout-warned',
-                status: 'pending_pause',
-                pause_reason: 'ignored',
-            },
-            {
-                ...BASE_CONFIG,
-                id: 'quiet-warning',
-                skill_name: 'signals-scout-quiet-warning',
-                status: 'pending_pause',
-                pause_reason: 'no_output',
-            },
-        ])
-        // `busy` filed a report in the window, which is what separates Working from Watching.
-        logic.actions.loadScoutRunsSuccess([makeRun({ skill_name: 'signals-scout-busy', emitted_report_ids: ['r-1'] })])
+        // The runs poll re-pins `rosterEvaluatedAt` to the wall clock when real time has moved a
+        // scout out of the pause window, so the fixture dates only hold with the clock pinned too.
+        jest.useFakeTimers()
+        try {
+            jest.setSystemTime(new Date('2026-08-28T12:00:00Z'))
+            logic.actions.setRosterEvaluatedAt(new Date('2026-08-28T12:00:00Z').valueOf())
+            logic.actions.loadScoutConfigsSuccess([
+                { ...BASE_CONFIG, id: 'quiet', skill_name: 'signals-scout-quiet' },
+                { ...BASE_CONFIG, id: 'busy', skill_name: 'signals-scout-busy' },
+                {
+                    ...BASE_CONFIG,
+                    id: 'off',
+                    skill_name: 'signals-scout-off',
+                    enabled: false,
+                    status: 'paused_by_user',
+                },
+                {
+                    ...BASE_CONFIG,
+                    id: 'broken',
+                    skill_name: 'signals-scout-broken',
+                    enabled: false,
+                    status: 'paused_by_system',
+                    pause_reason: 'repeated_failures',
+                    status_changed_at: '2026-08-27T12:00:00Z',
+                },
+                {
+                    ...BASE_CONFIG,
+                    id: 'stale-pause',
+                    skill_name: 'signals-scout-stale-pause',
+                    enabled: false,
+                    status: 'paused_by_system',
+                    pause_reason: 'no_output',
+                    status_changed_at: '2026-08-20T12:00:00Z',
+                },
+                {
+                    ...BASE_CONFIG,
+                    id: 'warned',
+                    skill_name: 'signals-scout-warned',
+                    status: 'pending_pause',
+                    pause_reason: 'ignored',
+                },
+                {
+                    ...BASE_CONFIG,
+                    id: 'quiet-warning',
+                    skill_name: 'signals-scout-quiet-warning',
+                    status: 'pending_pause',
+                    pause_reason: 'no_output',
+                },
+            ])
+            // `busy` filed a report in the window, which is what separates Working from Watching.
+            logic.actions.loadScoutRunsSuccess([
+                makeRun({ skill_name: 'signals-scout-busy', emitted_report_ids: ['r-1'] }),
+            ])
 
-        // One flat list ordered by name, not split across lifecycle sections.
-        expect(logic.values.rosterScouts.map((row) => [row.config.id, row.group])).toEqual([
-            ['broken', 'needs_you'],
-            ['busy', 'working'],
-            ['off', 'off'],
-            ['quiet', 'watching'],
-            ['quiet-warning', 'needs_you'],
-            ['stale-pause', 'needs_you'],
-            ['warned', 'needs_you'],
-        ])
-        // The stats tell a warning apart from a recent pause; human and stale pauses are neither.
-        expect(logic.values.pauseAttentionCounts).toEqual({ pausingSoon: 1, recentlyPaused: 1 })
+            // One flat list ordered by name, not split across lifecycle sections.
+            expect(logic.values.rosterScouts.map((row) => [row.config.id, row.group])).toEqual([
+                ['broken', 'needs_you'],
+                ['busy', 'working'],
+                ['off', 'off'],
+                ['quiet', 'watching'],
+                ['quiet-warning', 'needs_you'],
+                ['stale-pause', 'needs_you'],
+                ['warned', 'needs_you'],
+            ])
+            // The stats tell a warning apart from a recent pause; human and stale pauses are neither.
+            expect(logic.values.pauseAttentionCounts).toEqual({ pausingSoon: 1, recentlyPaused: 1 })
+        } finally {
+            jest.useRealTimers()
+        }
     })
 
     it('keeps configs unresolved until the current team is available', async () => {


### PR DESCRIPTION
## Problem

`scoutFleetLogic.test.ts` started failing on master at 2026-09-03T12:00Z, and it fails for every open PR, not just the one that noticed it. Nothing changed in the code — the test aged out.

The roster tells a recent system pause apart from a stale one using a 7-day window. The test pins `rosterEvaluatedAt` to a fixed instant, but leaves the wall clock real. The `loadScoutRunsSuccess` listener re-pins `rosterEvaluatedAt` to the real now whenever elapsed time has moved a scout across that window, which is exactly what that listener is for. The fixture pauses a scout at 2026-08-27T12:00Z, so the pin survived only while the real clock stayed within 7 days of it.

## Changes

- No behavior change. `pauseAttentionCounts` and the roster lifecycle grouping are untouched; only the test's clock handling changes.
- Mechanical: the test pins the system time to the same instant it already pinned `rosterEvaluatedAt` to, using the `useFakeTimers` / `try` / `finally` shape the other tests in this file already use. The listener then sees no elapsed time, so the fixture dates keep meaning what they say.

## How did you test this code?

- The suite fails on a clean master checkout at today's date and passes with this change — that is the regression, reproduced and fixed.
- The failure is inherently date-dependent, so the meaningful check is that the assertion no longer depends on the real date at all: the real clock now sits outside the fixture's 7-day window, and the test passes regardless.
- Jest over `products/signals/frontend`: all pass. No new tests — this fixes an existing one rather than covering new behavior.
- Audited the rest of the file for the same latent failure. Every remaining date literal that feeds a time-window comparison already sits inside a pinned-clock block.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found by Claude in a PostHog Desktop task while investigating red CI on an unrelated feature-flag-removal PR. The first step was confirming the failure reproduced on a clean master checkout, which ruled out that PR as the cause.

The fix is in the test rather than in `isRecentlySystemPaused` or the listener: re-pinning the evaluated instant when real time crosses a lifecycle boundary is deliberate product behavior, so the test was asserting against a clock it had only half-pinned.

Split into its own PR because it is unrelated to the work that surfaced it and unblocks every open PR.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
