### PR TITLE
fix(ci): deploy notebook Temporal worker changes

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -474,7 +474,9 @@ jobs:
             - name: Check for changes that affect general purpose temporal worker
               id: check_changes_general_purpose_temporal_worker
               run: |
-                  if git diff --name-only HEAD^ HEAD | grep -qE '^products/exports/backend/temporal/subscriptions|^products/engineering_analytics/backend/|^products/canvas/backend/|^posthog/temporal/common|^posthog/temporal/session_recordings|^posthog/temporal/proxy_service|^posthog/temporal/(ai_observability|llm_analytics)|^posthog/temporal/product_analytics|^posthog/temporal/delete_persons|^posthog/temporal/delete_teams|^posthog/temporal/ingestion_acceptance_test|^posthog/temporal/backfill_group_type_created_at|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$|^posthog/clickhouse/migrations/'; then
+                  # Changes to this detector must trigger once so newly covered code ships with the worker.
+                  if git diff --name-only HEAD^ HEAD | grep -qE '^products/notebooks/backend/|^products/exports/backend/temporal/subscriptions|^products/engineering_analytics/backend/|^products/canvas/backend/|^posthog/llm/|^posthog/temporal/common|^posthog/temporal/session_recordings|^posthog/temporal/proxy_service|^posthog/temporal/(ai_observability|llm_analytics)|^posthog/temporal/product_analytics|^posthog/temporal/delete_persons|^posthog/temporal/delete_teams|^posthog/temporal/ingestion_acceptance_test|^posthog/temporal/backfill_group_type_created_at|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$|^posthog/clickhouse/migrations/' \
+                      || git diff HEAD^ HEAD -- .github/workflows/container-images-cd.yml | grep -qE '^\+.*products/exports/backend/temporal/subscriptions'; then
                       echo "changed=true" >> $GITHUB_OUTPUT
                   else
                       echo "changed=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

Notebook widget fixes can reach the web deployment while the general-purpose Temporal worker keeps running the previous code.

The container workflow does not classify notebook backend or shared LLM client changes as worker changes.

## Changes

- Notebook widget fixes now trigger a general-purpose Temporal worker release.
- Detector edits trigger one release, so newly covered code ships immediately.
- No user-visible UI changes.

Before:

```mermaid
flowchart LR
    Change[Notebook backend fix] --> Image[PostHog image]
    Image --> Web[Web deployment]
    Image -. no dispatch .-> Worker[General-purpose Temporal worker]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Change phYellow;
    class Image phGray;
    class Web phBlue;
    class Worker phRed;
```

After:

```mermaid
flowchart LR
    Change[Notebook backend fix] --> Image[PostHog image]
    Image --> Detector[Worker change detector]
    Detector --> Worker[General-purpose Temporal worker]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Change phYellow;
    class Image phGray;
    class Detector,Worker phBlue;
```

## How did you test this code?

- `./bin/hogli lint:workflows`
- Pinned `actionlint` against the flattened workflow.
- `./bin/hogli ci:preflight --strict`
- The committed detector reports `changed=true` for this workflow-only commit.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No matching deployment documentation exists; the workflow remains the source of truth.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex prepared and validated the isolated hotfix.
- Skills: `/authoring-ci-workflows`, `/gating-production-deploys`, `/writing-code-comments`, `/running-ci-preflight`, and `/writing-pr-descriptions`.
- Production evidence informed the diagnosis; this PR contains no copied or derived production data.