### PR TITLE
chore(agents): widen the /writing-tests time-bomb rule and trigger

### DIFF
--- a/.agents/skills/writing-tests/SKILL.md
+++ b/.agents/skills/writing-tests/SKILL.md
@@ -159,7 +159,7 @@ Escalating to the next rung is the last resort, not the default.
   A fixture date keeps its meaning only while the real clock stays where you left it.
   If anything under test measures that date against `now` — an age, a window, a "recent" flag, an expiry — the assertion holds today and fails some weeks later, on every open branch at once.
   Pinning a date into application state is not pinning the clock: a test that sets an "evaluated at" value to a fixed instant, and leaves the wall clock real, still fails when real time drifts past the window, because the code re-reads `now` and the two stop agreeing.
-  Pin the process clock to the instant the fixtures speak in — `freeze_time` in Python, `jest.useFakeTimers()` with `jest.setSystemTime()` released in a `finally` in Jest — or write the fixture relative to `now` (`now - 2 days`), so the distance is what the test states.
+  Pin the process clock to the instant the fixtures speak in — `freeze_time` in Python, `jest.useFakeTimers()` with `jest.setSystemTime()` in Jest, released by `jest.useRealTimers()` in a `finally` — or write the fixture relative to `now` (`now - 2 days`), so the distance is what the test states.
   Pinning the clock covers only what reads it inside your process; the next rule covers the rest.
   Ask this of every absolute date in a test, not only of an explicit `freeze_time`: _what does this assert when today is a year past it?_ If the answer is not "the same thing", fix it before you commit.
 - **A frozen clock doesn't freeze the infrastructure.**

--- a/.agents/skills/writing-tests/SKILL.md
+++ b/.agents/skills/writing-tests/SKILL.md
@@ -3,7 +3,7 @@ name: writing-tests
 description: >
   Gates whether a new test should exist and forces it to be efficient, protecting CI from low-value test bloat.
   Use before adding or substantially changing any pytest, Jest, or Playwright test — whenever an agent or engineer is about to write tests for a new feature, bugfix, or PR.
-  Front-loads the value bar (every test must catch a realistic regression no existing test already catches; extend the nearest existing test before writing a new standalone one; test behavior through the public interface, not implementation details; collapse near-duplicates into parameterized cases) and the efficiency bar (deterministic, isolated, fast; pick the cheapest test level; Django TestCase over TransactionTestCase; no sleeps, no real network; no time bombs from a frozen clock meeting real-clock retention).
+  Front-loads the value bar (every test must catch a realistic regression no existing test already catches; extend the nearest existing test before writing a new standalone one; test behavior through the public interface, not implementation details; collapse near-duplicates into parameterized cases) and the efficiency bar (deterministic, isolated, fast; pick the cheapest test level; Django TestCase over TransactionTestCase; no sleeps, no real network; no time bombs from absolute dates left to age against the real clock).
   Includes a "don't write it" decision tree. For fixing an existing flaky test use `/fixing-flaky-tests`; after this gate says a Playwright test is warranted, use `/playwright-test` for mechanics.
 ---
 
@@ -154,11 +154,16 @@ Escalating to the next rung is the last resort, not the default.
 - **No `time.sleep` / arbitrary waits.**
   Use fake timers, `wait_for` / `waitFor` on a real condition, or `freeze_time`.
   A sleep is a flake waiting to happen, and it slows every run.
