### PR TITLE
feat(canvas): add MCP tool for moving canvases

### DIFF
--- a/products/canvas/backend/tests/test_canvas_api.py
+++ b/products/canvas/backend/tests/test_canvas_api.py
@@ -178,7 +178,7 @@ class TestCanvasCrud(CanvasAPIBaseTest):
         assert response.json()["channel"] == str(destination.id)
         assert Canvas.objects.unscoped().get(id=canvas_id).channel_id == destination.id
 
-    def test_cannot_file_canvas_to_another_users_personal_channel(self):
+    def test_cannot_file_canvas_to_invisible_personal_channel(self):
         canvas_id = self._create_canvas()
         other_user = self._create_user("canvas-owner@example.com")
         with team_scope(self.team.id):
@@ -196,6 +196,32 @@ class TestCanvasCrud(CanvasAPIBaseTest):
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == "Channel not found in this team."
+        assert Canvas.objects.unscoped().get(id=canvas_id).channel_id == self.channel.id
+
+    def test_task_bound_sandbox_cannot_move_canvas_to_another_space(self):
+        canvas_id = self._create_canvas()
+        bound_task = Task.objects.create(
+            team=self.team,
+            channel=self.channel,
+            created_by=self.user,
+            title="Bound",
+            description="d",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+        with team_scope(self.team.id):
+            destination = Channel.objects.create(team=self.team, name="destination", created_by=self.user)
+        client = self._sandbox_client(bound_task.id)
+
+        response = client.patch(
+            f"/api/projects/{self.team.id}/canvases/{canvas_id}/",
+            {"channel_id": str(destination.id)},
+            format="json",
+            HTTP_X_POSTHOG_TASK_ID=str(bound_task.id),
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.json()["detail"] == "This sandbox can file canvases only in its task's space."
         assert Canvas.objects.unscoped().get(id=canvas_id).channel_id == self.channel.id
 
     def test_personal_channel_canvases_are_invisible_to_other_users(self):

--- a/products/canvas/mcp/tools.yaml
+++ b/products/canvas/mcp/tools.yaml
@@ -220,6 +220,28 @@ tools:
                 description: Only return canvases of this kind. kind=component lists the component store.
             search:
                 description: Case-insensitive match on name and description — use to find store components by what they show.
+    canvas-move:
+        operation: canvases_partial_update
+        enabled: true
+        scopes:
+            - canvas:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Move canvas
+        description: >
+            Move a canvas to a visible destination space. The canvas and its full version history stay intact, but any
+            pin in the current space is cleared. Only the canvas creator can move it. A sandbox task can move a canvas
+            only within its own space; an attempted cross-space move returns 403.
+        include_params:
+            - channel_id
+        param_overrides:
+            id:
+                description: ID of the canvas to move.
+            channel_id:
+                description: ID of the visible destination space.
+                required: true
     canvas-promote-create:
         operation: canvases_promote_create
         enabled: true
@@ -371,28 +393,6 @@ tools:
     canvases-home-create:
         operation: canvases_home_create
         enabled: false
-    canvas-move:
-        operation: canvases_partial_update
-        enabled: true
-        scopes:
-            - canvas:write
-        annotations:
-            readOnly: false
-            destructive: false
-            idempotent: true
-        title: Move canvas
-        description: >
-            Move a canvas to a visible destination space. The canvas and its full version history stay intact, but any
-            pin in the current space is cleared. Only the canvas creator can move it. A sandbox task can move a canvas
-            only within its own space; an attempted cross-space move returns 403.
-        include_params:
-            - channel_id
-        param_overrides:
-            id:
-                description: ID of the canvas to move.
-            channel_id:
-                description: ID of the visible destination space.
-                required: true
     canvases-retrieve:
         operation: canvases_retrieve
         enabled: false

--- a/products/canvas/mcp/tools.yaml
+++ b/products/canvas/mcp/tools.yaml
@@ -371,9 +371,28 @@ tools:
     canvases-home-create:
         operation: canvases_home_create
         enabled: false
-    canvases-partial-update:
+    canvas-move:
         operation: canvases_partial_update
-        enabled: false
+        enabled: true
+        scopes:
+            - canvas:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Move canvas
+        description: >
+            Move a canvas to a visible destination space. The canvas and its full version history stay intact, but any
+            pin in the current space is cleared. Only the canvas creator can move it. A sandbox task can move a canvas
+            only within its own space; an attempted cross-space move returns 403.
+        include_params:
+            - channel_id
+        param_overrides:
+            id:
+                description: ID of the canvas to move.
+            channel_id:
+                description: ID of the visible destination space.
+                required: true
     canvases-retrieve:
         operation: canvases_retrieve
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1212,6 +1212,20 @@
             "readOnlyHint": true
         }
     },
