### PR TITLE
fix(tests): stop hardcoding the clickhouse database name

### DIFF
--- a/posthog/hogql/database/test/test_s3_table_clickhouse.py
+++ b/posthog/hogql/database/test/test_s3_table_clickhouse.py
@@ -12,6 +12,7 @@ from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from posthog.clickhouse.client import sync_execute
+from posthog.settings.data_stores import CLICKHOUSE_DATABASE
 
 MINIO_ENDPOINT = "http://localhost:19000"
 MINIO_CH_ENDPOINT = "http://objectstorage:19000"
@@ -133,7 +134,7 @@ class TestS3ParquetTimezoneConversion(ClickhouseTestMixin, BaseTest):
 
     def test_not_affected_on_mergetree(self):
         """The bug does not affect regular MergeTree tables."""
-        table_name = "posthog_test.test_tz_bug_mergetree"
+        table_name = f"{CLICKHOUSE_DATABASE}.test_tz_bug_mergetree"
         sync_execute(f"DROP TABLE IF EXISTS {table_name}")
         sync_execute(f"""
             CREATE TABLE {table_name} (

--- a/posthog/hogql/database/test/test_s3_table_clickhouse.py
+++ b/posthog/hogql/database/test/test_s3_table_clickhouse.py
@@ -12,7 +12,6 @@ from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from posthog.clickhouse.client import sync_execute
-from posthog.settings.data_stores import CLICKHOUSE_DATABASE
 
 MINIO_ENDPOINT = "http://localhost:19000"
 MINIO_CH_ENDPOINT = "http://objectstorage:19000"
@@ -134,7 +133,7 @@ class TestS3ParquetTimezoneConversion(ClickhouseTestMixin, BaseTest):
 
     def test_not_affected_on_mergetree(self):
         """The bug does not affect regular MergeTree tables."""
-        table_name = f"{CLICKHOUSE_DATABASE}.test_tz_bug_mergetree"
+        table_name = "test_tz_bug_mergetree"
         sync_execute(f"DROP TABLE IF EXISTS {table_name}")
         sync_execute(f"""
             CREATE TABLE {table_name} (

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -4020,9 +4020,9 @@ class TestPrinter(BaseTest):
         )
         assert (
             self._with_active_events_table(
-                "SELECT coalesce(dictGetOrNull('posthog_test.channel_definition_dict', 'domain_type', "
+                f"SELECT coalesce(dictGetOrNull('{CLICKHOUSE_DATABASE}.channel_definition_dict', 'domain_type', "
                 "(coalesce(%(hogql_val_0)s, ''), 'source')), "
-                "dictGetOrNull('posthog_test.channel_definition_dict', 'domain_type', "
+                f"dictGetOrNull('{CLICKHOUSE_DATABASE}.channel_definition_dict', 'domain_type', "
                 "(cutToFirstSignificantSubdomain(coalesce(%(hogql_val_0)s, '')), 'source'))) AS domain "
                 f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 50000 SETTINGS "
                 "readonly=2, max_execution_time=10, allow_experimental_object_type=1, "
@@ -4039,9 +4039,9 @@ class TestPrinter(BaseTest):
         )
         assert (
             self._with_active_events_table(
-                "SELECT coalesce(dictGetOrNull('posthog_test.channel_definition_dict', 'type_if_paid', "
+                f"SELECT coalesce(dictGetOrNull('{CLICKHOUSE_DATABASE}.channel_definition_dict', 'type_if_paid', "
                 "(coalesce(%(hogql_val_0)s, ''), 'source')) , "
-                "dictGetOrNull('posthog_test.channel_definition_dict', 'type_if_paid', "
+                f"dictGetOrNull('{CLICKHOUSE_DATABASE}.channel_definition_dict', 'type_if_paid', "
                 "(cutToFirstSignificantSubdomain(coalesce(%(hogql_val_0)s, '')), 'source'))) AS source "
                 f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 50000 SETTINGS "
                 "readonly=2, max_execution_time=10, allow_experimental_object_type=1, "
@@ -4058,7 +4058,7 @@ class TestPrinter(BaseTest):
         )
         assert (
             self._with_active_events_table(
-                "SELECT dictGetOrNull('posthog_test.channel_definition_dict', 'type_if_paid', "
+                f"SELECT dictGetOrNull('{CLICKHOUSE_DATABASE}.channel_definition_dict', 'type_if_paid', "
                 "(coalesce(%(hogql_val_0)s, ''), 'medium')) AS medium "
                 f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS} SETTINGS "
                 "readonly=2, max_execution_time=10, allow_experimental_object_type=1, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1, optimize_min_equality_disjunction_chain_length=4294967295, optimize_rewrite_aggregate_function_with_if=0, optimize_min_inequality_conjunction_chain_length=4294967295, allow_experimental_join_condition=1, use_hive_partitioning=0"
@@ -4073,9 +4073,9 @@ class TestPrinter(BaseTest):
         )
         assert (
             self._with_active_events_table(
-                "SELECT coalesce(dictGetOrNull('posthog_test.channel_definition_dict', 'type_if_organic', "
+                f"SELECT coalesce(dictGetOrNull('{CLICKHOUSE_DATABASE}.channel_definition_dict', 'type_if_organic', "
                 "(coalesce(%(hogql_val_0)s, ''), 'source')), "
-                "dictGetOrNull('posthog_test.channel_definition_dict', 'type_if_organic', "
+                f"dictGetOrNull('{CLICKHOUSE_DATABASE}.channel_definition_dict', 'type_if_organic', "
                 "(cutToFirstSignificantSubdomain(coalesce(%(hogql_val_0)s, '')), 'source'))) AS source "
                 f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 50000 SETTINGS "
                 "readonly=2, max_execution_time=10, allow_experimental_object_type=1, "
@@ -4092,7 +4092,7 @@ class TestPrinter(BaseTest):
         )
         assert (
             self._with_active_events_table(
-                "SELECT dictGetOrNull('posthog_test.channel_definition_dict', 'type_if_organic', "
+                f"SELECT dictGetOrNull('{CLICKHOUSE_DATABASE}.channel_definition_dict', 'type_if_organic', "
                 "(coalesce(%(hogql_val_0)s, ''), 'medium')) AS medium "
                 f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS} SETTINGS "
                 "readonly=2, max_execution_time=10, allow_experimental_object_type=1, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1, optimize_min_equality_disjunction_chain_length=4294967295, optimize_rewrite_aggregate_function_with_if=0, optimize_min_inequality_conjunction_chain_length=4294967295, allow_experimental_join_condition=1, use_hive_partitioning=0"


### PR DESCRIPTION
## Problem

Two test files spell out `posthog_test`, the value of `CLICKHOUSE_DATABASE`. They pass only while the test database carries that exact name.

- `test_printer.py` already imports `CLICKHOUSE_DATABASE` and uses it two assertions further down, then hardcodes the literal in eight others.
- `test_s3_table_clickhouse.py` is worse than a stale string. It builds a real table at the hardcoded name, so a different database name fails at runtime:

```
posthog.errors.CHQueryErrorUnknownDatabase: Code: 81.
DB::Exception: Database posthog_test does not exist.
```

## Changes

- The printer assertions interpolate `CLICKHOUSE_DATABASE`, matching what the same file already does for the exchange rate dictionary.
- The S3 test drops the qualification instead of parameterizing it. `sync_execute` connects with `database=settings.CLICKHOUSE_DATABASE`, so an unqualified name already lands in the right database. That removes a line and an import rather than adding one.
- Coverage does not change. The same tests run and assert the same SQL.

## How did you test this code?

`pytest posthog/hogql/database/test/test_s3_table_clickhouse.py` passes, 4 tests. The five channel-type cases in `test_printer.py` pass. Both resolve to the strings they asserted before, because the setting is `posthog_test` in a normal run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code; skills invoked: /writing-tests, /writing-pr-descriptions, /simplify.
- Found while trialling two pytest workers per shard, where each worker gets its own suffixed database. The coupling is worth removing on its own.
- A review pass caught that the S3 test never needed the database name at all, which is why that file shrinks.

https://claude.ai/code/session_018yEkBhpQFkw1rdCwRwKrdP
