### PR TITLE
feat(ai): report conversation, product, and PostHog AI credits for /usage

### DIFF
--- a/ee/api/quota_limits.py
+++ b/ee/api/quota_limits.py
@@ -20,7 +20,12 @@ from rest_framework.response import Response
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.constants import AvailableFeature
 
-from ee.billing.quota_limiting import INFORMATIONAL_USAGE_RESOURCES, QuotaResource, get_fresh_team_limited_resources
+from ee.billing.quota_limiting import (
+    INFORMATIONAL_USAGE_RESOURCES,
+    QuotaResource,
+    get_fresh_team_limited_resources,
+    resource_usage,
+)
 
 
 class QuotaResourceLimitSerializer(serializers.Serializer):
@@ -43,22 +48,6 @@ class QuotaResourceLimitSerializer(serializers.Serializer):
         allow_null=True,
         help_text="The organization's limit for this resource in the same unit. Null when unlimited or unknown.",
     )
-
-
-def _resource_usage(summary: dict[str, Any]) -> float | None:
-    """usage + todays_usage, the sum the quota limiter compares against the limit.
-
-    None rather than 0 when billing has never synced the resource, so clients read
-    it as unknown, not "$0 spent". The `limited` boolean stays authoritative for
-    gating; grace periods and refund offsets live only in that limiting decision.
-    """
-    if not summary:
-        return None
-    usage = summary.get("usage")
-    todays_usage = summary.get("todays_usage")
-    if usage is None and todays_usage is None:
-        return None
-    return (usage or 0) + (todays_usage or 0)
 
 
 class QuotaLimitsResponseSerializer(serializers.Serializer):
@@ -120,13 +109,13 @@ class QuotaLimitsViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
             summary = org_usage.get(resource.value) or {}
             limited[resource.value] = {
                 "limited": limited_resources[resource],
-                "usage": _resource_usage(summary),
+                "usage": resource_usage(summary),
                 "limit": summary.get("limit"),
             }
         for field in INFORMATIONAL_USAGE_RESOURCES:
             limited[field] = {
                 "limited": False,
-                "usage": _resource_usage(org_usage.get(field) or {}),
+                "usage": resource_usage(org_usage.get(field) or {}),
                 "limit": None,
             }
         data = QuotaLimitsResponseSerializer(

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -167,6 +167,29 @@ INFORMATIONAL_USAGE_RESOURCES = (
     "sandbox_compute_cpu_millicore_seconds",
     "sandbox_compute_memory_mib_seconds",
 )
+
+
+def resource_usage(summary: Mapping[str, Any] | None) -> float | None:
+    """usage + todays_usage, the sum the quota limiter compares against the limit.
+
+    None rather than 0 when billing has never synced the resource, so clients read
+    it as unknown, not "$0 spent". The `limited` boolean stays authoritative for
+    gating; grace periods and refund offsets live only in that limiting decision.
+    """
+    if not summary:
+        return None
+    usage = summary.get("usage")
+    todays_usage = summary.get("todays_usage")
+    if usage is None and todays_usage is None:
+        return None
+    return (usage or 0) + (todays_usage or 0)
+
+
+def organization_resource_usage(organization: Organization, resource: QuotaResource) -> float | None:
+    """What the organization has spent of one resource this billing period."""
+    return resource_usage((organization.usage or {}).get(resource.value))
+
+
 # -------------------------------------------------------------------------------------------------
 # REDIS FUNCTIONS
 # -------------------------------------------------------------------------------------------------

--- a/ee/hogai/chat_agent/slash_commands/commands/usage/command.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/usage/command.py
@@ -1,8 +1,5 @@
-from uuid import uuid4
+from uuid import UUID, uuid4
 
-from django.utils import timezone
-
-from asgiref.sync import sync_to_async
 from langchain_core.runnables import RunnableConfig
 from posthoganalytics import capture_exception
 
@@ -10,15 +7,9 @@ from posthog.schema import AssistantMessage
 
 from posthog.sync import database_sync_to_async
 
+from products.posthog_ai.backend.services.usage.report import build_usage_report
+
 from ee.hogai.chat_agent.slash_commands.commands import SlashCommand
-from ee.hogai.chat_agent.slash_commands.commands.usage.queries import (
-    format_usage_message,
-    get_ai_credits_for_conversation,
-    get_ai_credits_for_team,
-    get_ai_free_tier_credits,
-    get_ai_usage_period,
-    get_conversation_start_time,
-)
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
 
 
@@ -36,44 +27,15 @@ class UsageCommand(SlashCommand):
                     messages=[AssistantMessage(content="Unable to retrieve conversation information.", id=str(uuid4()))]
                 )
 
-            conversation_start = await database_sync_to_async(get_conversation_start_time)(conversation_id)
-            if not conversation_start:
-                return PartialAssistantState(
-                    messages=[AssistantMessage(content="Unable to retrieve conversation start time.", id=str(uuid4()))]
-                )
-
-            usage_period = await database_sync_to_async(get_ai_usage_period)(
-                self._team, config.get("configurable", {}).get("billing_context")
+            # The report reads Postgres and ClickHouse, so it runs in a worker thread; on the event
+            # loop the ORM reads raise SynchronousOnlyOperation.
+            report = await database_sync_to_async(build_usage_report, thread_sensitive=False)(
+                self._team,
+                conversation_id=UUID(str(conversation_id)),
+                billing_context=config.get("configurable", {}).get("billing_context"),
             )
 
-            conversation_credits = await sync_to_async(get_ai_credits_for_conversation, thread_sensitive=False)(
-                team_id=self._team.id,
-                conversation_id=conversation_id,
-                begin=conversation_start,
-                end=timezone.now(),
-            )
-
-            period_credits = (
-                await sync_to_async(get_ai_credits_for_team, thread_sensitive=False)(
-                    team_id=self._team.id,
-                    begin=usage_period.query_start,
-                    end=usage_period.end,
-                )
-                if usage_period.query_start < usage_period.end
-                else 0
-            )
-
-            free_tier_credits = get_ai_free_tier_credits(self._team.id)
-
-            usage_message = format_usage_message(
-                conversation_credits=conversation_credits,
-                period_credits=period_credits,
-                free_tier_credits=free_tier_credits,
-                conversation_start=conversation_start,
-                usage_period=usage_period,
-            )
-
-            return PartialAssistantState(messages=[AssistantMessage(content=usage_message, id=str(uuid4()))])
+            return PartialAssistantState(messages=[AssistantMessage(content=report.message, id=str(uuid4()))])
 
         except Exception as e:
             capture_exception(e)

--- a/ee/hogai/chat_agent/slash_commands/commands/usage/test/test_usage.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/usage/test/test_usage.py
@@ -1,7 +1,6 @@
 import asyncio
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import cast
-from uuid import uuid4
 
 from posthog.test.base import BaseTest
 from unittest.mock import patch
@@ -10,283 +9,19 @@ from django.core.exceptions import SynchronousOnlyOperation
 
 from asgiref.sync import async_to_sync
 from langchain_core.runnables import RunnableConfig
-from parameterized import parameterized
 
 from posthog.schema import AssistantMessage, HumanMessage
 
 from products.posthog_ai.backend.models.assistant import Conversation
+from products.posthog_ai.backend.services.usage.credits import AiUsagePeriod
 
 from ee.hogai.chat_agent.slash_commands.commands.usage.command import UsageCommand
-from ee.hogai.chat_agent.slash_commands.commands.usage.queries import (
-    CLOUD_REGION_TO_TEAM_ID,
-    CLOUD_REGION_TO_URL,
-    DEFAULT_FREE_TIER_CREDITS,
-    DEFAULT_GA_LAUNCH_DATE,
-    POSTHOG_AI_PRODUCTS,
-    AiUsagePeriod,
-    format_usage_message,
-    get_ai_credits,
-    get_ai_free_tier_credits,
-    get_ai_usage_period,
-    get_conversation_start_time,
-    get_ga_launch_date,
-    get_past_month_start,
-)
 from ee.hogai.utils.types import AssistantState
 
+REPORT_MODULE = "products.posthog_ai.backend.services.usage.report"
 
-class TestUsage(BaseTest):
-    @patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.posthoganalytics.get_feature_flag_payload")
-    @patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.get_instance_region")
-    def test_get_ai_free_tier_credits_default(self, mock_region, mock_payload):
-        """Test that teams without custom limits get the default free tier."""
-        mock_region.return_value = "EU"
-        mock_payload.return_value = None
-        credits = get_ai_free_tier_credits(team_id=999)
-        self.assertEqual(credits, DEFAULT_FREE_TIER_CREDITS)
 
-    @patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.posthoganalytics.get_feature_flag_payload")
-    @patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.get_instance_region")
-    def test_get_ai_free_tier_credits_custom_eu(self, mock_region, mock_payload):
-        """Test that EU internal team gets custom free tier limit from feature flag."""
-        mock_region.return_value = "EU"
-        mock_payload.return_value = {"EU": {"1": 9999999}, "US": {"2": 9999999}}
-        credits = get_ai_free_tier_credits(team_id=1)
-        self.assertEqual(credits, 9999999)
-
-    @patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.posthoganalytics.get_feature_flag_payload")
-    @patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.get_instance_region")
-    def test_get_ai_free_tier_credits_custom_us(self, mock_region, mock_payload):
-        """Test that US internal team gets custom free tier limit from feature flag."""
-        mock_region.return_value = "US"
-        mock_payload.return_value = {"EU": {"1": 9999999}, "US": {"2": 9999999}}
-        credits = get_ai_free_tier_credits(team_id=2)
-        self.assertEqual(credits, 9999999)
-
-    @patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.posthoganalytics.get_feature_flag_payload")
-    @patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.get_instance_region")
-    def test_get_ai_free_tier_credits_fallback_when_region_unknown(self, mock_region, mock_payload):
-        """Test that unknown regions fall back to default."""
-        mock_region.return_value = None
-        mock_payload.return_value = {"EU": {"1": 9999999}}
-        credits = get_ai_free_tier_credits(team_id=1)
-        self.assertEqual(credits, DEFAULT_FREE_TIER_CREDITS)
-
-    @patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.posthoganalytics.get_feature_flag_payload")
-    @patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.get_instance_region")
-    def test_get_ai_free_tier_credits_team_not_in_payload(self, mock_region, mock_payload):
-        """Test that teams not in the payload get default credits."""
-        mock_region.return_value = "EU"
-        mock_payload.return_value = {"EU": {"1": 9999999}}
-        credits = get_ai_free_tier_credits(team_id=999)
-        self.assertEqual(credits, DEFAULT_FREE_TIER_CREDITS)
-
-    @patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.posthoganalytics.get_feature_flag_payload")
-    @patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.get_instance_region")
-    def test_get_ai_free_tier_credits_invalid_payload(self, mock_region, mock_payload):
-        """Test that invalid payloads fall back to default."""
-        mock_region.return_value = "EU"
-        mock_payload.return_value = "invalid"
-        credits = get_ai_free_tier_credits(team_id=1)
-        self.assertEqual(credits, DEFAULT_FREE_TIER_CREDITS)
-
-    @parameterized.expand(
-        [
-            ("eu_cloud", "EU", CLOUD_REGION_TO_TEAM_ID["EU"], CLOUD_REGION_TO_URL["EU"], 2),
-            ("us_cloud", "US", CLOUD_REGION_TO_TEAM_ID["US"], CLOUD_REGION_TO_URL["US"], 1),
-            ("local_dev", None, CLOUD_REGION_TO_TEAM_ID["EU"], None, None),
-        ]
-    )
-    def test_get_ai_credits_scopes_ai_events_query(
-        self,
-        _name,
-        region,
-        expected_team_to_query,
-        expected_region_url,
-        instance_group_index,
-    ):
-        begin = datetime(2026, 5, 1, tzinfo=UTC)
-        end = datetime(2026, 5, 2, tzinfo=UTC)
-        conversation_id = uuid4()
-
-        with (
-            patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.get_instance_region") as mock_region,
-            patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.sync_execute") as mock_sync_execute,
-            patch(
-                "ee.hogai.chat_agent.slash_commands.commands.usage.queries.build_ai_billing_region_filter"
-            ) as mock_region_filter,
-        ):
-            mock_region.return_value = region
-            mock_sync_execute.return_value = [(42,)]
-            if expected_region_url is not None:
-                mock_region_filter.return_value = {
-                    "region_group_property": f"$group_{instance_group_index}",
-                    "region_url": expected_region_url,
-                }
-
-            credits = get_ai_credits(team_id=133393, begin=begin, end=end, conversation_id=conversation_id)
-
-            self.assertEqual(credits, 42)
-            query, params = mock_sync_execute.call_args[0][:2]
-            self.assertEqual(params["team_to_query"], expected_team_to_query)
-            self.assertEqual(params["session_id"], str(conversation_id))
-            # Only PostHog AI bucket products count — posthog_code bills separately.
-            self.assertIn("AND JSONExtractString(properties, 'ai_product') IN %(ai_products)s", query)
-            self.assertEqual(params["ai_products"], tuple(POSTHOG_AI_PRODUCTS))
-            if expected_region_url is None:
-                self.assertNotIn("region_url", params)
-                self.assertNotIn("%(region_url)s", query)
-                mock_region_filter.assert_not_called()
-            else:
-                self.assertEqual(params["region_url"], expected_region_url)
-                self.assertEqual(params["region_group_property"], f"$group_{instance_group_index}")
-                mock_region_filter.assert_called_once_with(expected_team_to_query, expected_region_url)
-                self.assertIn(
-                    "AND JSONExtractString(properties, %(region_group_property)s) = %(region_url)s",
-                    query,
-                )
-
-    def test_get_ai_credits_returns_zero_when_instance_group_missing(self):
-        begin = datetime(2026, 5, 1, tzinfo=UTC)
-        end = datetime(2026, 5, 2, tzinfo=UTC)
-        conversation_id = uuid4()
-
-        with (
-            patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.get_instance_region") as mock_region,
-            patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.sync_execute") as mock_sync_execute,
-            patch(
-                "ee.hogai.chat_agent.slash_commands.commands.usage.queries.build_ai_billing_region_filter",
-                return_value=None,
-            ),
-        ):
-            mock_region.return_value = "EU"
-
-            credits = get_ai_credits(team_id=133393, begin=begin, end=end, conversation_id=conversation_id)
-
-            self.assertEqual(credits, 0)
-            mock_sync_execute.assert_not_called()
-
-    def test_get_conversation_start_time_exists(self):
-        """Test retrieving conversation start time for existing conversation."""
-        conversation = Conversation.objects.create(
-            team=self.team,
-            user=self.user,
-        )
-        start_time = get_conversation_start_time(conversation.id)
-        self.assertIsNotNone(start_time)
-        self.assertEqual(
-            cast(datetime, start_time).replace(microsecond=0),
-            cast(datetime, conversation.created_at).replace(microsecond=0),
-        )
-
-    def test_get_conversation_start_time_not_exists(self):
-        """Test that non-existent conversation returns None."""
-        start_time = get_conversation_start_time(uuid4())
-        self.assertIsNone(start_time)
-
-    @patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.posthoganalytics.get_feature_flag_payload")
-    def test_get_ga_launch_date_from_payload(self, mock_payload):
-        """Test that GA launch date is fetched from feature flag payload."""
-        mock_payload.return_value = {"ga_launch_date": "2025-12-01", "EU": {"1": 10000}}
-        ga_date = get_ga_launch_date()
-        self.assertEqual(ga_date, datetime(2025, 12, 1, tzinfo=UTC))
-
-    @patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.posthoganalytics.get_feature_flag_payload")
-    def test_get_ga_launch_date_fallback(self, mock_payload):
-        """Test that GA launch date falls back to default when not in payload."""
-        mock_payload.return_value = None
-        ga_date = get_ga_launch_date()
-        self.assertEqual(ga_date, DEFAULT_GA_LAUNCH_DATE)
-
-    @patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.posthoganalytics.get_feature_flag_payload")
-    def test_get_ga_launch_date_invalid_format(self, mock_payload):
-        """Test that invalid date format falls back to default."""
-        mock_payload.return_value = {"ga_launch_date": "invalid-date"}
-        ga_date = get_ga_launch_date()
-        self.assertEqual(ga_date, DEFAULT_GA_LAUNCH_DATE)
-
-    def test_get_past_month_start_normal(self):
-        """Test past month start when 30 days ago is after GA launch."""
-        now = datetime(2025, 12, 20, tzinfo=UTC)
-        with patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.datetime") as mock_datetime:
-            mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
-            mock_datetime.now.return_value = now
-            past_month_start = get_past_month_start()
-            expected = datetime(2025, 11, 20, tzinfo=UTC)
-            self.assertEqual(past_month_start, expected)
-
-    @patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.posthoganalytics.get_feature_flag_payload")
-    def test_get_past_month_start_capped_at_ga_launch(self, mock_payload):
-        """Test that past month start is capped at GA launch date."""
-        mock_payload.return_value = None
-        now = DEFAULT_GA_LAUNCH_DATE + timedelta(days=10)
-        with patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.datetime") as mock_datetime:
-            mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
-            mock_datetime.now.return_value = now
-            past_month_start = get_past_month_start()
-            self.assertEqual(past_month_start, DEFAULT_GA_LAUNCH_DATE)
-
-    def test_get_ai_usage_period_from_billing_context(self):
-        billing_context = {
-            "billing_period": {
-                "current_period_start": "2026-05-02T14:51:12Z",
-                "current_period_end": "2026-06-02T14:51:12Z",
-                "interval": "month",
-            },
-            "billing_plan": "paid",
-            "has_active_subscription": True,
-            "is_deactivated": False,
-            "products": [],
-            "settings": {"autocapture_on": True, "active_destinations": 0},
-            "subscription_level": "paid",
-        }
-
-        usage_period = get_ai_usage_period(self.team, billing_context)
-
-        self.assertEqual(usage_period.label, "Billing period")
-        self.assertEqual(usage_period.start, datetime(2026, 5, 2, 14, 51, 12, tzinfo=UTC))
-        self.assertEqual(usage_period.end, datetime(2026, 6, 2, 14, 51, 12, tzinfo=UTC))
-        self.assertEqual(usage_period.query_start, datetime(2026, 5, 2, 14, 51, 12, tzinfo=UTC))
-
-    def test_get_ai_usage_period_from_organization_usage(self):
-        self.organization.usage = {
-            "period": ["2026-05-02T14:51:12Z", "2026-06-02T14:51:12Z"],
-        }
-
-        usage_period = get_ai_usage_period(self.team, None)
-
-        self.assertEqual(usage_period.label, "Billing period")
-        self.assertEqual(usage_period.start, datetime(2026, 5, 2, 14, 51, 12, tzinfo=UTC))
-        self.assertEqual(usage_period.end, datetime(2026, 6, 2, 14, 51, 12, tzinfo=UTC))
-        self.assertEqual(usage_period.query_start, datetime(2026, 5, 2, 14, 51, 12, tzinfo=UTC))
-
-    @patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.posthoganalytics.get_feature_flag_payload")
-    def test_get_ai_usage_period_caps_query_start_at_ga_launch(self, mock_payload):
-        mock_payload.return_value = None
-        self.organization.usage = {
-            "period": ["2025-11-01T00:00:00Z", "2025-12-01T00:00:00Z"],
-        }
-
-        usage_period = get_ai_usage_period(self.team, None)
-
-        self.assertEqual(usage_period.label, "Billing period")
-        self.assertEqual(usage_period.start, datetime(2025, 11, 1, tzinfo=UTC))
-        self.assertEqual(usage_period.end, datetime(2025, 12, 1, tzinfo=UTC))
-        self.assertEqual(usage_period.query_start, DEFAULT_GA_LAUNCH_DATE)
-
-    def test_get_ai_usage_period_falls_back_to_past_month(self):
-        now = datetime(2025, 12, 20, tzinfo=UTC)
-        with patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.datetime") as mock_datetime:
-            mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
-            mock_datetime.now.return_value = now
-
-            usage_period = get_ai_usage_period(self.team, None)
-
-        self.assertEqual(usage_period.label, "Past 30 days")
-        self.assertEqual(usage_period.start, datetime(2025, 11, 20, tzinfo=UTC))
-        self.assertEqual(usage_period.end, now)
-        self.assertEqual(usage_period.query_start, datetime(2025, 11, 20, tzinfo=UTC))
-
+class TestUsageCommand(BaseTest):
     def test_execute_runs_usage_period_off_event_loop(self):
         # Without a billing context, get_ai_usage_period falls back to team.organization.usage, a sync
         # ORM access. It must run off the event loop or Django raises SynchronousOnlyOperation, which the
@@ -311,22 +46,10 @@ class TestUsage(BaseTest):
             )
 
         with (
-            patch(
-                "ee.hogai.chat_agent.slash_commands.commands.usage.command.get_ai_usage_period",
-                side_effect=usage_period_guarded,
-            ),
-            patch(
-                "ee.hogai.chat_agent.slash_commands.commands.usage.command.get_ai_credits_for_conversation",
-                return_value=10,
-            ),
-            patch(
-                "ee.hogai.chat_agent.slash_commands.commands.usage.command.get_ai_credits_for_team",
-                return_value=100,
-            ),
-            patch(
-                "ee.hogai.chat_agent.slash_commands.commands.usage.command.get_ai_free_tier_credits",
-                return_value=2000,
-            ),
+            patch(f"{REPORT_MODULE}.get_ai_usage_period", side_effect=usage_period_guarded),
+            patch(f"{REPORT_MODULE}.get_ai_credits_for_conversation", return_value=10),
+            patch(f"{REPORT_MODULE}.get_ai_credits_for_team", return_value=100),
+            patch(f"{REPORT_MODULE}.get_ai_free_tier_credits", return_value=2000),
         ):
             result = async_to_sync(UsageCommand(self.team, self.user).execute)(config, state)
 
