### PR TITLE
feat(engineering-analytics): default DORA scope to every production environment

### DIFF
--- a/products/engineering_analytics/backend/facade/contracts.py
+++ b/products/engineering_analytics/backend/facade/contracts.py
@@ -1337,9 +1337,9 @@ class DoraOverview:
     # False when the deployments/deployment_statuses tables aren't synced for the selected repo.
     deploy_data_available: bool
     # What the environment filter resolved to: the exact environment name(s) it matches —
-    # the caller's picks (comma-joined when several), or by default the busiest environment
-    # GitHub marks production, falling back to the busiest persistent environment, so a
-    # multi-region repo doesn't multiply every count — or 'persistent' (no persistent
+    # the caller's picks (comma-joined when several), or by default every environment GitHub
+    # marks production (every production-named one when none is marked), falling back to the
+    # busiest persistent environment — or 'persistent' (no persistent
     # environment deployed in the window at all, so every non-transient one counts). Transient
     # environments (ephemeral per-PR previews) never join a default scope. The scope resolves
     # from deployments in the scan window, so two different windows can resolve different

--- a/products/engineering_analytics/backend/logic/queries/dora.py
+++ b/products/engineering_analytics/backend/logic/queries/dora.py
@@ -346,39 +346,38 @@ class _DoraScan:
 def _resolve_environment_scope(
     environments_filter: list[str] | None, environments: list[tuple[str, bool]]
 ) -> _EnvironmentScope:
-    """Pick the deploy population: the caller's exact environment(s) when given; otherwise the
-    single busiest environment GitHub marks production; otherwise the busiest environment whose
-    NAME says production; otherwise the single busiest persistent environment, so a repo that
-    never sets the production flag still gets numbers instead of a false zero.
+    """Pick the deploy population: the caller's exact environment(s) when given; otherwise every
+    environment GitHub marks production; otherwise every environment whose NAME says production;
+    otherwise the single busiest persistent environment, so a repo that never sets the production
+    flag still gets numbers instead of a false zero.
     The name tier exists because the ``production_environment`` flag is optional and widely
     unset, and a dev or staging environment can deploy more often than production, which would
     put every default DORA figure on that environment.
