### PR TITLE
feat(tasks): stamp a shared event_id on agent stream and log entries

### DIFF
--- a/products/desktop/packages/agent/src/adapters/acp-connection.test.ts
+++ b/products/desktop/packages/agent/src/adapters/acp-connection.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SessionLogWriter } from "../session-log-writer";
+import { createAcpConnection } from "./acp-connection";
+
+describe("createAcpConnection wire taps", () => {
+  it("hands the session log and the broadcast callback the same event id per message", async () => {
+    const appendNotification = vi.fn();
+    const logWriter = {
+      isRegistered: () => true,
+      register: vi.fn(),
+      appendNotification,
+    } as unknown as SessionLogWriter;
+    const onWireMessage = vi.fn();
+
+    const connection = createAcpConnection({
+      adapter: "claude",
+      taskRunId: "run-1",
+      taskId: "task-1",
+      logWriter,
+      onWireMessage,
+    });
+
+    const notification = {
+      jsonrpc: "2.0",
+      method: "_posthog/console",
+      params: { level: "info", message: "hello" },
+    };
+    const writer = connection.clientStreams.writable.getWriter();
+    await writer.write(
+      new TextEncoder().encode(`${JSON.stringify(notification)}\n`),
+    );
+    writer.releaseLock();
+
+    expect(appendNotification).toHaveBeenCalledTimes(1);
+    expect(onWireMessage).toHaveBeenCalledTimes(1);
+    const [, loggedMessage, loggedId] = appendNotification.mock.calls[0];
+    const [broadcastMessage, broadcastId] = onWireMessage.mock.calls[0];
+    expect(loggedMessage).toEqual(notification);
+    expect(broadcastMessage).toBe(loggedMessage);
+    expect(loggedId).toBeTruthy();
+    expect(broadcastId).toBe(loggedId);
+
+    await connection.cleanup();
+  });
+});

--- a/products/desktop/packages/agent/src/adapters/acp-connection.ts
+++ b/products/desktop/packages/agent/src/adapters/acp-connection.ts
@@ -7,6 +7,7 @@ import type {
   PostHogAPIConfig,
   ProcessSpawnedCallback,
 } from "../types";
