### PR TITLE
feat(flags): create a flag in other projects from the new flag form

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
@@ -37,6 +37,7 @@ import {
     LemonCollapse,
     LemonDivider,
     LemonInput,
+    LemonInputSelect,
     LemonLabel,
     LemonSelect,
     LemonSwitch,
@@ -58,6 +59,8 @@ import 'lib/lemon-ui/Lettermark'
 import { alphabet } from 'lib/utils/strings'
 import { ApprovalActionKey } from 'scenes/approvals/utils'
 import { JSONEditorInput } from 'scenes/feature-flags/JSONEditorInput'
+import { organizationLogic } from 'scenes/organizationLogic'
+import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
@@ -166,6 +169,7 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
         expandAdvancedOnEdit,
         hasEncryptedPayloadBeenSaved,
         hasEarlyAccessFeatures,
+        createInProjectIds,
     } = useValues(featureFlagLogic)
     const {
         setMultivariateEnabled,
@@ -183,11 +187,18 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
         setOpenVariants,
         setPayloadExpanded,
         resetEncryptedPayload,
+        setCreateInProjectIds,
     } = useActions(featureFlagLogic)
     const { tags: availableTags } = useValues(tagsModel)
     const { isApprovalRequired } = useValues(approvalsGateLogic)
+    const { currentOrganization } = useValues(organizationLogic)
+    const { currentTeamId } = useValues(teamLogic)
     const hasEvaluationContexts = useFeatureFlag('FLAG_EVALUATION_TAGS') // NB: the tag was named "flag-evaluation-tags" before we renamed the concept – i.e. this powers evaluation contexts even though the name implies tags
     const isNewFeatureFlag = id === 'new' || id === undefined
