### PR TITLE
fix(aio): stop capturing LLM judge and tagger calls as events

### DIFF
--- a/posthog/temporal/ai_observability/evaluation_llm_judge.py
+++ b/posthog/temporal/ai_observability/evaluation_llm_judge.py
@@ -309,16 +309,7 @@ def call_llm_judge(
     client = Client(
         provider_key=provider_key,
         config=config,
-        privacy_mode=True,
-        distinct_id=f"team-{team_id}",
-        properties={
-            "ai_product": "aio_evaluations",
-            "ai_feature": "llm-judge",
-            "team_id": team_id,
-            "evaluation_id": evaluation["id"],
-            "$ai_billable": not is_byok,
-            "is_byok": is_byok,
-        },
+        capture_analytics=False,
     )
 
     try:

--- a/posthog/temporal/ai_observability/run_tagger.py
+++ b/posthog/temporal/ai_observability/run_tagger.py
@@ -240,16 +240,7 @@ Output: {output_data}"""
     client = Client(
         provider_key=provider_key,
         config=config,
-        privacy_mode=True,
-        distinct_id=f"team-{team_id}",
-        properties={
-            "ai_product": "aio_evaluations",
-            "ai_feature": "tagger",
-            "team_id": team_id,
-            "tagger_id": tagger["id"],
-            "$ai_billable": not is_byok,
-            "is_byok": is_byok,
-        },
+        capture_analytics=False,
     )
 
     try:


### PR DESCRIPTION
## Problem

Evaluation runs no longer write AI observability events into the internal project. Before this change, every LLM-as-a-judge and run-tagger completion was captured as a generation event there, for our own evaluations and for every customer that uses LLM-as-a-judge.

That has three effects a person notices:

- Customer judge calls, including the conversation content they judge, land in an internal project.
- Cost that the customer pays shows up as internal spend.
- A judge run over a trace produces a trace that a judge can run over again.

The capture was added in #85516 to attribute internal AI spend to projects. The judge and tagger paths are the wrong place for it.

## Changes

- Both clients run with `capture_analytics=False` again, as they did before #85516.
- The internal attribution properties (`ai_product`, `ai_feature`, `team_id`, `$ai_billable`) go away with the capture that carried them.
- Judging and tagging behavior is unchanged. Only the event capture is removed.

## How did you test this code?

- Ran `ruff check` on both files.
- No test asserts on this capture, so no test changed.
- Not run: the change removes an argument set, so nothing new needs coverage. CI runs the backend suite.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change. No documented workflow or setting changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- The change reverts the two AI observability temporal files touched by #85516 and leaves the rest of that PR alone.
- Skills invoked: `/writing-pr-descriptions`.
- Nothing in this diff or description comes from the session that is not already in the repository.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1788454991117619?thread_ts=1788454991.117619&cid=C087XQ7K9K7)*
