### PR TITLE
fix(ci): name the specific target in the Trunk lane PR comment

### DIFF
--- a/.github/scripts/post-ci-sections.test.mjs
+++ b/.github/scripts/post-ci-sections.test.mjs
@@ -61,11 +61,29 @@ describe('CI report section builders', () => {
         },
         {
             name: 'describes a non-backend lane',
-            input: { impactedTargets: ['fe:core'], isUniversal: false },
+            input: { impactedTargets: ['fe:core', 'node:ingestion'], isUniversal: false },
             expected: {
                 status: 'ok',
                 summary: 'non-backend lane',
                 body: 'This PR is assigned to the non-backend lane. It does not run backend Python tests and may merge in parallel with PRs in other lanes.',
+            },
+        },
+        {
+            name: 'names the single non-backend target',
+            input: { impactedTargets: ['fe:product:desktop'], isUniversal: false },
+            expected: {
+                status: 'ok',
+                summary: 'non-backend lane (fe:product:desktop)',
+                body: 'This PR is assigned to the non-backend lane (fe:product:desktop). It does not run backend Python tests and may merge in parallel with PRs in other lanes.',
+            },
+        },
+        {
+            name: 'names the single backend Python target',
+            input: { impactedTargets: ['py:product:surveys'], isUniversal: false },
+            expected: {
+                status: 'warn',
+                summary: 'backend Python lane (py:product:surveys)',
+                body: 'This PR is assigned to the backend Python lane (py:product:surveys). It runs backend Python tests and may merge in parallel with PRs in other lanes.',
             },
         },
     ]) {

--- a/.github/scripts/post-ci-sections.test.mjs
+++ b/.github/scripts/post-ci-sections.test.mjs
@@ -73,8 +73,8 @@ describe('CI report section builders', () => {
             input: { impactedTargets: ['fe:product:desktop'], isUniversal: false },
             expected: {
                 status: 'ok',
-                summary: 'non-backend lane (fe:product:desktop)',
-                body: 'This PR is assigned to the non-backend lane (fe:product:desktop). It does not run backend Python tests and may merge in parallel with PRs in other lanes.',
+                summary: 'non-backend lane (<code>fe:product:desktop</code>)',
+                body: 'This PR is assigned to the non-backend lane (<code>fe:product:desktop</code>). It does not run backend Python tests and may merge in parallel with PRs in other lanes.',
             },
         },
         {
@@ -82,8 +82,17 @@ describe('CI report section builders', () => {
             input: { impactedTargets: ['py:product:surveys'], isUniversal: false },
             expected: {
                 status: 'warn',
-                summary: 'backend Python lane (py:product:surveys)',
-                body: 'This PR is assigned to the backend Python lane (py:product:surveys). It runs backend Python tests and may merge in parallel with PRs in other lanes.',
+                summary: 'backend Python lane (<code>py:product:surveys</code>)',
+                body: 'This PR is assigned to the backend Python lane (<code>py:product:surveys</code>). It runs backend Python tests and may merge in parallel with PRs in other lanes.',
+            },
+        },
+        {
+            name: 'escapes a target before rendering it',
+            input: { impactedTargets: ['</summary><img src="x">'], isUniversal: false },
+            expected: {
+                status: 'ok',
+                summary: 'non-backend lane (<code>&lt;/summary&gt;&lt;img src=&quot;x&quot;&gt;</code>)',
+                body: 'This PR is assigned to the non-backend lane (<code>&lt;/summary&gt;&lt;img src=&quot;x&quot;&gt;</code>). It does not run backend Python tests and may merge in parallel with PRs in other lanes.',
             },
         },
     ]) {

--- a/.github/scripts/post-trunk-lane-section.mjs
+++ b/.github/scripts/post-trunk-lane-section.mjs
@@ -17,7 +17,10 @@ export function buildTrunkLaneSection({ impactedTargets, isUniversal }) {
     }
 
     const runsBackendPythonTests = impactedTargets.some((target) => target.startsWith('py:'))
-    const summary = runsBackendPythonTests ? 'backend Python lane' : 'non-backend lane'
+    const laneName = runsBackendPythonTests ? 'backend Python lane' : 'non-backend lane'
+    // A single target names the exact lane; more than one collapses to the
+    // shared family name rather than listing them all.
+    const summary = impactedTargets.length === 1 ? `${laneName} (${impactedTargets[0]})` : laneName
 
     return {
         status: runsBackendPythonTests ? 'warn' : 'ok',

--- a/.github/scripts/post-trunk-lane-section.mjs
+++ b/.github/scripts/post-trunk-lane-section.mjs
@@ -3,6 +3,21 @@ import { pathToFileURL } from 'node:url'
 
 import { gh, postSection, resolvePrContext } from '../../frontend/bin/ci-report/update-ci-report.mjs'
 
+function formatTarget(target) {
+    const escapedTarget = target.replace(
+        /[&<>"']/g,
+        (character) =>
+            ({
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;',
+            })[character]
+    )
+    return `<code>${escapedTarget}</code>`
+}
+
 export function buildTrunkLaneSection({ impactedTargets, isUniversal }) {
     if (
         isUniversal ||
@@ -20,7 +35,7 @@ export function buildTrunkLaneSection({ impactedTargets, isUniversal }) {
     const laneName = runsBackendPythonTests ? 'backend Python lane' : 'non-backend lane'
     // A single target names the exact lane; more than one collapses to the
     // shared family name rather than listing them all.
-    const summary = impactedTargets.length === 1 ? `${laneName} (${impactedTargets[0]})` : laneName
+    const summary = impactedTargets.length === 1 ? `${laneName} (${formatTarget(impactedTargets[0])})` : laneName
 
     return {
         status: runsBackendPythonTests ? 'warn' : 'ok',


### PR DESCRIPTION
## Problem

The "Trunk lane" CI comment only ever says "backend Python lane" or "non-backend lane", even when the impacted-targets computation narrows a PR down to one specific target (a single product, service, or crate). [#94116](https://github.com/PostHog/posthog/pull/94116) is a good example: it was assigned the precise target `fe:product:desktop`, but the comment just said "non-backend lane" with no way to tell it apart from a PR touching every frontend file in the repo.

## Changes

- When exactly one target is impacted, the summary and body now name it, e.g. `non-backend lane (fe:product:desktop)` instead of just `non-backend lane`.
- Multiple targets still collapse to the generic family name, since listing many would be noisy.

## How did you test this code?

Extended `post-ci-sections.test.mjs` with two new cases (single non-backend target, single backend Python target) alongside the existing generic/universal cases, and ran `node --test post-ci-sections.test.mjs` — all 10 tests pass.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - this is an internal CI comment, not a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated with Claude Code, starting from a question about why [#94116](https://github.com/PostHog/posthog/pull/94116) was reported as "non-backend lane" instead of a desktop-specific lane. Traced the actual CI run logs for that PR's `trunk-impacted-targets` job to confirm the real assigned target was `fe:product:desktop`, then found `post-trunk-lane-section.mjs` collapses every non-Python target into one generic label. No skills were invoked for the investigation; `/writing-tests` and `/writing-pr-descriptions` conventions were followed for the test additions and this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*