### PR TITLE
feat(metrics): surface insight alerts from the Metrics UI

### DIFF
--- a/products/metrics/frontend/components/MetricsViewer.tsx
+++ b/products/metrics/frontend/components/MetricsViewer.tsx
@@ -123,6 +123,7 @@ export const MetricsViewer = (): JSX.Element => {
         clearAnomaly,
         saveAsInsight,
         addToDashboard,
+        createAlert,
         closeAddToDashboardModal,
         setDisplayType,
     } = useActions(logic)
@@ -309,6 +310,19 @@ export const MetricsViewer = (): JSX.Element => {
                             }
                         >
                             Save as insight
+                        </LemonButton>
+                        <LemonButton
+                            size="small"
+                            type="secondary"
+                            onClick={() => createAlert()}
+                            loading={savedInsightLoading}
+                            tooltip="Get notified when this metric crosses a threshold (uses insight alerts)"
+                            disabledReason={
+                                insightEditorDisabledReason ?? (!hasMetricName ? 'Pick a metric first' : undefined)
+                            }
+                            data-attr="metrics-viewer-create-alert"
+                        >
+                            Create alert
                         </LemonButton>
                         <LemonButton
                             size="small"

--- a/products/metrics/frontend/components/metricsViewerLogic.test.ts
+++ b/products/metrics/frontend/components/metricsViewerLogic.test.ts
@@ -436,7 +436,8 @@ describe('metricsViewerLogic', () => {
     it('create alert reuses the saved insight while the query is unchanged', async () => {
         const push = jest.spyOn(router.actions, 'push').mockImplementation(() => {})
         jest.mocked(insightsApi.create).mockImplementation(
-            async (insight: any) => ({ id: 1, short_id: 'abc123', ...insight, query: { ...insight.query, version: 1 } }) as any
+            async (insight: any) =>
+                ({ id: 1, short_id: 'abc123', ...insight, query: { ...insight.query, version: 1 } }) as any
         )
         logic.actions.setMetricName('queue_depth')
 

--- a/products/metrics/frontend/components/metricsViewerLogic.test.ts
+++ b/products/metrics/frontend/components/metricsViewerLogic.test.ts
@@ -470,6 +470,28 @@ describe('metricsViewerLogic', () => {
         push.mockRestore()
     })
 
+    // The armed createAlert flag must clear after routing: if it stayed set, a later plain
+    // "Save as insight" would be mis-routed to the alerts page (and its toast suppressed).
+    it('a plain save after a create-alert save does not route to the alerts page', async () => {
+        const push = jest.spyOn(router.actions, 'push').mockImplementation(() => {})
+        jest.mocked(insightsApi.create).mockImplementation(
+            async (insight: any) => ({ id: 1, short_id: 'abc123', ...insight }) as any
+        )
+        logic.actions.setMetricName('queue_depth')
+
+        logic.actions.createAlert()
+        await expectLogic(logic).toDispatchActions(['saveAsInsightSuccess'])
+        expect(push).toHaveBeenCalledWith('/insights/abc123/alerts')
+        expect(logic.values.pendingAlert).toBe(false)
+
+        push.mockClear()
+        logic.actions.setAggregation('rate')
+        logic.actions.saveAsInsight()
+        await expectLogic(logic).toDispatchActions(['saveAsInsightSuccess'])
+        expect(push).not.toHaveBeenCalled()
+        push.mockRestore()
+    })
+
     // A failed query (bad regex, 500) used to render the same "No data" empty state as a genuinely
     // empty result. The failure records the message so the viewer can show a real error instead.
     // kea-loaders dispatches `<key>Failure(error.message, error)`, so the reducer reads the message.

--- a/products/metrics/frontend/components/metricsViewerLogic.test.ts
+++ b/products/metrics/frontend/components/metricsViewerLogic.test.ts
@@ -1,3 +1,4 @@
+import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
 import { NEW_QUERY_STARTED_ERROR_MESSAGE } from 'lib/utils/kea-logic-builders'
@@ -413,6 +414,59 @@ describe('metricsViewerLogic', () => {
         logic.actions.saveAsInsight()
         await expectLogic(logic).toDispatchActions(['saveAsInsightSuccess'])
         expect(logic.values.isAddToDashboardModalOpen).toBe(false)
+    })
+
+    // "Create alert" surfaces the shared insight-alert flow for a metric: it saves the query as
+    // an insight (reusing it while unchanged) and routes to that insight's alerts page, rather
+    // than building a parallel metrics-specific alert model.
+    it('create alert saves the insight and routes to its alerts page', async () => {
+        const push = jest.spyOn(router.actions, 'push').mockImplementation(() => {})
+        jest.mocked(insightsApi.create).mockImplementation(
+            async (insight: any) => ({ id: 1, short_id: 'abc123', ...insight }) as any
+        )
+        logic.actions.setMetricName('queue_depth')
+
+        logic.actions.createAlert()
+        await expectLogic(logic).toDispatchActions(['saveAsInsightSuccess'])
+        expect(insightsApi.create).toHaveBeenCalledTimes(1)
+        expect(push).toHaveBeenCalledWith('/insights/abc123/alerts')
+        push.mockRestore()
+    })
+
+    it('create alert reuses the saved insight while the query is unchanged', async () => {
+        const push = jest.spyOn(router.actions, 'push').mockImplementation(() => {})
+        jest.mocked(insightsApi.create).mockImplementation(
+            async (insight: any) => ({ id: 1, short_id: 'abc123', ...insight, query: { ...insight.query, version: 1 } }) as any
+        )
+        logic.actions.setMetricName('queue_depth')
+
+        logic.actions.createAlert()
+        await expectLogic(logic).toDispatchActions(['saveAsInsightSuccess'])
+        expect(insightsApi.create).toHaveBeenCalledTimes(1)
+
+        push.mockClear()
+        // Unchanged query: route straight to the alerts page without a duplicate save.
+        logic.actions.createAlert()
+        await expectLogic(logic).toDispatchActions(['createAlert'])
+        expect(insightsApi.create).toHaveBeenCalledTimes(1)
+        expect(push).toHaveBeenCalledWith('/insights/abc123/alerts')
+        push.mockRestore()
+    })
+
+    it('create alert saves a fresh insight after the query changes', async () => {
+        const push = jest.spyOn(router.actions, 'push').mockImplementation(() => {})
+        jest.mocked(insightsApi.create).mockImplementation(
+            async (insight: any) => ({ id: 1, short_id: 'abc123', ...insight }) as any
+        )
+        logic.actions.setMetricName('queue_depth')
+        logic.actions.createAlert()
+        await expectLogic(logic).toDispatchActions(['saveAsInsightSuccess'])
+
+        logic.actions.setAggregation('rate')
+        logic.actions.createAlert()
+        await expectLogic(logic).toDispatchActions(['saveAsInsightSuccess'])
+        expect(insightsApi.create).toHaveBeenCalledTimes(2)
+        push.mockRestore()
     })
 
     // A failed query (bad regex, 500) used to render the same "No data" empty state as a genuinely

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -430,6 +430,9 @@ export interface metricsViewerLogicActions {
     cancelInProgressAnomaly: (controller: AbortController | null) => {
         controller: AbortController | null
     }
+    createAlert: () => {
+        value: true
+    }
     cancelInProgressQuery: (controller: AbortController | null) => {
         controller: AbortController | null
     }
@@ -690,6 +693,11 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         openAddToDashboardModal: true,
         closeAddToDashboardModal: true,
         setLastSavedQueryNode: (query: MetricsQuery) => ({ query }),
+        // Saves the current query as an insight (reusing the last save while the query is
+        // unchanged) and routes to its alerts page, where the shared insight-alert form
+        // builds a MetricsAlertConfig on it. Surfaces insight alerts for metrics instead of
+        // a parallel metrics-specific alert model.
+        createAlert: true,
         // AbortController plumbing mirrors logsViewerDataLogic: a `cancelInProgress`
         // action aborts the previous controller before storing the new one.
         setQueryAbortController: (controller: AbortController | null) => ({ controller }),
@@ -876,6 +884,15 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
                 saveAsInsightFailure: () => false,
             },
         ],
+        // Armed while a createAlert-initiated save is in flight, so the success listener routes to
+        // the alerts page instead of showing the "View insight" toast. Mirrors pendingAddToDashboard.
+        pendingAlert: [
+            false,
+            {
+                createAlert: (state) => (canCreateMetricsInsight() ? true : state),
+                saveAsInsightFailure: () => false,
+            },
+        ],
         // A real query failure (bad regex, 500, timeout) — surfaced as a banner so it isn't mistaken
         // for the empty-result state. Cleared when a new query starts or one succeeds; an aborted
         // (superseded) query leaves the previous state untouched so refetches don't flash an error.
@@ -1013,7 +1030,23 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
             saveAsInsightSuccess: ({ savedInsight }) => {
                 if (savedInsight && values.pendingAddToDashboard) {
                     actions.openAddToDashboardModal()
+                    return
                 }
+                if (savedInsight && values.pendingAlert) {
+                    router.actions.push(urls.insightAlerts(savedInsight.short_id))
+                }
+            },
+            createAlert: () => {
+                if (!canCreateMetricsInsight() || !values.metricsQueryNode) {
+                    return
+                }
+                // Reuse the saved insight while the query is unchanged; route straight to its
+                // alerts page since no save (and so no saveAsInsightSuccess) is coming.
+                if (values.savedInsight && objectsEqual(values.lastSavedQueryNode, values.metricsQueryNode)) {
+                    router.actions.push(urls.insightAlerts(values.savedInsight.short_id))
+                    return
+                }
+                actions.saveAsInsight()
             },
             setGroupBySearch: () => {
                 actions.loadAttributeKeyOptions({})
@@ -1119,8 +1152,8 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
                         saved: true,
                     })
                     actions.setLastSavedQueryNode(query)
-                    // The add-to-dashboard flow opens the dashboard picker instead of a toast.
-                    if (!values.pendingAddToDashboard) {
+                    // The add-to-dashboard and create-alert flows route onward instead of a toast.
+                    if (!values.pendingAddToDashboard && !values.pendingAlert) {
                         lemonToast.success('Insight saved', {
                             button: {
                                 label: 'View insight',

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -373,6 +373,7 @@ export interface metricsViewerLogicValues {
     metricsQueryNode: MetricsQuery | null
     namedClauses: MetricsViewerClause[]
     pendingAddToDashboard: boolean
+    pendingAlert: boolean
     queryAbortController: AbortController | null
     queryError: string | null
     queryFilters: _MetricFilterApi[]
@@ -430,9 +431,6 @@ export interface metricsViewerLogicActions {
     cancelInProgressAnomaly: (controller: AbortController | null) => {
         controller: AbortController | null
     }
-    createAlert: () => {
-        value: true
-    }
     cancelInProgressQuery: (controller: AbortController | null) => {
         controller: AbortController | null
     }
@@ -452,6 +450,9 @@ export interface metricsViewerLogicActions {
         payload?: any
     }
     closeAddToDashboardModal: () => {
+        value: true
+    }
+    createAlert: () => {
         value: true
     }
     duplicateClause: (index: number) => {

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -518,6 +518,9 @@ export interface metricsViewerLogicActions {
     removeGoalLine: (index: number) => {
         index: number
     }
+    resetPendingAlert: () => {
+        value: true
+    }
     saveAsInsight: () => any
     saveAsInsightFailure: (
         error: string,
@@ -699,6 +702,11 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         // builds a MetricsAlertConfig on it. Surfaces insight alerts for metrics instead of
         // a parallel metrics-specific alert model.
         createAlert: true,
+        // Clears the armed createAlert flag after the success listener has routed to the alerts
+        // page, so a later plain save isn't mis-routed. Resetting in the reducer on
+        // saveAsInsightSuccess wouldn't work — reducers run before listeners, so the listener
+        // would already read it cleared and never route.
+        resetPendingAlert: true,
         // AbortController plumbing mirrors logsViewerDataLogic: a `cancelInProgress`
         // action aborts the previous controller before storing the new one.
         setQueryAbortController: (controller: AbortController | null) => ({ controller }),
@@ -886,11 +894,14 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
             },
         ],
         // Armed while a createAlert-initiated save is in flight, so the success listener routes to
-        // the alerts page instead of showing the "View insight" toast. Mirrors pendingAddToDashboard.
+        // the alerts page instead of showing the "View insight" toast. Reducers run before listeners,
+        // so this can't reset on saveAsInsightSuccess (the listener needs to read it still armed);
+        // the listener clears it via resetPendingAlert after routing. Cleared on failure.
         pendingAlert: [
             false,
             {
                 createAlert: (state) => (canCreateMetricsInsight() ? true : state),
+                resetPendingAlert: () => false,
                 saveAsInsightFailure: () => false,
             },
         ],
@@ -1035,6 +1046,8 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
                 }
                 if (savedInsight && values.pendingAlert) {
                     router.actions.push(urls.insightAlerts(savedInsight.short_id))
+                    // Clear the armed flag so a later plain save isn't mis-routed to the alerts page.
+                    actions.resetPendingAlert()
                 }
             },
             createAlert: () => {


### PR DESCRIPTION
## Problem

Teams using the metrics product (private alpha) can't get notified when a metric crosses a threshold — they have to watch the chart. Metrics alerting already works through **insight alerts**: `MetricsExtractor` runs a metric insight through the shared alerting state machine, and `areAlertsSupportedForInsight` returns true for a `MetricsQuery`, both flag-gated on `METRICS`. What's missing is any way to *reach* that flow from the metrics UI.

This PR adds that entry point, rather than introducing a parallel metrics-specific alert model.

## Changes

A user in the Metrics viewer now sees a **Create alert** action beside "Save as insight". Clicking it saves the current query as an insight (reusing the already-saved insight while the query is unchanged) and routes to that insight's alerts page, where the shared alert form builds a `MetricsAlertConfig` on it.

- `MetricsViewer.tsx`: new secondary button, wired to `createAlert`, sharing the save/add-to-dashboard disabled logic and spinner.
- `metricsViewerLogic.tsx`: a `createAlert` listener + `pendingAlert` flag (mirroring `pendingAddToDashboard`) so an alert-initiated save routes to `urls.insightAlerts(short_id)` instead of showing the "Insight saved" toast; an unchanged query reuses the saved insight and routes directly.

This follows the same streamlining pattern as metrics → dashboards: special-case the rendering (`Query.tsx` renders a `MetricsQueryNode`), reuse the insight plumbing. No new model, migration, Temporal workflow, or destinations table — the alert inherits anomaly detection, schedule restrictions, snooze, and the rest of the insight-alert feature set.

*Frontend-only; no screenshots (headless environment, can't render the running app).*

## How did you test this code?

Automated tests added in `metricsViewerLogic.test.ts`, mirroring the existing add-to-dashboard coverage. Each catches a regression no existing test covered:

- `create alert saves the insight and routes to its alerts page` — a fresh query saves once and pushes to `/insights/:shortId/alerts`.
- `create alert reuses the saved insight while the query is unchanged` — a second click for an unchanged query routes straight to the alerts page without minting a duplicate saved insight (the mock normalizes the echoed query, so reuse must not depend on a byte-for-byte round-trip).
- `create alert saves a fresh insight after the query changes` — changing the aggregation saves a new insight.

I was **not** able to run the Jest suite or typecheck in this environment (no `node_modules` installed in the shallow clone; `pnpm build:products` codegen was too heavy to run). The tests are written against the existing patterns but have not been executed — CI should confirm.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built by Claude Code (PostHog Desktop). Direction came from a discussion weighing this UI-surfacing approach against the parallel standalone metrics alert model proposed elsewhere; the user chose to surface the existing insight-alert flow.
- Skills invoked: none beyond the repo's own conventions.
- Design decision: reuse the insight save + `areAlertsSupportedForInsight` path (which already returns true for `MetricsQuery`) so a metric alert is just an insight alert created from the metrics scene, consistent with how metrics were streamlined into dashboards. The `pendingAlert` flag mirrors the existing `pendingAddToDashboard` armed-save routing.
- Patch coverage: new logic paths covered by the three added tests above; the MetricsViewer button itself is presentational.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*