### PR TITLE
fix(warehouse): stop the seek gate rejecting every real table

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -2230,6 +2230,25 @@ def _build_xmin_query(
     return ordered
 
 
+def _column_is_not_null(table: Table[PostgreSQLColumn], column_name: str) -> bool:
+    """Whether `column_name` is declared NOT NULL.
+
+    `Column.nullable` is annotated `bool`, but `_get_table` fills it straight from
+    `information_schema.columns.is_nullable` for a table, which Postgres returns as the string
+    "YES"/"NO"; only the materialised-view branch produces a real boolean. A bare truth test
+    therefore reads every column of every table as nullable, because "NO" is truthy. Sibling
+    sources normalise at construction (Redshift, Trino), but doing that here would change the Arrow
+    field nullability this source has always emitted, so interpret both shapes at the point of use.
+    """
+
+    def is_not_null(nullable: object) -> bool:
+        if isinstance(nullable, str):
+            return nullable.strip().upper() == "NO"
+        return not nullable
+
+    return any(is_not_null(column.nullable) for column in table.columns if column.name == column_name)
+
+
 def _build_keyset_query(
     schema: str,
     table_name: str,
@@ -3983,16 +4002,17 @@ def postgres_source(
 
             # Seeking needs a key that is unique and never NULL. A page boundary inside a run of
             # equal keys drops the rest of that run, and `key > last` never matches NULL, so a NULL
-            # row is dropped unless it lands on the first page. A declared primary key is both. The
-            # assumed `id` is neither until checked, and its duplicate probe groups NULLs together,
-            # so a single NULL row passes it. A partitioned parent's key is unique only per child.
-            not_null_columns = {column.name for column in full_table.columns if not column.nullable}
+            # row is dropped unless it lands on the first page. Postgres guarantees both for a
+            # declared primary key, so that needs no further check. The assumed `id` is neither
+            # until proven: its duplicate probe groups NULLs together, so one NULL row alone passes
+            # it, and the column has to be NOT NULL as well. A partitioned parent's key is unique
+            # only per child.
+            assumed_id_is_seekable = not has_duplicate_primary_keys and all(
+                _column_is_not_null(full_table, key) for key in primary_keys or []
+            )
             keyset_primary_keys = (
                 primary_keys
-                if primary_keys
-                and not is_partitioned
-                and not (used_id_pk_fallback and has_duplicate_primary_keys)
-                and all(key in not_null_columns for key in primary_keys)
+                if primary_keys and not is_partitioned and (not used_id_pk_fallback or assumed_id_is_seekable)
                 else None
             )
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -3504,7 +3504,7 @@ class TestChunkedRereadAfterRecoveryConflict:
         should_use_incremental_field: bool,
         rows_before_conflict: int,
         primary_keys: list[str] | None = None,
-        nullable_value: Any = False,
+        nullable_value: bool | str = False,
         has_id_column: bool = False,
         has_duplicate_pks: bool = False,
     ) -> list[int]:
@@ -3515,7 +3515,12 @@ class TestChunkedRereadAfterRecoveryConflict:
         fake_table = mock.Mock()
         fake_table.to_arrow_schema.return_value = pa.schema([pa.field("id", pa.int64())])
         fake_table.type = "table"
-        fake_table.columns = [PostgreSQLColumn(name="id", data_type="integer", nullable=nullable_value)]
+        # `nullable` is annotated `bool`, but `_get_table` really does pass the
+        # information_schema "YES"/"NO" string for a table. That mismatch is the bug under test,
+        # so the fake has to reproduce it rather than respect the annotation.
+        fake_table.columns = [
+            PostgreSQLColumn(name="id", data_type="integer", nullable=nullable_value)  # type: ignore[arg-type]
+        ]
         fake_table.__contains__ = mock.Mock(return_value=has_id_column)
 
         scan = self._Scan(list(self._ROWS))
@@ -3555,25 +3560,33 @@ class TestChunkedRereadAfterRecoveryConflict:
             return [row["id"] for table in cast(Iterable[Any], response.items()) for row in table.to_pylist()]
 
     @pytest.mark.parametrize(
-        "should_use_incremental_field,rows_before_conflict,nullable_value",
-        [(False, 0, False), (False, 0, "NO"), (True, 2, False)],
+        "should_use_incremental_field,rows_before_conflict,nullable_value,primary_keys,has_id_column",
+        [
+            (False, 0, False, ["id"], False),
+            (False, 0, "NO", ["id"], False),
+            (False, 0, "NO", None, True),
+            (True, 2, False, ["id"], False),
+        ],
         ids=[
-            "full_refresh_has_no_order_of_its_own",
-            "full_refresh_with_information_schema_nullable_string",
+            "declared_key_with_boolean_nullable",
+            "declared_key_with_information_schema_nullable_string",
+            "assumed_id_that_is_unique_and_not_null",
             "incremental_read_is_ordered_by_its_cursor",
         ],
     )
     def test_chunked_reread_yields_every_row_exactly_once(
-        self, should_use_incremental_field, rows_before_conflict, nullable_value
+        self, should_use_incremental_field, rows_before_conflict, nullable_value, primary_keys, has_id_column
     ):
         # `_get_table` reports nullability as a bool for a materialised view but as the
         # information_schema "YES"/"NO" string for a table, and "NO" is truthy. Reading it naively
-        # made every real table look nullable, which disabled seeking for the whole fleet.
+        # made every real table look nullable, which disabled seeking for the whole fleet. The
+        # assumed-`id` case is here so a gate that rejects every fallback key cannot pass either.
         ids = self._read_ids(
             should_use_incremental_field=should_use_incremental_field,
             rows_before_conflict=rows_before_conflict,
-            primary_keys=["id"],
+            primary_keys=primary_keys,
             nullable_value=nullable_value,
+            has_id_column=has_id_column,
         )
 
         assert sorted(ids) == [row[0] for row in self._ROWS]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -3504,7 +3504,9 @@ class TestChunkedRereadAfterRecoveryConflict:
         should_use_incremental_field: bool,
         rows_before_conflict: int,
         primary_keys: list[str] | None = None,
-        key_is_nullable: bool = False,
+        nullable_value: Any = False,
+        has_id_column: bool = False,
+        has_duplicate_pks: bool = False,
     ) -> list[int]:
         @contextmanager
         def fake_tunnel():
@@ -3513,8 +3515,8 @@ class TestChunkedRereadAfterRecoveryConflict:
         fake_table = mock.Mock()
         fake_table.to_arrow_schema.return_value = pa.schema([pa.field("id", pa.int64())])
         fake_table.type = "table"
-        fake_table.columns = [PostgreSQLColumn(name="id", data_type="integer", nullable=key_is_nullable)]
-        fake_table.__contains__ = mock.Mock(return_value=False)
+        fake_table.columns = [PostgreSQLColumn(name="id", data_type="integer", nullable=nullable_value)]
+        fake_table.__contains__ = mock.Mock(return_value=has_id_column)
 
         scan = self._Scan(list(self._ROWS))
         connection = self._Connection(self._NamedCursor(rows_before_conflict, scan))
@@ -3527,6 +3529,7 @@ class TestChunkedRereadAfterRecoveryConflict:
             patch(f"{module}._is_read_replica", return_value=True),
             patch(f"{module}._is_duckdb_connection", return_value=False),
             patch(f"{module}._get_primary_keys", return_value=primary_keys),
+            patch(f"{module}._has_duplicate_primary_keys", return_value=has_duplicate_pks),
             patch(f"{module}._is_partitioned_table", return_value=False),
             patch(f"{module}._get_table_chunk_size", return_value=_TableChunking(batch_rows=2, fetch_rows=2)),
             patch(f"{module}._get_rows_to_sync", return_value=len(self._ROWS)),
@@ -3552,15 +3555,25 @@ class TestChunkedRereadAfterRecoveryConflict:
             return [row["id"] for table in cast(Iterable[Any], response.items()) for row in table.to_pylist()]
 
     @pytest.mark.parametrize(
-        "should_use_incremental_field,rows_before_conflict",
-        [(False, 0), (True, 2)],
-        ids=["full_refresh_has_no_order_of_its_own", "incremental_read_is_ordered_by_its_cursor"],
+        "should_use_incremental_field,rows_before_conflict,nullable_value",
+        [(False, 0, False), (False, 0, "NO"), (True, 2, False)],
+        ids=[
+            "full_refresh_has_no_order_of_its_own",
+            "full_refresh_with_information_schema_nullable_string",
+            "incremental_read_is_ordered_by_its_cursor",
+        ],
     )
-    def test_chunked_reread_yields_every_row_exactly_once(self, should_use_incremental_field, rows_before_conflict):
+    def test_chunked_reread_yields_every_row_exactly_once(
+        self, should_use_incremental_field, rows_before_conflict, nullable_value
+    ):
+        # `_get_table` reports nullability as a bool for a materialised view but as the
+        # information_schema "YES"/"NO" string for a table, and "NO" is truthy. Reading it naively
+        # made every real table look nullable, which disabled seeking for the whole fleet.
         ids = self._read_ids(
             should_use_incremental_field=should_use_incremental_field,
             rows_before_conflict=rows_before_conflict,
             primary_keys=["id"],
+            nullable_value=nullable_value,
         )
 
         assert sorted(ids) == [row[0] for row in self._ROWS]
@@ -3570,19 +3583,34 @@ class TestChunkedRereadAfterRecoveryConflict:
             self._read_ids(should_use_incremental_field=False, rows_before_conflict=2, primary_keys=["id"])
 
     @pytest.mark.parametrize(
-        "rows_before_conflict,primary_keys,key_is_nullable",
-        [(0, None, False), (2, None, False), (0, ["id"], True)],
-        ids=["no_key_at_all", "no_key_at_all_after_rows_written", "key_column_is_nullable"],
+        "rows_before_conflict,nullable_value,has_id_column,has_duplicate_pks",
+        [
+            (0, False, False, False),
+            (2, False, False, False),
+            (0, True, True, False),
+            (0, "YES", True, False),
+            (0, "NO", True, True),
+        ],
+        ids=[
+            "no_key_at_all",
+            "no_key_at_all_after_rows_written",
+            "assumed_id_is_nullable",
+            "assumed_id_is_nullable_as_information_schema_string",
+            "assumed_id_has_duplicates",
+        ],
     )
     def test_full_refresh_without_a_seekable_key_fails_non_retryably(
-        self, rows_before_conflict, primary_keys, key_is_nullable
+        self, rows_before_conflict, nullable_value, has_id_column, has_duplicate_pks
     ):
+        # No declared key, so the assumed `id` only qualifies once proven unique and NOT NULL.
         with pytest.raises(Exception) as exc_info:
             self._read_ids(
                 should_use_incremental_field=False,
                 rows_before_conflict=rows_before_conflict,
-                primary_keys=primary_keys,
-                key_is_nullable=key_is_nullable,
+                primary_keys=None,
+                nullable_value=nullable_value,
+                has_id_column=has_id_column,
+                has_duplicate_pks=has_duplicate_pks,
             )
 
         message = str(exc_info.value)


### PR DESCRIPTION
## Problem

- Since #93764 deployed, a Postgres full refresh that hits a read-replica recovery conflict fails outright instead of recovering, on every regular table.
- The customer-facing error tells them the table has no unique, non-null column, while the same run's logs show its primary key was detected a second earlier. It is wrong and it is confusing.
- Observed on a live enterprise source: three consecutive failed runs, every one aborting non-retryably.
- The fix from #93764 is therefore not protecting anyone. It replaced silent corruption with a hard stop and a misleading reason.

## Changes

- A full refresh that hits a recovery conflict recovers by seeking again, instead of aborting, so affected syncs go back to completing correctly.
- The cause was reading `Column.nullable` as a boolean. `_get_table` fills it straight from `information_schema.columns.is_nullable` for a table, which Postgres returns as the string `"YES"` or `"NO"`, and `"NO"` is truthy. Every column of every regular table read as nullable, so the not-null set was empty and the gate refused every key.
- Only a materialised view escaped, because that branch of `_get_table` selects `NOT a.attnotnull` and really does produce a boolean.
- Postgres guarantees a declared primary key is unique and NOT NULL, so the check is dropped there entirely. That is the 94% case and it now needs no nullability read at all.
- The assumed `id` fallback still has to prove itself, and reads nullability through a helper that accepts both shapes.

Normalising at construction, the way `Redshift` and `Trino` already do, would be the tidier fix. It is deliberately not done here: `PostgreSQLColumn.to_arrow_field` passes the same value to `pa.field(..., nullable=...)`, so making it a real boolean would start emitting non-nullable Arrow fields for the first time and change how existing Delta tables evolve. That belongs in its own change with its own testing, not in a hotfix.

```mermaid
flowchart TD
    A{{Recovery conflict on a full refresh}} --> B{Key check}
    B -->|Declared primary key| C[Seek and finish the read]
    B -->|Assumed id, unique and NOT NULL| C
    B -->|Assumed id, nullable or duplicated| D[Fail with the cause]
    B -->|No key| D
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class A phYellow;
    class B phBlue;
    class C phGray;
    class D phRed;
```

## How did you test this code?

- The existing tests built their fake columns with a real boolean, which is only ever the materialised-view shape, so they could not catch this. `test_chunked_reread_yields_every_row_exactly_once` now runs the full-refresh case with both `False` and the `"NO"` string, and the string case fails without this change.
- The refusal cases moved onto the assumed-`id` path, which is the only place nullability decides anything now. They cover a nullable boolean, a nullable `"YES"` string, and a duplicated key.
- Ran the Postgres source suite and the wider `sources/` suites, plus repo-wide mypy, locally.
- Not run: any live read against a replica. The failure was identified from production job rows and sync logs for the affected schema, and the mechanism confirmed by reading `_get_table`'s two query branches.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5). Found after a report that one schema had been failing since the deploy. Production job rows showed the abort text from #93764, and the same run's logs showed `Found primary keys: ['id']`, which is what pointed at the gate rather than the data.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Regression introduced by me in #93764. The nullability requirement itself was correct and came from review; reading it off a field whose runtime type does not match its annotation was the mistake.
- An earlier version of this fix kept a defensive `isinstance` check inline. mypy flagged it as unreachable, correctly, because `Column.nullable` is annotated `bool`. That is the real defect underneath, and the helper now documents it rather than hiding it.
- Public artifact: no customer names, ids, or table names appear here. The affected schema was identified privately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
