### PR TITLE
feat(desktop): instrument model picker interactions

### DIFF
--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -1,6 +1,7 @@
 // Analytics event types and properties
 
 import type { Adapter, ModelAccess } from "./adapter";
+import type { AgentRuntime } from "./agent-runtime";
 import type { EffortLevel } from "./domain-types";
 import type { SourceProduct } from "./inbox-types";
 
@@ -418,6 +419,52 @@ export interface ModelSwitchWarningActionProperties
   action: "cancel" | "copy_handoff_summary" | "switch_now";
   result?: "failed" | "succeeded";
 }
+
+export type ModelPickerSurface =
+  | "session"
+  | "task_input"
+  | "channel_home"
+  | "quick_ask_settings"
+  | "task_agent_defaults";
+
+type ModelPickerSelectionControl =
+  | "slider"
+  | "advanced_model"
+  | "advanced_reasoning"
+  | "advanced_context_window"
+  | "advanced_harness"
+  | "advanced_billing"
+  | "fast_mode_toggle"
+  | "reset_default"
+  | "pi_model"
+  | "pi_reasoning"
+  | "pi_harness";
+
+export type ModelPickerInteractionProperties =
+  | {
+      surface: ModelPickerSurface;
+      runtime: AgentRuntime;
+      action: "opened";
+      initial_view: "slider" | "advanced" | "menu";
+    }
+  | {
+      surface: ModelPickerSurface;
+      runtime: AgentRuntime;
+      action: "advanced_opened";
+    }
+  | {
+      surface: ModelPickerSurface;
+      runtime: AgentRuntime;
+      action: "selection";
+      control: "slider";
+      changed: boolean;
+    }
+  | {
+      surface: ModelPickerSurface;
+      runtime: AgentRuntime;
+      action: "selection";
+      control: Exclude<ModelPickerSelectionControl, "slider">;
+    };
 
 // Tour events
 type TourAction = "started" | "step_advanced" | "dismissed" | "completed";
@@ -1557,6 +1604,7 @@ export const ANALYTICS_EVENTS = {
   SESSION_CONFIG_CHANGED: "Session config changed",
   MODEL_SWITCH_WARNING_SHOWN: "Model switch warning shown",
   MODEL_SWITCH_WARNING_ACTION: "Model switch warning action",
+  MODEL_PICKER_INTERACTION: "Model picker interaction",
 
   // Settings events
   SETTING_CHANGED: "Setting changed",
@@ -1765,6 +1813,7 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.SESSION_CONFIG_CHANGED]: SessionConfigChangedProperties;
   [ANALYTICS_EVENTS.MODEL_SWITCH_WARNING_SHOWN]: ModelSwitchWarningShownProperties;
   [ANALYTICS_EVENTS.MODEL_SWITCH_WARNING_ACTION]: ModelSwitchWarningActionProperties;
+  [ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION]: ModelPickerInteractionProperties;
 
   // Settings events
   [ANALYTICS_EVENTS.SETTING_CHANGED]: SettingChangedProperties;

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -534,6 +534,7 @@ export const ChannelHomeComposer = forwardRef<
                 supportsPiThinking ? currentPiThinkingLevel : undefined
               }
               thinkingLevels={piThinkingLevels}
+              analyticsSurface="channel_home"
               disabled={isBusy || isPiConfigLoading}
               isLoading={isPiConfigLoading}
               onChange={handlePiModelChange}
@@ -554,6 +555,7 @@ export const ChannelHomeComposer = forwardRef<
               adapter={adapter ?? "claude"}
               contextWindowOption={contextWindowOption}
               fastModeOption={fastModeOption}
