### PR TITLE
chore(csp): report on cross-origin form posts

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -1225,6 +1225,9 @@ class CSPMiddleware:
                 "frame-src https:",
                 "manifest-src 'self'",
                 "base-uri 'self'",
+                # form-action has no default-src fallback, so leaving it unset lets an injected
+                # form post anywhere. Every form we serve targets a same-origin path.
+                "form-action 'self'",
             ]
 
             report_uri = csp_report_endpoint(sample_rate="0.1")


### PR DESCRIPTION
## Problem

An injected form on any app page can post to any host today. The data goes with it.

`form-action` is one of the few CSP directives with no fallback to `default-src`. Leaving it unset means no restriction at all, not an inherited one. An attacker who cannot run script, or who runs script under a tight `connect-src`, still has this channel.

The app policy has carried every other boundary directive since #39735. This one was never added.

## Changes

- Nothing changes for a user. The directive goes into the report-only header, so no form is blocked.
- Add `form-action 'self'` to the app policy.
- The admin policy is enforced rather than report-only, so it is left alone until this measurement comes back.

## How did you test this code?

No new tests. The change adds one directive string to a policy the existing `TestCSPMiddleware` cases already assert the shape of.

Ran `posthog/test/test_middleware.py::TestCSPMiddleware` locally: 10 passed.

Checked that every form in `posthog/templates/` targets a same-origin path. Not checked: SAML SSO, where the HTTP-POST binding posts an assertion to the identity provider. That is the case most likely to report, and it is the reason this lands report-only.

Query `$csp_violation` for `$csp_effective_directive = 'form-action'` after this deploys. No reports over a full week means the directive is safe to enforce.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this PR. Skills invoked: `/writing-pr-descriptions`, `superpowers:using-git-worktrees`.

This came out of a review of seven days of `$csp_violation` reports across both cloud regions, which asked what the app policy defends and what it leaves open. `form-action` and `frame-src` were the two gaps. `frame-src https:` is required by heatmaps, which frame customer sites by design, so it needs its own design work and is not addressed here.

https://claude.ai/code/session_01HgRWtAJHBL2hQArpctxYr4
