### PR TITLE
fix(tasks): keep duplicate references from updating activity

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -3272,6 +3272,7 @@ def register_task_run_posthog_references(
         by_id = {str(entry.get("id")): entry for entry in manifest if entry.get("id")}
         reference_count = sum(1 for entry in manifest if entry.get("type") == "reference")
         now = django_timezone.now().isoformat()
+        manifest_changed = False
 
         for reference in references:
             object_kind = str(reference["object_kind"])
@@ -3289,6 +3290,7 @@ def register_task_run_posthog_references(
                 metadata["source_message_ids"] = source_message_ids
                 metadata["occurrence_count"] = len(source_message_ids)
                 existing["metadata"] = metadata
+                manifest_changed = True
                 continue
 
             if reference_count >= MAX_RUN_REFERENCE_ARTIFACTS:
@@ -3314,8 +3316,10 @@ def register_task_run_posthog_references(
             manifest.append(entry)
             by_id[artifact_id] = entry
             created.append(entry)
+            manifest_changed = True
 
-        _save_artifact_manifest(run, manifest)
+        if manifest_changed:
+            _save_artifact_manifest(run, manifest)
 
     for entry in created if attribute_as_agent else []:
         reference_metadata = entry.get("metadata")

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -8454,7 +8454,15 @@ class TestTaskRunPostHogReferencesAPI(BaseTaskAPITest):
         }
 
         first = self.client.post(url, {"references": [reference]}, format="json")
+        run.refresh_from_db()
+        task.refresh_from_db()
+        first_run_updated_at = run.updated_at
+        first_task_activity_at = task.last_activity_at
         retry = self.client.post(url, {"references": [reference]}, format="json")
+        run.refresh_from_db()
+        task.refresh_from_db()
+        self.assertEqual(run.updated_at, first_run_updated_at)
+        self.assertEqual(task.last_activity_at, first_task_activity_at)
         second_message = self.client.post(
             url,
             {"references": [{**reference, "source_message_id": "turn-2-message-1"}]},


### PR DESCRIPTION
## Problem

Opening a completed Desktop task can move it to the top and mark it unread again.

**Why:** Reading a task must not create new task activity.

The client re-registers stored object references when it loads the transcript. The endpoint saved the unchanged artifact manifest as new activity.

## Changes

- Duplicate reference batches no longer write the run artifact manifest.
- New references and new source-message links still update activity.
- No screenshot: this change removes a transient sidebar state change.

## How did you test this code?

- The existing API test now catches duplicate requests that change the run or task activity timestamp.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The endpoint contract does not change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used PostHog task and log tools. It used the PostHog Desktop, Postgres, PostHog data, test-writing, PR-writing, and Simplified English skills.

The investigation identified an unchanged artifact manifest save as the source. The commit contains no private source data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*