### PR TITLE
fix: validate default organization role tenancy

### DIFF
--- a/ee/api/rbac/role.py
+++ b/ee/api/rbac/role.py
@@ -32,7 +32,9 @@ def role_memberships_prefetch() -> Prefetch:
     """
     return Prefetch(
         "roles",
-        queryset=RoleMembership.objects.select_related("user", "organization_member__user").prefetch_related(
+        queryset=RoleMembership.objects.valid_for_authorization()
+        .select_related("user", "organization_member__user")
+        .prefetch_related(
             Prefetch(
                 "organization_member__user__totpdevice_set",
                 queryset=TOTPDevice.objects.filter(confirmed=True),
@@ -196,7 +198,7 @@ class RoleMembershipViewSet(
     scope_object = "organization"
     permission_classes = [OrganizationAdminWritePermissions, TimeSensitiveActionPermission]
     serializer_class = RoleMembershipSerializer
-    queryset = RoleMembership.objects.select_related("role")
+    queryset = RoleMembership.objects.valid_for_authorization().select_related("role")
     filter_rewrite_rules = {"organization_id": "role__organization_id"}
 
     def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:

--- a/ee/api/scim/group.py
+++ b/ee/api/scim/group.py
@@ -48,7 +48,7 @@ class PostHogSCIMGroup(SCIMGroup):
         """
         Return list of group members in SCIM format.
         """
-        role_memberships = RoleMembership.objects.filter(role=self.obj).select_related("user")
+        role_memberships = RoleMembership.objects.filter(role=self.obj).valid_for_authorization().select_related("user")
         return [
             {
                 "value": str(rm.user.id),
@@ -141,7 +141,11 @@ class PostHogSCIMGroup(SCIMGroup):
             return
 
         # nosemgrep: idor-lookup-without-org (SCIM bearer token auth, org gated by middleware)
-        RoleMembership.objects.get_or_create(role=role, user=user, defaults={"organization_member": org_membership})
+        RoleMembership.objects.update_or_create(
+            role=role,
+            user=user,
+            defaults={"organization_member": org_membership},
+        )
 
     @classmethod
     def _update_members(cls, role: Role, members_data: list[dict], config: IdentityProviderConfig) -> None:

--- a/ee/api/scim/user.py
+++ b/ee/api/scim/user.py
@@ -136,9 +136,11 @@ class PostHogSCIMUser(SCIMUser):
         if self.display_name:
             base_dict["displayName"] = self.display_name
 
-        role_memberships = RoleMembership.objects.filter(
-            user=self.obj, role__organization=self._config.organization
-        ).select_related("role")
+        role_memberships = (
+            RoleMembership.objects.filter(user=self.obj, role__organization=self._config.organization)
+            .valid_for_authorization()
+            .select_related("role")
+        )
         base_dict["groups"] = [
             {
                 "value": str(rm.role.id),

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -57,6 +57,7 @@ from posthog.user_permissions import UserPermissions, UserPermissionsSerializerM
 from posthog.utils import get_safe_cache, safe_cache_set
 
 from products.access_control.backend.facade.user_access_control import UserAccessControl, visible_teams_for_user
+from products.access_control.backend.models.role import Role
 from products.access_control.backend.presentation.access_control import UserAccessControlSerializerMixin
 
 
@@ -99,6 +100,10 @@ tracer = trace.get_tracer(__name__)
 
 CacheField = Literal["teams", "projects"]
 OrgCacheField = Literal["member_count"]
+
+
+class OrganizationRoleScopedPrimaryKeyRelatedField(OrgScopedPrimaryKeyRelatedField):
+    scope_field = "organization"
 
 
 def _cached_org_serializer_field(cache_key: str, fetcher: Callable[[], Any]) -> Any:
@@ -155,7 +160,9 @@ class OrganizationSerializer(
     logo_media_id = OrgScopedPrimaryKeyRelatedField(
         queryset=UploadedMedia.objects.all(), required=False, allow_null=True
     )
-    default_role_id = serializers.CharField(
+    default_role_id = OrganizationRoleScopedPrimaryKeyRelatedField(
+        queryset=Role.objects.all(),
+        source="default_role",
         required=False,
         allow_null=True,
         help_text="ID of the role to automatically assign to new members joining the organization",
@@ -216,7 +223,6 @@ class OrganizationSerializer(
             "metadata",
             "customer_id",
             "member_count",
-            "default_role_id",
             "is_active",
             "is_not_active_reason",
             "is_pending_deletion",

--- a/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
+++ b/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
@@ -1146,8 +1146,11 @@
   SELECT "ee_role"."organization_id" AS "role__organization_id",
          "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  LEFT OUTER JOIN "posthog_organizationmembership" ON ("ee_rolemembership"."organization_member_id" = "posthog_organizationmembership"."id")
   INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
-  WHERE "ee_rolemembership"."user_id" = 99999
+  WHERE ("ee_rolemembership"."user_id" = 99999
+         AND ("ee_rolemembership"."organization_member_id" IS NULL
+              OR "posthog_organizationmembership"."organization_id" = ("ee_role"."organization_id")))
   '''
 # ---
 # name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.32
@@ -2641,8 +2644,11 @@
   SELECT "ee_role"."organization_id" AS "role__organization_id",
          "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  LEFT OUTER JOIN "posthog_organizationmembership" ON ("ee_rolemembership"."organization_member_id" = "posthog_organizationmembership"."id")
   INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
-  WHERE "ee_rolemembership"."user_id" = 99999
+  WHERE ("ee_rolemembership"."user_id" = 99999
+         AND ("ee_rolemembership"."organization_member_id" IS NULL
+              OR "posthog_organizationmembership"."organization_id" = ("ee_role"."organization_id")))
   '''
 # ---
 # name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.8
@@ -4630,8 +4636,11 @@
   SELECT "ee_role"."organization_id" AS "role__organization_id",
          "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  LEFT OUTER JOIN "posthog_organizationmembership" ON ("ee_rolemembership"."organization_member_id" = "posthog_organizationmembership"."id")
   INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
-  WHERE "ee_rolemembership"."user_id" = 99999
+  WHERE ("ee_rolemembership"."user_id" = 99999
+         AND ("ee_rolemembership"."organization_member_id" IS NULL
+              OR "posthog_organizationmembership"."organization_id" = ("ee_role"."organization_id")))
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.106
@@ -5711,8 +5720,11 @@
   SELECT "ee_role"."organization_id" AS "role__organization_id",
          "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  LEFT OUTER JOIN "posthog_organizationmembership" ON ("ee_rolemembership"."organization_member_id" = "posthog_organizationmembership"."id")
   INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
-  WHERE "ee_rolemembership"."user_id" = 99999
+  WHERE ("ee_rolemembership"."user_id" = 99999
+         AND ("ee_rolemembership"."organization_member_id" IS NULL
+              OR "posthog_organizationmembership"."organization_id" = ("ee_role"."organization_id")))
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.132
@@ -6786,8 +6798,11 @@
   SELECT "ee_role"."organization_id" AS "role__organization_id",
          "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  LEFT OUTER JOIN "posthog_organizationmembership" ON ("ee_rolemembership"."organization_member_id" = "posthog_organizationmembership"."id")
   INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
-  WHERE "ee_rolemembership"."user_id" = 99999
+  WHERE ("ee_rolemembership"."user_id" = 99999
+         AND ("ee_rolemembership"."organization_member_id" IS NULL
+              OR "posthog_organizationmembership"."organization_id" = ("ee_role"."organization_id")))
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.158
@@ -9133,8 +9148,11 @@
   SELECT "ee_role"."organization_id" AS "role__organization_id",
          "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  LEFT OUTER JOIN "posthog_organizationmembership" ON ("ee_rolemembership"."organization_member_id" = "posthog_organizationmembership"."id")
   INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
-  WHERE "ee_rolemembership"."user_id" = 99999
+  WHERE ("ee_rolemembership"."user_id" = 99999
+         AND ("ee_rolemembership"."organization_member_id" IS NULL
+              OR "posthog_organizationmembership"."organization_id" = ("ee_role"."organization_id")))
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.29
@@ -10232,8 +10250,11 @@
   SELECT "ee_role"."organization_id" AS "role__organization_id",
          "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  LEFT OUTER JOIN "posthog_organizationmembership" ON ("ee_rolemembership"."organization_member_id" = "posthog_organizationmembership"."id")
   INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
-  WHERE "ee_rolemembership"."user_id" = 99999
+  WHERE ("ee_rolemembership"."user_id" = 99999
+         AND ("ee_rolemembership"."organization_member_id" IS NULL
+              OR "posthog_organizationmembership"."organization_id" = ("ee_role"."organization_id")))
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.5
@@ -11095,8 +11116,11 @@
   SELECT "ee_role"."organization_id" AS "role__organization_id",
          "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  LEFT OUTER JOIN "posthog_organizationmembership" ON ("ee_rolemembership"."organization_member_id" = "posthog_organizationmembership"."id")
   INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
-  WHERE "ee_rolemembership"."user_id" = 99999
+  WHERE ("ee_rolemembership"."user_id" = 99999
+         AND ("ee_rolemembership"."organization_member_id" IS NULL
+              OR "posthog_organizationmembership"."organization_id" = ("ee_role"."organization_id")))
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.70
@@ -11523,8 +11547,11 @@
   SELECT "ee_role"."organization_id" AS "role__organization_id",
          "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  LEFT OUTER JOIN "posthog_organizationmembership" ON ("ee_rolemembership"."organization_member_id" = "posthog_organizationmembership"."id")
   INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
-  WHERE "ee_rolemembership"."user_id" = 99999
+  WHERE ("ee_rolemembership"."user_id" = 99999
+         AND ("ee_rolemembership"."organization_member_id" IS NULL
+              OR "posthog_organizationmembership"."organization_id" = ("ee_role"."organization_id")))
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.8
@@ -13749,8 +13776,11 @@
   SELECT "ee_role"."organization_id" AS "role__organization_id",
          "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  LEFT OUTER JOIN "posthog_organizationmembership" ON ("ee_rolemembership"."organization_member_id" = "posthog_organizationmembership"."id")
   INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
-  WHERE "ee_rolemembership"."user_id" = 99999
+  WHERE ("ee_rolemembership"."user_id" = 99999
+         AND ("ee_rolemembership"."organization_member_id" IS NULL
+              OR "posthog_organizationmembership"."organization_id" = ("ee_role"."organization_id")))
   '''
 # ---
 # name: TestDashboard.test_retrieve_dashboard.9
@@ -14989,8 +15019,11 @@
   SELECT "ee_role"."organization_id" AS "role__organization_id",
          "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  LEFT OUTER JOIN "posthog_organizationmembership" ON ("ee_rolemembership"."organization_member_id" = "posthog_organizationmembership"."id")
   INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
-  WHERE "ee_rolemembership"."user_id" = 99999
+  WHERE ("ee_rolemembership"."user_id" = 99999
+         AND ("ee_rolemembership"."organization_member_id" IS NULL
+              OR "posthog_organizationmembership"."organization_id" = ("ee_role"."organization_id")))
   '''
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.29
@@ -16088,8 +16121,11 @@
   SELECT "ee_role"."organization_id" AS "role__organization_id",
          "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  LEFT OUTER JOIN "posthog_organizationmembership" ON ("ee_rolemembership"."organization_member_id" = "posthog_organizationmembership"."id")
   INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
-  WHERE "ee_rolemembership"."user_id" = 99999
+  WHERE ("ee_rolemembership"."user_id" = 99999
+         AND ("ee_rolemembership"."organization_member_id" IS NULL
+              OR "posthog_organizationmembership"."organization_id" = ("ee_role"."organization_id")))
   '''
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.5
@@ -16333,8 +16369,11 @@
   SELECT "ee_role"."organization_id" AS "role__organization_id",
          "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  LEFT OUTER JOIN "posthog_organizationmembership" ON ("ee_rolemembership"."organization_member_id" = "posthog_organizationmembership"."id")
   INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
-  WHERE "ee_rolemembership"."user_id" = 99999
+  WHERE ("ee_rolemembership"."user_id" = 99999
+         AND ("ee_rolemembership"."organization_member_id" IS NULL
+              OR "posthog_organizationmembership"."organization_id" = ("ee_role"."organization_id")))
   '''
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.8

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -109,7 +109,39 @@ class TestOrganizationAPI(APIBaseTest):
         else:
             mock_group_identify.assert_not_called()
 
+    def test_cannot_create_organization_with_default_role(self):
+        role = Role.objects.create(name="Existing organization role", organization=self.organization)
+
+        with self.is_cloud(True):
+            response = self.client.post("/api/organizations/", {"name": "New org", "default_role_id": str(role.id)})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(Organization.objects.count(), 1)
+
     # Updating organizations
+
+    def test_update_organization_default_role(self):
+        self.organization_membership.level = OrganizationMembership.Level.OWNER
+        self.organization_membership.save()
+        role = Role.objects.create(name="Default role", organization=self.organization)
+
+        response = self.client.patch(f"/api/organizations/{self.organization.id}", {"default_role_id": str(role.id)})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.organization.refresh_from_db()
+        self.assertEqual(self.organization.default_role, role)
+
+    def test_cannot_update_organization_with_role_from_another_organization(self):
+        self.organization_membership.level = OrganizationMembership.Level.OWNER
+        self.organization_membership.save()
+        other_organization = Organization.objects.create(name="Other organization")
+        role = Role.objects.create(name="Other organization role", organization=other_organization)
+
+        response = self.client.patch(f"/api/organizations/{self.organization.id}", {"default_role_id": str(role.id)})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.organization.refresh_from_db()
+        self.assertIsNone(self.organization.default_role)
 
     def test_update_organization_if_admin(self):
         self.organization_membership.level = OrganizationMembership.Level.ADMIN

--- a/posthog/api/test/test_organization_invites.py
+++ b/posthog/api/test/test_organization_invites.py
@@ -1453,6 +1453,19 @@ class TestOrganizationInvitesAPI(APIBaseTest):
         # Check that the user was assigned to the default role
         assert RoleMembership.objects.filter(role=role, user=new_user, organization_member=membership).exists()
 
+    @patch("posthog.models.user.capture_exception")
+    def test_user_join_does_not_assign_default_role_from_another_organization(self, mock_capture_exception):
+        other_organization = Organization.objects.create(name="Other organization")
+        role = Role.objects.create(name="Other organization role", organization=other_organization)
+        self.organization.default_role = role
+        self.organization.save()
+        new_user = User.objects.create(email="test@example.com", first_name="Test")
+
+        new_user.join(organization=self.organization)
+
+        assert not RoleMembership.objects.filter(role=role, user=new_user).exists()
+        mock_capture_exception.assert_called_once()
+
     def test_user_join_without_default_role(self):
         """Test that new users don't get assigned any role when no default is set"""
         # Create a new user and have them join the organization

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -1221,6 +1221,7 @@ class Team(UUIDTClassicModel):
 
                 role_user_ids = (
                     RoleMembership.objects.filter(role_id__in=roles_with_access)
+                    .valid_for_authorization()
                     .values_list("organization_member__user_id", flat=True)
                     .distinct()
                 )