+    "canvas-move": {
+        "description": "Move a canvas to a visible destination space. The canvas and its full version history stay intact, but any pin in the current space is cleared. Only the canvas creator can move it. A sandbox task can move a canvas only within its own space; an attempted cross-space move returns 403.",
+        "category": "Canvas",
+        "feature": "canvas",
+        "summary": "Move canvas",
+        "title": "Move canvas",
+        "required_scopes": ["canvas:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "canvas-promote-create": {
         "description": "Make a draft version (staged with canvas-draft-create) the canvas's live head. A draft whose build is already ready goes live immediately with no rebuild; otherwise a fresh build is queued. Pass `expected_current_version_id` — the live `current_version_id` from canvas-source-retrieve — so a concurrent change is rejected with 409 version_conflict instead of overwritten. A 429 means the team's build capacity is exhausted; wait and retry. Returns the now-live build. This is the only way a draft reaches the head: revert does not act on drafts.",
         "category": "Canvas",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1227,6 +1227,20 @@
             "readOnlyHint": true
         }
     },
+    "canvas-move": {
+        "description": "Move a canvas to a visible destination space. The canvas and its full version history stay intact, but any pin in the current space is cleared. Only the canvas creator can move it. A sandbox task can move a canvas only within its own space; an attempted cross-space move returns 403.",
+        "category": "Canvas",
+        "feature": "canvas",
+        "summary": "Move canvas",
+        "title": "Move canvas",
+        "required_scopes": ["canvas:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "canvas-promote-create": {
         "description": "Make a draft version (staged with canvas-draft-create) the canvas's live head. A draft whose build is already ready goes live immediately with no rebuild; otherwise a fresh build is queued. Pass `expected_current_version_id` — the live `current_version_id` from canvas-source-retrieve — so a concurrent change is rejected with 409 version_conflict instead of overwritten. A 429 means the team's build capacity is exhausted; wait and retry. Returns the now-live build. This is the only way a draft reaches the head: revert does not act on drafts.",
         "category": "Canvas",

--- a/services/mcp/src/generated/canvas/api.ts
+++ b/services/mcp/src/generated/canvas/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 16 enabled ops
+ * PostHog API - MCP 17 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -78,6 +78,37 @@ export const CanvasesCreateBody = () => zod
             .describe('Canvas template identifier.'),
     })
     .describe('Payload for creating a new, empty canvas in a channel.')
