### PR TITLE
fix(desktop): return after creating an organization

### DIFF
--- a/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
+++ b/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
@@ -744,6 +744,39 @@ describe('onboardingLogic — flow composition', () => {
             expect(router.values.location.pathname).toMatch(/quickstart|insight/i)
         })
 
+        it('reloads the OAuth authorization page on completion', async () => {
+            const nextPath = '/oauth/authorize?client_id=desktop&redirect_uri=posthog-code%3A%2F%2Fcallback'
+            const originalLocation = window.location
+            let currentHref = originalLocation.href
+            Object.defineProperty(window, 'location', {
+                configurable: true,
+                value: {
+                    ...originalLocation,
+                    origin: originalLocation.origin,
+                    get href() {
+                        return currentHref
+                    },
+                    set href(value: string) {
+                        currentHref = new URL(value, originalLocation.origin).href
+                    },
+                },
+            })
+            logic.actions.setProductKey(ProductKey.PRODUCT_ANALYTICS)
+            logic.actions.setOnCompleteOnboardingRedirectUrl(nextPath)
+
+            try {
+                await expectLogic(logic, () => {
+                    completeProduct()
+                }).toFinishAllListeners()
+                expect(window.location.href).toBe(new URL(nextPath, originalLocation.origin).href)
+            } finally {
+                Object.defineProperty(window, 'location', {
+                    configurable: true,
+                    value: originalLocation,
+                })
+            }
+        })
+
         it('does not redirect on completion under the self-driving variant', async () => {
             setVariant('self-driving')
             router.actions.push(urls.default())

--- a/frontend/src/scenes/onboarding/legacy/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/legacy/onboardingLogic.tsx
@@ -998,6 +998,10 @@ export const onboardingLogic = kea<onboardingLogicType>([
                 if (values.onCompleteOnboardingRedirectUrlOverride) {
                     actions.setOnCompleteOnboardingRedirectUrl(null)
                 }
+                if (redirectUrl.split('?')[0] === urls.oauthAuthorize()) {
+                    window.location.href = redirectUrl
+                    return
+                }
                 return [redirectUrl]
             }
         },

--- a/frontend/src/scenes/onboarding/self-driving/onboardingLogic.test.ts
+++ b/frontend/src/scenes/onboarding/self-driving/onboardingLogic.test.ts
@@ -1,5 +1,6 @@
 import { MOCK_DEFAULT_TEAM } from 'lib/api.mock'
 
+import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 import posthog from 'posthog-js'
 
@@ -58,6 +59,37 @@ describe('onboardingLogic', () => {
                 return true
             },
         ])
+    })
+
+    it('returns to a preserved OAuth destination after completion', async () => {
+        const nextPath = '/oauth/authorize?client_id=desktop&redirect_uri=posthog-code%3A%2F%2Fcallback'
+        router.actions.push('/onboarding', { next: nextPath })
+        const originalLocation = window.location
+        let currentHref = originalLocation.href
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: {
+                ...originalLocation,
+                origin: originalLocation.origin,
+                get href() {
+                    return currentHref
+                },
+                set href(value: string) {
+                    currentHref = new URL(value, originalLocation.origin).href
+                },
+            },
+        })
+
+        try {
+            await logic.asyncActions.completeOnboarding()
+
+            expect(window.location.href).toBe(new URL(nextPath, originalLocation.origin).href)
+        } finally {
+            Object.defineProperty(window, 'location', {
+                configurable: true,
+                value: originalLocation,
+            })
+        }
     })
 
     it('short-circuits when a completion is already in flight', async () => {

--- a/frontend/src/scenes/onboarding/self-driving/onboardingLogic.ts
+++ b/frontend/src/scenes/onboarding/self-driving/onboardingLogic.ts
@@ -4,6 +4,7 @@ import { router } from 'kea-router'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import { eventUsageLogic, type OnboardingEventProperties } from 'lib/utils/eventUsageLogic'
+import { getRelativeNextPath } from 'lib/utils/url'
 import { completeProductOnboarding, teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
@@ -179,7 +180,12 @@ export const onboardingLogic = kea<onboardingLogicType>([
                 })
                 actions.clearUseCase()
                 actions.reportOnboardingCompleted(setup.primaryProduct, SELF_DRIVING_ONBOARDING_EVENT_PROPS)
-                router.actions.push(urls.inbox())
+                const nextUrl = getRelativeNextPath(router.values.searchParams.next, location)
+                if (nextUrl) {
+                    window.location.href = nextUrl
+                } else {
+                    router.actions.push(urls.inbox())
+                }
             } catch {
                 lemonToast.error("Couldn't finish onboarding. Please try again.")
             } finally {

--- a/frontend/src/scenes/organizationLogic.test.ts
+++ b/frontend/src/scenes/organizationLogic.test.ts
@@ -1,5 +1,6 @@
 import { MOCK_DEFAULT_ORGANIZATION } from 'lib/api.mock'
 
+import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
 import { initKeaTests } from '~/test/init'
@@ -29,6 +30,48 @@ describe('organizationLogic', () => {
         it('currentOrganizationId returns the id when loaded', async () => {
             await expectLogic(logic).toDispatchActions(['loadCurrentOrganizationSuccess'])
             expect(logic.values.currentOrganizationId).toBe('WXYZ')
+        })
+    })
+
+    describe('organization creation', () => {
+        it('preserves the OAuth return path through onboarding', () => {
+            window.POSTHOG_APP_CONTEXT = {
+                current_user: { organization: MOCK_DEFAULT_ORGANIZATION },
+            } as unknown as AppContext
+            initKeaTests()
+            const nextPath = '/oauth/authorize?client_id=desktop&redirect_uri=posthog-code%3A%2F%2Fcallback'
+            router.actions.push('/create-organization', { next: nextPath })
+            const originalLocation = window.location
+            let currentHref = originalLocation.href
+            Object.defineProperty(window, 'location', {
+                configurable: true,
+                value: {
+                    ...originalLocation,
+                    origin: originalLocation.origin,
+                    get href() {
+                        return currentHref
+                    },
+                    set href(value: string) {
+                        currentHref = new URL(value, originalLocation.origin).href
+                    },
+                },
+            })
+            logic = organizationLogic()
+            logic.mount()
+
+            try {
+                logic.actions.createOrganizationSuccess(MOCK_DEFAULT_ORGANIZATION)
+
+                const redirectUrl = new URL(window.location.href, originalLocation.origin)
+                expect(redirectUrl.pathname).toBe('/onboarding')
+                expect(redirectUrl.searchParams.get('next')).toBe(nextPath)
+            } finally {
+                logic.unmount()
+                Object.defineProperty(window, 'location', {
+                    configurable: true,
+                    value: originalLocation,
+                })
+            }
         })
     })
 

--- a/frontend/src/scenes/organizationLogic.tsx
+++ b/frontend/src/scenes/organizationLogic.tsx
@@ -1,6 +1,6 @@
 import { MakeLogicType, actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
-import { router } from 'kea-router'
+import { combineUrl, router } from 'kea-router'
 import type { LocationChangedPayload } from 'kea-router/lib/types'
 import posthog from 'posthog-js'
 
@@ -11,6 +11,7 @@ import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { isUserLoggedIn } from 'lib/utils/getAppContext'
 import { getAppContext } from 'lib/utils/getAppContext'
+import { getRelativeNextPath } from 'lib/utils/url'
 
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { AvailableFeature, OrganizationType } from '~/types'
@@ -348,7 +349,8 @@ export const organizationLogic = kea<organizationLogicType>([
         },
         createOrganizationSuccess: () => {
             sidePanelStateLogic.findMounted()?.actions.closeSidePanel()
-            window.location.href = urls.onboarding()
+            const nextUrl = getRelativeNextPath(router.values.searchParams.next, location)
+            window.location.href = combineUrl(urls.onboarding(), nextUrl ? { next: nextUrl } : {}).url
         },
         updateOrganizationSuccess: () => {
             lemonToast.success('Organization updated successfully!')

--- a/products/desktop/apps/code/src/main/services/auth/port-adapters.ts
+++ b/products/desktop/apps/code/src/main/services/auth/port-adapters.ts
@@ -51,6 +51,10 @@ export class OAuthFlowPortAdapter implements IAuthOAuthFlowService {
     return this.oauth.startSignupFlow(region);
   }
 
+  startOrganizationCreationFlow(region: CloudRegion): Promise<StartFlowOutput> {
+    return this.oauth.startOrganizationCreationFlow(region);
+  }
+
   refreshToken(
     refreshToken: string,
     region: CloudRegion,

--- a/products/desktop/apps/web/src/web-oauth-flow.ts
+++ b/products/desktop/apps/web/src/web-oauth-flow.ts
@@ -71,6 +71,10 @@ export class WebOAuthFlowService implements IAuthOAuthFlowService {
     return this.runFlow(region, "signup");
   }
 
+  startOrganizationCreationFlow(region: CloudRegion): Promise<StartFlowOutput> {
+    return this.runFlow(region, "organization");
+  }
+
   async refreshToken(
     refreshToken: string,
     region: CloudRegion,
@@ -101,7 +105,7 @@ export class WebOAuthFlowService implements IAuthOAuthFlowService {
 
   private async runFlow(
     region: CloudRegion,
-    kind: "login" | "signup",
+    kind: "login" | "signup" | "organization",
   ): Promise<StartFlowOutput> {
     this.pendingFlow?.cancel("Superseded by a new sign-in attempt");
     try {
@@ -109,7 +113,11 @@ export class WebOAuthFlowService implements IAuthOAuthFlowService {
       const state = randomBase64Url(16);
       const authUrl = await this.buildAuthorizeUrl(region, codeVerifier, state);
       const target =
-        kind === "signup" ? buildSignupUrl(region, authUrl) : authUrl;
+        kind === "signup"
+          ? buildSignupUrl(region, authUrl)
+          : kind === "organization"
+            ? buildOrganizationCreationUrl(region, authUrl)
+            : authUrl;
 
       // Open before any network round-trip so the click's transient activation
       // still permits the popup. The window name is unique per flow: a fixed
@@ -269,6 +277,17 @@ function buildSignupUrl(region: CloudRegion, authUrl: URL): URL {
   const signupUrl = new URL(`${getCloudUrlFromRegion(region)}/signup`);
   signupUrl.searchParams.set("next", `${authUrl.pathname}${authUrl.search}`);
   return signupUrl;
+}
+
+function buildOrganizationCreationUrl(region: CloudRegion, authUrl: URL): URL {
+  const organizationUrl = new URL(
+    `${getCloudUrlFromRegion(region)}/create-organization`,
+  );
+  organizationUrl.searchParams.set(
+    "next",
+    `${authUrl.pathname}${authUrl.search}`,
+  );
+  return organizationUrl;
 }
 
 function randomBase64Url(byteLength: number): string {

--- a/products/desktop/docs/DEEP-LINKS.md
+++ b/products/desktop/docs/DEEP-LINKS.md
@@ -189,6 +189,8 @@ These are issued by external services and consumed by the app. You should not ne
 
 PKCE OAuth callback for user sign-in. PostHog Cloud redirects to this URL after the user authorises in their browser.
 
+PostHog Desktop also uses this callback after browser organization creation. The callback refreshes the Desktop session and selects the new organization's first project.
+
 | Parameter | Required | Description |
 |---|---|---|
 | `code` | Conditional | Authorisation code on success |

--- a/products/desktop/packages/core/src/auth/auth.test.ts
+++ b/products/desktop/packages/core/src/auth/auth.test.ts
@@ -111,6 +111,7 @@ describe("AuthService", () => {
     refreshToken: vi.fn(),
     startFlow: vi.fn(),
     startSignupFlow: vi.fn(),
+    startOrganizationCreationFlow: vi.fn(),
     cancelFlow: vi.fn(),
   };
 
@@ -281,6 +282,244 @@ describe("AuthService", () => {
     });
     expect(sessionPort.getCurrent()).toBeNull();
   });
+
+  it("selects the new organization after its creation flow", async () => {
+    oauthFlow.startFlow.mockResolvedValue(
+      mockTokenResponse({ scopedOrgs: ["org-1"] }),
+    );
+    oauthFlow.startOrganizationCreationFlow.mockResolvedValue(
+      mockTokenResponse({ scopedOrgs: ["org-1", "org-2"] }),
+    );
+    stubAuthFetch({
+      currentOrgId: "org-2",
+      orgs: {
+        "org-1": {
+          name: "Org 1",
+          projects: [{ id: 42, name: "Project 42" }],
+        },
+        "org-2": {
+          name: "Org 2",
+          projects: [{ id: 84, name: "Project 84" }],
+        },
+      },
+    });
+
+    await service.initialize();
+    await service.login("us");
+    expect(service.getState()).toMatchObject({
+      currentOrgId: "org-1",
+      currentProjectId: 42,
+    });
+
+    await service.createOrganization("us");
+
+    expect(service.getState()).toMatchObject({
+      currentOrgId: "org-2",
+      currentProjectId: 84,
+    });
+  });
+
+  it("blocks project changes while organization creation is in progress", async () => {
+    oauthFlow.startFlow.mockResolvedValue(
+      mockTokenResponse({ scopedOrgs: ["org-1"] }),
+    );
+    let finishOrganizationCreation = (): void => {};
+    oauthFlow.startOrganizationCreationFlow.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishOrganizationCreation = () =>
+            resolve(mockTokenResponse({ scopedOrgs: ["org-1", "org-2"] }));
+        }),
+    );
+    stubAuthFetch({
+      currentOrgId: "org-2",
+      orgs: {
+        "org-1": {
+          name: "Org 1",
+          projects: [{ id: 42, name: "Project 42" }],
+        },
+        "org-2": {
+          name: "Org 2",
+          projects: [{ id: 84, name: "Project 84" }],
+        },
+      },
+    });
+    await service.initialize();
+    await service.login("us");
+
+    const organizationCreation = service.createOrganization("us");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await expect(service.selectProject(42)).rejects.toThrow(
+      "Authentication is in progress",
+    );
+    finishOrganizationCreation();
+    await organizationCreation;
+
+    expect(service.getState()).toMatchObject({
+      currentOrgId: "org-2",
+      currentProjectId: 84,
+    });
+  });
+
+  it("does not restore organization creation after logout", async () => {
+    oauthFlow.startFlow.mockResolvedValue(
+      mockTokenResponse({ scopedOrgs: ["org-1"] }),
+    );
+    oauthFlow.startOrganizationCreationFlow.mockResolvedValue(
+      mockTokenResponse({ scopedOrgs: ["org-1", "org-2"] }),
+    );
+    stubAuthFetch({
+      currentOrgId: "org-2",
+      orgs: {
+        "org-1": {
+          name: "Org 1",
+          projects: [{ id: 42, name: "Project 42" }],
+        },
+        "org-2": {
+          name: "Org 2",
+          projects: [{ id: 84, name: "Project 84" }],
+        },
+      },
+    });
+    await service.initialize();
+    await service.login("us");
+
+    const fetchBeforeOrganizationCreation = fetch;
+    let releaseUserFetch = (): void => {};
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: string | Request, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.url;
+        if (url.includes("/api/users/@me/") && init?.method !== "PATCH") {
+          return new Promise<Response>((resolve) => {
+            releaseUserFetch = () =>
+              fetchBeforeOrganizationCreation(input, init).then(resolve);
+          });
+        }
+        return fetchBeforeOrganizationCreation(input, init);
+      }),
+    );
+
+    const organizationCreation = service.createOrganization("us");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await service.logout();
+    releaseUserFetch();
+    await organizationCreation;
+
+    expect(service.getState().status).toBe("anonymous");
+    expect(sessionPort.getCurrent()).toBeNull();
+  });
+
+  it("does not let a delayed organization switch replace the new organization", async () => {
+    oauthFlow.startFlow.mockResolvedValue(
+      mockTokenResponse({ scopedOrgs: ["org-1", "org-2"] }),
+    );
+    oauthFlow.startOrganizationCreationFlow.mockResolvedValue(
+      mockTokenResponse({ scopedOrgs: ["org-1", "org-2", "org-3"] }),
+    );
+    stubAuthFetch({
+      currentOrgId: "org-3",
+      orgs: {
+        "org-1": {
+          name: "Org 1",
+          projects: [{ id: 42, name: "Project 42" }],
+        },
+        "org-2": {
+          name: "Org 2",
+          projects: [{ id: 84, name: "Project 84" }],
+        },
+        "org-3": {
+          name: "Org 3",
+          projects: [{ id: 126, name: "Project 126" }],
+        },
+      },
+    });
+    await service.initialize();
+    await service.login("us");
+
+    const fetchBeforeSwitch = fetch;
+    let releaseSwitch = (): void => {};
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: string | Request, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.url;
+        if (url.includes("/api/users/@me/") && init?.method === "PATCH") {
+          return new Promise<Response>((resolve) => {
+            releaseSwitch = () =>
+              resolve(
+                new Response(JSON.stringify({}), {
+                  status: 200,
+                  headers: { "Content-Type": "application/json" },
+                }),
+              );
+          });
+        }
+        return fetchBeforeSwitch(input, init);
+      }),
+    );
+
+    const switchOrganization = service.switchOrg("org-2");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await service.createOrganization("us");
+    releaseSwitch();
+    await switchOrganization;
+
+    expect(service.getState()).toMatchObject({
+      currentOrgId: "org-3",
+      currentProjectId: 126,
+    });
+  });
+
+  it.each([
+    {
+      browserAccountKey: "user-2",
+      error: "Your browser is signed in to a different PostHog account",
+    },
+    {
+      browserAccountKey: null,
+      error: "PostHog could not verify your browser account",
+    },
+  ])(
+    "keeps the Desktop account when $error",
+    async ({ browserAccountKey, error }) => {
+      oauthFlow.startFlow.mockResolvedValue(
+        mockTokenResponse({ scopedOrgs: ["org-1"] }),
+      );
+      oauthFlow.startOrganizationCreationFlow.mockResolvedValue(
+        mockTokenResponse({ scopedOrgs: ["org-2"] }),
+      );
+      stubAuthFetch({
+        accountKey: "user-1",
+        currentOrgId: "org-1",
+        orgs: {
+          "org-1": {
+            name: "Org 1",
+            projects: [{ id: 42, name: "Project 42" }],
+          },
+        },
+      });
+
+      await service.initialize();
+      await service.login("us");
+
+      stubAuthFetch({
+        accountKey: browserAccountKey,
+        currentOrgId: "org-2",
+        orgs: {
+          "org-2": {
+            name: "Org 2",
+            projects: [{ id: 84, name: "Project 84" }],
+          },
+        },
+      });
+
+      await expect(service.createOrganization("us")).rejects.toThrow(error);
+      expect(service.getState()).toMatchObject({
+        currentOrgId: "org-1",
+        currentProjectId: 42,
+      });
+    },
+  );
 
   it("signs out an impersonated session when a refresh is required", async () => {
     oauthFlow.startFlow.mockResolvedValue(

--- a/products/desktop/packages/core/src/auth/auth.ts
+++ b/products/desktop/packages/core/src/auth/auth.ts
@@ -80,6 +80,7 @@ interface TokenResponseOptions {
   cloudRegion: CloudRegion;
   selectedProjectId: number | null;
   fallbackRefreshToken?: string;
+  ignoreProjectPreference?: boolean;
 }
 
 @injectable()
@@ -102,6 +103,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
   private refreshPromise: Promise<InMemorySession> | null = null;
   private impersonationExpiryTimer: ReturnType<typeof setTimeout> | null = null;
   private sessionGeneration = 0;
+  private authFlow: symbol | null = null;
   // A refresh already refused, keyed to the session generation so every teardown
   // invalidates it. `until: null` is a proven-dead token, a timestamp is a pause.
   private refusedRefresh: {
@@ -162,6 +164,21 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       region,
       "Signup failed",
       sessionGeneration,
+    );
+    return this.getState();
+  }
+  async createOrganization(region: CloudRegion): Promise<AuthState> {
+    await this.initialize();
+    await this.ensureValidSession();
+    this.sessionGeneration += 1;
+    const sessionGeneration = this.sessionGeneration;
+    await this.authenticateWithFlow(
+      () => this.oauthFlow.startOrganizationCreationFlow(region),
+      region,
+      "Organization creation failed",
+      sessionGeneration,
+      true,
+      true,
     );
     return this.getState();
   }
@@ -281,6 +298,10 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     await this.initialize();
 
     const session = await this.ensureValidSession();
+    if (this.authFlow !== null) {
+      throw new Error("Authentication is in progress");
+    }
+    const sessionGeneration = this.sessionGeneration;
 
     if (!flattenProjectIds(session.orgProjectsMap).includes(projectId)) {
       throw new Error("Invalid project selection");
@@ -298,17 +319,25 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
         ? await this.applyOrgChange(session, newOrgId)
         : session.orgProjectsMap;
 
-    await this.commitSessionState(session, {
-      orgProjectsMap,
-      currentOrgId: newOrgId,
-      currentProjectId: projectId,
-    });
+    await this.commitSessionState(
+      session,
+      {
+        orgProjectsMap,
+        currentOrgId: newOrgId,
+        currentProjectId: projectId,
+      },
+      sessionGeneration,
+    );
     return this.getState();
   }
   async switchOrg(orgId: string): Promise<AuthState> {
     await this.initialize();
 
     const session = await this.ensureValidSession();
+    if (this.authFlow !== null) {
+      throw new Error("Authentication is in progress");
+    }
+    const sessionGeneration = this.sessionGeneration;
 
     if (!session.orgProjectsMap[orgId]) {
       throw new Error("Invalid organization");
@@ -321,11 +350,15 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       orgId,
     );
 
-    await this.commitSessionState(session, {
-      orgProjectsMap,
-      currentOrgId: orgId,
-      currentProjectId,
-    });
+    await this.commitSessionState(
+      session,
+      {
+        orgProjectsMap,
+        currentOrgId: orgId,
+        currentProjectId,
+      },
+      sessionGeneration,
+    );
     return this.getState();
   }
   private async applyOrgChange(
@@ -377,12 +410,12 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       currentOrgId: string | null;
       currentProjectId: number | null;
     },
+    sessionGeneration: number,
   ): Promise<void> {
     // Serialize commits onto a chain so overlapping selections can't
     // interleave across async encryption and clobber a newer one. The chain
     // swallows rejections so one failure doesn't wedge later commits; the
     // returned promise still rejects for the caller.
-    const sessionGeneration = this.sessionGeneration;
     const run = this.commitChain.then(() =>
       this.applyCommittedSession(prevSession, next, sessionGeneration),
     );
@@ -483,6 +516,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     const { cloudRegion, currentProjectId } = this.state;
 
     this.sessionGeneration += 1;
+    this.authFlow = null;
     this.authSession.clearCurrent();
     this.clearImpersonationExpiryTimer();
     this.session = null;
@@ -843,8 +877,9 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     const lastPrefs = accountKey
       ? this.authPreference.get(accountKey, options.cloudRegion)
       : null;
-    const preferredProjectId =
-      options.selectedProjectId ?? lastPrefs?.lastSelectedProjectId ?? null;
+    const preferredProjectId = options.ignoreProjectPreference
+      ? null
+      : (options.selectedProjectId ?? lastPrefs?.lastSelectedProjectId ?? null);
     let selection = this.reconcileInitialSelection({
       orgProjectsMap,
       currentOrgId,
@@ -1088,17 +1123,48 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     region: CloudRegion,
     fallbackError: string,
     sessionGeneration: number,
+    ignoreProjectPreference = false,
+    requireSameAccount = false,
   ): Promise<void> {
-    const result = await runFlow();
-    if (!result.success || !result.data) {
-      throw new Error(result.error || fallbackError);
-    }
+    const accountKey = this.session?.accountKey ?? null;
+    const authFlow = Symbol();
+    this.authFlow = authFlow;
+    try {
+      const result = await runFlow();
+      if (!result.success || !result.data) {
+        throw new Error(result.error || fallbackError);
+      }
+      if (this.sessionGeneration !== sessionGeneration) {
+        return;
+      }
 
-    const session = await this.createSessionFromTokenResponse(result.data, {
-      cloudRegion: region,
-      selectedProjectId: this.state.currentProjectId,
-    });
-    await this.syncAuthenticatedSession(session, sessionGeneration);
+      const session = await this.createSessionFromTokenResponse(result.data, {
+        cloudRegion: region,
+        selectedProjectId: this.state.currentProjectId,
+        ignoreProjectPreference,
+      });
+      if (this.sessionGeneration !== sessionGeneration) {
+        return;
+      }
+      if (requireSameAccount) {
+        if (accountKey === null || session.accountKey === null) {
+          throw new Error(
+            "PostHog could not verify your browser account. Check your connection, then try again.",
+          );
+        }
+        if (session.accountKey !== accountKey) {
+          throw new Error(
+            "Your browser is signed in to a different PostHog account. Sign in to the same account, then try again.",
+          );
+        }
+      }
+      const syncGeneration = ++this.sessionGeneration;
+      await this.syncAuthenticatedSession(session, syncGeneration);
+    } finally {
+      if (this.authFlow === authFlow) {
+        this.authFlow = null;
+      }
+    }
   }
   private async syncAuthenticatedSession(
     session: InMemorySession,
@@ -1569,6 +1635,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       }
 
       if (!session.orgProjectsIncomplete) return;
+      const sessionGeneration = this.sessionGeneration;
 
       let map: OrgProjectsMap;
       let incomplete: boolean;
@@ -1618,11 +1685,15 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
           }),
           preferredProjectId,
         );
-        await this.commitSessionState(session, {
-          orgProjectsMap: map,
-          currentOrgId: selection.currentOrgId,
-          currentProjectId: selection.currentProjectId,
-        });
+        await this.commitSessionState(
+          session,
+          {
+            orgProjectsMap: map,
+            currentOrgId: selection.currentOrgId,
+            currentProjectId: selection.currentProjectId,
+          },
+          sessionGeneration,
+        );
         this.logger.info(
           "Recovered organizations/projects after incomplete sync",
         );

--- a/products/desktop/packages/core/src/auth/identifiers.ts
+++ b/products/desktop/packages/core/src/auth/identifiers.ts
@@ -76,6 +76,7 @@ export const AUTH_PREFERENCE_STORE = Symbol.for(
 export interface IAuthOAuthFlowService {
   startFlow(region: CloudRegion): Promise<StartFlowOutput>;
   startSignupFlow(region: CloudRegion): Promise<StartFlowOutput>;
+  startOrganizationCreationFlow(region: CloudRegion): Promise<StartFlowOutput>;
   refreshToken(
     refreshToken: string,
     region: CloudRegion,

--- a/products/desktop/packages/core/src/oauth/oauth.test.ts
+++ b/products/desktop/packages/core/src/oauth/oauth.test.ts
@@ -228,6 +228,30 @@ describe("OAuthService deep-link callback handler", () => {
     expect(mainWindow.focus).toHaveBeenCalled();
   });
 
+  it("returns through OAuth after organization creation", async () => {
+    const { service, getCallbackHandler, urlLauncher } = createDeps();
+    fetchMock.mockResolvedValue(jsonResponse(TOKEN_RESPONSE));
+
+    const organizationCreation = service.startOrganizationCreationFlow("us");
+    const launchedUrl = new URL(urlLauncher.launch.mock.calls[0][0]);
+    const nextPath = launchedUrl.searchParams.get("next");
+
+    expect(launchedUrl.pathname).toBe("/create-organization");
+    expect(nextPath).not.toBeNull();
+    const authorizeUrl = new URL(nextPath ?? "", launchedUrl.origin);
+    expect(authorizeUrl.pathname).toBe("/oauth/authorize");
+    expect(authorizeUrl.searchParams.get("redirect_uri")).toBe(
+      "posthog-code://callback",
+    );
+
+    getCallbackHandler()?.("callback", new URLSearchParams("code=abc"));
+
+    await expect(organizationCreation).resolves.toEqual({
+      success: true,
+      data: TOKEN_RESPONSE,
+    });
+  });
+
   it("accepts a short-lived impersonated session without a refresh token", async () => {
     const { service, getCallbackHandler } = createDeps();
     fetchMock.mockResolvedValue(

--- a/products/desktop/packages/core/src/oauth/oauth.ts
+++ b/products/desktop/packages/core/src/oauth/oauth.ts
@@ -200,6 +200,37 @@ export class OAuthService {
     }
   }
 
+  public async startOrganizationCreationFlow(
+    region: CloudRegion,
+  ): Promise<StartFlowOutput> {
+    try {
+      this.cancelFlow();
+
+      const config: OAuthConfig = {
+        scopes: OAUTH_SCOPES,
+        cloudRegion: region,
+      };
+
+      const codeVerifier = this.generateCodeVerifier();
+      const authUrl = this.buildAuthorizeUrl(region, codeVerifier);
+      const organizationUrl = this.buildOrganizationCreationUrl(
+        region,
+        authUrl,
+      );
+
+      return await this.startFlowWithUrl(
+        config,
+        codeVerifier,
+        organizationUrl.toString(),
+      );
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  }
+
   /**
    * Refresh an access token using a refresh token.
    */
@@ -451,6 +482,16 @@ export class OAuthService {
     const nextPath = `${authUrl.pathname}${authUrl.search}`;
     signupUrl.searchParams.set("next", nextPath);
     return signupUrl;
+  }
+
+  private buildOrganizationCreationUrl(region: CloudRegion, authUrl: URL): URL {
+    const cloudUrl = getCloudUrlFromRegion(region);
+    const organizationUrl = new URL(`${cloudUrl}/create-organization`);
+    organizationUrl.searchParams.set(
+      "next",
+      `${authUrl.pathname}${authUrl.search}`,
+    );
+    return organizationUrl;
   }
 
   private async startFlowWithUrl(

--- a/products/desktop/packages/host-router/src/routers/auth.router.ts
+++ b/products/desktop/packages/host-router/src/routers/auth.router.ts
@@ -44,6 +44,15 @@ export const authRouter = router({
         .signup(input.region),
     })),
 
+  createOrganization: publicProcedure
+    .input(loginInput)
+    .output(loginOutput)
+    .mutation(async ({ ctx, input }) => ({
+      state: await ctx.container
+        .get<AuthService>(AUTH_SERVICE)
+        .createOrganization(input.region),
+    })),
+
   getValidAccessToken: publicProcedure
     .output(validAccessTokenOutput)
     .query(async ({ ctx }) =>

--- a/products/desktop/packages/ui/src/features/auth/useAuthMutations.ts
+++ b/products/desktop/packages/ui/src/features/auth/useAuthMutations.ts
@@ -1,6 +1,7 @@
 import { useService } from "@posthog/di/react";
 import { useHostTRPCClient } from "@posthog/host-router/react";
 import type { CloudRegion } from "@posthog/shared";
+import { toast } from "@posthog/ui/primitives/toast";
 import { clearCapturedLogs } from "@posthog/ui/shell/logCapture";
 import { useMutation } from "@tanstack/react-query";
 import { AUTH_SIDE_EFFECTS, type IAuthSideEffects } from "./identifiers";
@@ -13,6 +14,29 @@ export function useLoginMutation() {
       hostClient.auth.login.mutate({ region }).then((r) => r.state),
     onSuccess: (state, region) =>
       fx.onAuthSuccess(region, state.currentProjectId),
+  });
+}
+
+export function useCreateOrganizationMutation() {
+  const hostClient = useHostTRPCClient();
+  const fx = useService<IAuthSideEffects>(AUTH_SIDE_EFFECTS);
+  return useMutation({
+    mutationFn: (region: CloudRegion) =>
+      hostClient.auth.createOrganization
+        .mutate({ region })
+        .then((response) => response.state),
+    onSuccess: async (state) => {
+      if (state.status !== "authenticated") {
+        return;
+      }
+      fx.beforeProjectSwitch();
+      await fx.onProjectSelected();
+    },
+    onError: (error) => {
+      toast.error("Couldn't create organization", {
+        description: error instanceof Error ? error.message : "Try again.",
+      });
+    },
   });
 }
 

--- a/products/desktop/packages/ui/src/features/sidebar/components/ProjectSwitcher.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/ProjectSwitcher.tsx
@@ -29,12 +29,14 @@ import {
   ItemContent,
   ItemDescription,
   ItemTitle,
+  Spinner,
 } from "@posthog/quill";
 import { EXTERNAL_LINKS } from "@posthog/shared";
 import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import {
+  useCreateOrganizationMutation,
   useLogoutMutation,
   useSelectProjectMutation,
   useSwitchOrgMutation,
@@ -81,11 +83,13 @@ export function ProjectSwitcher({
     holdPeek(next);
   };
 
+  const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
   const currentOrgId = useAuthStateValue((state) => state.currentOrgId);
   const sessionType = useAuthStateValue((state) => state.sessionType);
   const sessionExpiresAt = useAuthStateValue((state) => state.sessionExpiresAt);
   const client = useOptionalAuthenticatedClient();
   const { data: currentUser } = useCurrentUser({ client });
+  const createOrganizationMutation = useCreateOrganizationMutation();
   const selectProjectMutation = useSelectProjectMutation();
   const switchOrgMutation = useSwitchOrgMutation();
   const logoutMutation = useLogoutMutation();
@@ -151,6 +155,9 @@ export function ProjectSwitcher({
   );
 
   const handleProjectSelect = (projectId: number) => {
+    if (createOrganizationMutation.isPending) {
+      return;
+    }
     if (projectId !== currentProjectId) {
       selectProjectMutation.mutate(projectId);
     }
@@ -158,6 +165,9 @@ export function ProjectSwitcher({
   };
 
   const handleOrgSelect = (orgId: string) => {
+    if (createOrganizationMutation.isPending) {
+      return;
+    }
     if (orgId !== currentOrgId) {
       switchOrgMutation.mutate(orgId);
     }
@@ -165,14 +175,19 @@ export function ProjectSwitcher({
   };
 
   const handleCreateProject = () => {
+    if (createOrganizationMutation.isPending) {
+      return;
+    }
     const url = getPostHogUrl("/organization/create-project");
     if (url) openExternalUrl(url);
     setPopoverOpen(false);
   };
 
   const handleCreateOrg = () => {
-    const url = getPostHogUrl("/create-organization");
-    if (url) openExternalUrl(url);
+    if (!cloudRegion || createOrganizationMutation.isPending) {
+      return;
+    }
+    createOrganizationMutation.mutate(cloudRegion);
     setPopoverOpen(false);
   };
 
@@ -292,7 +307,9 @@ export function ProjectSwitcher({
               <DropdownMenuLabel>Project</DropdownMenuLabel>
 
               <DropdownMenuSub>
-                <DropdownMenuSubTrigger>
+                <DropdownMenuSubTrigger
+                  disabled={createOrganizationMutation.isPending}
+                >
                   <FolderSimple size={14} className="text-gray-11" />
                   {currentProject?.name ?? "No project selected"}
                 </DropdownMenuSubTrigger>
@@ -306,7 +323,10 @@ export function ProjectSwitcher({
                 </MenuSubFlyout>
               </DropdownMenuSub>
 
-              <DropdownMenuItem onClick={handleCreateProject}>
+              <DropdownMenuItem
+                onClick={handleCreateProject}
+                disabled={createOrganizationMutation.isPending}
+              >
                 <Plus size={14} className="text-gray-11" />
                 Create project
                 <ArrowSquareOut size={14} className="ml-auto text-gray-11" />
@@ -317,7 +337,9 @@ export function ProjectSwitcher({
               <DropdownMenuLabel>Organization</DropdownMenuLabel>
 
               <DropdownMenuSub>
-                <DropdownMenuSubTrigger>
+                <DropdownMenuSubTrigger
+                  disabled={createOrganizationMutation.isPending}
+                >
                   <Buildings size={14} className="text-gray-11" />
                   {currentOrgName}
                 </DropdownMenuSubTrigger>
@@ -331,8 +353,15 @@ export function ProjectSwitcher({
                 </MenuSubFlyout>
               </DropdownMenuSub>
 
-              <DropdownMenuItem onClick={handleCreateOrg}>
-                <Plus size={14} className="text-gray-11" />
+              <DropdownMenuItem
+                onClick={handleCreateOrg}
+                disabled={!cloudRegion || createOrganizationMutation.isPending}
+              >
+                {createOrganizationMutation.isPending ? (
+                  <Spinner className="size-3.5" />
+                ) : (
+                  <Plus size={14} className="text-gray-11" />
+                )}
                 Create organization
                 <ArrowSquareOut size={14} className="ml-auto text-gray-11" />
               </DropdownMenuItem>


### PR DESCRIPTION
## Problem

The Desktop account menu cannot return to the app after a person creates an organization in the browser.

The direct browser link loses the Desktop return path during organization creation and onboarding.

## Changes

- Desktop now starts organization creation as a pending OAuth flow.
- Web onboarding preserves the validated OAuth destination and reloads the server authorization page.
- Desktop selects the new organization's first project after the callback.
- Desktop rejects browser account mismatches and blocks conflicting project changes during the flow.
- The account menu layout does not change, so this PR has no screenshot.

Before:

```mermaid
flowchart LR
    A[Desktop account menu] --> B[Browser organization creation]
    B --> C[Web onboarding]
    C --> D[Web app]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phBlue;
    class B,C phRed;
    class D phYellow;
```

After:

```mermaid
flowchart LR
    A[Desktop account menu] --> B[Browser organization creation]
    B --> C[Web onboarding]
    C --> D[OAuth authorization]
    D --> E[Desktop callback]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,E phBlue;
    class B,C,D phRed;
    class E phYellow;
```

## How did you test this code?

- Desktop OAuth and auth tests cover the callback, new organization selection, account mismatch, logout, and stale session races.
- Frontend logic tests cover organization creation and both onboarding variants.
- All Desktop packages passed type checks. Biome and the host boundary check passed.
- The frontend formatter passed. The full frontend type check exceeded this VM's memory limit after dependency builds completed.
- Manual browser testing was not run because this sandbox has no authenticated organization creation fixture.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated `products/desktop/docs/DEEP-LINKS.md` with the organization creation callback behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog MCP supplied the report context. Pi Explore and Plan agents checked the flow, tests, and session safety.

Skills invoked: `/inbox-exploration`, `/posthog-desktop`, `/adopting-generated-api-types`, `/writing-kea-logics`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-simplified-technical-english`, `/hogli`, `/running-ci-preflight`, and `/writing-pr-descriptions`.

The change uses a new OAuth grant because a token refresh cannot include a newly created organization.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*