### PR TITLE
fix(logs): re-mine patterns on refresh

### DIFF
--- a/products/logs/frontend/components/LogsPatterns/logsPatternsLogic.test.ts
+++ b/products/logs/frontend/components/LogsPatterns/logsPatternsLogic.test.ts
@@ -321,6 +321,40 @@ describe('logsPatternsLogic', () => {
         )
     })
 
+    it('re-mines when the refresh button runs the query', async () => {
+        // The refresh button dispatches `bumpFacetRefresh` on the shared filters logic. Without
+        // wiring, Patterns kept the earlier mine while the logs table below it re-ran.
+        const configLogic = logsViewerConfigLogic({ id: ID })
+        configLogic.mount()
+        configLogic.actions.setViewMode('patterns')
+        logic.mount()
+        await expectLogic(logic).toDispatchActions(['loadPatternsSuccess'])
+        mockCreate.mockClear()
+
+        await expectLogic(logic, () => {
+            filtersLogic.actions.bumpFacetRefresh()
+        }).toDispatchActions(['loadPatterns', 'loadPatternsSuccess'])
+
+        expect(mockCreate).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores the refresh button while Patterns is not the active lens', async () => {
+        // The logic can stay mounted after a lens switch; a refresh from the Logs table must not
+        // fire a stray mine.
+        const configLogic = logsViewerConfigLogic({ id: ID })
+        configLogic.mount()
+        configLogic.actions.setViewMode('patterns')
+        logic.mount()
+        await expectLogic(logic).toDispatchActions(['loadPatternsSuccess'])
+        configLogic.actions.setViewMode('logs')
+        mockCreate.mockClear()
+
+        filtersLogic.actions.bumpFacetRefresh()
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(mockCreate).not.toHaveBeenCalled()
+    })
+
     // The label format flips on a >= 24h window threshold (time-of-day vs date-prefixed) and
     // early-returns on empty buckets — none of the above tests read `sparklineLabels`, so a
     // flipped threshold or a broken dayjs format would otherwise go undetected.

--- a/products/logs/frontend/components/LogsPatterns/logsPatternsLogic.ts
+++ b/products/logs/frontend/components/LogsPatterns/logsPatternsLogic.ts
@@ -116,6 +116,9 @@ export interface logsPatternsLogicActions {
     setViewMode: (viewMode: LogsViewerViewMode) => {
         viewMode: LogsViewerViewMode
     } // logsViewerConfigLogic
+    bumpFacetRefresh: () => {
+        value: true
+    } // logsViewerFiltersLogic
     setDateRange: (dateRange: DateRange) => {
         dateRange: DateRange
     } // logsViewerFiltersLogic
@@ -230,7 +233,15 @@ export const logsPatternsLogic = kea<logsPatternsLogicType>([
         ],
         actions: [
             logsViewerFiltersLogic({ id: props.id }),
-            ['setDateRange', 'zoomDateRange', 'setSearchTerm', 'setFilters', 'setFilterGroup', 'setPinnedFilters'],
+            [
+                'setDateRange',
+                'zoomDateRange',
+                'setSearchTerm',
+                'setFilters',
+                'setFilterGroup',
+                'setPinnedFilters',
+                'bumpFacetRefresh',
+            ],
             logsViewerConfigLogic({ id: props.id }),
             ['setViewMode', 'setCompareEnabled', 'setBaselineMode'],
         ],
@@ -370,6 +381,20 @@ export const logsPatternsLogic = kea<logsPatternsLogicType>([
             setFilters: reload,
             setFilterGroup: reload,
             setPinnedFilters: reload,
+
+            // The refresh button fires `bumpFacetRefresh` through the shared filters logic. Re-mine
+            // immediately (no debounce) — it is a deliberate click, not typing — but only while
+            // Patterns is the active lens, and diff or plain to match compare mode.
+            bumpFacetRefresh: () => {
+                if (values.viewMode !== 'patterns') {
+                    return
+                }
+                if (values.compareEnabled) {
+                    actions.loadDiff()
+                } else {
+                    actions.loadPatterns()
+                }
+            },
 
             // Entering compare mode always diffs fresh; leaving it re-mines because the
             // filters may have changed while the plain response sat unused.


### PR DESCRIPTION
## Problem

On the logs viewer, a person who opens the Patterns lens and then clicks refresh gets a stale mine. The logs table and the facet rail both re-run, but the Patterns list keeps the results from the earlier query. Only a full browser reload updates it.

The pattern mining re-runs on filter, date range, and search changes, but nothing connected it to the refresh button.

## Changes

- Clicking refresh now re-mines the patterns, so the Patterns list moves with the logs table.
- `logsPatternsLogic` listens to `bumpFacetRefresh` on the shared filters logic, which `refreshQuery` already dispatches alongside the logs query. This is the same hook the facet rail and the Group lens use, so no new plumbing was needed. The re-mine runs immediately (not debounced, unlike a filter edit) because a refresh click is deliberate, and it uses the diff or plain path to match compare mode.

This is the Patterns counterpart to the same gap fixed for the Group lens in #94133.

## How did you test this code?

Added two cases to `logsPatternsLogic.test.ts`: one asserts a refresh re-mines while Patterns is active, the other asserts a refresh fires no mine when the lens is not Patterns (the logic can stay mounted after a lens switch). No existing test covered refresh reaching this logic.

Ran the logs patterns Jest suite locally; all 15 tests pass. I did not exercise this in a running app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app from a report that the Patterns lens does not update on refresh. No repo skills were invoked; the change mirrors the Group lens fix and is a few lines in one kea logic.

The alternative was to reuse the debounced `reload` path the filter listeners use. A refresh is a deliberate click rather than typing, so it re-mines immediately, matching how the Group lens handles the same action.

Nothing in this diff or description comes from non-public material.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S66N93FX/p1788438742379039?thread_ts=1788438742.379039&cid=C08S66N93FX)*