+              analyticsSurface="channel_home"
               onChange={handleThoughtChange}
               onModelChange={handleModelChange}
               onAdapterChange={setAdapter}

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.test.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.test.tsx
@@ -1,4 +1,5 @@
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { configure, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
@@ -7,6 +8,9 @@ import { PiModelSelector } from "./PiSessionControls";
 // Menu open/close and submenu reveals ride animations that starve under
 // parallel suite load; the default 1s async timeout flakes.
 configure({ asyncUtilTimeout: 5000 });
+
+const track = vi.hoisted(() => vi.fn());
+vi.mock("@posthog/ui/shell/analytics", () => ({ track }));
 
 const piModels = [
   { provider: "posthog" as const, id: "claude-opus-5", name: "Claude Opus 5" },
@@ -61,6 +65,7 @@ async function openSub(user: ReturnType<typeof userEvent.setup>, name: RegExp) {
 
 describe("PiModelSelector", () => {
   it("offers the full catalog and reports picks by gateway model id", async () => {
+    track.mockClear();
     const onChange = vi.fn();
     const onGatewayModelSelect = vi.fn();
     const user = userEvent.setup({ pointerEventsCheck: 0 });
@@ -71,6 +76,7 @@ describe("PiModelSelector", () => {
         onChange={onChange}
         modelOption={groupedModelOption()}
         onGatewayModelSelect={onGatewayModelSelect}
+        analyticsSurface="task_input"
       />,
     );
 
@@ -85,5 +91,26 @@ describe("PiModelSelector", () => {
     expect(onGatewayModelSelect).toHaveBeenCalledWith("gpt-5.5");
     expect(onGatewayModelSelect).toHaveBeenCalledTimes(1);
     expect(onChange).not.toHaveBeenCalled();
+    expect(track).toHaveBeenCalledTimes(2);
+    expect(track).toHaveBeenNthCalledWith(
+      1,
+      ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION,
+      {
+        surface: "task_input",
+        runtime: "pi",
+        action: "opened",
+        initial_view: "menu",
+      },
+    );
+    expect(track).toHaveBeenNthCalledWith(
+      2,
+      ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION,
+      {
+        surface: "task_input",
+        runtime: "pi",
+        action: "selection",
+        control: "pi_model",
+      },
+    );
   });
 });

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.tsx
@@ -18,6 +18,10 @@ import {
   MenuLabel,
 } from "@posthog/quill";
 import {
+  ANALYTICS_EVENTS,
+  type ModelPickerSurface,
+} from "@posthog/shared/analytics-events";
+import {
   type AgentHarness,
   HarnessSubmenu,
 } from "@posthog/ui/features/sessions/components/HarnessSubmenu";
@@ -28,6 +32,7 @@ import {
 import { ModelSelectList } from "@posthog/ui/features/sessions/components/ModelSelectList";
 import type { MessagingMode } from "@posthog/ui/features/sessions/messagingModeStore";
 import { Spinner } from "@posthog/ui/primitives/Spinner";
+import { track } from "@posthog/ui/shell/analytics";
 import { useState } from "react";
 
 type PiModelOption = PiModelSelection & { name?: string };
@@ -49,6 +54,7 @@ interface PiModelSelectorProps {
    */
   modelOption?: SessionConfigOption;
   onGatewayModelSelect?: (modelId: string) => void;
+  analyticsSurface?: ModelPickerSurface;
   menuOpen?: boolean;
   onMenuOpenChange?: (open: boolean) => void;
 }
@@ -83,6 +89,7 @@ export function PiModelSelector({
   onHarnessChange,
   modelOption,
   onGatewayModelSelect,
+  analyticsSurface,
   menuOpen,
   onMenuOpenChange,
 }: PiModelSelectorProps) {
@@ -93,6 +100,29 @@ export function PiModelSelector({
     modelOption?.type === "select" && onGatewayModelSelect
       ? modelOption
       : undefined;
+  const handleMenuOpenChange = (nextOpen: boolean) => {
+    if (nextOpen && !open && analyticsSurface) {
+      track(ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION, {
+        surface: analyticsSurface,
+        runtime: "pi",
+        action: "opened",
+        initial_view: "menu",
+      });
+    }
+    setOpen(nextOpen);
+  };
+  const handleHarnessChange = (harness: AgentHarness) => {
+    if (harness === "pi") return;
+    if (analyticsSurface) {
+      track(ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION, {
+        surface: analyticsSurface,
+        runtime: "pi",
+        action: "selection",
+        control: "pi_harness",
+      });
+    }
+    onHarnessChange?.(harness);
+  };
 
   if (models.length === 0) {
     if (isLoading) {
@@ -100,7 +130,7 @@ export function PiModelSelector({
       // harness switch to Pi): unmounting it closes a menu the user is
       // mid-interaction with.
       return (
-        <DropdownMenu open={open} onOpenChange={setOpen}>
+        <DropdownMenu open={open} onOpenChange={handleMenuOpenChange}>
           <DropdownMenuTrigger
             render={
               <Button type="button" variant="default" size="sm">
@@ -127,11 +157,7 @@ export function PiModelSelector({
                 value="pi"
                 includePi
                 closeOnChange={false}
-                onChange={(harness) => {
-                  if (harness !== "pi") {
-                    onHarnessChange(harness);
-                  }
-                }}
+                onChange={handleHarnessChange}
               />
             )}
           </DropdownMenuContent>
@@ -150,7 +176,7 @@ export function PiModelSelector({
     : undefined;
 
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
+    <DropdownMenu open={open} onOpenChange={handleMenuOpenChange}>
       <DropdownMenuTrigger
         render={
           <Button
@@ -200,7 +226,17 @@ export function PiModelSelector({
                 options={gatewayModelSelect.options}
                 currentValue={selectedModel?.id}
                 onGated={() => setOpen(false)}
-                onSelect={(value) => onGatewayModelSelect?.(value)}
+                onSelect={(value) => {
+                  if (analyticsSurface) {
+                    track(ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION, {
+                      surface: analyticsSurface,
+                      runtime: "pi",
+                      action: "selection",
+                      control: "pi_model",
+                    });
+                  }
+                  onGatewayModelSelect?.(value);
+                }}
               />
             ) : (
               <>
@@ -211,6 +247,14 @@ export function PiModelSelector({
                       (candidate) => modelKey(candidate) === value,
                     );
                     if (model) {
+                      if (analyticsSurface) {
+                        track(ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION, {
+                          surface: analyticsSurface,
+                          runtime: "pi",
+                          action: "selection",
+                          control: "pi_model",
+                        });
+                      }
                       onChange(model);
                     }
                   }}
@@ -238,11 +282,7 @@ export function PiModelSelector({
             value="pi"
             includePi
             closeOnChange={false}
-            onChange={(harness) => {
-              if (harness !== "pi") {
-                onHarnessChange(harness);
-              }
-            }}
+            onChange={handleHarnessChange}
           />
         )}
         {thinkingLevel &&
@@ -258,9 +298,17 @@ export function PiModelSelector({
               <DropdownMenuSubContent>
                 <DropdownMenuRadioGroup
                   value={thinkingLevel}
-                  onValueChange={(value) =>
-                    onThinkingLevelChange(value as PiThinkingLevel)
-                  }
+                  onValueChange={(value) => {
+                    if (analyticsSurface) {
+                      track(ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION, {
+                        surface: analyticsSurface,
+                        runtime: "pi",
+                        action: "selection",
+                        control: "pi_reasoning",
+                      });
+                    }
+                    onThinkingLevelChange(value as PiThinkingLevel);
+                  }}
                 >
                   {thinkingLevels.map((level) => (
                     <DropdownMenuRadioItem

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionModelControls.test.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionModelControls.test.tsx
@@ -6,7 +6,9 @@ import { describe, expect, it, vi } from "vitest";
 import { PiSessionModelControls } from "./PiSessionModelControls";
 
 const setConfig = vi.hoisted(() => vi.fn());
+const track = vi.hoisted(() => vi.fn());
 
+vi.mock("@posthog/ui/shell/analytics", () => ({ track }));
 vi.mock("./piPendingConfigStore", () => ({
   getPiPendingConfig: () => undefined,
   usePiPendingConfigStore: (

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionModelControls.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionModelControls.tsx
@@ -138,6 +138,7 @@ export function PiSessionModelControls({
           : undefined
       }
       thinkingLevels={thinkingLevels}
+      analyticsSurface="session"
       disabled={disabled}
       onChange={setModel}
       onThinkingLevelChange={setThinkingLevel}

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelDropdown.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelDropdown.tsx
@@ -213,12 +213,14 @@ export function ReasoningSliderFace({
   stops,
   currentKey,
   onSelect,
+  onSelectCommitted,
   onAdvanced,
   fastToggle,
 }: {
   stops: ReasoningSliderStop[];
   currentKey?: string;
   onSelect: (key: string) => void;
+  onSelectCommitted?: (key: string, changed: boolean) => void;
   onAdvanced: () => void;
   fastToggle?: {
     active: boolean;
@@ -234,6 +236,7 @@ export function ReasoningSliderFace({
   // a drag the thumb derives from the current selection, so releasing snaps
   // it to the notch the live-applied selection landed on.
   const [dragPosition, setDragPosition] = useState<number | null>(null);
+  const dragStartKeyRef = useRef<string | undefined>(undefined);
   const position = dragPosition ?? activeIndex;
   const nearestIndex = Math.min(
     stops.length - 1,
@@ -245,10 +248,17 @@ export function ReasoningSliderFace({
     if (stop && stop.key !== currentKey) onSelect(stop.key);
   };
 
+  const commitNotch = (notch: number, startKey: string | undefined) => {
+    const stop = stops[notch];
+    if (!stop) return;
+    onSelectCommitted?.(stop.key, stop.key !== startKey);
+  };
+
   const nudge = (delta: number) => {
     const next = Math.min(stops.length - 1, Math.max(0, nearestIndex + delta));
     setDragPosition(null);
     applyNotch(next);
+    commitNotch(next, stops[nearestIndex]?.key);
   };
 
   return (
@@ -324,6 +334,9 @@ export function ReasoningSliderFace({
       </div>
       <div
         className="relative py-1"
+        onPointerDownCapture={() => {
+          dragStartKeyRef.current = stops[activeIndex]?.key;
+        }}
         onKeyDownCapture={(event) => {
           if (event.key === "ArrowLeft" || event.key === "ArrowDown") {
             event.preventDefault();
@@ -352,10 +365,12 @@ export function ReasoningSliderFace({
           onValueCommitted={(next: number | readonly number[]) => {
             const raw = Array.isArray(next) ? next[0] : next;
             if (typeof raw === "number") {
-              applyNotch(
+              commitNotch(
                 Math.min(stops.length - 1, Math.max(0, Math.round(raw))),
+                dragStartKeyRef.current ?? stops[activeIndex]?.key,
               );
             }
+            dragStartKeyRef.current = undefined;
             setDragPosition(null);
           }}
         />

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
@@ -3,6 +3,7 @@ import {
   DEFAULT_OPTION_META_KEY,
   OPTION_DOCS_URL_META_KEY,
 } from "@posthog/shared";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { Theme } from "@radix-ui/themes";
 import { configure, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -15,7 +16,9 @@ import { ReasoningLevelSelector } from "./ReasoningLevelSelector";
 configure({ asyncUtilTimeout: 5000 });
 
 const openUrlInBrowser = vi.hoisted(() => vi.fn());
+const track = vi.hoisted(() => vi.fn());
 vi.mock("@posthog/ui/utils/browser", () => ({ openUrlInBrowser }));
+vi.mock("@posthog/ui/shell/analytics", () => ({ track }));
 vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
   useFeatureFlag: () => true,
 }));
@@ -448,6 +451,7 @@ describe("ReasoningLevelSelector", () => {
   });
 
   it("hides the slider when the combo is off the preset ladder", async () => {
+    track.mockClear();
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     render(
       <Theme>
@@ -455,6 +459,7 @@ describe("ReasoningLevelSelector", () => {
           thoughtOption={thoughtOption({ currentValue: "low" })}
           modelOption={claudeModelOption()}
           adapter="claude"
+          analyticsSurface="session"
         />
       </Theme>,
     );
@@ -469,6 +474,26 @@ describe("ReasoningLevelSelector", () => {
     expect(
       screen.queryByRole("button", { name: "Back" }),
     ).not.toBeInTheDocument();
+    expect(track).toHaveBeenCalledTimes(2);
+    expect(track).toHaveBeenNthCalledWith(
+      1,
+      ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION,
+      {
+        surface: "session",
+        runtime: "acp",
+        action: "opened",
+        initial_view: "advanced",
+      },
+    );
+    expect(track).toHaveBeenNthCalledWith(
+      2,
+      ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION,
+      {
+        surface: "session",
+        runtime: "acp",
+        action: "advanced_opened",
+      },
+    );
   });
 
   it("keeps the Back row when a model change moves off the preset ladder", async () => {
@@ -568,6 +593,7 @@ describe("ReasoningLevelSelector", () => {
   });
 
   it("changes the model from its advanced submenu", async () => {
+    track.mockClear();
     const onModelChange = vi.fn();
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     render(
@@ -576,6 +602,7 @@ describe("ReasoningLevelSelector", () => {
           thoughtOption={thoughtOption()}
           modelOption={claudeModelOption("claude-sonnet-5")}
           adapter="claude"
+          analyticsSurface="session"
           onModelChange={onModelChange}
         />
       </Theme>,
@@ -595,6 +622,15 @@ describe("ReasoningLevelSelector", () => {
     expect(
       screen.getByRole("menuitem", { name: /^Model/ }),
     ).toBeInTheDocument();
+    expect(track).toHaveBeenLastCalledWith(
+      ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION,
+      {
+        surface: "session",
+        runtime: "acp",
+        action: "selection",
+        control: "advanced_model",
+      },
+    );
   });
 
   it("switches the harness when picking a model the current harness cannot run", async () => {
@@ -638,6 +674,7 @@ describe("ReasoningLevelSelector", () => {
   });
 
   it("moves the model and effort together on a ladder notch that changes both", async () => {
+    track.mockClear();
     const onChange = vi.fn();
     const onModelChange = vi.fn();
     const user = userEvent.setup({ pointerEventsCheck: 0 });
@@ -647,6 +684,7 @@ describe("ReasoningLevelSelector", () => {
           thoughtOption={thoughtOption({ currentValue: "xhigh" })}
           modelOption={claudeModelOption("claude-opus-5")}
           adapter="claude"
+          analyticsSurface="session"
           onChange={onChange}
           onModelChange={onModelChange}
         />
@@ -665,6 +703,17 @@ describe("ReasoningLevelSelector", () => {
     );
     expect(onModelChange).toHaveBeenCalledWith("claude-fable-5");
     expect(onChange).toHaveBeenCalledWith("max");
+    expect(track).toHaveBeenCalledTimes(2);
+    expect(track).toHaveBeenLastCalledWith(
+      ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION,
+      {
+        surface: "session",
+        runtime: "acp",
+        action: "selection",
+        control: "slider",
+        changed: true,
+      },
+    );
   });
 
   it("resets to the middle ladder notch, moving model and effort together", async () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
@@ -27,6 +27,10 @@ import {
   selectOptionHarness,
 } from "@posthog/shared";
 import {
+  ANALYTICS_EVENTS,
+  type ModelPickerSurface,
+} from "@posthog/shared/analytics-events";
+import {
   EFFORT_LEVEL_LABELS,
   FAST_MODE_DOCS_URLS,
 } from "@posthog/shared/domain-types";
@@ -41,6 +45,7 @@ import type { WorkspaceModeForAccess } from "@posthog/ui/features/settings/adapt
 import type { AgentAdapter } from "@posthog/ui/features/settings/settingsStore";
 import { AnimatedHeight } from "@posthog/ui/primitives/AnimatedHeight";
 import { Spinner } from "@posthog/ui/primitives/Spinner";
+import { track } from "@posthog/ui/shell/analytics";
 import { AnimatePresence, motion } from "framer-motion";
 import { useRef, useState } from "react";
 import { flattenSelectOptions } from "../sessionStore";
@@ -107,6 +112,7 @@ interface ReasoningLevelSelectorProps {
    * trigger's "Default ·" marker — the two diverge when no default applies.
    */
   resetToDefaultDisabled?: boolean;
+  analyticsSurface?: ModelPickerSurface;
   /**
    * Position and size the popup against this element instead of the trigger.
    *
@@ -160,6 +166,7 @@ export function ReasoningLevelSelector({
   isDefaultSelection,
   onResetToDefault,
   resetToDefaultDisabled,
+  analyticsSurface,
   anchor,
 }: ReasoningLevelSelectorProps) {
   const [internalMenuOpen, setInternalMenuOpen] = useState(false);
@@ -198,6 +205,15 @@ export function ReasoningLevelSelector({
   const handleHarnessSelect = (harness: AgentHarness) => {
     if (harness === adapter) {
       return;
+    }
+
+    if (analyticsSurface) {
+      track(ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION, {
+        surface: analyticsSurface,
+        runtime: "acp",
+        action: "selection",
+        control: "advanced_harness",
+      });
     }
 
     if (harness === "pi") {
@@ -362,6 +378,14 @@ export function ReasoningLevelSelector({
           docsUrl: FAST_MODE_DOCS_URLS[adapter],
           onToggle: () => {
             if (fastSelect) {
+              if (analyticsSurface) {
+                track(ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION, {
+                  surface: analyticsSurface,
+                  runtime: "acp",
+                  action: "selection",
+                  control: "fast_mode_toggle",
+                });
+              }
               onConfigOptionChange(fastSelect.id, fastActive ? "off" : "on");
             }
           },
@@ -399,6 +423,14 @@ export function ReasoningLevelSelector({
   const defaultEffortOption = effortOptions.find((option) => option.isDefault);
 
   const resetToDefaults = () => {
+    if (analyticsSurface) {
+      track(ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION, {
+        surface: analyticsSurface,
+        runtime: "acp",
+        action: "selection",
+        control: "reset_default",
+      });
+    }
     // One reset for both meanings of "default": drop the pick so the configured
     // project/user default applies where the surface knows about one, else land
     // on the ladder's balanced notch.
@@ -478,8 +510,24 @@ export function ReasoningLevelSelector({
         // Only on the closed-to-open transition: submenu opens re-fire this
         // with true and must not yank the view back.
         if (nextOpen && !open) {
+          const initialView = onNotch ? "slider" : "advanced";
           setAdvanced(!onNotch);
           setShowBack(false);
+          if (analyticsSurface) {
+            track(ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION, {
+              surface: analyticsSurface,
+              runtime: "acp",
+              action: "opened",
+              initial_view: initialView,
+            });
+            if (!onNotch) {
+              track(ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION, {
+                surface: analyticsSurface,
+                runtime: "acp",
+                action: "advanced_opened",
+              });
+            }
+          }
         }
         setOpen(nextOpen);
       }}
@@ -566,6 +614,14 @@ export function ReasoningLevelSelector({
                         onGated={() => setOpen(false)}
                         unavailableReason={unavailableReason}
                         onSelect={(value) => {
+                          if (analyticsSurface) {
+                            track(ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION, {
+                              surface: analyticsSurface,
+                              runtime: "acp",
+                              action: "selection",
+                              control: "advanced_model",
+                            });
+                          }
                           // A model the current harness cannot run switches
                           // the harness and keeps the pick.
                           if (adapter && onHarnessModelChange) {
@@ -598,6 +654,16 @@ export function ReasoningLevelSelector({
                   <SubscriptionSubmenu
                     adapter={adapter}
                     workspaceMode={workspaceMode}
+                    onSelection={() => {
+                      if (analyticsSurface) {
+                        track(ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION, {
+                          surface: analyticsSurface,
+                          runtime: "acp",
+                          action: "selection",
+                          control: "advanced_billing",
+                        });
+                      }
+                    }}
                   />
                 )}
                 {hasEffort && (
@@ -611,7 +677,17 @@ export function ReasoningLevelSelector({
                     <DropdownMenuSubContent>
                       <DropdownMenuRadioGroup
                         value={currentEffort ?? ""}
-                        onValueChange={(value) => onChange?.(value)}
+                        onValueChange={(value) => {
+                          if (analyticsSurface) {
+                            track(ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION, {
+                              surface: analyticsSurface,
+                              runtime: "acp",
+                              action: "selection",
+                              control: "advanced_reasoning",
+                            });
+                          }
+                          onChange?.(value);
+                        }}
                       >
                         {effortOptions.map((option) => (
                           <LevelItem
@@ -635,9 +711,17 @@ export function ReasoningLevelSelector({
                     <DropdownMenuSubContent>
                       <DropdownMenuRadioGroup
                         value={row.value}
-                        onValueChange={(value) =>
-                          onConfigOptionChange?.(row.id, value)
-                        }
+                        onValueChange={(value) => {
+                          if (analyticsSurface) {
+                            track(ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION, {
+                              surface: analyticsSurface,
+                              runtime: "acp",
+                              action: "selection",
+                              control: "advanced_context_window",
+                            });
+                          }
+                          onConfigOptionChange?.(row.id, value);
+                        }}
                       >
                         {row.options.map((option) => (
                           <LevelItem
@@ -664,7 +748,25 @@ export function ReasoningLevelSelector({
                   stops={stops}
                   currentKey={currentStopKey}
                   onSelect={handleStopSelect}
+                  onSelectCommitted={(_key, changed) => {
+                    if (analyticsSurface) {
+                      track(ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION, {
+                        surface: analyticsSurface,
+                        runtime: "acp",
+                        action: "selection",
+                        control: "slider",
+                        changed,
+                      });
+                    }
+                  }}
                   onAdvanced={() => {
+                    if (analyticsSurface) {
+                      track(ANALYTICS_EVENTS.MODEL_PICKER_INTERACTION, {
+                        surface: analyticsSurface,
+                        runtime: "acp",
+                        action: "advanced_opened",
+                      });
+                    }
                     setShowBack(true);
                     setAdvanced(true);
                   }}

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -918,6 +918,7 @@ export function SessionView({
                                 adapter={adapter}
                                 contextWindowOption={contextWindowOption}
                                 fastModeOption={fastModeOption}
+                                analyticsSurface="session"
                                 onChange={handleThoughtChange}
                                 onConfigOptionChange={handleConfigOptionChange}
                                 disabled={!isRunning}

--- a/products/desktop/packages/ui/src/features/sessions/components/SubscriptionSubmenu.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SubscriptionSubmenu.tsx
@@ -52,12 +52,14 @@ interface SubscriptionSubmenuProps {
   closeOnChange?: boolean;
   /** Workspace mode of the task being composed; cloud forces PostHog credits. */
   workspaceMode?: WorkspaceModeForAccess;
+  onSelection?: () => void;
 }
 
 export function SubscriptionSubmenu({
   adapter,
   closeOnChange = false,
   workspaceMode,
+  onSelection,
 }: SubscriptionSubmenuProps): React.JSX.Element | null {
   const subscription = useAdapterSubscription(adapter);
   if (!subscription.flagEnabled) {
@@ -88,15 +90,20 @@ export function SubscriptionSubmenu({
       <DropdownMenuSubContent>
         <DropdownMenuRadioGroup
           value={value}
-          onValueChange={(next) =>
-            applyModelAccess(
-              adapter,
+          onValueChange={(next) => {
+            const nextValue =
               next === "own-subscription"
                 ? "own-subscription"
-                : "posthog-gateway",
-              subscription.loggedIn,
-            )
-          }
+                : "posthog-gateway";
+            if (
+              nextValue === value ||
+              (cloudTask && nextValue === "own-subscription")
+            ) {
+              return;
+            }
+            onSelection?.();
+            applyModelAccess(adapter, nextValue, subscription.loggedIn);
+          }}
         >
           <DropdownMenuRadioItem
             value="posthog-gateway"

--- a/products/desktop/packages/ui/src/features/settings/sections/QuickAskSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/QuickAskSettings.tsx
@@ -105,6 +105,7 @@ function AgentDefaults({
       thoughtOption={thoughtOption}
       modelOption={modelOption}
       adapter={adapter}
+      analyticsSurface="quick_ask_settings"
       onChange={handleThoughtChange}
       onModelChange={handleModelChange}
       onAdapterChange={(next) => {

--- a/products/desktop/packages/ui/src/features/settings/sections/TaskAgentDefaultsSettings.test.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/TaskAgentDefaultsSettings.test.tsx
@@ -14,6 +14,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 configure({ asyncUtilTimeout: 5000 });
 
 const saveMock = vi.hoisted(() => vi.fn());
+const track = vi.hoisted(() => vi.fn());
 const previewState = vi.hoisted(() => ({
   lastAdapter: null as string | null,
   setConfigOption: vi.fn(),
@@ -28,6 +29,7 @@ const defaultsState = vi.hoisted(() => ({
   },
 }));
 
+vi.mock("@posthog/ui/shell/analytics", () => ({ track }));
 vi.mock("@posthog/ui/features/auth/store", () => ({
   useAuthStateValue: (
     selector: (state: {

--- a/products/desktop/packages/ui/src/features/settings/sections/TaskAgentDefaultsSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/TaskAgentDefaultsSettings.tsx
@@ -144,6 +144,7 @@ function MyDefaultPicker({
         modelOption={modelOption}
         thoughtOption={thoughtOption}
         adapter={adapter}
+        analyticsSurface="task_agent_defaults"
         anchor={anchorRef}
         // Mid-switch the pill shows the new harness's own default, which is a
         // browse, not the inherited project default — no "Default ·" marker.

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -1649,6 +1649,7 @@ export function TaskInput({
                             : undefined
                         }
                         thinkingLevels={piThinkingLevels}
+                        analyticsSurface="task_input"
                         disabled={isCreatingTask || isPiConfigLoading}
                         isLoading={isPiConfigLoading}
                         onChange={handlePiModelChange}
@@ -1676,6 +1677,7 @@ export function TaskInput({
                         adapter={adapter ?? "claude"}
                         contextWindowOption={contextWindowOption}
                         fastModeOption={fastModeOption}
+                        analyticsSurface="task_input"
                         onChange={handleThoughtChange}
                         onModelChange={handleModelChange}
                         onAdapterChange={setAdapter}


### PR DESCRIPTION
## Problem

Product engineers cannot compare slider, Advanced, and Pi model-picker behavior.

## Changes

- The picker now records opens and the initial view for each supported surface.
- The picker now records selections by control, including committed slider actions.
- Pi interactions use separate control values because Pi has no slider.
- The events exclude model, provider, reasoning, harness, and billing values.
- No visible behavior changed.

## How did you test this code?

- Focused selector tests cover opening, Advanced model selection, Pi model selection, and committed slider use.
- Type checks passed for `@posthog/shared` and `@posthog/ui`.
- Not run to completion: `pnpm lint` stopped because ESLint could not find its configuration in this environment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This change adds internal analytics only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The desktop agent added privacy-safe picker telemetry after inspecting existing product data and code.

Skills invoked: `/instrument-product-analytics`, `/writing-ui-components`, `/writing-tests`, `/running-ci-preflight`, and `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*