### PR TITLE
fix(canvas): reject CSS variables that collide with Quill element tokens

### DIFF
--- a/products/canvas/backend/source.py
+++ b/products/canvas/backend/source.py
@@ -67,6 +67,33 @@ ALLOWED_CONFIG_SCHEMA_KEYWORDS = frozenset(
 
 # File extensions whose content is scanned as source code.
 _CODE_EXTENSIONS = (".ts", ".tsx", ".js", ".jsx")
+# Files scanned for CSS custom property declarations: stylesheets plus code,
+# because inline <style> blocks and CSS-in-JS carry CSS as strings.
+_STYLE_EXTENSIONS = (".css", *_CODE_EXTENSIONS)
+
+# Quill design tokens that the bundled platform stylesheet (@posthog/quill
+# color-system.css) declares on the universal selector `*`, not on `:root`.
+# Every element then gets Quill's value directly, so an author's `:root` or
+# `html.dark` declaration of the same name never reaches any descendant and
+# text colored with `var(--muted)` silently becomes Quill's pale surface color.
+# Keep in sync with the `* { ... }` rule of the pinned Quill version.
+_PLATFORM_ELEMENT_TOKENS = frozenset(
+    {
+        "background",
+        "border",
+        "card",
+        "chrome",
+        "fill-expanded",
+        "fill-hover",
+        "fill-selected",
+        "input",
+        "muted",
+        "primary",
+    }
+)
+_PLATFORM_TOKEN_DECLARATION_RE = re.compile(
+    r"(?<![\w-])--(" + "|".join(sorted(_PLATFORM_ELEMENT_TOKENS)) + r")\s*[\"']?\s*:"
+)
 
 # The synthetic entry shell presented for pre-relational canvases whose only
 # source is a single stored React component.
@@ -293,6 +320,24 @@ def _validate_network_capabilities(path: str, content: str, declared_origins: se
                     line=_line_of(content, position),
                 )
             )
+    return diagnostics
+
+
+def _validate_platform_tokens(path: str, content: str) -> list[dict[str, Any]]:
+    diagnostics: list[dict[str, Any]] = []
+    for match in _PLATFORM_TOKEN_DECLARATION_RE.finditer(content):
+        token = match.group(1)
+        diagnostics.append(
+            diagnostic(
+                "error",
+                "platform_token_redeclared",
+                f"--{token} is a platform design token that the platform stylesheet sets on every element, "
+                f"so this declaration is ignored and text colored with var(--{token}) can become unreadable. "
+                f"Rename it, for example --canvas-{token}, or use the platform token without redefining it",
+                path=path,
+                line=_line_of(content, match.start()),
+            )
+        )
     return diagnostics
 
 
@@ -739,6 +784,8 @@ def validate_source_project(project: dict[str, Any], *, kind: str = "freeform") 
         if not isinstance(content, str):
             continue
         diagnostics.extend(_validate_network_capabilities(path, content, declared_network_origins))
+        if path.endswith(_STYLE_EXTENSIONS):
+            diagnostics.extend(_validate_platform_tokens(path, content))
         if path.endswith(_CODE_EXTENSIONS):
             diagnostics.extend(_validate_code_file(path, content))
             diagnostics.extend(_validate_capabilities(path, content, capabilities))

--- a/products/canvas/backend/source.py
+++ b/products/canvas/backend/source.py
@@ -67,9 +67,10 @@ ALLOWED_CONFIG_SCHEMA_KEYWORDS = frozenset(
 
 # File extensions whose content is scanned as source code.
 _CODE_EXTENSIONS = (".ts", ".tsx", ".js", ".jsx")
-# Files scanned for CSS custom property declarations: stylesheets plus code,
-# because inline <style> blocks and CSS-in-JS carry CSS as strings.
-_STYLE_EXTENSIONS = (".css", *_CODE_EXTENSIONS)
+# Files scanned for CSS custom property declarations: stylesheets, the entry
+# HTML, and code, because inline <style> blocks and CSS-in-JS carry CSS as
+# strings.
+_STYLE_EXTENSIONS = (".css", ".html", *_CODE_EXTENSIONS)
 
 # Quill design tokens that the bundled platform stylesheet (@posthog/quill
 # color-system.css) declares on the universal selector `*`, not on `:root`.
@@ -91,8 +92,12 @@ _PLATFORM_ELEMENT_TOKENS = frozenset(
         "primary",
     }
 )
