### PR TITLE
chore(slack_app): remove the slack-app-turn-feedback flag

### DIFF
--- a/products/slack_app/backend/feature_flags.py
+++ b/products/slack_app/backend/feature_flags.py
@@ -46,7 +46,6 @@ logger = structlog.get_logger(__name__)
 
 SLACK_APP_AGENT_DESIGN_FLAG = "slack-app-agent-design"
 SLACK_APP_FORKING_FLAG = "slack-app-forking"
-SLACK_APP_TURN_FEEDBACK_FLAG = "slack-app-turn-feedback"
 
 
 # Linking a Slack identity to a PostHog user resolves the Slack profile and its email.
@@ -130,21 +129,6 @@ def is_slack_app_assistant_enabled(integration: Integration) -> bool:
     calls — ``im:history`` in particular, without which the assistant would answer
     once and then go deaf to follow-ups."""
     return has_scopes(integration, ASSISTANT_REQUIRED_SCOPES)
-
-
-def is_slack_app_turn_feedback_enabled(integration: Integration) -> bool:
-    """Gate for the thumbs under an agent answer.
-
-    Posts through the ``chat:write`` the mention flow already requires, so this is the
-    flag alone. Keyed on the Slack workspace like its neighbours: the thumbs hang off a
-    reply, and a workspace connected to two projects would otherwise show them on some
-    replies and not others.
-    """
-    return _workspace_flag_enabled(
-        SLACK_APP_TURN_FEEDBACK_FLAG,
-        integration,
-        failure_log_key="slack_app_turn_feedback_feature_flag_check_failed",
-    )
 
 
 def is_slack_app_forking_enabled(integration: Integration) -> bool:

--- a/products/slack_app/backend/slack_thread.py
+++ b/products/slack_app/backend/slack_thread.py
@@ -8,7 +8,7 @@ from slack_sdk.errors import SlackApiError
 
 from posthog.models.integration import Integration, SlackIntegration
 
-from products.slack_app.backend.feature_flags import is_slack_app_forking_enabled, is_slack_app_turn_feedback_enabled
+from products.slack_app.backend.feature_flags import is_slack_app_forking_enabled
 from products.slack_app.backend.services.model_catalogue import describe_run_model
 from products.slack_app.backend.services.slack_messages import (
     RunFooter,
@@ -145,7 +145,6 @@ class SlackThreadHandler:
         self._client: WebClient | None = None
         self._bot_user_id: str | None = None
         self._fork_flag: bool | None = None
-        self._feedback_flag: bool | None = None
         self._code_access: bool | None = None
 
     def _get_integration(self) -> Integration:
@@ -218,18 +217,12 @@ class SlackThreadHandler:
         """The thumbs for this reply, or `None` when there is nothing to rate.
 
         A reply with no run behind it — a note, a card posted before the run existed —
-        has nothing a rating could be attributed to, which is what keeps those replies
-        off the flag lookup here.
+        has nothing a rating could be attributed to.
         """
         run_id = self.run_footer.run_id
         if not run_id:
             return None
-        integration = self._get_integration()
-        if self._feedback_flag is None:
-            self._feedback_flag = is_slack_app_turn_feedback_enabled(integration)
-        if not self._feedback_flag:
-            return None
-        return turn_feedback_block(integration.id, run_id)
+        return turn_feedback_block(self._get_integration().id, run_id)
 
     def _append_trailing_blocks(self, ts: str) -> None:
         """Add the fork menu and the thumbs to a streamed reply, which has no section to


### PR DESCRIPTION
## Problem

Every Slack workspace with the agent connected already sees the thumbs under a reply, so the `slack-app-turn-feedback` gate only costs a remote flag call on each one.

## Changes

- The thumbs render for every workspace, with no flag lookup behind them.
- `is_slack_app_turn_feedback_enabled` and its flag constant are gone.
- Nothing else about the thumbs changes: the buttons, the modal, and the captured events are untouched.

## How did you test this code?

Ran `products/slack_app/backend/tests/` locally, all green. No test covered the flag-off branch, so none changed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code on request to remove the flag. Skills invoked: `/writing-pr-descriptions`.
