### PR TITLE
feat(cdp): create pg_stat_statements extension on the cyclotron database

### DIFF
--- a/rust/cyclotron-node-migrations/20260903000001_create_pg_stat_statements.sql
+++ b/rust/cyclotron-node-migrations/20260903000001_create_pg_stat_statements.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;


### PR DESCRIPTION
## Problem

The cyclotron database is being added to pganalyze for query monitoring, but the `pg_stat_statements` extension is not created on it, so the collector would connect and report no query stats.

## Changes

- Adds a cyclotron migration that runs `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`.
- The migration is a no-op where the extension already exists, and safe where the library is not preloaded (local dev, CI) - `CREATE EXTENSION` does not require it.
- Nothing user-visible changes.

Companion infra PR that adds the pganalyze monitoring user: PostHog/posthog-cloud-infra#10225.

## How did you test this code?

Not run against a live database. The statement is standard Postgres, transactional, and takes no locks on user tables; the sqlx migration runner applies it like any other migration in this directory.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Skills invoked: /writing-pr-descriptions. The alternative considered was creating the extension manually via psql per cluster; a migration was chosen so all environments get it through the existing sqlx-migrations deploy.
