### PR TITLE
fix(replay-vision): give scanner scout create its serializer context

### DIFF
--- a/products/replay_vision/backend/api/scanner_scouts.py
+++ b/products/replay_vision/backend/api/scanner_scouts.py
@@ -86,7 +86,11 @@ class ScannerScoutViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     )
     def create(self, request: Any, **kwargs: Any) -> Response:
         scanner = self._scanner_for_writing()
-        payload = ScannerScoutCreateSerializer(data=request.data)
+        # The nested config validates a Slack destination against the project's integrations and
+        # the caller's key scopes, so the body serializer needs the same context the facade gets.
+        # Without it, any create carrying a destination raises rather than returning a 400.
+        serializer_context = {"project_id": self.team.project_id, "request": request}
+        payload = ScannerScoutCreateSerializer(data=request.data, context=serializer_context)
         payload.is_valid(raise_exception=True)
         validated = payload.validated_data
 
@@ -102,7 +106,7 @@ class ScannerScoutViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
             files=[],
             config_options=validated.get("config", {}),
             request=request,
-            serializer_context={"project_id": self.team.project_id, "request": request},
+            serializer_context=serializer_context,
             # From the URL the caller's access was checked against, never from the body.
             source_product=SCOUT_SOURCE_PRODUCT,
             source_id=str(scanner.id),

--- a/products/replay_vision/backend/api/scanner_scouts.py
+++ b/products/replay_vision/backend/api/scanner_scouts.py
@@ -86,17 +86,16 @@ class ScannerScoutViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     )
     def create(self, request: Any, **kwargs: Any) -> Response:
         scanner = self._scanner_for_writing()
-        # The nested config validates a Slack destination against the project's integrations and
-        # the caller's key scopes, so the body serializer needs the same context the facade gets.
-        # Without it, any create carrying a destination raises rather than returning a 400.
-        serializer_context = {"project_id": self.team.project_id, "request": request}
+        # Scouts live on the canonical team, so the skill-authoring bar is checked against that team
+        # rather than the URL's: `create_scout_for_source` runs it on whichever team it is given.
+        canonical_team = self.team.parent_team or self.team
+        # The nested config checks a Slack destination against the project's integrations and the
+        # model pin against the team's flag, so the body serializer needs the context the facade gets.
+        serializer_context = {"project_id": self.team.project_id, "team": canonical_team, "request": request}
         payload = ScannerScoutCreateSerializer(data=request.data, context=serializer_context)
         payload.is_valid(raise_exception=True)
         validated = payload.validated_data
 
