### PR TITLE
fix(logs): read bare attribute keys from the physical map in SQL

### DIFF
--- a/posthog/hogql/transforms/clickhouse_property_resolution.py
+++ b/posthog/hogql/transforms/clickhouse_property_resolution.py
@@ -85,6 +85,11 @@ class MaterializedPropertySource:
     has_ngram_lower_index: bool = False
     has_bloom_filter_index: bool = False
     has_bloom_filter_lower_index: bool = False
+    # The key to read from a property-group map when it differs from the property name. Logs and spans store every
+    # attribute under a type-suffixed key (`session_id__str`), and the bare-key `attributes` column is an ALIAS that
+    # rebuilds the whole map from `attributes_map_str` on every read. Reading the suffixed key from the physical map
+    # avoids that rebuild while returning the same value.
+    map_key: str | None = None
 
 
 def _unwrap_to_table_type(field_type: ast.FieldType) -> ast.TableType | None:
@@ -227,6 +232,14 @@ def resolve_property_group_source(
         return None
     for group_column in property_groups.get_property_group_columns(table_name, field.name, property_name):
         return MaterializedPropertySource(kind="property_group", column=group_column, is_nullable=True)
+    if isinstance(field, MapStringDatabaseField):
+        # A bare key on a suffix-keyed Map column matches no group. The `__str` map holds every attribute value, and
+        # the bare-key ALIAS column is exactly that map with the suffix stripped, so the two reads are equivalent.
+        suffixed_key = f"{property_name}__str"
+        for group_column in property_groups.get_property_group_columns(table_name, field.name, suffixed_key):
+            return MaterializedPropertySource(
+                kind="property_group", column=group_column, is_nullable=True, map_key=suffixed_key
+            )
     return None
 
 
@@ -322,11 +335,12 @@ def _materialized_head_expr(
         get_field = _synthetic_column_field(field_type, source.column, is_nullable=True)
         if has_field is None or get_field is None:
             return None
+        map_key = source.map_key or first_key
         return ast.Call(
             name="if",
             args=[
-                ast.Call(name="has", args=[has_field, ast.Constant(value=first_key)]),
-                ast.ArrayAccess(array=get_field, property=ast.Constant(value=first_key)),
+                ast.Call(name="has", args=[has_field, ast.Constant(value=map_key)]),
+                ast.ArrayAccess(array=get_field, property=ast.Constant(value=map_key)),
                 ast.Constant(value=None),
             ],
         )
@@ -761,9 +775,13 @@ class _OptimizableProperty:
         assert field is not None
         return _call("isNotNull", [field])
 
+    def map_key(self) -> str:
+        """The key stored in the property-group map: the property name, or its suffixed form on suffix-keyed maps."""
+        return self.source.map_key or self.key
+
     def group_has(self) -> ast.Call:
         """`has(map_column, key)` — true when the property group contains the key (uses the keys bloom-filter index)."""
-        return _call("has", [self.bare_column(), _const(self.key)])
+        return _call("has", [self.bare_column(), _const(self.map_key())])
 
     def group_value(self) -> ast.ArrayAccess:
         """`map_column[key]`, typed non-nullable String — the property's value from the group map.
@@ -771,7 +789,9 @@ class _OptimizableProperty:
         A missing key reads as the '' default, never SQL NULL; the non-nullable type keeps `equals(map[key], v)` out of
         an `ifNull` wrapper so the values bloom-filter index still applies.
         """
-        return ast.ArrayAccess(array=self.bare_column(), property=_const(self.key), type=ast.StringType(nullable=False))
+        return ast.ArrayAccess(
+            array=self.bare_column(), property=_const(self.map_key()), type=ast.StringType(nullable=False)
+        )
 
 
 class ClickHousePropertyResolver(CloningVisitor):

--- a/products/logs/backend/test/test_logs_sql_panel.py
+++ b/products/logs/backend/test/test_logs_sql_panel.py
@@ -1,10 +1,15 @@
+import json
+
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 
 from parameterized import parameterized
 
-from posthog.schema import HogQLQuery
+from posthog.schema import HogQLQuery, HogQLQueryModifiers, PropertyGroupsMode
 
+from posthog.clickhouse.client import sync_execute
 from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
+
+OPTIMIZED = HogQLQueryModifiers(propertyGroupsMode=PropertyGroupsMode.OPTIMIZED)
 
 
 class TestLogsSqlPanel(ClickhouseTestMixin, APIBaseTest):
@@ -26,3 +31,41 @@ class TestLogsSqlPanel(ClickhouseTestMixin, APIBaseTest):
         response = runner.calculate()
         sql = response.clickhouse or ""
         assert "JSONExtract" not in sql
+
+    @parameterized.expand(
+        [
+            ("dot", "SELECT attributes.tennis_session_id FROM logs"),
+            ("subscript", "SELECT attributes['tennis_session_id'] FROM logs"),
+            ("dot_in_where", "SELECT count() FROM logs WHERE attributes.tennis_session_id = 'x'"),
+        ]
+    )
+    def test_bare_attribute_key_reads_the_physical_map(self, _name, query):
+        # The `attributes` column is an ALIAS that rebuilds the whole map from `attributes_map_str` per row. A bare key
+        # must route to the suffixed key on the physical map instead, or a SELECT over 30 days reads every attribute.
+        runner = HogQLQueryRunner(query=HogQLQuery(query=query, modifiers=OPTIMIZED), team=self.team)
+        sql = runner.calculate().clickhouse or ""
+        assert "attributes_map_str" in sql
+        assert "has(attributes," not in sql
+        assert "attributes[" not in sql
+
+    @parameterized.expand([("alias", None), ("property_group", OPTIMIZED)])
+    def test_bare_attribute_key_reads_the_same_value_as_the_alias(self, _name, modifiers):
+        sync_execute(
+            "INSERT INTO logs FORMAT JSONEachRow\n"
+            + json.dumps(
+                {
+                    "team_id": self.team.id,
+                    "timestamp": "2026-06-23 12:00:00.000000",
+                    "body": "retry_summary",
+                    "severity_text": "info",
+                    "service_name": "api",
+                    "attributes_map_str": {"retry_reason__str": "upstream_timeout", "retried__str": "true"},
+                }
+            )
+        )
+        query = (
+            "SELECT attributes.retry_reason, attributes['retry_reason'], attributes.missing, "
+            "countIf(attributes.retried = 'true') FROM logs GROUP BY 1, 2, 3"
+        )
+        runner = HogQLQueryRunner(query=HogQLQuery(query=query, modifiers=modifiers), team=self.team)
+        assert runner.calculate().results == [("upstream_timeout", "upstream_timeout", None, 1)]


### PR DESCRIPTION
## Problem

- A SQL editor query over logs that selects or filters an attribute by its plain name reads every attribute of every log in the time range. On a high-volume team, a 30-day window fails with the bytes-read limit.
- The logs and spans tables store attributes under type-suffixed keys in `attributes_map_str`. The plain-name `attributes` column is an ALIAS that rebuilds the whole map from that column on each read.
- The property-group router only recognizes keys that already carry a suffix, so a plain key falls through to the ALIAS.

## Changes

- Users see the same results from `attributes.key` and `attributes['key']` on logs and spans, and the query now reads the suffixed key from the physical map instead of the ALIAS.
- Comparisons on a plain key get the bare map read the optimizer already emits for suffixed keys, so the values bloom filter index applies.
- Mechanical: `MaterializedPropertySource` carries an optional `map_key`, and the property-group reads use it. The router retries a plain key with the `__str` suffix only on physical Map columns.
- Metrics attributes are unchanged because that table defines no property groups.

## How did you test this code?

- New printed-SQL cases in `test_logs_sql_panel.py` catch a plain key routing back to the ALIAS in dot, subscript, and WHERE forms.
- A new live ClickHouse case inserts a log and asserts the ALIAS path and the property-group path return the same value, and NULL for a missing key.
- Ran the HogQL transform suites, the property skip index tests, and the logs query tests locally. Three predicate pushdown tests with person and session joins fail on the base branch too.
- Not checked: read bytes on a production team before and after.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code shaped the change from a customer report of the bytes-read error on a logs query. The committed test data is invented and shares no identifiers with that report. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
