### PR TITLE
fix(insights): show actor counts on the stickiness y-axis

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -3093,21 +3093,21 @@ snapshots:
     insights-sqlscattergraph--multiple-series-with-legend--light:
         hash: v1.k794b7964.126c1ab8792efb2eb2067a114290f8b15d0c6d8101e7a9f6ab03421ccf09d7b3.H-ayjpYGiaEvQ22GkDbmDuI1dBPgmvemo9RLaS7j8Vc
     insights-stickinessbarchart--stacked--dark:
-        hash: v1.k794b7964.d5be1db7b3a836f2079373df9e450e82c6ce0f3b0527a9293037f1191289004f.PSzZmvwfQYG3q0lT4lis8t8f_4y7NfSJZu-FY9RQIGA
+        hash: v1.k794b7964.2851c3441228fcb4df9e4ccd038c0e34483ba0e96f2b6a9b3339cc8c66681818.DmCMccZ0nfwOLeFu9C9-B3IRb12mg6O_xHjelc-dWss
     insights-stickinessbarchart--stacked--light:
-        hash: v1.k794b7964.5910c399514ebe819eb8b8537f3b43e161585df9984f6966d51ccf5d4dd823b4.DB78l3dcfY_pdo3zZ-Qq_sKwMmury11oxpOfiqkI1Ew
+        hash: v1.k794b7964.b14804faf864351bbea0c8969503ade191942fc66c3247c5121abc2c313c5cf1.cN1MKd1syOxHOqOsDZgLlKAzKxGnJ323JjBShEJSTN4
     insights-stickinessbarchart--unstacked--dark:
-        hash: v1.k794b7964.172beb9d6b152e628cbddd0fb0e2b849605e6fb32ac1d8ee56027f9cc92d217f.EEHxYE0WFIsMbwK4S9tr2sqevzl8S1aJqGdzkEKrIpY
+        hash: v1.k794b7964.ad95661de345a382e72754223c8cc8ebb48dfe66da1717306e257a96bcea0d4f.8aPeSxe_gs9ncpLHezigPvm5Xyvu08tgMRZb0-Qi2LQ
     insights-stickinessbarchart--unstacked--light:
-        hash: v1.k794b7964.f68d39a4d2eba312ca9d0a706b4989f97d8340de314b2f695898d4f187f2791f.2EjkbVPglFjmVAsSJVBXqVJUG1MH7sjybYGoSjMuSKI
+        hash: v1.k794b7964.912d81135c8bd321d831708229d9ded606003068e0f376b8e1df30652b33a4c4.i8qVOiHoifRIYbvwU3AD64qLqjOPtdU02bxM0dAdW0Y
     insights-stickinesslinechart--area--dark:
-        hash: v1.k794b7964.6adac88e74f2e675963c5feb2f452ee63ec01084b277e1549a4c0c5cd4f51eb4.0HmSO_EnoHFQMDVWtoBIvB4fGfDgsFVXx0OgMHl7IQ0
+        hash: v1.k794b7964.5e648d788e5d1758fe5e3dafd56188b7f7e02decc2aebc3619047da89322ca02.SfHfYUSL7DNruG7bPBdp84GBFn201vFUqqdusFo9w4g
     insights-stickinesslinechart--area--light:
-        hash: v1.k794b7964.f5770537b151ccf6816d0df18ab49405d8cf87936cbbc41f6722b2fbf0406912.jQ81yLsBlA6WGpPV2v4mMQOT6gHKrAKvM-XbawdAsVs
+        hash: v1.k794b7964.b1b209a5bff4addba63915eb87bc1427614a2aeb2619e25007042537e67962dd.Ej0qJwH9jBW_BJx2Ft_bqdy5myzDLAXdALsxysG2E4Y
     insights-stickinesslinechart--default--dark:
