### PR TITLE
fix(frontend): load PostHog.js extensions locally

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -43,7 +43,6 @@ export function loadPostHogJS(options: LoadPostHogJSOptions = {}): void {
             api_host: window.JS_POSTHOG_HOST,
             ui_host: window.JS_POSTHOG_UI_HOST,
             defaults: SDK_DEFAULTS_DATE,
-            strict_script_versioning: true,
             persistence: 'localStorage+cookie',
             cookie_persisted_properties: [
                 'prod_interest', // posthog.com sets these based on what docs were browsed


### PR DESCRIPTION
## Problem

Local PostHog instances load SDK configuration, but lazy extensions fail because Vite does not serve versioned asset paths.

## Changes

- Local instances now load extensions through the SDK’s versioned-to-unversioned fallback.
- The app no longer overrides the SDK’s safer default.
- No screenshot: this restores existing extension UI without changing its design.

## How did you test this code?

- `pnpm --filter=@posthog/frontend exec oxfmt --check src/loadPostHogJS.tsx`
- Not manually verified in a browser.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change. This only restores SDK default behavior for local development.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Cursor assisted with code inspection, editing, validation, and GitHub updates. The `/writing-pr-descriptions` skill shaped this description.
