### PR TITLE
fix(cohorts): batch the dependency cache warm's Redis calls

### DIFF
--- a/products/cohorts/backend/models/dependencies.py
+++ b/products/cohorts/backend/models/dependencies.py
@@ -220,7 +220,7 @@ def extract_cohort_dependencies(cohort: Cohort) -> set[int]:
     return dependencies
 
 
-def get_cohort_dependencies(cohort: Cohort, _warming: bool = False) -> list[int]:
+def get_cohort_dependencies(cohort: Cohort) -> list[int]:
     """
     Get the list of cohort IDs that the given cohort depends on.
     """
@@ -230,11 +230,10 @@ def get_cohort_dependencies(cohort: Cohort, _warming: bool = False) -> list[int]
     cache_hit = cache.has_key(cache_key)
 
     def compute_dependencies():
-        if not _warming:
-            COHORT_DEPENDENCY_CACHE_COUNTER.labels(cache_type="dependencies", result="miss").inc()
+        COHORT_DEPENDENCY_CACHE_COUNTER.labels(cache_type="dependencies", result="miss").inc()
         return list(extract_cohort_dependencies(cohort))
 
-    if cache_hit and not _warming:
+    if cache_hit:
         COHORT_DEPENDENCY_CACHE_COUNTER.labels(cache_type="dependencies", result="hit").inc()
 
     result = cache.get_or_set(
@@ -294,6 +293,10 @@ def warm_team_cohort_dependency_cache(team_id: int, batch_size: int = 1000):
     Uses keyset pagination on id instead of .iterator(), which opens a named
     server-side cursor that can be invalidated by connection recycling between
     batches (e.g. behind a pooler) and raises InvalidCursorName mid-scan.
+
+    Redis is read and written once per batch rather than once per cohort. This runs on every
+    cohort save (see _on_cohort_changed), so the per-cohort read plus TTL refresh it replaces
+    made a single save cost three round trips for every cohort the team owns.
     """
     dependents_map: dict[str, list[int]] = {}
     last_id = 0
@@ -301,15 +304,27 @@ def warm_team_cohort_dependency_cache(team_id: int, batch_size: int = 1000):
         batch = list(Cohort.objects.filter(team_id=team_id, deleted=False, id__gt=last_id).order_by("id")[:batch_size])
         if not batch:
             break
-        for cohort in batch:
-            # Any invalidated dependencies cache is rebuilt here
+
+        dependency_keys = [_cohort_dependencies_key(cohort.id) for cohort in batch]
+        cached_dependencies = cache.get_many(dependency_keys)
+
+        dependencies_by_key: dict[str, list[int]] = {}
+        for cohort, dependency_key in zip(batch, dependency_keys):
             dependents_map.setdefault(_cohort_dependents_key(cohort.id), [])
-            dependencies = get_cohort_dependencies(cohort, _warming=True)
-            # Dependency keys aren't fully invalidated; make sure they don't expire.
-            cache.touch(_cohort_dependencies_key(cohort.id), timeout=DEPENDENCY_CACHE_TIMEOUT)
+            # Any invalidated dependencies cache is rebuilt here. A cached empty list is a real
+            # answer, so only a key missing from get_many counts as a miss.
+            cached = cached_dependencies.get(dependency_key)
+            dependencies = list(cached) if cached is not None else list(extract_cohort_dependencies(cohort))
+            dependencies_by_key[dependency_key] = dependencies
             # Build reverse map
             for dep_id in dependencies:
                 dependents_map.setdefault(_cohort_dependents_key(dep_id), []).append(cohort.id)
+
+        # Writing the cache hits back is what replaces the per-key cache.touch: dependency keys
+        # aren't fully invalidated, so they still need their TTL extended, and one set_many
+        # both fills the misses and extends every key in the batch.
+        cache.set_many(dependencies_by_key, timeout=DEPENDENCY_CACHE_TIMEOUT)
+
         last_id = batch[-1].id
     cache.set_many(dependents_map, timeout=DEPENDENCY_CACHE_TIMEOUT)
 

--- a/products/cohorts/backend/models/test/test_dependencies.py
+++ b/products/cohorts/backend/models/test/test_dependencies.py
@@ -239,24 +239,42 @@ class TestCohortDependencies(BaseTest):
         # Warm the cache initially
         warm_team_cohort_dependency_cache(self.team.id)
 
-        # Mock cache.touch and cache.set_many to verify TTL refresh
-        with mock.patch.object(cache, "touch") as mock_touch, mock.patch.object(cache, "set_many") as mock_set_many:
+        with mock.patch.object(cache, "set_many") as mock_set_many:
             # Call warm again - should refresh TTL
             warm_team_cohort_dependency_cache(self.team.id)
 
-            # Verify touch was called for dependency keys
-            expected_dependency_keys = [
-                f"cohort:dependencies:{cohort_a.id}",
-                f"cohort:dependencies:{cohort_b.id}",
-            ]
+        # Dependency keys are rewritten rather than touched, so the TTL refresh has to show up
+        # as a set_many carrying the dependency timeout.
+        written_keys: set[str] = set()
+        for call_args, call_kwargs in mock_set_many.call_args_list:
+            self.assertEqual(call_kwargs.get("timeout"), DEPENDENCY_CACHE_TIMEOUT)
+            written_keys.update(call_args[0].keys())
 
-            for key in expected_dependency_keys:
-                mock_touch.assert_any_call(key, timeout=DEPENDENCY_CACHE_TIMEOUT)
+        for key in (f"cohort:dependencies:{cohort_a.id}", f"cohort:dependencies:{cohort_b.id}"):
+            self.assertIn(key, written_keys)
 
-            # Verify set_many was called with timeout for dependents
-            self.assertTrue(mock_set_many.called)
-            args, kwargs = mock_set_many.call_args
-            self.assertEqual(kwargs.get("timeout"), DEPENDENCY_CACHE_TIMEOUT)
+    def test_warm_team_cohort_dependency_cache_batches_redis_calls(self) -> None:
+        """Redis work scales with batches, not with the number of cohorts in the team.
+
+        A per-cohort read plus TTL refresh made one cohort save cost three round trips per
+        cohort the team owns, which is minutes of a web worker for a team with tens of
+        thousands of cohorts.
+        """
+        for i in range(10):
+            self._create_cohort(name=f"Batched Cohort {i}")
+
+        cache.clear()
+
+        with (
+            mock.patch.object(cache, "get_many", wraps=cache.get_many) as mock_get_many,
+            mock.patch.object(cache, "has_key", wraps=cache.has_key) as mock_has_key,
+            mock.patch.object(cache, "touch", wraps=cache.touch) as mock_touch,
+        ):
+            warm_team_cohort_dependency_cache(self.team.id)
+
+        self.assertEqual(mock_get_many.call_count, 1)
+        self.assertEqual(mock_has_key.call_count, 0)
+        self.assertEqual(mock_touch.call_count, 0)
 
     def test_cache_miss_get_cohort_dependencies(self) -> None:
         cohort_a = self._create_cohort(name="Test Cohort A")


### PR DESCRIPTION
## Problem

A team that creates cohorts through the API pays for every cohort it already owns on each create. `warm_team_cohort_dependency_cache` runs on every cohort save (via the `post_save` signal in `_on_cohort_changed`) and walks every cohort in the team, touching Redis three times per cohort: a `has_key` probe, a `get_or_set`, and a `touch` to extend the TTL.

That makes one save cost `3 x cohorts_in_team` Redis round trips, and the cost grows every time the team adds a cohort. For a team holding tens of thousands of cohorts it is tens of thousands of serial round trips inside the request, which pins a sync web worker for minutes and pushes CPU across the whole deployment. The work is not database bound — the cohort rows are already read in batches of 1000.

Found while tracing a recurring CPU spike on the web deployment back to `POST /api/projects/:id/cohorts/`.

## Changes

- The warm now reads a batch of dependency keys with one `get_many` and writes them back with one `set_many`, so Redis round trips per batch drop from `3 x batch_size` to 2. A create stops scaling its Redis cost with the team's cohort count.
- Writing the cache hits back is what replaces the per-key `cache.touch`: dependency keys are not fully invalidated and still need their TTL extended, and one `set_many` both fills the misses and extends every key in the batch.
- A cached empty list stays distinct from a cache miss, because `get_many` omits absent keys rather than returning a default. Preserving that distinction is what keeps the warm from recomputing dependencies it already has.
- Mechanical: `get_cohort_dependencies` loses its `_warming` parameter. The warm loop was its only caller passing it, and the loop no longer goes through that function.

This is the narrow fix. The warm still runs inline on the request and still walks every cohort in the team on each save, so a follow-up should move it to a debounced per-team task — the enqueue pattern in `_trigger_cohort_backfill` in the same module already does this for backfills. Left out here to keep the change behavior-preserving: the read path in `get_cohort_dependents` self-heals from a miss by warming synchronously, so making the signal path async needs its own reasoning about staleness.

## How did you test this code?

Added and updated automated tests in `products/cohorts/backend/models/test/test_dependencies.py`:

- `test_warm_team_cohort_dependency_cache_batches_redis_calls` (new) asserts one `get_many` per batch and zero `has_key` / `touch` calls. This is the regression the PR exists to prevent — no existing test noticed that Redis calls scaled with the number of cohorts, only that the resulting cache contents were right.
- `test_warm_team_cohort_dependency_cache_refreshes_ttl` (updated) previously asserted `cache.touch` per dependency key. TTL refresh now happens through `set_many`, so the test asserts the dependency keys appear in a `set_many` carrying `DEPENDENCY_CACHE_TIMEOUT`. Same guarantee, different call.
- The existing warm, batching, counter, and invalidation tests are unchanged and still cover the cache contents and the hit/miss metrics.

Not done: the test suite was not run. This was authored in an environment with no Django, Postgres, or ClickHouse available, so the tests here are unexecuted and CI is the first run. The equivalence of the old and new loop was instead checked away from the repo by replaying both against a dictionary-backed cache stand-in over cold, fully warm, and cached-empty-list states at batch sizes 1, 2, and 1000; the resulting dependents map and dependency keys matched in every case. No manual testing was performed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a Slack thread investigating a recurring CPU spike on the web deployment. The route was identified from APM traces, and the per-cohort Redis pattern was then located by reading the cohort create path down to the `post_save` signal; the span data matched the `EXISTS` / `GET` / `PEXPIRE` triple this code emits per cohort.

Skills invoked: `exploring-apm-traces`.

The change was deliberately scoped down along the way. Moving the warm off the request into a debounced Celery task was considered and dropped from this PR, because the synchronous self-heal in `get_cohort_dependents` means an async warm changes staleness semantics on the read path and deserves its own review rather than riding along with a behavior-preserving batching fix.

No customer data, thread contents, or operational metrics from the originating investigation appear in this PR. No sample data was added.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B1AMH2CTD/p1788441522888569?thread_ts=1788441522.888569&cid=C0B1AMH2CTD)*