-    Busiest-single, not every-matching: a multi-region repo deploys each merge to several
-    production and persistent environments (and to dev, package registries, ...), which would
-    multiply every deploy count and hand lead time to whichever region deploys first.
+    Every production environment, not the busiest one: the default question is "how long until
+    it is in production", and a multi-region repo runs production as several environments, so a
+    single-region scope silently drops the other regions. The cost is that deploy counts add up
+    across regions (one merge deployed to two regions is two deployments) and a PR's lead time
+    ends at whichever region deploys it first; the scope label names every region so the reader
+    can see that.
     'persistent' survives only when the window has no persistent environment at all. Transient
     environments never join a default scope: they are ephemeral per-PR previews, and on this
     repo they outnumber real deploys by an order of magnitude."""
     if environments_filter:
-        return _EnvironmentScope(
-            scope=", ".join(environments_filter),
-            predicate="d.environment IN {environments}",
-            values=environments_filter,
-        )
-    # ``environments`` arrives busiest-first, so the first match in each tier is the busiest match.
-    production = next((name for name, is_production in environments if is_production), None)
-    if production is not None:
-        return _single_environment_scope(production)
-    named = next((name for name, _ in environments if _PRODUCTION_NAME_PATTERN.match(name)), None)
-    if named is not None:
-        return _single_environment_scope(named)
+        return _exact_environment_scope(environments_filter)
+    # ``environments`` arrives busiest-first, so each tier keeps that order.
+    production = [name for name, is_production in environments if is_production]
+    if production:
+        return _exact_environment_scope(production)
+    named = [name for name, _ in environments if _PRODUCTION_NAME_PATTERN.match(name)]
+    if named:
+        return _exact_environment_scope(named)
     if environments:
-        return _single_environment_scope(environments[0][0])
+        return _exact_environment_scope([environments[0][0]])
     return _EnvironmentScope(scope="persistent", predicate="NOT d.is_transient_environment", values=None)
 
 
-def _single_environment_scope(name: str) -> _EnvironmentScope:
-    return _EnvironmentScope(scope=name, predicate="d.environment IN {environments}", values=[name])
+def _exact_environment_scope(names: list[str]) -> _EnvironmentScope:
+    return _EnvironmentScope(scope=", ".join(names), predicate="d.environment IN {environments}", values=names)
 
 
 def _empty_overview(
@@ -643,8 +642,8 @@ def query_dora_overview(
         date_to_filter=_date_to_clause(date_to, "d.created_at"),
     )
     env_scope = _resolve_environment_scope(environments_filter, environments)
-    # The busiest-environment fallbacks bind the same placeholder as an explicit filter: either
-    # way ``values`` holds exactly the environment names the predicate matches.
+    # The default-scope tiers bind the same placeholder as an explicit filter: either way
+    # ``values`` holds exactly the environment names the predicate matches.
     if env_scope.values is not None:
         placeholders["environments"] = ast.Tuple(exprs=[ast.Constant(value=name) for name in env_scope.values])
 

--- a/products/engineering_analytics/backend/presentation/serializers/dora.py
+++ b/products/engineering_analytics/backend/presentation/serializers/dora.py
@@ -107,8 +107,9 @@ class DoraOverviewSerializer(DataclassSerializer):
             },
             "environment_scope": {
                 "help_text": "What the environment filter resolved to: the exact environment name(s) it matches "
-                "(the caller's picks, comma-joined when several; by default the busiest production-marked "
-                "environment, falling back to the busiest persistent one), or 'persistent' (no persistent "
+                "(the caller's picks, comma-joined when several; by default every production-marked "
+                "environment, then every production-named one, then the busiest persistent one), or "
+                "'persistent' (no persistent "
                 "environment deployed in the window, so every non-transient one counts). Transient environments "
                 "(ephemeral per-PR previews) never join a default scope. The scope resolves from deployments in "
                 "the scan window, so two different windows can resolve different scopes and are not always "

--- a/products/engineering_analytics/backend/presentation/views/dora.py
+++ b/products/engineering_analytics/backend/presentation/views/dora.py
@@ -28,8 +28,8 @@ _ENVIRONMENT = OpenApiParameter(
     # environment.
     explode=True,
     description="Deploy environment(s) to scope to, repeatable (from the response's `environments` list). Omit "
-    "to scope to the busiest environment GitHub marks production, falling back to the busiest persistent "
-    "(non-transient) environment when none are marked production.",
+    "to scope to every environment GitHub marks production (every production-named one when none is marked), "
+    "falling back to the busiest persistent (non-transient) environment.",
 )
 
 _GRANULARITY = OpenApiParameter(

--- a/products/engineering_analytics/backend/tests/test_dora.py
+++ b/products/engineering_analytics/backend/tests/test_dora.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from posthog.test.base import APIBaseTest, BaseTest, ClickhouseTestMixin
 
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models.team import Team
@@ -189,7 +190,7 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
         )
 
         assert result.deploy_data_available is True
-        assert result.environment_scope == "prod"  # the busiest (only) production-marked environment
+        assert result.environment_scope == "prod"  # the only production-marked environment
         assert result.environments == ["prod", "staging"]
         assert result.has_membership_data is False
         assert result.github_teams == []
@@ -446,21 +447,29 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
         assert both.deployment_count == 2  # the multi-environment scope admits d1 and d4
         assert both.series_granularity == "week"  # the caller's override beats the window fit
 
-    def test_default_scope_picks_busiest_production_environment(self):
-        # Two production-marked regions: the default scope takes the busiest one, so a
-        # multi-region repo doesn't double-count every deploy and hand lead time to
-        # whichever region ships first.
+    @parameterized.expand([("production_flag", True), ("production_name", False)])
+    def test_default_scope_covers_every_production_environment(self, _name: str, production: bool):
+        # Two production regions, marked by the GitHub flag or only by name: the default scope
+        # takes both, so "how long to production" reads across the whole production estate and
+        # the quieter region isn't silently dropped. Staging deploys more often than either
+        # region and still stays out.
         curated = self._curated(
             self.team,
             deployment_rows=[
-                _deployment_row(1, "sha-a", "prod-us", "2026-01-12 09:30:00", production=True),
-                _deployment_row(2, "sha-b", "prod-us", "2026-01-13 09:30:00", production=True),
-                _deployment_row(3, "sha-c", "prod-eu", "2026-01-12 09:30:00", production=True),
+                _deployment_row(1, "sha-a", "prod-us", "2026-01-12 09:30:00", production=production),
+                _deployment_row(2, "sha-b", "prod-us", "2026-01-13 09:30:00", production=production),
+                _deployment_row(3, "sha-c", "prod-eu", "2026-01-12 09:30:00", production=production),
+                _deployment_row(4, "sha-d", "staging", "2026-01-12 09:00:00", production=False),
+                _deployment_row(5, "sha-e", "staging", "2026-01-13 09:00:00", production=False),
+                _deployment_row(6, "sha-f", "staging", "2026-01-14 09:00:00", production=False),
             ],
             status_rows=[
                 _status_row(11, 1, "success", "prod-us", "2026-01-12 10:00:00"),
                 _status_row(21, 2, "success", "prod-us", "2026-01-13 10:00:00"),
                 _status_row(31, 3, "success", "prod-eu", "2026-01-12 10:00:00"),
+                _status_row(41, 4, "success", "staging", "2026-01-12 09:30:00"),
+                _status_row(51, 5, "success", "staging", "2026-01-13 09:30:00"),
+                _status_row(61, 6, "success", "staging", "2026-01-14 09:30:00"),
             ],
             pr_rows=[_pr_row(1, "alice", "open", 0, "2026-01-11 08:00:00")],
         )
@@ -470,6 +479,6 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
             date_to=datetime(2026, 1, 20, tzinfo=UTC),
         )
 
-        assert result.environment_scope == "prod-us"
-        assert result.environments == ["prod-us", "prod-eu"]
-        assert result.deployment_count == 2
+        assert result.environment_scope == "prod-us, prod-eu"
+        assert result.environments == ["staging", "prod-us", "prod-eu"]
+        assert result.deployment_count == 3

--- a/products/engineering_analytics/frontend/generated/api.schemas.ts
+++ b/products/engineering_analytics/frontend/generated/api.schemas.ts
@@ -266,7 +266,7 @@ export interface DoraOverviewApi {
     open_to_deploy_series: LeadTimeBucketApi[]
     /** False when the deployments/deployment_statuses tables aren't synced for the selected repo; every other field is then empty or null, never a fake zero. */
     deploy_data_available: boolean
-    /** What the environment filter resolved to: the exact environment name(s) it matches (the caller's picks, comma-joined when several; by default the busiest production-marked environment, falling back to the busiest persistent one), or 'persistent' (no persistent environment deployed in the window, so every non-transient one counts). Transient environments (ephemeral per-PR previews) never join a default scope. The scope resolves from deployments in the scan window, so two different windows can resolve different scopes and are not always comparable. */
+    /** What the environment filter resolved to: the exact environment name(s) it matches (the caller's picks, comma-joined when several; by default every production-marked environment, then every production-named one, then the busiest persistent one), or 'persistent' (no persistent environment deployed in the window, so every non-transient one counts). Transient environments (ephemeral per-PR previews) never join a default scope. The scope resolves from deployments in the scan window, so two different windows can resolve different scopes and are not always comparable. */
     environment_scope: string
     /** Distinct persistent environments deployed to in the scan window, most-deployed first — the environment picker's options. Transient environments are omitted but stay reachable by exact name. */
     environments: string[]
@@ -1741,7 +1741,7 @@ export type EngineeringAnalyticsDoraParams = {
      */
     date_to?: string
     /**
-     * Deploy environment(s) to scope to, repeatable (from the response's `environments` list). Omit to scope to the busiest environment GitHub marks production, falling back to the busiest persistent (non-transient) environment when none are marked production.
+     * Deploy environment(s) to scope to, repeatable (from the response's `environments` list). Omit to scope to every environment GitHub marks production (every production-named one when none is marked), falling back to the busiest persistent (non-transient) environment.
      */
     environment?: string[]
     /**

--- a/products/engineering_analytics/frontend/scenes/EngineeringAnalyticsHealth.stories.tsx
+++ b/products/engineering_analytics/frontend/scenes/EngineeringAnalyticsHealth.stories.tsx
@@ -57,7 +57,7 @@ function leadTimeSeries(stats: (number[] | null)[]): DoraOverviewApi['merge_to_d
 
 const DORA: DoraOverviewApi = {
     deploy_data_available: true,
-    environment_scope: 'prod-us',
+    environment_scope: 'prod-us, prod-eu',
     environments: ['prod-us', 'prod-eu', 'dev'],
     has_membership_data: true,
     github_teams: ['team-devex', 'team-ingestion', 'team-replay'],

--- a/products/engineering_analytics/frontend/scenes/EngineeringAnalyticsHealth.tsx
+++ b/products/engineering_analytics/frontend/scenes/EngineeringAnalyticsHealth.tsx
@@ -28,7 +28,7 @@ export function EngineeringAnalyticsHealth(): JSX.Element {
         dora,
         doraLoading,
         doraFailed,
-        environments,
+        selectedEnvironments,
         githubTeam,
         granularity,
         boxPlotBuckets,
@@ -102,7 +102,7 @@ export function EngineeringAnalyticsHealth(): JSX.Element {
                         <LemonInputSelect
                             size="small"
                             mode="multiple"
-                            value={environments}
+                            value={selectedEnvironments}
                             onChange={setEnvironments}
                             options={environmentOptions}
                             placeholder={`Default: ${environmentScopeLabel}`}

--- a/products/engineering_analytics/frontend/scenes/EngineeringAnalyticsHealth.tsx
+++ b/products/engineering_analytics/frontend/scenes/EngineeringAnalyticsHealth.tsx
@@ -105,7 +105,7 @@ export function EngineeringAnalyticsHealth(): JSX.Element {
                             value={environments}
                             onChange={setEnvironments}
                             options={environmentOptions}
-                            placeholder={`Default environment (${environmentScopeLabel})`}
+                            placeholder={`Default: ${environmentScopeLabel}`}
                             allowCustomValues={false}
                         />
                     </div>

--- a/products/engineering_analytics/frontend/scenes/doraLogic.test.ts
+++ b/products/engineering_analytics/frontend/scenes/doraLogic.test.ts
@@ -1,0 +1,86 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { ApiConfig } from 'lib/api'
+
+import { initKeaTests } from '~/test/init'
+
+import { engineeringAnalyticsDora } from '../generated/api'
+import type { DoraOverviewApi } from '../generated/api.schemas'
+import { doraLogic } from './doraLogic'
+
+jest.mock('../generated/api', () => ({
+    engineeringAnalyticsCiCards: jest.fn().mockResolvedValue({ open_prs: 0, repos: 0, stuck: 0, failing_ci: 0 }),
+    engineeringAnalyticsDora: jest.fn(),
+    engineeringAnalyticsPullRequests: jest.fn().mockResolvedValue({ items: [], truncated: false, limit: 0 }),
+    engineeringAnalyticsQuarantine: jest.fn().mockResolvedValue({ available: false, entries: [], source_url: '' }),
+    engineeringAnalyticsSources: jest.fn().mockResolvedValue([]),
+    engineeringAnalyticsTrunkQuarantine: jest.fn().mockResolvedValue({ available: false, teams: [], tests: [] }),
+    engineeringAnalyticsWorkflowHealth: jest.fn().mockResolvedValue([]),
+}))
+
+const mockDora = engineeringAnalyticsDora as jest.MockedFunction<typeof engineeringAnalyticsDora>
+
+function overview(environment_scope: string): DoraOverviewApi {
+    return {
+        deploy_data_available: true,
+        environment_scope,
+        environments: ['dev', 'prod-us', 'prod-eu'],
+        has_membership_data: false,
+        github_teams: [],
+        deployment_count: 0,
+        deployment_count_prev: 0,
+        deployments_per_day: null,
+        deployments_per_day_prev: null,
+        median_merge_to_deploy_seconds: null,
+        median_merge_to_deploy_seconds_prev: null,
+        median_open_to_deploy_seconds: null,
+        median_open_to_deploy_seconds_prev: null,
+        deployed_pr_count: 0,
+        deployed_pr_count_prev: 0,
+        failed_deployment_count: 0,
+        failed_deployment_count_prev: 0,
+        failed_deployment_share: null,
+        failed_deployment_share_prev: null,
+        median_failed_deploy_to_next_success_seconds: null,
+        median_failed_deploy_to_next_success_seconds_prev: null,
+        merged_pr_count: 0,
+        unattributed_merged_pr_share: null,
+        latest_deploy_status_at: null,
+        deployment_frequency_series: [],
+        merge_to_deploy_series: [],
+        open_to_merge_series: [],
+        open_to_deploy_series: [],
+        series_granularity: 'day',
+    }
+}
+
+describe('doraLogic', () => {
+    let logic: ReturnType<typeof doraLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        ApiConfig.setCurrentProjectId(1)
+        mockDora.mockReset()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    it.each([
+        ['the resolved default scope', 'prod-us, prod-eu', [], ['prod-us', 'prod-eu']],
+        ['nothing for the persistent fallback', 'persistent', [], []],
+        ["the user's picks over the default", 'prod-us, prod-eu', ['dev'], ['dev']],
+    ])('the environment picker shows %s', async (_label, scope, picks, expected) => {
+        mockDora.mockResolvedValue(overview(scope))
+        logic = doraLogic()
+        logic.mount()
+        await expectLogic(logic).toDispatchActions(['loadDoraSuccess'])
+
+        if (picks.length) {
+            logic.actions.setEnvironments(picks)
+        }
+
+        expect(logic.values.selectedEnvironments).toEqual(expected)
+    })
+})

--- a/products/engineering_analytics/frontend/scenes/doraLogic.ts
+++ b/products/engineering_analytics/frontend/scenes/doraLogic.ts
@@ -61,6 +61,7 @@ export interface doraLogicValues {
     granularity: DoraGranularity | null
     openToDeployBuckets: BoxPlotBucket[]
     openToMergeBuckets: BoxPlotBucket[]
+    selectedEnvironments: string[]
     showAllLeadTimeStages: boolean
 }
 
@@ -110,6 +111,7 @@ export interface doraLogicMeta {
         frequencyCounts: (dora: DoraOverviewApi | null) => number[]
         frequencyIsoLabels: (dora: DoraOverviewApi | null) => string[]
         environmentScopeLabel: (dora: DoraOverviewApi | null, environments: string[]) => string
+        selectedEnvironments: (dora: DoraOverviewApi | null, environments: string[]) => string[]
         environmentOptions: (
             dora: DoraOverviewApi | null,
             environments: string[]
@@ -255,6 +257,17 @@ export const doraLogic = kea<doraLogicType>([
                       : dora.environment_scope === 'persistent'
                         ? 'all persistent environments'
                         : dora.environment_scope,
+        ],
+        // What the picker shows as chosen: the user's picks, else the names the backend's default
+        // scope resolved to, so the default reads as a selection the user can edit.
+        selectedEnvironments: [
+            (s) => [s.dora, s.environments],
+            (dora: DoraOverviewApi | null, environments: string[]): string[] =>
+                environments.length
+                    ? environments
+                    : !dora || dora.environment_scope === 'persistent'
+                      ? []
+                      : dora.environment_scope.split(', '),
         ],
         // With environments selected, environment_scope echoes the picks, so the resolved default
         // can only be offered while the selection is empty; picked names stay selectable options.

--- a/products/engineering_analytics/frontend/scenes/doraLogic.ts
+++ b/products/engineering_analytics/frontend/scenes/doraLogic.ts
@@ -176,8 +176,8 @@ export const doraLogic = kea<doraLogicType>([
                 loadDoraFailure: () => true,
             },
         ],
-        // Empty means the backend's default scope: the busiest production-marked environment,
-        // falling back to the busiest persistent one. Reset on a source/repo scope change: an
+        // Empty means the backend's default scope: every production environment, falling back
+        // to the busiest persistent one. Reset on a source/repo scope change: an
         // environment or team from the old repo may not exist on the new one, and would
         // otherwise be sent as a silently-empty exact filter.
         environments: [

--- a/products/engineering_analytics/mcp/tools.yaml
+++ b/products/engineering_analytics/mcp/tools.yaml
@@ -93,8 +93,9 @@ tools:
             (deployments with a failure/error status over deployments that reached an outcome — NOT true change failure
             rate, since no incident data is linked) and median_failed_deploy_to_next_success_seconds (first failure
             status to the next successful deploy in the same environment — NOT true time-to-restore, since recovery by
-            anything other than a deploy is invisible). Environments default to the busiest production-marked
-            environment, falling back to the busiest persistent (non-transient) one when none are marked production —
+            anything other than a deploy is invisible). Environments default to every production-marked environment
+            (every production-named one when none is marked, then the busiest persistent non-transient one), so a
+            multi-region repo's deploy counts add up across regions and lead time ends at the first region to deploy —
             ephemeral per-PR preview environments never join a default scope; pass environment (repeatable, from the
             response's environments list) to scope exactly. Pass github_team (a slug from github_teams) to narrow the
             PR-scoped lead-time figures to that team's authors — deploy counts stay repo-wide. deploy_data_available is

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -29085,7 +29085,7 @@ export namespace Schemas {
       open_to_deploy_series: LeadTimeBucket[];
       /** False when the deployments/deployment_statuses tables aren't synced for the selected repo; every other field is then empty or null, never a fake zero. */
       deploy_data_available: boolean;
-      /** What the environment filter resolved to: the exact environment name(s) it matches (the caller's picks, comma-joined when several; by default the busiest production-marked environment, falling back to the busiest persistent one), or 'persistent' (no persistent environment deployed in the window, so every non-transient one counts). Transient environments (ephemeral per-PR previews) never join a default scope. The scope resolves from deployments in the scan window, so two different windows can resolve different scopes and are not always comparable. */
+      /** What the environment filter resolved to: the exact environment name(s) it matches (the caller's picks, comma-joined when several; by default every production-marked environment, then every production-named one, then the busiest persistent one), or 'persistent' (no persistent environment deployed in the window, so every non-transient one counts). Transient environments (ephemeral per-PR previews) never join a default scope. The scope resolves from deployments in the scan window, so two different windows can resolve different scopes and are not always comparable. */
       environment_scope: string;
       /** Distinct persistent environments deployed to in the scan window, most-deployed first — the environment picker's options. Transient environments are omitted but stay reachable by exact name. */
       environments: string[];
@@ -93314,7 +93314,7 @@ export namespace Schemas {
      */
     date_to?: string;
     /**
-     * Deploy environment(s) to scope to, repeatable (from the response's `environments` list). Omit to scope to the busiest environment GitHub marks production, falling back to the busiest persistent (non-transient) environment when none are marked production.
+     * Deploy environment(s) to scope to, repeatable (from the response's `environments` list). Omit to scope to every environment GitHub marks production (every production-named one when none is marked), falling back to the busiest persistent (non-transient) environment.
      */
     environment?: string[];
     /**


### PR DESCRIPTION
## Problem

- On the Health tab, the DORA figures default to one production region, so a team that runs production as several regions sees deploys and lead time for the busiest region only.
- The environment picker sat empty, with a placeholder that named the default. An empty picker reads as "nothing chosen", so the default was easy to miss and hard to edit.
- The question the default answers is "how long until it is in production". One region answers that for part of the estate.

## Changes

- The default deploy scope now covers every environment GitHub marks production. When none is marked, it covers every production-named environment. The single busiest persistent environment stays as the last fallback.
- The environment picker shows the default regions as selected chips, for example `prod-us` and `prod-eu`. Removing a chip narrows the scope to the rest. Clearing every chip returns to the default, and the default chips come back.
- The placeholder now appears only while the first load runs, or when no production environment exists and the scope falls back to the busiest persistent environment.

> [!NOTE]
> Deploy counts add up across regions: one merge deployed to two regions is two deployments. A PR's lead time ends at the first region that deploys it. The chips name every region in scope so a reader can see what the count covers.

- Mechanical: the API help text, the MCP tool description, and the regenerated OpenAPI types describe the new default. A new `selectedEnvironments` selector in `doraLogic` feeds the picker. No layout changes.

No screenshot: the local Storybook could not resolve the quill workspace packages inside Vite, so the Health story did not render. Before, the picker was an empty box with the text "Default: prod-us, prod-eu". After, the same box holds a `prod-us` chip and a `prod-eu` chip, each with a remove cross, and the rest of the tab is unchanged.

## How did you test this code?

- `test_default_scope_covers_every_production_environment` replaces the test that locked in the single-region default. It is parameterized over the production flag, so one case resolves through the flag tier and one through the name tier. Both cases fail on the old code, which returned only the busiest region. A busier staging environment in the fixture guards against a regression that widens the scope to every persistent environment.
- `doraLogic.test.ts` is new. Three `it.each` cases check that the picker shows the resolved default, shows nothing for the persistent fallback, and shows the user's picks over the default. No existing test mounted `doraLogic`.
- Ran the DORA Python test module on a devbox against Postgres and ClickHouse. Ran the new Jest file and `typescript:check` locally.
- Not run: the full mypy pass. The Python change only swaps `next(...)` for list comprehensions.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The default is described in the API help text and the MCP tool description, which this PR updates.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (PostHog Desktop). Skills invoked: /writing-tests, /writing-user-facing-copy, /improving-drf-endpoints, /writing-pr-descriptions. The report that started this work arrived before the multi-select picker from #91274 had deployed, so the picker complaint was already fixed; the default scope and how the picker shows it changed here. No customer material is in the diff.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