@@ -334,109 +57,5 @@ class TestUsage(BaseTest):
         assert isinstance(message, AssistantMessage)
         content = cast(str, message.content)
         self.assertIn("PostHog AI usage", content)
+        self.assertIn("**Current conversation**: 10 credits", content)
         self.assertNotIn("query failed", content)
-
-    def test_format_usage_message_no_usage(self):
-        """Test formatting when no credits have been used."""
-        message = format_usage_message(
-            conversation_credits=0,
-            period_credits=0,
-            free_tier_credits=2000,
-            usage_period=AiUsagePeriod(
-                label="Billing period",
-                start=datetime(2026, 5, 2, 14, 51, 12, tzinfo=UTC),
-                end=datetime(2026, 6, 2, 14, 51, 12, tzinfo=UTC),
-                query_start=datetime(2026, 5, 2, 14, 51, 12, tzinfo=UTC),
-            ),
-        )
-        self.assertIn("**Current conversation**: 0 credits", message)
-        self.assertIn("**Billing period** (2026-05-02 to 2026-06-02): 0 credits", message)
-        self.assertIn("**Free tier limit**: 2,000 credits", message)
-        self.assertIn("**Remaining**: 2,000 credits", message)
-        self.assertIn("0% of free tier", message)
-        self.assertIn("_Billing period resets on_: 2026-06-02 14:51 UTC", message)
-
-    def test_format_usage_message_partial_usage(self):
-        """Test formatting with partial usage."""
-        message = format_usage_message(
-            conversation_credits=50,
-            period_credits=500,
-            free_tier_credits=2000,
-            usage_period=AiUsagePeriod(
-                label="Billing period",
-                start=datetime(2026, 5, 2, tzinfo=UTC),
-                end=datetime(2026, 6, 2, tzinfo=UTC),
-                query_start=datetime(2026, 5, 2, tzinfo=UTC),
-            ),
-        )
-        self.assertIn("**Current conversation**: 50 credits", message)
-        self.assertIn("**Billing period** (2026-05-02 to 2026-06-02): 500 credits", message)
-        self.assertIn("**Remaining**: 1,500 credits", message)
-        self.assertIn("25% of free tier", message)
-
-    def test_format_usage_message_over_limit(self):
-        """Test formatting when over the free tier limit."""
-        message = format_usage_message(
-            conversation_credits=100,
-            period_credits=2500,
-            free_tier_credits=2000,
-            usage_period=AiUsagePeriod(
-                label="Billing period",
-                start=datetime(2026, 5, 2, tzinfo=UTC),
-                end=datetime(2026, 6, 2, tzinfo=UTC),
-                query_start=datetime(2026, 5, 2, tzinfo=UTC),
-            ),
-        )
-        self.assertIn("**Overage**: 500 credits over limit", message)
-        self.assertIn("125% of free tier", message)
-
-    @patch("ee.hogai.chat_agent.slash_commands.commands.usage.queries.posthoganalytics.get_feature_flag_payload")
-    def test_format_usage_message_with_ga_cap(self, mock_payload):
-        """Test formatting when GA cap is active."""
-        mock_payload.return_value = None
-        message = format_usage_message(
-            conversation_credits=10,
-            period_credits=100,
-            free_tier_credits=2000,
-            usage_period=AiUsagePeriod(
-                label="Billing period",
-                start=datetime(2025, 11, 1, tzinfo=UTC),
-                end=datetime(2025, 12, 1, tzinfo=UTC),
-                query_start=DEFAULT_GA_LAUNCH_DATE,
-            ),
-        )
-        self.assertIn(f"since {DEFAULT_GA_LAUNCH_DATE.strftime('%Y-%m-%d')}", message)
-        self.assertIn(
-            f"from PostHog AI general availability date ({DEFAULT_GA_LAUNCH_DATE.strftime('%b %d, %Y')})", message
-        )
-
-    def test_format_usage_message_with_conversation_start(self):
-        """Test formatting with conversation start time."""
-        conv_start = datetime(2025, 11, 18, 10, 30, tzinfo=UTC)
-        message = format_usage_message(
-            conversation_credits=25,
-            period_credits=200,
-            free_tier_credits=2000,
-            conversation_start=conv_start,
-        )
-        self.assertIn("_Conversation since_: 2025-11-18 10:30 UTC", message)
-
-    def test_format_usage_message_progress_bar(self):
-        """Test that progress bar is rendered correctly."""
-        message = format_usage_message(
-            conversation_credits=0,
-            period_credits=1000,
-            free_tier_credits=2000,
-        )
-        self.assertIn("█" * 10, message)
-        self.assertIn("░" * 10, message)
-
-    def test_format_usage_message_full_progress_bar(self):
-        """Test progress bar when at 100% usage."""
-        message = format_usage_message(
-            conversation_credits=0,
-            period_credits=2000,
-            free_tier_credits=2000,
-        )
-        self.assertIn("█" * 20, message)
-        self.assertNotIn("░", message)

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -517,6 +517,14 @@ class ClickHouseSustainedRateThrottle(PersonalApiKeyRateThrottle):
     rate = "1200/hour"
 
 
+class AIUsageRateThrottle(PersonalApiKeyRateThrottle):
+    # One AI usage report costs up to three ClickHouse scans over the whole billing period, so it
+    # gets a tighter budget than the general ClickHouse burst rate. A person asking `/usage` in a
+    # chat cannot approach this; an agent that asks in a loop is what it stops.
+    scope = "ai_usage"
+    rate = "30/minute"
+
+
 # copy_flags fans out to up to 50 target projects per call, creating a feature flag (and any
 # missing cohorts) in each one, a much heavier write than most endpoints, so it gets its own
 # tighter budget instead of the general per-project Burst/SustainedRateThrottle. It's a plain

--- a/products/posthog_ai/backend/api/__init__.py
+++ b/products/posthog_ai/backend/api/__init__.py
@@ -1,3 +1,4 @@
 from .mcp_tools import MCPToolsViewSet
+from .usage import AIUsageViewSet
 
-__all__ = ["MCPToolsViewSet"]
+__all__ = ["AIUsageViewSet", "MCPToolsViewSet"]