-        # Scouts live on the canonical team, so the skill-authoring bar is checked against that team
-        # rather than the URL's: `create_scout_for_source` runs it on whichever team it is given.
-        canonical_team = self.team.parent_team or self.team
         result = signals_facade.create_scout_for_source(
             team=canonical_team,
             user=request.user,

--- a/products/replay_vision/backend/tests/test_scanner_scouts_api.py
+++ b/products/replay_vision/backend/tests/test_scanner_scouts_api.py
@@ -9,6 +9,7 @@ from posthog.models.team import Team
 from products.replay_vision.backend.scout_source import SCOUT_SOURCE_PRODUCT
 from products.replay_vision.backend.tests.test_api import _VisionAPITestCase
 from products.signals.backend.models import SignalScoutConfig
+from products.signals.backend.scout_harness.model_selection import scout_model_pin_catalog
 
 
 class TestScannerScoutCreate(_VisionAPITestCase):
@@ -59,6 +60,22 @@ class TestScannerScoutCreate(_VisionAPITestCase):
         assert config.output_destinations == {
             "slack": {"integration_id": integration.id, "channel": "CSCOUTS|#scout-findings", "thread_reports": False}
         }
+
+    def test_a_scout_can_be_created_with_a_model_pin(self) -> None:
+        # The model gate reads the team from the serializer context, so a create without it rejected
+        # every pin as unavailable even where the flag was on.
+        model = scout_model_pin_catalog()[0]
+        with patch("products.signals.backend.scout_harness.serializers.scout_model_config_enabled", return_value=True):
+            response = self.client.post(
+                self._scouts_url(str(self.scanner.id)),
+                data=self._payload(config={"model": model}),
+                format="json",
+            )
+
+        assert response.status_code == 201, response.json()
+        with team_scope(self.team.id):
+            config = SignalScoutConfig.objects.get(skill_name="signals-scout-daily-digest")
+        assert config.model == model
 
     def test_a_slack_destination_on_another_project_is_rejected_as_bad_input(self) -> None:
         # A destination the project does not own is the caller's mistake, so it must come back as a

--- a/products/replay_vision/backend/tests/test_scanner_scouts_api.py
+++ b/products/replay_vision/backend/tests/test_scanner_scouts_api.py
@@ -2,7 +2,9 @@ from unittest.mock import patch
 
 from parameterized import parameterized
 
+from posthog.models.integration import Integration
 from posthog.models.scoping import team_scope
+from posthog.models.team import Team
 
 from products.replay_vision.backend.scout_source import SCOUT_SOURCE_PRODUCT
 from products.replay_vision.backend.tests.test_api import _VisionAPITestCase
@@ -33,6 +35,47 @@ class TestScannerScoutCreate(_VisionAPITestCase):
             config = SignalScoutConfig.objects.get(skill_name="signals-scout-daily-digest")
         assert config.source_product == SCOUT_SOURCE_PRODUCT
         assert config.source_id == str(self.scanner.id)
+
+    def test_a_scout_can_be_created_with_a_slack_destination(self) -> None:
+        # The create modal offers a Slack channel, so the destination arrives on the create call
+        # rather than a follow-up PATCH. Validating it needs the project and the request in the
+        # body serializer's context.
+        integration = Integration.objects.create(team=self.team, kind=Integration.IntegrationKind.SLACK)
+        response = self.client.post(
+            self._scouts_url(str(self.scanner.id)),
+            data=self._payload(
+                config={
+                    "output_destinations": {
+                        "slack": {"integration_id": integration.id, "channel": "CSCOUTS|#scout-findings"}
+                    }
+                },
+            ),
+            format="json",
+        )
+
+        assert response.status_code == 201, response.json()
+        with team_scope(self.team.id):
+            config = SignalScoutConfig.objects.get(skill_name="signals-scout-daily-digest")
+        assert config.output_destinations == {
+            "slack": {"integration_id": integration.id, "channel": "CSCOUTS|#scout-findings", "thread_reports": False}
+        }
+
+    def test_a_slack_destination_on_another_project_is_rejected_as_bad_input(self) -> None:
+        # A destination the project does not own is the caller's mistake, so it must come back as a
+        # 400 the modal can show — not a 500.
+        other_team = Team.objects.create(organization=self.organization, name="other project")
+        integration = Integration.objects.create(team=other_team, kind=Integration.IntegrationKind.SLACK)
+        response = self.client.post(
+            self._scouts_url(str(self.scanner.id)),
+            data=self._payload(
+                config={"output_destinations": {"slack": {"integration_id": integration.id, "channel": "C1|#c"}}},
+            ),
+            format="json",
+        )
+
+        assert response.status_code == 400, response.json()
+        with team_scope(self.team.id):
+            assert not SignalScoutConfig.objects.filter(skill_name="signals-scout-daily-digest").exists()
 
     def test_a_source_supplied_in_the_body_cannot_claim_another_scanner(self) -> None:
         # The pair is the reports endpoint's ownership record, so it must come from the URL the
@@ -123,7 +166,6 @@ class TestScannerScoutCreate(_VisionAPITestCase):
         # environment clears the default scope check (URL team is the child) while the skill and
         # config it creates land on the parent.
         from posthog.models.personal_api_key import PersonalAPIKey
-        from posthog.models.team import Team
         from posthog.models.utils import generate_random_token_personal, hash_key_value
 
         env = Team.objects.create(organization=self.organization, parent_team=self.team, name="env")


### PR DESCRIPTION
## Problem

Anyone adding a scout to a Replay Vision scanner with a Slack destination got a 500 instead of a scout. The create modal offers a Slack channel and sends it on the create call, so this hit the common path, and there was no way around it from the scanner UI.

`ScannerScoutViewSet.create` validated the request body with `ScannerScoutCreateSerializer(data=request.data)` — no context. The nested config's `validate_output_destinations` looks up the Slack integration by `project_id` from serializer context, and raises `RuntimeError` when it isn't there. The same view already built that context for the facade call a few lines below, so the two paths had drifted.

Live as error tracking issue [01a034cd-22bd-70c2-a467-d5c4a34859ea](https://us.posthog.com/project/2/error_tracking/01a034cd-22bd-70c2-a467-d5c4a34859ea) since 24 Aug.

## Changes

- Scouts with a Slack destination can be created from a scanner again: the context (`project_id` and `request`) is built once and given to the body serializer as well as the facade.
- A destination the project doesn't own now comes back as a 400 the modal can show, rather than a 500 — that check was already written, it just never got the chance to run.

- A scout can now pin a model from a scanner. The same missing context left the model gate unable to read the team, so every pin came back as "not available on this project yet", even where the flag was on.

## How did you test this code?

Three regression tests on `TestScannerScoutCreate`, neither covered before — no existing test posts `output_destinations` to this route at all, which is how the gap shipped:

- creating a scout with a valid Slack destination returns 201 and persists the destination
- a Slack integration belonging to another project returns 400 and writes no config
- creating a scout with a model pin returns 201 and persists the pin, with the model flag patched on

Not run locally: this sandbox has no ClickHouse, so the DB-backed API tests could not be executed here — CI runs them. `ruff` and `mypy` on the changed files pass locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing surface changed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) after tracing a reported scout-creation failure to the error tracking issue linked above; the stack trace named the view line directly. No repo skills were invoked. The fix stayed at passing the existing context through rather than giving the serializer a fallback, since the view already knows the project and the generic Signals endpoint does the same thing.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C03PB072FMJ/p1788454067694159?thread_ts=1788454067.694159&cid=C03PB072FMJ)*

