### PR TITLE
fix(ci): unbreak master for MCP typecheck and scout roster test

### DIFF
--- a/products/product_analytics/frontend/insights/trends/shared/magnitudeAxisIds.ts
+++ b/products/product_analytics/frontend/insights/trends/shared/magnitudeAxisIds.ts
@@ -26,7 +26,7 @@ export function computeMagnitudeAxisIds(datasets: readonly (readonly number[])[]
     const splitPositions = new Set(
         measured
             .slice(1)
-            .map((entry, k) => ({ pos: k + 1, gap: entry.magnitude - measured[k].magnitude }))
+            .map((entry, k) => ({ pos: k + 1, gap: entry.magnitude - (measured[k]?.magnitude ?? entry.magnitude) }))
             .filter(({ gap }) => gap >= MAGNITUDE_GAP)
             .sort((a, b) => b.gap - a.gap)
             .slice(0, MAX_Y_AXES - 1)
@@ -43,7 +43,7 @@ export function computeMagnitudeAxisIds(datasets: readonly (readonly number[])[]
         groupOf[seriesIndex] = group
     })
 
-    const idOf = new Map<number, string>(datasets.length ? [[groupOf[0], DEFAULT_Y_AXIS_ID]] : [])
+    const idOf = new Map<number, string>(groupOf.length ? [[groupOf[0] ?? 0, DEFAULT_Y_AXIS_ID]] : [])
     return groupOf.map((g) => {
         let id = idOf.get(g)
         if (!id) {

--- a/products/signals/frontend/inbox/logics/scoutFleetLogic.test.ts
+++ b/products/signals/frontend/inbox/logics/scoutFleetLogic.test.ts
@@ -223,65 +223,75 @@ describe('scoutFleetLogic', () => {
     })
 
     it('lists the whole roster A→Z and tags each row with its lifecycle group', () => {
-        logic.actions.setRosterEvaluatedAt(new Date('2026-08-28T12:00:00Z').valueOf())
-        logic.actions.loadScoutConfigsSuccess([
-            { ...BASE_CONFIG, id: 'quiet', skill_name: 'signals-scout-quiet' },
-            { ...BASE_CONFIG, id: 'busy', skill_name: 'signals-scout-busy' },
-            {
-                ...BASE_CONFIG,
-                id: 'off',
-                skill_name: 'signals-scout-off',
-                enabled: false,
-                status: 'paused_by_user',
-            },
-            {
-                ...BASE_CONFIG,
-                id: 'broken',
-                skill_name: 'signals-scout-broken',
-                enabled: false,
-                status: 'paused_by_system',
-                pause_reason: 'repeated_failures',
-                status_changed_at: '2026-08-27T12:00:00Z',
-            },
-            {
-                ...BASE_CONFIG,
-                id: 'stale-pause',
-                skill_name: 'signals-scout-stale-pause',
-                enabled: false,
-                status: 'paused_by_system',
-                pause_reason: 'no_output',
-                status_changed_at: '2026-08-20T12:00:00Z',
-            },
-            {
-                ...BASE_CONFIG,
-                id: 'warned',
-                skill_name: 'signals-scout-warned',
-                status: 'pending_pause',
-                pause_reason: 'ignored',
-            },
-            {
-                ...BASE_CONFIG,
-                id: 'quiet-warning',
-                skill_name: 'signals-scout-quiet-warning',
-                status: 'pending_pause',
-                pause_reason: 'no_output',
-            },
-        ])
-        // `busy` filed a report in the window, which is what separates Working from Watching.
-        logic.actions.loadScoutRunsSuccess([makeRun({ skill_name: 'signals-scout-busy', emitted_report_ids: ['r-1'] })])
+        // The runs listener re-evaluates pause recency against the clock, so the fixture's
+        // absolute dates only hold while the clock is pinned next to them.
+        jest.useFakeTimers()
+        try {
+            jest.setSystemTime(new Date('2026-08-28T12:00:00Z'))
+            logic.actions.setRosterEvaluatedAt(Date.now())
+            logic.actions.loadScoutConfigsSuccess([
+                { ...BASE_CONFIG, id: 'quiet', skill_name: 'signals-scout-quiet' },
+                { ...BASE_CONFIG, id: 'busy', skill_name: 'signals-scout-busy' },
+                {
+                    ...BASE_CONFIG,
+                    id: 'off',
+                    skill_name: 'signals-scout-off',
+                    enabled: false,
+                    status: 'paused_by_user',
+                },
+                {
+                    ...BASE_CONFIG,
+                    id: 'broken',
+                    skill_name: 'signals-scout-broken',
+                    enabled: false,
+                    status: 'paused_by_system',
+                    pause_reason: 'repeated_failures',
+                    status_changed_at: '2026-08-27T12:00:00Z',
+                },
+                {
+                    ...BASE_CONFIG,
+                    id: 'stale-pause',
+                    skill_name: 'signals-scout-stale-pause',
+                    enabled: false,
+                    status: 'paused_by_system',
+                    pause_reason: 'no_output',
+                    status_changed_at: '2026-08-20T12:00:00Z',
+                },
+                {
+                    ...BASE_CONFIG,
+                    id: 'warned',
+                    skill_name: 'signals-scout-warned',
+                    status: 'pending_pause',
+                    pause_reason: 'ignored',
+                },
+                {
+                    ...BASE_CONFIG,
+                    id: 'quiet-warning',
+                    skill_name: 'signals-scout-quiet-warning',
+                    status: 'pending_pause',
+                    pause_reason: 'no_output',
+                },
+            ])
+            // `busy` filed a report in the window, which is what separates Working from Watching.
+            logic.actions.loadScoutRunsSuccess([
+                makeRun({ skill_name: 'signals-scout-busy', emitted_report_ids: ['r-1'] }),
+            ])
 
-        // One flat list ordered by name, not split across lifecycle sections.
-        expect(logic.values.rosterScouts.map((row) => [row.config.id, row.group])).toEqual([
-            ['broken', 'needs_you'],
-            ['busy', 'working'],
-            ['off', 'off'],
-            ['quiet', 'watching'],
-            ['quiet-warning', 'needs_you'],
-            ['stale-pause', 'needs_you'],
-            ['warned', 'needs_you'],
-        ])
-        // The stats tell a warning apart from a recent pause; human and stale pauses are neither.
-        expect(logic.values.pauseAttentionCounts).toEqual({ pausingSoon: 1, recentlyPaused: 1 })
+            // One flat list ordered by name, not split across lifecycle sections.
+            expect(logic.values.rosterScouts.map((row) => [row.config.id, row.group])).toEqual([
+                ['broken', 'needs_you'],
+                ['busy', 'working'],
+                ['off', 'off'],
+                ['quiet', 'watching'],
+                ['quiet-warning', 'needs_you'],
+                ['stale-pause', 'needs_you'],
+                ['warned', 'needs_you'],
+            ])
+            // The stats tell a warning apart from a recent pause; human and stale pauses are neither.
+            expect(logic.values.pauseAttentionCounts).toEqual({ pausingSoon: 1, recentlyPaused: 1 })
+        } finally {
+            jest.useRealTimers()
+        }
     })
 
     it('keeps configs unresolved until the current team is available', async () => {


### PR DESCRIPTION
## Problem

Two master breakages fail CI on every PR right now, and neither is visible from master's own runs.

- Every PR that touches `services/mcp` fails its `Build Package` job. The MCP package compiles `magnitudeAxisIds.ts` (added in #94037) under `noUncheckedIndexedAccess`, where `measured[k]` and `groupOf[0]` read as possibly `undefined`. Master skips that job on runs that do not touch `services/mcp`.
- `scoutFleetLogic › lists the whole roster A→Z…` fails on every branch since 12:00 UTC today. The runs listener re-evaluates pause recency against the real clock, and the fixture's paused-by-system date (2026-08-27) fell out of the 7-day window. It passed on master this morning and fails now with the same code.

## Changes

- Two indexed reads in `magnitudeAxisIds.ts` get a fallback so the stricter typecheck passes. Neither read can miss at runtime, so trend y-axis grouping behaves the same.
- The scout roster test pins the clock to its fixture dates, the way the file's other time-sensitive tests do. No production code changes for signals.

## How did you test this code?

- `pnpm --filter=@posthog/mcp typecheck` no longer reports errors for `magnitudeAxisIds.ts`.
- `magnitudeAxisIds.test.ts` passes (8 tests), unchanged.
- `scoutFleetLogic.test.ts` passes (34 tests); before the change the roster test failed locally on master with `recentlyPaused: 0`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Desktop) while getting #93971 to green. That PR touches `services/mcp`, which surfaced the typecheck breakage; the roster test then failed on this PR's own CI and reproduced on a clean master checkout. Skills invoked: `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