--- a/posthog/models/test/test_team_model.py
+++ b/posthog/models/test/test_team_model.py
@@ -9,7 +9,7 @@ from parameterized import parameterized
 
 from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.core_event import CoreEvent
-from posthog.models.organization import OrganizationMembership
+from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.team.team import Team
 from posthog.models.team.team_caching import get_team_in_cache, set_team_in_cache
 from posthog.models.user import User
@@ -287,6 +287,52 @@ class TestTeam(BaseTest):
 
         # Both users should have access
         assert sorted(all_user_with_access_ids) == sorted([self.user.id, member_user.id])
+
+    def test_all_users_with_access_ignores_role_membership_from_another_organization(self):
+        self._enable_access_control(role_based=True)
+        AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            organization_member=None,
+            role=None,
+            access_level="none",
+        )
+        member_user = User.objects.create_and_join(
+            self.organization,
+            email="member-cross-org@posthog.com",
+            first_name="first_name",
+            password=None,
+            level=OrganizationMembership.Level.MEMBER,
+        )
+        other_organization = Organization.objects.create(name="Other organization")
+        OrganizationMembership.objects.create(
+            organization=other_organization,
+            user=member_user,
+            level=OrganizationMembership.Level.MEMBER,
+        )
+        role = Role.objects.create(name="Other organization role", organization=other_organization)
+        RoleMembership.objects.create(
+            role=role,
+            user=member_user,
+            organization_member=OrganizationMembership.objects.get(
+                organization=self.organization,
+                user=member_user,
+            ),
+        )
+        AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            role=role,
+            access_level="member",
+        )
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+        all_user_with_access_ids = list(self.team.all_users_with_access().values_list("id", flat=True))
+
+        assert all_user_with_access_ids == [self.user.id]
 
     def test_all_users_with_access_returns_all_org_members_without_access_control_feature(self):
         """Without ACCESS_CONTROL there are no private teams — every org member has access,

--- a/posthog/models/test/test_user_teams_access_control.py
+++ b/posthog/models/test/test_user_teams_access_control.py
@@ -140,6 +140,39 @@ class TestUserTeamsAccessControl(BaseTest):
         self.assertIn(self.team, user_teams)
         self.assertIn(private_team, user_teams)
 
+    def test_user_teams_ignores_role_membership_from_another_organization(self):
+        other_organization = Organization.objects.create(name="Other organization")
+        other_team = Team.objects.create(organization=other_organization, name="Other private team")
+        OrganizationMembership.objects.create(
+            organization=other_organization,
+            user=self.user,
+            level=OrganizationMembership.Level.MEMBER,
+        )
+        role = Role.objects.create(name="Other organization role", organization=other_organization)
+        RoleMembership.objects.create(
+            role=role,
+            user=self.user,
+            organization_member=self.organization_membership,
+        )
+        AccessControl.objects.create(
+            team=other_team,
+            resource="project",
+            resource_id=str(other_team.id),
+            access_level="none",
+            organization_member=None,
+            role=None,
+        )
+        AccessControl.objects.create(
+            team=other_team,
+            resource="project",
+            resource_id=str(other_team.id),
+            access_level="member",
+            organization_member=None,
+            role=role,
+        )
+
+        assert other_team not in self.user.teams.all()
+
     def test_user_teams_role_based_access_inert_without_role_based_access_feature(self):
         """Role-backed project AccessControl rows must NOT grant team visibility when the
         org lacks ROLE_BASED_ACCESS — mirrors the UI gate."""

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -409,9 +409,13 @@ class User(AbstractUser, UUIDTClassicModel, ModelActivityMixin):  # type: ignore
                     try:
                         from products.access_control.backend.models.role import RoleMembership
 
-                        user_roles = RoleMembership.objects.filter(
-                            user=self, organization_member__in=[membership.id for membership in org_memberships]
-                        ).values_list("role_id", flat=True)
+                        user_roles = (
+                            RoleMembership.objects.filter(
+                                user=self, organization_member__in=[membership.id for membership in org_memberships]
+                            )
+                            .valid_for_authorization()
+                            .values_list("role_id", flat=True)
+                        )
 
                         role_accessible_team_ids = set(
                             AccessControl.objects.filter(

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -562,9 +562,8 @@ class User(AbstractUser, UUIDTClassicModel, ModelActivityMixin):  # type: ignore
             try:
                 from products.access_control.backend.models.role import RoleMembership
 
-                RoleMembership.objects.create(
-                    role_id=organization.default_role_id, user=self, organization_member=membership
-                )
+                role = organization.roles.get(id=organization.default_role_id)
+                RoleMembership.objects.create(role=role, user=self, organization_member=membership)
             except Exception as e:
                 capture_exception(
                     e,

--- a/posthog/test/test_user_permissions.py
+++ b/posthog/test/test_user_permissions.py
@@ -542,6 +542,22 @@ class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
 
         assert self.permissions().current_team.effective_membership_level == expected_level
 
+    def test_role_membership_linked_to_another_organization_is_ignored(self):
+        from products.access_control.backend.models.role import Role, RoleMembership
+
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+        self._grant_project_access("none")
+        role = Role.objects.create(name="Target organization role", organization=self.organization)
+        other_organization = Organization.objects.create(name="Other organization")
+        other_membership = OrganizationMembership.objects.create(
+            organization=other_organization, user=self.user, level=OrganizationMembership.Level.MEMBER
+        )
+        RoleMembership.objects.create(role=role, user=self.user, organization_member=other_membership)
+        self._grant_project_access("admin", role=role)
+
+        assert self.permissions().current_team.effective_membership_level is None
+
     @parameterized.expand(
         [
             ("denial", "none", "member", OrganizationMembership.Level.MEMBER),

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -2,6 +2,8 @@ from functools import cached_property
 from typing import Any, Optional, cast
 from uuid import UUID
 
+from django.db.models import F, Q
+
 from posthog.constants import AvailableFeature
 from posthog.models import Organization, OrganizationMembership, Team, User
 from posthog.organization_caching import get_cached_organization_memberships
@@ -147,9 +149,10 @@ class UserPermissions:
         from products.access_control.backend.models.role import RoleMembership
 
         result: dict[UUID, set[UUID]] = {}
-        for organization_id, role_id in RoleMembership.objects.filter(user=self.user).values_list(
-            "role__organization_id", "role_id"
-        ):
+        role_memberships = RoleMembership.objects.filter(user=self.user).filter(
+            Q(organization_member__isnull=True) | Q(organization_member__organization_id=F("role__organization_id"))
+        )
+        for organization_id, role_id in role_memberships.values_list("role__organization_id", "role_id"):
             result.setdefault(organization_id, set()).add(role_id)
         return result
 

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -2,8 +2,6 @@ from functools import cached_property
 from typing import Any, Optional, cast
 from uuid import UUID
 
-from django.db.models import F, Q
-
 from posthog.constants import AvailableFeature
 from posthog.models import Organization, OrganizationMembership, Team, User
 from posthog.organization_caching import get_cached_organization_memberships
@@ -149,9 +147,7 @@ class UserPermissions:
         from products.access_control.backend.models.role import RoleMembership
 
         result: dict[UUID, set[UUID]] = {}
-        role_memberships = RoleMembership.objects.filter(user=self.user).filter(
-            Q(organization_member__isnull=True) | Q(organization_member__organization_id=F("role__organization_id"))
-        )
+        role_memberships = RoleMembership.objects.filter(user=self.user).valid_for_authorization()
         for organization_id, role_id in role_memberships.values_list("role__organization_id", "role_id"):
             result.setdefault(organization_id, set()).add(role_id)
         return result

--- a/products/access_control/backend/facade/resolution_preview.py
+++ b/products/access_control/backend/facade/resolution_preview.py
@@ -170,7 +170,7 @@ def _build_subjects(team: Team, user_access_control: UserAccessControl, rows: li
     role_ids_by_user: dict[int, list[str]] = {}
     for rm in RoleMembership.objects.filter(
         role__organization_id=team.organization_id, user_id__in=[membership.user_id for membership in memberships]
-    ):
+    ).valid_for_authorization():
         role_ids_by_user.setdefault(rm.user_id, []).append(str(rm.role_id))
 
     subjects: list[_Subject] = [

--- a/products/access_control/backend/facade/subject_access_control.py
+++ b/products/access_control/backend/facade/subject_access_control.py
@@ -246,6 +246,7 @@ class SubjectAccessControl(UserAccessControl):
             return list(
                 cast(Any, self._subject_member.user)
                 .role_memberships.filter(role__organization_id=self._organization_id)
+                .valid_for_authorization()
                 .values_list("role_id", flat=True)
             )
         return [self._subject_role_id] if self._subject_role_id else []
@@ -313,7 +314,7 @@ def get_project_scoped_visible_membership_ids(
     candidate_role_ids: dict[str, list[str]] = defaultdict(list)
     referenced_role_ids = {role_id for (_, role_id) in role_overrides}
     if referenced_role_ids:
-        for rm in RoleMembership.objects.filter(role_id__in=referenced_role_ids):
+        for rm in RoleMembership.objects.filter(role_id__in=referenced_role_ids).valid_for_authorization():
             if rm.organization_member_id:
                 candidate_role_ids[str(rm.organization_member_id)].append(str(rm.role_id))
     candidate_ids = {membership_id for (_, membership_id) in member_overrides} | set(candidate_role_ids)

--- a/products/access_control/backend/facade/user_access_control.py
+++ b/products/access_control/backend/facade/user_access_control.py
@@ -488,6 +488,7 @@ class UserAccessControl:
         return list(
             cast(Any, self._user)
             .role_memberships.filter(role__organization_id=self._organization_id)
+            .filter(Q(organization_member__isnull=True) | Q(organization_member__organization_id=self._organization_id))
             .values_list("role_id", flat=True)
         )
 

--- a/products/access_control/backend/facade/user_access_control.py
+++ b/products/access_control/backend/facade/user_access_control.py
@@ -488,7 +488,7 @@ class UserAccessControl:
         return list(
             cast(Any, self._user)
             .role_memberships.filter(role__organization_id=self._organization_id)
-            .filter(Q(organization_member__isnull=True) | Q(organization_member__organization_id=self._organization_id))
+            .valid_for_authorization()
             .values_list("role_id", flat=True)
         )
 

--- a/products/access_control/backend/models/role.py
+++ b/products/access_control/backend/models/role.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.db.models import F, Q
 
 from posthog.models.utils import UUIDTModel
 
@@ -39,7 +40,16 @@ class Role(UUIDTModel):
     )
 
 
+class RoleMembershipQuerySet(models.QuerySet["RoleMembership"]):
+    def valid_for_authorization(self) -> "RoleMembershipQuerySet":
+        return self.filter(
+            Q(organization_member__isnull=True) | Q(organization_member__organization_id=F("role__organization_id"))
+        )
+
+
 class RoleMembership(UUIDTModel):
+    objects = RoleMembershipQuerySet.as_manager()
+
     class Meta:
         app_label = "ee"
         constraints = [models.UniqueConstraint(fields=["role", "user"], name="unique_user_and_role")]

--- a/products/access_control/backend/presentation/access_control_settings.py
+++ b/products/access_control/backend/presentation/access_control_settings.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from django.core.cache import cache as django_cache
 from django.core.exceptions import ValidationError as DjangoValidationError
-from django.db.models import Count, Max, Model, Q
+from django.db.models import Count, Max, Model, Prefetch, Q
 from django.db.models.functions import Coalesce
 
 from rest_framework import exceptions
@@ -48,7 +48,7 @@ from products.access_control.backend.facade.user_access_control import (
     ordered_access_levels,
 )
 from products.access_control.backend.models.access_control import AccessControl
-from products.access_control.backend.models.role import Role
+from products.access_control.backend.models.role import Role, RoleMembership
 
 from .access_control import AccessControlSerializer, ResolvedAccessSerializer, upsert_access_control
 
@@ -288,7 +288,7 @@ class AccessControlSettingsViewSetMixin(_GenericViewSet):
         memberships = (
             OrganizationMembership.objects.filter(organization=team.organization, user__is_active=True)
             .select_related("user")
-            .prefetch_related("role_memberships")
+            .prefetch_related(Prefetch("role_memberships", queryset=RoleMembership.objects.valid_for_authorization()))
         )
         # An optional member_id narrows the walk to one member, so the detail panel doesn't pay for the whole list
         if request.query_params.get("member_id"):

--- a/products/access_control/backend/property_access_control.py
+++ b/products/access_control/backend/property_access_control.py
@@ -172,7 +172,9 @@ def get_property_access_level(
             raise ValueError("user does not have organization membership")
 
         user_role_ids = set(
-            RoleMembership.objects.filter(organization_member=membership).values_list("role_id", flat=True)
+            RoleMembership.objects.filter(organization_member=membership)
+            .valid_for_authorization()
+            .values_list("role_id", flat=True)
         )
 
     return _resolve_access_level(rules, membership=membership, user_role_ids=user_role_ids)
@@ -263,7 +265,11 @@ def get_non_writable_property_names(
 
         from products.access_control.backend.models.role import RoleMembership
 
-        user_role_ids = set(RoleMembership.objects.filter(user=user).values_list("role_id", flat=True))
+        user_role_ids = set(
+            RoleMembership.objects.filter(user=user, role__organization_id=org_id)
+            .valid_for_authorization()
+            .values_list("role_id", flat=True)
+        )
 
     non_writable: set[str] = set()
     for _prop_def_id, prop_rules in rules_by_property.items():
@@ -366,7 +372,9 @@ def get_restricted_properties_with_group_type_index_for_team(
             raise ValueError("user does not have organization membership")
 
         user_role_ids = set(
-            RoleMembership.objects.filter(organization_member=membership).values_list("role_id", flat=True)
+            RoleMembership.objects.filter(organization_member=membership)
+            .valid_for_authorization()
+            .values_list("role_id", flat=True)
         )
 
     restricted: set[RestrictedProperty] = set()

--- a/products/access_control/backend/tests/test_property_access_control.py
+++ b/products/access_control/backend/tests/test_property_access_control.py
@@ -2,9 +2,10 @@ from posthog.test.base import BaseTest
 from unittest.mock import patch
 
 from posthog.constants import AvailableFeature
-from posthog.models import PropertyDefinition
+from posthog.models import Organization, OrganizationMembership, PropertyDefinition
 
 from products.access_control.backend.models.property_access_control import PropertyAccessControl
+from products.access_control.backend.models.role import Role, RoleMembership
 from products.access_control.backend.property_access_control import (
     PropertyAccessLevel,
     _restriction_cache_var,
@@ -413,6 +414,30 @@ class TestGetRestrictedPropertiesForTeam(BaseTest):
         )
         restricted = get_restricted_properties_for_team(team_id=self.team.pk, user=self.user)
         assert restricted == set()
+
+    def test_role_membership_from_another_organization_does_not_remove_restriction(self):
+        other_organization = Organization.objects.create(name="Other organization")
+        other_membership = OrganizationMembership.objects.create(
+            organization=other_organization,
+            user=self.user,
+            level=OrganizationMembership.Level.MEMBER,
+        )
+        role = Role.objects.create(name="Analyst", organization=self.organization)
+        RoleMembership.objects.create(role=role, user=self.user, organization_member=other_membership)
+        PropertyAccessControl.objects.create(
+            team=self.team,
+            property_definition=self.event_prop,
+            access_level=PropertyAccessLevel.NONE.value,
+        )
+        PropertyAccessControl.objects.create(
+            team=self.team,
+            property_definition=self.event_prop,
+            access_level=PropertyAccessLevel.READ_WRITE.value,
+            role=role,
+        )
+
+        restricted = get_restricted_properties_for_team(team_id=self.team.pk, user=self.user)
+        assert restricted == {("secret_event_prop", PropertyDefinition.Type.EVENT)}
 
 
 class TestRestrictionCacheScope(BaseTest):

--- a/products/access_control/backend/tests/test_user_access_control.py
+++ b/products/access_control/backend/tests/test_user_access_control.py
@@ -130,6 +130,21 @@ class TestUserAccessControl(BaseUserAccessControlTest):
         assert self.user_access_control._user_role_ids == [self.role_a.id]
         assert self.user_access_control.get_user_access_level(self.team) == expected_level
 
+    def test_role_membership_linked_to_another_organization_is_ignored(self):
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+        self._create_access_control(resource_id=str(self.team.id), access_level="none")
+        other_organization = Organization.objects.create(name="Other organization")
+        other_membership = OrganizationMembership.objects.create(
+            organization=other_organization, user=self.user, level=OrganizationMembership.Level.MEMBER
+        )
+        RoleMembership.objects.create(role=self.role_b, user=self.user, organization_member=other_membership)
+        self._create_access_control(resource_id=str(self.team.id), access_level="admin", role=self.role_b)
+
+        self._clear_uac_caches()
+        assert self.user_access_control._user_role_ids == [self.role_a.id]
+        assert self.user_access_control.get_user_access_level(self.team) == "none"
+
     @parameterized.expand(
         [
             ("denial", "none", "member", "member"),

--- a/products/approvals/backend/models.py
+++ b/products/approvals/backend/models.py
@@ -224,10 +224,14 @@ class ApprovalPolicy(UUIDModel, CreatedMetaFields, UpdatedMetaFields):
             try:
                 from products.access_control.backend.models.role import RoleMembership
 
-                role_user_ids = RoleMembership.objects.filter(
-                    role_id__in=approver_roles,
-                    role__organization=self.organization,
-                ).values_list("user_id", flat=True)
+                role_user_ids = (
+                    RoleMembership.objects.filter(
+                        role_id__in=approver_roles,
+                        role__organization=self.organization,
+                    )
+                    .valid_for_authorization()
+                    .values_list("user_id", flat=True)
+                )
                 user_ids.update(role_user_ids)
             except ImportError:
                 pass

--- a/products/approvals/backend/permissions.py
+++ b/products/approvals/backend/permissions.py
@@ -45,10 +45,14 @@ class CanApprove(permissions.BasePermission):
         if approver_roles:
             user_roles = {
                 str(rid)
-                for rid in RoleMembership.objects.filter(
-                    user=user,
-                    role__organization=change_request.organization,
-                ).values_list("role_id", flat=True)
+                for rid in (
+                    RoleMembership.objects.filter(
+                        user=user,
+                        role__organization=change_request.organization,
+                    )
+                    .valid_for_authorization()
+                    .values_list("role_id", flat=True)
+                )
             }
 
             if user_roles & {str(r) for r in approver_roles}:

--- a/products/approvals/backend/policies.py
+++ b/products/approvals/backend/policies.py
@@ -299,7 +299,9 @@ class PolicyEngine:
                 for rid in RoleMembership.objects.filter(
                     user=actor,
                     role__organization=org,
-                ).values_list("role_id", flat=True)
+                )
+                .valid_for_authorization()
+                .values_list("role_id", flat=True)
             }
             if user_role_ids & set(bypass_role_ids):
                 return True
@@ -326,8 +328,10 @@ class PolicyEngine:
 
             actor_roles = {
                 str(rid)
-                for rid in RoleMembership.objects.filter(user=actor, role__organization=org).values_list(
-                    "role_id", flat=True
+                for rid in (
+                    RoleMembership.objects.filter(user=actor, role__organization=org)
+                    .valid_for_authorization()
+                    .values_list("role_id", flat=True)
                 )
             }
 

--- a/products/approvals/backend/serializers.py
+++ b/products/approvals/backend/serializers.py
@@ -127,10 +127,14 @@ class ChangeRequestSerializer(serializers.ModelSerializer):
                 # but RoleMembership.role_id is a UUID, so a raw set intersection always misses.
                 user_role_ids = {
                     str(rid)
-                    for rid in RoleMembership.objects.filter(
-                        user=user,
-                        role__organization=obj.organization,
-                    ).values_list("role_id", flat=True)
+                    for rid in (
+                        RoleMembership.objects.filter(
+                            user=user,
+                            role__organization=obj.organization,
+                        )
+                        .valid_for_authorization()
+                        .values_list("role_id", flat=True)
+                    )
                 }
 
                 if user_role_ids & {str(r) for r in approver_roles}:

--- a/products/error_tracking/backend/facade/api.py
+++ b/products/error_tracking/backend/facade/api.py
@@ -13,6 +13,8 @@ import posthoganalytics
 
 from posthog.event_usage import groups
 
+from products.access_control.backend.models.role import RoleMembership
+
 from .. import logic, weekly_digest, weekly_digest_delivery
 from ..logic import external_references, rules
 from ..models import (
@@ -106,7 +108,11 @@ def _to_issue(issue) -> contracts.ErrorTrackingIssue:
 def _to_issue_assignment_notification(assignment) -> contracts.ErrorTrackingIssueAssignmentNotification:
     role_member_user_ids: list[int] = []
     if assignment.role_id:
-        role_member_user_ids = list(assignment.role.members.values_list("id", flat=True))
+        role_member_user_ids = list(
+            RoleMembership.objects.filter(role=assignment.role)
+            .valid_for_authorization()
+            .values_list("user_id", flat=True)
+        )
 
     issue = assignment.issue
     return contracts.ErrorTrackingIssueAssignmentNotification(

--- a/products/notifications/backend/resolvers.py
+++ b/products/notifications/backend/resolvers.py
@@ -34,7 +34,9 @@ class RecipientsResolver:
             return list(
                 RoleMembership.objects.filter(
                     role_id=target_id,
-                ).values_list("user_id", flat=True)
+                )
+                .valid_for_authorization()
+                .values_list("user_id", flat=True)
             )
 
         raise ValueError(f"Unknown target type: {target_type}")

--- a/products/notifications/backend/tests/test_logic.py
+++ b/products/notifications/backend/tests/test_logic.py
@@ -7,8 +7,9 @@ from django.core.cache import cache
 from parameterized import parameterized
 
 from posthog.constants import AvailableFeature
-from posthog.models import Organization, Team, User
+from posthog.models import Organization, OrganizationMembership, Team, User
 
+from products.access_control.backend.models.role import Role, RoleMembership
 from products.notifications.backend.cache import _unread_count_cache_key
 from products.notifications.backend.facade.contracts import NotificationData
 from products.notifications.backend.facade.enums import (
@@ -330,6 +331,22 @@ class TestAccessControlFiltering(BaseTest):
         self.user = User.objects.create_and_join(self.organization, "ac1@test.com", "password")
         self.user2 = User.objects.create_and_join(self.organization, "ac2@test.com", "password")
         self.resolver = RecipientsResolver()
+
+    def test_role_recipient_ignores_membership_from_another_organization(self):
+        other_organization = Organization.objects.create(name="Other organization")
+        role = Role.objects.create(name="Other organization role", organization=other_organization)
+        RoleMembership.objects.create(
+            role=role,
+            user=self.user,
+            organization_member=OrganizationMembership.objects.get(
+                organization=self.organization,
+                user=self.user,
+            ),
+        )
+
+        result = self.resolver.resolve(TargetType.ROLE, str(role.id), self.team.id)
+
+        assert result == []
 
     def test_passthrough_when_org_lacks_access_control(self):
         self.organization.available_product_features = []

--- a/products/platform_features/frontend/generated/api.zod.ts
+++ b/products/platform_features/frontend/generated/api.zod.ts
@@ -62,7 +62,7 @@ export const CreateBody = /* @__PURE__ */ zod.object({
         .optional()
         .describe("Default setting for 'Discard client IP data' for new projects in this organization."),
     default_role_id: zod
-        .string()
+        .uuid()
         .nullish()
         .describe('ID of the role to automatically assign to new members joining the organization'),
 })
@@ -120,7 +120,7 @@ export const UpdateBody = /* @__PURE__ */ zod.object({
         .optional()
         .describe("Default setting for 'Discard client IP data' for new projects in this organization."),
     default_role_id: zod
-        .string()
+        .uuid()
         .nullish()
         .describe('ID of the role to automatically assign to new members joining the organization'),
 })
@@ -178,7 +178,7 @@ export const PartialUpdateBody = /* @__PURE__ */ zod.object({
         .optional()
         .describe("Default setting for 'Discard client IP data' for new projects in this organization."),
     default_role_id: zod
-        .string()
+        .uuid()
         .nullish()
         .describe('ID of the role to automatically assign to new members joining the organization'),
 })


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

We aren't validating organization for the default role in API requests that update the organization's default role.

## Changes

Validate that the default role belongs to the organization.

<!-- For each change a person can notice, say what they will now see or do differently, not only the code path that does it. Mark the rest as mechanical so a reviewer knows nothing user-visible is hiding in it. -->

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Tests

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the palette and role mapping.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
