### PR TITLE
feat(tasks): add recent task authors endpoint

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -7756,6 +7756,55 @@ def provision_default_channels(team_id: int, user_id: int) -> contracts.Provisio
     )
 
 
+CHANNEL_RECENT_TASK_AUTHOR_WINDOW = timedelta(hours=2)
+CHANNEL_RECENT_TASK_AUTHOR_LIMIT = 3
+
+
+def list_recent_task_authors(team_id: int, user_id: int | None) -> list[contracts.ChannelRecentTaskAuthorDTO]:
+    if user_id is None:
+        return []
+
+    cutoff = django_timezone.now() - CHANNEL_RECENT_TASK_AUTHOR_WINDOW
+    tasks = (
+        _visible_task_qs(team_id, user_id)
+        .filter(
+            archived=False,
+            channel_id__isnull=False,
+            created_by_id__isnull=False,
+            internal=False,
+            last_activity_at__gte=cutoff,
+        )
+        .exclude(created_by_id=user_id)
+    )
+    tasks = (
+        tasks.only("id", "channel_id", "created_by_id", "last_activity_at")
+        .prefetch_related(Prefetch("created_by", queryset=User.objects.only(*_TASK_CREATED_BY_FIELDS)))
+        .order_by("channel_id", "created_by_id", "-last_activity_at", "-id")
+        .distinct("channel_id", "created_by_id")
+    )
+
+    authors_by_channel: dict[UUID, list[contracts.ChannelRecentTaskAuthorDTO]] = {}
+    for task in tasks:
+        if task.channel_id is None or task.created_by is None or task.last_activity_at is None:
+            continue
+        user = _user_basic_info(task.created_by)
+        if user is None:
+            continue
+        authors_by_channel.setdefault(task.channel_id, []).append(
+            contracts.ChannelRecentTaskAuthorDTO(
+                channel_id=task.channel_id,
+                user=user,
+                last_activity_at=task.last_activity_at,
+            )
+        )
+
+    recent_authors: list[contracts.ChannelRecentTaskAuthorDTO] = []
+    for authors in authors_by_channel.values():
+        authors.sort(key=lambda author: author.last_activity_at, reverse=True)
+        recent_authors.extend(authors[:CHANNEL_RECENT_TASK_AUTHOR_LIMIT])
+    return recent_authors
+
+
 def list_channels(team_id: int, user_id: int | None) -> list[contracts.ChannelDTO]:
     """Every space the requester can see, by name. ``starred`` reflects the requester's
     stars. Creates nothing, which is what lets a caller gate on a space existing."""

--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -723,6 +723,13 @@ class TaskUserBasicInfo:
 
 
 @dataclass(frozen=True)
+class ChannelRecentTaskAuthorDTO:
+    channel_id: UUID
+    user: TaskUserBasicInfo
+    last_activity_at: datetime
+
+
+@dataclass(frozen=True)
 class SandboxEnvironmentDTO:
     """A sandbox execution environment."""
 

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -28,6 +28,7 @@ from products.tasks.backend.facade.contracts import (
     ChannelDTO,
     ChannelFeedMessageDTO,
     ChannelInstructionsDTO,
+    ChannelRecentTaskAuthorDTO,
     DesktopAccessReason,
     SandboxCustomImageDTO,
     SandboxEnvironmentDTO,
@@ -2081,6 +2082,15 @@ class ChannelSerializer(DataclassSerializer):
             "starred",
             "system_role",
         ]
+
+
+class ChannelRecentTaskAuthorSerializer(DataclassSerializer):
+    channel_id = serializers.UUIDField(help_text="Channel that contains the recently active task.")
+    user = TaskUserBasicInfoSerializer(help_text="User who created a task with recent activity in this channel.")
+    last_activity_at = serializers.DateTimeField(help_text="Most recent activity on a task created by this user.")
+
+    class Meta:
+        dataclass = ChannelRecentTaskAuthorDTO
 
 
 class OnboardingSessionSerializer(serializers.Serializer):

