### PR TITLE
feat(dashboards): add saved views badge

### DIFF
--- a/products/dashboards/frontend/saved-views/SavedDashboardViewsPicker.tsx
+++ b/products/dashboards/frontend/saved-views/SavedDashboardViewsPicker.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 
 import { IconCheck, IconChevronDown, IconPeople, IconPlus, IconUser } from '@posthog/icons'
-import { LemonButton, LemonSkeleton, Popover } from '@posthog/lemon-ui'
+import { LemonButton, LemonSkeleton, LemonTag, Popover } from '@posthog/lemon-ui'
 
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 
@@ -253,6 +253,11 @@ export function SavedDashboardViewsPicker({
             >
                 <span className="flex items-center gap-1">
                     <span>{activeSavedView?.name || 'Saved views'}</span>
+                    {!activeSavedView && (
+                        <LemonTag type="highlight" size="small">
+                            NEW
+                        </LemonTag>
+                    )}
                     {canEdit && activeSavedViewHasUnsavedChanges && <span className="text-warning">Unsaved</span>}
                 </span>
             </LemonButton>

--- a/products/dashboards/frontend/saved-views/SavedDashboardViewsPicker.tsx
+++ b/products/dashboards/frontend/saved-views/SavedDashboardViewsPicker.tsx
@@ -255,7 +255,7 @@ export function SavedDashboardViewsPicker({
                     <span>{activeSavedView?.name || 'Saved views'}</span>
                     {!activeSavedView && (
                         <LemonTag type="highlight" size="small">
-                            NEW
+                            New
                         </LemonTag>
                     )}
                     {canEdit && activeSavedViewHasUnsavedChanges && <span className="text-warning">Unsaved</span>}


### PR DESCRIPTION
## Problem

- Dashboard users can miss the recent Saved views control.
- **Why:** The badge makes the new control easier to find.

<img width="2072" height="438" alt="CleanShot 2026-09-04 at 16 00 59@2x" src="https://github.com/user-attachments/assets/e0e095b1-d4ff-43a7-8aff-de0f293dea52" />


## Changes

- Dashboard lists now show a small NEW badge beside Saved views until a saved view is selected.

## How did you test this code?

- The TypeScript check and frontend format check passed.
- Storybook started. The browser screenshot did not complete in this task environment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. This is a temporary visual discovery label.

## 🤖 Agent context

- **Autonomy:** Human-driven (agent-assisted)
- Skills used: `/writing-ui-components`, `/writing-user-facing-copy`, and `/writing-pr-descriptions`.
- The change uses the existing LemonTag highlight style.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*