### PR TITLE
fix(temporal): raise dlq-replay heartbeat and close timeouts

### DIFF
--- a/posthog/temporal/dlq_replay/workflow.py
+++ b/posthog/temporal/dlq_replay/workflow.py
@@ -109,8 +109,8 @@ class DLQReplayWorkflow(PostHogWorkflow):
                     end_timestamp_ms=end_timestamp_ms,
                     batch_size=inputs.batch_size,
                 ),
-                start_to_close_timeout=dt.timedelta(hours=4),
-                heartbeat_timeout=dt.timedelta(minutes=2),
+                start_to_close_timeout=dt.timedelta(hours=8),
+                heartbeat_timeout=dt.timedelta(minutes=10),
                 retry_policy=RetryPolicy(
                     initial_interval=dt.timedelta(seconds=10),
                     maximum_interval=dt.timedelta(minutes=5),


### PR DESCRIPTION
## Problem

Every `replay_partition` activity in the `dlq-replay` workflow fails with `activity Heartbeat timeout` (`TIMEOUT_TYPE_HEARTBEAT`), so a traces DLQ replay makes no progress.

The activity heartbeats every second (it wraps its body in `Heartbeater`, which fires at `heartbeat_timeout / 120`). A 2-minute gap in those heartbeats means the pod's single asyncio event loop did not run the heartbeat task for two minutes. On the `general-purpose` worker that is expected under load: async activities share one event loop per pod, the fleet is shared across many products at up to 50 concurrent activities per pod, and the replay does Kafka decompression and produce work on that loop. A wide DLQ makes it worse, because the workflow fans out one activity per partition at once.

The same fleet already hit this: `BATCH_EXPORT_HEARTBEAT_TIMEOUT_SECONDS` is set to 180 in prod-us for the same reason.

## Changes

- The `dlq-replay` replay activity now tolerates a 10-minute heartbeat gap instead of 2 minutes, so a replay survives event-loop contention on the shared worker.
- Raises `start_to_close_timeout` from 4 to 8 hours, so a large single-partition backlog is not cut off before it finishes.
- Timeouts only. No change to the activity code or the workflow command sequence.

> [!NOTE]
> This is the quick unblock. It does not bound the per-partition fan-out or move the job off the shared fleet; those are the follow-ups if timeouts persist under a very wide DLQ.

## How did you test this code?

Author is an agent (PostHog Desktop). Ran `hogli ci:preflight` (lint, format, complexity, size all pass; mypy advisory only).

Changing activity timeout values is a Temporal-safe change: already-scheduled activities keep their recorded options, and timeout values are not part of the workflow's non-determinism check, so no `workflow.patched()` gate is needed. No test asserts these constants, and asserting exact timeout values would be a brittle implementation-detail test, so none was added.

Not run: an end-to-end replay against a live cluster.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Desktop (Claude). Diagnosed from a live `TIMEOUT_TYPE_HEARTBEAT` failure during a traces DLQ replay.
The heartbeat interval (1s via `Heartbeater`) rules out slow Kafka calls as the cause and points at event-loop saturation on the shared general-purpose fleet, which already carries a documented heartbeat-timeout workaround for batch exports.
Chosen scope: the lowest-risk unblock (raise the timeouts). Bounding partition concurrency and moving the workload off the shared queue were considered and deferred as follow-ups.
