### PR TITLE
fix(temporal): bound dlq-replay partition fan-out

### DIFF
--- a/posthog/temporal/dlq_replay/workflow.py
+++ b/posthog/temporal/dlq_replay/workflow.py
@@ -2,6 +2,7 @@ import json
 import asyncio
 import datetime as dt
 import dataclasses
+from collections.abc import Awaitable
 
 from temporalio import workflow
 from temporalio.common import RetryPolicy
@@ -29,6 +30,8 @@ class DLQReplayWorkflowInputs:
         end_timestamp: ISO format datetime string for the end of the replay window.
             If None, defaults to current UTC time when the workflow starts.
         batch_size: Number of messages to process in each batch.
+        max_concurrent_partitions: Maximum number of partition replays to run at once.
+            Bounds the fan-out so a wide DLQ does not overload the shared worker fleet.
     """
 
     source_topic: str
@@ -36,6 +39,7 @@ class DLQReplayWorkflowInputs:
     start_timestamp: str
     end_timestamp: str | None = None
     batch_size: int = 1000
+    max_concurrent_partitions: int = 8
 
 
 @dataclasses.dataclass
@@ -96,10 +100,10 @@ class DLQReplayWorkflow(PostHogWorkflow):
         if not partitions:
             return DLQReplayWorkflowResult(total_messages_replayed=0, partition_results={})
 
-        # Step 2: Replay each partition in parallel
-        partition_tasks = []
-        for partition in partitions:
-            task = workflow.execute_activity(
+        # Step 2: Replay partitions. Bound how many run at once so a wide DLQ does not
+        # burst the shared worker fleet and starve activity heartbeats.
+        def schedule_partition(partition: int) -> Awaitable[ReplayPartitionResult]:
+            return workflow.execute_activity(
                 replay_partition,
                 ReplayPartitionInputs(
                     source_topic=inputs.source_topic,
@@ -117,10 +121,15 @@ class DLQReplayWorkflow(PostHogWorkflow):
                     maximum_attempts=3,
                 ),
             )
-            partition_tasks.append(task)
 
-        # Wait for all partition replays to complete
-        results: list[ReplayPartitionResult] = await asyncio.gather(*partition_tasks)
+        results: list[ReplayPartitionResult] = []
+        if workflow.patched("dlq-replay-bounded-fanout"):
+            max_concurrent = max(1, inputs.max_concurrent_partitions)
+            for start in range(0, len(partitions), max_concurrent):
+                chunk = partitions[start : start + max_concurrent]
+                results.extend(await asyncio.gather(*[schedule_partition(partition) for partition in chunk]))
+        else:
+            results = await asyncio.gather(*[schedule_partition(partition) for partition in partitions])
 
         # Step 3: Aggregate results
         total_messages_replayed = 0

--- a/posthog/temporal/tests/dlq_replay/test_workflow.py
+++ b/posthog/temporal/tests/dlq_replay/test_workflow.py
@@ -27,15 +27,16 @@ def activity_call_tracker():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "partition_count,expected_replay_calls",
+    "partition_count,expected_replay_calls,max_concurrent_partitions",
     [
-        pytest.param(1, 1, id="single_partition"),
-        pytest.param(3, 3, id="multiple_partitions"),
-        pytest.param(10, 10, id="many_partitions"),
+        pytest.param(1, 1, 8, id="single_partition"),
+        pytest.param(3, 3, 8, id="multiple_partitions"),
+        pytest.param(10, 10, 8, id="many_partitions"),
+        pytest.param(10, 10, 3, id="bounded_concurrency_multiple_chunks"),
     ],
 )
 async def test_dlq_replay_workflow_processes_all_partitions(
-    activity_call_tracker, partition_count, expected_replay_calls
+    activity_call_tracker, partition_count, expected_replay_calls, max_concurrent_partitions
 ):
     """Verify the workflow discovers partitions and replays each one."""
     get_partitions_calls = activity_call_tracker["get_partitions_calls"]
@@ -74,6 +75,7 @@ async def test_dlq_replay_workflow_processes_all_partitions(
                     start_timestamp=start_time.isoformat(),
                     end_timestamp=end_time.isoformat(),
                     batch_size=500,
+                    max_concurrent_partitions=max_concurrent_partitions,
                 ),
                 id=str(uuid.uuid4()),
                 task_queue=task_queue_name,


### PR DESCRIPTION
## Problem

The `dlq-replay` workflow schedules one activity per partition and starts them all at once (`asyncio.gather` over every partition). On a wide DLQ that lands a burst of Kafka-heavy activities on the shared `general-purpose` worker fleet at the same moment, saturating each pod's single asyncio event loop and starving the 1-second heartbeat — the heartbeat timeouts seen on the traces replay.

Raising the heartbeat timeout (the base PR in this stack) buys headroom but does not stop the burst. This PR removes the burst.

## Changes

- The workflow now replays partitions in bounded chunks instead of all at once, so at most `max_concurrent_partitions` replay activities run concurrently.
- Adds `max_concurrent_partitions` to the workflow input, default 8. An operator can raise it for more throughput or lower it to be gentler on the fleet.
- The change is gated behind `workflow.patched("dlq-replay-bounded-fanout")`. In-flight pre-patch executions keep the old all-at-once path; new executions take the bounded path. This keeps replay deterministic across the deploy.

## How did you test this code?

Author is an agent (PostHog Desktop). Ran the workflow suite: `hogli test posthog/temporal/tests/dlq_replay/test_workflow.py` (8 passed). Ran `uv run mypy` on the workflow file (clean) and `hogli ci:preflight` (lint, format, complexity, size pass).

Extended the existing `test_dlq_replay_workflow_processes_all_partitions` with a `bounded_concurrency_multiple_chunks` case (10 partitions, `max_concurrent_partitions=3`). It catches a chunk-boundary regression: an off-by-one in the range slicing would drop partitions and silently under-replay, which no prior case exercised because they all fit in a single chunk.

Not run: an end-to-end replay against a live cluster.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Desktop (Claude). Skills invoked: `/writing-tests`.
Stacked on the heartbeat-timeout PR because both touch the same fan-out block; the timeout raise is the quick unblock and this is the robust follow-up.
The determinism gate follows the repo rule in `.claude/rules/temporal-workflow-versioning.md`: reordering `execute_activity` commands breaks in-flight replay, so the new path is behind `workflow.patched()` with the old path kept in the `else`.
