### PR TITLE
fix(funnels): wrap long step names in the funnel step legend

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarVertical/FunnelBarVertical.scss
+++ b/frontend/src/scenes/funnels/FunnelBarVertical/FunnelBarVertical.scss
@@ -185,6 +185,7 @@
 
         &:first-child {
             width: fit-content;
+            max-width: 100%;
             margin-top: 0;
             font-weight: 600;
             white-space: normal;
@@ -194,7 +195,10 @@
                 -webkit-line-clamp: 5;
                 -webkit-box-orient: vertical;
                 overflow: hidden;
-                overflow-wrap: break-word;
+
+                // `anywhere` (unlike `break-word`) shrinks the intrinsic min-content width, so an
+                // unbroken event name wraps instead of blowing the row past its step column.
+                overflow-wrap: anywhere;
             }
         }
 


### PR DESCRIPTION
## Problem

A funnel step with a long unbroken event name overflows its column in the steps chart legend and overlaps the next step's name, making both unreadable.

The step-name row wraps with `overflow-wrap: break-word`, but `break-word` does not shrink the row's intrinsic min-content width. Combined with `width: fit-content`, an unbroken name sizes the row to the full string.

## Changes

- Long step names now wrap inside their own step column, keeping the existing 5-line clamp with an ellipsis.
- `overflow-wrap: anywhere` replaces `break-word` so the intrinsic width can shrink, and `max-width: 100%` caps the row as a backstop.
- Names with spaces still wrap at spaces; nothing else changes visually.

| Before | After |
| --- | --- |
| ![Long event names overflowing the funnel step legend](https://raw.githubusercontent.com/PostHog/pr-assets/0fe1a1656254950e99fdf8534861b24b686c7572/2026/09/ce74e140-fed3-43b6-aa43-d4c935b7d3da.png) | ![Long event names wrapping inside their step columns](https://raw.githubusercontent.com/PostHog/pr-assets/1fda9a1bef0f6fd349c7e37e4a39ddfa14b3612c/2026/09/2892687f-8d13-419b-964f-1b97bedecdc1.png) |

## How did you test this code?

No automated test: this is a pure CSS intrinsic-sizing change, best covered by visual review. The after screenshot above is from a local funnel insight with the fix applied.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code from a screenshot of the overflow. Skills invoked: /writing-pr-descriptions, /look (Playwright screenshot of the fixed chart). Session: https://claude.ai/code/session_01UmEtBgqNPfdFMB5usJ8kML
