### PR TITLE
feat(tasks): support onboarding test session model

### DIFF
--- a/products/tasks/backend/facade/onboarding.py
+++ b/products/tasks/backend/facade/onboarding.py
@@ -36,6 +36,7 @@ from products.tasks.backend.facade.onboarding_prompt import (
     missing_onboarding_prompt_placeholders,
     render_onboarding_prompt,
 )
+from products.tasks.backend.logic.services.model_catalogue import filter_unsupported_effort, runtime_adapter_for
 from products.tasks.backend.models import Task, TaskClientProvenance
 
 from ee.billing.salesforce_enrichment.constants import PERSONAL_EMAIL_DOMAINS
@@ -187,6 +188,7 @@ def start_onboarding_session(
     homepage_override: str = "",
     force: bool = False,
     channel_id: UUID | None = None,
+    model: str | None = None,
 ) -> UUID | None:
     """Create the session a new user lands in. ``None`` when no session was started."""
     if not force and not _session_enabled(team, user):
@@ -240,6 +242,8 @@ def start_onboarding_session(
         homepage=homepage,
         channel_id=str(channel_id),
     )
+    session_model = model or onboarding_session_model(team)
+    session_runtime_adapter = runtime_adapter_for(session_model)
 
     try:
         with transaction.atomic():
@@ -255,8 +259,11 @@ def start_onboarding_session(
                 client_provenance=TaskClientProvenance.POSTHOG_DESKTOP,
                 create_pr=False,
                 mode="interactive",
-                model=onboarding_session_model(team),
-                reasoning_effort=ONBOARDING_SESSION_EFFORT,
+                runtime_adapter=session_runtime_adapter,
+                model=session_model,
+                reasoning_effort=filter_unsupported_effort(
+                    session_runtime_adapter, session_model, ONBOARDING_SESSION_EFFORT
+                ),
                 posthog_mcp_scopes=ONBOARDING_SESSION_SCOPES,
                 initial_permission_mode="auto",
             )
@@ -299,6 +306,7 @@ def start_onboarding_test_session(
     sources_enabled: list[str],
     sources_watching: list[str],
     sources_newly_enabled: bool,
+    model: str | None,
 ) -> UUID | None:
     """Runs in the requester's personal space, so repeated tests leave #general alone."""
     domain = normalize_target(company_domain) if company_domain else None
@@ -321,4 +329,5 @@ def start_onboarding_test_session(
         homepage_override=homepage,
         force=True,
         channel_id=ensure_personal_channel_id(team.id, user.id),
+        model=model,
     )

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -59,6 +59,7 @@ from products.tasks.backend.facade.run_config import (
     TaskArtifactType,
     get_model_access_error,
     get_reasoning_effort_error,
+    get_runtime_adapter_for_model,
 )
 
 logger = logging.getLogger(__name__)
@@ -2094,6 +2095,14 @@ class OnboardingSessionTestResponseSerializer(OnboardingSessionSerializer):
 
 
 class OnboardingSessionTestSerializer(serializers.Serializer):
