### PR TITLE
fix(data-warehouse): persist Shipmail snapshot watermark

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
@@ -731,6 +731,25 @@ async def finalize_desc_sort_incremental_value(
             await database_sync_to_async_pool(schema.update_incremental_field_value)(last_incremental_field_value)
 
 
+async def advance_incremental_field_last_value_on_complete(
+    resource: SourceResponse,
+    schema: "ExternalDataSchema",
+    logger: FilteringBoundLogger,
+    log_prefix: str = "",
+    staging_run_uuid: str | None = None,
+) -> None:
+    value = resource.incremental_field_last_value_on_complete
+    if not schema.should_use_incremental_field or value is None:
+        return
+
+    await logger.adebug(f"{log_prefix}Advancing incremental field to completed source boundary {value}")
+    await database_sync_to_async_pool(schema.refresh_from_db)()
+    if staging_run_uuid is not None:
+        await database_sync_to_async_pool(schema.stage_incremental_field_value)(staging_run_uuid, value)
+    else:
+        await database_sync_to_async_pool(schema.update_incremental_field_value)(value)
+
+
 async def advance_xmin_state(
     resource: SourceResponse,
     schema: "ExternalDataSchema",

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
@@ -20,6 +20,7 @@ from products.warehouse_sources.backend.temporal.data_imports.external_data_job 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.extract import (
     NON_RETRYABLE_ERROR_RETRY_LIMIT,
     _get_redis,
+    advance_incremental_field_last_value_on_complete,
     handle_corrupted_delta_log,
     handle_non_retryable_error,
     handle_reset_or_full_refresh,
@@ -33,9 +34,57 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.e
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import (
     MissingPrimaryKeysException,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.util import NonRetryableException
 
 _EXTRACT_MODULE = "products.warehouse_sources.backend.temporal.data_imports.pipelines.common.extract"
+
+
+@pytest.mark.asyncio
+async def test_advances_source_boundary_only_after_completion() -> None:
+    resource = SourceResponse(
+        name="messages",
+        items=lambda: [],
+        primary_keys=["id"],
+        incremental_field_last_value_on_complete="2026-07-29T12:00:00Z",
+    )
+    schema = MagicMock(should_use_incremental_field=True)
+    logger = AsyncMock()
+
+    def fake_pool(function):
+        async def call(*args, **kwargs):
+            return function(*args, **kwargs)
+
+        return call
+
+    with patch(f"{_EXTRACT_MODULE}.database_sync_to_async_pool", fake_pool):
+        await advance_incremental_field_last_value_on_complete(resource, schema, logger)
+
+    schema.refresh_from_db.assert_called_once_with()
+    schema.update_incremental_field_value.assert_called_once_with("2026-07-29T12:00:00Z")
+
+
+@pytest.mark.asyncio
+async def test_stages_source_boundary_for_v3_load() -> None:
+    resource = SourceResponse(
+        name="messages",
+        items=lambda: [],
+        primary_keys=["id"],
+        incremental_field_last_value_on_complete="2026-07-29T12:00:00Z",
+    )
+    schema = MagicMock(should_use_incremental_field=True)
+
+    def fake_pool(function):
+        async def call(*args, **kwargs):
+            return function(*args, **kwargs)
+
+        return call
+
+    with patch(f"{_EXTRACT_MODULE}.database_sync_to_async_pool", fake_pool):
+        await advance_incremental_field_last_value_on_complete(resource, schema, AsyncMock(), staging_run_uuid="run-1")
+
+    schema.stage_incremental_field_value.assert_called_once_with("run-1", "2026-07-29T12:00:00Z")
+    schema.update_incremental_field_value.assert_not_called()
 
 
 class TestResolvePrimaryKeys:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v2/pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v2/pipeline.py
@@ -19,6 +19,7 @@ from products.warehouse_sources.backend.models.external_data_schema import (
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.models.table import DataWarehouseTable
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.extract import (
+    advance_incremental_field_last_value_on_complete,
     advance_xmin_state,
     cleanup_memory,
     handle_corrupted_delta_log,
@@ -273,6 +274,7 @@ class PipelineNonDLT(Generic[ResumableData]):
 
             prepared_queryable_folder = await self._post_run_operations(row_count=row_count)
 
+            await advance_incremental_field_last_value_on_complete(self._resource, self._schema, self._logger)
             await advance_xmin_state(self._resource, self._schema, self._logger)
 
             result = PipelineResult(should_trigger_cdp_producer=await self._sinks.cdp_producer.should_run())

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
@@ -27,6 +27,7 @@ from products.warehouse_sources.backend.models.external_data_schema import (
 )
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.extract import (
+    advance_incremental_field_last_value_on_complete,
     advance_xmin_state,
     cleanup_memory,
     finalize_desc_sort_incremental_value,
@@ -544,6 +545,9 @@ class PipelineV3(Generic[ResumableData]):
             # no batches the load consumer is never notified. Without this a v3 schema whose
             # source stays quiet could never satisfy `_fast_return_eligible`.
             await self._stamp_full_run()
+            await advance_incremental_field_last_value_on_complete(
+                self._resource, self._schema, self._logger, log_prefix="V3 Pipeline: "
+            )
             self._logger.debug("V3 Pipeline: No batches extracted, skipping finalization")
             return
 
@@ -571,6 +575,14 @@ class PipelineV3(Generic[ResumableData]):
             self._resource,
             self._schema,
             self._last_incremental_field_value,
+            self._logger,
+            log_prefix="V3 Pipeline: ",
+            staging_run_uuid=self._s3_batch_writer.get_run_uuid(),
+        )
+
+        await advance_incremental_field_last_value_on_complete(
+            self._resource,
+            self._schema,
             self._logger,
             log_prefix="V3 Pipeline: ",
             staging_run_uuid=self._s3_batch_writer.get_run_uuid(),

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/test_pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/test_pipeline.py
@@ -173,6 +173,21 @@ class TestAttemptScopedRunUuid:
         mock_reset.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_empty_sync_advances_source_completion_boundary() -> None:
+    pipeline = _make_pipeline()
+
+    with patch(
+        "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.pipeline.advance_incremental_field_last_value_on_complete",
+        new_callable=AsyncMock,
+    ) as advance_boundary:
+        await pipeline._finalize(row_count=0)
+
+    advance_boundary.assert_awaited_once_with(
+        pipeline._resource, pipeline._schema, pipeline._logger, log_prefix="V3 Pipeline: "
+    )
+
+
 class TestExtractionFailureDoesNotCleanupS3:
     @pytest.mark.asyncio
     async def test_s3_files_preserved_when_extraction_fails(self) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/typings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/typings.py
@@ -59,6 +59,8 @@ class SourceResponse:
     """Override partition format at a source level"""
     sort_mode: Optional[SortMode] = "asc"
     """our source typically return data in ascending timestamp order, but some (eg Stripe) do not"""
+    incremental_field_last_value_on_complete: Optional[Any] = None
+    """A source-provided upper boundary that becomes durable only after the sync completes."""
     rows_to_sync: Optional[int] = None
     has_duplicate_primary_keys: Optional[bool] = None
     """Whether incremental tables have non-unique primary keys"""

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shipmail/shipmail.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shipmail/shipmail.py
@@ -1,5 +1,8 @@
+from collections.abc import Callable
 from datetime import datetime
 from typing import Any, Optional
+
+from requests import Response
 
 from posthog.dataclasses import frozen
 
@@ -22,6 +25,23 @@ REQUEST_TIMEOUT_SECONDS = 30.0
 @frozen
 class ShipmailResumeConfig:
     cursor: str | None = None
+
+
+class ShipmailMessagesPaginator(JSONResponseCursorPaginator):
+    def __init__(self, on_complete: Callable[[str], None]) -> None:
+        super().__init__(cursor_path="pagination.next_cursor", cursor_param="cursor")
+        self._on_complete = on_complete
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        super().update_state(response, data)
+        if self.has_next_page:
+            return
+
+        body = response.json()
+        pagination = body.get("pagination") if isinstance(body, dict) else None
+        snapshot_at = pagination.get("snapshot_at") if isinstance(pagination, dict) else None
+        if isinstance(snapshot_at, str) and snapshot_at:
+            self._on_complete(snapshot_at)
 
 
 def _incremental_value(value: Any) -> str:
@@ -53,6 +73,10 @@ def shipmail_source(
 ) -> SourceResponse:
     endpoint_config = SHIPMAIL_ENDPOINTS[endpoint]
     params: dict[str, Any] = {"limit": 100}
+    source_response: SourceResponse
+
+    def set_completion_watermark(snapshot_at: str) -> None:
+        source_response.incremental_field_last_value_on_complete = snapshot_at
 
     if (
         endpoint == "messages"
@@ -68,10 +92,9 @@ def shipmail_source(
             "headers": {"Accept": "application/json"},
             "auth": {"type": "bearer", "token": api_key},
             "request_timeout": REQUEST_TIMEOUT_SECONDS,
-            "paginator": JSONResponseCursorPaginator(
-                cursor_path="pagination.next_cursor",
-                cursor_param="cursor",
-            ),
+            "paginator": ShipmailMessagesPaginator(set_completion_watermark)
+            if endpoint == "messages"
+            else JSONResponseCursorPaginator(cursor_path="pagination.next_cursor", cursor_param="cursor"),
             "session": make_tracked_session(redact_values=(api_key,), capture=False),
         },
         "resource_defaults": {},
@@ -101,7 +124,7 @@ def shipmail_source(
         initial_paginator_state=_initial_paginator_state(resumable_source_manager),
     )
 
-    return SourceResponse(
+    source_response = SourceResponse(
         name=endpoint,
         items=lambda: resource,
         primary_keys=endpoint_config.primary_keys,
@@ -112,6 +135,7 @@ def shipmail_source(
         partition_keys=[endpoint_config.partition_key],
         sort_mode="asc" if endpoint == "messages" else "desc",
     )
+    return source_response
 
 
 def get_capabilities(api_key: str) -> tuple[int | None, set[str]]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shipmail/tests/test_shipmail.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shipmail/tests/test_shipmail.py
@@ -62,6 +62,10 @@ def _rows(source_response) -> list[dict[str, Any]]:
     return [row for page in source_response.items() for row in page]
 
 
+def _completion_watermark(source_response) -> Any:
+    return source_response.incremental_field_last_value_on_complete
+
+
 def test_incremental_value_preserves_iso_timestamp() -> None:
     value = datetime(2026, 7, 29, 12, 30, tzinfo=UTC)
     assert _incremental_value(value) == "2026-07-29T12:30:00+00:00"
@@ -77,28 +81,43 @@ def test_messages_paginates_checkpoints_and_sends_incremental_watermark(make_ses
             _response(
                 {
                     "data": [{"id": "msg_1"}],
-                    "pagination": {"next_cursor": "cursor_2", "has_more": True, "limit": 100},
+                    "pagination": {
+                        "next_cursor": "cursor_2",
+                        "has_more": True,
+                        "limit": 100,
+                        "snapshot_at": "2026-07-29T12:00:00Z",
+                    },
                 }
             ),
             _response(
                 {
                     "data": [{"id": "msg_2"}],
-                    "pagination": {"next_cursor": None, "has_more": False, "limit": 100},
+                    "pagination": {
+                        "next_cursor": None,
+                        "has_more": False,
+                        "limit": 100,
+                        "snapshot_at": "2026-07-29T12:00:00Z",
+                    },
                 }
             ),
         ],
     )
     manager = _manager()
 
-    rows = _rows(
-        _source(
-            "messages",
-            manager,
-            should_use_incremental_field=True,
-            db_incremental_field_last_value="2026-07-01T00:00:00Z",
-            incremental_field="updated_at",
-        )
+    source_response = _source(
+        "messages",
+        manager,
+        should_use_incremental_field=True,
+        db_incremental_field_last_value="2026-07-01T00:00:00Z",
+        incremental_field="updated_at",
     )
+    pages = iter(source_response.items())
+    first_page = next(pages)
+
+    assert first_page == [{"id": "msg_1"}]
+    assert _completion_watermark(source_response) is None
+
+    rows = first_page + [row for page in pages for row in page]
 
     assert rows == [{"id": "msg_1"}, {"id": "msg_2"}]
     assert params[0] == {"limit": 100, "updated_after": "2026-07-01T00:00:00Z"}
@@ -108,6 +127,7 @@ def test_messages_paginates_checkpoints_and_sends_incremental_watermark(make_ses
         "cursor": "cursor_2",
     }
     manager.save_state.assert_called_once_with(ShipmailResumeConfig(cursor="cursor_2"))
+    assert _completion_watermark(source_response) == "2026-07-29T12:00:00Z"
     make_session.assert_called_once_with(redact_values=("test-key",), capture=False)
 
 
@@ -130,6 +150,37 @@ def test_resumes_from_saved_cursor(make_session: mock.MagicMock) -> None:
 
     assert rows == [{"id": "mbx_2"}]
     assert params[0] == {"limit": 100, "cursor": "cursor_2"}
+
+
+@mock.patch(TRACKED_SESSION_PATCH)
+def test_empty_messages_sync_captures_snapshot_watermark(make_session: mock.MagicMock) -> None:
+    session = make_session.return_value
+    _wire(
+        session,
+        [
+            _response(
+                {
+                    "data": [],
+                    "pagination": {
+                        "next_cursor": None,
+                        "has_more": False,
+                        "limit": 100,
+                        "snapshot_at": "2026-07-30T12:00:00Z",
+                    },
+                }
+            )
+        ],
+    )
+    source_response = _source(
+        "messages",
+        _manager(),
+        should_use_incremental_field=True,
+        db_incremental_field_last_value="2026-07-29T12:00:00Z",
+        incremental_field="updated_at",
+    )
+
+    assert _rows(source_response) == []
+    assert source_response.incremental_field_last_value_on_complete == "2026-07-30T12:00:00Z"
 
 
 @mock.patch(TRACKED_SESSION_PATCH)


### PR DESCRIPTION
## Problem

Shipmail warehouse imports can replay quiet time ranges because the stored cursor advances only from returned rows. A zero-row response provides no row timestamp, although Shipmail returns a stable `pagination.snapshot_at` boundary.

## Changes

Before:

```mermaid
flowchart LR
    A[Shipmail pages] --> B[Maximum row updated_at]
    B --> C[Stored watermark]
    D[Zero-row page] --> E[No new watermark]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,D phRed;
    class B phBlue;
    class C,E phGray;
```

After:

```mermaid
flowchart LR
    A[Shipmail pages] --> B[Final snapshot_at]
    B --> C[Successful sync boundary]
    C --> D[Stored watermark]
    D --> E[Next updated_after]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phRed;
    class B,D phGray;
    class C,E phBlue;
```

- The Shipmail paginator exposes `snapshot_at` only after the final page completes.
- The pipelines persist that boundary after successful extraction, including zero-row syncs.
- Pipeline V3 stages the boundary until its data load succeeds.

## How did you test this code?

- Shipmail source tests cover paginated completion, interrupted pagination, and zero-row snapshot advancement.
- Pipeline tests cover durable V2-style updates, staged V3 updates, and zero-batch V3 completion.
- `hogli ci:preflight --strict --against origin/master`
- `uv run mypy --cache-fine-grained` on all changed files
- Production smoke test (2026-09-08): all four tables completed successfully — messages 4,390 rows, mailboxes 27, domains 10, suppressions 7. After completion, `incremental_field_last_value` remained null; an immediate second messages sync therefore imported all 4,390 rows again, reproducing the missing-watermark behavior this PR fixes.

The full database-backed extract test file was not run because this checkout has no reachable Postgres service.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change is required because the connector behavior remains the same.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex produced this fix with `gh` and `hogli`. The repo skills `writing-tests`, `writing-code-comments`, and `writing-pr-descriptions` guided the tests, comments, and PR structure. The `gh-cli` and `git-commit` skills guided publication. All fixtures are invented and contain no customer data.

