### PR TITLE
fix(queries): re-ask for a result when the async status record has expired

### DIFF
--- a/frontend/src/queries/query.test.ts
+++ b/frontend/src/queries/query.test.ts
@@ -283,6 +283,51 @@ describe('query', () => {
         })
     })
 
+    describe('expired async status record', () => {
+        const query = { kind: NodeKind.EventsQuery, select: ['*'] } as EventsQuery
+        const asyncResponse = { query_status: { id: 'expired-query-id', complete: false } }
+        const notFound = (): ApiError =>
+            new ApiError('Query expired-query-id not found for team 1', 404, undefined, {
+                detail: 'Query expired-query-id not found for team 1',
+            })
+
+        afterEach(() => {
+            jest.restoreAllMocks()
+        })
+
+        it('asks again without forcing a recompute when the record of its own query is gone', async () => {
+            jest.spyOn(api.queryStatus, 'get').mockRejectedValueOnce(notFound())
+            const querySpy = jest
+                .spyOn(api, 'query')
+                .mockResolvedValueOnce(asyncResponse as any)
+                .mockResolvedValueOnce({ results: ['cached'] } as any)
+
+            await expect(performQuery(query, undefined, 'force_async')).resolves.toMatchObject({
+                results: ['cached'],
+            })
+            expect(querySpy).toHaveBeenCalledTimes(2)
+            expect(querySpy.mock.calls[1][1]).toMatchObject({ refresh: 'async' })
+        })
+
+        it('surfaces the 404 when the retry finds no record either', async () => {
+            jest.spyOn(api.queryStatus, 'get').mockRejectedValue(notFound())
+            const querySpy = jest.spyOn(api, 'query').mockResolvedValue(asyncResponse as any)
+
+            await expect(performQuery(query, undefined, 'async')).rejects.toMatchObject({ status: 404 })
+            expect(querySpy).toHaveBeenCalledTimes(2)
+        })
+
+        it('does not start a new query when only polling', async () => {
+            jest.spyOn(api.queryStatus, 'get').mockRejectedValueOnce(notFound())
+            const querySpy = jest.spyOn(api, 'query')
+
+            await expect(
+                performQuery(query, undefined, 'async', 'expired-query-id', undefined, undefined, undefined, true)
+            ).rejects.toMatchObject({ status: 404 })
+            expect(querySpy).not.toHaveBeenCalled()
+        })
+    })
+
     describe('pollForResults error message parsing', () => {
         it('prefers the structured error_code from the query status over one parsed from the message', async () => {
             jest.spyOn(api.queryStatus, 'get').mockRejectedValueOnce({

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -181,7 +181,16 @@ async function executeQuery<N extends DataNode>(
      * (stale-while-revalidate: `is_cached` is true *and* an incomplete `query_status` is
      * attached), return the cached results immediately instead of blocking on the recompute.
      */
-    acceptStaleCache = false
+    acceptStaleCache = false,
+    /**
+     * Ask the backend once more when the async status record of a query this call started has
+     * expired. The backend forgets that record a fixed time after the query finishes
+     * (STATUS_TTL_SECONDS in execute_async.py) but keeps the result in the query cache for days.
+     * A tab that stays hidden past that window resumes polling, gets a 404 for its own query ID,
+     * and would show an error for a result that is one request away. Off on the retry itself, so
+     * a second 404 surfaces instead of looping.
+     */
+    retryOnExpiredStatus = true
 ): Promise<NonNullable<N['response']>> {
     if (!pollOnly) {
         const refreshParam: RefreshType = refresh || 'blocking'
@@ -220,8 +229,30 @@ async function executeQuery<N extends DataNode>(
         }
     }
 
-    const statusResponse = await pollForResults(queryId, methodOptions, setPollResponse)
-    return statusResponse.results
+    try {
+        const statusResponse = await pollForResults(queryId, methodOptions, setPollResponse)
+        return statusResponse.results
+    } catch (e: any) {
+        const statusRecordExpired = e?.status === 404
+        if (pollOnly || !retryOnExpiredStatus || !statusRecordExpired) {
+            throw e
+        }
+        // The forced recompute already ran, so the retry only needs the cached result.
+        const retryRefresh: RefreshType | undefined = refresh === 'force_async' ? 'async' : refresh
+        return executeQuery(
+            queryNode,
+            methodOptions,
+            retryRefresh,
+            undefined,
+            setPollResponse,
+            filtersOverride,
+            variablesOverride,
+            false,
+            limitContext,
+            acceptStaleCache,
+            false
+        )
+    }
 }
 
 // Return data for a given query


### PR DESCRIPTION
## Problem

- A person who refreshes an insight or an experiment, switches tabs, and comes back later sees "Query … not found for team …" on every card, and has to click "Try again" to get results that were computed long ago.
- Polling stops while the tab is hidden, and the backend keeps the async status record for a fixed time after the query finishes (`STATUS_TTL_SECONDS` in `execute_async.py`).
- The result is still in the query cache, one request away.

## Changes

- A page that gets a 404 for a query it started itself now asks the backend once more and shows the cached result. A forced refresh retries without forcing, because the recompute already ran.
- Poll-only callers (shared dashboards) and the retry itself still surface the 404, so a real miss cannot loop.
- Nothing looks different while the status record is still there.

## How did you test this code?

- Three cases in `frontend/src/queries/query.test.ts`: the retry returns the cached result and drops `force_async` to `async`; a second 404 surfaces after exactly two requests; poll-only mode never starts a query. No existing test covered a 404 from the status endpoint.
- Not run: the app in a browser.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Claude Fable 5.1), directed by the assignee.
- Skills invoked: /writing-tests, /writing-code-comments, /adopting-generated-api-types, /writing-pr-descriptions.
- Origin: a customer report of "Query not found" cards on an experiment page after the tab sat in the background. Access logs showed the polls arriving after the status record expired, while the results were already cached. No customer material is in this PR.
- Rejected alternative: serving the cached result from the status endpoint when the record is gone. That needs a new query-id-to-cache-key pointer with a longer lifetime, so the client-side retry shipped first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
