### PR TITLE
feat(desktop): reuse hover-fetched preview on insight and hogql object pages

### DIFF
--- a/products/desktop/packages/ui/src/features/editor/evidencePreview.test.ts
+++ b/products/desktop/packages/ui/src/features/editor/evidencePreview.test.ts
@@ -26,6 +26,11 @@ describe("fetchEvidencePreview", () => {
       headline: { value: "1.5M", delta: { direction: "down" } },
       spark: { points: [5096547, 1506301], render: "line" },
     });
+    // The page renders the full shaped chart from the same fetch.
+    expect(preview?.chartData).toMatchObject({
+      type: "series",
+      labels: ["2026-08-13", "2026-08-14"],
+    });
   });
 
   it("summarizes a hogql table result by counts, never echoing column titles", async () => {
@@ -50,6 +55,12 @@ describe("fetchEvidencePreview", () => {
     expect(preview?.detail).toBeUndefined();
     expect(preview?.facts?.join(" ")).not.toContain("arrayJoin");
     expect(preview?.facts?.join(" ")).not.toContain("ifNull");
+    // The page's chart table keeps the real columns; only the hover reduction
+    // hides the raw SQL.
+    expect(preview?.chartData).toMatchObject({
+      type: "table",
+      columns: ["arrayJoin(events.event)", "ifNull(count(), 0)"],
+    });
   });
 
   it("keeps raw SQL column titles out of a HogQL-backed insight preview", async () => {
@@ -127,6 +138,9 @@ describe("fetchEvidencePreview", () => {
       title: "Checkout funnel",
       spark: { points: [5096547, 1506301] },
     });
+    // chartData rides along for the page chart without renaming the insight.
+    expect(preview?.chartData).toMatchObject({ type: "series" });
+    expect(preview?.title).toBe("Checkout funnel");
   });
 
   it("uses the saved insight result without running a second query", async () => {
@@ -169,6 +183,14 @@ describe("fetchEvidencePreview", () => {
     ).resolves.toMatchObject({
       title: "Unique users per variant",
     });
+    expect(runQuery).not.toHaveBeenCalled();
+
+    // The saved-result short-circuit still produces the page's chart data.
+    const preview = await fetchEvidencePreview(client, {
+      kind: "insight",
+      id: "sdyR2Pn8",
+    });
+    expect(preview?.chartData).toMatchObject({ type: "table" });
     expect(runQuery).not.toHaveBeenCalled();
   });
 

--- a/products/desktop/packages/ui/src/features/editor/evidencePreview.test.ts
+++ b/products/desktop/packages/ui/src/features/editor/evidencePreview.test.ts
@@ -26,7 +26,6 @@ describe("fetchEvidencePreview", () => {
       headline: { value: "1.5M", delta: { direction: "down" } },
       spark: { points: [5096547, 1506301], render: "line" },
     });
-    // The page renders the full shaped chart from the same fetch.
     expect(preview?.chartData).toMatchObject({
       type: "series",
       labels: ["2026-08-13", "2026-08-14"],
@@ -55,8 +54,6 @@ describe("fetchEvidencePreview", () => {
     expect(preview?.detail).toBeUndefined();
     expect(preview?.facts?.join(" ")).not.toContain("arrayJoin");
     expect(preview?.facts?.join(" ")).not.toContain("ifNull");
-    // The page's chart table keeps the real columns; only the hover reduction
-    // hides the raw SQL.
     expect(preview?.chartData).toMatchObject({
       type: "table",
       columns: ["arrayJoin(events.event)", "ifNull(count(), 0)"],
@@ -138,7 +135,6 @@ describe("fetchEvidencePreview", () => {
       title: "Checkout funnel",
       spark: { points: [5096547, 1506301] },
     });
-    // chartData rides along for the page chart without renaming the insight.
     expect(preview?.chartData).toMatchObject({ type: "series" });
     expect(preview?.title).toBe("Checkout funnel");
   });
@@ -185,7 +181,6 @@ describe("fetchEvidencePreview", () => {
     });
     expect(runQuery).not.toHaveBeenCalled();
 
-    // The saved-result short-circuit still produces the page's chart data.
     const preview = await fetchEvidencePreview(client, {
       kind: "insight",
       id: "sdyR2Pn8",

--- a/products/desktop/packages/ui/src/features/editor/evidencePreview.ts
+++ b/products/desktop/packages/ui/src/features/editor/evidencePreview.ts
@@ -34,6 +34,13 @@ export interface EvidenceCardData {
   headline?: ChartHeadlineStat | null;
   /** Mini chart of the primary series; `labels` carries bucket dates. */
   spark?: { points: number[]; labels?: string[]; render: "line" | "bar" };
+  /**
+   * The full shaped chart behind `headline`/`spark`, kept so the object's
+   * page can render its interactive chart from the same fetch instead of
+   * re-running the query. Only set by the query-backed kinds (insight,
+   * hogql); object kinds shape their own `chart` inside `getEvidencePreview`.
+   */
+  chartData?: ReportChartData;
   /** A titled multi-series time chart, drawn with hover values on full pages. */
   chart?: {
     title: string;
@@ -110,10 +117,11 @@ async function hogqlPreview(
   if (data.type === "series" && preview.spark) {
     return {
       ...preview,
+      chartData: data,
       facts: [`${data.labels.length} rows · ${data.series.length + 1} columns`],
     };
   }
-  return preview;
+  return { ...preview, chartData: data };
 }
 
 async function insightPreview(
@@ -129,8 +137,14 @@ async function insightPreview(
   const plan = planReportChart(insight.query);
   if (plan.kind !== "run") return base;
   const response = insight.response ?? (await client.runQuery(plan.source));
-  const chart = fromChartData(shapeReportChartData(response, plan), base.title);
-  return { ...chart, title: base.title, detail: chart.detail ?? base.detail };
+  const data = shapeReportChartData(response, plan);
+  const chart = fromChartData(data, base.title);
+  return {
+    ...chart,
+    chartData: data,
+    title: base.title,
+    detail: chart.detail ?? base.detail,
+  };
 }
 
 /**

--- a/products/desktop/packages/ui/src/features/editor/evidencePreview.ts
+++ b/products/desktop/packages/ui/src/features/editor/evidencePreview.ts
@@ -21,6 +21,13 @@ import type { EvidenceLinkTarget } from "../../utils/evidenceLinks";
 export interface EvidenceCardData {
   title: string;
   detail?: string;
+  /**
+   * The object's own description, shown on the full page's subtitle. Kept
+   * separate from `detail`, which for a multi-series chart holds joined
+   * series labels for the hover card and is wrong on the page. Only insights
+   * set it today.
+   */
+  description?: string;
   /** Lifecycle state as a badge label + tone, kept out of `detail`. */
   status?: {
     label: string;
@@ -127,6 +134,7 @@ async function insightPreview(
   const base: EvidenceCardData = {
     title: insight.name || shortId,
     detail: insight.description || undefined,
+    description: insight.description || undefined,
   };
   const plan = planReportChart(insight.query);
   if (plan.kind !== "run") return base;
@@ -138,6 +146,7 @@ async function insightPreview(
     chartData: data,
     title: base.title,
     detail: chart.detail ?? base.detail,
+    description: insight.description || undefined,
   };
 }
 

--- a/products/desktop/packages/ui/src/features/editor/evidencePreview.ts
+++ b/products/desktop/packages/ui/src/features/editor/evidencePreview.ts
@@ -34,12 +34,6 @@ export interface EvidenceCardData {
   headline?: ChartHeadlineStat | null;
   /** Mini chart of the primary series; `labels` carries bucket dates. */
   spark?: { points: number[]; labels?: string[]; render: "line" | "bar" };
-  /**
-   * The full shaped chart behind `headline`/`spark`, kept so the object's
-   * page can render its interactive chart from the same fetch instead of
-   * re-running the query. Only set by the query-backed kinds (insight,
-   * hogql); object kinds shape their own `chart` inside `getEvidencePreview`.
-   */
   chartData?: ReportChartData;
   /** A titled multi-series time chart, drawn with hover values on full pages. */
   chart?: {

--- a/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.test.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.test.tsx
@@ -1,3 +1,4 @@
+import type { EvidenceCardData } from "@posthog/ui/features/editor/evidencePreview";
 import { Theme } from "@radix-ui/themes";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
@@ -14,8 +15,20 @@ const useEvidenceUrl = vi.hoisted(() =>
   ),
 );
 
-vi.mock("@posthog/ui/hooks/useAuthenticatedQuery", () => ({
-  useAuthenticatedQuery: () => ({
+// quill-charts is canvas-backed and does not load in the test environment;
+// the card chrome around it is what these tests exercise.
+vi.mock("@posthog/quill-charts", () => ({
+  BarChart: () => <div data-testid="chart-plot" />,
+  LineChart: () => <div data-testid="chart-plot" />,
+  TimeSeriesBarChart: () => <div data-testid="chart-plot" />,
+  TimeSeriesLineChart: () => <div data-testid="chart-plot" />,
+  useChartTheme: () => ({}),
+}));
+
+// The page reads the shared evidence-preview entry. Each test sets the cache
+// state it needs through this mutable stand-in.
+const queryState = vi.hoisted(() => ({
+  current: {
     isPending: false,
     isError: false,
     data: {
@@ -33,7 +46,15 @@ vi.mock("@posthog/ui/hooks/useAuthenticatedQuery", () => ({
           ],
         },
       ],
-    },
+    } as EvidenceCardData | null,
+  },
+}));
+
+vi.mock("@posthog/ui/hooks/useAuthenticatedQuery", () => ({
+  useAuthenticatedQuery: () => ({
+    isPending: queryState.current.isPending,
+    isError: queryState.current.isError,
+    data: queryState.current.data,
   }),
 }));
 
@@ -42,8 +63,37 @@ vi.mock("@posthog/ui/features/editor/components/EvidenceRefChip", () => ({
   EvidenceSparkline: () => null,
 }));
 
+function setQueryState(state: {
+  isPending?: boolean;
+  isError?: boolean;
+  data?: EvidenceCardData | null;
+}): void {
+  queryState.current = {
+    isPending: state.isPending ?? false,
+    isError: state.isError ?? false,
+    data: state.data ?? null,
+  };
+}
+
 describe("PostHogObjectPage", () => {
   it("renders live reference details and copies the exact identifier", async () => {
+    setQueryState({
+      data: {
+        title: "new-checkout-flow",
+        detail: "Enabled",
+        resolvedId: "42",
+        facts: ["100% rollout", "Used by 1 experiment"],
+        sections: [
+          {
+            title: "Configuration",
+            fields: [
+              { label: "Type", value: "Boolean" },
+              { label: "Release conditions", value: "All users" },
+            ],
+          },
+        ],
+      },
+    });
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { writeText },
@@ -81,5 +131,116 @@ describe("PostHogObjectPage", () => {
         screen.getByRole("button", { name: "ID copied" }),
       ).toBeInTheDocument(),
     );
+  });
+
+  it("draws an insight's chart from the cached preview, with no loading state", () => {
+    setQueryState({
+      data: {
+        title: "Checkout funnel",
+        chartData: { type: "number", value: 68831577 },
+      },
+    });
+    render(
+      <Theme>
+        <PostHogObjectPage
+          fallbackName="Checkout funnel"
+          metadata={{
+            reference_type: "posthog_object",
+            object_kind: "insight",
+            object_id: "9pQx3",
+            source_message_ids: ["turn-1"],
+            occurrence_count: 1,
+          }}
+        />
+      </Theme>,
+    );
+
+    // The chart renders from the warmed cache: value present, no skeleton.
+    expect(screen.getByTestId("report-chart")).toBeInTheDocument();
+    expect(screen.getByText("68,831,577")).toBeInTheDocument();
+  });
+
+  it("shows a chart skeleton while the insight preview loads", () => {
+    setQueryState({ isPending: true, data: null });
+    render(
+      <Theme>
+        <PostHogObjectPage
+          fallbackName="Checkout funnel"
+          metadata={{
+            reference_type: "posthog_object",
+            object_kind: "insight",
+            object_id: "9pQx3",
+            source_message_ids: ["turn-1"],
+            occurrence_count: 1,
+          }}
+        />
+      </Theme>,
+    );
+
+    expect(screen.queryByTestId("report-chart")).toBeNull();
+  });
+
+  it("reports an insight the project does not resolve", () => {
+    setQueryState({ data: null });
+    render(
+      <Theme>
+        <PostHogObjectPage
+          fallbackName="Missing insight"
+          metadata={{
+            reference_type: "posthog_object",
+            object_kind: "insight",
+            object_id: "nope",
+            source_message_ids: ["turn-1"],
+            occurrence_count: 1,
+          }}
+        />
+      </Theme>,
+    );
+
+    expect(
+      screen.getByText(/No insight matches "nope" in the current project/),
+    ).toBeInTheDocument();
+  });
+
+  it("never titles a hogql chart card with raw SQL", () => {
+    setQueryState({
+      data: {
+        title: "Events by day",
+        chartData: {
+          type: "series",
+          labels: ["2026-08-13", "2026-08-14"],
+          series: [
+            {
+              key: "series-0",
+              label: "arrayJoin(events.event)",
+              data: [5096547, 1506301],
+            },
+          ],
+          render: "line",
+          isTimeSeries: true,
+          interval: "day",
+        },
+      },
+    });
+    render(
+      <Theme>
+        <PostHogObjectPage
+          fallbackName="Events by day"
+          metadata={{
+            reference_type: "posthog_object",
+            object_kind: "hogql",
+            object_id: "SELECT arrayJoin(events.event) ...",
+            source_message_ids: ["turn-1"],
+            occurrence_count: 1,
+          }}
+        />
+      </Theme>,
+    );
+
+    expect(screen.getByTestId("report-chart")).toBeInTheDocument();
+    // The card title is the page title (header + card both show it); the raw
+    // SQL series label only ever reaches the (mocked) chart plot, not the DOM.
+    expect(screen.getAllByText("Events by day").length).toBeGreaterThan(0);
+    expect(screen.queryByText("arrayJoin(events.event)")).toBeNull();
   });
 });

--- a/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.test.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.test.tsx
@@ -5,8 +5,6 @@ import { describe, expect, it, vi } from "vitest";
 import { PostHogObjectPage } from "./PostHogObjectPage";
 
 const writeText = vi.fn().mockResolvedValue(undefined);
-// Mirror the real hook: a flag page resolves only from a numeric id, so the
-// link is available only if the page passes the resolved id, not the key.
 const useEvidenceUrl = vi.hoisted(() =>
   vi.fn((_kind: string, id: string) =>
     /^\d+$/.test(id)
@@ -15,8 +13,6 @@ const useEvidenceUrl = vi.hoisted(() =>
   ),
 );
 
-// quill-charts is canvas-backed and does not load in the test environment;
-// the card chrome around it is what these tests exercise.
 vi.mock("@posthog/quill-charts", () => ({
   BarChart: () => <div data-testid="chart-plot" />,
   LineChart: () => <div data-testid="chart-plot" />,
@@ -25,8 +21,6 @@ vi.mock("@posthog/quill-charts", () => ({
   useChartTheme: () => ({}),
 }));
 
-// The page reads the shared evidence-preview entry. Each test sets the cache
-// state it needs through this mutable stand-in.
 const queryState = vi.hoisted(() => ({
   current: {
     isPending: false,
@@ -34,7 +28,6 @@ const queryState = vi.hoisted(() => ({
     data: {
       title: "new-checkout-flow",
       detail: "Enabled",
-      // The preview resolves the flag key to its numeric id.
       resolvedId: "42",
       facts: ["100% rollout", "Used by 1 experiment"],
       sections: [
@@ -122,7 +115,6 @@ describe("PostHogObjectPage", () => {
     expect(
       screen.getByText("Referenced 2 times in this task"),
     ).toBeInTheDocument();
-    // A flag cited by key still links out, via the resolved numeric id.
     expect(screen.getByText(/Open in PostHog/)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Copy ID" }));
     expect(writeText).toHaveBeenCalledWith("new-checkout-flow");
@@ -155,7 +147,6 @@ describe("PostHogObjectPage", () => {
       </Theme>,
     );
 
-    // The chart renders from the warmed cache: value present, no skeleton.
     expect(screen.getByTestId("report-chart")).toBeInTheDocument();
     expect(screen.getByText("68,831,577")).toBeInTheDocument();
   });
@@ -238,8 +229,6 @@ describe("PostHogObjectPage", () => {
     );
 
     expect(screen.getByTestId("report-chart")).toBeInTheDocument();
-    // The card title is the page title (header + card both show it); the raw
-    // SQL series label only ever reaches the (mocked) chart plot, not the DOM.
     expect(screen.getAllByText("Events by day").length).toBeGreaterThan(0);
     expect(screen.queryByText("arrayJoin(events.event)")).toBeNull();
   });

--- a/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.test.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.test.tsx
@@ -196,7 +196,8 @@ describe("PostHogObjectPage", () => {
   it("never titles a hogql chart card with raw SQL", () => {
     setQueryState({
       data: {
-        title: "Events by day",
+        // hogqlPreview puts the first result column in the hover title.
+        title: "arrayJoin(events.event)",
         chartData: {
           type: "series",
           labels: ["2026-08-13", "2026-08-14"],
@@ -229,6 +230,8 @@ describe("PostHogObjectPage", () => {
     );
 
     expect(screen.getByTestId("report-chart")).toBeInTheDocument();
+    // The page header and chart card use the chip label, never the raw SQL
+    // the hover reduction stored in the preview title or series label.
     expect(screen.getAllByText("Events by day").length).toBeGreaterThan(0);
     expect(screen.queryByText("arrayJoin(events.event)")).toBeNull();
   });

--- a/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.test.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.test.tsx
@@ -235,4 +235,87 @@ describe("PostHogObjectPage", () => {
     expect(screen.getAllByText("Events by day").length).toBeGreaterThan(0);
     expect(screen.queryByText("arrayJoin(events.event)")).toBeNull();
   });
+
+  it("keeps a multi-series insight's series labels out of the page subtitle", () => {
+    setQueryState({
+      data: {
+        title: "Checkout funnel",
+        // insightPreview stores joined series labels in the hover detail.
+        detail: "control · aggressive",
+        description: "Daily unique visitors",
+        chartData: {
+          type: "series",
+          labels: ["2026-08-13", "2026-08-14"],
+          series: [
+            { key: "series-0", label: "control", data: [40, 44] },
+            { key: "series-1", label: "aggressive", data: [38, 45] },
+          ],
+          render: "line",
+          isTimeSeries: true,
+          interval: "day",
+        },
+      },
+    });
+    render(
+      <Theme>
+        <PostHogObjectPage
+          fallbackName="Checkout funnel"
+          metadata={{
+            reference_type: "posthog_object",
+            object_kind: "insight",
+            object_id: "9pQx3",
+            source_message_ids: ["turn-1"],
+            occurrence_count: 1,
+          }}
+        />
+      </Theme>,
+    );
+
+    // The subtitle shows the insight's description, not the series labels.
+    expect(screen.getByText(/Daily unique visitors/)).toBeInTheDocument();
+    expect(screen.queryByText(/control · aggressive/)).toBeNull();
+  });
+
+  it("keeps a multi-series hogql query's column labels out of the page subtitle", () => {
+    setQueryState({
+      data: {
+        title: "ifNull(count(), 0)",
+        // hogqlPreview joins the result columns into the hover detail.
+        detail: "ifNull(count(), 0) · arrayJoin(events.event)",
+        chartData: {
+          type: "series",
+          labels: ["2026-08-13", "2026-08-14"],
+          series: [
+            { key: "series-0", label: "ifNull(count(), 0)", data: [40, 44] },
+            {
+              key: "series-1",
+              label: "arrayJoin(events.event)",
+              data: [38, 45],
+            },
+          ],
+          render: "line",
+          isTimeSeries: true,
+          interval: "day",
+        },
+      },
+    });
+    render(
+      <Theme>
+        <PostHogObjectPage
+          fallbackName="Events by day"
+          metadata={{
+            reference_type: "posthog_object",
+            object_kind: "hogql",
+            object_id: "SELECT arrayJoin(events.event), ifNull(count(), 0) ...",
+            source_message_ids: ["turn-1"],
+            occurrence_count: 1,
+          }}
+        />
+      </Theme>,
+    );
+
+    // The subtitle shows kind and source only, never the raw SQL detail.
+    expect(screen.queryByText(/ifNull\(count\(\), 0\)/)).toBeNull();
+    expect(screen.queryByText(/arrayJoin\(events\.event\)/)).toBeNull();
+  });
 });

--- a/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.tsx
@@ -238,7 +238,11 @@ export function PostHogObjectPageView({
   const object = getObjectKind(objectKind);
   const ObjectIcon = object.icon;
   const usesChartRenderer = objectKind === "insight" || objectKind === "hogql";
-  const title = preview?.title ?? fallbackName;
+  // A hogql preview's title is the first result column (raw SQL), a row
+  // count, or a formatted number, never the chip label, so the page shows the
+  // chip label instead. An insight's title is its live name and stays.
+  const title =
+    objectKind === "hogql" ? fallbackName : (preview?.title ?? fallbackName);
   const status = preview?.status;
   // The product name earns its place only when it adds context ("Insight ·
   // Product analytics"); drop it when it restates the kind ("Feature flag ·

--- a/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.tsx
@@ -251,10 +251,14 @@ export function PostHogObjectPageView({
     .toLowerCase()
     .split(" ")[0]
     .startsWith(object.kindLabel.toLowerCase().split(" ")[0]);
+  // A chart preview's `detail` joins its series labels for the hover card,
+  // which is raw SQL for hogql and duplicates the insight's legend; the page
+  // subtitle shows the object's own description instead, or nothing for hogql.
+  const subtitle = usesChartRenderer ? preview?.description : preview?.detail;
   const metaLine = [
     object.kindLabel,
     showSource ? object.source : null,
-    preview?.detail,
+    subtitle,
   ]
     .filter(Boolean)
     .join(" · ");

--- a/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.tsx
@@ -100,15 +100,6 @@ const STATUS_BADGE_VARIANT = {
   critical: "destructive",
 } as const;
 
-/**
- * Full interactive chart for a query-backed object (insight, hogql), rendered
- * from the shared evidence-preview cache. The hover card and idle prefetch
- * already ran the query and kept the shaped result on `preview.chartData`, so
- * opening the page draws the chart without a second fetch. Title comes from
- * the page header (the insight's live name, or the chip label for hogql),
- * never from a chart series label — a HogQL series label is raw SQL, not a
- * name worth showing.
- */
 function ObjectChartCard({
   objectKind,
   objectId,
@@ -316,8 +307,6 @@ export function PostHogObjectPageView({
               {preview && <PostHogObjectDetails preview={preview} />}
             </div>
           ) : usesChartRenderer ? (
-            // The shared evidence-preview cache carries the shaped chart, so a
-            // page opened from a hovered or prefetched chip draws immediately.
             state === "loading" ? (
               <Skeleton className="h-72 w-full rounded-lg" />
             ) : state === "error" ? (
@@ -345,8 +334,6 @@ export function PostHogObjectPageView({
                 }}
               />
             ) : (
-              // The preview resolved without chart data: the insight's query
-              // plan isn't runnable here, so link out like InsightChartCard.
               <ObjectChartCard
                 objectKind={objectKind}
                 objectId={objectId}
@@ -396,9 +383,6 @@ export function PostHogObjectPage({
     Partial<Omit<PostHogObjectArtifactMetadata, "object_kind" | "object_id">>;
   fallbackName: string;
 }) {
-  // The page reads the same evidence-preview entry the hover card and idle
-  // prefetch warm, for every kind. For insight/hogql that entry now carries
-  // the shaped chart, so opening from a chip draws the chart with no refetch.
   const query = useAuthenticatedQuery(
     evidencePreviewQueryKey({
       kind: metadata.object_kind,

--- a/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPage.tsx
@@ -1,6 +1,11 @@
 import { CheckIcon, CopyIcon } from "@phosphor-icons/react";
 import type { PostHogObjectArtifactMetadata } from "@posthog/core/canvas/runArtifactSchemas";
 import {
+  chartHeadlineStat,
+  reportChartHeightClass,
+  reportChartOpenTarget,
+} from "@posthog/core/inbox/reportCharts";
+import {
   Badge,
   Button,
   Empty,
@@ -12,12 +17,20 @@ import {
   Skeleton,
   Text,
 } from "@posthog/quill";
+import { getCloudUrlFromRegion } from "@posthog/shared";
+import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { useEvidenceUrl } from "@posthog/ui/features/editor/components/EvidenceRefChip";
 import { MessageChartCard } from "@posthog/ui/features/editor/components/MessageChartCard";
 import {
+  EVIDENCE_PREVIEW_STALE_TIME,
   type EvidenceCardData,
+  evidencePreviewQueryKey,
   fetchEvidencePreview,
 } from "@posthog/ui/features/editor/evidencePreview";
+import {
+  type ReportChartCardState,
+  ReportChartCardView,
+} from "@posthog/ui/features/inbox/components/detail/ReportChartCard";
 import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
 import { useCopy } from "@posthog/ui/primitives/useCopy";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
@@ -27,6 +40,9 @@ import {
 } from "@posthog/ui/utils/objectKinds";
 import { ExperimentResultsSummary } from "./ExperimentResultsSummary";
 import { PostHogObjectDetails } from "./PostHogObjectDetails";
+
+const CHART_ERROR_MESSAGE =
+  "Couldn't run the query behind this chart. Open it in PostHog to investigate.";
 
 function StatStrip({
   stats,
@@ -83,6 +99,55 @@ const STATUS_BADGE_VARIANT = {
   caution: "warning",
   critical: "destructive",
 } as const;
+
+/**
+ * Full interactive chart for a query-backed object (insight, hogql), rendered
+ * from the shared evidence-preview cache. The hover card and idle prefetch
+ * already ran the query and kept the shaped result on `preview.chartData`, so
+ * opening the page draws the chart without a second fetch. Title comes from
+ * the page header (the insight's live name, or the chip label for hogql),
+ * never from a chart series label — a HogQL series label is raw SQL, not a
+ * name worth showing.
+ */
+function ObjectChartCard({
+  objectKind,
+  objectId,
+  title,
+  state,
+}: {
+  objectKind: string;
+  objectId: string;
+  title: string;
+  state: ReportChartCardState;
+}) {
+  const projectId = useAuthStateValue((s) => s.currentProjectId);
+  const cloudRegion = useAuthStateValue((s) => s.cloudRegion);
+  const data = state.kind === "data" ? state.data : null;
+  const openTarget =
+    projectId && cloudRegion
+      ? reportChartOpenTarget(
+          objectKind === "insight"
+            ? { kind: "SavedInsightNode", shortId: objectId }
+            : {
+                kind: "DataVisualizationNode",
+                source: { kind: "HogQLQuery", query: objectId },
+              },
+          { cloudUrl: getCloudUrlFromRegion(cloudRegion), projectId },
+        )
+      : null;
+  return (
+    <div className="mb-2">
+      <ReportChartCardView
+        chartId={`artifact:${objectKind}:${objectId}`}
+        title={title}
+        heightClass={reportChartHeightClass(null, data)}
+        state={state}
+        openTarget={openTarget}
+        stat={data ? chartHeadlineStat(data) : null}
+      />
+    </div>
+  );
+}
 
 function FactChips({ facts }: { facts: string[] }) {
   return (
@@ -251,14 +316,44 @@ export function PostHogObjectPageView({
               {preview && <PostHogObjectDetails preview={preview} />}
             </div>
           ) : usesChartRenderer ? (
-            <MessageChartCard
-              spec={
-                objectKind === "insight"
-                  ? { mode: "insight", shortId: objectId }
-                  : { mode: "hogql", query: objectId }
-              }
-              blockKey={`artifact:${objectKind}:${objectId}`}
-            />
+            // The shared evidence-preview cache carries the shaped chart, so a
+            // page opened from a hovered or prefetched chip draws immediately.
+            state === "loading" ? (
+              <Skeleton className="h-72 w-full rounded-lg" />
+            ) : state === "error" ? (
+              <ObjectChartCard
+                objectKind={objectKind}
+                objectId={objectId}
+                title={title}
+                state={{ kind: "error", message: CHART_ERROR_MESSAGE }}
+              />
+            ) : preview?.chartData ? (
+              <ObjectChartCard
+                objectKind={objectKind}
+                objectId={objectId}
+                title={title}
+                state={{ kind: "data", data: preview.chartData }}
+              />
+            ) : state === "missing" ? (
+              <ObjectChartCard
+                objectKind={objectKind}
+                objectId={objectId}
+                title={title}
+                state={{
+                  kind: "error",
+                  message: `No ${objectKind === "insight" ? "insight" : "query"} matches "${objectId}" in the current project.`,
+                }}
+              />
+            ) : (
+              // The preview resolved without chart data: the insight's query
+              // plan isn't runnable here, so link out like InsightChartCard.
+              <ObjectChartCard
+                objectKind={objectKind}
+                objectId={objectId}
+                title={title}
+                state={{ kind: "link-out" }}
+              />
+            )
           ) : state === "loading" ? (
             // Mirrors the loaded layout (stat strip, chart, detail card) so
             // content lands in place instead of reflowing the page.
@@ -301,18 +396,21 @@ export function PostHogObjectPage({
     Partial<Omit<PostHogObjectArtifactMetadata, "object_kind" | "object_id">>;
   fallbackName: string;
 }) {
-  const usesChartRenderer =
-    metadata.object_kind === "insight" || metadata.object_kind === "hogql";
+  // The page reads the same evidence-preview entry the hover card and idle
+  // prefetch warm, for every kind. For insight/hogql that entry now carries
+  // the shaped chart, so opening from a chip draws the chart with no refetch.
   const query = useAuthenticatedQuery(
-    ["evidence-preview", metadata.object_kind, metadata.object_id],
+    evidencePreviewQueryKey({
+      kind: metadata.object_kind,
+      id: metadata.object_id,
+    }),
     (client) =>
       fetchEvidencePreview(client, {
         kind: metadata.object_kind,
         id: metadata.object_id,
       }),
     {
-      enabled: !usesChartRenderer,
-      staleTime: 5 * 60 * 1000,
+      staleTime: EVIDENCE_PREVIEW_STALE_TIME,
       refetchOnWindowFocus: false,
       retry: 1,
     },
@@ -321,15 +419,13 @@ export function PostHogObjectPage({
     metadata.object_kind,
     query.data?.resolvedId ?? metadata.object_id,
   );
-  const state = usesChartRenderer
-    ? "ready"
-    : query.isPending
-      ? "loading"
-      : query.isError
-        ? "error"
-        : query.data
-          ? "ready"
-          : "missing";
+  const state = query.isPending
+    ? "loading"
+    : query.isError
+      ? "error"
+      : query.data
+        ? "ready"
+        : "missing";
 
   return (
     <PostHogObjectPageView

--- a/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPageView.stories.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPageView.stories.tsx
@@ -204,7 +204,35 @@ export const SqlQuery: Story = {
     fallbackName: "Total pageviews",
     url: "https://us.posthog.com/project/2/sql?open_query=SELECT+1",
     state: "ready",
-    preview: null,
+    preview: {
+      title: "Total pageviews",
+      chartData: { type: "number", value: 68831577 },
+    },
+  },
+};
+
+export const InsightChart: Story = {
+  args: {
+    objectKind: "insight",
+    objectId: "9pQx3",
+    fallbackName: "Checkout funnel",
+    url: "https://us.posthog.com/project/2/insights/9pQx3",
+    occurrenceCount: 2,
+    state: "ready",
+    preview: {
+      title: "Checkout funnel",
+      detail: "Daily unique visitors",
+      headline: { value: "1.5M", delta: { direction: "down", label: "70%" } },
+      spark: { points: [24, 32, 28, 46, 51, 63, 58], render: "line" },
+      chartData: {
+        type: "series",
+        labels: DAYS,
+        series: [{ key: "series-0", label: "DAU", data: [24, 32, 28, 46, 51, 63, 58] }],
+        render: "line",
+        isTimeSeries: true,
+        interval: "day",
+      },
+    },
   },
 };
 

--- a/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPageView.stories.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPageView.stories.tsx
@@ -227,7 +227,9 @@ export const InsightChart: Story = {
       chartData: {
         type: "series",
         labels: DAYS,
-        series: [{ key: "series-0", label: "DAU", data: [24, 32, 28, 46, 51, 63, 58] }],
+        series: [
+          { key: "series-0", label: "DAU", data: [24, 32, 28, 46, 51, 63, 58] },
+        ],
         render: "line",
         isTimeSeries: true,
         interval: "day",


### PR DESCRIPTION
## Problem

When a person opens a PostHog-object page from an inline chip in the Desktop app (hover an `<insight>` or `<hogql>` reference, then click it), the page re-ran the exact query the hover card had just run. The chart waited on a second identical network call before it could draw.

Both surfaces already fetched the same data. For the 14 non-chart kinds the page always rendered the shared hover payload, so there was no refetch. The two query-backed kinds, insight and hogql, bypassed the shared cache: the hover reduced the query result to a sparkline and discarded the full `ReportChartData` the page's interactive chart needs, so the page fetched again under a separate cache key.

## Changes

Opening an insight or SQL-query page from a hovered or prefetched chip now draws the chart immediately, with no second query. A skeleton shows only when the data was never fetched.

Fetch behavior per object kind, before and now:

| Object kind | Before: hover card | Before: page | Now (hover + page) |
|---|---|---|---|
| insight | `getInsightDefinition` + `runQuery`, reduced to a sparkline | Same two calls again, under `["message-chart-block", blockKey]` | One shared fetch under `["evidence-preview", "insight", id]`; the full shaped chart rides the entry as `chartData`, and the page renders it |
| hogql | `runQuery`, reduced to a sparkline | Same call again, under `["message-chart-block", blockKey]` | One shared fetch under `["evidence-preview", "hogql", id]`; `chartData` carries the shaped chart |
| flag, experiment, error, event, dashboard, ticket, report, person, replay, survey, trace, cohort, action, eval | `getEvidencePreview` | Same `getEvidencePreview`, same cache key | Unchanged (already shared) |

- The query-backed previews keep the full shaped chart on the shared cache entry as `EvidenceCardData.chartData`; the page renders from it. Same fetch, no extra network cost.
- The chart card title comes from the page header (the insight's live name, or the chip label for a SQL query), never from a chart series label. A HogQL series label is raw SQL, not a name worth showing.
- Mechanical: `MessageChartCard` (inline charts in message transcripts, keyed by source hash) is unchanged; the page gains a small `ObjectChartCard` that wires the shared `ReportChartCardView` from the cache.

## How did you test this code?

Automated tests only; I did not run the Desktop app manually.

- `evidencePreview.test.ts`: extended existing cases to assert `chartData` carries the full shaped chart — for a hogql time series, for a HogQL-backed table (chart columns kept while hover facts stay label-free), for a saved insight that runs its query, and for the saved-result short-circuit where `runQuery` is never called. Each catches the full chart data being dropped on the way to the page, which the previous assertions did not cover.
- `PostHogObjectPage.test.tsx`: new cases render the page from a warmed cache — an insight chart draws with no loading state, a loading preview shows a chart skeleton, an unresolved insight shows the "No insight matches" card, and a HogQL chart card is never titled with raw SQL. These catch the page refetching or ignoring the cached preview, which the old flag-only test did not cover.
- Updated the `PostHogObjectPageView` stories (`SqlQuery`, new `InsightChart`) to render from `chartData`.

Not run: the live hover-then-click flow in a running Desktop session; that path depends on the shared react-query cache and is covered only at the unit level here. No UI looks different, so no screenshots.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

skip-inkeep-docs

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with an Explore/Plan subagent pass to map the fetch inventory and pressure-test the design, then implemented directly. The two candidate approaches (carry the shaped chart on the existing preview entry vs. extract a new shared raw-chart query) were weighed; the first ships because it adds no new cache keys or fetch paths and leaves the message-transcript chart surface untouched. Tests run: `vitest run src/features/posthog-objects/ src/features/editor/` and `tsc --noEmit` in `products/desktop/packages/ui`. Biome could not run here (the linter process ran out of memory in this environment); import ordering was matched to the repo's existing convention by hand.

Public artifact: nothing in this PR draws on session material beyond the repo itself; sample data in tests and stories is invented.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