--- a/products/posthog_ai/backend/api/test_usage.py
+++ b/products/posthog_ai/backend/api/test_usage.py
@@ -1,0 +1,54 @@
+from uuid import uuid4
+
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from django.core.cache import cache
+
+from rest_framework import status
+
+from posthog.models import Organization, Team
+
+REPORT_MODULE = "products.posthog_ai.backend.services.usage.report"
+
+
+class TestAIUsageAPI(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        # The report is cached per team, so one test must not serve the next one's answer.
+        cache.clear()
+        self.organization.usage = {"period": ["2026-05-02T14:51:12Z", "2026-06-02T14:51:12Z"]}
+        self.organization.save()
+
+    def _get(self, query: str = ""):
+        with (
+            patch(f"{REPORT_MODULE}.get_ai_credits_for_team", return_value=800),
+            patch(f"{REPORT_MODULE}.get_ai_credits_for_conversation", return_value=12),
+            patch(f"{REPORT_MODULE}.get_ai_free_tier_credits", return_value=2000),
+            patch(f"{REPORT_MODULE}.get_ai_credits", return_value=250),
+        ):
+            return self.client.get(f"/api/projects/{self.team.id}/ai_usage/{query}")
+
+    def test_reports_conversation_product_and_team_credits(self):
+        response = self._get(f"?conversation_id={uuid4()}&product=slack_app")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["conversation_credits"], 12)
+        self.assertEqual(body["period_credits"], 800)
+        self.assertEqual(body["remaining_credits"], 1200)
+        self.assertEqual(body["product"], {"name": "Slack app", "credits": 250, "separate_bucket": False})
+        self.assertIn("**Slack app this billing period**: 250 credits", body["message"])
+
+    def test_rejects_a_conversation_id_that_is_not_a_uuid(self):
+        response = self._get("?conversation_id=not-a-uuid")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_cannot_read_another_organizations_project(self):
+        other_org = Organization.objects.create(name="Other Org")
+        other_team = Team.objects.create(organization=other_org, name="Other Team")
+
+        response = self.client.get(f"/api/projects/{other_team.id}/ai_usage/")
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/products/posthog_ai/backend/api/usage.py
+++ b/products/posthog_ai/backend/api/usage.py
@@ -6,10 +6,11 @@ numbers match what the Max chat shows for the same team.
 
 from typing import Any
 
-from drf_spectacular.utils import OpenApiResponse, extend_schema
+from drf_spectacular.utils import OpenApiResponse
 from rest_framework import serializers, viewsets
 from rest_framework.response import Response
 
+from posthog.api.documentation import PostHogAutoSchema
 from posthog.api.mixins import ValidatedRequest, validated_request
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.rate_limit import AIUsageRateThrottle, ClickHouseSustainedRateThrottle
@@ -110,10 +111,21 @@ def serialize_usage_report(report: UsageReport) -> dict[str, Any]:
     }
 
 
-@extend_schema(tags=["ai_usage"])
+class _SingletonSchema(PostHogAutoSchema):
+    """Prevents drf-spectacular from wrapping the ``list`` response in an array.
+
+    The report is one object per project, not a collection, and the schema is what an MCP client
+    reads to know the shape it will get.
+    """
+
+    def _is_list_view(self, serializer: object = None) -> bool:
+        return False
+
+
 class AIUsageViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     """Read-only view of a team's PostHog AI credit usage."""
 
+    schema = _SingletonSchema()
     scope_object = "project"
     required_scopes = ["project:read"]
     http_method_names = ["get", "head", "options"]

--- a/products/posthog_ai/backend/api/usage.py
+++ b/products/posthog_ai/backend/api/usage.py
@@ -1,0 +1,141 @@
+"""Report PostHog AI credit usage to the surfaces that offer a `/usage` command.
+
+A cloud agent and the Slack app answer the command from here rather than from a model call, so the
+numbers match what the Max chat shows for the same team.
+"""
+
+from typing import Any
+
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import serializers, viewsets
+from rest_framework.response import Response
+
+from posthog.api.mixins import ValidatedRequest, validated_request
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.rate_limit import AIUsageRateThrottle, ClickHouseSustainedRateThrottle
+
+from products.posthog_ai.backend.services.usage.report import UsageReport, build_usage_report
+
+
+class AIUsageQuerySerializer(serializers.Serializer):
+    conversation_id = serializers.UUIDField(
+        required=False,
+        help_text=(
+            "The conversation to report on, which is the `$ai_session_id` its generations carry: "
+            "the Max conversation for a chat, the task for an agent run. Omitted, the report covers "
+            "the team only."
+        ),
+    )
+    conversation_started_at = serializers.DateTimeField(
+        required=False,
+        help_text=(
+            "When the conversation started. Only a Max conversation can be looked up here, so a "
+            "caller that knows its own start time passes it; without one the reported period bounds "
+            "the search and a conversation older than the period is undercounted."
+        ),
+    )
+    product = serializers.CharField(
+        required=False,
+        help_text=(
+            "The `ai_product` of the calling surface, e.g. `slack_app` or `posthog_code`. Adds a row "
+            "for what that product alone spent. A product with no credit counter is reported as null."
+        ),
+    )
+
+
+class AIUsageProductSerializer(serializers.Serializer):
+    # `label` is taken by DRF's own field attribute, so the wire name is `name`.
+    name = serializers.CharField(help_text="What a person calls the product, e.g. `PostHog Desktop`.")
+    credits = serializers.IntegerField(help_text="Credits the product spent over the reported period.")
+    separate_bucket = serializers.BooleanField(
+        help_text=(
+            "True when the product bills against its own credit counter, so its credits are not part "
+            "of the PostHog AI total in this response."
+        )
+    )
+
+
+class AIUsageResponseSerializer(serializers.Serializer):
+    conversation_credits = serializers.IntegerField(
+        allow_null=True,
+        help_text="Credits spent in the requested conversation. Null when no conversation was requested.",
+    )
+    period_credits = serializers.IntegerField(
+        help_text="PostHog AI credits the team spent over the reported period, across every product."
+    )
+    free_tier_credits = serializers.IntegerField(help_text="The team's free tier limit in credits.")
+    remaining_credits = serializers.IntegerField(
+        help_text="Free tier credits left. Negative once the team is over the limit."
+    )
+    period_label = serializers.CharField(
+        help_text=(
+            "`Billing period`, or `Past 30 days` when billing has not told us the team's period. "
+            "Every credit figure in the response covers this period."
+        )
+    )
+    period_start = serializers.DateTimeField()
+    period_end = serializers.DateTimeField()
+    conversation_start = serializers.DateTimeField(
+        allow_null=True, help_text="When the conversation started, when that is known."
+    )
+    product = AIUsageProductSerializer(allow_null=True)
+    message = serializers.CharField(
+        help_text=(
+            "The whole report as Markdown, so every surface renders one wording. Clients that lay "
+            "the numbers out themselves read the fields above instead."
+        )
+    )
+
+
+def serialize_usage_report(report: UsageReport) -> dict[str, Any]:
+    return {
+        "conversation_credits": report.conversation_credits,
+        "period_credits": report.period_credits,
+        "free_tier_credits": report.free_tier_credits,
+        "remaining_credits": report.remaining_credits,
+        "period_label": report.usage_period.label,
+        "period_start": report.usage_period.start,
+        "period_end": report.usage_period.end,
+        "conversation_start": report.conversation_start,
+        "product": (
+            {
+                "name": report.product.label,
+                "credits": report.product.credits,
+                "separate_bucket": report.product.separate_bucket,
+            }
+            if report.product
+            else None
+        ),
+        "message": report.message,
+    }
+
+
+@extend_schema(tags=["ai_usage"])
+class AIUsageViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
+    """Read-only view of a team's PostHog AI credit usage."""
+
+    scope_object = "project"
+    required_scopes = ["project:read"]
+    http_method_names = ["get", "head", "options"]
+    # A cache miss costs up to three ClickHouse scans over the billing period, so this endpoint
+    # carries its own per-project budget rather than the general ClickHouse burst rate.
+    throttle_classes = [AIUsageRateThrottle, ClickHouseSustainedRateThrottle]
+
+    @validated_request(
+        query_serializer=AIUsageQuerySerializer,
+        responses={200: OpenApiResponse(response=AIUsageResponseSerializer, description="PostHog AI usage")},
+        summary="Get a team's PostHog AI usage",
+        description=(
+            "Return credits spent in one conversation, by the calling product, and across PostHog AI, "
+            "for the team's current billing period."
+        ),
+    )
+    def list(self, request: ValidatedRequest, **kwargs: Any) -> Response:
+        query = request.validated_query_data
+        report = build_usage_report(
+            self.team,
+            conversation_id=query.get("conversation_id"),
+            conversation_started_at=query.get("conversation_started_at"),
+            product=query.get("product"),
+        )
+        return Response(AIUsageResponseSerializer(serialize_usage_report(report)).data)

--- a/products/posthog_ai/backend/routes.py
+++ b/products/posthog_ai/backend/routes.py
@@ -1,6 +1,6 @@
 from posthog.api.routing import RouterRegistry
 
-from products.posthog_ai.backend.api import MCPToolsViewSet
+from products.posthog_ai.backend.api import AIUsageViewSet, MCPToolsViewSet
 
 
 def register_routes(routers: RouterRegistry) -> None:
@@ -8,5 +8,11 @@ def register_routes(routers: RouterRegistry) -> None:
         r"mcp_tools",
         MCPToolsViewSet,
         "project_mcp_tools",
+        ["team_id"],
+    )
+    routers.projects.register(
+        r"ai_usage",
+        AIUsageViewSet,
+        "project_ai_usage",
         ["team_id"],
     )

--- a/products/posthog_ai/backend/services/usage/credits.py
+++ b/products/posthog_ai/backend/services/usage/credits.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Optional
 from uuid import UUID
@@ -41,12 +41,25 @@ CH_BILLING_SETTINGS = {
 }
 
 
-@dataclass(frozen=True)
+@frozen
 class AiUsagePeriod:
     label: str
     start: datetime
     end: datetime
     query_start: datetime
+
+
+@frozen
+class ProductUsage:
+    """Credits one product spent over the reported period.
+
+    `separate_bucket` marks a product billed against its own credit counter rather than the
+    PostHog AI one, so the message can say the number sits outside the total above it.
+    """
+
+    label: str
+    credits: int
+    separate_bucket: bool
 
 
 def _get_billing_config_payload() -> dict | None:
@@ -141,9 +154,13 @@ def get_ai_credits(
     begin: datetime,
     end: datetime,
     conversation_id: Optional[UUID] = None,
+    ai_products: Sequence[str] = POSTHOG_AI_PRODUCTS,
 ) -> int:
     """
     Calculate AI credits used for a specific team (and optionally a specific conversation) in the given time period.
+
+    `ai_products` narrows the count to one of the products that roll into the PostHog AI credit
+    bucket, for a caller reporting what a single product spent.
     """
     # Depending on the region, events are stored in different teams
     # Default to EU (team_id 1) for local dev or unknown regions
@@ -281,7 +298,7 @@ def get_ai_credits(
             "end": end,
             "markup_multiplier": 1 + AI_COST_MARKUP_PERCENT,
             "excluded_tools": AI_BILLING_EXCLUDED_TOOLS,
-            "ai_products": tuple(POSTHOG_AI_PRODUCTS),
+            "ai_products": tuple(ai_products),
             **region_filter_params,
         }
 