+    const otherProjectOptions = (currentOrganization?.teams ?? [])
+        .filter((team) => team.id !== currentTeamId)
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map((team) => ({ key: String(team.id), label: team.name, value: team.id }))
     const implementationRef = useRef<HTMLDivElement>(null)
 
     const handleShowImplementation = (): void => {
@@ -479,6 +490,22 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
                                         placeholder="(Optional) A description of the feature flag for your reference."
                                     />
                                 </LemonField>
+
+                                {isNewFeatureFlag && otherProjectOptions.length > 0 && (
+                                    <LemonField.Pure
+                                        label="Also create in"
+                                        info="Creates a flag with the same key, description, and release conditions in each selected project. Cohorts are matched by name; static cohorts aren't copied."
+                                    >
+                                        <LemonInputSelect<number>
+                                            mode="multiple"
+                                            value={createInProjectIds}
+                                            onChange={setCreateInProjectIds}
+                                            options={otherProjectOptions}
+                                            placeholder="(Optional) Select other projects"
+                                            data-attr="feature-flag-create-in-projects"
+                                        />
+                                    </LemonField.Pure>
+                                )}
 
                                 <LemonDivider />
 

--- a/frontend/src/scenes/feature-flags/featureFlagCreateInProjects.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagCreateInProjects.ts
@@ -1,0 +1,26 @@
+import type { CopyFlagsResponseApi } from 'products/feature_flags/frontend/generated/api.schemas'
+
+export interface CreateInProjectsSummary {
+    createdProjectIds: number[]
+    updatedProjectIds: number[]
+    pendingApprovalProjectIds: number[]
+    failures: Array<{ projectId: number | null; errorMessage: string }>
+}
+
+/** Groups a copy_flags response by outcome so the create flow can report each group once. */
+export function summarizeCreateInProjects(response: CopyFlagsResponseApi): CreateInProjectsSummary {
+    return {
+        createdProjectIds: response.success.filter((item) => !item.updated_existing).map((item) => item.team_id),
+        updatedProjectIds: response.success.filter((item) => item.updated_existing).map((item) => item.team_id),
+        pendingApprovalProjectIds: response.failed
+            .filter((entry) => entry.approval_pending)
+            .map((entry) => entry.project_id)
+            .filter((id): id is number => id != null),
+        failures: response.failed
+            .filter((entry) => !entry.approval_pending)
+            .map((entry) => ({
+                projectId: entry.project_id ?? null,
+                errorMessage: entry.error_message || 'Copy failed',
+            })),
+    }
+}

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -1,5 +1,6 @@
 import {
     MOCK_DEFAULT_BASIC_USER,
+    MOCK_DEFAULT_ORGANIZATION,
     MOCK_DEFAULT_PROJECT,
     MOCK_DEFAULT_TEAM,
     MOCK_ORGANIZATION_ID,
@@ -15,6 +16,7 @@ import { dayjs } from 'lib/dayjs'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { organizationLogic } from 'scenes/organizationLogic'
 import { urls } from 'scenes/urls'
 
 import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
@@ -78,6 +80,7 @@ function capturesOf(event: string): any[][] {
 jest.mock('lib/lemon-ui/LemonToast/LemonToast', () => ({
     lemonToast: {
         success: jest.fn(),
+        info: jest.fn(),
         error: jest.fn(),
         warning: jest.fn(),
     },
@@ -3348,6 +3351,101 @@ describe('variant reordering', () => {
             expect(payloads?.[0]).toBeUndefined() // test-a had no payload
             expect(payloads?.[1]).toEqual({ option: 'variant-b' }) // test-b payload
             expect(payloads?.[2]).toEqual({ option: 'default' }) // control payload
+        })
+    })
+
+    describe('creating a flag in other projects', () => {
+        const OTHER_TEAM = { ...MOCK_DEFAULT_TEAM, id: 555, name: 'Staging' }
+        const createdFlag = { ...MOCK_FEATURE_FLAG, id: 77, key: 'multi-project-flag' }
+        let capturedCopyBody: Record<string, unknown> | null = null
+        let copyResponse: CopyFlagsResponseApi = { success: [], failed: [] }
+
+        beforeEach(() => {
+            capturedCopyBody = null
+            useMocks({
+                post: {
+                    [`/api/projects/${MOCK_DEFAULT_PROJECT.id}/feature_flags/`]: () => [201, createdFlag],
+                    '/api/organizations/:organization_id/feature_flags/copy_flags': async ({ request }) => {
+                        capturedCopyBody = (await request.json()) as Record<string, unknown>
+                        return [200, copyResponse]
+                    },
+                },
+            })
+        })
+
+        async function createFlagPickingOtherTeam(
+            response: CopyFlagsResponseApi
+        ): Promise<ReturnType<typeof featureFlagLogic.build>> {
+            copyResponse = response
+            organizationLogic.actions.loadCurrentOrganizationSuccess({
+                ...MOCK_DEFAULT_ORGANIZATION,
+                teams: [MOCK_DEFAULT_TEAM, OTHER_TEAM],
+            })
+            const newLogic = featureFlagLogic({ id: 'new' })
+            newLogic.mount()
+            newLogic.actions.setCreateInProjectIds([OTHER_TEAM.id])
+            await expectLogic(newLogic, () => {
+                newLogic.actions.saveFeatureFlag({ ...newLogic.values.featureFlag, key: createdFlag.key })
+            })
+                .toDispatchActions(['createInProjectsFinished', 'saveFeatureFlagSuccess'])
+                .toFinishAllListeners()
+            return newLogic
+        }
+
+        it('copies the new flag to the picked projects right after creating it, then clears the picks', async () => {
+            const newLogic = await createFlagPickingOtherTeam({
+                success: [{ ...createdFlag, team_id: OTHER_TEAM.id, updated_existing: false }],
+                failed: [],
+            })
+            try {
+                expect(capturedCopyBody).toEqual({
+                    feature_flag_key: createdFlag.key,
+                    from_project: MOCK_DEFAULT_PROJECT.id,
+                    target_project_ids: [OTHER_TEAM.id],
+                })
+                expect(newLogic.values.createInProjectIds).toEqual([])
+            } finally {
+                newLogic.unmount()
+            }
+        })
+
+        it.each<[string, CopyFlagsResponseApi, 'success' | 'info' | 'warning' | 'error', string]>([
+            [
+                'a new copy',
+                { success: [{ ...createdFlag, team_id: OTHER_TEAM.id, updated_existing: false }], failed: [] },
+                'success',
+                'Flag also created in Staging',
+            ],
+            [
+                'an overwritten existing flag',
+                { success: [{ ...createdFlag, team_id: OTHER_TEAM.id, updated_existing: true }], failed: [] },
+                'info',
+                'A flag with this key already existed in Staging and was updated to match',
+            ],
+            [
+                'a pending approval',
+                {
+                    success: [],
+                    failed: [{ project_id: OTHER_TEAM.id, error_message: 'Gated', approval_pending: true }],
+                },
+                'warning',
+                'Staging requires approval. A change request was created and the flag will be created once approved.',
+            ],
+            [
+                'a failure',
+                { success: [], failed: [{ project_id: OTHER_TEAM.id, error_message: 'Project not found.' }] },
+                'error',
+                "Couldn't create the flag in Staging: Project not found.",
+            ],
+        ])('names the project when reporting %s', async (_, copyResponse, toastMethod, message) => {
+            const toastSpy = jest.spyOn(lemonToast, toastMethod).mockReturnValue('toast-id')
+            const newLogic = await createFlagPickingOtherTeam(copyResponse)
+            try {
+                expect(toastSpy).toHaveBeenCalledWith(message)
+            } finally {
+                toastSpy.mockRestore()
+                newLogic.unmount()
+            }
         })
     })
 })

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -22,7 +22,7 @@ import { CombinedLocation } from 'kea-router/lib/utils'
 import { createElement } from 'react'
 
 import api, { PaginatedResponse } from 'lib/api'
-import { isAccessDeniedError } from 'lib/api-error'
+import { ApiError, isAccessDeniedError } from 'lib/api-error'
 import { handleApprovalRequired } from 'lib/approvals/utils'
 import { ACTIVITY_SEARCH_PARAM } from 'lib/components/ActivityLog/activityLogLogic'
 import { tryShowMCPHint } from 'lib/components/MCPHint/mcpHintLogic'
@@ -126,6 +126,7 @@ import type { DefaultReleaseConditionsResponse } from './defaultReleaseCondition
 import { uniformAggregationGroupTypeIndex } from './defaultReleaseConditionsUtils'
 import { FeatureFlagArchivedSource, reportFeatureFlagArchived } from './featureFlagArchiveDialog'
 import { checkFeatureFlagConfirmation } from './featureFlagConfirmationLogic'
+import { summarizeCreateInProjects } from './featureFlagCreateInProjects'
 import type { FlagIntent } from './featureFlagIntentWarningLogic'
 import {
     ScheduleOccurrence,
@@ -227,6 +228,37 @@ function parseUrlIntent(): FlagIntent | undefined {
 }
 
 /** Apply the intent from the URL param (idempotent — no-ops if already applied). */
+async function copyNewFlagToProjects(
+    values: { createInProjectIds: number[]; currentOrganizationId: string; currentProjectId: number | null },
+    actions: {
+        createInProjectsFinished: (
+            response: CopyFlagsResponseApi | null,
+            targetProjectIds: number[],
+            errorMessage?: string
+        ) => void
+    },
+    flagKey: string
+): Promise<void> {
+    const { createInProjectIds: targetProjectIds, currentOrganizationId, currentProjectId } = values
+    if (targetProjectIds.length === 0 || !currentOrganizationId || !currentProjectId) {
+        return
+    }
+    try {
+        const response = await featureFlagsCopyFlagsCreate(String(currentOrganizationId), {
+            feature_flag_key: flagKey,
+            from_project: currentProjectId,
+            target_project_ids: targetProjectIds,
+        })
+        actions.createInProjectsFinished(response, targetProjectIds)
+    } catch (error) {
+        actions.createInProjectsFinished(
+            null,
+            targetProjectIds,
+            error instanceof ApiError ? (error.detail ?? error.message) : String(error)
+        )
+    }
+}
+
 function maybeApplyUrlIntent(
     values: { urlIntentApplied: boolean; featureFlag: FeatureFlagType },
     actions: {
@@ -756,6 +788,7 @@ export interface featureFlagLogicValues {
     copyDependencyRequirementsLoading: boolean
     copyDestinationProject: number | null
     copySchedule: boolean
+    createInProjectIds: number[]
     cronExpression: string | null
     cronPreview: string | null
     customPairDisableCron: string
@@ -1009,6 +1042,15 @@ export interface featureFlagLogicActions {
     ) => {
         newEarlyAccessFeature: EarlyAccessFeatureType
         payload?: any
+    }
+    createInProjectsFinished: (
+        response: CopyFlagsResponseApi | null,
+        targetProjectIds: number[],
+        errorMessage?: string
+    ) => {
+        errorMessage: string | undefined
+        response: CopyFlagsResponseApi | null
+        targetProjectIds: number[]
     }
     createPairedSchedule: () => {
         value: true
@@ -1408,6 +1450,9 @@ export interface featureFlagLogicActions {
     }
     setCopySchedule: (copySchedule: boolean) => {
         copySchedule: boolean
+    }
+    setCreateInProjectIds: (projectIds: number[]) => {
+        projectIds: number[]
     }
     setCronExpression: (cronExpression: string | null) => {
         cronExpression: string | null
@@ -2055,6 +2100,12 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
         distributeVariantsEqually: true,
         enrichUsageDashboard: true,
         setCopyDestinationProject: (id: number | null) => ({ id }),
+        setCreateInProjectIds: (projectIds: number[]) => ({ projectIds }),
+        createInProjectsFinished: (
+            response: CopyFlagsResponseApi | null,
+            targetProjectIds: number[],
+            errorMessage?: string
+        ) => ({ response, targetProjectIds, errorMessage }),
         setCopySchedule: (copySchedule: boolean) => ({ copySchedule }),
         setDisableCopiedFlag: (disableCopiedFlag: boolean) => ({ disableCopiedFlag }),
         setCopyDependencies: (copyDependencies: boolean) => ({ copyDependencies }),
@@ -2422,6 +2473,13 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
             null as number | null,
             {
                 setCopyDestinationProject: (_, { id }) => id,
+            },
+        ],
+        createInProjectIds: [
+            [] as number[],
+            {
+                setCreateInProjectIds: (_, { projectIds }) => projectIds,
+                saveFeatureFlagSuccess: () => [],
             },
         ],
         projectFlagsToggling: [
@@ -2937,6 +2995,9 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                             product_type: ProductKey.FEATURE_FLAGS,
                             intent_context: ProductIntentContext.FEATURE_FLAG_CREATED,
                         })
+                        // Must finish before saveFeatureFlagSuccess. That listener redirects to the new id, which
+                        // unmounts this "new"-keyed logic, so a later listener cannot run the copy.
+                        await copyNewFlagToProjects(values, actions, savedFlag.key)
                     } else {
                         // Updating an existing flag - include version in preparedFlag
                         const cachedFlag = featureFlagsLogic
@@ -3955,6 +4016,38 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
             actions.setCopySchedule(false)
             actions.setDisableCopiedFlag(false)
             actions.setCopyDependencies(false)
+        },
+        createInProjectsFinished: ({ response, targetProjectIds, errorMessage }) => {
+            const projectName = (id: number | null): string =>
+                values.currentOrganization?.teams.find((team) => team.id === id)?.name ?? `project ${id ?? 'unknown'}`
+            const projectNames = (ids: number[]): string => ids.map(projectName).join(', ')
+
+            if (!response) {
+                lemonToast.error(
+                    `The flag was created here, but couldn't be created in ${projectNames(targetProjectIds)}: ${errorMessage}`
+                )
+                return
+            }
+
+            const summary = summarizeCreateInProjects(response)
+            if (summary.createdProjectIds.length > 0) {
+                lemonToast.success(`Flag also created in ${projectNames(summary.createdProjectIds)}`)
+            }
+            if (summary.updatedProjectIds.length > 0) {
+                lemonToast.info(
+                    `A flag with this key already existed in ${projectNames(summary.updatedProjectIds)} and was updated to match`
+                )
+            }
+            if (summary.pendingApprovalProjectIds.length > 0) {
+                lemonToast.warning(
+                    `${projectNames(summary.pendingApprovalProjectIds)} requires approval. A change request was created and the flag will be created once approved.`
+                )
+            }
+            for (const failure of summary.failures) {
+                lemonToast.error(
+                    `Couldn't create the flag in ${projectName(failure.projectId)}: ${failure.errorMessage}`
+                )
+            }
         },
         copyFlagFailure: () => {
             if (values.copyDependencies && values.copyDestinationProject) {


### PR DESCRIPTION
## Problem

Teams that run staging and production as separate projects create the same flag twice, or create it once and copy it from the Projects tab afterwards. The new flag form only targets the current project.

This is a proof of concept for creating the flag in several projects in one go. Multiple environments per project were removed in #46511, so "other environments" here means the organization's other projects.

## Changes

- The new flag form gets an "Also create in" multi-select with the organization's other projects. It only shows when the organization has more than one project.
- Saving creates the flag in the current project, then copies it to the picked projects with the existing `copy_flags` endpoint. One toast per outcome names the projects: created, updated an existing flag with the same key, approval pending, or failed.
- The copy runs inside the save loader before the success listener redirects. The redirect unmounts the "new"-keyed logic, so a later listener could not run the copy.
- Not copied by the endpoint today: tags, evaluation contexts, and static cohorts. Cohorts match by name.
- No backend changes. Creating in all projects in one request would need the copy logic extracted from the organization viewset; that is the follow-up if this direction holds.

Screenshot: not taken. The worktree has no dev stack running, so the form was not rendered in a browser.

## How did you test this code?

- Jest, `featureFlagLogic.test.ts`: creating a new flag with picked projects posts to `copy_flags` with the new key, the current project, and the picked ids, then clears the picks. Catches the copy being skipped or sent with the wrong body.
- Jest, same file, `test.each` over four copy outcomes (created, overwritten, approval pending, failed). Each produces a toast naming the project. Catches a regression in the outcome mapping.
- Not run: the app in a browser. The frontend typecheck reports no errors in the changed files; the only errors in this worktree come from the unbuilt `@posthog/hogvm` package elsewhere.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5.1). Skills invoked: /writing-ui-components, /writing-kea-logics, /writing-user-facing-copy, /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- The session started as an investigation of what creating a flag in several environments would need. The frontend-only route reuses the copy endpoint and the bulk-copy modal's multi-select, so it became the POC; the backend route is described in Changes.
- The copy first lived as a closure inside the loaders block. It moved to a module-level helper so the inline kea types and the loaders block stayed untouched.
