### PR TITLE
fix(warehouse-sources): only read a fan-out parent worth opening

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/stripe/test_stripe_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/stripe/test_stripe_source.py
@@ -1191,6 +1191,12 @@ FANOUT_GATE = (
     "products.warehouse_sources.backend.temporal.data_imports.workflow_activities."
     "import_data_sync.is_fanout_warehouse_reuse_enabled"
 )
+# The mock account holds a handful of customers, far under the production size floor. These tests
+# cover the conversion itself; the floor is policy, covered by the gate's own unit tests.
+PARENT_SIZE_FLOOR = (
+    "products.warehouse_sources.backend.temporal.data_imports.workflow_activities."
+    "import_data_sync.MIN_WAREHOUSE_PARENT_ROWS"
+)
 
 
 @sync_to_async
@@ -1247,7 +1253,7 @@ async def _sync_parent_then_child(team, source, parent, child, mock_stripe_api, 
     calls_before = len(mock_stripe_api.get_all_api_calls())
 
     expected_rows = sum(len(rows) for rows in CUSTOMER_BALANCE_TRANSACTIONS.values())
-    with mock.patch(FANOUT_GATE, return_value=reuse_enabled):
+    with mock.patch(FANOUT_GATE, return_value=reuse_enabled), mock.patch(PARENT_SIZE_FLOOR, 0):
         response = await run_external_data_job_workflow(
             team=team,
             external_data_source=source,

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -145,8 +145,19 @@ WAREHOUSE_READABLE_PARENT_SYNC_TYPES = frozenset(
 )
 
 
+# Opening the parent's Delta table costs a few seconds that paging the vendor listing does not:
+# resolve the table, read the transaction log, start the scan. That cost is fixed, while the
+# listing it replaces grows with the parent, so a small parent pays more than it saves. Measured
+# after the conversion shipped, the swap costs ~3s a run against a listing of ~0.5s per 100-row
+# page, putting break-even near 700 rows. This floor sits above it with margin.
+MIN_WAREHOUSE_PARENT_ROWS = 1_000
+
+
 def _parent_unusable_reason(parent: ExternalDataSchema | None) -> str | None:
-    """Why a fan-out child can't read this parent from the warehouse, or None when it can."""
+    """Why a fan-out child can't read this parent from the warehouse, or None when it can.
+
+    Reads the parent's row count, so callers have to run this where a query is allowed.
+    """
     if parent is None:
         return "missing"
     if not parent.should_sync:
@@ -155,6 +166,11 @@ def _parent_unusable_reason(parent: ExternalDataSchema | None) -> str | None:
         return "unsupported_sync_type"
     if not parent.initial_sync_complete:
         return "no_initial_sync"
+    parent_rows = parent.table.row_count if parent.table else None
+    if parent_rows is None or parent_rows < MIN_WAREHOUSE_PARENT_ROWS:
+        # An unknown count is treated as too small: it cannot be shown to pay for the read, and
+        # the API path it falls back to is what the child does today anyway.
+        return "parent_too_small"
     return None
 
 
@@ -184,7 +200,7 @@ async def _warehouse_parent_reuse_available(
 
     for parent_name in required_parents:
         parent = await database_sync_to_async_pool(get_schema_if_exists)(parent_name, team_id, source_id)
-        unusable_reason = _parent_unusable_reason(parent)
+        unusable_reason = await database_sync_to_async_pool(_parent_unusable_reason)(parent)
         if unusable_reason is not None:
             await logger.ainfo(
                 "data_imports.fanout_parent_unusable",

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -762,24 +762,27 @@ def _parent(
     should_sync: bool,
     initial_sync_complete: bool,
     sync_type: str = ExternalDataSchema.SyncType.INCREMENTAL,
+    row_count: int | None = 50_000,
 ) -> mock.MagicMock:
     parent = mock.MagicMock()
     parent.should_sync = should_sync
     parent.initial_sync_complete = initial_sync_complete
     parent.sync_type = sync_type
     parent.is_incremental = sync_type == ExternalDataSchema.SyncType.INCREMENTAL
+    parent.table = mock.MagicMock(row_count=row_count) if row_count is not None else None
     return parent
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "parent",
-    [None, "disabled", "never_synced", "append_mode", "cdc_mode"],
+    [None, "disabled", "never_synced", "append_mode", "cdc_mode", "too_small", "unknown_size"],
 )
 async def test_unusable_parent_falls_back_to_the_api_path(parent):
     # A child enabled without its parent is a config that syncs today, so turning the flag on
     # must leave it working: fall back to the parent API instead of failing the run. Append and
-    # CDC parents hold more than one row per key, so the reader must not stream them either.
+    # CDC parents hold more than one row per key, so the reader must not stream them either. A
+    # parent under the size floor costs more to open than the listing it would replace.
     parent_obj = None
     if parent == "disabled":
         parent_obj = _parent(should_sync=False, initial_sync_complete=True)
@@ -789,6 +792,10 @@ async def test_unusable_parent_falls_back_to_the_api_path(parent):
         parent_obj = _parent(should_sync=True, initial_sync_complete=True, sync_type=ExternalDataSchema.SyncType.APPEND)
     elif parent == "cdc_mode":
         parent_obj = _parent(should_sync=True, initial_sync_complete=True, sync_type=ExternalDataSchema.SyncType.CDC)
+    elif parent == "too_small":
+        parent_obj = _parent(should_sync=True, initial_sync_complete=True, row_count=999)
+    elif parent == "unknown_size":
+        parent_obj = _parent(should_sync=True, initial_sync_complete=True, row_count=None)
 
     with (
         mock.patch.object(module, "database_sync_to_async_pool", new=_passthrough),


### PR DESCRIPTION
## Problem

- Teams with a small Stripe customer list saw their `CustomerBalanceTransaction` syncs get **slower** after warehouse parent reuse ([#88745](https://github.com/PostHog/posthog/pull/88745)) shipped, not faster.
- Opening the parent's Delta table has a fixed cost the vendor listing does not: resolve the table, read the transaction log, start the scan. Measured against a control cohort on the same parent sync types, the swap costs about **3 seconds a run** once background drift is subtracted.
- The listing it replaces costs roughly 0.5 seconds per 100-row page, so it only pays once the parent is big enough. Break-even lands near 700 rows. Every converted parent below that got slower; the large ones ran 2-3x faster, as intended.
- Most fan-out parents are small, so as it stands the change costs the majority of runs a few seconds each to win back a minority.

## Changes

- A fan-out child now falls back to the parent API when the parent holds fewer than `MIN_WAREHOUSE_PARENT_ROWS` (1,000) rows, reported as `parent_too_small`. Large parents are unaffected and keep the full saving.
- The floor is deliberately above break-even rather than at it. A parent just over the line saves almost nothing, so there is no value in shaving it, and a margin absorbs error in the per-page estimate.
- An unknown row count counts as too small. It cannot be shown to pay for the read, and the fallback is what the child does today anyway.
- `_parent_unusable_reason` now runs inside the sync pool, because reading the row count touches the parent's table row. It was previously called from async context, where a lazy relation access raises `SynchronousOnlyOperation`.

> [!NOTE]
> This narrows an existing optimization rather than adding one. It cannot break a schema that syncs today: refusing a parent falls the run back to the API path, which is what every unconverted child already does.

## How did you test this code?

**Unit — `test_unusable_parent_falls_back_to_the_api_path`.** Two cases added to the existing parameterized list: a parent under the floor, and a parent whose row count is unknown. Both catch a revert of the floor — removing it fails exactly those two while the five pre-existing cases still pass. The `_parent` helper gained a `row_count` argument defaulting well above the floor, so the existing eligible-parent cases keep asserting what they always did.

**End to end.** The Stripe e2e mock account holds a handful of customers, far under the floor, so every fan-out test would otherwise have fallen back and stopped exercising the conversion. Those tests patch the floor to 0: they cover the conversion mechanism, and the floor is policy covered by the gate's own unit tests. Both facts are recorded next to the patch so the next reader does not mistake it for a workaround.

Full Stripe e2e suite and the gate's unit suite both pass. `mypy --cache-fine-grained .` reports no errors in `products/warehouse_sources`; the repo-wide count is unchanged from master.

**Not done:** no live verification that the floor restores the previous timings on the affected schemas. That needs a deploy, and it is the first thing to check afterwards.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/writing-code-comments`.

This came out of reading production data after #88745 deployed, rather than from review. The conversion behaved exactly as modelled on large parents and regressed small ones, which the original estimate missed by assuming the Delta read cost about a second when it costs three or four. The regression was isolated by comparing converted schemas against unconverted ones sharing the same parent sync types, which separated the change's effect from a background drift affecting both.

The threshold is a single constant rather than anything adaptive, on the grounds that the break-even is a property of the two mechanisms and not of a given source. If a future fan-out parent has a much cheaper listing, this becomes a per-source value.
