### PR TITLE
chore(frontend): measure the cost of zod's JIT parser compiler

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -12,16 +12,25 @@ import { ChunkLoadErrorBoundary } from './scenes/ChunkLoadErrorBoundary'
 
 // Lazy-load App so the entry chunk stays minimal: the entire transitive dependency
 // graph (kea, posthog-js, scene logic, UI components) is only fetched when it renders.
-// bootApp() runs the one-time boot side effects (posthog-js, kea) after the chunks
-// load and before <App /> first renders. It lives in its own module so scenes/App
-// keeps component-only exports and stays a React Fast Refresh boundary.
+// configureZod() is imported and called on its own before the App chunk, because zod
+// binds its jitless setting when it constructs each object schema and the App graph
+// constructs some at module scope. bootApp() runs the remaining one-time boot side
+// effects (posthog-js, kea) after the chunks load and before <App /> first renders.
+// It lives in its own module so scenes/App keeps component-only exports and stays a
+// React Fast Refresh boundary.
 const App = lazy(() =>
-    Promise.all([retryBootImport(() => import('scenes/App')), retryBootImport(() => import('scenes/bootApp'))]).then(
-        ([appModule, bootModule]) => {
+    retryBootImport(() => import('lib/configureZod'))
+        .then(({ configureZod }) => {
+            configureZod()
+            return Promise.all([
+                retryBootImport(() => import('scenes/App')),
+                retryBootImport(() => import('scenes/bootApp')),
+            ])
+        })
+        .then(([appModule, bootModule]) => {
             bootModule.bootApp()
             return { default: appModule.App }
-        }
-    )
+        })
 )
 
 declare global {

--- a/frontend/src/lib/configureZod.ts
+++ b/frontend/src/lib/configureZod.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+
+/**
+ * Turn zod's JIT parser compiler off for a share of users so we can measure what it costs us.
+ *
+ * zod compiles a parser per schema with `new Function`, which needs `'unsafe-eval'` in `script-src`
+ * — about half of all CSP violations the app reports. The compiler pays for itself only when one
+ * schema is parsed many times, and most of ours are parsed a handful of times per page load, so
+ * turning it off may well be free or better. Measure rather than assume.
+ *
+ * The flag is read from the bootstrap Django renders into the page, not from `featureFlagLogic`.
+ * zod compiles a schema the first time it is parsed and caches the result, so a flag arriving later
+ * would leave a mix of compiled and interpreted schemas and a measurement that means nothing.
+ */
+export function configureZod(): void {
+    const bootstrapFlags = window.POSTHOG_USER_IDENTITY_WITH_FLAGS?.featureFlags
+    z.config({ jitless: !!bootstrapFlags?.[FEATURE_FLAGS.ZOD_JITLESS] })
+}

--- a/frontend/src/lib/configureZod.ts
+++ b/frontend/src/lib/configureZod.ts
@@ -6,13 +6,18 @@ import { FEATURE_FLAGS } from 'lib/constants'
  * Turn zod's JIT parser compiler off for a share of users so we can measure what it costs us.
  *
  * zod compiles a parser per schema with `new Function`, which needs `'unsafe-eval'` in `script-src`
- * — about half of all CSP violations the app reports. The compiler pays for itself only when one
- * schema is parsed many times, and most of ours are parsed a handful of times per page load, so
+ * and is about half of all CSP violations the app reports. The compiler pays for itself only when
+ * one schema is parsed many times, and most of ours are parsed a handful of times per page load, so
  * turning it off may well be free or better. Measure rather than assume.
  *
  * The flag is read from the bootstrap Django renders into the page, not from `featureFlagLogic`.
- * zod compiles a schema the first time it is parsed and caches the result, so a flag arriving later
- * would leave a mix of compiled and interpreted schemas and a measurement that means nothing.
+ * zod binds `jitless` when it constructs each object schema, so this must run before any module
+ * that builds a schema at module scope evaluates. src/index.tsx imports and calls it before it
+ * imports the App chunk. A flag arriving later would leave a mix of compiled and interpreted
+ * schemas and a measurement that means nothing.
+ *
+ * Django renders bootstrap flags only for authenticated users, so anonymous pages such as login
+ * and signup keep the compiler whatever the flag says.
  */
 export function configureZod(): void {
     const bootstrapFlags = window.POSTHOG_USER_IDENTITY_WITH_FLAGS?.featureFlags

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -260,6 +260,7 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_FOR_MOBILE: 'web-analytics-for-mobile', // owner: #team-web-analytics
     WEB_ANALYTICS_PATH_CLEANING_SUGGESTIONS: 'web-analytics-path-cleaning-suggestions', // owner: @lricoy #team-web-analytics
     WEB_ANALYTICS_REFERRER_URL_DRILLDOWN: 'web-analytics-referrer-url-drilldown', // owner: @jabahamondes #team-web-analytics
+    ZOD_JITLESS: 'zod-jitless', // owner: @Piccirello measuring the cost of zod's JIT parser compiler
 
     // Temporary feature flags, still WIP, should be removed eventually
     ACTION_REFERENCE_COUNT: 'action-reference-count', // owner: @andyzzhao #team-product-analytics, gates bulk action reference counting on actions list

--- a/frontend/src/scenes/bootApp.ts
+++ b/frontend/src/scenes/bootApp.ts
@@ -1,3 +1,4 @@
+import { configureZod } from 'lib/configureZod'
 import { registerNotebookLinkDrag } from 'scenes/notebooks/AddToNotebook/registerNotebookLinkDrag'
 
 import { initKea } from '../initKea'
@@ -21,6 +22,9 @@ export function bootApp(): void {
     }
     appBooted = true
 
+    // Before anything parses a zod schema: zod compiles a parser on first parse and caches it, so
+    // this has to settle before the first one or the measurement mixes both modes.
+    configureZod()
     loadPostHogJS()
     // Kea must initialize before any component mounts
     initKea()

--- a/frontend/src/scenes/bootApp.ts
+++ b/frontend/src/scenes/bootApp.ts
@@ -1,4 +1,3 @@
-import { configureZod } from 'lib/configureZod'
 import { registerNotebookLinkDrag } from 'scenes/notebooks/AddToNotebook/registerNotebookLinkDrag'
 
 import { initKea } from '../initKea'
@@ -15,6 +14,8 @@ let appBooted = false
  * Lives outside App.tsx so scenes/App keeps component-only exports and stays a React
  * Fast Refresh boundary; with a mixed-export App.tsx, HMR invalidations cascade into
  * src/index.tsx and force a full page reload on routine edits.
+ * zod is configured in src/index.tsx before this chunk is imported, not here: by the time
+ * this runs, the App graph has already constructed schemas at module scope.
  */
 export function bootApp(): void {
     if (appBooted) {
@@ -22,9 +23,6 @@ export function bootApp(): void {
     }
     appBooted = true
 
-    // Before anything parses a zod schema: zod compiles a parser on first parse and caches it, so
-    // this has to settle before the first one or the measurement mixes both modes.
-    configureZod()
     loadPostHogJS()
     // Kea must initialize before any component mounts
     initKea()


### PR DESCRIPTION
## Problem

Half of every CSP violation the app reports comes from one library.

zod compiles a parser per schema with the `Function` constructor. That needs `'unsafe-eval'` in `script-src`, which is the directive most worth having and the one an attacker most wants back. Over seven days across both cloud regions, `eval` accounted for **300,010 reports**, or 49% of all violations. Nothing else is close.

So the compiler is what stands between us and a real `script-src`. Adding `'unsafe-eval'` would silence the reports and cancel the directive, which is not a fix.

Whether turning it off costs anything is genuinely unknown. The compiler only pays for itself when one schema is parsed many times, and most of ours are parsed a handful of times per page load, so it may be free or better. This PR measures it rather than guessing.

## Changes

- [`zod-jitless`](https://us.posthog.com/project/2/feature_flags/864526) is off for 90% of users, who keep today's behaviour. The other 10% get jitless.
- With the flag on, `z.config({ jitless: true })` runs at boot and zod interprets schemas instead of compiling them.
- The flag is read from the bootstrap Django renders into the page, not from `featureFlagLogic`.

That last point is the one that decides whether the measurement means anything. zod binds `jitless` when it constructs each object schema, and the App import graph constructs schemas at module scope. A flag arriving asynchronously would leave some schemas compiled and others interpreted, and a treatment group that is really a mixture. `window.POSTHOG_USER_IDENTITY_WITH_FLAGS` is written by `head.html` before the app bundle loads and is evaluated per user server-side.

`configureZod()` is imported and called from the entry before the App chunk is imported. A call inside `bootApp()` came too late: three eagerly imported modules build `z.object` schemas at module scope, and those kept the compiler.

> [!WARNING]
> Django renders bootstrap flags only for authenticated users, so anonymous pages such as login and signup keep the compiler. posthog-js still resolves the flag for those sessions, so their events carry `$feature/zod-jitless` while the page ran the compiler. A flag condition only identified persons satisfy, such as `email` is set, keeps those sessions out of the treatment bucket. The bootstrap already passes `email`, so local evaluation still works.

## How did you test this code?

Measured the mechanism directly, since the whole change rests on it. A throwaway script replaced the global `Function` constructor with a counting subclass and parsed a representative schema under both settings:

| | `Function` calls after first parse | 200,000 parses |
| --- | --- | --- |
| default (JIT) | 3 | 19 ms |
| `jitless` | **0** | 55 ms |

So `jitless` removes the constructor entirely, which is what the CSP violation is. It costs 2.91x per parse, but that is 19 ms to 55 ms across 200,000 parses, roughly 0.28 microseconds each. The absolute cost only matters if something parses in a hot loop, which is exactly what the rollout will show.

Checked against the installed zod 4.3.6 with a counting `Function` proxy: a schema built before `z.config({ jitless: true })` makes 1 `Function` call on first parse, and one built after makes 0. An esbuild build of `scenes/App.tsx` with code splitting shows 849 modules in the eager graph, three of which build `z.object` schemas at module scope.

Not checked: no automated test covers this. A test asserting `z.config` was called would assert the line exists rather than that anything works, and the behaviour it guards is zod's, not ours. The dashboard is the check.

## Measurement

Dashboard: [zod jitless — parser compiler cost](https://us.posthog.com/project/2/dashboard/2062310), project 2.

| Tile | Reads |
| --- | --- |
| [INP p75](https://us.posthog.com/project/2/insights/s1cbtaB9) | Most sensitive to main-thread JS, so a slower parser shows here first |
| [LCP p75](https://us.posthog.com/project/2/insights/LDuJcXcq) | Catches a load regression rather than an interaction one |
| [FCP p75](https://us.posthog.com/project/2/insights/LrwgbbJg) | The compiler runs during boot, so this shows compile cost |
| [eval violations per day](https://us.posthog.com/project/2/insights/gTvbd6oS) | Confirms the flag is doing what it claims |

The vitals tiles split by `$feature/zod-jitless`. The violations tile cannot: browsers post CSP reports to the report endpoint rather than through posthog-js, so they carry no flag properties. Read it as total volume falling as the rollout widens.

INP p75 on app pages sits at roughly 248 ms today, which is the baseline to compare against.

> [!NOTE]
> These tiles answer whether jitless causes a regression a person would notice, which is the question that decides whether to ship it. They do not measure the cost precisely: the parse delta is about 0.18 microseconds, so moving INP by even 10 ms would take tens of thousands of parses inside a single interaction. If something surprising shows up, instrument the specific path that surfaced rather than the whole library.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this PR. Skills invoked: `superpowers:brainstorming`, `superpowers:using-git-worktrees`, `/writing-pr-descriptions`.

zod was identified by pulling the live bundle and its sourcemap rather than by reading `package.json`. `chunk-ZPV4DOZP.js` is zod 4.3.6; line 3 is `Doc.compile()` and line 1 is zod's own `new Function("")` probe. The shipped bundle already reads the escape hatch, visible as `c=!gt.jitless`.

A parse counter was built and then dropped. It wrapped zod at a new `lib/zod` module because zod seals its module namespace and assigns `parse` and `safeParse` per schema, so there is no global seam to patch — verified against both the raw package and an esbuild bundle. It worked, but it touched 17 files, forced `z.infer` to become `ZodInfer` at every call site, and produced a number that does not change whether we ship jitless. Web vitals already answer that. Instrumentation belongs after a surprise, aimed at whatever surfaced.

An earlier plan put that instrumentation in `localStorageSlot`, on the assumption that it was the hot path. It is not: only two files call it. The generated `api.zod.ts` files are not the cause either, because nothing outside `frontend/src/generated/` imports them. Rather than instrument a path that may not be hot, this measures the app as a whole through web vitals, which already carry the flag.

The flag exists as a boolean at 10% of all users, bucketed on `distinct_id`. It does nothing until this deploys. It was briefly scoped to staff emails; widening it to everyone trades a little more exposure for a sample large enough that a null result means something.

Review follow-up in a second session (Claude Code, Fable 5.1): moved `configureZod()` ahead of the App import after review found that zod binds `jitless` at schema construction, and corrected the bootstrap claim above. Skills invoked: `superpowers:receiving-code-review`, `superpowers:using-git-worktrees`, `/writing-code-comments`, `/writing-pr-descriptions`.

https://claude.ai/code/session_01HgRWtAJHBL2hQArpctxYr4
https://claude.ai/code/session_017U5LqqmNs4fLWXHraeZQPA