+- **An absolute date in a test is a time bomb until you pin the clock.**
+  A fixture date keeps its meaning only while the real clock stays where you left it.
+  If anything under test measures that date against `now` — an age, a window, a "recent" flag, an expiry — the assertion holds today and fails some weeks later, on every open branch at once.
+  Pinning a date into application state is not pinning the clock: a test that sets an "evaluated at" value to a fixed instant, and leaves the wall clock real, still fails when real time drifts past the window, because the code re-reads `now` and the two stop agreeing.
+  Pin the process clock to the instant the fixtures speak in — `freeze_time` in Python, `jest.useFakeTimers()` with `jest.setSystemTime()` released in a `finally` in Jest — or write the fixture relative to `now` (`now - 2 days`), so the distance is what the test states.
+  Ask it of every absolute date in a test, not only of an explicit `freeze_time`: _what does this assert when today is a year past it?_ If the answer is not "the same thing", fix it before you commit.
 - **A frozen clock doesn't freeze the infrastructure.**
   `freeze_time` patches the clock inside your process; everything outside it still runs on the real one — ClickHouse TTL, Postgres `now()` defaults, S3 lifecycle rules, another service's token-expiry check.
   So freezing to an absolute date and then writing rows that something judges by age builds a **time bomb**: green for weeks, then red forever once wall-clock time drifts past the retention window.
   It fails on every branch at once, so it reads as though whichever PR is in front of you caused it — and that misattribution, not the fix, is where the time goes.
-  Ask it of every absolute `freeze_time`: _what happens when today is a year past this date?_ If the answer isn't "the same thing", fix it before you commit.
   Most ClickHouse tables are already safe: they build their TTL through `ttl_period()` ([`posthog/clickhouse/kafka_engine.py`](../../../posthog/clickhouse/kafka_engine.py)), which returns `""` under `settings.TEST`, so tests get no TTL at all.
   A table that hardcodes its `TTL` clause opts out of that guard — `ai_events` is one. Check rather than assume: `grep -rlE '^\s*TTL ' posthog/models/ posthog/clickhouse/ --include=*.py`.
   Make the row's lifetime independent of the ambient clock instead — pin the retention column on insert, the way `bulk_create_ai_events` writes `retention_days=10000`. Moving the frozen date forward only resets the timer.

--- a/.agents/skills/writing-tests/SKILL.md
+++ b/.agents/skills/writing-tests/SKILL.md
@@ -2,7 +2,7 @@
 name: writing-tests
 description: >
   Gates whether a new test should exist and forces it to be efficient, protecting CI from low-value test bloat.
-  Use before adding or substantially changing any pytest, Jest, or Playwright test — whenever an agent or engineer is about to write tests for a new feature, bugfix, or PR.
+  Use before any change to what a pytest, Jest, or Playwright test asserts or sets up, down to one fixture or one assertion added to an existing block.
   Front-loads the value bar (every test must catch a realistic regression no existing test already catches; extend the nearest existing test before writing a new standalone one; test behavior through the public interface, not implementation details; collapse near-duplicates into parameterized cases) and the efficiency bar (deterministic, isolated, fast; pick the cheapest test level; Django TestCase over TransactionTestCase; no sleeps, no real network; no time bombs from absolute dates left to age against the real clock).
   Includes a "don't write it" decision tree. For fixing an existing flaky test use `/fixing-flaky-tests`; after this gate says a Playwright test is warranted, use `/playwright-test` for mechanics.
 ---
