### PR TITLE
fix(replay): scale with transform on iOS so recordings render correctly

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerFrame.scss
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrame.scss
@@ -10,7 +10,6 @@
     overflow: hidden;
     background-color: var(--color-bg-3000-dark);
 
-    // iOS WebKit pinch-zoom crash (FB13816677).
     &--ios {
         touch-action: pan-x pan-y;
     }

--- a/frontend/src/scenes/session-recordings/player/PlayerFrame.scss
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrame.scss
@@ -10,8 +10,7 @@
     overflow: hidden;
     background-color: var(--color-bg-3000-dark);
 
-    // Pinch-zooming the scaled replay iframe crashes the tab in iOS WebKit (FB13816677). Allow
-    // panning but not pinch, so a pinch that starts on the player cannot re-rasterize the iframe.
+    // iOS WebKit pinch-zoom crash (FB13816677).
     &--ios {
         touch-action: pan-x pan-y;
     }

--- a/frontend/src/scenes/session-recordings/player/PlayerFrame.scss
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrame.scss
@@ -10,6 +10,12 @@
     overflow: hidden;
     background-color: var(--color-bg-3000-dark);
 
+    // Pinch-zooming the scaled replay iframe crashes the tab in iOS WebKit (FB13816677). Allow
+    // panning but not pinch, so a pinch that starts on the player cannot re-rasterize the iframe.
+    &--ios {
+        touch-action: pan-x pan-y;
+    }
+
     .PlayerFrame__content--masking-window .replayer-wrapper::before {
         position: absolute;
         inset: 0; /* Cover the entire wrapper */

--- a/frontend/src/scenes/session-recordings/player/PlayerFrame.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrame.tsx
@@ -37,14 +37,9 @@ export const PlayerFrame = (): JSX.Element => {
 
             const parentDimensions = frameRef.current.parentElement.getBoundingClientRect()
 
-            const { scale, zoom, transform } = getPlayerFrameScale(parentDimensions, dimensions, isIOS())
+            const { scale, transform } = getPlayerFrameScale(parentDimensions, dimensions)
 
             const wrapperStyle = player.replayer.wrapper.style
-            if (zoom === null) {
-                wrapperStyle.removeProperty('zoom')
-            } else {
-                wrapperStyle.setProperty('zoom', zoom)
-            }
             if (transform === null) {
                 wrapperStyle.removeProperty('transform')
             } else {
@@ -93,7 +88,7 @@ export const PlayerFrame = (): JSX.Element => {
         // Click indicator duration scales with playback speed: 1/3s at 1x, 1/6s at 2x, etc.
         <div
             ref={containerRef}
-            className={clsx('PlayerFrame ph-no-capture PlayerFrame--llm-highlight')}
+            className={clsx('PlayerFrame ph-no-capture PlayerFrame--llm-highlight', isIOS() && 'PlayerFrame--ios')}
             style={
                 {
                     '--player-frame-click-duration': `${BASE_CLICK_INDICATOR_DURATION_S / speed}s`,

--- a/frontend/src/scenes/session-recordings/player/playerFrameScaling.test.ts
+++ b/frontend/src/scenes/session-recordings/player/playerFrameScaling.test.ts
@@ -7,15 +7,9 @@ import {
 
 const IPHONE =
     'Mozilla/5.0 (iPhone; CPU iPhone OS 18_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1 Mobile/15E148 Safari/604.1'
-const IPAD_LEGACY =
-    'Mozilla/5.0 (iPad; CPU OS 12_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1 Mobile/15E148 Safari/604.1'
 // iPadOS 13+ reports the same user agent as desktop Safari. Only maxTouchPoints separates them.
 const MAC_SAFARI =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15'
-const MAC_CHROME =
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
-const WINDOWS_CHROME =
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
 const ANDROID_CHROME =
     'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36'
 
@@ -33,11 +27,8 @@ describe('isIOS', () => {
 
     it.each([
         ['iPhone Safari', IPHONE, 5, true],
-        ['iPad on iPadOS 12', IPAD_LEGACY, 5, true],
         ['iPad reporting a Macintosh user agent', MAC_SAFARI, 5, true],
         ['macOS Safari', MAC_SAFARI, 0, false],
-        ['macOS Chrome', MAC_CHROME, 0, false],
-        ['Windows Chrome', WINDOWS_CHROME, 0, false],
         ['Android Chrome', ANDROID_CHROME, 5, false],
     ] as [string, string, number, boolean][])('%s', (_, userAgent, maxTouchPoints, expected) => {
         setNavigator(userAgent, maxTouchPoints)
@@ -49,44 +40,27 @@ describe('isIOS', () => {
 describe('getPlayerFrameScale', () => {
     it.each([
         [
-            'shrinks a desktop capture with transform off iOS',
+            'shrinks a desktop capture with transform',
             { width: 855, height: 500 },
             { width: 1710, height: 881 },
-            false,
-            { scale: 0.5, zoom: null, transform: 'scale(0.5)' },
-        ],
-        [
-            'shrinks the same capture with zoom on iOS',
-            { width: 855, height: 500 },
-            { width: 1710, height: 881 },
-            true,
-            { scale: 0.5, zoom: '0.5', transform: null },
+            { scale: 0.5, transform: 'scale(0.5)' },
         ],
         [
             'drops the transform when no shrink is needed, so Chrome does not paint outside the clip',
             { width: 1920, height: 1080 },
             { width: 1710, height: 881 },
-            false,
-            { scale: 1, zoom: null, transform: null },
-        ],
-        [
-            'still sets zoom at full size on iOS',
-            { width: 1920, height: 1080 },
-            { width: 1710, height: 881 },
-            true,
-            { scale: 1, zoom: '1', transform: null },
+            { scale: 1, transform: null },
         ],
         [
             'picks the height ratio when that axis is the tighter fit',
             { width: 1710, height: 440 },
             { width: 1710, height: 880 },
-            false,
-            { scale: 0.5, zoom: null, transform: 'scale(0.5)' },
+            { scale: 0.5, transform: 'scale(0.5)' },
         ],
-    ] as [string, PlayerFrameDimensions, PlayerFrameDimensions, boolean, PlayerFrameScale][])(
+    ] as [string, PlayerFrameDimensions, PlayerFrameDimensions, PlayerFrameScale][])(
         '%s',
-        (_, parent, recorded, onIOS, expected) => {
-            expect(getPlayerFrameScale(parent, recorded, onIOS)).toEqual(expected)
+        (_, parent, recorded, expected) => {
+            expect(getPlayerFrameScale(parent, recorded)).toEqual(expected)
         }
     )
 })

--- a/frontend/src/scenes/session-recordings/player/playerFrameScaling.test.ts
+++ b/frontend/src/scenes/session-recordings/player/playerFrameScaling.test.ts
@@ -7,7 +7,6 @@ import {
 
 const IPHONE =
     'Mozilla/5.0 (iPhone; CPU iPhone OS 18_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1 Mobile/15E148 Safari/604.1'
-// iPadOS 13+ reports the same user agent as desktop Safari. Only maxTouchPoints separates them.
 const MAC_SAFARI =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15'
 const ANDROID_CHROME =

--- a/frontend/src/scenes/session-recordings/player/playerFrameScaling.ts
+++ b/frontend/src/scenes/session-recordings/player/playerFrameScaling.ts
@@ -5,13 +5,10 @@ export interface PlayerFrameDimensions {
 
 export interface PlayerFrameScale {
     scale: number
-    // null clears the property on the replay wrapper.
     transform: string | null
 }
 
-// Pinch-zooming the transformed replay iframe crashes the tab in iOS WebKit (FB13816677), so the
-// player blocks pinch on iOS only. iPadOS 13+ reports a Mac user agent; desktop Safari reports
-// maxTouchPoints 0.
+// iPadOS 13+ reports a Mac user agent.
 export function isIOS(): boolean {
     if (typeof navigator === 'undefined') {
         return false
@@ -20,14 +17,10 @@ export function isIOS(): boolean {
     return /iPad|iPhone|iPod/.test(ua) || (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1)
 }
 
-// The replay wrapper is scaled with `transform`, never `zoom`. WebKit propagates `zoom` into the
-// replay iframe: the iframe's inner viewport shrinks to the zoomed size and the page inside is
-// zoomed again, so a recording renders at scale squared in the top-left corner and fires its
-// mobile breakpoints (#89409, #91417). `transform` is visual only, so the recorded viewport survives.
-// The iOS pinch-zoom crash that motivated `zoom` is handled by `PlayerFrame--ios` in PlayerFrame.scss.
+// Not `zoom`: WebKit propagates it into the iframe (#91417).
 export function getPlayerFrameScale(parent: PlayerFrameDimensions, recorded: PlayerFrameDimensions): PlayerFrameScale {
     const scale = Math.min(parent.width / recorded.width, parent.height / recorded.height, 1)
 
-    // Chrome paints the iframe outside its clip bounds under an identity transform, so drop it at scale 1.
+    // Chrome clips wrongly under an identity transform.
     return { scale, transform: scale === 1 ? null : `scale(${scale})` }
 }

--- a/frontend/src/scenes/session-recordings/player/playerFrameScaling.ts
+++ b/frontend/src/scenes/session-recordings/player/playerFrameScaling.ts
@@ -6,12 +6,12 @@ export interface PlayerFrameDimensions {
 export interface PlayerFrameScale {
     scale: number
     // null clears the property on the replay wrapper.
-    zoom: string | null
     transform: string | null
 }
 
-// A decimal `transform: scale()` crashes the tab on pinch-zoom in iOS WebKit (FB13816677).
-// iPadOS 13+ reports a Mac user agent; desktop Safari reports maxTouchPoints 0.
+// Pinch-zooming the transformed replay iframe crashes the tab in iOS WebKit (FB13816677), so the
+// player blocks pinch on iOS only. iPadOS 13+ reports a Mac user agent; desktop Safari reports
+// maxTouchPoints 0.
 export function isIOS(): boolean {
     if (typeof navigator === 'undefined') {
         return false
@@ -20,20 +20,14 @@ export function isIOS(): boolean {
     return /iPad|iPhone|iPod/.test(ua) || (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1)
 }
 
-export function getPlayerFrameScale(
-    parent: PlayerFrameDimensions,
-    recorded: PlayerFrameDimensions,
-    onIOS: boolean
-): PlayerFrameScale {
+// The replay wrapper is scaled with `transform`, never `zoom`. WebKit propagates `zoom` into the
+// replay iframe: the iframe's inner viewport shrinks to the zoomed size and the page inside is
+// zoomed again, so a recording renders at scale squared in the top-left corner and fires its
+// mobile breakpoints (#89409, #91417). `transform` is visual only, so the recorded viewport survives.
+// The iOS pinch-zoom crash that motivated `zoom` is handled by `PlayerFrame--ios` in PlayerFrame.scss.
+export function getPlayerFrameScale(parent: PlayerFrameDimensions, recorded: PlayerFrameDimensions): PlayerFrameScale {
     const scale = Math.min(parent.width / recorded.width, parent.height / recorded.height, 1)
 
-    if (onIOS) {
-        // `zoom` scales through layout, so no composited layer exists to re-rasterize.
-        return { scale, zoom: String(scale), transform: null }
-    }
-
-    // WebKit's `zoom` shrinks the iframe's documentElement.clientWidth, firing a desktop capture's
-    // mobile breakpoints. `transform` is visual only, so the recorded viewport survives. Chrome
-    // paints the iframe outside its clip bounds under an identity transform, so drop it at scale 1.
-    return { scale, zoom: null, transform: scale === 1 ? null : `scale(${scale})` }
+    // Chrome paints the iframe outside its clip bounds under an identity transform, so drop it at scale 1.
+    return { scale, transform: scale === 1 ? null : `scale(${scale})` }
 }


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

Recordings viewed on iOS render crushed into the top-left corner of the player with a blank band beside them, and desktop captures show their mobile breakpoint.

## Changes

- The player always scales with `transform`. The `zoom` path is removed.
- On iOS the frame gets `touch-action: pan-x pan-y`, so a pinch starting on the replay cannot trigger the crash. A pinch elsewhere on the page still can. Correct rendering on every iOS view outweighs a crash we never reproduced.
- Tests updated accordingly.

## How did you test this code?

Unit tests, oxlint, stylelint and oxfmt pass. Reproduced the broken rendering in mobile Safari before the change. Also a Playwright WebKit mock with iPhone emulation reproduces the bug under `zoom` (inner viewport 390, mobile breakpoint fires, content crushed top-left) and renders correctly under `transform` (inner viewport 1710).

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the palette and role mapping.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