--- a/products/tasks/backend/presentation/views/channels_api.py
+++ b/products/tasks/backend/presentation/views/channels_api.py
@@ -35,6 +35,7 @@ from products.tasks.backend.presentation.serializers import (
     ChannelFeedMessageWriteSerializer,
     ChannelInstructionsSerializer,
     ChannelInstructionsWriteSerializer,
+    ChannelRecentTaskAuthorSerializer,
     ChannelSerializer,
     ChannelStarWriteSerializer,
     ChannelUpdateSerializer,
@@ -99,7 +100,14 @@ class ChannelViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     # GET /instructions/ and /context_generation/ are reads; the PUT/PATCH/DELETE
     # method mappings resolve to their own action names, so they go in the write
     # bucket by name.
-    scope_object_read_actions = ["list", "retrieve", "instructions", "instructions_versions", "context_generation"]
+    scope_object_read_actions = [
+        "list",
+        "retrieve",
+        "instructions",
+        "instructions_versions",
+        "context_generation",
+        "recent_task_authors",
+    ]
     scope_object_write_actions = [
         "create",
         "provision_defaults",
@@ -142,6 +150,25 @@ class ChannelViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         if page is None:
             return Response(ChannelSerializer(channels, many=True).data)
         return paginator.get_paginated_response(ChannelSerializer(page, many=True).data)
+
+    @extend_schema(
+        request=None,
+        responses={
+            200: OpenApiResponse(
+                response=ChannelRecentTaskAuthorSerializer(many=True),
+                description="Recent task authors grouped by channel",
+            )
+        },
+        summary="List recent task authors by channel",
+        description=(
+            "Returns up to three authors per visible channel with task activity in the last two hours. "
+            "The response excludes the requesting user."
+        ),
+    )
+    @action(methods=["GET"], detail=False, url_path="recent_task_authors", pagination_class=None)
+    def recent_task_authors(self, request: Request, **kwargs) -> Response:
+        authors = tasks_facade.list_recent_task_authors(self.team_id, self._user_id())
+        return Response(ChannelRecentTaskAuthorSerializer(authors, many=True).data)
 
     @extend_schema(
         request=None,

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -113,6 +113,83 @@ class ChannelsAPITestCase(TestCase):
         response = self.client.get(self._channels_url())
         self.assertEqual([channel["name"] for channel in response.json()], ["alpha", "bravo", "charlie"])
 
+    def test_recent_task_authors_are_per_channel_and_exclude_self_and_stale_activity(self):
+        now = django_timezone.now()
+        target_channel = Channel.objects.for_team(self.team.id).create(
+            team_id=self.team.id,
+            created_by=self.user,
+            name="target",
+        )
+        other_channel = Channel.objects.for_team(self.team.id).create(
+            team_id=self.team.id,
+            created_by=self.user,
+            name="other",
+        )
+        collaborators = [
+            self.other_user,
+            User.objects.create_user(email="cara@example.com", first_name="Cara", password="password"),
+            User.objects.create_user(email="dan@example.com", first_name="Dan", password="password"),
+            User.objects.create_user(email="eve@example.com", first_name="Eve", password="password"),
+        ]
+        stale_user = User.objects.create_user(email="stale@example.com", first_name="Stale", password="password")
+        for user in [*collaborators[1:], stale_user]:
+            self.organization.members.add(user)
+
+        Task.objects.bulk_create(
+            [
+                Task(
+                    team=self.team,
+                    created_by=author,
+                    channel=target_channel,
+                    title=author.first_name,
+                    description="d",
+                    origin_product=Task.OriginProduct.USER_CREATED,
+                    last_activity_at=now - timedelta(minutes=30 + index * 10),
+                )
+                for index, author in enumerate(collaborators)
+            ]
+            + [
+                Task(
+                    team=self.team,
+                    created_by=self.user,
+                    channel=target_channel,
+                    title="Self",
+                    description="d",
+                    origin_product=Task.OriginProduct.USER_CREATED,
+                    last_activity_at=now - timedelta(minutes=5),
+                ),
+                Task(
+                    team=self.team,
+                    created_by=stale_user,
+                    channel=target_channel,
+                    title="Stale",
+                    description="d",
+                    origin_product=Task.OriginProduct.USER_CREATED,
+                    last_activity_at=now - timedelta(hours=3),
+                ),
+            ]
+            + [
+                Task(
+                    team=self.team,
+                    created_by=self.user,
+                    channel=other_channel,
+                    title=f"Newer {index}",
+                    description="d",
+                    origin_product=Task.OriginProduct.USER_CREATED,
+                    last_activity_at=now - timedelta(seconds=index),
+                )
+                for index in range(101)
+            ]
+        )
+
+        response = self.client.get(f"{self._channels_url()}recent_task_authors/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(
+            [(row["channel_id"], row["user"]["id"]) for row in response.json()],
+            [(str(target_channel.id), user.id) for user in collaborators[:3]],
+        )
+
     def test_personal_channels_are_per_user(self):
         mine = self._provision()["channels"]
         other_client = APIClient()

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -1358,6 +1358,15 @@ export interface ProvisionedChannelsApi {
     general_created: boolean
 }
 
+export interface ChannelRecentTaskAuthorDTOApi {
+    /** Channel that contains the recently active task. */
+    channel_id: string
+    /** User who created a task with recent activity in this channel. */
+    user: TaskUserBasicInfoApi
+    /** Most recent activity on a task created by this user. */
+    last_activity_at: string
+}
+
 export interface TeachingCanvasApi {
     /** The teaching canvas that was resolved or created. */
     canvas_id: string

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -15,6 +15,7 @@ import type {
     ChannelFeedMessageWriteApi,
     ChannelInstructionsDTOApi,
     ChannelInstructionsWriteApi,
+    ChannelRecentTaskAuthorDTOApi,
     ChannelStarWriteApi,
     ChannelWriteApi,
     ConnectionTokenResponseApi,
@@ -1180,6 +1181,24 @@ export const taskChannelsProvisionDefaultsCreate = async (
     return apiMutator<ProvisionedChannelsApi>(getTaskChannelsProvisionDefaultsCreateUrl(projectId), {
         ...options,
         method: 'POST',
+    })
+}
+
+export const getTaskChannelsRecentTaskAuthorsRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/task_channels/recent_task_authors/`
+}
+
+/**
+ * Returns up to three authors per visible channel with task activity in the last two hours. The response excludes the requesting user.
+ * @summary List recent task authors by channel
+ */
+export const taskChannelsRecentTaskAuthorsRetrieve = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<ChannelRecentTaskAuthorDTOApi[]> => {
+    return apiMutator<ChannelRecentTaskAuthorDTOApi[]>(getTaskChannelsRecentTaskAuthorsRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
     })
 }
 

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -360,6 +360,9 @@ tools:
     task-channels-provision-defaults-create:
         operation: task_channels_provision_defaults_create
         enabled: false
+    task-channels-recent-task-authors-retrieve:
+        operation: task_channels_recent_task_authors_retrieve
+        enabled: false
     task-channels-star-create:
         operation: task_channels_star_create
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -17158,6 +17158,15 @@ export namespace Schemas {
       base_version?: number | null;
     }
 
+    export interface ChannelRecentTaskAuthorDTO {
+      /** Channel that contains the recently active task. */
+      channel_id: string;
+      /** User who created a task with recent activity in this channel. */
+      user: TaskUserBasicInfo;
+      /** Most recent activity on a task created by this user. */
+      last_activity_at: string;
+    }
+
     /**
      * Request body for starring/unstarring a channel for the requesting user.
      */


### PR DESCRIPTION
## Problem

Space avatars can miss recent collaborators when the Desktop app samples one project-wide task page.

The Desktop release can ship separately from Django, so the server contract must land first.

## Changes

- The Tasks API returns up to three recent non-self task authors for each visible space.
- The query uses a two-hour activity window and ignores archived and internal tasks.
- Generated frontend and MCP files include the new response contract.
- This PR does not change the UI. [#94390](https://github.com/PostHog/posthog/pull/94390) will use the endpoint after deployment.

Before:

```mermaid
flowchart LR
classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
Desktop{{Desktop}} --> TaskPage[Project task page]
TaskPage --> Sample[Limited client sample]
class Desktop phBlue;
class TaskPage phRed;
class Sample phYellow;
```

After:

```mermaid
flowchart LR
classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
Desktop{{Desktop}} --> RecentAuthors[Recent task authors API]
RecentAuthors --> PerSpace[Complete per-space summary]
class Desktop phBlue;
class RecentAuthors phRed;
class PerSpace phYellow;
```

## How did you test this code?

- Added endpoint coverage for self exclusion, stale activity, per-space limits, and unrelated newer tasks.
- Ran Ruff checks and formatting on all changed Python files.
- Not run: the database-backed endpoint test. CI will run it.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This internal API supports the Desktop presence UI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used `/posthog-desktop`, `/review-hog-resolution-criteria`, `/improving-drf-endpoints`, `/writing-tests`, and `/writing-pr-descriptions`.

Review split the server contract from [#94390](https://github.com/PostHog/posthog/pull/94390) so Django can deploy first.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*