+    model = serializers.CharField(
+        required=False,
+        default=None,
+        allow_null=True,
+        allow_blank=False,
+        max_length=255,
+        help_text="Optional LLM model identifier for the test session. Omit to use the plan default.",
+    )
     company_domain = serializers.CharField(
         required=False,
         default="",
@@ -2130,6 +2139,14 @@ class OnboardingSessionTestSerializer(serializers.Serializer):
     sources_newly_enabled = serializers.BooleanField(
         default=False, help_text="Whether onboarding enabled any signal sources."
     )
+
+    def validate_model(self, value: str | None) -> str | None:
+        model_access_error = get_model_access_error(value, distinct_id=request_distinct_id(self.context))
+        if model_access_error is not None:
+            raise serializers.ValidationError(model_access_error)
+        if value is not None and get_runtime_adapter_for_model(value) is None:
+            raise serializers.ValidationError(f"'{value}' is not supported for onboarding test sessions.")
+        return value
 
 
 class TeachingCanvasSerializer(serializers.Serializer):

--- a/products/tasks/backend/presentation/views/channels_api.py
+++ b/products/tasks/backend/presentation/views/channels_api.py
@@ -184,7 +184,7 @@ class ChannelViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     def onboarding_session_test(self, request: Request, **kwargs) -> Response:
         if not isinstance(request.user, User) or not onboarding_test_tools_enabled(self.team, request.user):
             raise PermissionDenied("The onboarding test tools feature is not enabled.")
-        serializer = OnboardingSessionTestSerializer(data=request.data)
+        serializer = OnboardingSessionTestSerializer(data=request.data, context={"request": request})
         serializer.is_valid(raise_exception=True)
         values = serializer.validated_data
         task_id = start_onboarding_test_session(

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 from unittest.mock import patch
 
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.utils import timezone as django_timezone
 
 from parameterized import parameterized
@@ -143,8 +144,10 @@ class ChannelsAPITestCase(TestCase):
             response = self.client.post(f"{self._channels_url()}{action}/", {}, format="json")
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    @override_settings(DEBUG=False)
+    @patch("products.tasks.backend.feature_flags.posthoganalytics.feature_enabled", return_value=True)
     @patch("products.tasks.backend.presentation.views.channels_api.onboarding_test_tools_enabled", return_value=True)
-    def test_flagged_user_can_create_test_onboarding_artifacts(self, _enabled):
+    def test_flagged_user_can_create_test_onboarding_artifacts(self, _enabled, _model_enabled):
         personal_id = next(
             channel["id"] for channel in self._provision()["channels"] if channel["system_role"] == "personal"
         )
@@ -156,7 +159,12 @@ class ChannelsAPITestCase(TestCase):
         ) as start:
             response = self.client.post(
                 f"{self._channels_url()}onboarding_session_test/",
-                {"joining_existing_organization": True, "other_members": ["Max"], "has_events": True},
+                {
+                    "joining_existing_organization": True,
+                    "other_members": ["Max"],
+                    "has_events": True,
+                    "model": "zai-org/glm-5.3",
+                },
                 format="json",
             )
 
@@ -164,6 +172,7 @@ class ChannelsAPITestCase(TestCase):
         self.assertEqual(response.json(), {"task_id": str(task_id), "channel_id": personal_id})
         self.assertTrue(start.call_args.kwargs["joining_existing_organization"])
         self.assertEqual(start.call_args.kwargs["other_members"], ["Max"])
+        self.assertEqual(start.call_args.kwargs["model"], "zai-org/glm-5.3")
 
         teaching = TeachingCanvas(channel_id=uuid4(), canvas_id=canvas_id)
         with patch(

--- a/products/tasks/backend/tests/test_onboarding_session.py
+++ b/products/tasks/backend/tests/test_onboarding_session.py
@@ -22,6 +22,7 @@ from products.tasks.backend.facade.onboarding import (
     _session_enabled,
     onboarding_test_tools_enabled,
     start_onboarding_session,
+    start_onboarding_test_session,
 )
 from products.tasks.backend.facade.onboarding_canvas import TeachingCanvas
 from products.tasks.backend.models import Task, TaskClientProvenance
@@ -145,6 +146,35 @@ class TestOnboardingSessionIdempotency(TestCase):
 
         self.assertEqual(started, task_id)
         self.assertEqual(create_calls, 1)
+
+    @parameterized.expand(
+        [
+            ("claude", "claude-opus-4-8", "claude"),
+            ("codex", "gpt-5.5", "codex"),
+        ]
+    )
+    def test_test_session_uses_the_selected_model(self, _name: str, model: str, runtime_adapter: str) -> None:
+        task_id = uuid4()
+        created = contracts.CreatedTaskDTO(task_id=task_id, team_id=self.team.id, latest_run=None)
+
+        with patch(f"{MODULE}.create_and_run_task", return_value=created) as create:
+            started = start_onboarding_test_session(
+                self.team,
+                self.user,
+                company_domain="",
+                joining_existing_organization=False,
+                has_events=False,
+                signal_reports_waiting=0,
+                other_members=[],
+                sources_enabled=[],
+                sources_watching=[],
+                sources_newly_enabled=False,
+                model=model,
+            )
+
+        self.assertEqual(started, task_id)
+        self.assertEqual(create.call_args.kwargs["model"], model)
+        self.assertEqual(create.call_args.kwargs["runtime_adapter"], runtime_adapter)
 
     def test_seeding_the_tour_failing_does_not_block_the_session(self) -> None:
         task_id = uuid4()

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -1300,6 +1300,12 @@ export interface OnboardingSessionApi {
 
 export interface OnboardingSessionTestApi {
     /**
+     * Optional LLM model identifier for the test session. Omit to use the plan default.
+     * @maxLength 255
+     * @nullable
+     */
+    model?: string | null
+    /**
      * Company domain to research. Blank simulates a personal email address.
      * @maxLength 253
      */

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -1059,6 +1059,8 @@ export const TaskChannelsStarCreateBody = /* @__PURE__ */ zod
  * Feature-flagged test path that creates a repeatable session from explicit prompt-building inputs, in the requester's personal space.
  * @summary Start a test first-run onboarding session
  */
+export const taskChannelsOnboardingSessionTestCreateBodyModelMax = 255
+
 export const taskChannelsOnboardingSessionTestCreateBodyCompanyDomainDefault = ``
 export const taskChannelsOnboardingSessionTestCreateBodyCompanyDomainMax = 253
 
@@ -1083,6 +1085,11 @@ export const taskChannelsOnboardingSessionTestCreateBodySourcesWatchingMax = 25
 export const taskChannelsOnboardingSessionTestCreateBodySourcesNewlyEnabledDefault = false
 
 export const TaskChannelsOnboardingSessionTestCreateBody = /* @__PURE__ */ zod.object({
+    model: zod
+        .string()
+        .max(taskChannelsOnboardingSessionTestCreateBodyModelMax)
+        .nullish()
+        .describe('Optional LLM model identifier for the test session. Omit to use the plan default.'),
     company_domain: zod
         .string()
         .max(taskChannelsOnboardingSessionTestCreateBodyCompanyDomainMax)

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -52964,6 +52964,12 @@ export namespace Schemas {
 
     export interface OnboardingSessionTest {
       /**
+         * Optional LLM model identifier for the test session. Omit to use the plan default.
+         * @maxLength 255
+         * @nullable
+         */
+      model?: string | null;
+      /**
          * Company domain to research. Blank simulates a personal email address.
          * @maxLength 253
          */


### PR DESCRIPTION
## Problem

Desktop onboarding test tools cannot request a chosen model without backend support.

## Changes

- Test sessions accept an optional supported model and retain the plan default when no model is supplied.
- The endpoint validates requester access and starts the matching runtime.
- Generated API contracts expose the optional model field.
- This layer has no visible UI change.

## How did you test this code?

- Ran Python lint, formatting, and syntax checks.
- Not run: database-backed tests, because the local database is stopped.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change. This is a feature-flagged internal test endpoint.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Desktop agent created the backend layer for a stack. Skills used: posthog-desktop, improving-drf-endpoints, writing-tests, debugging-ci-failures, stacking-prs, and writing-pr-descriptions.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*