+
+/**
+ * Update canvas metadata, including the space it belongs to.
+ */
+export const CanvasesPartialUpdateParams = () => zod.object({
+    id: zod.string().describe('A UUID string identifying this canvas.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const canvasesPartialUpdateBodyNameMax = 400
+
+export const CanvasesPartialUpdateBody = () => zod
+    .object({
+        name: zod.string().max(canvasesPartialUpdateBodyNameMax).optional().describe('Updated display name.'),
+        context: zod.string().optional().describe('Updated author context markdown.'),
+        description: zod
+            .string()
+            .optional()
+            .describe('Updated canvas description (for components, the store-search text).'),
+        channel_id: zod.string().optional().describe('Id of the space the canvas belongs to.'),
+        pinned: zod.boolean().optional().describe('Whether the canvas is pinned in its channel.'),
+        generation_task_id: zod
+            .string()
+            .nullish()
+            .describe('Task currently generating this canvas, or null to clear it.'),
+    })
+    .describe('Writable canvas fields: metadata only — source changes go through publish\/edit.')
 
 /**
  * Read the canvas's build lifecycle: live pointers plus recent builds.

--- a/services/mcp/src/lib/instructions.ts
+++ b/services/mcp/src/lib/instructions.ts
@@ -241,6 +241,7 @@ export class ToolDomainExtractor {
         'end',
         'freeze',
         'launch',
+        'move',
         'patch',
         'pause',
         'publish',

--- a/services/mcp/src/tools/generated/canvas.ts
+++ b/services/mcp/src/tools/generated/canvas.ts
@@ -518,6 +518,45 @@ const canvasValidateCreate = (): ToolBase<
     },
 })
 
+const CanvasMoveSchema = () => {
+    const CanvasesPartialUpdateBody = orvalSchemas.CanvasesPartialUpdateBody()
+    const CanvasesPartialUpdateParams = orvalSchemas.CanvasesPartialUpdateParams()
+    return CanvasesPartialUpdateParams.omit({ project_id: true })
+        .extend(
+            CanvasesPartialUpdateBody.omit({
+                name: true,
+                context: true,
+                description: true,
+                pinned: true,
+                generation_task_id: true,
+            }).shape
+        )
+        .extend({
+            id: CanvasesPartialUpdateParams.shape['id'].describe('ID of the canvas to move.'),
+            channel_id: CanvasesPartialUpdateBody.shape['channel_id']
+                .unwrap()
+                .describe('ID of the visible destination space.'),
+        })
+}
+
+const canvasMove = (): ToolBase<ReturnType<typeof CanvasMoveSchema>, Schemas.Canvas> => ({
+    name: 'canvas-move',
+    schema: CanvasMoveSchema(),
+    handler: async (context: Context, params: z.infer<ReturnType<typeof CanvasMoveSchema>>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.channel_id !== undefined) {
+            body['channel_id'] = params.channel_id
+        }
+        const result = await context.api.request<Schemas.Canvas>({
+            method: 'PATCH',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/canvases/${encodeURIComponent(String(params.id))}/`,
+            body,
+        })
+        return result
+    },
+})
+
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'canvas-builds-retrieve': canvasBuildsRetrieve,
     'canvas-create': canvasCreate,
@@ -535,4 +574,5 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'canvas-state-retrieve': canvasStateRetrieve,
     'canvas-state-set': canvasStateSet,
     'canvas-validate-create': canvasValidateCreate,
+    'canvas-move': canvasMove,
 }

--- a/services/mcp/src/tools/generated/canvas.ts
+++ b/services/mcp/src/tools/generated/canvas.ts
@@ -311,6 +311,45 @@ const canvasList = (): ToolBase<ReturnType<typeof CanvasListSchema>, Schemas.Pag
     },
 })
 
+const CanvasMoveSchema = () => {
+    const CanvasesPartialUpdateBody = orvalSchemas.CanvasesPartialUpdateBody()
+    const CanvasesPartialUpdateParams = orvalSchemas.CanvasesPartialUpdateParams()
+    return CanvasesPartialUpdateParams.omit({ project_id: true })
+        .extend(
+            CanvasesPartialUpdateBody.omit({
+                name: true,
+                context: true,
+                description: true,
+                pinned: true,
+                generation_task_id: true,
+            }).shape
+        )
+        .extend({
+            id: CanvasesPartialUpdateParams.shape['id'].describe('ID of the canvas to move.'),
+            channel_id: CanvasesPartialUpdateBody.shape['channel_id']
+                .unwrap()
+                .describe('ID of the visible destination space.'),
+        })
+}
+
+const canvasMove = (): ToolBase<ReturnType<typeof CanvasMoveSchema>, Schemas.Canvas> => ({
+    name: 'canvas-move',
+    schema: CanvasMoveSchema(),
+    handler: async (context: Context, params: z.infer<ReturnType<typeof CanvasMoveSchema>>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.channel_id !== undefined) {
+            body['channel_id'] = params.channel_id
+        }
+        const result = await context.api.request<Schemas.Canvas>({
+            method: 'PATCH',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/canvases/${encodeURIComponent(String(params.id))}/`,
+            body,
+        })
+        return result
+    },
+})
+
 const CanvasPromoteCreateSchema = () => {
     const CanvasesPromoteCreateBody = orvalSchemas.CanvasesPromoteCreateBody()
     const CanvasesPromoteCreateParams = orvalSchemas.CanvasesPromoteCreateParams()
@@ -518,45 +557,6 @@ const canvasValidateCreate = (): ToolBase<
     },
 })
 
-const CanvasMoveSchema = () => {
-    const CanvasesPartialUpdateBody = orvalSchemas.CanvasesPartialUpdateBody()
-    const CanvasesPartialUpdateParams = orvalSchemas.CanvasesPartialUpdateParams()
-    return CanvasesPartialUpdateParams.omit({ project_id: true })
-        .extend(
-            CanvasesPartialUpdateBody.omit({
-                name: true,
-                context: true,
-                description: true,
-                pinned: true,
-                generation_task_id: true,
-            }).shape
-        )
-        .extend({
-            id: CanvasesPartialUpdateParams.shape['id'].describe('ID of the canvas to move.'),
-            channel_id: CanvasesPartialUpdateBody.shape['channel_id']
-                .unwrap()
-                .describe('ID of the visible destination space.'),
-        })
-}
-
-const canvasMove = (): ToolBase<ReturnType<typeof CanvasMoveSchema>, Schemas.Canvas> => ({
-    name: 'canvas-move',
-    schema: CanvasMoveSchema(),
-    handler: async (context: Context, params: z.infer<ReturnType<typeof CanvasMoveSchema>>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const body: Record<string, unknown> = {}
-        if (params.channel_id !== undefined) {
-            body['channel_id'] = params.channel_id
-        }
-        const result = await context.api.request<Schemas.Canvas>({
-            method: 'PATCH',
-            path: `/api/projects/${encodeURIComponent(String(projectId))}/canvases/${encodeURIComponent(String(params.id))}/`,
-            body,
-        })
-        return result
-    },
-})
-
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'canvas-builds-retrieve': canvasBuildsRetrieve,
     'canvas-create': canvasCreate,
@@ -567,6 +567,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'canvas-layout-patch': canvasLayoutPatch,
     'canvas-layout-publish': canvasLayoutPublish,
     'canvas-list': canvasList,
+    'canvas-move': canvasMove,
     'canvas-promote-create': canvasPromoteCreate,
     'canvas-publish-create': canvasPublishCreate,
     'canvas-publish-current-version': canvasPublishCurrentVersion,
@@ -574,5 +575,4 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'canvas-state-retrieve': canvasStateRetrieve,
     'canvas-state-set': canvasStateSet,
     'canvas-validate-create': canvasValidateCreate,
-    'canvas-move': canvasMove,
 }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-move.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-move.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "channel_id": {
+            "description": "ID of the visible destination space.",
+            "type": "string"
+        },
+        "id": {
+            "description": "ID of the canvas to move.",
+            "type": "string"
+        }
+    },
+    "required": ["id", "channel_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/canvas-move-tool.test.ts
+++ b/services/mcp/tests/unit/canvas-move-tool.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+
+import { GENERATED_TOOL_MAP } from '@/tools/generated'
+import { getToolDefinition } from '@/tools/toolDefinitions'
+import type { Context } from '@/tools/types'
+
+describe('canvas-move tool', () => {
+    it('is discoverable with only the required canvas and destination ids', () => {
+        const tool = GENERATED_TOOL_MAP['canvas-move']?.()
+        expect(tool, 'canvas-move is missing from the generated tool map').not.toBeUndefined()
+
+        const schema = z.toJSONSchema(tool!.schema, { io: 'input', reused: 'inline' }) as {
+            properties?: Record<string, unknown>
+            required?: string[]
+        }
+
+        expect(Object.keys(schema.properties ?? {}).sort()).toEqual(['channel_id', 'id'])
+        expect(schema.required?.sort()).toEqual(['channel_id', 'id'])
+    })
+
+    it('declares a reversible, idempotent canvas write', () => {
+        const definition = getToolDefinition('canvas-move')
+
+        expect(definition.description).toContain('full version history stay intact')
+        expect(definition.description).toContain('pin in the current space is cleared')
+        expect(definition.required_scopes).toEqual(['canvas:write'])
+        expect(definition.annotations?.readOnlyHint).toBe(false)
+        expect(definition.annotations?.destructiveHint).toBe(false)
+        expect(definition.annotations?.idempotentHint).toBe(true)
+    })
+
+    it('patches only the destination space', async () => {
+        const request = vi.fn().mockResolvedValue({
+            id: 'canvas-1',
+            channel: 'space-2',
+            pinned: false,
+        })
+        const context = {
+            api: { request },
+            stateManager: { getProjectId: vi.fn().mockResolvedValue('17') },
+        } as unknown as Context
+
+        const result = await GENERATED_TOOL_MAP['canvas-move']!().handler(context, {
+            id: 'canvas-1',
+            channel_id: 'space-2',
+        })
+
+        expect(request).toHaveBeenCalledWith({
+            method: 'PATCH',
+            path: '/api/projects/17/canvases/canvas-1/',
+            body: { channel_id: 'space-2' },
+        })
+        expect(result).toMatchObject({ id: 'canvas-1', channel: 'space-2', pinned: false })
+    })
+})

--- a/services/mcp/tests/unit/instructions.test.ts
+++ b/services/mcp/tests/unit/instructions.test.ts
@@ -166,6 +166,7 @@ describe('buildToolDomainsBlock', () => {
             'end',
             'freeze',
             'launch',
+            'move',
             'patch',
             'pause',
             'publish',


### PR DESCRIPTION
## Problem

**Why:** Agents cannot move an existing canvas between spaces through MCP, although the canvas API supports this action.

A raw sandbox call must stay within its assigned space.

Refs #88718

## Changes

- Agents can call `canvas-move` with only the canvas ID and destination space ID.
- The move preserves the canvas and version history, but clears its space pin.
- The existing API still enforces creator access, destination visibility, and sandbox space boundaries.
- Generated MCP files provide the handler and catalog entry. There is no UI change.

## How did you test this code?

- Added MCP coverage for discovery, the restricted schema, annotations, and the PATCH request.
- Added API coverage for hidden destinations and sandbox rejection. The successful move and pin tests also passed.
- No manual UI test was needed because this PR has no UI change.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The generated tool description documents the move behavior and its access limits.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used the repository generators and GitHub CLI. Skills: `/implementing-mcp-tools`, `/posthog-desktop`, `/writing-pr-descriptions`, and `/writing-simplified-technical-english`.

The generated canvas files overlap with [#86147](https://github.com/PostHog/posthog/pull/86147), which adds parameter aliases for other canvas tools.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
