### PR TITLE
fix(propdefs): mark dedup cache entries referenced on lookups

### DIFF
--- a/rust/property-defs-rs/src/update_cache.rs
+++ b/rust/property-defs-rs/src/update_cache.rs
@@ -5,10 +5,9 @@ use crate::{
 use metrics::Counter;
 use quick_cache::{sync, DefaultHashBuilder, Lifecycle, UnitWeighter};
 
-// Per-subcache eviction observer. quick_cache's built-in `stats` feature
-// only tracks hits/misses on `get`/`get_key_value` paths (not `contains_key`/
-// `insert`, which is what we use), so all cache hit/miss/eviction signal in
-// this service comes from explicit metrics emitted here and in `contains_key`.
+// Per-subcache eviction observer. The `stats` feature of quick_cache is not
+// enabled, so all cache hit/miss/eviction signal in this service comes from
+// explicit metrics emitted here and in `contains_key`.
 //
 // Counter handles are resolved once at construction and reused: these paths run
 // per update (and `on_evict` runs under the shard write lock), so a registry
@@ -104,7 +103,12 @@ impl Cache {
 
     pub fn contains_key(&self, key: &Update) -> bool {
         let entry = self.entry_for(key);
-        let found = entry.cache.contains_key(key);
+        // `get` marks the entry referenced, which quick_cache's S3-FIFO eviction
+        // uses to keep the working set resident. The `contains_key` of quick_cache
+        // skips that marking, so every entry looks cold at eviction time and the
+        // cache degrades to FIFO: live keys cycle out and each cycle costs a
+        // useless definition upsert against Postgres.
+        let found = entry.cache.get(key).is_some();
         if found {
             entry.hits.increment(1);
         } else {

--- a/rust/property-defs-rs/tests/update_cache.rs
+++ b/rust/property-defs-rs/tests/update_cache.rs
@@ -220,6 +220,40 @@ fn test_contains_key_emits_hit_miss_metrics(#[case] label: &'static str, #[case]
     assert_miss_then_hit(label, update);
 }
 
+// Guards the recency contract of `Cache::contains_key`: a lookup must mark the
+// entry referenced (quick_cache `get`), so a key that was checked survives the
+// next eviction pass by promotion into the protected segment. quick_cache's
+// own `contains_key` skips that marking, which degrades S3-FIFO to FIFO; in
+// production that evicts the working set on a fixed schedule and re-issues a
+// useless Postgres upsert per cycle.
+//
+// The filler prelude matters: a nearly-empty cache admits inserts straight
+// into the protected (hot) segment, where eviction pressure never reaches
+// them and the assertion would pass with or without recency marking. Filling
+// the cache first forces the probe key into the probationary (cold) segment,
+// where only a referenced entry survives.
+#[test]
+fn test_checked_key_survives_eviction_pressure() {
+    let cache = Cache::new(2, 2, 2);
+
+    for i in 0..40 {
+        cache.insert(make_event_def(&format!("recency_fill_{i}")));
+    }
+
+    let probe = make_event_def("recency_probe");
+    cache.insert(probe.clone());
+    assert!(cache.contains_key(&probe), "probe should be resident");
+
+    for i in 0..100 {
+        cache.insert(make_event_def(&format!("recency_flood_{i}")));
+    }
+
+    assert!(
+        cache.contains_key(&probe),
+        "checked key was evicted instead of promoted"
+    );
+}
+
 // quick_cache enforces a minimum of 32 items per shard (`sync.rs` ~134:
 // `while shard_items_cap < 32 && num_shards > 1 { num_shards /= 2; ... }`),
 // so even with `Cache::new(2, 2, 2)` we get a single 32-slot shard per


### PR DESCRIPTION
## Problem

property-defs-rs keeps re-writing definitions Postgres already has: at steady state, with warm caches, the vast majority of definition upserts change no rows.

- The dedup cache's only read path used quick_cache's `contains_key`, which does not mark the entry referenced.
- S3-FIFO eviction decides survival by that marker, so every entry looked cold and the cache degraded to FIFO.
- Working-set keys cycled out on a fixed schedule, and each cycle re-issued an upsert for an existing row.
- The production signature: a uniform per-pod miss floor, and daily evictions at a large multiple of total cache capacity.

## Changes

Nothing user-visible changes; the service sends Postgres fewer no-op rows.

- `Cache::contains_key` reads through quick_cache `get`, which bumps the entry's referenced counter, so checked keys survive eviction passes.
- Hit/miss metric semantics are unchanged.

## How did you test this code?

- New test: a checked key in a full cache must survive eviction pressure by promotion. Verified red with the previous recency-blind lookup and green with this change.
- The filler prelude in the test is load-bearing: a near-empty cache admits inserts straight into the protected segment, where the assertion passes either way.
- After deploy, the steady-state `prop_defs_cache_misses` floor and `prop_defs_cache_evictions` rate should drop sharply.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code during a cache-behavior investigation driven by the assignee, following the CPU work in #94374. The eviction mechanics were verified against the quick_cache 0.6.21 source. Skills invoked: /stacking-prs, /writing-tests, /writing-code-comments, /writing-pr-descriptions. A first test attempt did not discriminate (the probe landed in the protected segment); the shipped test was rewritten and red/green verified both ways.