@@ -11,6 +11,7 @@ description: >
 
 The rationale and the same rules in human-facing form live in the handbook: [Backend coding conventions › Testing](https://posthog.com/handbook/engineering/conventions/backend-coding#testing) (`docs/published/handbook/engineering/conventions/backend-coding.md`).
 This skill is the operational gate — run it before writing tests. It carries the decision procedure plus [a catalog of the bug shapes we actually ship](references/mistakes-we-make.md).
+The gate covers added coverage, not new test functions. One fixture and one assertion added to an existing block goes through the same two questions, because that is the shape this skill asks you to prefer.
 
 ## The gate: two questions
 

--- a/.agents/skills/writing-tests/SKILL.md
+++ b/.agents/skills/writing-tests/SKILL.md
@@ -160,7 +160,8 @@ Escalating to the next rung is the last resort, not the default.
   If anything under test measures that date against `now` — an age, a window, a "recent" flag, an expiry — the assertion holds today and fails some weeks later, on every open branch at once.
   Pinning a date into application state is not pinning the clock: a test that sets an "evaluated at" value to a fixed instant, and leaves the wall clock real, still fails when real time drifts past the window, because the code re-reads `now` and the two stop agreeing.
   Pin the process clock to the instant the fixtures speak in — `freeze_time` in Python, `jest.useFakeTimers()` with `jest.setSystemTime()` released in a `finally` in Jest — or write the fixture relative to `now` (`now - 2 days`), so the distance is what the test states.
-  Ask it of every absolute date in a test, not only of an explicit `freeze_time`: _what does this assert when today is a year past it?_ If the answer is not "the same thing", fix it before you commit.
+  Pinning the clock covers only what reads it inside your process; the next rule covers the rest.
+  Ask this of every absolute date in a test, not only of an explicit `freeze_time`: _what does this assert when today is a year past it?_ If the answer is not "the same thing", fix it before you commit.
 - **A frozen clock doesn't freeze the infrastructure.**
   `freeze_time` patches the clock inside your process; everything outside it still runs on the real one — ClickHouse TTL, Postgres `now()` defaults, S3 lifecycle rules, another service's token-expiry check.
   So freezing to an absolute date and then writing rows that something judges by age builds a **time bomb**: green for weeks, then red forever once wall-clock time drifts past the retention window.

--- a/.claude/rules/writing-tests.md
+++ b/.claude/rules/writing-tests.md
@@ -12,10 +12,13 @@ paths:
 Agents keep shipping low-value test bloat here — change-detector assertions,
 redundant near-duplicates, sleep-laden waits, zero-assertion mock choreography.
 
-If this change adds a new test or substantially alters an existing one, you MUST
-invoke the `/writing-tests` skill before writing it. It carries the value gate
-("what realistic regression does this catch that no existing test does?"), the
-"don't write it" decision tree, and the efficiency bar. Do not skip it because the
-change looks small.
+If this change touches what a test asserts or how it sets up, you MUST invoke the
+`/writing-tests` skill before writing it. It carries the value gate ("what realistic
+regression does this catch that no existing test does?"), the "don't write it"
+decision tree, and the efficiency bar.
+
+There is no size threshold. One fixture and one assertion added to an existing block
+is in scope, and the skill tells you to extend an existing test rather than write a
+new one, so that is the shape most changes take.
 
 Touching a test file for an unrelated reason (rename, formatter, import sort) is exempt.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,7 +267,7 @@ ALWAYS invoke the matching skill **before** writing or reviewing code in these a
 - `/clickhouse-migrations` — any ClickHouse migration
 - `/adopting-generated-api-types` — any frontend file using `lib/api`, `api.get<`, `api.create<`, or handwritten API types
 - `/writing-ui-components` — creating, moving, splitting, or restructuring any component or file under `frontend/src/` or `products/*/frontend/`, extracting or promoting a shared component, or renaming frontend symbols or feature vocabulary
-- `/writing-tests` — adding or substantially changing any test (pytest, Jest, or Playwright)
+- `/writing-tests` — any change to what a test asserts or sets up (pytest, Jest, or Playwright), down to one fixture or one assertion added to an existing block; renames, formatting, and import sorts are exempt
 - `/writing-user-facing-copy` — writing or editing any text a user reads (UI labels, tooltips, empty/error states, notifications, docs, support replies), or any code change that adds or changes a visible string
 - `/writing-code-comments` — writing or editing a code comment in any language, or reviewing a diff that adds comments
 - `/writing-pr-descriptions` — writing or editing any PR body, before `gh pr create` or `gh pr edit --body`

--- a/docs/published/handbook/engineering/conventions/backend-coding.md
+++ b/docs/published/handbook/engineering/conventions/backend-coding.md
@@ -120,6 +120,7 @@ Escalating to the next rung is the last resort, not the default.
 - Mock only true boundaries — network, external APIs, the clock, queues. Don't mock your own internal helpers; that's how change-detector tests are born.
 - Frontend: prefer a kea logic test (`logic.actions` / `logic.values`) over a full component render whenever the behavior lives in the logic, and don't snapshot large rendered trees — assert specific fields instead.
 - Keep tests deterministic and isolated: no `time.sleep` or arbitrary waits (use `freeze_time` or wait on a real condition), no real network or live external services, and they must pass in any order. Don't leave a `@skip`/`xfail`/`.only` without a one-line reason and a linked issue.
+- **An absolute date in a test is a time bomb until you pin the clock.** A fixture date holds its meaning only while the real clock stays where you left it, so a test that measures that date against `now` — an age, a window, a "recent" flag, an expiry — passes today and fails weeks later on every open branch. Pin the process clock to the same instant (`freeze_time`, or `jest.useFakeTimers()` with `jest.setSystemTime()`), or write the fixture relative to `now`. Pinning covers only what reads the clock inside your process: anything outside it, such as a ClickHouse TTL or an S3 lifecycle rule, still runs on the real one.
 
 #### Fast developer ("unit") tests
 


### PR DESCRIPTION
## Problem

A Jest test picks an absolute fixture date, passes review, and turns CI red for every open branch some weeks later. `scoutFleetLogic.test.ts` did that on 2026-09-03: a fixture paused a scout on 2026-08-27, and the assertion says the roster still calls that pause recent, which is a 7-day window. [#94159](https://github.com/PostHog/posthog/pull/94159) fixes the test itself.

Two things let it through, and this PR fixes both.

- The `writing-tests` skill warns about time bombs, but only about a frozen clock meeting real-clock infrastructure, and its check reads "Ask it of every absolute `freeze_time`". That test froze nothing. It pinned a date into application state and left the wall clock real, so an agent that follows the rule finds no `freeze_time` to ask the question of.
- The skill's own trigger reads "adding or substantially changing any test". The change was three fixtures and one assertion dropped into an existing block, which reads as neither, so an agent skips the gate on exactly the edit the skill asks it to prefer.

## Changes

- The determinism rules now flag every absolute date in a test, not only an explicit `freeze_time`. An agent that pins a date into state and leaves the clock real reads that this is the failure, and gets the Jest shape (`jest.useFakeTimers()` with `setSystemTime`) next to the Python one.
- The trigger names the small edit instead of asking for a size judgment: any change to what a test asserts or sets up, down to one fixture or one assertion in an existing block. Renames, formatting, and import sorts stay exempt.
- The trigger reads the same in all three places an agent meets it: the `AGENTS.md` mandatory list, the `.claude/rules` file that fires on test paths, and the skill's own description and opening.
- The "what does this assert a year from now?" check moves onto the new time-bomb bullet, so it covers both cases and appears once.
- The human-facing handbook carries the new time-bomb rule too, so a person who reads the conventions rather than the skill gets the same warning.
- Nothing a user sees changes. The diff is markdown that agents and engineers read.

## How did you test this code?

- No tests. The change is agent-facing prose.
- Not run: `hogli lint:skills`, which is not installed in this sandbox and covers `products/*/skills` rather than `.agents/skills`.
- The skill description stays under the 1024-character limit, at 979.
- Review threads: graphite flagged that the Jest cleanup phrasing read as if `setSystemTime()` needed releasing, and Codex flagged the missing handbook mirror. Both are fixed in this branch.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`docs/published/handbook/engineering/conventions/backend-coding.md` gains the time-bomb rule under its testing conventions. The rest of that section stays accurate.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The PostHog Slack app wrote this from a thread about the red test. Skills invoked: `/writing-skills`, `/writing-pr-descriptions`.

The thread asked first why the skill did not protect us, and the audit of [#91020](https://github.com/PostHog/posthog/pull/91020) found the two gaps above. The trigger half came second, from a reviewer pointing out that a rule nobody invokes protects nobody.

An alternative was a lint rule over absolute dates in test files. It was rejected: the signal is a date compared against `now` somewhere in the code under test, which a pattern match cannot see, so the rule would be noise on most hits.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8QA6740/p1788441175265369?thread_ts=1788441175.265369&cid=C09G8QA6740)*