-        hash: v1.k794b7964.d364776b8ed7ba7002901b71756536dc1ee0028136e9739b2414d92dc547fb6a.KUzxS6wrm01K6FIvoQQfmGiVLBFLHGsE9jdji3sH5mM
+        hash: v1.k794b7964.65d1fcb149624d2b9b6d171aa281d84a7cc650c47b1a277f1f84c40264f48669.QlgPP-Lha_-TMpsVW2xIBTPf2BD_i-oDH8im72NN_Bg
     insights-stickinesslinechart--default--light:
-        hash: v1.k794b7964.fce3fac48f295e832697006e14ef17cb8840494c835c9fadd1df36e5ecba5fe8.oScAuhvF3d1ej90sE3nwueNzsfU5dd2QtDnh2W0sF2A
+        hash: v1.k794b7964.4ff3adefb93e08ac24d19893737d105fca13126151a9b44fbaec9c4efeacf67e.WZK-L9dPSOGwSPgX4J9dTjASbn_z7lneq90aL8yq-ZI
     insights-trendsbarchart--aggregated-compare-breakdown--dark:
         hash: v1.k794b7964.85ef8d6c1f570b23b3178b895e71f9ebdf34c8d668619d0dc6b0056a30a4b246.M1jJLUgTCGwdWxX1MpRcF6eZMrkNssTizjV5HydLnIw
     insights-trendsbarchart--aggregated-compare-breakdown--light:

--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.test.tsx
@@ -52,11 +52,12 @@ describe('StickinessBarChart', () => {
         )
     })
 
