### PR TITLE
fix(data-imports): stop the partition measurement clobbering sync_type_config

### DIFF
--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -714,8 +714,21 @@ class ExternalDataSchema(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
         )
 
     def record_partition_measurement(self, max_partition_bytes: int) -> None:
-        self.sync_type_config["max_partition_bytes"] = max_partition_bytes
-        self._save_sync_type_config()
+        # Merges under the row lock instead of saving the whole in-memory blob. Post-load stamps
+        # `last_full_run_at` through its own locked write moments earlier, so a full-blob save from
+        # the copy this instance loaded at run start silently drops that key — and this runs on
+        # every post-load, so it dropped it on nearly every sync.
+        # Keeps the connection-drop retry the plain save had: this fires once per sync across every
+        # schema, so a transient pooler wait_timeout is worth one retry rather than a lost write.
+        from posthog.temporal.common.utils import retry_on_db_connection_drop  # noqa: PLC0415
+
+        self.sync_type_config = retry_on_db_connection_drop(
+            lambda: update_sync_type_config_keys(
+                self.id,
+                self.team_id,
+                updates={"max_partition_bytes": max_partition_bytes},
+            )
+        )
 
     def set_repartition_pending(self, target: dict[str, Any]) -> None:
         self.sync_type_config["repartition_pending"] = target

--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -714,12 +714,6 @@ class ExternalDataSchema(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
         )
 
     def record_partition_measurement(self, max_partition_bytes: int) -> None:
-        # Merges under the row lock instead of saving the whole in-memory blob. Post-load stamps
-        # `last_full_run_at` through its own locked write moments earlier, so a full-blob save from
-        # the copy this instance loaded at run start silently drops that key — and this runs on
-        # every post-load, so it dropped it on nearly every sync.
-        # Keeps the connection-drop retry the plain save had: this fires once per sync across every
-        # schema, so a transient pooler wait_timeout is worth one retry rather than a lost write.
         from posthog.temporal.common.utils import retry_on_db_connection_drop  # noqa: PLC0415
 
         self.sync_type_config = retry_on_db_connection_drop(

--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -714,6 +714,7 @@ class ExternalDataSchema(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
         )
 
     def record_partition_measurement(self, max_partition_bytes: int) -> None:
+        # Deferred: this module loads during django.setup() and the util pulls in temporalio.
         from posthog.temporal.common.utils import retry_on_db_connection_drop  # noqa: PLC0415
 
         self.sync_type_config = retry_on_db_connection_drop(

--- a/products/warehouse_sources/backend/tests/test_models.py
+++ b/products/warehouse_sources/backend/tests/test_models.py
@@ -322,6 +322,32 @@ class TestSaveSyncTypeConfigRetriesOnConnectionDrop(BaseTest):
                 schema.record_partition_measurement(123)
 
 
+class TestPartitionMeasurementPreservesConcurrentKeys(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.source = ExternalDataSource.objects.create(
+            team_id=self.team.pk,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            status="Completed",
+            source_type="Postgres",
+        )
+
+    def test_a_key_written_after_this_instance_loaded_survives(self) -> None:
+        schema = ExternalDataSchema.objects.create(
+            team_id=self.team.pk, source=self.source, name="users", sync_type_config={"incremental_field": "updated_at"}
+        )
+        stale = ExternalDataSchema.objects.get(id=schema.id)
+
+        update_sync_type_config_keys(schema.id, self.team.pk, updates={"last_full_run_at": "2026-09-03T12:00:00+00:00"})
+        stale.record_partition_measurement(4096)
+
+        schema.refresh_from_db()
+        assert schema.sync_type_config["last_full_run_at"] == "2026-09-03T12:00:00+00:00"
+        assert schema.sync_type_config["max_partition_bytes"] == 4096
+        assert schema.sync_type_config["incremental_field"] == "updated_at"
+
+
 class TestExternalDataSchemaOOMEvent(BaseTest):
     def _source(self, team_id: int | None = None) -> ExternalDataSource:
         return ExternalDataSource.objects.create(


### PR DESCRIPTION
## Problem

- Any key written to a schema's `sync_type_config` during a sync is erased before the run ends, unless the writer happens to run last.
- `record_partition_measurement` saves the whole `sync_type_config` blob from the copy its instance loaded at run start, so it drops anything written to the row since.
- It runs on **every** post-load, inside `_run_post_load_steps`, immediately after `_finalize_sync_bookkeeping` writes `last_full_run_at` through its own row-locked query.
- So the stamp lands and is overwritten out of existence moments later, on nearly every sync.

The first casualty is the fast-return gate from [#86729](https://github.com/PostHog/posthog/pull/86729), which reads that stamp: among schemas meeting every other precondition (past initial sync, watermark set, table present), only **4.4%** carry it.

That post-load really ran for the rest is measurable from the outside. `_publish_queryable_files` updates the warehouse table row and runs immediately *before* the stamp:

| schemas | warehouse table updated in the last 6h |
|---|---|
| carrying the stamp | 98.2% |
| missing the stamp | 56.2% |

If post-load were skipping these runs, that second number would be near zero.

## Changes

- `record_partition_measurement` now merges its key under the row lock via `update_sync_type_config_keys`, so a concurrent key written during the same run survives. Anything reading `sync_type_config` after a sync now sees what the sync actually wrote.
- The connection-drop retry the plain save had is kept. This write fires once per sync on every schema, so a transient pooler `wait_timeout` is still worth one retry rather than a lost write.

> [!NOTE]
> Deliberately narrow. The tempting fix is to make `_save_sync_type_config` itself merge, repairing all six of its callers at once. That breaks two of them: `clear_repartition_pending` and `clear_xmin_state` work by popping keys from the in-memory dict and saving the smaller blob, and a merge helper ignores a local pop, so they would silently stop clearing. The other callers fire on repartition transitions rather than every run, so they are far less likely to collide with a concurrent write. They can move to `removes=` separately.

## How did you test this code?

- One case in `test_models.py`: a key written to the row after an instance loaded survives that instance's partition measurement. Verified it fails without the fix and passes with it, so it reproduces the production bug rather than restating the new code.
- The existing `TestSaveSyncTypeConfigRetriesOnConnectionDrop` cases still pass. They caught a real regression in an earlier revision of this change, which dropped the retry by routing through a helper that has none.
- Ran the warehouse-sources model tests and the repartition controller suite locally.
- Not verified in production: the fix needs a deploy. The percentages above come from reading the replica, not from running this branch.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: no user-facing behavior, API, or config change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Implemented with Claude Code while investigating why the fast-return gate would not open after [#86729](https://github.com/PostHog/posthog/pull/86729) deployed.
- Skills invoked: /writing-tests, /writing-pr-descriptions.
- Several explanations were eliminated first, each by measurement rather than reading: incomplete deploy (coverage was flat over 26h, and an apparent rate spike turned out to be an artifact of grouping a last-write-wins field by hour), a second writer of the field, schemas that had never synced, and a conditional post-load call site. The warehouse-table freshness split above is what proved post-load runs for unstamped schemas, which pointed at a write ordering problem rather than a skipped step.
- The bug class is the one `update_sync_type_config_keys` was introduced to prevent; its docstring already describes this failure. The remaining `_save_sync_type_config` callers are the same hazard at lower frequency.