+# A declaration sits at the start of a line or right after `{`, `;`, or `,`
+# (CSS rule bodies and inline-style object keys). Requiring that context keeps
+# a comment such as `// --muted: legacy` or a `var(--muted)` use from matching.
 _PLATFORM_TOKEN_DECLARATION_RE = re.compile(
-    r"(?<![\w-])--(" + "|".join(sorted(_PLATFORM_ELEMENT_TOKENS)) + r")\s*[\"']?\s*:"
+    r"(?:^|[{;,])\s*[\"']?--(" + "|".join(sorted(_PLATFORM_ELEMENT_TOKENS)) + r")[\"']?\s*:",
+    re.MULTILINE,
 )
 
 # The synthetic entry shell presented for pre-relational canvases whose only
@@ -335,7 +340,7 @@ def _validate_platform_tokens(path: str, content: str) -> list[dict[str, Any]]:
                 f"so this declaration is ignored and text colored with var(--{token}) can become unreadable. "
                 f"Rename it, for example --canvas-{token}, or use the platform token without redefining it",
                 path=path,
-                line=_line_of(content, match.start()),
+                line=_line_of(content, match.start(1)),
             )
         )
     return diagnostics

--- a/products/canvas/backend/tests/test_cloud_builder.py
+++ b/products/canvas/backend/tests/test_cloud_builder.py
@@ -1,4 +1,5 @@
 import os
+import re
 import hashlib
 import tempfile
 import subprocess
@@ -14,7 +15,7 @@ from parameterized import parameterized
 from products.canvas.backend.build_service import node_executable, run_cloud_builder, validate_builder_output
 from products.canvas.backend.contract import allowed_import_specifiers, canvas_sdk_version, platform_dependencies
 from products.canvas.backend.presentation.serializers import CanvasSourceProjectSerializer
-from products.canvas.backend.source import synthetic_source_project, validate_source_project
+from products.canvas.backend.source import _PLATFORM_ELEMENT_TOKENS, synthetic_source_project, validate_source_project
 
 
 class TestCanvasCloudBuilder(SimpleTestCase):
@@ -55,6 +56,13 @@ class TestCanvasCloudBuilder(SimpleTestCase):
         self.assertIn(".md\\:grid-cols-2", stylesheet["content"])
         self.assertIn(".quill-button", stylesheet["content"])
         self.assertIn("--background", stylesheet["content"])
+        # Source validation rejects author declarations of the tokens Quill sets
+        # on every element; that list must follow the pinned Quill version.
+        universal_rule = re.search(r"^\* \{\n(.*?)^\}", stylesheet["content"], re.MULTILINE | re.DOTALL)
+        assert universal_rule is not None
+        self.assertEqual(
+            set(re.findall(r"^\s*--([\w-]+):", universal_rule.group(1), re.MULTILINE)), _PLATFORM_ELEMENT_TOKENS
+        )
 
     def test_publication_validation_allows_relative_worker_and_asset_imports(self) -> None:
         payload = synthetic_source_project(

--- a/products/canvas/backend/tests/test_source.py
+++ b/products/canvas/backend/tests/test_source.py
@@ -148,6 +148,13 @@ class TestCanvasSourceAdapter(SimpleTestCase):
                 "platform_token_redeclared",
             ),
             (
+                "platform_token_in_entry_html",
+                project(
+                    files={CANVAS_ENTRY_HTML: '<style>\n:root {\n  --muted: #5d5a52;\n}\n</style><div id="root"></div>'}
+                ),
+                "platform_token_redeclared",
+            ),
+            (
                 "file_too_large",
                 project(files={CANVAS_COMPONENT_PATH: "a" * (MAX_FILE_BYTES + 1)}),
                 "file_too_large",
@@ -203,9 +210,23 @@ class TestCanvasSourceAdapter(SimpleTestCase):
         diagnostics = validate_source_project(candidate)
         self.assertNotIn("capability_missing_state", [d["code"] for d in diagnostics])
 
-    def test_own_css_variables_and_root_scoped_platform_tokens_pass(self):
-        css = ":root { --doc-muted: #5d5a52; --muted-foreground: #444; } .lead { color: var(--muted); }"
-        candidate = project(files={CANVAS_COMPONENT_PATH: CODE, "src/styles.css": css})
+    @parameterized.expand(
+        [
+            (
+                "prefixed_and_suffixed_names",
+                "src/styles.css",
+                ":root { --doc-muted: #5d5a52; --muted-foreground: #444; } .lead { color: var(--muted); }",
+            ),
+            ("comment_mentioning_token", CANVAS_COMPONENT_PATH, CODE + "// --muted: legacy name, do not use\n"),
+            (
+                "prose_mentioning_token",
+                CANVAS_COMPONENT_PATH,
+                CODE + 'const hint = "Rename --muted: it is reserved";\n',
+            ),
+        ]
+    )
+    def test_platform_token_uses_and_mentions_pass(self, _name: str, path: str, content: str) -> None:
+        candidate = project(files={CANVAS_COMPONENT_PATH: CODE, path: content})
         self.assertEqual(validate_source_project(candidate), [])
 
     def test_direct_network_calls_warn_but_stay_publishable(self):

--- a/products/canvas/backend/tests/test_source.py
+++ b/products/canvas/backend/tests/test_source.py
@@ -138,6 +138,16 @@ class TestCanvasSourceAdapter(SimpleTestCase):
                 "forbidden_inline_script",
             ),
             (
+                "platform_token_in_stylesheet",
+                project(files={CANVAS_COMPONENT_PATH: CODE, "src/styles.css": ":root { --muted: #5d5a52; }"}),
+                "platform_token_redeclared",
+            ),
+            (
+                "platform_token_in_inline_style",
+                project(files={CANVAS_COMPONENT_PATH: CODE + "const css = `html.dark { --background:#141416 }`;"}),
+                "platform_token_redeclared",
+            ),
+            (
                 "file_too_large",
                 project(files={CANVAS_COMPONENT_PATH: "a" * (MAX_FILE_BYTES + 1)}),
                 "file_too_large",
@@ -192,6 +202,11 @@ class TestCanvasSourceAdapter(SimpleTestCase):
         )
         diagnostics = validate_source_project(candidate)
         self.assertNotIn("capability_missing_state", [d["code"] for d in diagnostics])
