### PR TITLE
perf(clickhouse): put the $session_id bloom filter on the bare column

### DIFF
--- a/posthog/clickhouse/hcl/golden/local-multi/data.hcl
+++ b/posthog/clickhouse/hcl/golden/local-multi/data.hcl
@@ -5496,8 +5496,8 @@ database "posthog" {
       granularity = 1
     }
     index "bloom_filter_$session_id" {
-      expr        = "nullIf(nullIf(`$session_id`, ''), 'null')"
-      type        = "bloom_filter"
+      expr        = "`$session_id`"
+      type        = "bloom_filter(0.01)"
       granularity = 1
     }
     index "minmax_$group_0" {

--- a/posthog/clickhouse/hcl/golden/local-single/all.hcl
+++ b/posthog/clickhouse/hcl/golden/local-single/all.hcl
@@ -9883,8 +9883,8 @@ SQL
       granularity = 1
     }
     index "bloom_filter_$session_id" {
-      expr        = "nullIf(nullIf(`$session_id`, ''), 'null')"
-      type        = "bloom_filter"
+      expr        = "`$session_id`"
+      type        = "bloom_filter(0.01)"
       granularity = 1
     }
     index "minmax_$group_0" {

--- a/posthog/clickhouse/hcl/roles/data/shared/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/data/shared/tables.hcl
@@ -211,8 +211,8 @@ database "posthog" {
       granularity = 1
     }
     index "bloom_filter_$session_id" {
-      expr        = "nullIf(nullIf(`$session_id`, ''), 'null')"
-      type        = "bloom_filter"
+      expr        = "`$session_id`"
+      type        = "bloom_filter(0.01)"
       granularity = 1
     }
     engine "replicated_replacing_merge_tree" {

--- a/posthog/clickhouse/hcl/sql/local-multi/data.sql
+++ b/posthog/clickhouse/hcl/sql/local-multi/data.sql
@@ -1027,7 +1027,7 @@ CREATE TABLE posthog.sharded_events (
   INDEX bloom_filter_$ai_experiment_id `mat_$ai_experiment_id` TYPE bloom_filter GRANULARITY 1,
   INDEX minmax_$ai_experiment_id `mat_$ai_experiment_id` TYPE minmax GRANULARITY 1,
   INDEX minmax_$session_id_uuid `$session_id_uuid` TYPE minmax GRANULARITY 1,
-  INDEX bloom_filter_$session_id nullIf(nullIf(`$session_id`, ''), 'null') TYPE bloom_filter GRANULARITY 1,
+  INDEX bloom_filter_$session_id `$session_id` TYPE bloom_filter(0.01) GRANULARITY 1,
   INDEX minmax_$group_0 `$group_0` TYPE minmax GRANULARITY 1,
   INDEX minmax_$group_1 `$group_1` TYPE minmax GRANULARITY 1,
   INDEX minmax_$group_2 `$group_2` TYPE minmax GRANULARITY 1,

--- a/posthog/clickhouse/hcl/sql/local-single/all.sql
+++ b/posthog/clickhouse/hcl/sql/local-single/all.sql
@@ -1774,7 +1774,7 @@ CREATE TABLE posthog.sharded_events (
   INDEX bloom_filter_$ai_experiment_id `mat_$ai_experiment_id` TYPE bloom_filter GRANULARITY 1,
   INDEX minmax_$ai_experiment_id `mat_$ai_experiment_id` TYPE minmax GRANULARITY 1,
   INDEX minmax_$session_id_uuid `$session_id_uuid` TYPE minmax GRANULARITY 1,
-  INDEX bloom_filter_$session_id nullIf(nullIf(`$session_id`, ''), 'null') TYPE bloom_filter GRANULARITY 1,
+  INDEX bloom_filter_$session_id `$session_id` TYPE bloom_filter(0.01) GRANULARITY 1,
   INDEX minmax_$group_0 `$group_0` TYPE minmax GRANULARITY 1,
   INDEX minmax_$group_1 `$group_1` TYPE minmax GRANULARITY 1,
   INDEX minmax_$group_2 `$group_2` TYPE minmax GRANULARITY 1,

--- a/posthog/clickhouse/migrations/0314_session_id_bloom_filter_on_bare_column.py
+++ b/posthog/clickhouse/migrations/0314_session_id_bloom_filter_on_bare_column.py
@@ -1,18 +1,7 @@
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 
-# Migration 0293 indexed nullIf(nullIf(`$session_id`, ''), 'null'), the null-scrubbed read HogQL prints for
-# properties.$session_id. That index cannot serve the queries that filter on a session id: HogQL's default
-# transform_null_in=1 makes ClickHouse plan `in()` as `nullIn()`, which the bloom-filter index condition does not
-# handle, and every other session-id predicate HogQL prints is against the bare column. `equals(...)` and the
-# `has([...], col)` rewrite in clickhouse_property_resolution engage a bare-column bloom filter under default settings.
-# The name stays `bloom_filter_$session_id` so the materialized-column registry (`bloom_filter_<column>`) detects it.
-#
-# DROP INDEX is a lightweight mutation (hardlinks each part without the index files). ClickHouse's alter sequence
-# holds the ADD until that mutation finishes on each replica, so reusing the name does not race.
-# No MATERIALIZE INDEX on purpose: existing parts get the index when they merge, new parts get it immediately.
 DROP_EXPRESSION_BLOOM_FILTER_INDEX = "ALTER TABLE sharded_events DROP INDEX IF EXISTS `bloom_filter_$session_id`"
 
-# 0.01 is the false-positive rate BloomFilterIndex in ee/clickhouse/materialized_columns uses for bare columns.
 ADD_BARE_COLUMN_BLOOM_FILTER_INDEX = """
 ALTER TABLE sharded_events
 ADD INDEX IF NOT EXISTS `bloom_filter_$session_id` `$session_id`

--- a/posthog/clickhouse/migrations/0314_session_id_bloom_filter_on_bare_column.py
+++ b/posthog/clickhouse/migrations/0314_session_id_bloom_filter_on_bare_column.py
@@ -1,0 +1,34 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+# Migration 0293 indexed nullIf(nullIf(`$session_id`, ''), 'null'), the null-scrubbed read HogQL prints for
+# properties.$session_id. That index cannot serve the queries that filter on a session id: HogQL's default
+# transform_null_in=1 makes ClickHouse plan `in()` as `nullIn()`, which the bloom-filter index condition does not
+# handle, and every other session-id predicate HogQL prints is against the bare column. `equals(...)` and the
+# `has([...], col)` rewrite in clickhouse_property_resolution engage a bare-column bloom filter under default settings.
+# The name stays `bloom_filter_$session_id` so the materialized-column registry (`bloom_filter_<column>`) detects it.
+#
+# DROP INDEX is a lightweight mutation (hardlinks each part without the index files). ClickHouse's alter sequence
+# holds the ADD until that mutation finishes on each replica, so reusing the name does not race.
+# No MATERIALIZE INDEX on purpose: existing parts get the index when they merge, new parts get it immediately.
+DROP_EXPRESSION_BLOOM_FILTER_INDEX = "ALTER TABLE sharded_events DROP INDEX IF EXISTS `bloom_filter_$session_id`"
+
+# 0.01 is the false-positive rate BloomFilterIndex in ee/clickhouse/materialized_columns uses for bare columns.
+ADD_BARE_COLUMN_BLOOM_FILTER_INDEX = """
+ALTER TABLE sharded_events
+ADD INDEX IF NOT EXISTS `bloom_filter_$session_id` `$session_id`
+TYPE bloom_filter(0.01)
+GRANULARITY 1
+"""
+
+operations = [
+    run_sql_with_exceptions(
+        DROP_EXPRESSION_BLOOM_FILTER_INDEX,
+        sharded=True,
+        is_alter_on_replicated_table=True,
+    ),
+    run_sql_with_exceptions(
+        ADD_BARE_COLUMN_BLOOM_FILTER_INDEX,
+        sharded=True,
+        is_alter_on_replicated_table=True,
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0313_logs_pattern_buckets
+0314_session_id_bloom_filter_on_bare_column

--- a/posthog/clickhouse/test/test_0314.py
+++ b/posthog/clickhouse/test/test_0314.py
@@ -1,0 +1,48 @@
+import importlib
+
+from posthog.test.base import ClickhouseDestroyTablesMixin, _create_event, flush_persons_and_events
+
+from posthog.hogql.test.test_property_skip_indexes import _run_explain_and_get_skip_indexes
+
+from posthog.clickhouse.client import sync_execute
+
+module = importlib.import_module("posthog.clickhouse.migrations.0314_session_id_bloom_filter_on_bare_column")
+
+INDEX_FROM_0293 = """
+ALTER TABLE sharded_events
+ADD INDEX IF NOT EXISTS `bloom_filter_$session_id` nullIf(nullIf(`$session_id`, ''), 'null')
+TYPE bloom_filter GRANULARITY 1
+"""
+SESSION_ID = "019f9a50-0000-7000-8000-000000000001"
+
+
+def _apply_migration() -> None:
+    sync_execute(module.DROP_EXPRESSION_BLOOM_FILTER_INDEX)
+    sync_execute(module.ADD_BARE_COLUMN_BLOOM_FILTER_INDEX)
+
+
+def _session_id_bloom_filter_indexes() -> list[tuple[str, str]]:
+    return sync_execute(
+        "SELECT name, expr FROM system.data_skipping_indices "
+        "WHERE database = currentDatabase() AND table = 'sharded_events' AND type = 'bloom_filter' "
+        "AND position(expr, '$session_id') > 0"
+    )
+
+
+class Test0314(ClickhouseDestroyTablesMixin):
+    def test_replaces_the_expression_index_with_one_on_the_bare_column_and_can_be_reapplied(self):
+        sync_execute(INDEX_FROM_0293)
+        _apply_migration()
+        _apply_migration()
+        assert _session_id_bloom_filter_indexes() == [("bloom_filter_$session_id", "`$session_id`")]
+
+    def test_bare_column_index_engages_for_equals_and_has_under_default_hogql_settings(self):
+        _apply_migration()
+        _create_event(team=self.team, distinct_id="d", event="$pageview", properties={"$session_id": SESSION_ID})
+        flush_persons_and_events()
+        values = {"team_id": self.team.pk, "session_ids": [SESSION_ID], "session_id": SESSION_ID}
+        for predicate in ("has(%(session_ids)s, `$session_id`)", "equals(`$session_id`, %(session_id)s)"):
+            skip_indexes = _run_explain_and_get_skip_indexes(
+                f"SELECT count() FROM events WHERE team_id = %(team_id)s AND {predicate}", values
+            )
+            assert "bloom_filter_$session_id" in skip_indexes, predicate

--- a/posthog/clickhouse/test/test_0314.py
+++ b/posthog/clickhouse/test/test_0314.py
@@ -2,6 +2,8 @@ import importlib
 
 from posthog.test.base import ClickhouseDestroyTablesMixin, _create_event, flush_persons_and_events
 
+from parameterized import parameterized
+
 from posthog.hogql.test.test_property_skip_indexes import _run_explain_and_get_skip_indexes
 
 from posthog.clickhouse.client import sync_execute
@@ -36,13 +38,18 @@ class Test0314(ClickhouseDestroyTablesMixin):
         _apply_migration()
         assert _session_id_bloom_filter_indexes() == [("bloom_filter_$session_id", "`$session_id`")]
 
-    def test_bare_column_index_engages_for_equals_and_has_under_default_hogql_settings(self):
+    @parameterized.expand(
+        [
+            ("has", "has(%(session_ids)s, `$session_id`)"),
+            ("equals", "equals(`$session_id`, %(session_id)s)"),
+        ]
+    )
+    def test_bare_column_index_engages_under_default_hogql_settings(self, _name: str, predicate: str):
         _apply_migration()
         _create_event(team=self.team, distinct_id="d", event="$pageview", properties={"$session_id": SESSION_ID})
         flush_persons_and_events()
         values = {"team_id": self.team.pk, "session_ids": [SESSION_ID], "session_id": SESSION_ID}
-        for predicate in ("has(%(session_ids)s, `$session_id`)", "equals(`$session_id`, %(session_id)s)"):
-            skip_indexes = _run_explain_and_get_skip_indexes(
-                f"SELECT count() FROM events WHERE team_id = %(team_id)s AND {predicate}", values
-            )
-            assert "bloom_filter_$session_id" in skip_indexes, predicate
+        skip_indexes = _run_explain_and_get_skip_indexes(
+            f"SELECT count() FROM events WHERE team_id = %(team_id)s AND {predicate}", values
+        )
+        assert "bloom_filter_$session_id" in skip_indexes


### PR DESCRIPTION
## Problem

Filtering events by session id (replay matching events, the recordings list filtered to specific sessions, the ReplayVision scans) reads every event the team has in the date range. The `$session_id` bloom filter from PR 74973 (https://github.com/PostHog/posthog/pull/74973) never engages.

It indexes the null-scrubbed expression `nullIf(nullIf($session_id, ''), 'null')`, picked to match what HogQL prints for `properties.$session_id`. An `IN` on that expression never uses a bloom filter under `transform_null_in=1` (HogQL's default), and the shapes ClickHouse does index (`=` and `has([..], col)`) are on the bare column, which an expression index can't match.

## Changes

- Replaces `bloom_filter_$session_id` on `sharded_events`: drop the expression index, add `bloom_filter(0.01)` on the bare `$session_id` column under the same name. No `MATERIALIZE INDEX`, existing parts pick it up as they merge.

## How did you test this code?

`hogli test posthog/clickhouse/test/test_0314.py posthog/clickhouse/test/test_migrations.py`

- `test_replaces_the_expression_index_with_one_on_the_bare_column_and_can_be_reapplied`: fails if the migration drops the wrong index, indexes the wrong expression, or loses its `IF EXISTS` / `IF NOT EXISTS` guards.
- `test_bare_column_index_engages_for_equals_and_has_under_default_hogql_settings`: runs `EXPLAIN indexes=1` with the HogQL default settings, so it fails if the index stops engaging for `equals(...)` or `has([..], $session_id)`, e.g. if it goes back onto an expression.

The decision comes from an EXPLAIN matrix on a local ClickHouse 26.6 (same build as prod): with `transform_null_in=1`, `IN` engages no bloom filter (bare or wrapped key, tuple or array literal), while `=` and `has([..], col)` engage a bare-column one. `bash posthog/clickhouse/hcl/check.sh` passes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1), with Metabase `query_log` analysis and a local ClickHouse for EXPLAIN. Skills invoked: /clickhouse-migrations, /writing-tests, /writing-code-comments, /writing-pr-descriptions, plus the superpowers TDD and worktree skills. The session started by measuring PR 74973 in production (no effect since it shipped), traced the cause to `nullIn`, and confirmed the bare column is the shape HogQL's materialized-column rewrite already targets. Andy chose replace rather than add a second index, and no backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013A8zoSs3ZyCFjVQi1YvEmF