@@ -401,11 +418,12 @@ def get_ai_usage_period(team: "Team", billing_context: MaxBillingContext | dict[
 
 
 def format_usage_message(
-    conversation_credits: int,
+    conversation_credits: Optional[int],
     period_credits: int,
     free_tier_credits: int,
     conversation_start: Optional[datetime] = None,
     usage_period: Optional[AiUsagePeriod] = None,
+    product_usage: Optional[ProductUsage] = None,
 ) -> str:
     """
     Format the usage information into a user-friendly message with a compact layout
@@ -441,7 +459,13 @@ def format_usage_message(
     if ga_cap_active:
         period_label += f" (since {ga_launch_date.strftime('%Y-%m-%d')})"
 
-    lines.append(f"**Current conversation**: {conversation_credits:,} credits\n")
+    # A surface with no conversation in scope, such as a Slack channel command, omits the row
+    # rather than reporting a conversation that spent nothing.
+    if conversation_credits is not None:
+        lines.append(f"**Current conversation**: {conversation_credits:,} credits\n")
+    if product_usage:
+        period_phrase = "this billing period" if usage_period.label == "Billing period" else "in the past 30 days"
+        lines.append(f"**{product_usage.label} {period_phrase}**: {product_usage.credits:,} credits\n")
     lines.append(f"{period_label}: {period_credits:,} credits\n")
     lines.append(f"**Free tier limit**: {free_tier_credits:,} credits\n")
 
@@ -466,14 +490,19 @@ def format_usage_message(
 
     lines.append("")
     if usage_period.label == "Billing period":
-        lines.append(
-            "_Current conversation resets when you start a new chat; billing period usage resets at the end of this billing period._"
-        )
+        period_note = "billing period usage resets at the end of this billing period."
     else:
-        lines.append(
-            "_Current conversation resets when you start a new chat; past 30 days is rolling usage for this project because billing period information is unavailable._"
+        period_note = (
+            "past 30 days is rolling usage for this project because billing period information is unavailable."
         )
+    if conversation_credits is not None:
+        lines.append(f"_Current conversation resets when you start a new chat; {period_note}_")
+    else:
+        lines.append(f"_{period_note[0].upper()}{period_note[1:]}_")
     lines.append("_Note: Usage data depends on AI trace ingestion and may lag slightly behind real-time activity._")
+
+    if product_usage and product_usage.separate_bucket:
+        lines.append(f"_{product_usage.label} credits are billed separately from PostHog AI credits._")
 
     # Add GA cap explanation if active
     if ga_cap_active:

--- a/products/posthog_ai/backend/services/usage/report.py
+++ b/products/posthog_ai/backend/services/usage/report.py
@@ -1,0 +1,188 @@
+"""Assemble what `/usage` answers: this conversation, this product, and all of PostHog AI.
+
+Every surface that offers the command — the Max chat, the Slack app, a cloud agent — reports the
+same three numbers over the same period, so a person reading one recognizes the others.
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+from uuid import UUID
+
+from django.core.cache import cache
+from django.utils import timezone
+
+from posthog.schema import MaxBillingContext
+
+from posthog.dataclasses import frozen
+from posthog.tasks.usage_report import POSTHOG_AI_PRODUCTS, POSTHOG_CODE_AI_PRODUCTS
+
+from products.posthog_ai.backend.services.usage.credits import (
+    AiUsagePeriod,
+    ProductUsage,
+    format_usage_message,
+    get_ai_credits,
+    get_ai_credits_for_conversation,
+    get_ai_credits_for_team,
+    get_ai_free_tier_credits,
+    get_ai_usage_period,
+    get_conversation_start_time,
+)
+
+from ee.billing.quota_limiting import QuotaResource, organization_resource_usage
+
+if TYPE_CHECKING:
+    from posthog.models import Team
+
+# What a person calls the product a surface belongs to. A product missing here reads as its
+# `ai_product` slug, which is still recognizable.
+PRODUCT_LABELS = {
+    "alert_investigation_agent": "Alert investigation",
+    "posthog_ai": "PostHog AI",
+    "posthog_code": "PostHog Desktop",
+    "product_analytics": "Product analytics",
+    "replay_vision": "Replay vision",
+    "slack_app": "Slack app",
+    "subscriptions": "Subscriptions",
+    "surveys": "Surveys",
+}
+
+# Products billed against their own credit counter, read from billing rather than summed from
+# events. Billing is region-independent, which is what makes the row correct on both deployments:
+# Desktop generations are only readable from the US.
+SEPARATE_CREDIT_BUCKETS = dict.fromkeys(POSTHOG_CODE_AI_PRODUCTS, QuotaResource.POSTHOG_CODE_CREDITS)
+
+# Long enough to collapse a person re-asking, short enough that a report still tracks a run in
+# progress. `get_task_usage` caches its own ClickHouse read for the same span.
+REPORT_CACHE_TIMEOUT_SECONDS = 60
+
+
+def product_label(product: str) -> str:
+    return PRODUCT_LABELS.get(product, product.replace("_", " "))
+
+
+@frozen
+class UsageReport:
+    # None where the surface has no conversation in scope, which reads as unknown rather than as a
+    # conversation that spent nothing.
+    conversation_credits: Optional[int]
+    period_credits: int
+    free_tier_credits: int
+    usage_period: AiUsagePeriod
+    conversation_start: Optional[datetime] = None
+    product: Optional[ProductUsage] = None
+
+    @property
+    def remaining_credits(self) -> int:
+        return self.free_tier_credits - self.period_credits
+
+    @property
+    def message(self) -> str:
+        return format_usage_message(
+            conversation_credits=self.conversation_credits,
+            period_credits=self.period_credits,
+            free_tier_credits=self.free_tier_credits,
+            conversation_start=self.conversation_start,
+            usage_period=self.usage_period,
+            product_usage=self.product,
+        )
+
+
+def build_usage_report(
+    team: "Team",
+    *,
+    conversation_id: Optional[UUID] = None,
+    conversation_started_at: Optional[datetime] = None,
+    product: Optional[str] = None,
+    billing_context: MaxBillingContext | dict[str, object] | None = None,
+) -> UsageReport:
+    """The three usage numbers for one team, as of now.
+
+    `conversation_id` is the `$ai_session_id` every generation of a conversation carries — the Max
+    conversation for a chat, the task for an agent run. A caller that knows when its conversation
+    started passes it, because only a Max conversation can be looked up here; without one the
+    reported period bounds the search.
+
+    The answer is cached briefly. Credits are reported from ingested traces, which lag anyway, so a
+    caller asking twice in a minute reads the same numbers either way and pays for one set of scans.
+    """
+    cache_key = _cache_key(team.id, conversation_id, product)
+    cached = cache.get(cache_key)
+    if isinstance(cached, UsageReport):
+        return cached
+
+    report = _build_usage_report(
+        team,
+        conversation_id=conversation_id,
+        conversation_started_at=conversation_started_at,
+        product=product,
+        billing_context=billing_context,
+    )
+    cache.set(cache_key, report, timeout=REPORT_CACHE_TIMEOUT_SECONDS)
+    return report
+
+
+def _cache_key(team_id: int, conversation_id: Optional[UUID], product: Optional[str]) -> str:
+    return f"ai_usage_report:v1:{team_id}:{conversation_id or '-'}:{product or '-'}"
+
+
+def _build_usage_report(
+    team: "Team",
+    *,
+    conversation_id: Optional[UUID] = None,
+    conversation_started_at: Optional[datetime] = None,
+    product: Optional[str] = None,
+    billing_context: MaxBillingContext | dict[str, object] | None = None,
+) -> UsageReport:
+    usage_period = get_ai_usage_period(team, billing_context)
+    period_has_run = usage_period.query_start < usage_period.end
+
+    conversation_start = conversation_started_at
+    if conversation_start is None and conversation_id is not None:
+        conversation_start = get_conversation_start_time(conversation_id)
+
+    conversation_credits = (
+        get_ai_credits_for_conversation(
+            team_id=team.id,
+            conversation_id=conversation_id,
+            begin=conversation_start or usage_period.query_start,
+            end=timezone.now(),
+        )
+        if conversation_id is not None
+        else None
+    )
+
+    period_credits = (
+        get_ai_credits_for_team(team_id=team.id, begin=usage_period.query_start, end=usage_period.end)
+        if period_has_run
+        else 0
+    )
+
+    return UsageReport(
+        conversation_credits=conversation_credits,
+        period_credits=period_credits,
+        free_tier_credits=get_ai_free_tier_credits(team.id),
+        usage_period=usage_period,
+        conversation_start=conversation_start,
+        product=_product_usage(team, product, usage_period) if product else None,
+    )
+
+
+def _product_usage(team: "Team", product: str, usage_period: AiUsagePeriod) -> Optional[ProductUsage]:
+    """What one product spent over the reported period, or None when it has no credit counter."""
+    if product in POSTHOG_AI_PRODUCTS:
+        credits = (
+            get_ai_credits(team.id, usage_period.query_start, usage_period.end, ai_products=[product])
+            if usage_period.query_start < usage_period.end
+            else 0
+        )
+        return ProductUsage(label=product_label(product), credits=credits, separate_bucket=False)
+
+    bucket = SEPARATE_CREDIT_BUCKETS.get(product)
+    if bucket is None:
+        return None
+
+    used = organization_resource_usage(team.organization, bucket)
+    if used is None:
+        # Billing has never synced the bucket. Absent reads as unknown; 0 would read as unspent.
+        return None
+    return ProductUsage(label=product_label(product), credits=round(used), separate_bucket=True)

--- a/products/posthog_ai/backend/services/usage/test/test_credits.py
+++ b/products/posthog_ai/backend/services/usage/test/test_credits.py
@@ -1,0 +1,438 @@
+from datetime import UTC, datetime, timedelta
+from typing import cast
+from uuid import uuid4
+
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from parameterized import parameterized
+
+from products.posthog_ai.backend.models.assistant import Conversation
+from products.posthog_ai.backend.services.usage.credits import (
+    CLOUD_REGION_TO_TEAM_ID,
+    CLOUD_REGION_TO_URL,
+    DEFAULT_FREE_TIER_CREDITS,
+    DEFAULT_GA_LAUNCH_DATE,
+    POSTHOG_AI_PRODUCTS,
+    AiUsagePeriod,
+    ProductUsage,
+    format_usage_message,
+    get_ai_credits,
+    get_ai_free_tier_credits,
+    get_ai_usage_period,
+    get_conversation_start_time,
+    get_ga_launch_date,
+    get_past_month_start,
+)
+
+
+class TestAiCredits(BaseTest):
+    @patch("products.posthog_ai.backend.services.usage.credits.posthoganalytics.get_feature_flag_payload")
+    @patch("products.posthog_ai.backend.services.usage.credits.get_instance_region")
+    def test_get_ai_free_tier_credits_default(self, mock_region, mock_payload):
+        """Test that teams without custom limits get the default free tier."""
+        mock_region.return_value = "EU"
+        mock_payload.return_value = None
+        credits = get_ai_free_tier_credits(team_id=999)
+        self.assertEqual(credits, DEFAULT_FREE_TIER_CREDITS)
+
+    @patch("products.posthog_ai.backend.services.usage.credits.posthoganalytics.get_feature_flag_payload")
+    @patch("products.posthog_ai.backend.services.usage.credits.get_instance_region")
+    def test_get_ai_free_tier_credits_custom_eu(self, mock_region, mock_payload):
+        """Test that EU internal team gets custom free tier limit from feature flag."""
+        mock_region.return_value = "EU"
+        mock_payload.return_value = {"EU": {"1": 9999999}, "US": {"2": 9999999}}
+        credits = get_ai_free_tier_credits(team_id=1)
+        self.assertEqual(credits, 9999999)
+
+    @patch("products.posthog_ai.backend.services.usage.credits.posthoganalytics.get_feature_flag_payload")
+    @patch("products.posthog_ai.backend.services.usage.credits.get_instance_region")
+    def test_get_ai_free_tier_credits_custom_us(self, mock_region, mock_payload):
+        """Test that US internal team gets custom free tier limit from feature flag."""
+        mock_region.return_value = "US"
+        mock_payload.return_value = {"EU": {"1": 9999999}, "US": {"2": 9999999}}
+        credits = get_ai_free_tier_credits(team_id=2)
+        self.assertEqual(credits, 9999999)
+
+    @patch("products.posthog_ai.backend.services.usage.credits.posthoganalytics.get_feature_flag_payload")
+    @patch("products.posthog_ai.backend.services.usage.credits.get_instance_region")
+    def test_get_ai_free_tier_credits_fallback_when_region_unknown(self, mock_region, mock_payload):
+        """Test that unknown regions fall back to default."""
+        mock_region.return_value = None
+        mock_payload.return_value = {"EU": {"1": 9999999}}
+        credits = get_ai_free_tier_credits(team_id=1)
+        self.assertEqual(credits, DEFAULT_FREE_TIER_CREDITS)
+
+    @patch("products.posthog_ai.backend.services.usage.credits.posthoganalytics.get_feature_flag_payload")
+    @patch("products.posthog_ai.backend.services.usage.credits.get_instance_region")
+    def test_get_ai_free_tier_credits_team_not_in_payload(self, mock_region, mock_payload):
+        """Test that teams not in the payload get default credits."""
+        mock_region.return_value = "EU"
+        mock_payload.return_value = {"EU": {"1": 9999999}}
+        credits = get_ai_free_tier_credits(team_id=999)
+        self.assertEqual(credits, DEFAULT_FREE_TIER_CREDITS)
+
+    @patch("products.posthog_ai.backend.services.usage.credits.posthoganalytics.get_feature_flag_payload")
+    @patch("products.posthog_ai.backend.services.usage.credits.get_instance_region")
+    def test_get_ai_free_tier_credits_invalid_payload(self, mock_region, mock_payload):
+        """Test that invalid payloads fall back to default."""
+        mock_region.return_value = "EU"
+        mock_payload.return_value = "invalid"
+        credits = get_ai_free_tier_credits(team_id=1)
+        self.assertEqual(credits, DEFAULT_FREE_TIER_CREDITS)
+
+    @parameterized.expand(
+        [
+            ("eu_cloud", "EU", CLOUD_REGION_TO_TEAM_ID["EU"], CLOUD_REGION_TO_URL["EU"], 2),
+            ("us_cloud", "US", CLOUD_REGION_TO_TEAM_ID["US"], CLOUD_REGION_TO_URL["US"], 1),
+            ("local_dev", None, CLOUD_REGION_TO_TEAM_ID["EU"], None, None),
+        ]
+    )
+    def test_get_ai_credits_scopes_ai_events_query(
+        self,
+        _name,
+        region,
+        expected_team_to_query,
+        expected_region_url,
+        instance_group_index,
+    ):
+        begin = datetime(2026, 5, 1, tzinfo=UTC)
+        end = datetime(2026, 5, 2, tzinfo=UTC)
+        conversation_id = uuid4()
+
+        with (
+            patch("products.posthog_ai.backend.services.usage.credits.get_instance_region") as mock_region,
+            patch("products.posthog_ai.backend.services.usage.credits.sync_execute") as mock_sync_execute,
+            patch(
+                "products.posthog_ai.backend.services.usage.credits.build_ai_billing_region_filter"
+            ) as mock_region_filter,
+        ):
+            mock_region.return_value = region
+            mock_sync_execute.return_value = [(42,)]
+            if expected_region_url is not None:
+                mock_region_filter.return_value = {
+                    "region_group_property": f"$group_{instance_group_index}",
+                    "region_url": expected_region_url,
+                }
+
+            credits = get_ai_credits(team_id=133393, begin=begin, end=end, conversation_id=conversation_id)
+
+            self.assertEqual(credits, 42)
+            query, params = mock_sync_execute.call_args[0][:2]
+            self.assertEqual(params["team_to_query"], expected_team_to_query)
+            self.assertEqual(params["session_id"], str(conversation_id))
+            # Only PostHog AI bucket products count — posthog_code bills separately.
+            self.assertIn("AND JSONExtractString(properties, 'ai_product') IN %(ai_products)s", query)
+            self.assertEqual(params["ai_products"], tuple(POSTHOG_AI_PRODUCTS))
+            if expected_region_url is None:
+                self.assertNotIn("region_url", params)
+                self.assertNotIn("%(region_url)s", query)
+                mock_region_filter.assert_not_called()
+            else:
+                self.assertEqual(params["region_url"], expected_region_url)
+                self.assertEqual(params["region_group_property"], f"$group_{instance_group_index}")
+                mock_region_filter.assert_called_once_with(expected_team_to_query, expected_region_url)
+                self.assertIn(
+                    "AND JSONExtractString(properties, %(region_group_property)s) = %(region_url)s",
+                    query,
+                )
+
+    def test_get_ai_credits_returns_zero_when_instance_group_missing(self):
+        begin = datetime(2026, 5, 1, tzinfo=UTC)
+        end = datetime(2026, 5, 2, tzinfo=UTC)
+        conversation_id = uuid4()
+
+        with (
+            patch("products.posthog_ai.backend.services.usage.credits.get_instance_region") as mock_region,
+            patch("products.posthog_ai.backend.services.usage.credits.sync_execute") as mock_sync_execute,
+            patch(
+                "products.posthog_ai.backend.services.usage.credits.build_ai_billing_region_filter",
+                return_value=None,
+            ),
+        ):
+            mock_region.return_value = "EU"
+
+            credits = get_ai_credits(team_id=133393, begin=begin, end=end, conversation_id=conversation_id)
+
+            self.assertEqual(credits, 0)
+            mock_sync_execute.assert_not_called()
+
+    def test_get_conversation_start_time_exists(self):
+        """Test retrieving conversation start time for existing conversation."""
+        conversation = Conversation.objects.create(
+            team=self.team,
+            user=self.user,
+        )
+        start_time = get_conversation_start_time(conversation.id)
+        self.assertIsNotNone(start_time)
+        self.assertEqual(
+            cast(datetime, start_time).replace(microsecond=0),
+            cast(datetime, conversation.created_at).replace(microsecond=0),
+        )
+
+    def test_get_conversation_start_time_not_exists(self):
+        """Test that non-existent conversation returns None."""
+        start_time = get_conversation_start_time(uuid4())
+        self.assertIsNone(start_time)
+
+    @patch("products.posthog_ai.backend.services.usage.credits.posthoganalytics.get_feature_flag_payload")
+    def test_get_ga_launch_date_from_payload(self, mock_payload):
+        """Test that GA launch date is fetched from feature flag payload."""
+        mock_payload.return_value = {"ga_launch_date": "2025-12-01", "EU": {"1": 10000}}
+        ga_date = get_ga_launch_date()
+        self.assertEqual(ga_date, datetime(2025, 12, 1, tzinfo=UTC))
+
+    @patch("products.posthog_ai.backend.services.usage.credits.posthoganalytics.get_feature_flag_payload")
+    def test_get_ga_launch_date_fallback(self, mock_payload):
+        """Test that GA launch date falls back to default when not in payload."""
+        mock_payload.return_value = None
+        ga_date = get_ga_launch_date()
+        self.assertEqual(ga_date, DEFAULT_GA_LAUNCH_DATE)
+
+    @patch("products.posthog_ai.backend.services.usage.credits.posthoganalytics.get_feature_flag_payload")
+    def test_get_ga_launch_date_invalid_format(self, mock_payload):
+        """Test that invalid date format falls back to default."""
+        mock_payload.return_value = {"ga_launch_date": "invalid-date"}
+        ga_date = get_ga_launch_date()
+        self.assertEqual(ga_date, DEFAULT_GA_LAUNCH_DATE)
+
+    def test_get_past_month_start_normal(self):
+        """Test past month start when 30 days ago is after GA launch."""
+        now = datetime(2025, 12, 20, tzinfo=UTC)
+        with patch("products.posthog_ai.backend.services.usage.credits.datetime") as mock_datetime:
+            mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+            mock_datetime.now.return_value = now
+            past_month_start = get_past_month_start()
+            expected = datetime(2025, 11, 20, tzinfo=UTC)
+            self.assertEqual(past_month_start, expected)
+
+    @patch("products.posthog_ai.backend.services.usage.credits.posthoganalytics.get_feature_flag_payload")
+    def test_get_past_month_start_capped_at_ga_launch(self, mock_payload):
+        """Test that past month start is capped at GA launch date."""
+        mock_payload.return_value = None
+        now = DEFAULT_GA_LAUNCH_DATE + timedelta(days=10)
+        with patch("products.posthog_ai.backend.services.usage.credits.datetime") as mock_datetime:
+            mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+            mock_datetime.now.return_value = now
+            past_month_start = get_past_month_start()
+            self.assertEqual(past_month_start, DEFAULT_GA_LAUNCH_DATE)
+
+    def test_get_ai_usage_period_from_billing_context(self):
+        billing_context = {
+            "billing_period": {
+                "current_period_start": "2026-05-02T14:51:12Z",
+                "current_period_end": "2026-06-02T14:51:12Z",
+                "interval": "month",
+            },
+            "billing_plan": "paid",
+            "has_active_subscription": True,
+            "is_deactivated": False,
+            "products": [],
+            "settings": {"autocapture_on": True, "active_destinations": 0},
+            "subscription_level": "paid",
+        }
+
+        usage_period = get_ai_usage_period(self.team, billing_context)
+
+        self.assertEqual(usage_period.label, "Billing period")
+        self.assertEqual(usage_period.start, datetime(2026, 5, 2, 14, 51, 12, tzinfo=UTC))
+        self.assertEqual(usage_period.end, datetime(2026, 6, 2, 14, 51, 12, tzinfo=UTC))
+        self.assertEqual(usage_period.query_start, datetime(2026, 5, 2, 14, 51, 12, tzinfo=UTC))
+
+    def test_get_ai_usage_period_from_organization_usage(self):
+        self.organization.usage = {
+            "period": ["2026-05-02T14:51:12Z", "2026-06-02T14:51:12Z"],
+        }
+
+        usage_period = get_ai_usage_period(self.team, None)
+
+        self.assertEqual(usage_period.label, "Billing period")
+        self.assertEqual(usage_period.start, datetime(2026, 5, 2, 14, 51, 12, tzinfo=UTC))
+        self.assertEqual(usage_period.end, datetime(2026, 6, 2, 14, 51, 12, tzinfo=UTC))
+        self.assertEqual(usage_period.query_start, datetime(2026, 5, 2, 14, 51, 12, tzinfo=UTC))
+
+    @patch("products.posthog_ai.backend.services.usage.credits.posthoganalytics.get_feature_flag_payload")
+    def test_get_ai_usage_period_caps_query_start_at_ga_launch(self, mock_payload):
+        mock_payload.return_value = None
+        self.organization.usage = {
+            "period": ["2025-11-01T00:00:00Z", "2025-12-01T00:00:00Z"],
+        }
+
+        usage_period = get_ai_usage_period(self.team, None)
+
+        self.assertEqual(usage_period.label, "Billing period")
+        self.assertEqual(usage_period.start, datetime(2025, 11, 1, tzinfo=UTC))
+        self.assertEqual(usage_period.end, datetime(2025, 12, 1, tzinfo=UTC))
+        self.assertEqual(usage_period.query_start, DEFAULT_GA_LAUNCH_DATE)
+
+    def test_get_ai_usage_period_falls_back_to_past_month(self):
+        now = datetime(2025, 12, 20, tzinfo=UTC)
+        with patch("products.posthog_ai.backend.services.usage.credits.datetime") as mock_datetime:
+            mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+            mock_datetime.now.return_value = now
+
+            usage_period = get_ai_usage_period(self.team, None)
+
+        self.assertEqual(usage_period.label, "Past 30 days")
+        self.assertEqual(usage_period.start, datetime(2025, 11, 20, tzinfo=UTC))
+        self.assertEqual(usage_period.end, now)
+        self.assertEqual(usage_period.query_start, datetime(2025, 11, 20, tzinfo=UTC))
+
+    def test_format_usage_message_no_usage(self):
+        """Test formatting when no credits have been used."""
+        message = format_usage_message(
+            conversation_credits=0,
+            period_credits=0,
+            free_tier_credits=2000,
+            usage_period=AiUsagePeriod(
+                label="Billing period",
+                start=datetime(2026, 5, 2, 14, 51, 12, tzinfo=UTC),
+                end=datetime(2026, 6, 2, 14, 51, 12, tzinfo=UTC),
+                query_start=datetime(2026, 5, 2, 14, 51, 12, tzinfo=UTC),
+            ),
+        )
+        self.assertIn("**Current conversation**: 0 credits", message)
+        self.assertIn("**Billing period** (2026-05-02 to 2026-06-02): 0 credits", message)
+        self.assertIn("**Free tier limit**: 2,000 credits", message)
+        self.assertIn("**Remaining**: 2,000 credits", message)
+        self.assertIn("0% of free tier", message)
+        self.assertIn("_Billing period resets on_: 2026-06-02 14:51 UTC", message)
+
+    @parameterized.expand(
+        [
+            (
+                "separate_bucket",
+                ProductUsage(label="PostHog Desktop", credits=4300, separate_bucket=True),
+                "**PostHog Desktop this billing period**: 4,300 credits",
+                True,
+            ),
+            (
+                "same_bucket",
+                ProductUsage(label="Slack app", credits=250, separate_bucket=False),
+                "**Slack app this billing period**: 250 credits",
+                False,
+            ),
+        ]
+    )
+    def test_format_usage_message_with_product(
+        self, _name: str, product_usage: ProductUsage, expected_row: str, expects_bucket_note: bool
+    ):
+        message = format_usage_message(
+            conversation_credits=12,
+            period_credits=800,
+            free_tier_credits=2000,
+            usage_period=AiUsagePeriod(
+                label="Billing period",
+                start=datetime(2026, 5, 2, 14, 51, 12, tzinfo=UTC),
+                end=datetime(2026, 6, 2, 14, 51, 12, tzinfo=UTC),
+                query_start=datetime(2026, 5, 2, 14, 51, 12, tzinfo=UTC),
+            ),
+            product_usage=product_usage,
+        )
+        self.assertIn(expected_row, message)
+        # A product on its own counter must say so: its credits are not part of the total above it.
+        note = f"_{product_usage.label} credits are billed separately from PostHog AI credits._"
+        if expects_bucket_note:
+            self.assertIn(note, message)
+        else:
+            self.assertNotIn(note, message)
+
+    def test_format_usage_message_without_a_conversation(self):
+        message = format_usage_message(
+            conversation_credits=None,
+            period_credits=800,
+            free_tier_credits=2000,
+            usage_period=AiUsagePeriod(
+                label="Billing period",
+                start=datetime(2026, 5, 2, 14, 51, 12, tzinfo=UTC),
+                end=datetime(2026, 6, 2, 14, 51, 12, tzinfo=UTC),
+                query_start=datetime(2026, 5, 2, 14, 51, 12, tzinfo=UTC),
+            ),
+        )
+        self.assertNotIn("Current conversation", message)
+        self.assertIn("_Billing period usage resets at the end of this billing period._", message)
+
+    def test_format_usage_message_partial_usage(self):
+        """Test formatting with partial usage."""
+        message = format_usage_message(
+            conversation_credits=50,
+            period_credits=500,
+            free_tier_credits=2000,
+            usage_period=AiUsagePeriod(
+                label="Billing period",
+                start=datetime(2026, 5, 2, tzinfo=UTC),
+                end=datetime(2026, 6, 2, tzinfo=UTC),
+                query_start=datetime(2026, 5, 2, tzinfo=UTC),
+            ),
+        )
+        self.assertIn("**Current conversation**: 50 credits", message)
+        self.assertIn("**Billing period** (2026-05-02 to 2026-06-02): 500 credits", message)
+        self.assertIn("**Remaining**: 1,500 credits", message)
+        self.assertIn("25% of free tier", message)
+
+    def test_format_usage_message_over_limit(self):
+        """Test formatting when over the free tier limit."""
+        message = format_usage_message(
+            conversation_credits=100,
+            period_credits=2500,
+            free_tier_credits=2000,
+            usage_period=AiUsagePeriod(
+                label="Billing period",
+                start=datetime(2026, 5, 2, tzinfo=UTC),
+                end=datetime(2026, 6, 2, tzinfo=UTC),
+                query_start=datetime(2026, 5, 2, tzinfo=UTC),
+            ),
+        )
+        self.assertIn("**Overage**: 500 credits over limit", message)
+        self.assertIn("125% of free tier", message)
+
+    @patch("products.posthog_ai.backend.services.usage.credits.posthoganalytics.get_feature_flag_payload")
+    def test_format_usage_message_with_ga_cap(self, mock_payload):
+        """Test formatting when GA cap is active."""
+        mock_payload.return_value = None
+        message = format_usage_message(
+            conversation_credits=10,
+            period_credits=100,
+            free_tier_credits=2000,
+            usage_period=AiUsagePeriod(
+                label="Billing period",
+                start=datetime(2025, 11, 1, tzinfo=UTC),
+                end=datetime(2025, 12, 1, tzinfo=UTC),
+                query_start=DEFAULT_GA_LAUNCH_DATE,
+            ),
+        )
+        self.assertIn(f"since {DEFAULT_GA_LAUNCH_DATE.strftime('%Y-%m-%d')}", message)
+        self.assertIn(
+            f"from PostHog AI general availability date ({DEFAULT_GA_LAUNCH_DATE.strftime('%b %d, %Y')})", message
+        )
+
+    def test_format_usage_message_with_conversation_start(self):
+        """Test formatting with conversation start time."""
+        conv_start = datetime(2025, 11, 18, 10, 30, tzinfo=UTC)
+        message = format_usage_message(
+            conversation_credits=25,
+            period_credits=200,
+            free_tier_credits=2000,
+            conversation_start=conv_start,
+        )
+        self.assertIn("_Conversation since_: 2025-11-18 10:30 UTC", message)
+
+    def test_format_usage_message_progress_bar(self):
+        """Test that progress bar is rendered correctly."""
+        message = format_usage_message(
+            conversation_credits=0,
+            period_credits=1000,
+            free_tier_credits=2000,
+        )
+        self.assertIn("█" * 10, message)
+        self.assertIn("░" * 10, message)
+
+    def test_format_usage_message_full_progress_bar(self):
+        """Test progress bar when at 100% usage."""
+        message = format_usage_message(
+            conversation_credits=0,
+            period_credits=2000,
+            free_tier_credits=2000,
+        )
+        self.assertIn("█" * 20, message)
+        self.assertNotIn("░", message)

--- a/products/posthog_ai/backend/services/usage/test/test_report.py
+++ b/products/posthog_ai/backend/services/usage/test/test_report.py
@@ -1,0 +1,107 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from django.core.cache import cache
+
+from parameterized import parameterized
+
+from products.posthog_ai.backend.services.usage.report import build_usage_report
+
+MODULE = "products.posthog_ai.backend.services.usage.report"
+
+BILLING_PERIOD = ["2026-05-02T14:51:12Z", "2026-06-02T14:51:12Z"]
+
+
+class TestUsageReport(BaseTest):
+    def setUp(self):
+        super().setUp()
+        # The report is cached per team, so one test must not serve the next one's answer.
+        cache.clear()
+        self.organization.usage = {
+            "period": BILLING_PERIOD,
+            "posthog_code_credits": {"usage": 4000, "todays_usage": 300, "limit": 10000},
+        }
+        self.organization.save()
+
+    def _build(self, **kwargs):
+        with (
+            patch(f"{MODULE}.get_ai_credits_for_team", return_value=800),
+            patch(f"{MODULE}.get_ai_credits_for_conversation", return_value=12) as conversation_credits,
+            patch(f"{MODULE}.get_ai_free_tier_credits", return_value=2000),
+            patch(f"{MODULE}.get_ai_credits", return_value=250) as product_credits,
+        ):
+            report = build_usage_report(self.team, **kwargs)
+        return report, product_credits, conversation_credits
+
+    def test_reports_a_products_own_credits_from_its_events(self):
+        report, product_credits, _ = self._build(product="slack_app")
+
+        assert report.product is not None
+        self.assertEqual(report.product.label, "Slack app")
+        self.assertEqual(report.product.credits, 250)
+        self.assertFalse(report.product.separate_bucket)
+        self.assertEqual(product_credits.call_args.kwargs["ai_products"], ["slack_app"])
+
+    def test_reports_desktop_credits_from_billing_rather_than_events(self):
+        # Desktop generations are only readable from the US, so summing events would report 0 on EU.
+        # Billing is region-independent, and posthog_code is the whole of its own bucket.
+        report, product_credits, _ = self._build(product="posthog_code")
+
+        assert report.product is not None
+        self.assertEqual(report.product.label, "PostHog Desktop")
+        self.assertEqual(report.product.credits, 4300)
+        self.assertTrue(report.product.separate_bucket)
+        product_credits.assert_not_called()
+
+    @parameterized.expand(
+        [
+            # An internal surface with no credit counter of its own.
+            ("no_counter", "background_agents", {"period": BILLING_PERIOD}),
+            # Billing has never synced the bucket, which is unknown spend rather than none.
+            ("bucket_unsynced", "posthog_code", {"period": BILLING_PERIOD}),
+        ]
+    )
+    def test_omits_the_product_row(self, _name: str, product: str, usage: dict):
+        self.organization.usage = usage
+        self.organization.save()
+
+        report, _, _ = self._build(product=product)
+
+        self.assertIsNone(report.product)
+
+    def test_omits_the_conversation_row_when_no_conversation_is_in_scope(self):
+        report, _, conversation_credits = self._build(product="slack_app")
+
+        self.assertIsNone(report.conversation_credits)
+        conversation_credits.assert_not_called()
+        self.assertNotIn("Current conversation", report.message)
+
+    def test_counts_a_conversation_from_its_own_start(self):
+        started_at = datetime(2026, 5, 3, 9, 0, tzinfo=UTC)
+        conversation_id = uuid4()
+
+        report, _, conversation_credits = self._build(
+            conversation_id=conversation_id, conversation_started_at=started_at
+        )
+
+        self.assertEqual(report.conversation_credits, 12)
+        self.assertEqual(conversation_credits.call_args.kwargs["begin"], started_at)
+        self.assertEqual(conversation_credits.call_args.kwargs["conversation_id"], conversation_id)
+        self.assertIn("**Current conversation**: 12 credits", report.message)
+
+    def test_serves_a_repeated_ask_without_querying_again(self):
+        # Every miss costs up to three ClickHouse scans over the whole billing period.
+        self._build(product="slack_app")
+        _, product_credits, _ = self._build(product="slack_app")
+
+        product_credits.assert_not_called()
+
+    def test_reports_the_teams_billing_period(self):
+        report, _, _ = self._build()
+
+        self.assertEqual(report.usage_period.label, "Billing period")
+        self.assertEqual(report.period_credits, 800)
+        self.assertEqual(report.remaining_credits, 1200)

--- a/products/posthog_ai/frontend/generated/api.schemas.ts
+++ b/products/posthog_ai/frontend/generated/api.schemas.ts
@@ -617,7 +617,7 @@ export interface DocsSearchResponseApi {
     content: string
 }
 
-export type AiUsageListParams = {
+export type AiUsageRetrieveParams = {
     /**
      * The conversation to report on, which is the `$ai_session_id` its generations carry: the Max conversation for a chat, the task for an agent run. Omitted, the report covers the team only.
      */

--- a/products/posthog_ai/frontend/generated/api.schemas.ts
+++ b/products/posthog_ai/frontend/generated/api.schemas.ts
@@ -7,6 +7,41 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
+export interface AIUsageProductApi {
+    /** What a person calls the product, e.g. `PostHog Desktop`. */
+    name: string
+    /** Credits the product spent over the reported period. */
+    credits: number
+    /** True when the product bills against its own credit counter, so its credits are not part of the PostHog AI total in this response. */
+    separate_bucket: boolean
+}
+
+export interface AIUsageResponseApi {
+    /**
+     * Credits spent in the requested conversation. Null when no conversation was requested.
+     * @nullable
+     */
+    conversation_credits: number | null
+    /** PostHog AI credits the team spent over the reported period, across every product. */
+    period_credits: number
+    /** The team's free tier limit in credits. */
+    free_tier_credits: number
+    /** Free tier credits left. Negative once the team is over the limit. */
+    remaining_credits: number
+    /** `Billing period`, or `Past 30 days` when billing has not told us the team's period. Every credit figure in the response covers this period. */
+    period_label: string
+    period_start: string
+    period_end: string
+    /**
+     * When the conversation started, when that is known.
+     * @nullable
+     */
+    conversation_start: string | null
+    product: AIUsageProductApi | null
+    /** The whole report as Markdown, so every surface renders one wording. Clients that lay the numbers out themselves read the fields above instead. */
+    message: string
+}
+
 /**
  * * `idle` - Idle
  * * `in_progress` - In progress
@@ -580,6 +615,22 @@ export interface DocsSearchRequestApi {
 export interface DocsSearchResponseApi {
     /** Markdown-formatted documentation results. Each block has a title, URL and excerpt; an empty result set returns guidance to navigate to https://posthog.com/docs. */
     content: string
+}
+
+export type AiUsageListParams = {
+    /**
+     * The conversation to report on, which is the `$ai_session_id` its generations carry: the Max conversation for a chat, the task for an agent run. Omitted, the report covers the team only.
+     */
+    conversation_id?: string
+    /**
+     * When the conversation started. Only a Max conversation can be looked up here, so a caller that knows its own start time passes it; without one the reported period bounds the search and a conversation older than the period is undercounted.
+     */
+    conversation_started_at?: string
+    /**
+     * The `ai_product` of the calling surface, e.g. `slack_app` or `posthog_code`. Adds a row for what that product alone spent. A product with no credit counter is reported as null.
+     * @minLength 1
+     */
+    product?: string
 }
 
 export type ConversationsListParams = {

--- a/products/posthog_ai/frontend/generated/api.ts
+++ b/products/posthog_ai/frontend/generated/api.ts
@@ -10,7 +10,7 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  */
 import type {
     AIUsageResponseApi,
-    AiUsageListParams,
+    AiUsageRetrieveParams,
     ConversationApi,
     ConversationsListParams,
     DocsSearchRequestApi,
@@ -41,7 +41,7 @@ type NonReadonly<T> = [T] extends [UnionToIntersection<T>]
       }
     : DistributeReadOnlyOverUnions<T>
 
-export const getAiUsageListUrl = (projectId: string, params?: AiUsageListParams) => {
+export const getAiUsageRetrieveUrl = (projectId: string, params?: AiUsageRetrieveParams) => {
     const normalizedParams = new URLSearchParams()
 
     Object.entries(params || {}).forEach(([key, value]) => {
@@ -61,12 +61,12 @@ export const getAiUsageListUrl = (projectId: string, params?: AiUsageListParams)
  * Return credits spent in one conversation, by the calling product, and across PostHog AI, for the team's current billing period.
  * @summary Get a team's PostHog AI usage
  */
-export const aiUsageList = async (
+export const aiUsageRetrieve = async (
     projectId: string,
-    params?: AiUsageListParams,
+    params?: AiUsageRetrieveParams,
     options?: RequestInit
-): Promise<AIUsageResponseApi[]> => {
-    return apiMutator<AIUsageResponseApi[]>(getAiUsageListUrl(projectId, params), {
+): Promise<AIUsageResponseApi> => {
+    return apiMutator<AIUsageResponseApi>(getAiUsageRetrieveUrl(projectId, params), {
         ...options,
         method: 'GET',
     })

--- a/products/posthog_ai/frontend/generated/api.ts
+++ b/products/posthog_ai/frontend/generated/api.ts
@@ -9,6 +9,8 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  * OpenAPI spec version: 1.0.0
  */
 import type {
+    AIUsageResponseApi,
+    AiUsageListParams,
     ConversationApi,
     ConversationsListParams,
     DocsSearchRequestApi,
@@ -38,6 +40,37 @@ type NonReadonly<T> = [T] extends [UnionToIntersection<T>]
           [P in keyof Writable<T>]: T[P] extends object ? NonReadonly<NonNullable<T[P]>> : T[P]
       }
     : DistributeReadOnlyOverUnions<T>
+
+export const getAiUsageListUrl = (projectId: string, params?: AiUsageListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/ai_usage/?${stringifiedParams}`
+        : `/api/projects/${projectId}/ai_usage/`
+}
+
+/**
+ * Return credits spent in one conversation, by the calling product, and across PostHog AI, for the team's current billing period.
+ * @summary Get a team's PostHog AI usage
+ */
+export const aiUsageList = async (
+    projectId: string,
+    params?: AiUsageListParams,
+    options?: RequestInit
+): Promise<AIUsageResponseApi[]> => {
+    return apiMutator<AIUsageResponseApi[]>(getAiUsageListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
 
 export const getConversationsListUrl = (projectId: string, params?: ConversationsListParams) => {
     const normalizedParams = new URLSearchParams()

--- a/products/posthog_ai/mcp/tools.yaml
+++ b/products/posthog_ai/mcp/tools.yaml
@@ -9,9 +9,24 @@ feature: posthog_ai
 url_prefix: /ai
 ui_apps: {}
 tools:
-    ai-usage-list:
-        operation: ai_usage_list
-        enabled: false
+    ai-usage-get:
+        operation: ai_usage_retrieve
+        enabled: true
+        scopes:
+            - project:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get PostHog AI credit usage
+        description: >
+            Report PostHog AI credits for the project: what one conversation spent, what a single product spent, and
+            what the whole PostHog AI bucket spent over the current billing period, with the free tier limit and what
+            remains. Pass conversation_id to scope the first figure to one conversation, which is the $ai_session_id
+            its generations carry: the chat thread for a Max conversation, the task for an agent run. Pass product to
+            add the per-product figure, using an ai_product value such as slack_app or posthog_code. A product billed
+            against its own credit counter, such as PostHog Desktop, reports separate_bucket true, and its credits are
+            not part of the period total. Credits come from ingested AI traces and lag live activity by a few minutes.
     conversations-append-message-create:
         operation: conversations_append_message_create
         enabled: false

--- a/products/posthog_ai/mcp/tools.yaml
+++ b/products/posthog_ai/mcp/tools.yaml
@@ -22,9 +22,9 @@ tools:
         description: >
             Report PostHog AI credits for the project: what one conversation spent, what a single product spent, and
             what the whole PostHog AI bucket spent over the current billing period, with the free tier limit and what
-            remains. Pass conversation_id to scope the first figure to one conversation, which is the $ai_session_id
-            its generations carry: the chat thread for a Max conversation, the task for an agent run. Pass product to
-            add the per-product figure, using an ai_product value such as slack_app or posthog_code. A product billed
+            remains. Pass conversation_id to scope the first figure to one conversation, which is the $ai_session_id its
+            generations carry: the chat thread for a Max conversation, the task for an agent run. Pass product to add
+            the per-product figure, using an ai_product value such as slack_app or posthog_code. A product billed
             against its own credit counter, such as PostHog Desktop, reports separate_bucket true, and its credits are
             not part of the period total. Credits come from ingested AI traces and lag live activity by a few minutes.
     conversations-append-message-create:

--- a/products/posthog_ai/mcp/tools.yaml
+++ b/products/posthog_ai/mcp/tools.yaml
@@ -9,6 +9,9 @@ feature: posthog_ai
 url_prefix: /ai
 ui_apps: {}
 tools:
+    ai-usage-list:
+        operation: ai_usage_list
+        enabled: false
     conversations-append-message-create:
         operation: conversations_append_message_create
         enabled: false

--- a/products/slack_app/backend/analytics.py
+++ b/products/slack_app/backend/analytics.py
@@ -14,6 +14,13 @@ from posthog.ph_client import ph_scoped_capture
 
 logger = structlog.get_logger(__name__)
 
+# What the gateway stamps onto every `$ai_generation` a Slack-origin run makes: the run resolves to
+# this gateway product (`_ORIGIN_TO_GATEWAY_PRODUCT` in
+# `products/tasks/backend/temporal/process_task/ai_gateway_token.py`). The other clients make the
+# same match — desktop sends `posthog_code`, web sends `posthog_ai` — which is what puts all PostHog
+# AI feedback on one metric, and what lets a usage report attribute credits to this surface.
+AI_PRODUCT = "slack_app"
+
 
 def slack_event_props(integration: Integration, *, slack_user_id: str | None = None, **extra: object) -> dict:
     """The standard property bundle attached to every Slack app event, plus any ``extra`` props."""

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -228,7 +228,7 @@ class SlackUserContext:
     slack_email: str | None
 
 
-@dataclass
+@frozen
 class RulesCommand:
     """Parsed `@PostHog <command>` mention text.
 
@@ -245,6 +245,7 @@ class RulesCommand:
         "add",
         "remove",
         "help",
+        "usage",
         "deprecated_default_repo",
         "project_show",
         "project_set",
@@ -910,6 +911,9 @@ def parse_rules_command(text: str) -> RulesCommand | None:
 
     if re.fullmatch(r"help", cleaned, flags=re.IGNORECASE):
         return RulesCommand(action="help")
+
+    if re.fullmatch(r"usage", cleaned, flags=re.IGNORECASE):
+        return RulesCommand(action="usage")
 
     # Intercept legacy `default repo` verbs so `default repo set org/repo` doesn't
     # fall through into the explicit-repo cascade and spawn a junk task.

--- a/products/slack_app/backend/services/commands.py
+++ b/products/slack_app/backend/services/commands.py
@@ -1,12 +1,19 @@
 from typing import TYPE_CHECKING
 
+import structlog
+
 from posthog.models.integration import Integration, SlackIntegration
 
+from products.posthog_ai.backend.services.usage.report import build_usage_report
+from products.signals.backend.slack_formatting import prepare_slack_markdown, slack_markdown_block
+from products.slack_app.backend.analytics import AI_PRODUCT
 from products.slack_app.backend.services.slack_messages import post_slack_ephemeral
 
 if TYPE_CHECKING:
     from products.slack_app.backend.api import RulesCommand
     from products.slack_app.backend.services.integration_resolver import ResolutionResult
+
+logger = structlog.get_logger(__name__)
 
 MENTION_COMMAND_PREFIX = "@PostHog"
 
@@ -38,6 +45,7 @@ def _handle_help(
         f"`{command_prefix} rules remove <number(s)>` — Remove routing rules by number (e.g. `remove 1` or `remove 1,2`)",
         f"`{command_prefix} project` — Show which PostHog project your mentions route to in this workspace",
         f"`{command_prefix} project <id>` — Set the PostHog project your mentions route to in this workspace",
+        f"`{command_prefix} usage` — Show PostHog AI credits this project used this billing period",
     ]
 
     # The workspace-wide default is admins/owners-only, so only surface it to them.
@@ -55,6 +63,44 @@ def _handle_help(
         user=slack_user_id,
         thread_ts=thread_ts,
         text="\n".join(lines),
+    )
+
+
+def _handle_usage(
+    slack: SlackIntegration,
+    integration: Integration,
+    channel: str,
+    thread_ts: str,
+    slack_user_id: str,
+) -> None:
+    """Report PostHog AI credits for the project this workspace routes to.
+
+    No conversation is in scope: the command answers for the project, and a channel or a thread
+    does not resolve to one agent run. The Slack app's own credits are reported alongside the
+    PostHog AI total they are part of.
+    """
+    try:
+        report = build_usage_report(integration.team, product=AI_PRODUCT)
+    except Exception:
+        logger.exception("slack_app_usage_report_failed", team_id=integration.team_id)
+        post_slack_ephemeral(
+            slack.client,
+            channel=channel,
+            user=slack_user_id,
+            thread_ts=thread_ts,
+            text="Couldn't load PostHog AI usage. Try again in a moment.",
+        )
+        return
+
+    post_slack_ephemeral(
+        slack.client,
+        channel=channel,
+        user=slack_user_id,
+        thread_ts=thread_ts,
+        # The report is Markdown, which only a markdown block renders. `text` stays as the
+        # notification fallback for clients that show no blocks.
+        text="PostHog AI usage",
+        blocks=[slack_markdown_block(prepare_slack_markdown(report.message))],
     )
 
 
@@ -527,6 +573,8 @@ def dispatch_rules_command(
             slack_user_id=slack_user_id,
             command_prefix=command_prefix,
         )
+    elif command.action == "usage":
+        _handle_usage(slack, integration, channel, thread_ts, slack_user_id)
     elif command.action == "add":
         if not command.repository:
             post_slack_ephemeral(

--- a/products/slack_app/backend/services/turn_feedback.py
+++ b/products/slack_app/backend/services/turn_feedback.py
@@ -31,7 +31,7 @@ from posthog.dataclasses import frozen
 from posthog.event_usage import groups
 from posthog.models.integration import Integration, SlackIntegration
 
-from products.slack_app.backend.analytics import slack_event_props
+from products.slack_app.backend.analytics import AI_PRODUCT, slack_event_props
 from products.slack_app.backend.services.slack_messages import SLACK_WEBHOOK_TIMEOUT_SECONDS, TURN_FEEDBACK_ACTION_ID
 from products.slack_app.backend.services.slack_user_info import get_cached_bot_user_id
 
@@ -42,14 +42,6 @@ SLACK_INTEGRATION_KIND = "slack"
 TURN_FEEDBACK_MODAL_CALLBACK_ID = "slack_app_turn_feedback_modal"
 _MODAL_TEXT_BLOCK_ID = "feedback_text"
 _MODAL_TEXT_ACTION_ID = "text"
-
-# What the run's own generations are already tagged with, so a rating joins them: a
-# Slack-origin run resolves to this gateway product (`_ORIGIN_TO_GATEWAY_PRODUCT` in
-# `products/tasks/backend/temporal/process_task/ai_gateway_token.py`) and the gateway
-# stamps it onto every `$ai_generation`. The other clients make the same match — desktop
-# sends `posthog_code`, web sends `posthog_ai` — which is what puts all PostHog AI
-# feedback on one metric, split by this property.
-AI_PRODUCT = "slack_app"
 
 # Slack's own cap on a `plain_text_input`, and Slack rejects the whole view past it, so the
 # modal would not open at all. Below the desktop client's 4000 on purpose: a reason typed

--- a/products/slack_app/backend/tests/test_mention_command_activity.py
+++ b/products/slack_app/backend/tests/test_mention_command_activity.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 from unittest.mock import patch
 
@@ -27,9 +29,9 @@ class TestMentionCommandActivity:
         self.user = User.objects.create_and_join(self.organization, "u@example.com", "pw")
 
     def _inputs(
-        self, *, command_prefix: str, event_extra: dict[str, str]
+        self, *, command_prefix: str, event_extra: dict[str, str], event_text: str = "help"
     ) -> PostHogCodeSlackMentionCommandWorkflowInputs:
-        event = {"channel": "C1", "user": "U1", "text": "help", **event_extra}
+        event = {"channel": "C1", "user": "U1", "text": event_text, **event_extra}
         return PostHogCodeSlackMentionCommandWorkflowInputs(
             event=event,
             integration_ids=[self.integration.id],
@@ -42,13 +44,20 @@ class TestMentionCommandActivity:
         [
             # A slash command outside a thread carries neither ts nor thread_ts, so the reply
             # anchors to the channel root.
-            ("slash_outside_thread", "/posthog", {}, "", "*Available commands:*"),
+            ("slash_outside_thread", "/posthog", {}, "help", "", "*Available commands:*"),
             # A top-level mention carries only its own ts (no thread_ts). The reply
             # must anchor to the channel root, not that ts — a thread-anchored reply
             # is invisible to a user who isn't already viewing the thread.
-            ("mention_top_level", "@PostHog", {"ts": "111.1"}, "", MENTION_HELP_REDIRECT),
+            ("mention_top_level", "@PostHog", {"ts": "111.1"}, "help", "", MENTION_HELP_REDIRECT),
             # A mention inside a real thread carries thread_ts; the reply threads there.
-            ("mention_in_thread", "@PostHog", {"ts": "222.2", "thread_ts": "111.1"}, "111.1", MENTION_HELP_REDIRECT),
+            (
+                "mention_in_thread",
+                "@PostHog",
+                {"ts": "222.2", "thread_ts": "111.1"},
+                "help",
+                "111.1",
+                MENTION_HELP_REDIRECT,
+            ),
         ]
     )
     @patch("products.slack_app.backend.services.slack_user_info.get_slack_user_info")
@@ -58,6 +67,7 @@ class TestMentionCommandActivity:
         _name: str,
         command_prefix: str,
         event_extra: dict[str, str],
+        event_text: str,
         expected_thread_ts: str,
         expected_text: str,
         mock_slack_cls,
@@ -67,7 +77,7 @@ class TestMentionCommandActivity:
         client = mock_slack_cls.return_value.client
 
         result = handle_posthog_code_slack_mention_command_activity(
-            self._inputs(command_prefix=command_prefix, event_extra=event_extra), self.user.id
+            self._inputs(command_prefix=command_prefix, event_extra=event_extra, event_text=event_text), self.user.id
         )
 
         assert result.status == "done"
@@ -77,3 +87,24 @@ class TestMentionCommandActivity:
         # A channel-root reply carries no anchor at all rather than an empty one.
         assert client.chat_postEphemeral.call_args.kwargs.get("thread_ts", "") == expected_thread_ts
         assert expected_text in client.chat_postEphemeral.call_args.kwargs["text"]
+
+    @patch(
+        "products.slack_app.backend.services.commands.build_usage_report",
+        return_value=SimpleNamespace(message="## PostHog AI usage\n\n**Billing period**: 800 credits"),
+    )
+    @patch("products.slack_app.backend.services.slack_user_info.get_slack_user_info")
+    @patch("posthog.models.integration.SlackIntegration")
+    def test_usage_answers_in_a_markdown_block(self, mock_slack_cls, mock_info, _mock_report) -> None:
+        # The report is Markdown, so a plain `text` reply would show its syntax rather than render it.
+        mock_info.return_value = {"user": {"is_admin": False, "is_owner": False}}
+        client = mock_slack_cls.return_value.client
+
+        result = handle_posthog_code_slack_mention_command_activity(
+            self._inputs(command_prefix="/posthog", event_extra={}, event_text="usage"), self.user.id
+        )
+
+        assert result.status == "done"
+        assert client.chat_postMessage.call_count == 0
+        blocks = client.chat_postEphemeral.call_args.kwargs["blocks"]
+        assert blocks[0]["type"] == "markdown"
+        assert "**Billing period**: 800 credits" in blocks[0]["text"]

--- a/products/slack_app/backend/tests/test_project_directive_parser.py
+++ b/products/slack_app/backend/tests/test_project_directive_parser.py
@@ -100,6 +100,7 @@ class TestParseProjectCommand:
                 "project workspace *8*",
                 RulesCommand(action="project_set_workspace", project_team_id=8),
             ),
+            ("usage", "usage", RulesCommand(action="usage")),
         ]
     )
     def test_recognized(self, _name: str, text: str, expected: RulesCommand) -> None:

--- a/products/slack_app/backend/views/slack_command.py
+++ b/products/slack_app/backend/views/slack_command.py
@@ -156,4 +156,5 @@ def _unknown_command_help(command_name: str) -> str:
         f'• `{command_name} rules add "description" org/repo`\n'
         f"• `{command_name} rules remove <number(s)>`\n"
         f"• `{command_name} project [<id>]`"
+        f"\n• `{command_name} usage`"
     )

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -414,6 +414,20 @@
         },
         "feature_entitlement": "audit_logs"
     },
+    "ai-usage-get": {
+        "description": "Report PostHog AI credits for the project: what one conversation spent, what a single product spent, and what the whole PostHog AI bucket spent over the current billing period, with the free tier limit and what remains. Pass conversation_id to scope the first figure to one conversation, which is the $ai_session_id its generations carry: the chat thread for a Max conversation, the task for an agent run. Pass product to add the per-product figure, using an ai_product value such as slack_app or posthog_code. A product billed against its own credit counter, such as PostHog Desktop, reports separate_bucket true, and its credits are not part of the period total. Credits come from ingested AI traces and lag live activity by a few minutes.",
+        "category": "PostHog AI",
+        "feature": "posthog_ai",
+        "summary": "Get PostHog AI credit usage",
+        "title": "Get PostHog AI credit usage",
+        "required_scopes": ["project:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "alert-create": {
         "description": "Create a new alert on an insight. Alerts can use either threshold-based conditions or anomaly detection. For threshold alerts: set condition (absolute_value, relative_increase, relative_decrease) and threshold configuration with bounds — at least one of lower or upper is required (omit detector_config). For anomaly detection: set detector_config with a detector type (zscore, mad, iqr, threshold, copod, ecod, hbos, isolation_forest, knn, lof, ocsvm, pca) and parameters like threshold (sensitivity 0-1, default 0.9) and window size. Ensemble detectors combine 2+ sub-detectors with AND/OR logic. Requires an insight ID and at least one subscribed user.\nThe config type must match the insight kind. Trends insights: TrendsAlertConfig (series_index, check_ongoing_interval). SQL/HogQL insights: HogQLAlertConfig — column picks which result column to evaluate (defaults to the single numeric column), evaluation is required and selects how rows are read: 'last_row' (query ordered oldest->newest, the last row is the current value), 'first_row' (query ordered newest->oldest, the first row is the current value — pair with a LIMIT, and it is unaffected by result truncation), or 'any_row' (every row is checked and the alert fires if any value breaches; absolute_value condition only). label_column names the evaluated row(s) in breach messages in every evaluation mode (defaults to the first non-evaluated column). Label values appear in delivered notifications — avoid label columns containing PII. Funnel insights: FunnelsAlertConfig — funnel_step picks the step to monitor (null for the overall last step), metric is 'conversion_from_start' or 'conversion_from_previous', and check_ongoing_interval (historical-trend funnels: also evaluate the current in-progress period). Steps funnels support only absolute_value conditions; historical-trend funnels also support relative_increase/relative_decrease. Anomaly detection (detector_config) is supported for trends and SQL insights (not funnels).\ncalculation_interval sets how often the alert runs: real_time, every_15_minutes, hourly, daily, weekly, or monthly. real_time needs a Scale or Enterprise plan. every_15_minutes needs a Boost, Scale, or Enterprise add-on. The field is optional and defaults to daily. If the user does not specify a cadence, ask before creating the alert.\nNote: subscribed_users only controls email recipients. For Slack, HTTPS webhook, or Discord delivery, see the recipe on cdp-functions-create — it covers integration lookup (integrations-channels-retrieve), dedupe (cdp-functions-list filtered by alert id, limit=1000), and the exact filters/inputs shape to pass.",
         "category": "Alerts",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -429,6 +429,20 @@
             "readOnlyHint": true
         }
     },
+    "ai-usage-get": {
+        "description": "Report PostHog AI credits for the project: what one conversation spent, what a single product spent, and what the whole PostHog AI bucket spent over the current billing period, with the free tier limit and what remains. Pass conversation_id to scope the first figure to one conversation, which is the $ai_session_id its generations carry: the chat thread for a Max conversation, the task for an agent run. Pass product to add the per-product figure, using an ai_product value such as slack_app or posthog_code. A product billed against its own credit counter, such as PostHog Desktop, reports separate_bucket true, and its credits are not part of the period total. Credits come from ingested AI traces and lag live activity by a few minutes.",
+        "category": "PostHog AI",
+        "feature": "posthog_ai",
+        "summary": "Get PostHog AI credit usage",
+        "title": "Get PostHog AI credit usage",
+        "required_scopes": ["project:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "alert-create": {
         "description": "Create a new alert on an insight. Alerts can use either threshold-based conditions or anomaly detection. For threshold alerts: set condition (absolute_value, relative_increase, relative_decrease) and threshold configuration with bounds — at least one of lower or upper is required (omit detector_config). For anomaly detection: set detector_config with a detector type (zscore, mad, iqr, threshold, copod, ecod, hbos, isolation_forest, knn, lof, ocsvm, pca) and parameters like threshold (sensitivity 0-1, default 0.9) and window size. Ensemble detectors combine 2+ sub-detectors with AND/OR logic. Requires an insight ID and at least one subscribed user.\nThe config type must match the insight kind. Trends insights: TrendsAlertConfig (series_index, check_ongoing_interval). SQL/HogQL insights: HogQLAlertConfig — column picks which result column to evaluate (defaults to the single numeric column), evaluation is required and selects how rows are read: 'last_row' (query ordered oldest->newest, the last row is the current value), 'first_row' (query ordered newest->oldest, the first row is the current value — pair with a LIMIT, and it is unaffected by result truncation), or 'any_row' (every row is checked and the alert fires if any value breaches; absolute_value condition only). label_column names the evaluated row(s) in breach messages in every evaluation mode (defaults to the first non-evaluated column). Label values appear in delivered notifications — avoid label columns containing PII. Funnel insights: FunnelsAlertConfig — funnel_step picks the step to monitor (null for the overall last step), metric is 'conversion_from_start' or 'conversion_from_previous', and check_ongoing_interval (historical-trend funnels: also evaluate the current in-progress period). Steps funnels support only absolute_value conditions; historical-trend funnels also support relative_increase/relative_decrease. Anomaly detection (detector_config) is supported for trends and SQL insights (not funnels).\ncalculation_interval sets how often the alert runs: real_time, every_15_minutes, hourly, daily, weekly, or monthly. real_time needs a Scale or Enterprise plan. every_15_minutes needs a Boost, Scale, or Enterprise add-on. The field is optional and defaults to daily. If the user does not specify a cadence, ask before creating the alert.\nNote: subscribed_users only controls email recipients. For Slack, HTTPS webhook, or Discord delivery, see the recipe on cdp-functions-create — it covers integration lookup (integrations-channels-retrieve), dedupe (cdp-functions-list filtered by alert id, limit=1000), and the exact filters/inputs shape to pass.",
         "category": "Alerts",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -93174,7 +93174,7 @@ export namespace Schemas {
     refresh?: boolean;
     };
 
-    export type AiUsageListParams = {
+    export type AiUsageRetrieveParams = {
     /**
      * The conversation to report on, which is the `$ai_session_id` its generations carry: the Max conversation for a chat, the task for an agent run. Omitted, the report covers the team only.
      */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -125,6 +125,41 @@ export namespace Schemas {
       human_readable_error?: string | null;
     }
 
+    export interface AIUsageProduct {
+      /** What a person calls the product, e.g. `PostHog Desktop`. */
+      name: string;
+      /** Credits the product spent over the reported period. */
+      credits: number;
+      /** True when the product bills against its own credit counter, so its credits are not part of the PostHog AI total in this response. */
+      separate_bucket: boolean;
+    }
+
+    export interface AIUsageResponse {
+      /**
+         * Credits spent in the requested conversation. Null when no conversation was requested.
+         * @nullable
+         */
+      conversation_credits: number | null;
+      /** PostHog AI credits the team spent over the reported period, across every product. */
+      period_credits: number;
+      /** The team's free tier limit in credits. */
+      free_tier_credits: number;
+      /** Free tier credits left. Negative once the team is over the limit. */
+      remaining_credits: number;
+      /** `Billing period`, or `Past 30 days` when billing has not told us the team's period. Every credit figure in the response covers this period. */
+      period_label: string;
+      period_start: string;
+      period_end: string;
+      /**
+         * When the conversation started, when that is known.
+         * @nullable
+         */
+      conversation_start: string | null;
+      product: AIUsageProduct | null;
+      /** The whole report as Markdown, so every surface renders one wording. Clients that lay the numbers out themselves read the fields above instead. */
+      message: string;
+    }
+
     export interface AccessControlFilterWarning {
       /** Human-readable warning shown to the user */
       message: string;
@@ -93137,6 +93172,22 @@ export namespace Schemas {
      * Grade the checks against a fresh read instead of a recent cached one. Use it after changing instrumentation, when a cached verdict would still describe the old code.
      */
     refresh?: boolean;
+    };
+
+    export type AiUsageListParams = {
+    /**
+     * The conversation to report on, which is the `$ai_session_id` its generations carry: the Max conversation for a chat, the task for an agent run. Omitted, the report covers the team only.
+     */
+    conversation_id?: string;
+    /**
+     * When the conversation started. Only a Max conversation can be looked up here, so a caller that knows its own start time passes it; without one the reported period bounds the search and a conversation older than the period is undercounted.
+     */
+    conversation_started_at?: string;
+    /**
+     * The `ai_product` of the calling surface, e.g. `slack_app` or `posthog_code`. Adds a row for what that product alone spent. A product with no credit counter is reported as null.
+     * @minLength 1
+     */
+    product?: string;
     };
 
     export type AlertsListParams = {

--- a/services/mcp/src/generated/posthog_ai/api.ts
+++ b/services/mcp/src/generated/posthog_ai/api.ts
@@ -3,10 +3,44 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 2 enabled ops
+ * PostHog API - MCP 3 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
+
+/**
+ * Return credits spent in one conversation, by the calling product, and across PostHog AI, for the team's current billing period.
+ * @summary Get a team's PostHog AI usage
+ */
+export const AiUsageRetrieveParams = () => zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const AiUsageRetrieveQueryParams = () => zod.object({
+    conversation_id: zod
+        .string()
+        .optional()
+        .describe(
+            'The conversation to report on, which is the `$ai_session_id` its generations carry: the Max conversation for a chat, the task for an agent run. Omitted, the report covers the team only.'
+        ),
+    conversation_started_at: zod.iso
+        .datetime({ offset: true })
+        .optional()
+        .describe(
+            'When the conversation started. Only a Max conversation can be looked up here, so a caller that knows its own start time passes it; without one the reported period bounds the search and a conversation older than the period is undercounted.'
+        ),
+    product: zod
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+            'The `ai_product` of the calling surface, e.g. `slack_app` or `posthog_code`. Adds a row for what that product alone spent. A product with no credit counter is reported as null.'
+        ),
+})
 
 export const ConversationsListParams = () => zod.object({
     project_id: zod

--- a/services/mcp/src/tools/generated/posthog_ai.ts
+++ b/services/mcp/src/tools/generated/posthog_ai.ts
@@ -12,6 +12,29 @@ import {
 } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
+const AiUsageGetSchema = () => {
+    const AiUsageRetrieveQueryParams = orvalSchemas.AiUsageRetrieveQueryParams()
+    return AiUsageRetrieveQueryParams
+}
+
+const aiUsageGet = (): ToolBase<ReturnType<typeof AiUsageGetSchema>, Schemas.AIUsageResponse> => ({
+    name: 'ai-usage-get',
+    schema: AiUsageGetSchema(),
+    handler: async (context: Context, params: z.infer<ReturnType<typeof AiUsageGetSchema>>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.AIUsageResponse>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/ai_usage/`,
+            query: {
+                conversation_id: params.conversation_id,
+                conversation_started_at: params.conversation_started_at,
+                product: params.product,
+            },
+        })
+        return result
+    },
+})
+
 const ConversationsListSchema = () => {
     const ConversationsListQueryParams = orvalSchemas.ConversationsListQueryParams()
     return ConversationsListQueryParams
@@ -97,6 +120,7 @@ const conversationsRetrieve = (): ToolBase<
 })
 
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
+    'ai-usage-get': aiUsageGet,
     'conversations-list': conversationsList,
     'conversations-retrieve': conversationsRetrieve,
 }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/ai-usage-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/ai-usage-get.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "conversation_id": {
+            "description": "The conversation to report on, which is the `$ai_session_id` its generations carry: the Max conversation for a chat, the task for an agent run. Omitted, the report covers the team only.",
+            "type": "string"
+        },
+        "conversation_started_at": {
+            "description": "When the conversation started. Only a Max conversation can be looked up here, so a caller that knows its own start time passes it; without one the reported period bounds the search and a conversation older than the period is undercounted.",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+            "type": "string"
+        },
+        "product": {
+            "description": "The `ai_product` of the calling surface, e.g. `slack_app` or `posthog_code`. Adds a row for what that product alone spent. A product with no credit counter is reported as null.",
+            "minLength": 1,
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/tach.toml
+++ b/tach.toml
@@ -822,6 +822,7 @@ depends_on = [
     "products.alerts",
     "products.conversations",
     "products.dashboards",
+    "products.posthog_ai",
     "products.product_analytics",
     "products.signals",
     "products.tasks", "products.access_control",


### PR DESCRIPTION
## Problem

A Slack user cannot see what their project has spent on PostHog AI without leaving the conversation they work in, and the Max chat's `/usage` cannot say which product the credits went to.

- The Max chat reports two figures: this conversation, and the PostHog AI total for the billing period.
- Neither figure answers "what is this surface costing me", which is the question someone asks from inside the surface.
- Slack had no usage command at all.
- The desktop half is [#96409](https://github.com/PostHog/posthog/pull/96409). It calls the endpoint this PR adds, and merges once this one is deployed.

## Changes

- The report carries a third figure: what the product a surface belongs to spent this billing period.

```text
**Current conversation**: 340 credits
**PostHog Desktop this billing period**: 4,300 credits
**Billing period** (2026-08-18 to 2026-09-18): 17,950 credits
**Free tier limit**: 50,000 credits
**Billing period usage**: [███████░░░░░░░░░░░░░] 36% of free tier
**Remaining**: 32,050 credits
_PostHog Desktop credits are billed separately from PostHog AI credits._
```

- A Slack user runs `/posthog usage` and gets that report ephemerally, for the project their workspace routes to, rendered as a markdown block.
- The product row names its own counter when the product has one, so nobody adds Desktop credits to the PostHog AI total.
- A surface with no conversation in scope, such as a Slack channel, omits that row instead of reporting zero credits.
- The Max chat keeps its current output. Its assembly and wording move to a shared module that Slack and the new endpoint call.
- An agent can read the same numbers through the `ai-usage-get` MCP tool, for the questions a fixed command cannot answer ("what is burning my credits this month"). The command stays deterministic and free; the tool is for prose.

The product row is sourced the way each product is billed. Products in the PostHog AI bucket are summed from their `$ai_generation` events, which is what the Max command already did. PostHog Desktop reads its own credit bucket from billing. That is also what makes the row correct on EU: `get_task_usage` already hops to the US for Desktop token cost, so summing events on EU would report 0.

The credit query keeps its SQL. It gains one keyword that narrows the count to a single product.

One report costs up to three ClickHouse scans over the billing period, so two limits sit in front of it. The report is cached for 60 seconds per team, conversation and product, which is what `get_task_usage` already does for its own read; credits are reported from ingested traces and lag anyway, so a second ask inside that minute reads the same numbers either way. The endpoint carries `AIUsageRateThrottle` at 30 requests per minute per project, tighter than the general ClickHouse burst rate, plus the standard hourly ceiling. A person typing `/usage` cannot approach that; an agent asking in a loop is what it stops.

Before:

```mermaid
flowchart LR
    M[Max /usage] --> Q[ClickHouse credits]
    S[Slack] --> X[No usage command]
    Q --> O[Conversation and PostHog AI total]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class M,S phYellow;
    class Q phRed;
    class O phGray;
    class X phBlue;
```

After:

```mermaid
flowchart LR
    M[Max /usage] --> R{{Shared usage report}}
    S[Slack /posthog usage] --> R
    A[Agent via ai_usage endpoint] --> R
    R --> C[ClickHouse credits]
    R --> B[Billing credit bucket]
    R --> O[Conversation, product, PostHog AI]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class M,S,A phYellow;
    class R phBlue;
    class C,B phRed;
    class O phGray;
```

The endpoint reports one object per project, so it carries the singleton schema the AI observability checklist uses. Without it drf-spectacular reads a `list` action as a collection and hands every generated client an array type for a response that is never an array.

Mechanical: the credit module moves out of the slash-command package so Slack and the endpoint can reach it, `resource_usage` moves from the quota-limits view into `ee/billing/quota_limiting.py` for its second caller, `AI_PRODUCT` moves to the Slack app's analytics module, and the OpenAPI artifacts are regenerated for the new endpoint.

Nothing looks different in the app: the change produces text in a chat and in Slack.

## How did you test this code?

- `services/usage/test/test_report.py` guards the source rule per product: an event-summed row for a PostHog AI product, a billing-bucket row for Desktop, and no row when the product has no counter or billing has never synced it. A regression here reports 0 credits on EU, which reads as free.
- `test_credits.py` gains the product row, the separate-bucket note, and the omitted conversation row. Without the note a reader adds two counters together.
- `products/posthog_ai/backend/api/test_usage.py` is the wiring guard: query params reach the report, a bad `conversation_id` is a 400, another organization's project is a 403.
- The Slack test asserts the reply is a markdown block. A plain `text` reply would show Markdown syntax rather than render it.
- The report test asserts a second ask serves the cache. Without it every ask re-scans ClickHouse, which is the failure mode the cache exists for.
- The MCP suite passes on the regenerated tool, and `lint-tool-names` accepts the name.
- Not run: no live Slack workspace or Max session. These tests stub ClickHouse, so the credit numbers themselves are unverified end to end.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [x] Publish to changelog?

## Docs update

The built-in `/posthog help` output documents the Slack command. No standalone command reference exists in this repository.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) rewrote this branch after review of the first approach, which read the gateway's quota endpoint and formatted a single bucket total in TypeScript. The desktop half then split into [#96409](https://github.com/PostHog/posthog/pull/96409), because the two together fail the desktop/backend coupling gate.

Two decisions shaped the result. The credit query stays as it is, so the diff adds one keyword rather than restructuring the ClickHouse SQL. The report is rendered once in Python and returned as Markdown, so no client reimplements the wording.

`products.slack_app` gains a `products.posthog_ai` entry in `tach.toml`. posthog_ai has no facade package, so the dependency is on the service module, the same shape as slack_app's existing entries for signals and tasks.

Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-pr-descriptions`.

Nothing in this PR carries material from the session that is not already in this repository.
