### PR TITLE
docs(kafka): correct the assignor migration guidance in ConsumerConfig

### DIFF
--- a/rust/common/kafka/src/config.rs
+++ b/rust/common/kafka/src/config.rs
@@ -117,14 +117,38 @@ pub struct ConsumerConfig {
 
     pub kafka_consumer_max_partition_fetch_bytes: Option<u32>,
 
-    // Consumer group protocol tuning for WarpStream rebalance resilience.
-    // Set to a stable pod identity to enable static group membership (avoids
-    // rebalances when a pod restarts within the session timeout window).
+    // Static group membership (KIP-345): set to a stable identity so a member can
+    // leave and rejoin within session.timeout.ms without triggering a rebalance.
+    //
+    // Only worth setting where the identity really is stable across restarts,
+    // i.e. a StatefulSet ordinal. Do NOT use a Deployment pod name: those change
+    // on every rollout, so the rebalance is triggered anyway, and librdkafka
+    // suppresses the LeaveGroup request for a terminating static member
+    // (rdkafka_cgrp.c, `rd_kafka_cgrp_leave_maybe`), leaving that member's
+    // partitions assigned to a pod that no longer exists until the session
+    // timeout expires. Pair it with a session.timeout.ms large enough to cover
+    // the restart it is meant to mask.
     pub kafka_consumer_group_instance_id: Option<String>,
 
     // Override partition assignment strategy, e.g. "cooperative-sticky" for
-    // incremental rebalancing instead of the default eager "range" protocol.
-    // During migration, use "range,cooperative-sticky" then drop "range".
+    // incremental rebalancing instead of the default eager "range,roundrobin".
+    //
+    // Must name exactly one protocol family. librdkafka refuses to construct a
+    // consumer whose assignor list mixes eager and cooperative strategies —
+    // `rd_kafka_assignor_rebalance_protocol_check` returns ERR__CONFLICT and
+    // client creation fails with "online migration between assignors with
+    // different protocol types is not supported" — so the Java client's
+    // two-phase "range,cooperative-sticky" then drop-"range" upgrade does not
+    // work here.
+    //
+    // Migrating an existing group therefore means one hard switch. While old
+    // (eager-only) and new (cooperative-only) members coexist, the group has no
+    // protocol common to all of them, the coordinator returns
+    // INCONSISTENT_GROUP_PROTOCOL, and the group consumes nothing until the last
+    // old member is gone. librdkafka retries the join on an interval rather than
+    // failing, so it recovers on its own — but plan for a lag spike, and keep the
+    // mixed window short. A group shared with another service cannot be migrated
+    // at all until that service moves too.
     pub kafka_consumer_partition_strategy: Option<String>,
 
     // WarpStream recommends "0" so the kernel auto-tunes TCP buffers.

--- a/rust/common/kafka/src/config.rs
+++ b/rust/common/kafka/src/config.rs
@@ -117,38 +117,27 @@ pub struct ConsumerConfig {
 
     pub kafka_consumer_max_partition_fetch_bytes: Option<u32>,
 
-    // Static group membership (KIP-345): set to a stable identity so a member can
-    // leave and rejoin within session.timeout.ms without triggering a rebalance.
+    // Static group membership (KIP-345): a stable identity lets a member leave and
+    // rejoin within session.timeout.ms without a rebalance.
     //
-    // Only worth setting where the identity really is stable across restarts,
-    // i.e. a StatefulSet ordinal. Do NOT use a Deployment pod name: those change
-    // on every rollout, so the rebalance is triggered anyway, and librdkafka
-    // suppresses the LeaveGroup request for a terminating static member
-    // (rdkafka_cgrp.c, `rd_kafka_cgrp_leave_maybe`), leaving that member's
-    // partitions assigned to a pod that no longer exists until the session
-    // timeout expires. Pair it with a session.timeout.ms large enough to cover
-    // the restart it is meant to mask.
+    // Only set this where the identity survives a restart, e.g. a StatefulSet
+    // ordinal. A Deployment pod name does not: it changes on every rollout, so the
+    // rebalance happens anyway. librdkafka also sends no LeaveGroup for a static
+    // member that stops, so its partitions stay assigned until the session expires.
     pub kafka_consumer_group_instance_id: Option<String>,
 
     // Override partition assignment strategy, e.g. "cooperative-sticky" for
     // incremental rebalancing instead of the default eager "range,roundrobin".
     //
-    // Must name exactly one protocol family. librdkafka refuses to construct a
-    // consumer whose assignor list mixes eager and cooperative strategies —
-    // `rd_kafka_assignor_rebalance_protocol_check` returns ERR__CONFLICT and
-    // client creation fails with "online migration between assignors with
-    // different protocol types is not supported" — so the Java client's
-    // two-phase "range,cooperative-sticky" then drop-"range" upgrade does not
-    // work here.
+    // Name exactly one protocol family. librdkafka rejects a list that mixes eager
+    // and cooperative strategies, and consumer creation fails. The Java client's
+    // two-phase "range,cooperative-sticky" upgrade does not work here.
     //
-    // Migrating an existing group therefore means one hard switch. While old
-    // (eager-only) and new (cooperative-only) members coexist, the group has no
-    // protocol common to all of them, the coordinator returns
-    // INCONSISTENT_GROUP_PROTOCOL, and the group consumes nothing until the last
-    // old member is gone. librdkafka retries the join on an interval rather than
-    // failing, so it recovers on its own — but plan for a lag spike, and keep the
-    // mixed window short. A group shared with another service cannot be migrated
-    // at all until that service moves too.
+    // Migrating a live group is one hard switch. Old and new members share no
+    // common protocol, so the group consumes nothing until the last old member
+    // leaves. librdkafka retries the join instead of failing, so it recovers on its
+    // own. Expect a lag spike. A group shared with another service cannot migrate
+    // until that service moves too.
     pub kafka_consumer_partition_strategy: Option<String>,
 
     // WarpStream recommends "0" so the kernel auto-tunes TCP buffers.


### PR DESCRIPTION
## Summary

The comment on `kafka_consumer_partition_strategy` documents a migration path that librdkafka rejects outright, and following it takes the service down at startup. property-defs-rs did exactly that in April 2026 and has been stuck on the eager default ever since. This corrects the guidance. Comments only, no behaviour change.

## Changes

- Rewrite the `kafka_consumer_partition_strategy` comment: one protocol family only, migration is a single hard switch, expect a pause while eager and cooperative members coexist, and a group shared with another service cannot be migrated until that service moves too.
- Narrow the `kafka_consumer_group_instance_id` guidance to where static membership can actually work (a stable identity, i.e. a StatefulSet ordinal), and warn against Deployment pod names.

## Why this matters

The old comment said:

```rust
// During migration, use "range,cooperative-sticky" then drop "range".
```

That is the Java client's two-phase upgrade. librdkafka refuses to construct a consumer whose assignor list mixes eager and cooperative strategies — `rd_kafka_assignor_rebalance_protocol_check` returns `ERR__CONFLICT` and `rd_kafka_assignors_init` fails with *"online migration between assignors with different protocol types is not supported"*. Since the strategy is applied inside `ClientConfig::create()`, a service that follows this advice fails to build its consumer and exits: a full outage, not a degraded rollout.

The `group_instance_id` note had a related footgun. On a Deployment, pod names change every rollout, so static membership never delivers its benefit — but librdkafka still suppresses the LeaveGroup request for a terminating static member, leaving its partitions assigned to a pod that no longer exists until the session timeout expires.

## Testing

`cargo fmt -p common-kafka --check` and `cargo check -p common-kafka` both pass.