+import { createEventIdSource, type NextEventId } from "../utils/event-id";
 import { Logger } from "../utils/logger";
 import {
   createBidirectionalStreams,
@@ -23,6 +24,10 @@ import type { CodexOptions } from "./codex-app-server/spawn";
 export type AcpConnectionConfig = {
   adapter?: Adapter;
   logWriter?: SessionLogWriter;
+  /** Receives every parsed ACP wire message with the event id the session log stored it under. */
+  onWireMessage?: (message: Record<string, unknown>, eventId: string) => void;
+  /** Shared id source so wire events and server-born events stay on one sequence. */
+  eventIdSource?: NextEventId;
   taskRunId?: string;
   taskId?: string;
   /** Deployment environment - "local" for desktop, "cloud" for cloud sandbox */
@@ -77,46 +82,78 @@ function resolveEnricherApiConfig(
   return enabled ? config.posthogApiConfig : undefined;
 }
 
+/**
+ * Wraps both directions of the ACP wire so every message fans out once:
+ * parsed a single time, stamped with the next event id, then handed to the
+ * session log writer and the optional broadcast callback with that shared id.
+ */
+function installWireTaps(
+  streams: ReturnType<typeof createBidirectionalStreams>,
+  config: AcpConnectionConfig,
+  logger: Logger,
+): {
+  agentWritable: WritableStream<Uint8Array>;
+  clientWritable: WritableStream<Uint8Array>;
+} {
+  const { logWriter, taskRunId } = config;
+  if (!taskRunId || !logWriter) {
+    logger.info("Tapped streams NOT enabled", {
+      hasTaskRunId: !!taskRunId,
+      hasLogWriter: !!logWriter,
+    });
+    return {
+      agentWritable: streams.agent.writable,
+      clientWritable: streams.client.writable,
+    };
+  }
+
+  if (!logWriter.isRegistered(taskRunId)) {
+    logWriter.register(taskRunId, {
+      taskId: config.taskId ?? taskRunId,
+      runId: taskRunId,
+      deviceType: config.deviceType,
+    });
+  }
+
+  const nextEventId = config.eventIdSource ?? createEventIdSource();
+  const onMessage = (line: string) => {
+    let message: Record<string, unknown>;
+    try {
+      message = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      logger.warn("Failed to parse ACP wire line", {
+        lineLength: line.length,
+      });
+      return;
+    }
+    const eventId = nextEventId();
+    logWriter.appendNotification(taskRunId, message, eventId);
+    config.onWireMessage?.(message, eventId);
+  };
+
+  return {
+    agentWritable: createTappedWritableStream(streams.agent.writable, {
+      onMessage,
+      logger,
+    }),
+    clientWritable: createTappedWritableStream(streams.client.writable, {
+      onMessage,
+      logger,
+    }),
+  };
+}
+
 function createClaudeConnection(config: AcpConnectionConfig): AcpConnection {
   const logger =
     config.logger?.child("AcpConnection") ??
     new Logger({ debug: true, prefix: "[AcpConnection]" });
   const streams = createBidirectionalStreams();
 
-  const { logWriter } = config;
-
-  let agentWritable = streams.agent.writable;
-  let clientWritable = streams.client.writable;
-
-  if (config.taskRunId && logWriter) {
-    if (!logWriter.isRegistered(config.taskRunId)) {
-      logWriter.register(config.taskRunId, {
-        taskId: config.taskId ?? config.taskRunId,
-        runId: config.taskRunId,
-        deviceType: config.deviceType,
-      });
-    }
-
-    const taskRunId = config.taskRunId;
-    agentWritable = createTappedWritableStream(streams.agent.writable, {
-      onMessage: (line) => {
-        logWriter.appendRawLine(taskRunId, line);
-      },
-      logger,
-    });
-
-    clientWritable = createTappedWritableStream(streams.client.writable, {
-      onMessage: (line) => {
-        logWriter.appendRawLine(taskRunId, line);
-      },
-      logger,
-    });
-  } else {
-    logger.info("Tapped streams NOT enabled", {
-      hasTaskRunId: !!config.taskRunId,
-      hasLogWriter: !!logWriter,
-    });
-  }
+  const { agentWritable, clientWritable } = installWireTaps(
+    streams,
+    config,
+    logger,
+  );
 
   const agentStream = ndJsonStream(agentWritable, streams.agent.readable);
 
@@ -171,44 +208,14 @@ function createCodexConnection(config: AcpConnectionConfig): AcpConnection {
     config.logger?.child("CodexConnection") ??
     new Logger({ debug: true, prefix: "[CodexConnection]" });
 
-  const { logWriter } = config;
-
   // Create bidirectional streams for client ↔ agent communication
   const streams = createBidirectionalStreams();
 
-  let agentWritable = streams.agent.writable;
-  let clientWritable = streams.client.writable;
-
-  // Tap streams for session log writing
-  if (config.taskRunId && logWriter) {
-    if (!logWriter.isRegistered(config.taskRunId)) {
-      logWriter.register(config.taskRunId, {
-        taskId: config.taskId ?? config.taskRunId,
-        runId: config.taskRunId,
-        deviceType: config.deviceType,
-      });
-    }
-
-    const taskRunId = config.taskRunId;
-    agentWritable = createTappedWritableStream(streams.agent.writable, {
-      onMessage: (line) => {
-        logWriter.appendRawLine(taskRunId, line);
-      },
-      logger,
-    });
-
-    clientWritable = createTappedWritableStream(streams.client.writable, {
-      onMessage: (line) => {
-        logWriter.appendRawLine(taskRunId, line);
-      },
-      logger,
-    });
-  } else {
-    logger.info("Tapped streams NOT enabled for Codex", {
-      hasTaskRunId: !!config.taskRunId,
-      hasLogWriter: !!logWriter,
-    });
-  }
+  const { agentWritable, clientWritable } = installWireTaps(
+    streams,
+    config,
+    logger,
+  );
 
   const agentStream = ndJsonStream(agentWritable, streams.agent.readable);
 

--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -1558,6 +1558,42 @@ describe("AgentServer HTTP Mode", () => {
       expect(appendRawLine).toHaveBeenCalledTimes(1);
     });
 
+    it("stamps console and turn-failure fan-outs with the id persisted to the log", () => {
+      const appendRawLine = vi.fn();
+      const testServer = new AgentServer({
+        port,
+        jwtPublicKey: TEST_PUBLIC_KEY,
+        repositoryPath: repo.path,
+        apiUrl: "http://localhost:8000",
+        apiKey: "test-api-key",
+        projectId: 1,
+        mode: "interactive",
+        taskId: "test-task-id",
+        runId: "test-run-id",
+      }) as unknown as {
+        session: unknown;
+        pendingEvents: Array<Record<string, unknown>>;
+        emitConsoleLog(level: string, scope: string, message: string): void;
+        broadcastTurnFailure(classification: string, message: string): void;
+      };
+      testServer.session = {
+        acpSessionId: "session-1",
+        payload: { run_id: "run-1" },
+        logWriter: { appendRawLine },
+        sseController: null,
+      };
+
+      testServer.emitConsoleLog("info", "scope", "hello");
+      testServer.broadcastTurnFailure("unknown", "boom");
+
+      expect(appendRawLine).toHaveBeenCalledTimes(2);
+      expect(testServer.pendingEvents).toHaveLength(2);
+      testServer.pendingEvents.forEach((event, index) => {
+        expect(event.event_id).toEqual(expect.any(String));
+        expect(appendRawLine.mock.calls[index]?.[2]).toBe(event.event_id);
+      });
+    });
+
     it("recognizes adapter turn_complete notifications on the tapped stream", () => {
       expect(
         isTurnCompleteNotification({

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -115,8 +115,8 @@ import type {
   TaskRunStateField,
 } from "../types";
 import { resourceLink } from "../utils/acp-content";
-import { AsyncMutex } from "../utils/async-mutex";
 import { withTimeout } from "../utils/common";
+import { createEventIdSource } from "../utils/event-id";
 import { resolveGatewayProduct, resolveGatewayTarget } from "../utils/gateway";
 import { resolveGithubToken } from "../utils/github-token";
 import { Logger } from "../utils/logger";
@@ -173,8 +173,6 @@ const errorWithClassificationSchema = z.object({
   data: z.object({ classification: agentErrorClassificationSchema }),
 });
 
-type MessageCallback = (message: unknown) => void;
-
 export const SSE_KEEPALIVE_INTERVAL_MS = 25_000;
 
 // Bounded per-turn retries for unattended (initial/resume) turns that hit a
@@ -206,106 +204,6 @@ export function buildCloudSessionSystemPrompt(
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-class NdJsonTap {
-  private decoder = new TextDecoder();
-  private buffer = "";
-
-  constructor(private onMessage: MessageCallback) {}
-
-  process(chunk: Uint8Array): void {
-    this.buffer += this.decoder.decode(chunk, { stream: true });
-    const lines = this.buffer.split("\n");
-    this.buffer = lines.pop() ?? "";
-
-    for (const line of lines) {
-      if (!line.trim()) continue;
-      try {
-        this.onMessage(JSON.parse(line));
-      } catch {
-        // Not valid JSON, skip
-      }
-    }
-  }
-}
-
-function createTappedReadableStream(
-  underlying: ReadableStream<Uint8Array>,
-  onMessage: MessageCallback,
-  logger?: Logger,
-): ReadableStream<Uint8Array> {
-  const reader = underlying.getReader();
-  const tap = new NdJsonTap(onMessage);
-
-  return new ReadableStream<Uint8Array>({
-    async pull(controller) {
-      try {
-        const { value, done } = await reader.read();
-        if (done) {
-          controller.close();
-          return;
-        }
-        tap.process(value);
-        controller.enqueue(value);
-      } catch (error) {
-        logger?.debug("Read failed, closing stream", error);
-        controller.close();
-      }
-    },
-    cancel() {
-      reader.releaseLock();
-    },
-  });
-}
-
-function createTappedWritableStream(
-  underlying: WritableStream<Uint8Array>,
-  onMessage: MessageCallback,
-  logger?: Logger,
-): WritableStream<Uint8Array> {
-  const tap = new NdJsonTap(onMessage);
-  const mutex = new AsyncMutex();
-
-  return new WritableStream<Uint8Array>({
-    async write(chunk) {
-      tap.process(chunk);
-      await mutex.acquire();
-      try {
-        const writer = underlying.getWriter();
-        await writer.write(chunk);
-        writer.releaseLock();
-      } catch (error) {
-        logger?.debug("Write failed (stream may be closed)", error);
-      } finally {
-        mutex.release();
-      }
-    },
-    async close() {
-      await mutex.acquire();
-      try {
-        const writer = underlying.getWriter();
-        await writer.close();
-        writer.releaseLock();
-      } catch (error) {
-        logger?.debug("Close failed (stream may be closed)", error);
-      } finally {
-        mutex.release();
-      }
-    },
-    async abort(reason) {
-      await mutex.acquire();
-      try {
-        const writer = underlying.getWriter();
-        await writer.abort(reason);
-        writer.releaseLock();
-      } catch (error) {
-        logger?.debug("Abort failed (stream may be closed)", error);
-      } finally {
-        mutex.release();
-      }
-    },
-  });
 }
 
 export function isTurnCompleteNotification(message: unknown): boolean {
@@ -532,6 +430,7 @@ export class AgentServer {
   private app: Hono;
   private posthogAPI: PostHogAPIClient;
   private eventStreamSender: TaskRunEventStreamSender | null = null;
+  private readonly nextEventId = createEventIdSource();
   private rtkSavingsAttempted = false;
   private questionRelayedToSlack = false;
   private adapterEmittedTurnComplete = false;
@@ -639,22 +538,11 @@ export class AgentServer {
     const formatted =
       data !== undefined ? `${message} ${JSON.stringify(data)}` : message;
 
-    const notification = {
+    this.broadcastAndPersistNotification({
       jsonrpc: "2.0",
       method: POSTHOG_NOTIFICATIONS.CONSOLE,
       params: { level, message: formatted },
-    };
-
-    this.broadcastEvent({
-      type: "notification",
-      timestamp: new Date().toISOString(),
-      notification,
     });
-
-    this.session.logWriter.appendRawLine(
-      this.session.payload.run_id,
-      JSON.stringify(notification),
-    );
   };
 
   constructor(config: AgentServerConfig) {
@@ -1961,6 +1849,9 @@ export class AgentServer {
       taskId: payload.task_id,
       deviceType: deviceInfo.type,
       logWriter,
+      eventIdSource: this.nextEventId,
+      onWireMessage: (message, eventId) =>
+        this.handleAcpTransportMessage(message, eventId),
       logger: this.logger,
       claudeGatewayEnv: runtimeAdapter !== "codex" ? gatewayEnv : undefined,
       codexOptions:
@@ -1999,24 +1890,12 @@ export class AgentServer {
       },
     });
 
-    // Tap both streams to broadcast all ACP messages via SSE (mimics local transport)
+    // The connection's wire taps broadcast all ACP messages via SSE (mimics local transport)
     this.adapterEmittedTurnComplete = false;
-    const onAcpMessage = (message: unknown) =>
-      this.handleAcpTransportMessage(message);
-
-    const tappedReadable = createTappedReadableStream(
-      acpConnection.clientStreams.readable as ReadableStream<Uint8Array>,
-      onAcpMessage,
-      this.logger,
-    );
-
-    const tappedWritable = createTappedWritableStream(
+    const clientStream = ndJsonStream(
       acpConnection.clientStreams.writable as WritableStream<Uint8Array>,
-      onAcpMessage,
-      this.logger,
+      acpConnection.clientStreams.readable as ReadableStream<Uint8Array>,
     );
-
-    const clientStream = ndJsonStream(tappedWritable, tappedReadable);
 
     const clientConnection = new ClientSideConnection(
       () => this.createCloudClient(payload),
@@ -2251,15 +2130,7 @@ export class AgentServer {
         ...(conversationClear ? { conversationClear } : {}),
       },
     };
-    this.broadcastEvent({
-      type: "notification",
-      timestamp: new Date().toISOString(),
-      notification: runStartedNotification,
-    });
-    this.session.logWriter.appendRawLine(
-      payload.run_id,
-      JSON.stringify(runStartedNotification),
-    );
+    this.broadcastAndPersistNotification(runStartedNotification);
 
     // Mirror the "agent" setup step onto the ingest leg the client is reading;
     // the orchestrator's completed progress only lands in Django.
@@ -2273,15 +2144,7 @@ export class AgentServer {
         label: "Started agent",
       },
     };
-    this.broadcastEvent({
-      type: "notification",
-      timestamp: new Date().toISOString(),
-      notification: agentStartedProgress,
-    });
-    this.session.logWriter.appendRawLine(
-      payload.run_id,
-      JSON.stringify(agentStartedProgress),
-    );
+    this.broadcastAndPersistNotification(agentStartedProgress);
 
     // Signal in_progress so the UI can start polling for updates
     this.posthogAPI
@@ -2466,7 +2329,7 @@ export class AgentServer {
     message: string,
   ): void {
     if (!this.session) return;
-    const notification = {
+    this.broadcastAndPersistNotification({
       jsonrpc: "2.0",
       method: "session/update",
       params: {
@@ -2477,18 +2340,7 @@ export class AgentServer {
           message,
         },
       },
-    };
-
-    this.broadcastEvent({
-      type: "notification",
-      timestamp: new Date().toISOString(),
-      notification,
     });
-
-    this.session.logWriter.appendRawLine(
-      this.session.payload.run_id,
-      JSON.stringify(notification),
-    );
   }
 
   private async sendInitialTaskMessage(
@@ -5607,7 +5459,7 @@ ${commonInstructions}
     );
   }
 
-  private handleAcpTransportMessage(message: unknown): void {
+  private handleAcpTransportMessage(message: unknown, eventId?: string): void {
     if (isTurnCompleteNotification(message)) {
       if (this.suppressAdapterTurnComplete) {
         return;
@@ -5617,6 +5469,7 @@ ${commonInstructions}
     const event = {
       type: "notification",
       timestamp: new Date().toISOString(),
+      ...(eventId ? { event_id: eventId } : {}),
       notification: message,
     };
     if (!this.session) {
@@ -5632,24 +5485,31 @@ ${commonInstructions}
       this.adapterEmittedTurnComplete = false;
       return;
     }
-    const notification = {
+    this.broadcastAndPersistNotification({
       jsonrpc: "2.0",
       method: POSTHOG_NOTIFICATIONS.TURN_COMPLETE,
       params: {
         sessionId: this.session.acpSessionId,
         stopReason,
       },
-    };
+    });
+  }
 
+  private broadcastAndPersistNotification(
+    notification: Record<string, unknown>,
+  ): void {
+    if (!this.session) return;
+    const eventId = this.nextEventId();
     this.broadcastEvent({
       type: "notification",
       timestamp: new Date().toISOString(),
+      event_id: eventId,
       notification,
     });
-
     this.session.logWriter.appendRawLine(
       this.session.payload.run_id,
       JSON.stringify(notification),
+      eventId,
     );
   }
 
@@ -5671,17 +5531,11 @@ ${commonInstructions}
     const runId = this.session.payload.run_id;
     if (this.commandDispatchedRunId === runId) return;
     this.commandDispatchedRunId = runId;
-    const notification = {
+    this.broadcastAndPersistNotification({
       jsonrpc: "2.0" as const,
       method: POSTHOG_NOTIFICATIONS.COMMAND_DISPATCHED,
       params: {},
-    };
-    this.broadcastEvent({
-      type: "notification",
-      timestamp: new Date().toISOString(),
-      notification,
     });
-    this.session.logWriter.appendRawLine(runId, JSON.stringify(notification));
   }
 
   private flushPreSessionEvents(): void {

--- a/products/desktop/packages/agent/src/server/pi-agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/pi-agent-server.test.ts
@@ -198,6 +198,7 @@ describe("PiAgentServer", () => {
         id: expect.any(String),
         type: "pi_event",
         timestamp: expect.any(String),
+        event_id: expect.any(String),
         event: {
           type: "user_message",
           timestamp: 1,
@@ -209,6 +210,7 @@ describe("PiAgentServer", () => {
         id: expect.any(String),
         type: "pi_event",
         timestamp: expect.any(String),
+        event_id: expect.any(String),
         event: {
           type: "turn_completed",
           timestamp: 2,
@@ -347,15 +349,26 @@ describe("PiAgentServer", () => {
     }
 
     expect(server.pendingEvents).toHaveLength(1_000);
-    expect(server.pendingEvents[0]).toEqual({ type: "test", index: 100 });
+    expect(server.pendingEvents[0]).toEqual({
+      type: "test",
+      index: 100,
+      event_id: expect.any(String),
+    });
   });
 
   it("coalesces replay and log buffers for repeated tool updates", () => {
     const server = new PiAgentServer(config()) as unknown as {
       broadcast(event: Record<string, unknown>): void;
+      nextEventId: () => string;
       pendingEvents: Record<string, unknown>[];
-      pendingLogEntries: Array<{ event?: Record<string, unknown> }>;
+      pendingLogEntries: Array<{
+        event?: Record<string, unknown>;
+        event_id?: string;
+        covered_event_ids?: string[];
+      }>;
     };
+    let seq = 0;
+    server.nextEventId = () => `boot-${++seq}`;
 
     server.broadcast({
       type: "pi_event",
@@ -370,20 +383,79 @@ describe("PiAgentServer", () => {
       event: {
         type: "tool_call_updated",
         timestamp: 2,
+        toolCall: { id: "tool-2", status: "in_progress" },
+      },
+    });
+    server.broadcast({
+      type: "pi_event",
+      event: {
+        type: "tool_call_updated",
+        timestamp: 3,
         toolCall: { id: "tool-1", status: "completed" },
       },
     });
 
-    expect(server.pendingEvents).toHaveLength(1);
-    expect(server.pendingLogEntries).toHaveLength(1);
+    expect(server.pendingEvents).toHaveLength(2);
+    expect(server.pendingLogEntries).toHaveLength(2);
     expect(server.pendingLogEntries[0]?.event).toMatchObject({
-      timestamp: 2,
+      timestamp: 3,
       toolCall: {
         id: "tool-1",
         status: "completed",
         content: [{ type: "content" }],
       },
     });
+    expect(server.pendingLogEntries[0]?.event_id).toBe("boot-3");
+    expect(server.pendingLogEntries[0]?.covered_event_ids).toEqual(["boot-1"]);
+    expect(server.pendingLogEntries[1]?.event_id).toBe("boot-2");
+    expect(server.pendingLogEntries[1]?.covered_event_ids).toBeUndefined();
+    expect(JSON.stringify(server.pendingLogEntries[0])).toBe(
+      JSON.stringify(server.pendingEvents[0]),
+    );
+    expect(JSON.stringify(server.pendingLogEntries[1])).toBe(
+      JSON.stringify(server.pendingEvents[1]),
+    );
+  });
+
+  it("keeps the durable log entry byte-identical to the live envelope", () => {
+    const server = new PiAgentServer(config()) as unknown as {
+      handleEvent(event: Record<string, unknown>): void;
+      pendingEvents: Record<string, unknown>[];
+      pendingLogEntries: Record<string, unknown>[];
+    };
+
+    server.handleEvent({
+      type: "agent_message",
+      timestamp: 1,
+      content: [{ type: "text", text: "hello" }],
+    });
+
+    expect(server.pendingEvents).toHaveLength(1);
+    expect(server.pendingLogEntries).toHaveLength(1);
+    expect(JSON.stringify(server.pendingLogEntries[0])).toBe(
+      JSON.stringify(server.pendingEvents[0]),
+    );
+  });
+
+  it("bounds covered ids accumulated by a long tool update stream", () => {
+    const server = new PiAgentServer(config()) as unknown as {
+      broadcast(event: Record<string, unknown>): void;
+      pendingLogEntries: Array<{ covered_event_ids?: string[] }>;
+    };
+
+    for (let index = 0; index < 10_005; index++) {
+      server.broadcast({
+        type: "pi_event",
+        event: {
+          type: "tool_call_updated",
+          timestamp: index,
+          toolCall: { id: "tool-1", status: "in_progress" },
+        },
+      });
+    }
+
+    expect(server.pendingLogEntries).toHaveLength(1);
+    expect(server.pendingLogEntries[0]?.covered_event_ids).toHaveLength(10_000);
   });
 
   it("flushes long-running conversation logs in bounded batches", async () => {

--- a/products/desktop/packages/agent/src/server/pi-agent-server.ts
+++ b/products/desktop/packages/agent/src/server/pi-agent-server.ts
@@ -39,6 +39,7 @@ import {
   type RpcExtensionUIResponse,
 } from "../pi/types";
 import { PostHogAPIClient } from "../posthog-api";
+import { createEventIdSource } from "../utils/event-id";
 import { resolveLlmGatewayUrl } from "../utils/gateway";
 import { Logger } from "../utils/logger";
 import { TaskRunEventStreamSender } from "./event-stream-sender";
@@ -69,6 +70,7 @@ interface PiCloudSession {
 const emptySchema = z.object({});
 const MAX_PENDING_EVENTS = 1_000;
 const MAX_PENDING_LOG_ENTRIES = 10_000;
+const MAX_COVERED_EVENT_IDS = 10_000;
 const LOG_FLUSH_ENTRY_COUNT = 100;
 
 const userMessageCommandSchema = z
@@ -131,6 +133,7 @@ export class PiAgentServer {
   });
   private readonly posthogAPI: PostHogAPIClient;
   private readonly eventStreamSender: TaskRunEventStreamSender | null;
+  private readonly nextEventId = createEventIdSource();
   private server: ServerType | null = null;
   private session: PiCloudSession | null = null;
   private initializationPromise: Promise<void> | null = null;
@@ -1056,7 +1059,12 @@ export class PiAgentServer {
     return sync;
   }
 
-  private broadcast(event: Record<string, unknown>): void {
+  private broadcast(rawEvent: Record<string, unknown>): void {
+    const eventId = this.nextEventId();
+    const event: Record<string, unknown> = {
+      ...rawEvent,
+      event_id: eventId,
+    };
     const isConversationEvent =
       event.type === "pi_event" || event.type === "pi_run_started";
     const isExtensionMessage =
@@ -1075,6 +1083,7 @@ export class PiAgentServer {
               method: "_posthog/pi_extension_event",
               params: event,
             },
+            event_id: eventId,
           }
         : {
             id: typeof event.id === "string" ? event.id : undefined,
@@ -1085,6 +1094,7 @@ export class PiAgentServer {
               event.type === "pi_event"
                 ? (event.event as AgentConversationEvent)
                 : undefined,
+            event_id: eventId,
           };
       const toolCallId = updatedToolCallId(logEntry.event);
       const pendingLogIndex = toolCallId
@@ -1094,9 +1104,19 @@ export class PiAgentServer {
         : -1;
       if (pendingLogIndex >= 0) {
         const previous = this.pendingLogEntries[pendingLogIndex];
+        const coveredEventIds = previous?.covered_event_ids ?? [];
+        if (
+          previous?.event_id &&
+          coveredEventIds.length < MAX_COVERED_EVENT_IDS
+        ) {
+          coveredEventIds.push(previous.event_id);
+        }
         this.pendingLogEntries[pendingLogIndex] = {
           ...logEntry,
           event: mergeToolCallUpdate(previous?.event, logEntry.event),
+          ...(coveredEventIds.length > 0
+            ? { covered_event_ids: coveredEventIds }
+            : {}),
         };
       } else {
         this.pendingLogEntries.push(logEntry);
@@ -1140,12 +1160,23 @@ export class PiAgentServer {
         : -1;
       if (pendingEventIndex >= 0) {
         const previous = this.pendingEvents[pendingEventIndex];
+        const coveredEventIds =
+          (previous?.covered_event_ids as string[] | undefined) ?? [];
+        if (
+          typeof previous?.event_id === "string" &&
+          coveredEventIds.length < MAX_COVERED_EVENT_IDS
+        ) {
+          coveredEventIds.push(previous.event_id);
+        }
         this.pendingEvents[pendingEventIndex] = {
           ...event,
           event: mergeToolCallUpdate(
             previous?.event as AgentConversationEvent | undefined,
             event.event as AgentConversationEvent | undefined,
           ),
+          ...(coveredEventIds.length > 0
+            ? { covered_event_ids: coveredEventIds }
+            : {}),
         };
       } else {
         this.pendingEvents.push(event);

--- a/products/desktop/packages/agent/src/session-log-writer.test.ts
+++ b/products/desktop/packages/agent/src/session-log-writer.test.ts
@@ -86,6 +86,24 @@ describe("SessionLogWriter", () => {
       });
     });
 
+    it("persists the event id it was appended with", async () => {
+      const sessionId = "s1";
+      logWriter.register(sessionId, { taskId: "t1", runId: sessionId });
+
+      logWriter.appendRawLine(
+        sessionId,
+        JSON.stringify({ method: "test" }),
+        "boot-7",
+      );
+      logWriter.appendRawLine(sessionId, JSON.stringify({ method: "test2" }));
+
+      await logWriter.flush(sessionId);
+
+      const entries: StoredNotification[] = mockAppendLog.mock.calls[0][2];
+      expect(entries[0].event_id).toBe("boot-7");
+      expect(entries[1].event_id).toBeUndefined();
+    });
+
     it("ignores unregistered sessions", async () => {
       logWriter.appendRawLine("unknown", JSON.stringify({ method: "test" }));
       await logWriter.flush("unknown");
@@ -223,6 +241,39 @@ describe("SessionLogWriter", () => {
         content: { type: "text", text: "Hello world" },
       });
       expect(logWriter.getLastAgentMessage(sessionId)).toBe("Hello world");
+    });
+
+    it("stamps the coalesced entry with the covered chunk id range", async () => {
+      const sessionId = "s1";
+      logWriter.register(sessionId, { taskId: "t1", runId: sessionId });
+
+      logWriter.appendRawLine(
+        sessionId,
+        makeSessionUpdate("agent_message_chunk", {
+          content: { type: "text", text: "Hello " },
+        }),
+        "boot-3",
+      );
+      logWriter.appendRawLine(
+        sessionId,
+        makeSessionUpdate("agent_message_chunk", {
+          content: { type: "text", text: "world" },
+        }),
+        "boot-4",
+      );
+      logWriter.appendRawLine(
+        sessionId,
+        makeSessionUpdate("tool_call", { toolCallId: "tc1" }),
+        "boot-5",
+      );
+
+      await logWriter.flush(sessionId);
+
+      const entries: StoredNotification[] = mockAppendLog.mock.calls[0][2];
+      expect(entries[0].first_event_id).toBe("boot-3");
+      expect(entries[0].event_id).toBe("boot-4");
+      expect(entries[1].event_id).toBe("boot-5");
+      expect(entries[1].first_event_id).toBeUndefined();
     });
 
     it("tracks direct agent_message updates", async () => {
@@ -555,12 +606,14 @@ describe("SessionLogWriter", () => {
         makeSessionUpdate("agent_message_chunk", {
           content: { type: "text", text: "partial" },
         }),
+        "boot-1",
       );
       logWriter.appendRawLine(
         sessionId,
         makeSessionUpdate("agent_message", {
           content: { type: "text", text: "complete" },
         }),
+        "boot-2",
       );
 
       await logWriter.flush(sessionId);
@@ -574,6 +627,8 @@ describe("SessionLogWriter", () => {
         sessionUpdate: "agent_message",
         content: { type: "text", text: "complete" },
       });
+      expect(entries[0].first_event_id).toBe("boot-1");
+      expect(entries[0].event_id).toBe("boot-2");
     });
   });
 

--- a/products/desktop/packages/agent/src/session-log-writer.ts
+++ b/products/desktop/packages/agent/src/session-log-writer.ts
@@ -45,6 +45,8 @@ export interface SessionLogWriterOptions {
 interface ChunkBuffer {
   text: string;
   firstTimestamp: string;
+  firstEventId?: string;
+  lastEventId?: string;
 }
 
 /**
@@ -186,7 +188,7 @@ export class SessionLogWriter {
     return this.sessions.has(sessionId);
   }
 
-  appendRawLine(sessionId: string, line: string): void {
+  appendRawLine(sessionId: string, line: string, eventId?: string): void {
     const session = this.sessions.get(sessionId);
     if (!session) {
       this.logger.warn("appendRawLine called for unregistered session", {
@@ -195,8 +197,34 @@ export class SessionLogWriter {
       return;
     }
 
+    let message: Record<string, unknown>;
     try {
-      const message = JSON.parse(line);
+      message = JSON.parse(line);
+    } catch {
+      this.logger.warn("Failed to parse raw line for persistence", {
+        taskId: session.context.taskId,
+        runId: session.context.runId,
+        lineLength: line.length,
+      });
+      return;
+    }
+    this.appendNotification(sessionId, message, eventId);
+  }
+
+  appendNotification(
+    sessionId: string,
+    message: Record<string, unknown>,
+    eventId?: string,
+  ): void {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      this.logger.warn("appendNotification called for unregistered session", {
+        sessionId,
+      });
+      return;
+    }
+
+    try {
       const timestamp = new Date().toISOString();
 
       // Persisted empty thought chunks poison session resume: they rebuild
@@ -210,10 +238,20 @@ export class SessionLogWriter {
         const text = this.extractChunkText(message);
         if (text) {
           if (!session.chunkBuffer) {
-            session.chunkBuffer = { text, firstTimestamp: timestamp };
+            session.chunkBuffer = {
+              text,
+              firstTimestamp: timestamp,
+              firstEventId: eventId,
+              lastEventId: eventId,
+            };
           } else {
             session.chunkBuffer.text += text;
+            if (eventId) {
+              session.chunkBuffer.lastEventId = eventId;
+            }
           }
+        } else if (session.chunkBuffer && eventId) {
+          session.chunkBuffer.lastEventId = eventId;
         }
         // Don't emit chunk events
         return;
@@ -222,7 +260,9 @@ export class SessionLogWriter {
       // Non-chunk event: flush any buffered chunks first.
       // If this is a direct agent_message AND there are buffered chunks,
       // the direct message supersedes the partial chunks
+      let supersededChunks: ChunkBuffer | undefined;
       if (this.isDirectAgentMessage(message) && session.chunkBuffer) {
+        supersededChunks = session.chunkBuffer;
         session.chunkBuffer = undefined;
       } else {
         this.emitCoalescedMessage(sessionId, session);
@@ -234,9 +274,14 @@ export class SessionLogWriter {
         session.currentTurnMessages.push(nonChunkAgentText);
       }
 
+      const entryEventId = eventId ?? supersededChunks?.lastEventId;
       const entry: StoredNotification = {
         type: "notification",
         timestamp,
+        ...(entryEventId ? { event_id: entryEventId } : {}),
+        ...(supersededChunks?.firstEventId
+          ? { first_event_id: supersededChunks.firstEventId }
+          : {}),
         notification: redactAuthorizationHeaders(
           message,
         ) as StoredNotification["notification"],
@@ -301,11 +346,11 @@ export class SessionLogWriter {
       if (this.posthogAPI) {
         this.queueForApiLog(sessionId, session, entry, tcu);
       }
-    } catch {
-      this.logger.warn("Failed to parse raw line for persistence", {
+    } catch (error) {
+      this.logger.warn("Failed to persist notification", {
         taskId: session.context.taskId,
         runId: session.context.runId,
-        lineLength: line.length,
+        error: serializeError(error),
       });
     }
   }
@@ -547,14 +592,18 @@ export class SessionLogWriter {
   private emitCoalescedMessage(sessionId: string, session: SessionState): void {
     if (!session.chunkBuffer) return;
 
-    const { text, firstTimestamp } = session.chunkBuffer;
+    const { text, firstTimestamp, firstEventId, lastEventId } =
+      session.chunkBuffer;
     session.chunkBuffer = undefined;
     session.lastAgentMessage = text;
     session.currentTurnMessages.push(text);
 
+    // The id range covers the chunk events this entry replaces.
     const entry: StoredNotification = {
       type: "notification",
       timestamp: firstTimestamp,
+      ...(lastEventId ? { event_id: lastEventId } : {}),
+      ...(firstEventId ? { first_event_id: firstEventId } : {}),
       notification: {
         jsonrpc: "2.0",
         method: "session/update",

--- a/products/desktop/packages/agent/src/types.ts
+++ b/products/desktop/packages/agent/src/types.ts
@@ -23,6 +23,10 @@ export interface StoredNotification {
   type: "notification";
   /** When this notification was stored */
   timestamp: string;
+  /** Shared identity with the event's Redis stream copy, when stamped */
+  event_id?: string;
+  /** First covered event id, on entries coalesced from a run of chunks */
+  first_event_id?: string;
   /** JSON-RPC 2.0 notification (no id field = notification, not request) */
   notification: {
     jsonrpc: "2.0";

--- a/products/desktop/packages/agent/src/utils/event-id.ts
+++ b/products/desktop/packages/agent/src/utils/event-id.ts
@@ -1,0 +1,18 @@
+import { randomUUID } from "node:crypto";
+
+export type NextEventId = () => string;
+
+/**
+ * Per-process source of task run event ids: a random boot prefix plus a
+ * monotonic counter. Ids are unique across agent restarts within a run and
+ * ordered within one boot, so the same id can key an event in both the Redis
+ * stream and the S3 run log.
+ */
+export function createEventIdSource(): NextEventId {
+  const bootId = randomUUID().slice(0, 8);
+  let seq = 0;
+  return () => {
+    seq += 1;
+    return `${bootId}-${seq}`;
+  };
+}

--- a/products/desktop/packages/shared/src/session-events.ts
+++ b/products/desktop/packages/shared/src/session-events.ts
@@ -77,6 +77,9 @@ export interface StoredLogEntry {
   id?: string;
   type: string;
   timestamp?: string;
+  /** Shared identity with the entry's Redis stream copy, when stamped */
+  event_id?: string;
+  covered_event_ids?: string[];
   event?: AgentConversationEvent;
   notification?: {
     id?: number;


### PR DESCRIPTION
## Problem

- A viewer that joins a task run stream late needs history from the durable S3 run log plus the live Redis tail, and today nothing can match an event across the two stores.
- The agent fans each notification out twice: the stream envelope and the log entry get independent timestamps, and identical notifications (repeated tool updates, keepalives) make content matching only probabilistic.
- Without a shared key, the connect-time merge planned for the stream backlog cannot deduplicate exactly, and Redis streams must stay large enough to serve full history on their own.

## Changes

- Nothing changes for users yet; this PR only adds identity that a later server-side merge will read.
- The agent now stamps a per-run `event_id` (random boot prefix plus a monotonic counter) on each event, and both stores carry the same id: the stream event envelope and the S3 log entry.
- One wire tap in `acp-connection` now feeds both consumers: each ACP line is parsed once, stamped, then handed to the session log writer and the agent-server broadcast with the same id. The duplicate ND-JSON tap layer in `agent-server` is deleted.
- A log entry coalesced from a run of message chunks carries the covered id range (`first_event_id` to `event_id`), so a merge can drop the tail's chunk events that the coalesced entry replaces.
- Notifications born in the agent server itself (run started, progress, turn complete, command dispatched) stamp the same way before their fan-out.
- The Pi server stamps in its single `broadcast()`, so Pi log entries and stream events share ids too.