+
+    def test_own_css_variables_and_root_scoped_platform_tokens_pass(self):
+        css = ":root { --doc-muted: #5d5a52; --muted-foreground: #444; } .lead { color: var(--muted); }"
+        candidate = project(files={CANVAS_COMPONENT_PATH: CODE, "src/styles.css": css})
+        self.assertEqual(validate_source_project(candidate), [])
 
     def test_direct_network_calls_warn_but_stay_publishable(self):
         candidate = project(files={CANVAS_COMPONENT_PATH: CODE + "fetch(dynamicUrl);"})

--- a/products/canvas/skills/building-html-canvases/SKILL.md
+++ b/products/canvas/skills/building-html-canvases/SKILL.md
@@ -47,6 +47,12 @@ build pipeline's dependency admission ships.
   Define your colors as CSS variables under `:root { … }` with overrides under `html.dark { … }`,
   or use theme token utilities (`bg-background`, `text-foreground`, `border-border`) — never a
   light-only hardcoded color.
+- Give your own CSS variables a prefix (`--doc-bg`, `--doc-muted`). Never reuse a platform token
+  name: the bundled Quill stylesheet sets `--background`, `--border`, `--card`, `--chrome`,
+  `--input`, `--muted`, `--primary`, and `--fill-*` on every element, so a `:root` or `html.dark`
+  value with one of those names never reaches any element. A page that colors its text with its own
+  `--muted` then renders unreadable (pale text on a pale page). Validation rejects such a
+  declaration with `platform_token_redeclared`.
 - For canvas/WebGL drawing colors, read the resolved token at runtime
   (`getComputedStyle(document.documentElement).getPropertyValue("--primary")`) or your own CSS
   variables, and re-read on theme change if the scene is long-lived.

