### PR TITLE
fix(batch-exports): stop echoing the host in the invalid-host error

### DIFF
--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -1138,6 +1138,9 @@ def is_local_dev_or_test() -> bool:
     return settings.DEBUG or settings.TEST
 
 
+INVALID_HOST_MESSAGE = "Invalid host. Enter a hostname or IP address without credentials, scheme, or path."
+
+
 def resolve_and_validate_host(host: str) -> None:
     """Ensure provided host resolves to a non-internal IP."""
     if host == "localhost" and is_local_dev_or_test():
@@ -1699,7 +1702,7 @@ class BatchExportSerializer(serializers.ModelSerializer):
                 try:
                     resolve_and_validate_host(host)
                 except ValueError:
-                    raise serializers.ValidationError(f"Invalid host: '{host}'")
+                    raise serializers.ValidationError(INVALID_HOST_MESSAGE)
 
         return destination_attrs
 

--- a/products/batch_exports/backend/tests/api/test_create_postgres.py
+++ b/products/batch_exports/backend/tests/api/test_create_postgres.py
@@ -7,6 +7,7 @@ from rest_framework import status
 
 from posthog.models.integration import Integration
 
+from products.batch_exports.backend.api.batch_export import INVALID_HOST_MESSAGE
 from products.batch_exports.backend.tests.api.operations import create_batch_export
 
 pytestmark = [
@@ -77,6 +78,7 @@ def test_creating_postgres_batch_export_using_integration(client: HttpClient, te
         "127.0.0.1",
         "10.0.0.1",
         "192.168.1.1",
+        "postgres://alice:hunter2@db.example.com/app",
     ],
 )
 def test_creating_postgres_batch_export_validates_integration_host(
@@ -110,7 +112,9 @@ def test_creating_postgres_batch_export_validates_integration_host(
         response = create_batch_export(client, team.pk, batch_export_data)
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
-    assert f"Invalid host: '{host}'" in response.json()["detail"]
+    assert response.json()["detail"] == INVALID_HOST_MESSAGE
+    assert host not in response.content.decode()
+    assert "hunter2" not in response.content.decode()
 
 
 def test_creating_postgres_batch_export_without_integration_is_rejected(

--- a/products/batch_exports/backend/tests/api/test_create_redshift.py
+++ b/products/batch_exports/backend/tests/api/test_create_redshift.py
@@ -7,6 +7,7 @@ from rest_framework import status
 
 from posthog.models.integration import Integration
 
+from products.batch_exports.backend.api.batch_export import INVALID_HOST_MESSAGE
 from products.batch_exports.backend.tests.api.fixtures import create_organization, create_team, create_user
 from products.batch_exports.backend.tests.api.operations import create_batch_export, get_batch_export_ok
 
@@ -208,6 +209,7 @@ def test_create_redshift_batch_export_rejects_invalid_authorization_type(
         "10.0.0.1",
         "169.254.0.0",
         "localhost",
+        "postgres://alice:hunter2@db.example.com/app",
     ],
 )
 def test_create_redshift_batch_export_fails_with_invalid_host(
@@ -246,7 +248,9 @@ def test_create_redshift_batch_export_fails_with_invalid_host(
         )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
-    assert f"Invalid host: '{host}'" in response.json()["detail"]
+    assert response.json()["detail"] == INVALID_HOST_MESSAGE
+    assert host not in response.content.decode()
+    assert "hunter2" not in response.content.decode()
 
 
 def test_create_redshift_batch_export_with_aws_integration(


### PR DESCRIPTION
## Problem

A user who pastes a full connection string into the host field of a Postgres or Redshift batch export gets a 400 whose message repeats the pasted value, password included.

- The frontend surfaces that message and exception capture ships it onwards, so a rejected credential ends up stored as error text.
- The host validator in the batch export serializer raised `Invalid host: '<value>'` after `resolve_and_validate_host` rejected the value.

## Changes

- The error now reads "Invalid host. Enter a hostname or IP address without credentials, scheme, or path." and never contains the submitted value.
- Mechanical: the message moves to an `INVALID_HOST_MESSAGE` constant so the tests assert the same string.

## How did you test this code?

- Extended the existing invalid-host cases for Postgres and Redshift with a `postgres://user:password@…` value written from scratch with invented parts.
- Each case now asserts the response body contains neither the host string nor the password, which no existing test checked.
- Ran both test modules locally. Not run: the rest of the batch exports suite, which CI covers.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code in a worktree. Skills invoked: `/writing-pr-descriptions`. The change was found while reviewing what error messages carry user-submitted values; the committed test data is invented.
