### PR TITLE
fix(desktop): handle missing repository access

### DIFF
--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -5330,6 +5330,9 @@ describe("AgentServer HTTP Mode", () => {
           "`posthog:metric-list`",
           "`posthog:metric-describe`",
           "`posthog:data-catalog-metric-run`",
+          "Codebase analysis, code review, and code changes require repository content.",
+          "do not replace the requested code work with generic guidance or PostHog data analysis",
+          "/settings/user-personal-integrations",
         ],
         shouldNotContain: [
           "gh repo clone",

--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -5330,14 +5330,19 @@ describe("AgentServer HTTP Mode", () => {
           "`posthog:metric-list`",
           "`posthog:metric-describe`",
           "`posthog:data-catalog-metric-run`",
-          "Codebase analysis, code review, and code changes require repository content.",
+          "You do not have GitHub access in this session.",
+          "Codebase analysis and code review require readable repository content.",
           "do not replace the requested code work with generic guidance or PostHog data analysis",
+          "The connection applies to a new task, not this task.",
+          "call `show_actions` with one `compose` action",
+          "Try again in a new task",
           "/settings/user-personal-integrations",
         ],
         shouldNotContain: [
           "gh repo clone",
           "query-run",
           "event-definitions-list",
+          "send the request again",
         ],
       },
       {
@@ -5414,6 +5419,7 @@ describe("AgentServer HTTP Mode", () => {
       vi.stubEnv("GITHUB_TOKEN", "ghu_actor");
       const s = createServer();
       const prompt = (s as unknown as TestableServer).buildCloudSystemPrompt();
+      expect(prompt).toContain("You have GitHub access in this session.");
       expect(prompt).toContain('gh issue create --assignee "@me"');
       expect(prompt).toContain("gh api user --jq .login");
       // An installation token resolves to the app, so acting on it would assign a bot.

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -4204,12 +4204,14 @@ ${unsupportedDeliverable}`;
   private buildSourceControlAccessInstructions(): string {
     const settingsUrl = `${this.config.apiUrl.replace(/\/$/, "")}/project/${this.config.projectId}/settings/user-personal-integrations`;
     return `
-## When you cannot reach the code
-You may have no repository checked out, or no credentials to push and open a pull request with.
-- Answer the part of the request that does not need the code first — questions about PostHog, their data, or their configuration are all still answerable.
-- If the request turns out not to need a code change at all, just answer it and say nothing about GitHub.
-- Only if it genuinely needs a code change, say so plainly and link them to ${settingsUrl} to connect GitHub, then ask them to come back to you.
-- Do not work around it: no guessing at file contents you cannot read, and no starting a change you have no way to deliver.`;
+## When repository access is unavailable
+A cloud run can start without repository content or GitHub credentials.
+- If the request does not need repository content, answer it and do not mention GitHub.
+- Codebase analysis, code review, and code changes require repository content.
+- If repository content is unavailable, do not replace the requested code work with generic guidance or PostHog data analysis.
+- State the access limit. Link the user to ${settingsUrl} to connect GitHub. Ask the user to send the request again.
+- If repository content is available but publishing credentials are not, complete read-only work. Request GitHub access before you change code.
+- Do not guess file contents. Do not start a change that you cannot deliver.`;
   }
 
   private buildCloudSystemPrompt(

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -4186,31 +4186,28 @@ ${unsupportedDeliverable}`;
 - If you created a local file but no upload or delivery tool is available, say that plainly and summarize the result in Slack instead.`;
   }
 
-  /**
-   * What to do when a cloud run has no way to reach the user's code.
-   *
-   * Repository access on a cloud run comes from the user's own GitHub connection in
-   * PostHog, so a run can legitimately start without one — nothing is checked out and
-   * there are no credentials to push with. The Slack mention path used to refuse those
-   * mentions outright, which walled off every question that only looked like it needed
-   * code; it now starts the run and leaves the judgement here, where the request itself
-   * is visible. The settings link is built from this run's own host and project so it
-   * lands the user in the right region rather than a hardcoded one.
-   *
-   * Appended to every cloud branch on purpose: a checkout is not proof of access. A
-   * public repository clones with no token at all, so a run can hold the code and still
-   * have no way to push it.
-   */
-  private buildSourceControlAccessInstructions(): string {
+  private buildGithubAccessInstructions(hasGithubToken: boolean): string {
+    if (hasGithubToken) {
+      return `
+## GitHub access
+You have GitHub access in this session.`;
+    }
+
     const settingsUrl = `${this.config.apiUrl.replace(/\/$/, "")}/project/${this.config.projectId}/settings/user-personal-integrations`;
     return `
-## When repository access is unavailable
-A cloud run can start without repository content or GitHub credentials.
-- If the request does not need repository content, answer it and do not mention GitHub.
-- Codebase analysis, code review, and code changes require repository content.
-- If repository content is unavailable, do not replace the requested code work with generic guidance or PostHog data analysis.
-- State the access limit. Link the user to ${settingsUrl} to connect GitHub. Ask the user to send the request again.
-- If repository content is available but publishing credentials are not, complete read-only work. Request GitHub access before you change code.
+## GitHub access
+You do not have GitHub access in this session.
+- You can read repository content that is already in the workspace.
+- You can clone an exact public repository. Do not call \`list_repos\` without GitHub access.
+- Codebase analysis and code review require readable repository content.
+- Code changes also require publishing access.
+- If the required access is unavailable, do not replace the requested code work with generic guidance or PostHog data analysis.
+- Tell the user to connect GitHub at ${settingsUrl}.
+- The connection applies to a new task, not this task.
+- Write the access explanation first.
+- Then call \`show_actions\` with one \`compose\` action.
+- Use the label \`Try again in a new task\` and prefill the original repository request.
+- Include the exact \`owner/repo\` in the action when you know it.
 - Do not guess file contents. Do not start a change that you cannot deliver.`;
   }
 
@@ -4352,7 +4349,7 @@ Optimize for the fewest shell round trips.
 When you create a non-code file the user should be able to download (such as a report, chart, image, archive, or data file), call the \`upload_artifact\` tool with its path before your final reply. In your final reply, link to the download URL returned by the tool—never link to the file's local workspace path. Files left in the workspace don't reach the user. Don't upload source code or repository changes—those belong in a commit or PR.`;
 
     // Closes out every branch below, so a new section is added once rather than five times.
-    const commonInstructions = `${signedCommitInstructions}${stackInstructions}${prLinkInstructions}${shellEfficiencyInstructions}${artifactInstructions}${this.buildSlackDeliveryInstructions()}${this.buildSourceControlAccessInstructions()}`;
+    const commonInstructions = `${signedCommitInstructions}${stackInstructions}${prLinkInstructions}${shellEfficiencyInstructions}${artifactInstructions}${this.buildSlackDeliveryInstructions()}${this.buildGithubAccessInstructions(hasGithubToken)}`;
 
     const whyContextInstruction = `   - Add a brief **Why** to the body — one or two sentences capturing the reason the user asked for this change (the motivation, not a restatement of the diff). Keep it short.`;
     const publicRepoSafetyInstruction = `   - **Public-repo safety.** Treat the target repository as public-readable unless you have verified otherwise. The PR title, description, and commit messages must not contain private operational scale (exact event counts, internal row volumes, customer-usage percentages), customer names / emails / companies, references to internal tickets or incidents, the contents of Slack threads (do not quote or paraphrase what was said), or unreleased roadmap details. Linking to the originating Slack thread is fine and encouraged — Slack links are auth-gated and useful as context — as are channel references like "raised in #team-foo". Describe findings qualitatively ("present on nearly all X events, absent from Y") rather than with quantitative figures pulled from analytics queries — the reasoning that uses those numbers can stay in the thread; the PR copy cannot.`;


### PR DESCRIPTION
## Problem

Cloud tasks can replace a requested codebase analysis with a different analysis when GitHub access is unavailable.

The prompt described access as uncertain and asked users to retry inside the same task.

## Changes

- The prompt now states whether GitHub access is available.
- Without access, the agent distinguishes existing workspace content and exact public repositories from private repository access.
- The agent links GitHub settings and opens a new task composer with the original request.
- The agent does not substitute generic guidance or product data analysis for requested code work.

## How did you test this code?

- Prompt regression tests cover available and unavailable GitHub access.
- Desktop type checks, Biome, and CI preflight passed.
- The complete agent suite has three local failures in unrelated execution-mode and JSONL hydration tests.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not needed. This change only updates internal agent instructions.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The PostHog Desktop agent used repository tools and PostHog MCP trace tools.

Skills: `/posthog-desktop`, `/exploring-llm-traces`, `/querying-posthog-data`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, `/running-ci-preflight`, and `/writing-simplified-technical-english`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