-    it('tooltip: formats series values as percentages of the series total', async () => {
+    it('tooltip: shows the raw actor count for the bucket, not its share of the series total', async () => {
         renderInsight({ query: stickinessBar() })
 
         const tooltip = await chart.hoverTooltip(2)
-        expect(tooltip.row('Pageview')).toMatch(/%/)
+        // Pageview canned series is [45, 82, 134, 210, 95], so bucket 2 is 134 actors.
+        expect(tooltip.row('Pageview')).toBe('134')
     })
 
     it('renders InsightEmptyState when all series are zero', async () => {

--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.tsx
@@ -5,6 +5,7 @@ import { TimeSeriesBarChart } from '@posthog/quill-charts'
 import type { PointClickData, Series, TimeSeriesBarChartConfig, TooltipContext } from '@posthog/quill-charts'
 
 import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
+import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
@@ -34,7 +35,6 @@ import { handleStickinessChartClick } from '../StickinessLineChart/handleStickin
 import {
     buildStickinessLabels,
     buildStickinessTooltipTitle,
-    stickinessPercentFormatter,
     STICKINESS_TOOLTIP_CONFIG,
 } from '../StickinessLineChart/stickinessChartTransforms'
 import { buildStickinessBarSeries, buildStickinessBarTimeSeriesConfig } from './stickinessBarChartTransforms'
@@ -105,18 +105,34 @@ export function StickinessBarChart({ context }: StickinessBarChartProps): JSX.El
         [indexedResults, getTrendsColor, getLabel]
     )
 
+    const valueLabelFormatter = useCallback(
+        (value: number) => formatAggregationAxisValue(trendsFilter, value, baseCurrency),
+        [trendsFilter, baseCurrency]
+    )
+
     const chartConfig: TimeSeriesBarChartConfig = useChartConfig(
         () => ({
             ...buildStickinessBarTimeSeriesConfig({
+                trendsFilter,
+                baseCurrency,
                 yAxisScaleType,
                 isGrouped,
-                valueLabels: showValuesOnSeries ? { formatter: stickinessPercentFormatter } : false,
+                valueLabels: showValuesOnSeries ? { formatter: valueLabelFormatter } : false,
                 tooltip: tooltipConfig,
             }),
             // Interactive legend is a component concern, kept out of the pure transform.
             legend: legendConfig,
         }),
-        [yAxisScaleType, isGrouped, showValuesOnSeries, legendConfig, tooltipConfig]
+        [
+            trendsFilter,
+            baseCurrency,
+            yAxisScaleType,
+            isGrouped,
+            showValuesOnSeries,
+            valueLabelFormatter,
+            legendConfig,
+            tooltipConfig,
+        ]
     )
 
     // Close over the primitives so the click memos don't invalidate when unrelated
@@ -160,7 +176,7 @@ export function StickinessBarChart({ context }: StickinessBarChartProps): JSX.El
                 interval: interval ?? undefined,
                 breakdownFilter: breakdownFilter ?? undefined,
                 trendsFilter,
-                showPercentView: true as const,
+                showPercentView: false as const,
                 isPercentStackView: false as const,
                 baseCurrency,
                 groupTypeLabel: resolvedGroupTypeLabel,

--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/stickinessBarChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/stickinessBarChartTransforms.test.ts
@@ -18,10 +18,11 @@ describe('buildStickinessBarTimeSeriesConfig', () => {
         expect(buildStickinessBarTimeSeriesConfig({ isGrouped: false }).xAxis).toBeUndefined()
     })
 
-    it('delegates the yAxis to the shared stickiness builder (percent + scale + grid)', () => {
+    it('delegates the yAxis to the shared stickiness builder (count format + scale + grid)', () => {
         const cfg = buildStickinessBarTimeSeriesConfig({ isGrouped: false, yAxisScaleType: 'log10' })
         expect(cfg.yAxis!.scale).toBe('log')
-        expect(cfg.yAxis!.tickFormatter!(50)).toBe('50.0%')
+        expect(cfg.yAxis!.showGrid).toBe(true)
+        expect(cfg.yAxis!.format).toBe('numeric')
     })
 
     it('passes through valueLabels and tooltip', () => {

--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/stickinessBarChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/stickinessBarChartTransforms.ts
@@ -1,5 +1,6 @@
 import type { TimeSeriesBarChartConfig, TooltipConfig, YAxisConfig } from '@posthog/quill-charts'
 
+import type { YFormatterFields } from '../../trends/shared/trendsChartDisplayOptions'
 import {
     buildStickinessSeries,
     buildStickinessYAxisConfig,
@@ -9,6 +10,8 @@ import {
 export { buildStickinessSeries as buildStickinessBarSeries }
 
 export interface BuildStickinessBarTimeSeriesConfigOpts {
+    trendsFilter?: YFormatterFields | null
+    baseCurrency?: string
     yAxisScaleType?: StickinessYAxisScaleType
     /** ActionsBar → stacked; ActionsUnstackedBar → grouped. */
     isGrouped: boolean
@@ -22,7 +25,12 @@ export function buildStickinessBarTimeSeriesConfig(
 ): TimeSeriesBarChartConfig & { yAxis?: YAxisConfig } {
     // No xAxis date config — labels are pre-formatted interval counts (Day 0, Day 1, …).
     return {
-        yAxis: buildStickinessYAxisConfig({ yAxisScaleType: opts.yAxisScaleType, showGrid: opts.showGrid }),
+        yAxis: buildStickinessYAxisConfig({
+            trendsFilter: opts.trendsFilter,
+            baseCurrency: opts.baseCurrency,
+            yAxisScaleType: opts.yAxisScaleType,
+            showGrid: opts.showGrid,
+        }),
         valueLabels: opts.valueLabels,
         barLayout: opts.isGrouped ? 'grouped' : 'stacked',
         tooltip: opts.tooltip,

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.test.tsx
@@ -6,7 +6,7 @@ import { setupJsdom, setupSyncRaf } from '@posthog/quill-charts/testing'
 
 import { ExportType } from '~/exporter/types'
 import { NodeKind } from '~/queries/schema/schema-general'
-import { buildStickinessQuery, chart, personsModal, renderInsight } from '~/test/insight-testing'
+import { buildStickinessQuery, chart, getHogChart, personsModal, renderInsight } from '~/test/insight-testing'
 
 configure({ asyncUtilTimeout: 5000 })
 // With asyncUtilTimeout at 5s, a single legitimate waitFor can exhaust Jest's default
@@ -37,13 +37,26 @@ describe('StickinessLineChart', () => {
         })
     })
 
+    describe('axes', () => {
+        it('renders the y-axis as counts rather than percentages', async () => {
+            renderInsight({ query: buildStickinessQuery() })
+            await screen.findByLabelText(/chart with 1 data series/i)
+
+            await waitFor(() => {
+                const ticks = getHogChart().yTicks()
+                expect(ticks.length).toBeGreaterThan(0)
+                expect(ticks.some((t) => t.includes('%'))).toBe(false)
+            })
+        })
+    })
+
     describe('tooltips', () => {
-        it('formats series values as percentages of the series total', async () => {
+        it('shows the raw actor count for the bucket, not its share of the series total', async () => {
             renderInsight({ query: buildStickinessQuery() })
 
             const tooltip = await chart.hoverTooltip(2)
-            // Pageview canned series is [45, 82, 134, 210, 95], total 566, so bucket 2 == 134/566 ≈ 23.7%.
-            expect(tooltip.row('Pageview')).toMatch(/%/)
+            // Pageview canned series is [45, 82, 134, 210, 95], so bucket 2 is 134 actors.
+            expect(tooltip.row('Pageview')).toBe('134')
         })
     })
 

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.tsx
@@ -5,6 +5,7 @@ import { TimeSeriesLineChart } from '@posthog/quill-charts'
 import type { PointClickData, Series, TimeSeriesLineChartConfig, TooltipContext } from '@posthog/quill-charts'
 
 import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
+import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
@@ -36,7 +37,6 @@ import {
     buildStickinessLineTimeSeriesConfig,
     buildStickinessSeries,
     buildStickinessTooltipTitle,
-    stickinessPercentFormatter,
     STICKINESS_TOOLTIP_CONFIG,
 } from './stickinessChartTransforms'
 
@@ -106,11 +106,18 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
         [indexedResults, display, getTrendsColor, getLabel, showMultipleYAxes]
     )
 
+    const valueLabelFormatter = useCallback(
+        (value: number) => formatAggregationAxisValue(trendsFilter, value, baseCurrency),
+        [trendsFilter, baseCurrency]
+    )
+
     const chartConfig: TimeSeriesLineChartConfig = useChartConfig(
         () => ({
             ...buildStickinessLineTimeSeriesConfig({
+                trendsFilter,
+                baseCurrency,
                 yAxisScaleType,
-                valueLabels: showValuesOnSeries ? { formatter: stickinessPercentFormatter } : false,
+                valueLabels: showValuesOnSeries ? { formatter: valueLabelFormatter } : false,
                 showCrosshair: true,
                 tooltip: tooltipConfig,
             }),
@@ -118,7 +125,16 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
             // Interactive legend is a component concern, kept out of the pure transform.
             legend: legendConfig,
         }),
-        [yAxisScaleType, showValuesOnSeries, legendConfig, tooltipConfig, stickinessFilter?.chartStyle]
+        [
+            trendsFilter,
+            baseCurrency,
+            yAxisScaleType,
+            showValuesOnSeries,
+            valueLabelFormatter,
+            legendConfig,
+            tooltipConfig,
+            stickinessFilter?.chartStyle,
+        ]
     )
 
     const canHandleClick = !!context?.onDataPointClick || !!hasPersonsModal
@@ -158,7 +174,7 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
                 interval: interval ?? undefined,
                 breakdownFilter: breakdownFilter ?? undefined,
                 trendsFilter,
-                showPercentView: true as const,
+                showPercentView: false as const,
                 isPercentStackView: false as const,
                 baseCurrency,
                 groupTypeLabel: resolvedGroupTypeLabel,

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.test.ts
@@ -12,8 +12,6 @@ import {
     buildStickinessMainSeries,
     buildStickinessSeries,
     buildStickinessTooltipTitle,
-    stickinessPercentFormatter,
-    toPercentData,
     type StickinessResultLike,
 } from './stickinessChartTransforms'
 
@@ -29,27 +27,9 @@ const makeResult = (overrides: Partial<StickinessResultLike> = {}): StickinessRe
 })
 
 describe('stickinessChartTransforms', () => {
-    describe('toPercentData', () => {
-        it.each<[string, number[], number, number[]]>([
-            ['typical share split', [50, 30, 15, 5], 100, [50, 30, 15, 5]],
-            ['fractional output', [1, 2, 3], 4, [25, 50, 75]],
-            ['count of 0 returns the raw values (avoids divide-by-zero)', [0, 0, 0], 0, [0, 0, 0]],
-            ['empty data stays empty', [], 10, []],
-        ])('%s', (_, data, count, expected) => {
-            expect(toPercentData(data, count)).toEqual(expected)
-        })
-
-        it('returns a copy when count is 0 (no aliasing of the input array)', () => {
-            const input = [1, 2, 3]
-            const out = toPercentData(input, 0)
-            expect(out).toEqual(input)
-            expect(out).not.toBe(input)
-        })
-    })
-
     describe('buildStickinessMainSeries', () => {
-        it('builds a single main series with data transformed to percentages', () => {
-            const series = buildStickinessMainSeries(makeResult(), 0, { getColor: () => RED })
+        it('builds a single main series with the raw data untouched, regardless of count', () => {
+            const series = buildStickinessMainSeries(makeResult({ count: 200 }), 0, { getColor: () => RED })
 
             expect(series).toMatchObject({
                 key: '0',
@@ -147,26 +127,26 @@ describe('stickinessChartTransforms', () => {
             expect(series.map((s) => s.key)).toEqual(['a', 'b'])
         })
 
-        it('groups y-axes by the magnitude of the percent-converted values when showMultipleYAxes is true', () => {
-            // Same raw data, but b's much larger count makes its percentages ~2 orders smaller.
+        it('groups y-axes by the magnitude of the raw counts when showMultipleYAxes is true', () => {
+            // b's counts sit two orders of magnitude above a's and c's, so b alone moves to a second axis.
             const results = [
-                makeResult({ id: 'a', count: 100 }),
-                makeResult({ id: 'b', count: 10000 }),
-                makeResult({ id: 'c', count: 100 }),
+                makeResult({ id: 'a', data: [50, 30, 15, 5] }),
+                makeResult({ id: 'b', data: [5000, 3000, 1500, 500] }),
+                makeResult({ id: 'c', data: [60, 20, 10, 10] }),
             ]
             const series = buildStickinessSeries(results, { getColor: () => RED, showMultipleYAxes: true })
 
             expect(series.map((s) => s.yAxisId)).toEqual([DEFAULT_Y_AXIS_ID, 'y1', DEFAULT_Y_AXIS_ID])
         })
 
-        it('transforms each result independently using its own count', () => {
+        it("passes each result's raw data through unchanged regardless of its count", () => {
             const results = [
                 makeResult({ id: 'a', count: 200, data: [100, 50, 25, 25] }),
                 makeResult({ id: 'b', count: 50, data: [10, 20, 10, 10] }),
             ]
             const series = buildStickinessSeries(results, { getColor: () => RED })
-            expect(series[0].data).toEqual([50, 25, 12.5, 12.5])
-            expect(series[1].data).toEqual([20, 40, 20, 20])
+            expect(series[0].data).toEqual([100, 50, 25, 25])
+            expect(series[1].data).toEqual([10, 20, 10, 10])
         })
     })
 
@@ -187,17 +167,6 @@ describe('stickinessChartTransforms', () => {
 
         it('returns empty array when count is 0', () => {
             expect(buildStickinessLabels(0, 'day')).toEqual([])
-        })
-    })
-
-    describe('stickinessPercentFormatter', () => {
-        it.each([
-            [0, '0.0%'],
-            [50, '50.0%'],
-            [85.16, '85.2%'],
-            [100, '100.0%'],
-        ])('formats %s → %s', (value, expected) => {
-            expect(stickinessPercentFormatter(value)).toBe(expected)
         })
     })
 
@@ -226,14 +195,14 @@ describe('stickinessChartTransforms', () => {
     describe('buildStickinessLineTimeSeriesConfig', () => {
         const TOOLTIP: TooltipConfig = { pinnable: true, placement: 'top' }
 
-        it('returns yAxis with percent tick formatter and a linear scale by default', () => {
+        it('returns yAxis with a plain numeric (count) format and a linear scale by default', () => {
             const config = buildStickinessLineTimeSeriesConfig({})
             const yAxis = config.yAxis as YAxisConfig
             expect(yAxis).not.toBeUndefined()
             expect(yAxis.scale).toBe('linear')
             expect(yAxis.showGrid).toBe(true)
-            expect(yAxis.tickFormatter).not.toBeUndefined()
-            expect(yAxis.tickFormatter!(50)).toBe('50.0%')
+            expect(yAxis.format).toBe('numeric')
+            expect(yAxis.tickFormatter).toBeUndefined()
         })
 
         it('switches the y-scale to log when yAxisScaleType is log10', () => {
@@ -241,6 +210,16 @@ describe('stickinessChartTransforms', () => {
             const yAxis = config.yAxis as YAxisConfig
             expect(yAxis).not.toBeUndefined()
             expect(yAxis.scale).toBe('log')
+        })
+
+        it('threads trendsFilter/baseCurrency through to the y-axis format', () => {
+            const config = buildStickinessLineTimeSeriesConfig({
+                trendsFilter: { aggregationAxisFormat: 'currency' },
+                baseCurrency: 'USD',
+            })
+            const yAxis = config.yAxis as YAxisConfig
+            expect(yAxis.format).toBe('currency')
+            expect(yAxis.currency).toBe('USD')
         })
 
         it('omits an xAxis date config — labels are pre-formatted interval counts', () => {
@@ -260,7 +239,7 @@ describe('stickinessChartTransforms', () => {
             expect(config.tooltip).toBe(TOOLTIP)
         })
 
-        it('does not enable percentStackView (stickiness already pre-percents data)', () => {
+        it('does not enable percentStackView', () => {
             const config = buildStickinessLineTimeSeriesConfig({})
             expect(config.percentStackView).toBeUndefined()
         })

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.ts
@@ -10,6 +10,8 @@ import { INSIGHT_TOOLTIP_CONFIG } from '../../shared/tooltipConfig'
 import { COMPARE_PREVIOUS_DIM_OPACITY, dimHexColor } from '../../trends/shared/compareDimming'
 import { humanizeSeriesLabel } from '../../trends/shared/humanizeSeriesLabel'
 import { computeMagnitudeAxisIds } from '../../trends/shared/magnitudeAxisIds'
+import { buildTrendsYAxisConfig } from '../../trends/shared/trendsAxisFormat'
+import type { YFormatterFields } from '../../trends/shared/trendsChartDisplayOptions'
 
 // Shape both IndexedTrendResult (kea) and StickinessResultItem (MCP) satisfy.
 export interface StickinessResultLike {
@@ -40,15 +42,6 @@ export interface BuildStickinessSeriesOpts<R extends StickinessResultLike, M = u
     getLabel?: (r: R) => string
 }
 
-/** Convert raw counts to percentages of `count`. Mirrors the legacy `showPercentView`
- * behavior in LineGraph: each y-value becomes its share of the series total. */
-export function toPercentData(data: number[], count: number): number[] {
-    if (!count) {
-        return data.slice()
-    }
-    return data.map((v) => (v / count) * 100)
-}
-
 export function buildStickinessMainSeries<R extends StickinessResultLike, M = unknown>(
     r: R,
     index: number,
@@ -63,7 +56,7 @@ export function buildStickinessMainSeries<R extends StickinessResultLike, M = un
     return {
         key: String(r.id),
         label: opts.getLabel ? opts.getLabel(r) : humanizeSeriesLabel(r.label),
-        data: toPercentData(r.data, r.count),
+        data: r.data,
         color,
         yAxisId,
         meta,
@@ -76,10 +69,7 @@ export function buildStickinessSeries<R extends StickinessResultLike, M = unknow
     results: R[],
     opts: BuildStickinessSeriesOpts<R, M>
 ): Series<M>[] {
-    // Group on the rendered (percent-converted) values, not the raw counts.
-    const yAxisIds = opts.showMultipleYAxes
-        ? computeMagnitudeAxisIds(results.map((r) => toPercentData(r.data, r.count)))
-        : undefined
+    const yAxisIds = opts.showMultipleYAxes ? computeMagnitudeAxisIds(results.map((r) => r.data)) : undefined
     return results.map((r, index) => buildStickinessMainSeries(r, index, opts, yAxisIds?.[index]))
 }
 
@@ -89,11 +79,6 @@ export function buildStickinessSeries<R extends StickinessResultLike, M = unknow
 export function buildStickinessLabels(count: number, interval: string | null | undefined): string[] {
     const prefix = capitalizeFirstLetter(interval ?? 'day')
     return Array.from({ length: count }, (_, i) => `${prefix} ${i}`)
-}
-
-/** Emit `85.0%`-style ticks — legacy parity with `${value.toFixed(1)}%` in LineGraph. */
-export function stickinessPercentFormatter(value: number): string {
-    return `${value.toFixed(1)}%`
 }
 
 export const STICKINESS_TOOLTIP_CONFIG = INSIGHT_TOOLTIP_CONFIG
@@ -110,19 +95,24 @@ export function buildStickinessTooltipTitle(
     }
 }
 
-/** Shared stickiness y-axis: percent tick formatter + linear/log scale toggle. */
+/** Shared stickiness y-axis. Delegates to the trends formatter so stickiness shows a plain
+ * count by default like every other insight type, while still respecting an explicit
+ * aggregation axis format (currency, duration, etc.) if one is set on the insight. */
 export function buildStickinessYAxisConfig(opts: {
+    trendsFilter?: YFormatterFields | null
+    baseCurrency?: string
     yAxisScaleType?: StickinessYAxisScaleType
     showGrid?: boolean
 }): YAxisConfig {
-    return {
-        scale: opts.yAxisScaleType === 'log10' ? 'log' : 'linear',
+    return buildTrendsYAxisConfig(opts.trendsFilter, false, opts.baseCurrency, {
+        yAxisScaleType: opts.yAxisScaleType,
         showGrid: opts.showGrid ?? true,
-        tickFormatter: stickinessPercentFormatter,
-    }
+    })
 }
 
 export interface BuildStickinessLineTimeSeriesConfigOpts {
+    trendsFilter?: YFormatterFields | null
+    baseCurrency?: string
     yAxisScaleType?: StickinessYAxisScaleType
     showGrid?: boolean
     valueLabels?: TimeSeriesLineChartConfig['valueLabels']
@@ -135,7 +125,12 @@ export function buildStickinessLineTimeSeriesConfig(
 ): TimeSeriesLineChartConfig {
     return {
         // No xAxis date config — labels are pre-formatted interval counts (Day 0, Day 1, …).
-        yAxis: buildStickinessYAxisConfig({ yAxisScaleType: opts.yAxisScaleType, showGrid: opts.showGrid }),
+        yAxis: buildStickinessYAxisConfig({
+            trendsFilter: opts.trendsFilter,
+            baseCurrency: opts.baseCurrency,
+            yAxisScaleType: opts.yAxisScaleType,
+            showGrid: opts.showGrid,
+        }),
         valueLabels: opts.valueLabels,
         showCrosshair: opts.showCrosshair,
         tooltip: opts.tooltip,


### PR DESCRIPTION
## Problem

A stickiness chart shows every series as a percentage of its own total, and there is no way to see counts. The [stickiness docs](https://posthog.com/docs/product-analytics/stickiness) show a count y-axis. The two have disagreed since #29030 (2025-03-14).

- The insight table already shows both numbers: the percentage with the raw count beneath it. The chart shows only the percentage.
- The underlying query returns actor counts, and clicking a point opens a list of actors.
- Stacked bars stack the per-series percentages, so a three-series chart's y-axis runs past 100% (to 250% in the screenshot below).

This is the y-axis half of the first version of #93575, split out because it changes intended behavior rather than fixing a defect. The x-axis fix stays in #93575.

> [!NOTE]
> This is an open question, not a settled fix. Percentages were a deliberate choice in #29030, and the MCP app's `StickinessVisualizer` chose them independently with its reasoning in a comment. Either the chart or the docs has to move. This PR moves the chart; if the decision goes the other way, the docs page needs a new screenshot instead and this PR closes.

## Changes

- Both stickiness charts show actor counts on the y-axis, in the tooltip, and on the on-series value labels.
- An explicit aggregation axis format set on the insight (currency, duration, prefix or postfix) now applies, as it does for trends. `buildStickinessYAxisConfig` delegates to `buildTrendsYAxisConfig` instead of hardcoding a percent formatter.
- Multi-axis magnitude grouping from #94037 runs on the raw counts instead of the percent-converted values.
- Deleted: `toPercentData`, `stickinessPercentFormatter`, and their tests.
- The x-axis labels are untouched here. They are fixed in #93575, and the two PRs will conflict trivially on imports in the same four files when the second one rebases.

| | Before | After |
| --- | --- | --- |
| Line | ![Stickiness line chart before: y-axis 0% to 100%](https://raw.githubusercontent.com/PostHog/pr-assets/main/2026/09/9bfe55bf-0c77-4341-b73f-20adc6ba3b2e.png) | ![Stickiness line chart after: y-axis 0 to 25,000, x-axis unchanged](https://raw.githubusercontent.com/PostHog/pr-assets/main/2026/09/c9c6839b-03b9-4549-ae1e-7a7128bf439c.png) |
| Stacked bar | ![Stickiness stacked bar chart before: y-axis 0% to 250%](https://raw.githubusercontent.com/PostHog/pr-assets/main/2026/09/b0615dc3-fa22-4b6c-9a9f-66d92243ac95.png) | ![Stickiness stacked bar chart after: y-axis 0 to 18,000, x-axis unchanged](https://raw.githubusercontent.com/PostHog/pr-assets/main/2026/09/141fadcb-5e5a-4c01-8d62-313cfdade47e.png) |

Rendered from the Storybook stories `insights-stickinesslinechart--default` and `insights-stickinessbarchart--stacked`, master on the left and this branch on the right, same fixture data. Series shapes do not change, since percent-of-total is a linear rescale of each series.

Not changed: the MCP app's `StickinessVisualizer` still shows percentages. If this lands, it should follow in a separate PR so the two surfaces agree. The `yAxisScaleType` / `log10` plumbing is also left alone; it is unreachable for stickiness today (`ScalePicker` only renders for trends) and removing it is a separate call.

## How did you test this code?

- `StickinessLineChart.test.tsx`: new test asserts no y-axis tick contains `%`. The tooltip tests in both chart suites now assert the raw count `134` for bucket 2 instead of matching `/%/`.
- `stickinessChartTransforms.test.ts`: the y-axis format is `numeric` by default and `currency` with `USD` when set on the filter; series data passes through unchanged; the #94037 magnitude-grouping test is rebuilt on raw counts (b two orders of magnitude above a and c gets its own axis).
- Run locally on this branch: the five stickiness suites, `oxlint`, `oxfmt --check`, and `tsgo --noEmit` (zero errors in stickiness or insights; the 22 repo-wide errors are pre-existing missing-module noise in unrelated products from this environment).
- Not run: `hogli ci:preflight` (no Python env available) and a live dev stack.
- Visual Review should flag the eight `insights-stickiness*` stories: the y-axis ticks and scale move, the x-axis and series shapes do not. `mcp-apps-stickiness--*` and `components-cards-insight-details--stickiness--*` should not move.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Nothing in this repo. The website docs already show a count y-axis, so they need no change if this lands. If the decision is to keep percentages, the docs page needs a new screenshot instead.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Jack had Claude Code trace the stickiness axes. Both changes started as bug fixes; reading the history turned up #29030, which showed the percentage y-axis was intentional, so this half is framed as reconciling the chart with the docs and opened separately from the x-axis defect at Jack's request. The split was done with Claude Code (Fable 5.1) by rebuilding this half from master, which is also where the #94037 magnitude-grouping update was folded in. Repo skills invoked across the sessions: `/writing-pr-descriptions`, `/writing-code-comments`, `/writing-tests`.