### PR TITLE
chore(hogql): publish parser wheels for Python 3.14

### DIFF
--- a/.github/workflows/build-hogql-parser.yml
+++ b/.github/workflows/build-hogql-parser.yml
@@ -114,7 +114,7 @@ jobs:
 
             - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
-                  python-version: '3.12.10' # There is no 3.12.11/3.12.12 binary for mac/darwin architectures yet
+                  python-version: '3.13.13'
 
             - name: Build sdist
               if: matrix.os == 'ubuntu-22.04' # Only build the sdist once
@@ -123,7 +123,7 @@ jobs:
                   cd common/hogql_parser && python setup.py sdist
 
             - name: Install cibuildwheel
-              run: pip install cibuildwheel==2.23.*
+              run: pip install cibuildwheel==4.2.*
 
             - name: Build wheels
               run: cd common/hogql_parser && python -m cibuildwheel --output-dir dist

--- a/common/hogql_parser/pyproject.toml
+++ b/common/hogql_parser/pyproject.toml
@@ -9,6 +9,7 @@ build = [ # Build CPython wheels on Linux and macOS, for x86 as well as ARM
     "cp3*-manylinux_x86_64",
     "cp3*-manylinux_aarch64",
 ]
+skip = ["cp3*t-*", "cp315-*"]
 build-frontend = "build" # This is the successor to building with pip
 
 [tool.cibuildwheel.macos]

--- a/common/hogql_parser/setup.py
+++ b/common/hogql_parser/setup.py
@@ -36,7 +36,7 @@ module = Extension(
 
 setup(
     name="hogql_parser",
-    version="1.3.84",
+    version="1.3.85",
     url="https://github.com/PostHog/posthog/tree/master/common/hogql_parser",
     description="HogQL parser for internal PostHog use",
     author="PostHog Inc.",
@@ -59,5 +59,6 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "grimp~=3.14",
     "grpcio~=1.71.0",
     "gspread==6.2.1",
-    "hogql-parser==1.3.84",
+    "hogql-parser==1.3.85",
     "hogql-parser-rs==1.3.109",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
     "humanize~=4.12.3",
     "infi-clickhouse-orm",

--- a/uv.lock
+++ b/uv.lock
@@ -3158,14 +3158,14 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "hogql-parser"
-version = "1.3.84"
+version = "1.3.85"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/47/8899163a8a02ef242f816e9c9c62b376271591fe06cc4876304c65f2ecd3/hogql_parser-1.3.84.tar.gz", hash = "sha256:bb9caa3d0fcb0f6d7faadfdbf10db8d20f93c64be40a331f1134302994cc6de4", size = 92995, upload-time = "2026-08-17T12:54:36.406Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/a0/c3ad9c4fe998896e19b60c97d7f30416cfa4f07b70fd5bc545354ea41984/hogql_parser-1.3.85.tar.gz", hash = "sha256:affcc5d88cc7dce12735eba621741988edfebb0b6a32a1d7d1bfb593a41018cc", size = 93026, upload-time = "2026-09-03T18:21:11.171Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/ee/733c62d24180d3ce8a08a32ec059d5dce4b61b485ee24275086eca76d590/hogql_parser-1.3.84-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:9c4e050542a38e526ba28360382f241a747144fec0911b3f654ae72fbb3a0a55", size = 658667, upload-time = "2026-08-17T12:54:30.582Z" },
-    { url = "https://files.pythonhosted.org/packages/24/f0/d33bc908c5cf6597726483f05242ae06d113d3de9e20716adbe8020e28b9/hogql_parser-1.3.84-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:4434287edb0d1adb55601466b6a04fe0eb48becf3cf8adbadc6f1e82b1d60546", size = 668172, upload-time = "2026-08-17T12:54:31.924Z" },
-    { url = "https://files.pythonhosted.org/packages/56/25/a5c9d05851c9587546908337fffbccd95abe3b616fd52732078d1ca18f31/hogql_parser-1.3.84-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:4059b614279c4f58f43c74589fc27f0325a3e211044f0b961e49b92e39d1791b", size = 5111187, upload-time = "2026-08-17T12:54:33.328Z" },
-    { url = "https://files.pythonhosted.org/packages/72/07/1f500742a8fea6400d6676ae63204006e60f90dcd5525efbd10ea3dfd2ee/hogql_parser-1.3.84-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:221ec153b9dc5810c7f74729a33b89ceef6142216ce1c7a837f52312ab02c713", size = 5219820, upload-time = "2026-08-17T12:54:34.882Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a3/3e95e0c36c81be63aceb8c4799ae4f02e0d997d0f4aa11847bb2250af434/hogql_parser-1.3.85-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:de9e0f1aab3f76660d43dcafb1df3ec8dd33803c8c8b4932ee1b7a65855325e9", size = 658679, upload-time = "2026-09-03T18:20:57.765Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/4f/c8e5c9318635fc2a7adc96c02bc76e35540aa48b54be19653db95db8085c/hogql_parser-1.3.85-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:59560520efd04e3878ce12a839b9019891fc264525e24ec3b1e368679f51489d", size = 668172, upload-time = "2026-09-03T18:20:59.119Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/0a/59ab64fb3bb913ac474d3457e0ed2cd1e9aa5d050afa7168f98398d068e0/hogql_parser-1.3.85-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46982fb45ec452135c380fd1ac458dea3ed06c830978d58d2eab82e5335ab52f", size = 5111194, upload-time = "2026-09-03T18:21:00.954Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/42/79daca030ed0ecdd6bb8516dc62e29f131fe14f076e8cecea1f886e5b3db/hogql_parser-1.3.85-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd187ca49ae1c91299bf70a91713b70ed233245f8407366165ccb3d19d186f6f", size = 5219699, upload-time = "2026-09-03T18:21:02.75Z" },
 ]
 
 [[package]]
@@ -5902,7 +5902,7 @@ requires-dist = [
     { name = "grimp", specifier = "~=3.14" },
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
-    { name = "hogql-parser", specifier = "==1.3.84" },
+    { name = "hogql-parser", specifier = "==1.3.85" },
     { name = "hogql-parser-rs", specifier = "==1.3.109" },
     { name = "humanize", specifier = "~=4.12.3" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },


### PR DESCRIPTION
## Problem

- [The Python 3.14 upgrade](https://github.com/PostHog/posthog/pull/94402) cannot install hogql-parser because PyPI 1.3.84 has no CPython 3.14 wheels.

## Changes

- Release hogql-parser 1.3.85 with CPython 3.14 metadata and wheels for CPython 3.10 through 3.14.
- cibuildwheel 4.2 excludes free-threaded and CPython 3.15 wheels. Nothing user-visible changes.

## How did you test this code?

- `uvx cibuildwheel@4.2.0 --print-build-identifiers --platform linux` selects CPython 3.10 through 3.14 on Linux.
- `bin/hogli lint:workflows` and `actionlint` pass.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. This change only expands package compatibility.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Pi coding agent. Skills: `/authoring-ci-workflows`, `/writing-code-comments`, `/writing-pr-descriptions`, `/running-ci-preflight`.
