### PR TITLE
chore(csp): accept any https image host

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -1218,7 +1218,18 @@ class CSPMiddleware:
                 "child-src 'none'",
                 "object-src 'none'",
                 "media-src https://res.cloudinary.com",
-                f"img-src 'self' data: {resource_url} https://posthog.com https://www.gravatar.com https://res.cloudinary.com https://platform.slack-edge.com https://raw.githubusercontent.com",
+                # `https:` is here for the OAuth authorize page, which renders an application's icon
+                # from a URL its registrant supplied. There is no allowlist that covers those, so
+                # until we serve them ourselves the directive has to accept any host.
+                #
+                # The named origins below are the set we actually load images from, and `https:`
+                # makes them redundant. They stay so that removing `https:` is a one-line change
+                # rather than an archaeology exercise.
+                #
+                # Do not promote this to an enforced header as-is. An open `img-src` is an
+                # exfiltration channel: an attacker who injects markup but cannot run script still
+                # gets a beacon out through an image URL.
+                f"img-src 'self' data: https: {resource_url} https://posthog.com https://www.gravatar.com https://res.cloudinary.com https://platform.slack-edge.com https://raw.githubusercontent.com",
                 "frame-ancestors https://posthog.com https://preview.posthog.com https://vercel.com",
                 f"connect-src 'self' https://www.posthogstatus.com {resource_url} {connect_debug_url} https://raw.githubusercontent.com https://api.github.com",
                 # allow all sites for displaying heatmaps


### PR DESCRIPTION
## Problem

The OAuth authorize page shows the icon of the application asking for access. The application's registrant supplies that URL, so no allowlist covers it, and `img-src` reports every one:

| Route | Reports per week | Distinct hosts |
| --- | --- | --- |
| `us.posthog.com/oauth/<id>` | 1,781 | 19 |
| `eu.posthog.com/oauth/<id>` | 907 | 8 |

The icon is worth keeping. It is how someone recognises the application they are about to authorise, which makes it an anti-phishing signal on a consent screen rather than decoration.

## Changes

- Nothing changes for a user. The app policy is report-only, so no image is blocked before or after this PR.
- Add `https:` to `img-src`.
- Keep the named origins. `https:` makes them redundant today, but they record what we actually load, so removing `https:` later is a one-line change rather than an archaeology exercise.

> [!WARNING]
> Do not promote this to an enforced header as it stands. An open `img-src` is an exfiltration channel: an attacker who injects markup but cannot run script still gets a beacon out through an image URL, and it undercuts a tight `connect-src` for one who can.

The real fix is serving the icons ourselves — fetch once at registration, store the bytes, serve them under the application's id. Then the browser requests an opaque path on our own origin and `img-src` needs one host instead of an open set. That is a migration, a fetch path with SSRF validation, object storage and a backfill, so it is not this PR.

Proxying the icons through a third party was considered and rejected. `res.cloudinary.com` is already in our `img-src`, and its fetch mode would turn that allowlisted origin into an open proxy reachable from a single injected tag, with no CSP diff for a reviewer to see. That is worse than an open `img-src`, which at least stays visible in the header.

## How did you test this code?

No new tests. The change adds one source expression to one directive, and the existing `TestCSPMiddleware` cases already assert the header's shape.

Ran `posthog/test/test_middleware.py::TestCSPMiddleware` locally: 10 passed.

Not checked: nothing to check at runtime. The policy is report-only, so the only observable effect is that `img-src` reports stop arriving.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this PR. Skills invoked: `/writing-pr-descriptions`, `superpowers:using-git-worktrees`.

This came out of classifying seven days of `$csp_violation` reports across both cloud regions. `img-src` carries about 28,600 reports a week; the replay player accounts for 63% of them and is handled separately in #94400. The OAuth icons are the largest remaining source that no allowlist can ever cover, which is why this directive opens rather than growing another entry.

About 2,850 `img-src` reports a week are still unclassified — neither OAuth icons nor confirmed browser-extension noise. They need identifying before anyone reasons about enforcing this directive.

https://claude.ai/code/session_01HgRWtAJHBL2hQArpctxYr4