--- a/products/canvas/skills/building-react-quill-canvases/SKILL.md
+++ b/products/canvas/skills/building-react-quill-canvases/SKILL.md
@@ -71,6 +71,11 @@ text-card-foreground`; borders `border-border`. Never a hardcoded hex or light-o
   always use the `-foreground` utility; a filled pill pairs `bg-success text-success-foreground`.
   Prefer the Quill `Badge` (`variant="success"`/`"destructive"`) for deltas so you don't hand-pick.
 - `bg-secondary`, `text-secondary`, `bg-accent`, and `bg-popover` are not defined in the canvas — avoid them.
+- Never declare a CSS variable with a platform token name (`--background`, `--border`, `--card`,
+  `--chrome`, `--input`, `--muted`, `--primary`, `--fill-*`), in a stylesheet or a `<style>` block.
+  Quill sets those on every element, so your value never applies and text can turn unreadable.
+  Prefix your own variables (`--doc-muted`); validation rejects the collision with
+  `platform_token_redeclared`.
 - recharts strokes/fills use token CSS variables (`stroke="var(--primary)"`, grid/axes in
   `var(--border)`/`var(--muted-foreground)`).
 - Write Unicode glyphs (curly quotes, ellipsis, arrows, emoji) as literal characters in JSX —

--- a/products/canvas/skills/validating-and-publishing-canvases/SKILL.md
+++ b/products/canvas/skills/validating-and-publishing-canvases/SKILL.md
@@ -69,7 +69,9 @@ Diagnostics carry `severity`, a stable `code`, a `message`, and (for file-specif
   `invalid_path`, `capability_missing_insight` / `capability_missing_capture_event` /
   `capability_missing_inline_queries` / `capability_missing_agent_requests` /
   `capability_missing_network_origin`,
-  `dependency_not_admitted` / `dependency_version_mismatch`, and path/size violations.
+  `dependency_not_admitted` / `dependency_version_mismatch`, `platform_token_redeclared` (a CSS
+  variable named like a Quill token that the platform stylesheet sets on every element, so the
+  value never applies; prefix your own variables), and path/size violations.
 - `warning` diagnostics don't block, but heed them: `network_fetch` / `network_xhr` mean the code
   reaches for the network directly. Declare the exact HTTPS origin or use the `ph` bridge.
 


### PR DESCRIPTION
## Problem

- A freshly generated canvas can render its body text in a color almost equal to its background, in light and in dark mode. The reader sees a page with a title and no readable paragraphs.
- The cause is a name collision. Quill's `color-system.css`, which the builder bundles into every canvas, sets `--background`, `--border`, `--card`, `--chrome`, `--input`, `--muted`, `--primary` and `--fill-*` on the universal selector `*`.
- Every element receives Quill's value directly. An author's `:root { --muted: … }` or `html.dark { --muted: … }` therefore never reaches any element.
- Quill's `--muted` is a pale surface color, so `color: var(--muted)` on body copy produces pale text on a pale page. Nothing warned the authoring agent, and the `building-html-canvases` skill told it to define colors as `:root` variables without naming the reserved names.

**Why:** canvases created in PostHog Desktop regularly came out unreadable on the first publish and needed a second round to fix.

## Changes

- An agent that publishes a canvas with such a declaration now gets an `error` diagnostic, `platform_token_redeclared`, with the file, the line and the fix (prefix the variable, for example `--canvas-muted`). Publish is blocked until it is fixed.
- The check scans `.css` files and code files, because inline `<style>` blocks and CSS-in-JS hold CSS as strings. `--muted-foreground` and `--doc-muted` stay allowed; only the exact token names are rejected.
- The token list is a hardcoded set in `source.py`. The existing builder test now compiles the platform stylesheet and asserts the `*` rule declares exactly that set, so a Quill version bump that moves a token fails the test instead of silently dropping the guard.
- The three canvas skills (`building-html-canvases`, `building-react-quill-canvases`, `validating-and-publishing-canvases`) now tell authors to prefix their own variables and name the reserved tokens and the diagnostic code. Mechanical: docs only.
- Nothing in this repo's UI changes, so there is no screenshot.

## How did you test this code?

- Reproduced the failure by rendering a published canvas artifact in headless Chromium: `p.lead` computed to `oklch(0.953 …)` in light mode and `oklch(0.209 …)` in dark mode, in both cases Quill's `--muted` instead of the author's value. Renaming the variable to `--doc-muted` restored the author's colors.
- New parameterized cases in `test_invalid_projects_produce_error_diagnostics` (a `.css` file and an inline template string) catch a validator that stops flagging the collision.
- `test_own_css_variables_and_root_scoped_platform_tokens_pass` catches a regex that over-matches prefixed names or `--muted-foreground`.
- The extended `test_legacy_canvas_build_compiles_tailwind_and_quill_styles` catches drift between the hardcoded token set and the pinned Quill build.
- Ran `products/canvas/backend/tests/test_source.py` and `test_cloud_builder.py` locally with the builder installed. Not run: repo-wide mypy.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The canvas skills under `products/canvas/skills/` are the documentation for this behavior and are updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: Claude Code (PostHog Desktop task). Tools: the PostHog MCP canvas tools to read the affected canvas source and builds, Playwright via the desktop package to reproduce the render, `hogli test`, `hogli ci:preflight`.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.
- Decisions: severity is `error` rather than `warning`, because the declaration can never take effect and a warning is what the current flow lets through. A builder-side check was considered and rejected in favor of validation, so the agent gets the diagnostic before the async build; the builder test pins the list instead.
- The affected canvas in the user's workspace was republished with the variable renamed. No material from that canvas is in this PR.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
