### PR TITLE
fix(desktop): keep action buttons visible outside tool groups

### DIFF
--- a/products/desktop/apps/code/electron-builder.ts
+++ b/products/desktop/apps/code/electron-builder.ts
@@ -52,6 +52,7 @@ const config: Configuration = {
     ".vite/build/product-engineer/**",
     ".vite/build/rpc-host.js",
     ".vite/build/rpc-host.js.map",
+    ".vite/build/adapters/codex-app-server/local-tools-mcp-server.js",
     ...asarUnpackGlobs,
   ],
 

--- a/products/desktop/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.test.ts
+++ b/products/desktop/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.test.ts
@@ -8,6 +8,19 @@ import { describe, expect, it, vi } from "vitest";
 import { DesktopPiRpcClientFactory } from "./desktop-pi-rpc-client-factory";
 
 const createPiRpcClient = vi.hoisted(() => vi.fn());
+const createLocalRuntimeMcpServers = vi.hoisted(() =>
+  vi.fn(() => ({
+    "posthog-code-tools": {
+      args: ["local-tools-mcp-server.js"],
+      command: process.execPath,
+      directTools: true,
+      env: { POSTHOG_LOCAL_TOOLS_ENABLED: "show_actions" },
+      lifecycle: "eager",
+      requestTimeoutMs: 300_000,
+      transport: "stdio",
+    },
+  })),
+);
 const createRuntimeMcpServers = vi.hoisted(() =>
   vi.fn(() => ({
     posthog: {
@@ -22,6 +35,7 @@ const createRuntimeMcpServers = vi.hoisted(() =>
 );
 
 vi.mock("@posthog/agent/pi/rpc-client", () => ({
+  createLocalRuntimeMcpServers,
   createPiRpcClient,
   createRuntimeMcpServers,
 }));
@@ -106,6 +120,7 @@ describe("DesktopPiRpcClientFactory", () => {
       },
     );
     expect(authProxy.start).toHaveBeenCalledWith("https://eu.posthog.com");
+    expect(createLocalRuntimeMcpServers).toHaveBeenCalledWith("/workspace");
     expect(createPiRpcClient).toHaveBeenCalledWith({
       enrichment: {
         apiUrl: "http://127.0.0.1:5678",
@@ -115,6 +130,15 @@ describe("DesktopPiRpcClientFactory", () => {
       },
       mcpToolPolicies: policies,
       runtimeMcpServers: {
+        "posthog-code-tools": {
+          args: ["local-tools-mcp-server.js"],
+          command: process.execPath,
+          directTools: true,
+          env: { POSTHOG_LOCAL_TOOLS_ENABLED: "show_actions" },
+          lifecycle: "eager",
+          requestTimeoutMs: 300_000,
+          transport: "stdio",
+        },
         posthog: {
           args: [],
           directTools: false,

--- a/products/desktop/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.ts
+++ b/products/desktop/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 import {
+  createLocalRuntimeMcpServers,
   createPiRpcClient,
   createRuntimeMcpServers,
   type PiRpcClient,
@@ -62,7 +63,10 @@ export class DesktopPiRpcClientFactory implements PiRpcClientFactory {
         this.mcpServerSource.getMcpRuntimeConfiguration(),
         this.mountContextWiki(projectId),
       ]);
-    const runtimeMcpServers = createRuntimeMcpServers(mcpConfiguration.servers);
+    const runtimeMcpServers = {
+      ...createRuntimeMcpServers(mcpConfiguration.servers),
+      ...createLocalRuntimeMcpServers(input.taskContext.cwd),
+    };
     const taskContext: TaskContext = {
       projectId,
       apiHost: access.apiHost,

--- a/products/desktop/apps/code/vite-main-plugins.mts
+++ b/products/desktop/apps/code/vite-main-plugins.mts
@@ -188,6 +188,10 @@ export function copyPiRpcHost(): Plugin {
       );
       const bundledAgents = join(dirname(source), "bundled-agents");
       const orchestrationSkills = join(dirname(source), "skills");
+      const localToolsMcpServer = join(
+        dirname(source),
+        "../adapters/codex-app-server/local-tools-mcp-server.js",
+      );
       if (!existsSync(productEngineerResources)) {
         throw new Error(
           `[copy-pi-rpc-host] Unable to find product engineer resources at ${productEngineerResources}. Build @posthog/agent first.`,
@@ -203,8 +207,22 @@ export function copyPiRpcHost(): Plugin {
           `[copy-pi-rpc-host] Unable to find orchestration skills at ${orchestrationSkills}. Build @posthog/agent first.`,
         );
       }
+      if (!existsSync(localToolsMcpServer)) {
+        throw new Error(
+          `[copy-pi-rpc-host] Unable to find local tools MCP server at ${localToolsMcpServer}. Build @posthog/agent first.`,
+        );
+      }
 
       copyFileSync(source, join(buildDirectory, "rpc-host.js"));
+      const localToolsBuildDirectory = join(
+        buildDirectory,
+        "adapters/codex-app-server",
+      );
+      mkdirSync(localToolsBuildDirectory, { recursive: true });
+      copyFileSync(
+        localToolsMcpServer,
+        join(localToolsBuildDirectory, "local-tools-mcp-server.js"),
+      );
       cpSync(
         productEngineerResources,
         join(buildDirectory, "product-engineer"),

--- a/products/desktop/packages/agent/src/adapters/local-tools/tools/show-actions.ts
+++ b/products/desktop/packages/agent/src/adapters/local-tools/tools/show-actions.ts
@@ -17,9 +17,11 @@ const SHOW_ACTIONS_TOOL_DESCRIPTION =
   "act on what you just told them without retyping it. Pass 1 to 4 actions. " +
   "Each action is a typed verb, never a URL: there is no URL parameter and " +
   "free-form URLs are not accepted. " +
-  "`compose` opens the new-task composer prefilled with `prompt` (and `repo` " +
-  "when given). The user reads, edits and sends it themselves, so it does NOT " +
-  "start a task and does NOT send anything on click. " +
+  "`compose` opens the new-task composer for a separate task. It pre-fills " +
+  "`prompt` (and `repo` when given). It never sends a prompt in the current " +
+  "session. The user reads, edits, and sends the new task. Do not use " +
+  "`compose` for an approval, a confirmation, or more work in the current " +
+  "task. Ask the user in your message instead. " +
   "A `compose` action also takes an optional `description`, which no other " +
   "kind accepts. Giving one draws that button as a larger card instead of a " +
   "pill, so use it for the offers that matter most. Write one short sentence " +

--- a/products/desktop/packages/agent/src/pi/conversation/translatePiMessage.test.ts
+++ b/products/desktop/packages/agent/src/pi/conversation/translatePiMessage.test.ts
@@ -194,6 +194,45 @@ describe("createPiMessageTranslator", () => {
     ]);
   });
 
+  it("adds canonical metadata to a bridged MCP tool result", () => {
+    const translator = createPiMessageTranslator();
+    const content: ToolResultMessage["content"] = [
+      { type: "text", text: "ok" },
+    ];
+
+    expect(
+      translator.translateToolExecutionEnd(
+        "action-1",
+        "mcp_posthog_code_tools_show_actions",
+        {
+          content,
+          details: {
+            posthog: {
+              mcp: { server: "posthog-code-tools", tool: "show_actions" },
+            },
+          },
+        },
+        false,
+        12,
+      ),
+    ).toMatchObject([
+      {
+        type: "tool_call_updated",
+        toolCall: {
+          _meta: {
+            posthog: {
+              toolName: "mcp__posthog-code-tools__show_actions",
+              mcp: {
+                server: "posthog-code-tools",
+                tool: "show_actions",
+              },
+            },
+          },
+        },
+      },
+    ]);
+  });
+
   it("classifies ls as a directory listing", () => {
     const translator = createPiMessageTranslator();
     const message = makeAssistant([

--- a/products/desktop/packages/agent/src/pi/conversation/translatePiMessage.ts
+++ b/products/desktop/packages/agent/src/pi/conversation/translatePiMessage.ts
@@ -11,8 +11,11 @@ import {
   type AgentToolCallStatus,
   createPiToolCallRecord,
   isPiToolName,
+  mcpToolKey,
   type PiToolName,
+  posthogToolMeta,
 } from "@posthog/shared";
+import { z } from "zod";
 import { bashTranslator } from "./tools/bashTranslator";
 import { editTranslator } from "./tools/editTranslator";
 import { findTranslator } from "./tools/findTranslator";
@@ -41,6 +44,12 @@ interface PiToolExecutionResult {
   content: ToolResultMessage["content"];
   details?: unknown;
 }
+
+const mcpToolDetailsSchema = z.object({
+  posthog: z.object({
+    mcp: z.object({ server: z.string().min(1), tool: z.string().min(1) }),
+  }),
+});
 
 function toGenericToolContent(
   resultContent: ToolResultMessage["content"],
@@ -220,7 +229,7 @@ export function createPiMessageTranslator(): PiMessageTranslator {
     const toolCall: Extract<
       AgentConversationEvent,
       { type: "tool_call_updated" }
-    >["toolCall"] = {
+    >["toolCall"] & { _meta?: ReturnType<typeof posthogToolMeta> } = {
       id: toolCallId,
       status,
       rawOutput: result.content,
@@ -228,6 +237,12 @@ export function createPiMessageTranslator(): PiMessageTranslator {
 
     if (result.details !== undefined) {
       toolCall.details = result.details;
+    }
+
+    const mcpDetails = mcpToolDetailsSchema.safeParse(result.details);
+    if (mcpDetails.success) {
+      const mcp = mcpDetails.data.posthog.mcp;
+      toolCall._meta = posthogToolMeta({ toolName: mcpToolKey(mcp), mcp });
     }
 
     const translator = isPiToolName(toolName)

--- a/products/desktop/packages/agent/src/pi/rpc-client.ts
+++ b/products/desktop/packages/agent/src/pi/rpc-client.ts
@@ -16,6 +16,7 @@ import type {
   McpToolPermissionRequest,
   McpToolPolicy,
 } from "@posthog/shared";
+import { buildLocalToolsServer } from "../adapters/codex-app-server/local-tools-mcp";
 import type { PiEnrichmentConfig } from "./enrichment-extension";
 import { safePiEnvironment } from "./rpc-environment";
 import type { TaskContext } from "./task-system-prompt";
@@ -140,6 +141,11 @@ export function createRuntimeMcpStdioServers(
       },
     ]),
   );
+}
+
+export function createLocalRuntimeMcpServers(cwd: string): PiRuntimeMcpServers {
+  const server = buildLocalToolsServer({ cwd }, { environment: "local" });
+  return createRuntimeMcpStdioServers(server ? [server] : []);
 }
 
 interface PiHostRequest {

--- a/products/desktop/packages/harness/src/extensions/mcp/tool-bridge.test.ts
+++ b/products/desktop/packages/harness/src/extensions/mcp/tool-bridge.test.ts
@@ -424,7 +424,12 @@ describe("ToolBridge", () => {
         name: "echo",
         arguments: { text: "hi" },
       });
-      expect(result?.content).toEqual([{ type: "text", text: "hi jonathan" }]);
+      expect(result).toMatchObject({
+        content: [{ type: "text", text: "hi jonathan" }],
+        details: {
+          posthog: { mcp: { server: "demo", tool: "echo" } },
+        },
+      });
     });
 
     it("throws McpError with code tool when the server reports isError", async () => {

--- a/products/desktop/packages/harness/src/extensions/mcp/tool-bridge.ts
+++ b/products/desktop/packages/harness/src/extensions/mcp/tool-bridge.ts
@@ -549,7 +549,12 @@ export class ToolBridge {
           timeoutMs,
           signal,
         );
-        return { content, details: {} };
+        return {
+          content,
+          details: {
+            posthog: { mcp: { server: serverName, tool: tool.name } },
+          },
+        };
       },
     });
     return description;

--- a/products/desktop/packages/shared/src/agent-actions.ts
+++ b/products/desktop/packages/shared/src/agent-actions.ts
@@ -16,8 +16,9 @@ const requiredField = z.string().trim().min(1);
 const composeFields = {
   kind: z.literal("compose"),
   prompt: requiredField.describe(
-    "Text to prefill the new-task composer with. The user reads it and sends " +
-      "it themselves, so nothing runs on click.",
+    "Text to prefill in a separate new task. This does not send a prompt in " +
+      "the current session. Do not use compose for approval, confirmation, " +
+      "or continued work in the current task.",
   ),
   repo: requiredField
     .optional()

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -11,6 +11,7 @@ import {
 import { WorkerPoolContextProvider } from "@pierre/diffs/react";
 import { buildTurnRatingMetric } from "@posthog/core/analytics/aiFeedback";
 import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
+import { isShowActionsCall } from "@posthog/core/sessions/showActions";
 import { useService } from "@posthog/di/react";
 import {
   Button,
@@ -173,6 +174,14 @@ function isToolCallItem(item: ConversationItem): item is SessionUpdateItem {
   );
 }
 
+function isShowActionsItem(item: SessionUpdateItem): boolean {
+  if (item.update.sessionUpdate !== "tool_call") return false;
+  const resolved = item.turnContext.toolCalls.get(item.update.toolCallId);
+  return (
+    isShowActionsCall(resolved?._meta) || isShowActionsCall(item.update._meta)
+  );
+}
+
 function isSessionUpdateItem(
   item: ConversationItem,
 ): item is SessionUpdateItem {
@@ -280,10 +289,7 @@ export function groupToolRuns(items: ConversationItem[]): ThreadItem[] {
 
   for (const item of items) {
     if (isToolCallItem(item)) {
-      // A plan presented for approval renders as the full PlanApprovalView
-      // card — folded into a "N tool calls" chip, the plan the user is being
-      // asked to approve is invisible. Same exemption as buildThreadGroups.
-      if (isPlanItem(item)) {
+      if (isPlanItem(item) || isShowActionsItem(item)) {
         flush();
         out.push(item);
         continue;

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -11,7 +11,6 @@ import {
 import { WorkerPoolContextProvider } from "@pierre/diffs/react";
 import { buildTurnRatingMetric } from "@posthog/core/analytics/aiFeedback";
 import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
-import { isShowActionsCall } from "@posthog/core/sessions/showActions";
 import { useService } from "@posthog/di/react";
 import {
   Button,
@@ -114,6 +113,7 @@ import {
 import { extractPeerAgentMessage } from "@posthog/ui/features/sessions/components/session-update/peerAgentMessage";
 import { collapsePiSkillInvocation } from "@posthog/ui/features/sessions/components/session-update/piSkillInvocation";
 import { SessionUpdateView } from "@posthog/ui/features/sessions/components/session-update/SessionUpdateView";
+import { isShowActionsItem } from "@posthog/ui/features/sessions/components/session-update/showActionsItem";
 import { UserShellExecuteView } from "@posthog/ui/features/sessions/components/session-update/UserShellExecuteView";
 import { UserMessageAttachments } from "@posthog/ui/features/sessions/components/UserMessageAttachments";
 import {
@@ -171,14 +171,6 @@ type SessionUpdateItem = Extract<ConversationItem, { type: "session_update" }>;
 function isToolCallItem(item: ConversationItem): item is SessionUpdateItem {
   return (
     item.type === "session_update" && item.update.sessionUpdate === "tool_call"
-  );
-}
-
-function isShowActionsItem(item: SessionUpdateItem): boolean {
-  if (item.update.sessionUpdate !== "tool_call") return false;
-  const resolved = item.turnContext.toolCalls.get(item.update.toolCallId);
-  return (
-    isShowActionsCall(resolved?._meta) || isShowActionsCall(item.update._meta)
   );
 }
 

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/groupToolRuns.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/groupToolRuns.test.ts
@@ -1,3 +1,4 @@
+import { posthogToolMeta } from "@posthog/shared";
 import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import { describe, expect, it } from "vitest";
 import { groupToolRuns } from "./ChatThread";
@@ -75,5 +76,49 @@ describe("groupToolRuns", () => {
       "session_update",
       "session_update",
     ]);
+  });
+
+  it.each([
+    ["Claude initial call", true],
+    ["Pi resolved call", false],
+  ])("keeps action buttons visible from the %s metadata", (_, initial) => {
+    const action = toolItem("action", {
+      ...(initial
+        ? {
+            _meta: {
+              claudeCode: {
+                toolName: "mcp__posthog-code-tools__show_actions",
+              },
+            },
+          }
+        : {}),
+    });
+    if (!initial) {
+      action.turnContext.toolCalls.set("action", {
+        toolCallId: "action",
+        title: "action",
+        kind: "execute",
+        status: "completed",
+        _meta: posthogToolMeta({
+          toolName: "mcp__posthog-code-tools__show_actions",
+          mcp: { server: "posthog-code-tools", tool: "show_actions" },
+        }),
+      });
+    }
+
+    const out = groupToolRuns([
+      toolItem("before-1"),
+      toolItem("before-2"),
+      action,
+      toolItem("after-1"),
+      toolItem("after-2"),
+    ]);
+
+    expect(out.map((row) => row.type)).toEqual([
+      "tool_group",
+      "session_update",
+      "tool_group",
+    ]);
+    expect(out[1]).toMatchObject({ id: "action" });
   });
 });

--- a/products/desktop/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.test.ts
@@ -69,6 +69,32 @@ describe("buildThreadGroups MCP detection", () => {
     expect(grouping.keepMounted).toEqual([0]);
   });
 
+  it("keeps a Pi MCP tool standalone when its result supplies the metadata", () => {
+    const action = toolCallItem("action", undefined, {
+      title: "mcp_posthog_code_tools_show_actions",
+      rawInput: {
+        actions: [
+          { kind: "open_space", label: "Open space", channel_id: "space-1" },
+        ],
+      },
+    });
+    resolveToolCall(action, {
+      toolCallId: "action",
+      status: "completed",
+      _meta: {
+        posthog: {
+          toolName: "mcp__posthog-code-tools__show_actions",
+          mcp: { server: "posthog-code-tools", tool: "show_actions" },
+        },
+      },
+    });
+
+    expect(isGroupableItem(action)).toBe(false);
+    const grouping = buildThreadGroups([action], {});
+    expect(grouping.rows[0].kind).toBe("item");
+    expect(grouping.keepMounted).toEqual([0]);
+  });
+
   it("folds non-MCP tool calls into a collapsed group", () => {
     const plain = toolCallItem("t1", {
       posthog: { toolName: "Bash" },

--- a/products/desktop/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.test.ts
@@ -69,9 +69,9 @@ describe("buildThreadGroups MCP detection", () => {
     expect(grouping.keepMounted).toEqual([0]);
   });
 
-  it("keeps a Pi MCP tool standalone when its result supplies the metadata", () => {
+  it("keeps an MCP tool standalone when only its result supplies metadata", () => {
     const action = toolCallItem("action", undefined, {
-      title: "mcp_posthog_code_tools_show_actions",
+      title: "show_actions",
       rawInput: {
         actions: [
           { kind: "open_space", label: "Open space", channel_id: "space-1" },

--- a/products/desktop/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.ts
@@ -111,7 +111,12 @@ function subagentCount(item: ConversationItem): number {
 function isMcpToolItem(item: ConversationItem): boolean {
   if (item.type !== "session_update") return false;
   if (item.update.sessionUpdate !== "tool_call") return false;
-  return readMcpToolDescriptor(item.update._meta) !== undefined;
+  const resolved = item.update.toolCallId
+    ? item.turnContext.toolCalls.get(item.update.toolCallId)
+    : undefined;
+  return (
+    readMcpToolDescriptor(resolved?._meta ?? item.update._meta) !== undefined
+  );
 }
 
 function isAlwaysVisibleItem(item: ConversationItem): boolean {

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/SubagentToolView.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/SubagentToolView.test.tsx
@@ -1,0 +1,103 @@
+import { ServiceProvider } from "@posthog/di/react";
+import type {
+  ConversationItem,
+  TurnContext,
+} from "@posthog/ui/features/sessions/components/buildConversationItems";
+import { ChatThreadChromeProvider } from "@posthog/ui/features/sessions/components/chat-thread/chatThreadChrome";
+import type { ToolCall } from "@posthog/ui/features/sessions/types";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { Container } from "inversify";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@posthog/host-router/react", () => ({
+  useHostTRPC: () => ({
+    deepLink: {
+      openAgentAction: {
+        mutationOptions: () => ({ mutationFn: vi.fn() }),
+      },
+    },
+  }),
+}));
+
+import { SubagentToolView } from "./SubagentToolView";
+
+describe("SubagentToolView", () => {
+  it("keeps action buttons visible while the subagent row is collapsed", () => {
+    const action: ToolCall = {
+      toolCallId: "action",
+      title: "show_actions",
+      kind: "other",
+      status: "completed",
+      rawInput: {
+        actions: [
+          {
+            kind: "compose",
+            label: "Start a follow-up task",
+            prompt: "Review the test commands.",
+          },
+        ],
+      },
+      _meta: {
+        claudeCode: {
+          toolName: "mcp__posthog-code-tools__show_actions",
+          parentToolCallId: "agent",
+        },
+      },
+    };
+    const read: ToolCall = {
+      toolCallId: "read",
+      title: "Read package.json",
+      kind: "read",
+      status: "completed",
+    };
+    const turnContext: TurnContext = {
+      toolCalls: new Map([
+        [read.toolCallId, read],
+        [action.toolCallId, action],
+      ]),
+      childItems: new Map(),
+      turnCancelled: false,
+      turnComplete: true,
+    };
+    const childItems: ConversationItem[] = [
+      {
+        type: "session_update",
+        id: "child-read",
+        update: { ...read, sessionUpdate: "tool_call" },
+        turnContext,
+      },
+      {
+        type: "session_update",
+        id: "child-action",
+        update: { ...action, sessionUpdate: "tool_call" },
+        turnContext,
+      },
+    ];
+
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <ServiceProvider container={new Container()}>
+          <ChatThreadChromeProvider value>
+            <SubagentToolView
+              toolCall={{
+                toolCallId: "agent",
+                title: "Test nested actions",
+                kind: "think",
+                status: "completed",
+              }}
+              childItems={childItems}
+              turnContext={turnContext}
+              turnComplete
+            />
+          </ChatThreadChromeProvider>
+        </ServiceProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Start a follow-up task" }),
+    ).toBeVisible();
+    expect(document.querySelector('[aria-expanded="false"]')).not.toBeNull();
+  });
+});

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/SubagentToolView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/SubagentToolView.tsx
@@ -15,6 +15,7 @@ import { useState } from "react";
 import type { ConversationItem, TurnContext } from "../buildConversationItems";
 import { useChatThreadChrome } from "../chat-thread/chatThreadChrome";
 import { SessionUpdateView } from "./SessionUpdateView";
+import { isShowActionsItem } from "./showActionsItem";
 import { ToolRow } from "./ToolRow";
 
 interface SubagentToolViewProps extends ToolViewProps {
@@ -43,21 +44,21 @@ export function SubagentToolView({
   const chatChrome = useChatThreadChrome();
   const [isExpanded, setIsExpanded] = useState(false);
 
+  const renderItems = (items: ConversationItem[]) =>
+    items.map((child) =>
+      child.type === "session_update" ? (
+        <SessionUpdateView
+          key={child.id}
+          item={child.update}
+          toolCalls={turnContext.toolCalls}
+          childItems={turnContext.childItems}
+          turnCancelled={turnContext.turnCancelled}
+          turnComplete={turnContext.turnComplete}
+        />
+      ) : null,
+    );
   const hasChildren = childItems.length > 0;
-  const childContent = hasChildren
-    ? childItems.map((child) =>
-        child.type === "session_update" ? (
-          <SessionUpdateView
-            key={child.id}
-            item={child.update}
-            toolCalls={turnContext.toolCalls}
-            childItems={turnContext.childItems}
-            turnCancelled={turnContext.turnCancelled}
-            turnComplete={turnContext.turnComplete}
-          />
-        ) : null,
-      )
-    : undefined;
+  const childContent = hasChildren ? renderItems(childItems) : undefined;
 
   // Legacy thread: bespoke bordered box with an expand toggle.
   if (!chatChrome) {
@@ -114,6 +115,18 @@ export function SubagentToolView({
     );
   }
 
+  const nestedItems: ConversationItem[] = [];
+  const actionItems: ConversationItem[] = [];
+  for (const child of childItems) {
+    (isShowActionsItem(child, turnContext.toolCalls)
+      ? actionItems
+      : nestedItems
+    ).push(child);
+  }
+  const nestedContent =
+    nestedItems.length > 0 ? renderItems(nestedItems) : undefined;
+  const actionContent = renderItems(actionItems);
+
   // New thread: same minimal shape as ThoughtView — a single ToolRow whose collapsible body holds the
   // subagent's child tool calls. ToolRow supplies the ChatMarker chrome, so no bespoke box here.
   return (
@@ -134,13 +147,14 @@ export function SubagentToolView({
         isLoading={isLoading}
         isFailed={isFailed}
         wasCancelled={wasCancelled}
-        content={childContent}
+        content={nestedContent}
       >
         <span>
           <span className="font-medium text-gray-12">Subagent</span>
           {title && title !== "Subagent" ? ` · ${title}` : ""}
         </span>
       </ToolRow>
+      {actionContent}
     </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/showActionsItem.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/showActionsItem.ts
@@ -1,0 +1,21 @@
+import { isShowActionsCall } from "@posthog/core/sessions/showActions";
+import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
+import type { ToolCall } from "@posthog/ui/features/sessions/types";
+
+export function isShowActionsItem(
+  item: ConversationItem,
+  toolCalls?: Map<string, ToolCall>,
+): boolean {
+  if (
+    item.type !== "session_update" ||
+    item.update.sessionUpdate !== "tool_call"
+  ) {
+    return false;
+  }
+  const resolved = (toolCalls ?? item.turnContext.toolCalls).get(
+    item.update.toolCallId,
+  );
+  return (
+    isShowActionsCall(resolved?._meta) || isShowActionsCall(item.update._meta)
+  );
+}


### PR DESCRIPTION
## Problem

action buttons borked
- not rendering in pi cloud
- tool not even available in local pi
- sometimes hidden in tool call output in claude
- sometimes agents try to use the `compose` button as a "follow-up message" button, but it actually makes a whole new task

## Changes

- updated pi local runs to get local phd tools
- fixed tool metadata so pi will render
- updated tool call grouping to ensure buttons render outside of the groups
- updated tool instructions to be clear about it creating a new task

| claude - normal tool call group | claude - subagent tool call | pi (local) |
| --- | --- | --- |
| <img width="1426" height="1250" alt="Screenshot 2026-09-03 at 12 55 44 PM" src="https://github.com/user-attachments/assets/f827a7cd-a91f-47d8-b1ac-f1d2a0707bf6" /> | <img width="1450" height="1302" alt="Screenshot 2026-09-03 at 12 59 37 PM" src="https://github.com/user-attachments/assets/13e9cd52-d4f8-485f-9f2e-b0fc8f30e398" /> | <img width="1422" height="1302" alt="Screenshot 2026-09-03 at 1 06 27 PM" src="https://github.com/user-attachments/assets/2c83116f-04b8-4a71-ba2d-74399973984c" /> |


--- ai gen below ---

- Action buttons now stay outside normal tool groups and collapsed subagent rows.
- Local Pi sessions now load the same local action tool as cloud Pi.
- The renderer reads Claude call metadata and Pi result metadata.
- The `compose` guidance states that it opens the new-task composer for a separate task.
- No screenshot: the supplied reproduction contains private task content.

## How did you test this code?

- Unit tests cover normal Claude grouping and action buttons under a collapsed subagent.
- Unit tests cover local Pi registration and Pi result metadata.
- Ran the targeted Vitest files, `pnpm lint`, and `pnpm typecheck`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The action schema and tool description define this agent contract.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used PostHog task data and local repository tools. Skills: `/posthog-desktop`, `/writing-pr-descriptions`, and `/writing-simplified-technical-english`.

The final fix separates normal tool groups, nested subagents, and local Pi registration. The committed fixtures are invented.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*