### PR TITLE
fix(queries): keep results out of the app Redis and recover dropped requests by id

### DIFF
--- a/frontend/src/queries/query.test.ts
+++ b/frontend/src/queries/query.test.ts
@@ -388,6 +388,21 @@ describe('query', () => {
             expect(statusSpy).toHaveBeenCalledTimes(1)
         })
 
+        it('does not follow up on a timeout the app answered with itself', async () => {
+            // A ClickHouse timeout is a 504 too, and the failure breaker replays it at once, so
+            // there is no run left to wait for and no record to wait for it under.
+            jest.spyOn(api, 'query').mockRejectedValueOnce(
+                new ApiError('timed out', 504, undefined, {
+                    detail: 'Query has hit the max execution time before completing.',
+                })
+            )
+            const statusSpy = jest.spyOn(api.queryStatus, 'get')
+
+            await expect(performQuery(query, undefined, 'blocking')).rejects.toMatchObject({ status: 504 })
+
+            expect(statusSpy).not.toHaveBeenCalled()
+        })
+
         it('does not follow up on a failed async submission', async () => {
             jest.spyOn(api, 'query').mockRejectedValueOnce(gatewayTimeout())
             const statusSpy = jest.spyOn(api.queryStatus, 'get')

--- a/frontend/src/queries/query.test.ts
+++ b/frontend/src/queries/query.test.ts
@@ -324,7 +324,7 @@ describe('query', () => {
 
             expect(statusSpy.mock.calls[0][0]).toBe(querySpy.mock.calls[0][1]?.clientQueryId)
             const completed = captureSpy.mock.calls.filter((call) => call[0] === 'query completed')
-            expect(completed[0][1]).toMatchObject({ recovered_after_drop: true, recovered_after_status: 504 })
+            expect(completed[0][1]).toMatchObject({ recovered_after_drop: true })
         })
 
         it('surfaces the recorded error of a dropped request without waiting', async () => {

--- a/frontend/src/queries/query.test.ts
+++ b/frontend/src/queries/query.test.ts
@@ -283,6 +283,90 @@ describe('query', () => {
         })
     })
 
+    describe('dropped blocking request recovery', () => {
+        const query = { kind: NodeKind.EventsQuery, select: ['*'] } as EventsQuery
+        const gatewayTimeout = (): ApiError => new ApiError('upstream request timeout', 504)
+        const notRecordedYet = (): ApiError =>
+            new ApiError('Query not found', 404, undefined, { detail: 'Query not found' })
+        let now: number
+
+        beforeEach(() => {
+            now = 1_700_000_000_000
+            jest.spyOn(Date, 'now').mockImplementation(() => now)
+        })
+
+        afterEach(() => {
+            jest.restoreAllMocks()
+        })
+
+        it('sends every blocking request with a client query id', async () => {
+            const querySpy = jest.spyOn(api, 'query').mockResolvedValueOnce({ results: [] } as any)
+
+            await performQuery(query, undefined, 'blocking')
+
+            expect(querySpy.mock.calls[0][1]).toMatchObject({ clientQueryId: expect.any(String) })
+        })
+
+        it('returns the recorded result once the server finishes a dropped request', async () => {
+            const querySpy = jest.spyOn(api, 'query').mockRejectedValueOnce(gatewayTimeout())
+            const statusSpy = jest
+                .spyOn(api.queryStatus, 'get')
+                .mockImplementationOnce(async () => {
+                    // Not recorded yet. Jump to just before the deadline so the next poll follows a
+                    // short wait instead of the real interval.
+                    now += 10 * 60 * 1000 - 10
+                    throw notRecordedYet()
+                })
+                .mockResolvedValueOnce({ query_status: { complete: true, results: { results: ['late'] } } } as any)
+            const captureSpy = jest.spyOn(posthog, 'capture')
+
+            await expect(performQuery(query, undefined, 'blocking')).resolves.toMatchObject({ results: ['late'] })
+
+            expect(statusSpy.mock.calls[0][0]).toBe(querySpy.mock.calls[0][1]?.clientQueryId)
+            const completed = captureSpy.mock.calls.filter((call) => call[0] === 'query completed')
+            expect(completed[0][1]).toMatchObject({ recovered_after_drop: true, recovered_after_status: 504 })
+        })
+
+        it('surfaces the recorded error of a dropped request without waiting', async () => {
+            jest.spyOn(api, 'query').mockRejectedValueOnce(gatewayTimeout())
+            jest.spyOn(api.queryStatus, 'get').mockRejectedValueOnce(
+                new ApiError('failed', 400, undefined, {
+                    query_status: { error_message: 'Try changing the time range', error_code: 'too_wide' },
+                })
+            )
+
+            await expect(performQuery(query, undefined, 'blocking')).rejects.toMatchObject({
+                status: 400,
+                detail: 'Try changing the time range',
+                code: 'too_wide',
+            })
+        })
+
+        it('gives up with the original error when nothing is recorded by the deadline', async () => {
+            jest.spyOn(api, 'query').mockRejectedValueOnce(gatewayTimeout())
+            const statusSpy = jest.spyOn(api.queryStatus, 'get').mockImplementation(async () => {
+                now += 10 * 60 * 1000
+                throw notRecordedYet()
+            })
+            const captureSpy = jest.spyOn(posthog, 'capture')
+
+            await expect(performQuery(query, undefined, 'blocking')).rejects.toMatchObject({ status: 504 })
+
+            expect(statusSpy).toHaveBeenCalledTimes(1)
+            const failed = captureSpy.mock.calls.filter((call) => call[0] === 'query failed')
+            expect(failed[0][1]).toMatchObject({ drop_recovery_attempted: true, error_status: 504 })
+        })
+
+        it('does not follow up on a failed async submission', async () => {
+            jest.spyOn(api, 'query').mockRejectedValueOnce(gatewayTimeout())
+            const statusSpy = jest.spyOn(api.queryStatus, 'get')
+
+            await expect(performQuery(query, undefined, 'async')).rejects.toMatchObject({ status: 504 })
+
+            expect(statusSpy).not.toHaveBeenCalled()
+        })
+    })
+
     describe('pollForResults error message parsing', () => {
         it('prefers the structured error_code from the query status over one parsed from the message', async () => {
             jest.spyOn(api.queryStatus, 'get').mockRejectedValueOnce({

--- a/frontend/src/queries/query.test.ts
+++ b/frontend/src/queries/query.test.ts
@@ -357,6 +357,19 @@ describe('query', () => {
             expect(failed[0][1]).toMatchObject({ drop_recovery_attempted: true, error_status: 504 })
         })
 
+        it('recovers a dropped force_cache request, which the endpoint runs when the cache is stale', async () => {
+            jest.spyOn(api, 'query').mockRejectedValueOnce(gatewayTimeout())
+            const statusSpy = jest
+                .spyOn(api.queryStatus, 'get')
+                .mockResolvedValueOnce({ query_status: { complete: true, results: { results: ['late'] } } } as any)
+
+            await expect(performQuery(query, undefined, 'force_cache')).resolves.toMatchObject({
+                results: ['late'],
+            })
+
+            expect(statusSpy).toHaveBeenCalledTimes(1)
+        })
+
         it('does not follow up on a failed async submission', async () => {
             jest.spyOn(api, 'query').mockRejectedValueOnce(gatewayTimeout())
             const statusSpy = jest.spyOn(api.queryStatus, 'get')

--- a/frontend/src/queries/query.test.ts
+++ b/frontend/src/queries/query.test.ts
@@ -286,6 +286,12 @@ describe('query', () => {
     describe('dropped blocking request recovery', () => {
         const query = { kind: NodeKind.EventsQuery, select: ['*'] } as EventsQuery
         const gatewayTimeout = (): ApiError => new ApiError('upstream request timeout', 504)
+        /** A drop, which by definition happens after the request has run long enough to be worth
+         * recovering. Anything faster has no record waiting for it. */
+        const dropAfterRunningLong = async (): Promise<never> => {
+            now += 5 * 60 * 1000
+            throw gatewayTimeout()
+        }
         const notRecordedYet = (): ApiError =>
             new ApiError('Query not found', 404, undefined, { detail: 'Query not found' })
         let now: number
@@ -308,7 +314,7 @@ describe('query', () => {
         })
 
         it('returns the recorded result once the server finishes a dropped request', async () => {
-            const querySpy = jest.spyOn(api, 'query').mockRejectedValueOnce(gatewayTimeout())
+            const querySpy = jest.spyOn(api, 'query').mockImplementationOnce(dropAfterRunningLong)
             const statusSpy = jest
                 .spyOn(api.queryStatus, 'get')
                 .mockImplementationOnce(async () => {
@@ -328,7 +334,7 @@ describe('query', () => {
         })
 
         it('surfaces the recorded error of a dropped request without waiting', async () => {
-            jest.spyOn(api, 'query').mockRejectedValueOnce(gatewayTimeout())
+            jest.spyOn(api, 'query').mockImplementationOnce(dropAfterRunningLong)
             jest.spyOn(api.queryStatus, 'get').mockRejectedValueOnce(
                 new ApiError('failed', 400, undefined, {
                     query_status: { error_message: 'Try changing the time range', error_code: 'too_wide' },
@@ -343,7 +349,7 @@ describe('query', () => {
         })
 
         it('gives up with the original error when nothing is recorded by the deadline', async () => {
-            jest.spyOn(api, 'query').mockRejectedValueOnce(gatewayTimeout())
+            jest.spyOn(api, 'query').mockImplementationOnce(dropAfterRunningLong)
             const statusSpy = jest.spyOn(api.queryStatus, 'get').mockImplementation(async () => {
                 now += 10 * 60 * 1000
                 throw notRecordedYet()
@@ -376,7 +382,7 @@ describe('query', () => {
         })
 
         it('recovers a dropped force_cache request, which the endpoint runs when the cache is stale', async () => {
-            jest.spyOn(api, 'query').mockRejectedValueOnce(gatewayTimeout())
+            jest.spyOn(api, 'query').mockImplementationOnce(dropAfterRunningLong)
             const statusSpy = jest
                 .spyOn(api.queryStatus, 'get')
                 .mockResolvedValueOnce({ query_status: { complete: true, results: { results: ['late'] } } } as any)
@@ -396,6 +402,17 @@ describe('query', () => {
                     detail: 'Query has hit the max execution time before completing.',
                 })
             )
+            const statusSpy = jest.spyOn(api.queryStatus, 'get')
+
+            await expect(performQuery(query, undefined, 'blocking')).rejects.toMatchObject({ status: 504 })
+
+            expect(statusSpy).not.toHaveBeenCalled()
+        })
+
+        it('does not follow up on a 504 that arrived too fast to have left a record', async () => {
+            // The server records a blocking outcome only after the request has run a while, so a
+            // 504 that arrives at once has nothing to wait for however it was produced.
+            jest.spyOn(api, 'query').mockRejectedValueOnce(gatewayTimeout())
             const statusSpy = jest.spyOn(api.queryStatus, 'get')
 
             await expect(performQuery(query, undefined, 'blocking')).rejects.toMatchObject({ status: 504 })

--- a/frontend/src/queries/query.test.ts
+++ b/frontend/src/queries/query.test.ts
@@ -357,6 +357,24 @@ describe('query', () => {
             expect(failed[0][1]).toMatchObject({ drop_recovery_attempted: true, error_status: 504 })
         })
 
+        it('waits for a record written past the time the request itself was allowed to run', async () => {
+            jest.spyOn(api, 'query').mockImplementationOnce(async () => {
+                // The gateway drops the request a minute in, while the query keeps running.
+                now += 60 * 1000
+                throw gatewayTimeout()
+            })
+            jest.spyOn(api.queryStatus, 'get')
+                .mockImplementationOnce(async () => {
+                    // The server writes the record just short of ten minutes after the drop, which
+                    // is past the ten minutes the query itself was allowed to spend in ClickHouse.
+                    now += 10 * 60 * 1000 - 10
+                    throw notRecordedYet()
+                })
+                .mockResolvedValueOnce({ query_status: { complete: true, results: { results: ['late'] } } } as any)
+
+            await expect(performQuery(query, undefined, 'blocking')).resolves.toMatchObject({ results: ['late'] })
+        })
+
         it('recovers a dropped force_cache request, which the endpoint runs when the cache is stale', async () => {
             jest.spyOn(api, 'query').mockRejectedValueOnce(gatewayTimeout())
             const statusSpy = jest

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -84,9 +84,14 @@ export interface QueryRecoveryOutcome {
  * The gateway gave up waiting for a response it had already accepted, so the server may still be
  * running the query. A 502 or 503 means the request never reached a worker, and waiting on those
  * would only add minutes of silence to an error the user should see now.
+ *
+ * 504 is also an answer the app gives: a ClickHouse timeout carries it, and the failure breaker
+ * replays that answer in milliseconds. Those come with the API's error body and describe a query
+ * that has already stopped, so only a 504 without one is a request the gateway dropped.
  */
 function isDroppedRequest(error: unknown): boolean {
-    return (error as { status?: number } | null)?.status === 504
+    const failure = error as { status?: number; detail?: unknown; data?: { detail?: unknown } } | null
+    return failure?.status === 504 && (failure.data?.detail ?? failure.detail) == null
 }
 
 /**

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -67,8 +67,9 @@ const QUERY_ASYNC_TOTAL_POLL_SECONDS = 10 * 60 + 6 // keep in sync with backend-
 export const QUERY_TIMEOUT_ERROR_MESSAGE = 'Query timed out'
 
 // The server keeps running a query after the ingress drops the request, then records the outcome
-// under the client's query ID. Give it longer than a blocking query is allowed to run, and stay
-// inside the record's lifetime (BLOCKING_QUERY_STATUS_TTL_SECONDS, 15 minutes).
+// under the client's query ID. The wait runs from the drop, not from the request: a blocking query
+// may spend ten minutes in ClickHouse (HOGQL_INCREASED_MAX_EXECUTION_TIME) and only then write the
+// record, which itself lives for fifteen (BLOCKING_QUERY_STATUS_TTL_SECONDS).
 const DROPPED_REQUEST_RECOVERY_DEADLINE_MS = 10 * 60 * 1000
 const DROPPED_REQUEST_RECOVERY_POLL_INTERVAL_MS = 5_000
 
@@ -106,9 +107,9 @@ function blocksOnServer(refresh: RefreshType | undefined): boolean {
 async function waitForRecordedResult(
     queryId: string,
     methodOptions: ApiMethodOptions | undefined,
-    requestStartedAtMs: number
+    droppedAtMs: number
 ): Promise<QueryStatus | null> {
-    const untilMs = requestStartedAtMs + DROPPED_REQUEST_RECOVERY_DEADLINE_MS
+    const untilMs = droppedAtMs + DROPPED_REQUEST_RECOVERY_DEADLINE_MS
     for (;;) {
         try {
             const statusResponse = (await api.queryStatus.get(queryId, false)).query_status
@@ -261,7 +262,6 @@ async function executeQuery<N extends DataNode>(
      */
     recovery?: QueryRecoveryOutcome
 ): Promise<NonNullable<N['response']>> {
-    const requestStartedAtMs = Date.now()
     if (!pollOnly) {
         const refreshParam: RefreshType = refresh || 'blocking'
         // Every blocking request carries an ID the server records its outcome under, so a
@@ -286,7 +286,7 @@ async function executeQuery<N extends DataNode>(
             }
             const droppedAtMs = Date.now()
             recovery.attempted = true
-            const recorded = await waitForRecordedResult(queryId, methodOptions, requestStartedAtMs)
+            const recorded = await waitForRecordedResult(queryId, methodOptions, droppedAtMs)
             if (!recorded) {
                 throw e
             }

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -88,8 +88,14 @@ function isDroppedRequest(error: unknown): boolean {
     return (error as { status?: number } | null)?.status === 504
 }
 
+/**
+ * Whether the server keeps running the query after the gateway gives up on the request. Only the
+ * async modes hand the work off and answer with a query status. `force_cache` counts as blocking
+ * here, because the query endpoint upgrades it to compute-if-stale rather than only reading the
+ * cache, so a stale entry runs the query inside the request.
+ */
 function blocksOnServer(refresh: RefreshType | undefined): boolean {
-    return refresh !== 'async' && refresh !== 'force_async' && refresh !== 'lazy_async' && refresh !== 'force_cache'
+    return refresh !== 'async' && refresh !== 'force_async' && refresh !== 'lazy_async'
 }
 
 /**

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -72,6 +72,9 @@ export const QUERY_TIMEOUT_ERROR_MESSAGE = 'Query timed out'
 // record, which itself lives for fifteen (BLOCKING_QUERY_STATUS_TTL_SECONDS).
 const DROPPED_REQUEST_RECOVERY_DEADLINE_MS = 10 * 60 * 1000
 const DROPPED_REQUEST_RECOVERY_POLL_INTERVAL_MS = 5_000
+// The server records a blocking outcome only once the request has run this long
+// (BLOCKING_QUERY_RECORD_AFTER_SECONDS), so a faster failure has no record to wait for.
+const DROPPED_REQUEST_MIN_REQUEST_MS = 60 * 1000
 
 /** What the dropped-request recovery did for one request, reported on the query telemetry events. */
 export interface QueryRecoveryOutcome {
@@ -87,11 +90,16 @@ export interface QueryRecoveryOutcome {
  *
  * 504 is also an answer the app gives: a ClickHouse timeout carries it, and the failure breaker
  * replays that answer in milliseconds. Those come with the API's error body and describe a query
- * that has already stopped, so only a 504 without one is a request the gateway dropped.
+ * that has already stopped, so only a 504 without one is a request the gateway dropped. The elapsed
+ * time is the second half of the test, and it holds whatever the body looks like: below the server's
+ * recording threshold there is no record to wait for, so waiting can only end in the same error.
  */
-function isDroppedRequest(error: unknown): boolean {
+function isDroppedRequest(error: unknown, elapsedMs: number): boolean {
     const failure = error as { status?: number; detail?: unknown; data?: { detail?: unknown } } | null
-    return failure?.status === 504 && (failure.data?.detail ?? failure.detail) == null
+    if (failure?.status !== 504 || elapsedMs < DROPPED_REQUEST_MIN_REQUEST_MS) {
+        return false
+    }
+    return (failure.data?.detail ?? failure.detail) == null
 }
 
 /**
@@ -267,6 +275,7 @@ async function executeQuery<N extends DataNode>(
      */
     recovery?: QueryRecoveryOutcome
 ): Promise<NonNullable<N['response']>> {
+    const requestStartedAtMs = Date.now()
     if (!pollOnly) {
         const refreshParam: RefreshType = refresh || 'blocking'
         // Every blocking request carries an ID the server records its outcome under, so a
@@ -286,10 +295,11 @@ async function executeQuery<N extends DataNode>(
                 limitContext,
             })
         } catch (e: any) {
-            if (!recovery || !queryId || !blocksOnServer(refreshParam) || !isDroppedRequest(e)) {
+            const droppedAtMs = Date.now()
+            const elapsedMs = droppedAtMs - requestStartedAtMs
+            if (!recovery || !queryId || !blocksOnServer(refreshParam) || !isDroppedRequest(e, elapsedMs)) {
                 throw e
             }
-            const droppedAtMs = Date.now()
             recovery.attempted = true
             const recorded = await waitForRecordedResult(queryId, methodOptions, droppedAtMs)
             if (!recorded) {

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -1,6 +1,7 @@
 import api, { ApiMethodOptions, isAbortError } from 'lib/api'
 import posthog from 'lib/posthog-typed'
 import { delay } from 'lib/utils/async'
+import { uuid } from 'lib/utils/dom'
 
 import {
     DashboardFilter,
@@ -64,6 +65,68 @@ export function waitForPageVisible(signal?: AbortSignal): Promise<void> {
 const QUERY_ASYNC_MAX_INTERVAL_SECONDS = 3
 const QUERY_ASYNC_TOTAL_POLL_SECONDS = 10 * 60 + 6 // keep in sync with backend-side timeout (currently 10min) + a small buffer
 export const QUERY_TIMEOUT_ERROR_MESSAGE = 'Query timed out'
+
+// The server lets a query run for this long (MAX_QUERY_TIMEOUT in posthog/api/query.py) and keeps
+// running it after the ingress drops the request, then records the outcome under the client's
+// query ID. Until then the ID can still turn into a result.
+const DROPPED_REQUEST_RECOVERY_DEADLINE_MS = 10 * 60 * 1000
+const DROPPED_REQUEST_RECOVERY_POLL_INTERVAL_MS = 5_000
+
+/** What the dropped-request recovery did for one request, reported on the query telemetry events. */
+export interface QueryRecoveryOutcome {
+    attempted: boolean
+    recovered: boolean
+    waitMs: number
+    afterStatus: number | null
+}
+
+/** The request reached the server but no answer came back: a gateway timeout or a dead upstream. */
+function isDroppedRequest(error: unknown): boolean {
+    const status = (error as { status?: number } | null)?.status
+    return status === 502 || status === 503 || status === 504
+}
+
+function blocksOnServer(refresh: RefreshType | undefined): boolean {
+    return refresh !== 'async' && refresh !== 'force_async' && refresh !== 'lazy_async' && refresh !== 'force_cache'
+}
+
+/**
+ * Poll the status of a query whose blocking request was dropped. Resolves with the recorded result,
+ * rejects with the recorded error, and returns null when nothing was recorded before the deadline.
+ * A 404 means the server has not finished the query yet, or has already forgotten it.
+ */
+async function waitForRecordedResult(
+    queryId: string,
+    methodOptions: ApiMethodOptions | undefined,
+    requestStartedAtMs: number
+): Promise<QueryStatus | null> {
+    const untilMs = requestStartedAtMs + DROPPED_REQUEST_RECOVERY_DEADLINE_MS
+    for (;;) {
+        try {
+            const statusResponse = (await api.queryStatus.get(queryId, false)).query_status
+            if (statusResponse.complete) {
+                return statusResponse
+            }
+        } catch (e: any) {
+            if (isAbortError(e)) {
+                throw e
+            }
+            const expired = e?.data?.code === 'query_result_expired'
+            if (e?.status !== 404 || expired) {
+                const parsed = parseErrorMessage(e.data?.query_status?.error_message ?? e.data?.detail ?? e.detail)
+                e.detail = parsed.message
+                e.code = e.data?.query_status?.error_code ?? e.data?.code ?? parsed.code ?? e.code
+                e.queryId = queryId
+                throw e
+            }
+        }
+        const remainingMs = untilMs - Date.now()
+        if (remainingMs <= 0) {
+            return null
+        }
+        await delay(Math.min(DROPPED_REQUEST_RECOVERY_POLL_INTERVAL_MS, remainingMs), methodOptions?.signal)
+    }
+}
 
 /**
  * Parse error message that may be in ErrorDetail string format.
@@ -181,19 +244,49 @@ async function executeQuery<N extends DataNode>(
      * (stale-while-revalidate: `is_cached` is true *and* an incomplete `query_status` is
      * attached), return the cached results immediately instead of blocking on the recompute.
      */
-    acceptStaleCache = false
+    acceptStaleCache = false,
+    /**
+     * Filled in when a blocking request was dropped by the ingress or a gateway while the server
+     * kept running the query. The server records the outcome under the client query ID, so this
+     * call polls that ID and returns the result instead of the gateway error. Absent for poll-only
+     * callers, which cannot send queries.
+     */
+    recovery?: QueryRecoveryOutcome
 ): Promise<NonNullable<N['response']>> {
+    const requestStartedAtMs = Date.now()
     if (!pollOnly) {
         const refreshParam: RefreshType = refresh || 'blocking'
+        // Every blocking request carries an ID the server records its outcome under, so a
+        // dropped request can be followed up on. Async requests get their ID from the response.
+        if (!queryId && blocksOnServer(refreshParam)) {
+            queryId = uuid()
+        }
 
-        const response = await api.query(queryNode, {
-            requestOptions: methodOptions,
-            clientQueryId: queryId,
-            refresh: refreshParam,
-            filtersOverride,
-            variablesOverride,
-            limitContext,
-        })
+        let response: any
+        try {
+            response = await api.query(queryNode, {
+                requestOptions: methodOptions,
+                clientQueryId: queryId,
+                refresh: refreshParam,
+                filtersOverride,
+                variablesOverride,
+                limitContext,
+            })
+        } catch (e: any) {
+            if (!recovery || !queryId || !blocksOnServer(refreshParam) || !isDroppedRequest(e)) {
+                throw e
+            }
+            const droppedAtMs = Date.now()
+            recovery.attempted = true
+            recovery.afterStatus = e?.status ?? null
+            const recorded = await waitForRecordedResult(queryId, methodOptions, requestStartedAtMs)
+            if (!recorded) {
+                throw e
+            }
+            recovery.recovered = true
+            recovery.waitMs = Date.now() - droppedAtMs
+            return recorded.results
+        }
 
         if (response.detail) {
             throw new Error(response.detail)
@@ -240,6 +333,7 @@ export async function performQuery<N extends DataNode>(
     let response: NonNullable<N['response']>
     const logParams: Record<string, any> = {}
     const startTime = performance.now()
+    const recovery: QueryRecoveryOutcome = { attempted: false, recovered: false, waitMs: 0, afterStatus: null }
 
     try {
         if (isPersonsNode(queryNode)) {
@@ -255,8 +349,14 @@ export async function performQuery<N extends DataNode>(
                 variablesOverride,
                 pollOnly,
                 limitContext,
-                acceptStaleCache
+                acceptStaleCache,
+                pollOnly ? undefined : recovery
             )
+            if (recovery.recovered) {
+                logParams.recovered_after_drop = true
+                logParams.recovery_wait_ms = Math.round(recovery.waitMs)
+                logParams.recovered_after_status = recovery.afterStatus
+            }
             if (isHogQLQuery(queryNode) && response && typeof response === 'object') {
                 logParams.clickhouse_sql = (response as HogQLQueryResponse)?.clickhouse
             }
@@ -302,6 +402,7 @@ export async function performQuery<N extends DataNode>(
                 error_status: error?.status ?? null,
                 error_code: error?.code ?? null,
                 uses_data_warehouse_source: queryUsesDataWarehouse(queryNode),
+                drop_recovery_attempted: recovery.attempted,
                 ...logParams,
             })
         }

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -248,10 +248,10 @@ async function executeQuery<N extends DataNode>(
      */
     acceptStaleCache = false,
     /**
-     * Filled in when a blocking request was dropped by the ingress or a gateway while the server
-     * kept running the query. The server records the outcome under the client query ID, so this
-     * call polls that ID and returns the result instead of the gateway error. Absent for poll-only
-     * callers, which cannot send queries.
+     * Filled in when the gateway gave up on a blocking request while the server kept running the
+     * query. The server records the outcome under the client query ID, so this call polls that ID
+     * and returns the result instead of the gateway error. Absent for poll-only callers, which
+     * cannot send queries.
      */
     recovery?: QueryRecoveryOutcome
 ): Promise<NonNullable<N['response']>> {

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -66,9 +66,9 @@ const QUERY_ASYNC_MAX_INTERVAL_SECONDS = 3
 const QUERY_ASYNC_TOTAL_POLL_SECONDS = 10 * 60 + 6 // keep in sync with backend-side timeout (currently 10min) + a small buffer
 export const QUERY_TIMEOUT_ERROR_MESSAGE = 'Query timed out'
 
-// The server lets a query run for this long (MAX_QUERY_TIMEOUT in posthog/api/query.py) and keeps
-// running it after the ingress drops the request, then records the outcome under the client's
-// query ID. Until then the ID can still turn into a result.
+// The server keeps running a query after the ingress drops the request, then records the outcome
+// under the client's query ID. Give it longer than a blocking query is allowed to run, and stay
+// inside the record's lifetime (BLOCKING_QUERY_STATUS_TTL_SECONDS, 15 minutes).
 const DROPPED_REQUEST_RECOVERY_DEADLINE_MS = 10 * 60 * 1000
 const DROPPED_REQUEST_RECOVERY_POLL_INTERVAL_MS = 5_000
 
@@ -77,13 +77,15 @@ export interface QueryRecoveryOutcome {
     attempted: boolean
     recovered: boolean
     waitMs: number
-    afterStatus: number | null
 }
 
-/** The request reached the server but no answer came back: a gateway timeout or a dead upstream. */
+/**
+ * The gateway gave up waiting for a response it had already accepted, so the server may still be
+ * running the query. A 502 or 503 means the request never reached a worker, and waiting on those
+ * would only add minutes of silence to an error the user should see now.
+ */
 function isDroppedRequest(error: unknown): boolean {
-    const status = (error as { status?: number } | null)?.status
-    return status === 502 || status === 503 || status === 504
+    return (error as { status?: number } | null)?.status === 504
 }
 
 function blocksOnServer(refresh: RefreshType | undefined): boolean {
@@ -278,7 +280,6 @@ async function executeQuery<N extends DataNode>(
             }
             const droppedAtMs = Date.now()
             recovery.attempted = true
-            recovery.afterStatus = e?.status ?? null
             const recorded = await waitForRecordedResult(queryId, methodOptions, requestStartedAtMs)
             if (!recorded) {
                 throw e
@@ -333,7 +334,7 @@ export async function performQuery<N extends DataNode>(
     let response: NonNullable<N['response']>
     const logParams: Record<string, any> = {}
     const startTime = performance.now()
-    const recovery: QueryRecoveryOutcome = { attempted: false, recovered: false, waitMs: 0, afterStatus: null }
+    const recovery: QueryRecoveryOutcome = { attempted: false, recovered: false, waitMs: 0 }
 
     try {
         if (isPersonsNode(queryNode)) {
@@ -355,7 +356,6 @@ export async function performQuery<N extends DataNode>(
             if (recovery.recovered) {
                 logParams.recovered_after_drop = true
                 logParams.recovery_wait_ms = Math.round(recovery.waitMs)
-                logParams.recovered_after_status = recovery.afterStatus
             }
             if (isHogQLQuery(queryNode) && response && typeof response === 'object') {
                 logParams.clickhouse_sql = (response as HogQLQueryResponse)?.clickhouse

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -46,7 +46,13 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.services.query import process_query_model
 from posthog.api.streaming import sse_streaming_response
 from posthog.api.utils import action, is_async_query, is_insight_actors_options_query, is_insight_actors_query
-from posthog.clickhouse.client.execute_async import QueryNotFoundError, cancel_query, get_query_status
+from posthog.clickhouse.client.execute_async import (
+    QueryNotFoundError,
+    cancel_query,
+    get_query_status,
+    record_blocking_query_failure,
+    record_blocking_query_result,
+)
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
 from posthog.clickhouse.query_tagging import get_query_tag_value, get_query_tags, tag_queries
 from posthog.constants import AvailableFeature
@@ -305,18 +311,25 @@ class QueryViewSet(QueryCoalescingMixin, TeamAndOrgViewSetMixin, PydanticModelMi
                 )
                 if limit_context is not None:
                     process_span.set_attribute("query.limit_context", limit_context.value)
-                result = process_query_model(
-                    self.team,
-                    query,
-                    execution_mode=execution_mode,
-                    query_id=client_query_id,
-                    user=request.user,  # type: ignore[arg-type]
-                    is_query_service=(get_query_tag_value("access_method") == "personal_api_key"),
-                    limit_context=limit_context,
-                    analytics_props=analytics_props,
-                )
+                try:
+                    result = process_query_model(
+                        self.team,
+                        query,
+                        execution_mode=execution_mode,
+                        query_id=client_query_id,
+                        user=request.user,  # type: ignore[arg-type]
+                        is_query_service=(get_query_tag_value("access_method") == "personal_api_key"),
+                        limit_context=limit_context,
+                        analytics_props=analytics_props,
+                    )
+                except Exception as e:
+                    if data.client_query_id:
+                        record_blocking_query_failure(self.team.pk, data.client_query_id, e)
+                    raise
                 if isinstance(result, BaseModel):
                     result = result.model_dump(by_alias=True)
+                if data.client_query_id and not result.get("query_status"):
+                    record_blocking_query_result(self.team.pk, data.client_query_id, result)
 
             total_time_ms = round((perf_counter() - start_time) * 1000, 2)
             try:

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -104,6 +104,15 @@ QUERY_VALIDATION_ERROR_TOTAL = Counter(
 )
 
 
+def _ran_long_enough_to_be_dropped(start_time: float) -> bool:
+    """Whether the ingress could have cut this request while the server kept running the query.
+
+    A faster request reached the client with its answer, so recording its outcome would only add
+    a record nobody polls.
+    """
+    return perf_counter() - start_time >= settings.BLOCKING_QUERY_RECORD_AFTER_SECONDS
+
+
 def _extract_validation_code(error: ValidationError) -> str:
     validation_codes = error.get_codes()
     if isinstance(validation_codes, list):
@@ -323,12 +332,16 @@ class QueryViewSet(QueryCoalescingMixin, TeamAndOrgViewSetMixin, PydanticModelMi
                         analytics_props=analytics_props,
                     )
                 except Exception as e:
-                    if data.client_query_id:
+                    if data.client_query_id and _ran_long_enough_to_be_dropped(start_time):
                         record_blocking_query_failure(self.team.pk, data.client_query_id, e)
                     raise
                 if isinstance(result, BaseModel):
                     result = result.model_dump(by_alias=True)
-                if data.client_query_id and not result.get("query_status"):
+                if (
+                    data.client_query_id
+                    and not result.get("query_status")
+                    and _ran_long_enough_to_be_dropped(start_time)
+                ):
                     record_blocking_query_result(self.team.pk, data.client_query_id, result)
 
             total_time_ms = round((perf_counter() - start_time) * 1000, 2)

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -29,6 +29,7 @@ from posthog.schema import (
     HogQLQuery,
     PersonPropertyFilter,
     PropertyOperator,
+    QueryStatus,
 )
 
 from posthog.hogql.constants import LimitContext
@@ -40,12 +41,15 @@ from posthog.api.query import (
 )
 from posthog.api.services.query import process_query_dict, process_query_model
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.client.execute_async import QueryStatusManager
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
 from posthog.clickhouse.query_tagging import Product, QueryTags
 from posthog.event_usage import EventSource
 from posthog.exceptions import ClickHouseQueryTimeOut
 from posthog.llm.completions import OpenAICompletion
 from posthog.models.utils import UUIDT
+from posthog.query_cache.cache import QueryCache
+from posthog.redis import get_client
 
 from products.event_definitions.backend.models.property_definition import PropertyDefinition, PropertyType
 from products.managed_warehouse.backend.facade.query_labels import MANAGED_WAREHOUSE_QUERY_STATUS_LABEL_PREFIX
@@ -1169,56 +1173,42 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
 class TestQueryRetrieve(APIBaseTest):
     def setUp(self):
         super().setUp()
+        get_client().flushall()
         self.team_id = self.team.pk
         self.valid_query_id = "12345"
         self.invalid_query_id = "invalid-query-id"
-        self.redis_client_mock = mock.Mock()
-        self.redis_get_patch = mock.patch("posthog.redis.get_client", return_value=self.redis_client_mock)
-        self.redis_get_patch.start()
 
-    def tearDown(self):
-        self.redis_get_patch.stop()
+    def _store_status(self, **fields) -> None:
+        QueryStatusManager(self.valid_query_id, self.team_id).store_query_status(
+            QueryStatus(id=self.valid_query_id, team_id=self.team_id, **fields)
+        )
+
+    def _store_finished_query(self, results: list, labels: list[str] | None = None) -> None:
+        cache_key = f"cache_query_retrieve_{self.team_id}"
+        QueryCache(team_id=self.team_id, cache_key=cache_key).store_result(
+            response={"results": results, "cache_key": cache_key, "is_cached": False}, target_age=None
+        )
+        self._store_status(complete=True, error=False, labels=labels, results={"cache_key": cache_key})
 
     def test_with_valid_query_id(self):
-        self.redis_client_mock.get.return_value = json.dumps(
-            {
-                "id": self.valid_query_id,
-                "team_id": self.team_id,
-                "error": False,
-                "complete": True,
-                "results": ["result1", "result2"],
-            }
-        ).encode()
+        self._store_finished_query(["result1", "result2"])
         response = self.client.get(f"/api/environments/{self.team.id}/query/{self.valid_query_id}/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["query_status"]["complete"], True, response.content)
+        self.assertEqual(response.json()["query_status"]["results"]["results"], ["result1", "result2"])
 
     def test_with_invalid_query_id(self):
-        self.redis_client_mock.get.return_value = None
         response = self.client.get(f"/api/environments/{self.team.id}/query/{self.invalid_query_id}/")
         self.assertEqual(response.status_code, 404)
 
-    def test_completed_query(self):
-        self.redis_client_mock.get.return_value = json.dumps(
-            {
-                "id": self.valid_query_id,
-                "team_id": self.team_id,
-                "complete": True,
-                "results": ["result1", "result2"],
-            }
-        ).encode()
+    def test_finished_query_whose_result_left_the_cache(self):
+        self._store_status(complete=True, error=False, results={"cache_key": "cache_gone"})
         response = self.client.get(f"/api/environments/{self.team.id}/query/{self.valid_query_id}/")
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.json()["query_status"]["complete"])
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["code"], "query_result_expired")
 
     def test_running_query(self):
-        self.redis_client_mock.get.return_value = json.dumps(
-            {
-                "id": self.valid_query_id,
-                "team_id": self.team_id,
-                "complete": False,
-            }
-        ).encode()
+        self._store_status(complete=False)
         response = self.client.get(f"/api/environments/{self.team.id}/query/{self.valid_query_id}/")
         self.assertEqual(response.status_code, 202)
         self.assertFalse(response.json()["query_status"]["complete"])
@@ -1256,15 +1246,7 @@ class TestQueryRetrieve(APIBaseTest):
                 "password": "reader-password",
             },
         )
-        self.redis_client_mock.get.return_value = json.dumps(
-            {
-                "id": self.valid_query_id,
-                "team_id": self.team_id,
-                "complete": True,
-                "labels": [f"{MANAGED_WAREHOUSE_QUERY_STATUS_LABEL_PREFIX}{source.id}"],
-                "results": ["result1"],
-            }
-        ).encode()
+        self._store_finished_query(["result1"], labels=[f"{MANAGED_WAREHOUSE_QUERY_STATUS_LABEL_PREFIX}{source.id}"])
 
         with patch(
             "posthog.permissions.posthog_feature_flag_enabled",
@@ -1281,43 +1263,23 @@ class TestQueryRetrieve(APIBaseTest):
             self.assertNotIn(str(self.team_id), response.json()["detail"])
 
     def test_failed_query_with_internal_error(self):
-        self.redis_client_mock.get.return_value = json.dumps(
-            {
-                "id": self.valid_query_id,
-                "team_id": self.team_id,
-                "error": True,
-                "error_message": None,
-            }
-        ).encode()
+        self._store_status(complete=True, error=True, error_message=None)
         response = self.client.get(f"/api/environments/{self.team.id}/query/{self.valid_query_id}/")
         self.assertEqual(response.status_code, 500)
         self.assertTrue(response.json()["query_status"]["error"])
 
     def test_failed_query_with_exposed_error(self):
-        self.redis_client_mock.get.return_value = json.dumps(
-            {
-                "id": self.valid_query_id,
-                "team_id": self.team_id,
-                "error": True,
-                "error_message": "Try changing the time range",
-            }
-        ).encode()
+        self._store_status(complete=True, error=True, error_message="Try changing the time range")
         response = self.client.get(f"/api/environments/{self.team.id}/query/{self.valid_query_id}/")
         self.assertEqual(response.status_code, 400)
         self.assertTrue(response.json()["query_status"]["error"])
 
     def test_destroy(self):
-        self.redis_client_mock.get.return_value = json.dumps(
-            {
-                "id": self.valid_query_id,
-                "team_id": self.team_id,
-                "error": True,
-                "error_message": "Query failed",
-            }
-        ).encode()
+        self._store_status(complete=False, error=True, error_message="Query failed")
         response = self.client.delete(f"/api/environments/{self.team.id}/query/{self.valid_query_id}/")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(self.redis_client_mock.delete.call_count, 2)
+        response = self.client.get(f"/api/environments/{self.team.id}/query/{self.valid_query_id}/")
+        self.assertEqual(response.status_code, 404)
 
 
 class TestQueryDraftSql(APIBaseTest):

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -1178,9 +1178,9 @@ class TestQueryRetrieve(APIBaseTest):
         self.valid_query_id = "12345"
         self.invalid_query_id = "invalid-query-id"
 
-    def _store_status(self, **fields) -> None:
+    def _store_status(self, cache_key: str | None = None, **fields) -> None:
         QueryStatusManager(self.valid_query_id, self.team_id).store_query_status(
-            QueryStatus(id=self.valid_query_id, team_id=self.team_id, **fields)
+            QueryStatus(id=self.valid_query_id, team_id=self.team_id, **fields), cache_key=cache_key
         )
 
     def _store_finished_query(self, results: list, labels: list[str] | None = None) -> None:
@@ -1188,7 +1188,7 @@ class TestQueryRetrieve(APIBaseTest):
         QueryCache(team_id=self.team_id, cache_key=cache_key).store_result(
             response={"results": results, "cache_key": cache_key, "is_cached": False}, target_age=None
         )
-        self._store_status(complete=True, error=False, labels=labels, results={"cache_key": cache_key})
+        self._store_status(complete=True, error=False, labels=labels, cache_key=cache_key)
 
     def test_with_valid_query_id(self):
         self._store_finished_query(["result1", "result2"])
@@ -1202,7 +1202,7 @@ class TestQueryRetrieve(APIBaseTest):
         self.assertEqual(response.status_code, 404)
 
     def test_finished_query_whose_result_left_the_cache(self):
-        self._store_status(complete=True, error=False, results={"cache_key": "cache_gone"})
+        self._store_status(complete=True, error=False, cache_key="cache_gone")
         response = self.client.get(f"/api/environments/{self.team.id}/query/{self.valid_query_id}/")
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.json()["code"], "query_result_expired")

--- a/posthog/clickhouse/client/async_task_chain.py
+++ b/posthog/clickhouse/client/async_task_chain.py
@@ -31,7 +31,7 @@ def kick_off_task(
 
     # During end-to-end tests, the task is executed synchronously, so we have to refresh the status.
     if isinstance(task, EagerResult):
-        query_status = manager.get_query_status()
+        query_status = manager.get_query_status(resolve_results=False)
         manager.store_query_status(query_status)
 
 

--- a/posthog/clickhouse/client/async_task_chain.py
+++ b/posthog/clickhouse/client/async_task_chain.py
@@ -8,7 +8,6 @@ from django.db import transaction
 
 from celery import chain
 from celery.canvas import Signature
-from celery.result import EagerResult
 
 from posthog.schema import QueryStatus
 
@@ -27,12 +26,7 @@ def kick_off_task(
     task_id = str(uuid.uuid4())
     query_status.task_id = task_id
     manager.store_query_status(query_status)
-    task = task_signature.apply_async(task_id=task_id)
-
-    # During end-to-end tests, the task is executed synchronously, so we have to refresh the status.
-    if isinstance(task, EagerResult):
-        query_status = manager.get_query_status()
-        manager.store_query_status(query_status)
+    task_signature.apply_async(task_id=task_id)
 
 
 def get_task_chain() -> list[tuple[Signature, "QueryStatusManager", QueryStatus]]:

--- a/posthog/clickhouse/client/async_task_chain.py
+++ b/posthog/clickhouse/client/async_task_chain.py
@@ -31,7 +31,7 @@ def kick_off_task(
 
     # During end-to-end tests, the task is executed synchronously, so we have to refresh the status.
     if isinstance(task, EagerResult):
-        query_status = manager.get_query_status(resolve_results=False)
+        query_status = manager.get_query_status()
         manager.store_query_status(query_status)
 
 

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -107,12 +107,20 @@ class QueryStatusManager:
         `cache_key` is where the finished query left its result in the query cache. It rides
         beside the status instead of on it, because QueryStatus is the body of the poll
         response and the cache key is not part of that contract.
+
+        Without a `ttl_seconds` the record lives as long as its state is worth keeping: a day for
+        a finished run, so a late poll still finds it, and minutes for one still in flight.
         """
-        ttl = ttl_seconds if ttl_seconds is not None else settings.ASYNC_QUERY_STATUS_TTL_SECONDS
+        if ttl_seconds is None:
+            ttl_seconds = (
+                settings.ASYNC_QUERY_STATUS_TTL_SECONDS
+                if query_status.complete
+                else settings.RUNNING_QUERY_STATUS_TTL_SECONDS
+            )
         record = query_status.model_dump()
         record["cache_key"] = cache_key
-        query_status.expiration_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=ttl)
-        self.redis_client.set(self.status_key, SafeJSONRenderer().render(record), ex=ttl)
+        query_status.expiration_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=ttl_seconds)
+        self.redis_client.set(self.status_key, SafeJSONRenderer().render(record), ex=ttl_seconds)
 
     def _store_clickhouse_query_progress_dict(self, query_progress_dict):
         value = json.dumps(query_progress_dict)

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -75,7 +75,6 @@ class QueryStatusManager:
     _DATETIME_FIELDS = ("start_time", "pickup_time", "end_time")
     _INT_FIELDS = ("insight_id", "dashboard_id")
     _STRING_FIELDS = ("task_id", "error_message", "error_code")
-    INLINE_RESULT_REFERENCE_MAX_BYTES = 1024
 
     def __init__(self, query_id: str, team_id: int):
         self.redis_client = redis.get_client()
@@ -98,7 +97,16 @@ class QueryStatusManager:
     def running_queries_key(self) -> str:
         return f"{self.KEY_PREFIX_RUNNING_QUERIES}:{self.team_id}"
 
-    def store_query_status(self, query_status: QueryStatus, ttl_seconds: Optional[int] = None) -> None:
+    def store_query_status(
+        self,
+        query_status: QueryStatus,
+        ttl_seconds: Optional[int] = None,
+        result_reference: Optional[dict] = None,
+    ) -> None:
+        """Write the record. `query_status.results` is never stored: a query-runner result is
+        pointed at through the cache key it carries, and a caller whose result lives elsewhere
+        passes a small `result_reference` (for example the object key a notebook frame was
+        written under), which the poll hands back in place of the result."""
         ttl = ttl_seconds if ttl_seconds is not None else settings.ASYNC_QUERY_STATUS_TTL_SECONDS
         query_status.expiration_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=ttl)
         fields: dict[str, str] = {
@@ -122,13 +130,8 @@ class QueryStatusManager:
         cache_key = query_status.results.get("cache_key") if isinstance(query_status.results, dict) else None
         if cache_key:
             fields["cache_key"] = cache_key
-        elif query_status.results is not None:
-            # A result without a cache key is kept only if it is itself a reference, such as the
-            # object key a notebook frame is materialized under. Anything payload-sized is dropped:
-            # the record must not turn back into a result cache.
-            encoded = json.dumps(query_status.results)
-            if len(encoded) <= self.INLINE_RESULT_REFERENCE_MAX_BYTES:
-                fields["results"] = encoded.decode("utf-8")
+        if result_reference is not None:
+            fields["result_reference"] = json.dumps(result_reference).decode("utf-8")
         self.redis_client.hset(self.status_key, mapping=fields)
         self.redis_client.expire(self.status_key, ttl)
 
@@ -211,8 +214,8 @@ class QueryStatusManager:
         )
 
         if query_status.complete and not query_status.error and resolve_results:
-            if record.get("results"):
-                query_status.results = json.loads(record["results"])
+            if record.get("result_reference"):
+                query_status.results = json.loads(record["result_reference"])
             else:
                 query_status.results = self._load_result(record.get("cache_key"))
 

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -101,12 +101,9 @@ class QueryStatusManager:
         self,
         query_status: QueryStatus,
         ttl_seconds: Optional[int] = None,
-        result_reference: Optional[dict] = None,
     ) -> None:
-        """Write the record. `query_status.results` is never stored: a query-runner result is
-        pointed at through the cache key it carries, and a caller whose result lives elsewhere
-        passes a small `result_reference` (for example the object key a notebook frame was
-        written under), which the poll hands back in place of the result."""
+        """Write the record. `query_status.results` is never stored; the record points at the
+        result through the cache key it carries."""
         ttl = ttl_seconds if ttl_seconds is not None else settings.ASYNC_QUERY_STATUS_TTL_SECONDS
         query_status.expiration_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=ttl)
         fields: dict[str, str] = {
@@ -130,8 +127,6 @@ class QueryStatusManager:
         cache_key = query_status.results.get("cache_key") if isinstance(query_status.results, dict) else None
         if cache_key:
             fields["cache_key"] = cache_key
-        if result_reference is not None:
-            fields["result_reference"] = json.dumps(result_reference).decode("utf-8")
         self.redis_client.hset(self.status_key, mapping=fields)
         self.redis_client.expire(self.status_key, ttl)
 
@@ -214,10 +209,7 @@ class QueryStatusManager:
         )
 
         if query_status.complete and not query_status.error and resolve_results:
-            if record.get("result_reference"):
-                query_status.results = json.loads(record["result_reference"])
-            else:
-                query_status.results = self._load_result(record.get("cache_key"))
+            query_status.results = self._load_result(record.get("cache_key"))
 
         if show_progress and not query_status.complete:
             query_status.query_progress = self.get_clickhouse_progresses()

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -119,7 +119,7 @@ class QueryStatusManager:
         self.redis_client.hset(self.handle_key, mapping=fields)
         self.redis_client.expire(self.handle_key, settings.CACHED_RESULTS_TTL)
 
-    def _status_from_handle(self) -> QueryStatus:
+    def _status_from_handle(self, resolve_cached_results: bool) -> QueryStatus:
         raw_handle = self.redis_client.hgetall(self.handle_key)
         if not raw_handle:
             raise QueryNotFoundError(f"Query {self.query_id} not found for team {self.team_id}")
@@ -134,6 +134,11 @@ class QueryStatusManager:
                 error_message=handle.get("error_message") or None,
                 error_code=handle.get("error_code") or None,
             )
+        if complete and not resolve_cached_results:
+            # The enqueue dedup check only needs to know the earlier run is over. Reading the
+            # cache entry here would put a cache lookup, and for large entries an S3 read, on
+            # the enqueue path of every query whose earlier run left a stale dedup mapping.
+            return QueryStatus(id=self.query_id, team_id=self.team_id, complete=True, error=False)
         cache_key = handle.get("cache_key")
         if complete and cache_key:
             entry = QueryCache(team_id=self.team_id, cache_key=cache_key).lookup().entry
@@ -195,11 +200,11 @@ class QueryStatusManager:
             logger.exception("Clickhouse Status Check Failed", error=e)
             return None
 
-    def get_query_status(self, show_progress: bool = False) -> QueryStatus:
+    def get_query_status(self, show_progress: bool = False, resolve_cached_results: bool = True) -> QueryStatus:
         byte_results = self._get_results()
 
         if not byte_results:
-            return self._status_from_handle()
+            return self._status_from_handle(resolve_cached_results)
 
         loaded = json.loads(byte_results)
         # Drop unknown keys so a status written by a newer deploy (with extra fields) doesn't fail
@@ -419,7 +424,7 @@ def enqueue_process_query_task(
         if cache_key:
             existing_query_id = manager.get_running_query_by_cache_key(cache_key)
             if existing_query_id:
-                query_status = get_query_status(team.id, existing_query_id)
+                query_status = get_query_status(team.id, existing_query_id, resolve_cached_results=False)
                 if not query_status.complete:
                     # Only deduplicate against a query that is still in progress
                     posthoganalytics.capture(
@@ -488,12 +493,14 @@ def enqueue_process_query_task(
     return query_status
 
 
-def get_query_status(team_id: int, query_id: str, show_progress: bool = False) -> QueryStatus:
+def get_query_status(
+    team_id: int, query_id: str, show_progress: bool = False, resolve_cached_results: bool = True
+) -> QueryStatus:
     """
     Abstracts away the manager for any caller and returns a QueryStatus object
     """
     manager = QueryStatusManager(query_id, team_id)
-    return manager.get_query_status(show_progress=show_progress)
+    return manager.get_query_status(show_progress=show_progress, resolve_cached_results=resolve_cached_results)
 
 
 def cancel_query(team_id: int, query_id: str, dequeue_only: bool = False) -> str:

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -26,7 +26,6 @@ from posthog.errors import ExposedCHQueryError
 from posthog.exceptions import ClickHouseAtCapacity
 from posthog.exceptions_capture import capture_exception
 from posthog.query_cache.cache import QueryCache
-from posthog.renderers import SafeJSONRenderer
 
 if TYPE_CHECKING:
     from posthog.event_usage import AnalyticsProps
@@ -62,12 +61,21 @@ class QueryRetrievalError(Exception):
 
 
 class QueryStatusManager:
-    STATUS_TTL_SECONDS = 60 * 20  # 20 minutes
     DEDUP_TTL_SECONDS = 60 * 20  # 20 minutes
+    PROGRESS_TTL_SECONDS = 60 * 20  # 20 minutes
     POLL_INTERVAL_SECONDS = 20
     HEARTBEAT_TTL_SECONDS = POLL_INTERVAL_SECONDS * 3
     KEY_PREFIX_ASYNC_RESULTS = "query_async"
     KEY_PREFIX_RUNNING_QUERIES = "running_queries"
+
+    # The status record is a small hash: state, timings, task id, error, and once the query
+    # finishes the cache key of its result. The result itself is never copied here. A poll for a
+    # finished query reads it from the query cache through that key, so the record can stay
+    # small enough to keep for a day while the result lives in the cache tier.
+    _DATETIME_FIELDS = ("start_time", "pickup_time", "end_time")
+    _INT_FIELDS = ("insight_id", "dashboard_id")
+    _STRING_FIELDS = ("task_id", "error_message", "error_code")
+    INLINE_RESULT_REFERENCE_MAX_BYTES = 1024
 
     def __init__(self, query_id: str, team_id: int):
         self.redis_client = redis.get_client()
@@ -75,8 +83,8 @@ class QueryStatusManager:
         self.team_id = team_id
 
     @property
-    def results_key(self) -> str:
-        return f"{self.KEY_PREFIX_ASYNC_RESULTS}:{self.team_id}:{self.query_id}"
+    def status_key(self) -> str:
+        return f"{self.KEY_PREFIX_ASYNC_RESULTS}:{self.team_id}:{self.query_id}:record"
 
     @property
     def clickhouse_query_status_key(self) -> str:
@@ -90,75 +98,43 @@ class QueryStatusManager:
     def running_queries_key(self) -> str:
         return f"{self.KEY_PREFIX_RUNNING_QUERIES}:{self.team_id}"
 
-    @property
-    def handle_key(self) -> str:
-        return f"{self.KEY_PREFIX_ASYNC_RESULTS}:{self.team_id}:{self.query_id}:handle"
-
-    def store_query_status(self, query_status: QueryStatus, cache_key: Optional[str] = None):
-        value = SafeJSONRenderer().render(query_status.model_dump(exclude={"clickhouse_query_progress"}))
-        query_status.expiration_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(
-            seconds=self.STATUS_TTL_SECONDS
-        )
-        self.redis_client.set(self.results_key, value, exat=int(query_status.expiration_time.timestamp()))
-        self._store_handle(query_status, cache_key)
-
-    def _store_handle(self, query_status: QueryStatus, cache_key: Optional[str]) -> None:
-        # The status record above carries the result payload, so it is short-lived. This handle
-        # carries only the outcome and the cache key, and it outlives the status record by
-        # ASYNC_QUERY_HANDLE_TTL_SECONDS. A client that polls after the status record is gone
-        # (a browser tab that stayed hidden, an API script that resumed late) can still be
-        # served from the cache instead of getting a 404 for a result that exists.
-        fields = {
+    def store_query_status(self, query_status: QueryStatus, ttl_seconds: Optional[int] = None) -> None:
+        ttl = ttl_seconds if ttl_seconds is not None else settings.ASYNC_QUERY_STATUS_TTL_SECONDS
+        query_status.expiration_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=ttl)
+        fields: dict[str, str] = {
             "complete": "1" if query_status.complete else "0",
             "error": "1" if query_status.error else "0",
-            "error_message": query_status.error_message or "",
-            "error_code": query_status.error_code or "",
         }
+        for name in self._STRING_FIELDS:
+            value = getattr(query_status, name)
+            if value is not None:
+                fields[name] = str(value)
+        for name in self._INT_FIELDS:
+            value = getattr(query_status, name)
+            if value is not None:
+                fields[name] = str(value)
+        for name in self._DATETIME_FIELDS:
+            value = getattr(query_status, name)
+            if value is not None:
+                fields[name] = value.isoformat()
+        if query_status.labels is not None:
+            fields["labels"] = json.dumps(query_status.labels).decode("utf-8")
+        cache_key = query_status.results.get("cache_key") if isinstance(query_status.results, dict) else None
         if cache_key:
             fields["cache_key"] = cache_key
-        self.redis_client.hset(self.handle_key, mapping=fields)
-        self.redis_client.expire(self.handle_key, settings.ASYNC_QUERY_HANDLE_TTL_SECONDS)
-
-    def _status_from_handle(self, resolve_cached_results: bool) -> QueryStatus:
-        raw_handle = self.redis_client.hgetall(self.handle_key)
-        if not raw_handle:
-            raise QueryNotFoundError(f"Query {self.query_id} not found for team {self.team_id}")
-        handle = {key.decode("utf-8"): value.decode("utf-8") for key, value in raw_handle.items()}
-        complete = handle.get("complete") == "1"
-        if complete and handle.get("error") == "1":
-            return QueryStatus(
-                id=self.query_id,
-                team_id=self.team_id,
-                complete=True,
-                error=True,
-                error_message=handle.get("error_message") or None,
-                error_code=handle.get("error_code") or None,
-            )
-        if complete and not resolve_cached_results:
-            # The enqueue dedup check only needs to know the earlier run is over. Reading the
-            # cache entry here would put a cache lookup, and for large entries an S3 read, on
-            # the enqueue path of every query whose earlier run left a stale dedup mapping.
-            return QueryStatus(id=self.query_id, team_id=self.team_id, complete=True, error=False)
-        cache_key = handle.get("cache_key")
-        if complete and cache_key:
-            entry = QueryCache(team_id=self.team_id, cache_key=cache_key).lookup().entry
-            response = entry.as_full_response() if entry else None
-            if response is not None:
-                response["is_cached"] = True
-                return QueryStatus(id=self.query_id, team_id=self.team_id, complete=True, error=False, results=response)
-        raise QueryResultExpiredError("The result expired. Refresh to run the query again.")
+        elif query_status.results is not None:
+            # A result without a cache key is kept only if it is itself a reference, such as the
+            # object key a notebook frame is materialized under. Anything payload-sized is dropped:
+            # the record must not turn back into a result cache.
+            encoded = json.dumps(query_status.results)
+            if len(encoded) <= self.INLINE_RESULT_REFERENCE_MAX_BYTES:
+                fields["results"] = encoded.decode("utf-8")
+        self.redis_client.hset(self.status_key, mapping=fields)
+        self.redis_client.expire(self.status_key, ttl)
 
     def _store_clickhouse_query_progress_dict(self, query_progress_dict):
         value = json.dumps(query_progress_dict)
-        self.redis_client.set(self.clickhouse_query_status_key, value, ex=self.STATUS_TTL_SECONDS)
-
-    def _get_results(self):
-        try:
-            byte_results = self.redis_client.get(self.results_key)
-        except Exception as e:
-            raise QueryRetrievalError(f"Error retrieving query {self.query_id} for team {self.team_id}") from e
-
-        return byte_results
+        self.redis_client.set(self.clickhouse_query_status_key, value, ex=self.PROGRESS_TTL_SECONDS)
 
     def _get_clickhouse_query_progress_dict(self):
         try:
@@ -180,7 +156,7 @@ class QueryStatusManager:
         self.redis_client.set(self.heartbeat_key, "1", ex=self.HEARTBEAT_TTL_SECONDS)
 
     def has_results(self) -> bool:
-        return self.redis_client.exists(self.results_key) == 1
+        return self.redis_client.exists(self.status_key) == 1
 
     def get_clickhouse_progresses(self) -> Optional[ClickhouseQueryProgress]:
         try:
@@ -200,27 +176,67 @@ class QueryStatusManager:
             logger.exception("Clickhouse Status Check Failed", error=e)
             return None
 
-    def get_query_status(self, show_progress: bool = False, resolve_cached_results: bool = True) -> QueryStatus:
-        byte_results = self._get_results()
+    def _read_record(self) -> dict[str, str]:
+        try:
+            raw = self.redis_client.hgetall(self.status_key)
+        except Exception as e:
+            raise QueryRetrievalError(f"Error retrieving query {self.query_id} for team {self.team_id}") from e
+        return {key.decode("utf-8"): value.decode("utf-8") for key, value in raw.items()}
 
-        if not byte_results:
-            return self._status_from_handle(resolve_cached_results)
+    def get_query_status(self, show_progress: bool = False, resolve_results: bool = True) -> QueryStatus:
+        """The status of this query.
 
-        loaded = json.loads(byte_results)
-        # Drop unknown keys so a status written by a newer deploy (with extra fields) doesn't fail
-        # validation here — QueryStatus forbids extra fields.
-        query_status = QueryStatus(**{k: v for k, v in loaded.items() if k in QueryStatus.model_fields})
+        `resolve_results=False` skips the query cache read for a finished query. Use it where only
+        the state matters (dedup at enqueue, the retry guard), so those paths never pay for a cache
+        lookup, which for large results means an S3 read.
+        """
+        record = self._read_record()
+        if not record:
+            raise QueryNotFoundError(f"Query {self.query_id} not found for team {self.team_id}")
+
+        query_status = QueryStatus(
+            id=self.query_id,
+            team_id=self.team_id,
+            complete=record.get("complete") == "1",
+            error=record.get("error") == "1",
+            task_id=record.get("task_id"),
+            error_message=record.get("error_message"),
+            error_code=record.get("error_code"),
+            insight_id=int(record["insight_id"]) if record.get("insight_id") else None,
+            dashboard_id=int(record["dashboard_id"]) if record.get("dashboard_id") else None,
+            labels=json.loads(record["labels"]) if record.get("labels") else None,
+            start_time=self._parse_datetime(record.get("start_time")),
+            pickup_time=self._parse_datetime(record.get("pickup_time")),
+            end_time=self._parse_datetime(record.get("end_time")),
+        )
+
+        if query_status.complete and not query_status.error and resolve_results:
+            if record.get("results"):
+                query_status.results = json.loads(record["results"])
+            else:
+                query_status.results = self._load_result(record.get("cache_key"))
 
         if show_progress and not query_status.complete:
             query_status.query_progress = self.get_clickhouse_progresses()
 
         return query_status
 
+    def _load_result(self, cache_key: Optional[str]) -> dict:
+        entry = QueryCache(team_id=self.team_id, cache_key=cache_key).lookup().entry if cache_key else None
+        response = entry.as_full_response() if entry else None
+        if response is None:
+            raise QueryResultExpiredError("The result expired. Refresh to run the query again.")
+        response["is_cached"] = True
+        return response
+
+    @staticmethod
+    def _parse_datetime(value: Optional[str]) -> Optional[datetime.datetime]:
+        return datetime.datetime.fromisoformat(value) if value else None
+
     def delete_query_status(self) -> None:
-        logger.info("Deleting redis query key %s", self.results_key)
-        self.redis_client.delete(self.results_key)
+        logger.info("Deleting redis query key %s", self.status_key)
+        self.redis_client.delete(self.status_key)
         self.redis_client.delete(self.clickhouse_query_status_key)
-        self.redis_client.delete(self.handle_key)
 
     def get_running_query_by_cache_key(self, cache_key: str) -> Optional[str]:
         """Get the query_id of a running query with the given cache_key, if any."""
@@ -424,7 +440,7 @@ def enqueue_process_query_task(
         if cache_key:
             existing_query_id = manager.get_running_query_by_cache_key(cache_key)
             if existing_query_id:
-                query_status = get_query_status(team.id, existing_query_id, resolve_cached_results=False)
+                query_status = get_query_status(team.id, existing_query_id, resolve_results=False)
                 if not query_status.complete:
                     # Only deduplicate against a query that is still in progress
                     posthoganalytics.capture(
@@ -456,7 +472,7 @@ def enqueue_process_query_task(
         labels=labels,
     )
     query_tags = get_query_tags().model_dump()
-    manager.store_query_status(query_status, cache_key=cache_key)
+    manager.store_query_status(query_status)
 
     if cache_key:
         try:
@@ -494,13 +510,58 @@ def enqueue_process_query_task(
 
 
 def get_query_status(
-    team_id: int, query_id: str, show_progress: bool = False, resolve_cached_results: bool = True
+    team_id: int, query_id: str, show_progress: bool = False, resolve_results: bool = True
 ) -> QueryStatus:
     """
     Abstracts away the manager for any caller and returns a QueryStatus object
     """
     manager = QueryStatusManager(query_id, team_id)
-    return manager.get_query_status(show_progress=show_progress, resolve_cached_results=resolve_cached_results)
+    return manager.get_query_status(show_progress=show_progress, resolve_results=resolve_results)
+
+
+def record_blocking_query_result(team_id: int, query_id: str, result: dict) -> None:
+    """Point a finished blocking query at its cached result.
+
+    The ingress drops a request that runs longer than its idle timeout while the server keeps
+    running the query. With this record the client can poll the query ID it sent and get the
+    result once it lands in the cache, instead of reporting a gateway timeout for work that
+    completed.
+    """
+    query_status = QueryStatus(
+        id=query_id,
+        team_id=team_id,
+        complete=True,
+        error=False,
+        end_time=datetime.datetime.now(datetime.UTC),
+        results=result,
+    )
+    QueryStatusManager(query_id, team_id).store_query_status(
+        query_status, ttl_seconds=settings.BLOCKING_QUERY_STATUS_TTL_SECONDS
+    )
+
+
+def record_blocking_query_failure(team_id: int, query_id: str, error: Exception) -> None:
+    query_status = QueryStatus(
+        id=query_id,
+        team_id=team_id,
+        complete=True,
+        error=True,
+        end_time=datetime.datetime.now(datetime.UTC),
+        error_message=_user_safe_error_message(error),
+    )
+    QueryStatusManager(query_id, team_id).store_query_status(
+        query_status, ttl_seconds=settings.BLOCKING_QUERY_STATUS_TTL_SECONDS
+    )
+
+
+def _user_safe_error_message(error: Exception) -> Optional[str]:
+    # Same rule as the async path: only errors we already show to the user may be stored
+    # in the record, everything else stays a generic failure.
+    if isinstance(error, APIException):
+        return str(error.detail)
+    if isinstance(error, ExposedHogQLError | ExposedCHQueryError):
+        return str(error)
+    return None
 
 
 def cancel_query(team_id: int, query_id: str, dequeue_only: bool = False) -> str:
@@ -516,7 +577,7 @@ def cancel_query(team_id: int, query_id: str, dequeue_only: bool = False) -> str
     message = "Query task revoked"
 
     try:
-        query_status = manager.get_query_status()
+        query_status = manager.get_query_status(resolve_results=False)
 
         if query_status.complete:
             return "Query already complete"

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -26,6 +26,7 @@ from posthog.errors import ExposedCHQueryError
 from posthog.exceptions import ClickHouseAtCapacity
 from posthog.exceptions_capture import capture_exception
 from posthog.query_cache.cache import QueryCache
+from posthog.renderers import SafeJSONRenderer
 
 if TYPE_CHECKING:
     from posthog.event_usage import AnalyticsProps
@@ -68,14 +69,6 @@ class QueryStatusManager:
     KEY_PREFIX_ASYNC_RESULTS = "query_async"
     KEY_PREFIX_RUNNING_QUERIES = "running_queries"
 
-    # The status record is a small hash: state, timings, task id, error, and once the query
-    # finishes the cache key of its result. A query-runner result is never copied here. A poll
-    # for a finished query reads it from the query cache through that key, so the record can
-    # stay small enough to keep for a day while the result lives in the cache tier.
-    _DATETIME_FIELDS = ("start_time", "pickup_time", "end_time")
-    _INT_FIELDS = ("insight_id", "dashboard_id")
-    _STRING_FIELDS = ("task_id", "error_message", "error_code")
-
     def __init__(self, query_id: str, team_id: int):
         self.redis_client = redis.get_client()
         self.query_id = query_id
@@ -83,7 +76,7 @@ class QueryStatusManager:
 
     @property
     def status_key(self) -> str:
-        return f"{self.KEY_PREFIX_ASYNC_RESULTS}:{self.team_id}:{self.query_id}:record"
+        return f"{self.KEY_PREFIX_ASYNC_RESULTS}:{self.team_id}:{self.query_id}"
 
     @property
     def clickhouse_query_status_key(self) -> str:
@@ -103,34 +96,17 @@ class QueryStatusManager:
         ttl_seconds: Optional[int] = None,
         cache_key: Optional[str] = None,
     ) -> None:
-        """Write the record. `results` is stored as given. A query-runner result does not go in
-        it: the caller passes its cache key and the poll reads the result from the query cache."""
+        """Write the record, replacing whatever was under this query ID.
+
+        `cache_key` is where the finished query left its result in the query cache. It rides
+        beside the status instead of on it, because QueryStatus is the body of the poll
+        response and the cache key is not part of that contract.
+        """
         ttl = ttl_seconds if ttl_seconds is not None else settings.ASYNC_QUERY_STATUS_TTL_SECONDS
+        record = query_status.model_dump()
+        record["cache_key"] = cache_key
         query_status.expiration_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=ttl)
-        fields: dict[str | bytes, str] = {
-            "complete": "1" if query_status.complete else "0",
-            "error": "1" if query_status.error else "0",
-        }
-        for name in self._STRING_FIELDS:
-            value = getattr(query_status, name)
-            if value is not None:
-                fields[name] = str(value)
-        for name in self._INT_FIELDS:
-            value = getattr(query_status, name)
-            if value is not None:
-                fields[name] = str(value)
-        for name in self._DATETIME_FIELDS:
-            value = getattr(query_status, name)
-            if value is not None:
-                fields[name] = value.isoformat()
-        if query_status.labels is not None:
-            fields["labels"] = json.dumps(query_status.labels).decode("utf-8")
-        if query_status.results is not None:
-            fields["results"] = json.dumps(query_status.results).decode("utf-8")
-        if cache_key:
-            fields["cache_key"] = cache_key
-        self.redis_client.hset(self.status_key, mapping=fields)
-        self.redis_client.expire(self.status_key, ttl)
+        self.redis_client.set(self.status_key, SafeJSONRenderer().render(record), ex=ttl)
 
     def _store_clickhouse_query_progress_dict(self, query_progress_dict):
         value = json.dumps(query_progress_dict)
@@ -155,9 +131,6 @@ class QueryStatusManager:
         self._store_clickhouse_query_progress_dict(clickhouse_query_progress_dict)
         self.redis_client.set(self.heartbeat_key, "1", ex=self.HEARTBEAT_TTL_SECONDS)
 
-    def has_results(self) -> bool:
-        return self.redis_client.exists(self.status_key) == 1
-
     def get_clickhouse_progresses(self) -> Optional[ClickhouseQueryProgress]:
         try:
             clickhouse_query_progress_dict = self._get_clickhouse_query_progress_dict()
@@ -176,62 +149,56 @@ class QueryStatusManager:
             logger.exception("Clickhouse Status Check Failed", error=e)
             return None
 
-    def _read_record(self) -> dict[str, str]:
+    def _load_record(self) -> tuple[QueryStatus, Optional[str]]:
+        """The stored status, and the cache key its result is under once the query finished."""
         try:
-            raw = self.redis_client.hgetall(self.status_key)
+            raw = self.redis_client.get(self.status_key)
         except Exception as e:
             raise QueryRetrievalError(f"Error retrieving query {self.query_id} for team {self.team_id}") from e
-        return {key.decode("utf-8"): value.decode("utf-8") for key, value in raw.items()}
 
-    def get_query_status(self, show_progress: bool = False, resolve_results: bool = True) -> QueryStatus:
-        """The status of this query.
-
-        `resolve_results=False` skips the query cache read for a finished query. Use it where only
-        the state matters (dedup at enqueue, the retry guard), so those paths never pay for a cache
-        lookup, which for large results means an S3 read.
-        """
-        record = self._read_record()
-        if not record:
+        if not raw:
             raise QueryNotFoundError(f"Query {self.query_id} not found for team {self.team_id}")
 
-        query_status = QueryStatus(
-            id=self.query_id,
-            team_id=self.team_id,
-            complete=record.get("complete") == "1",
-            error=record.get("error") == "1",
-            task_id=record.get("task_id"),
-            error_message=record.get("error_message"),
-            error_code=record.get("error_code"),
-            insight_id=int(record["insight_id"]) if record.get("insight_id") else None,
-            dashboard_id=int(record["dashboard_id"]) if record.get("dashboard_id") else None,
-            labels=json.loads(record["labels"]) if record.get("labels") else None,
-            start_time=self._parse_datetime(record.get("start_time")),
-            pickup_time=self._parse_datetime(record.get("pickup_time")),
-            end_time=self._parse_datetime(record.get("end_time")),
-        )
+        record = json.loads(raw)
+        # Drop unknown keys so a status written by a newer deploy (with extra fields) doesn't fail
+        # validation here — QueryStatus forbids extra fields.
+        query_status = QueryStatus(**{k: v for k, v in record.items() if k in QueryStatus.model_fields})
+        return query_status, record.get("cache_key")
 
-        if query_status.complete and not query_status.error and resolve_results:
-            if record.get("results"):
-                query_status.results = json.loads(record["results"])
-            else:
-                query_status.results = self._load_result(record.get("cache_key"))
+    def get_query_status(self, show_progress: bool = False) -> QueryStatus:
+        """The state of this query, without its result.
 
+        A query run through the query runner leaves its result in the query cache, so `results`
+        is empty here unless whoever stored the status put one in it. Callers that need the
+        result of a finished query use `get_query_status_with_result`; every other caller reads
+        state alone and does not pay for a cache lookup, which for a large result means an S3 read.
+        """
+        query_status, _ = self._load_record()
         if show_progress and not query_status.complete:
             query_status.query_progress = self.get_clickhouse_progresses()
-
         return query_status
 
-    def _load_result(self, cache_key: Optional[str]) -> dict:
+    def get_query_status_with_result(self, show_progress: bool = False) -> QueryStatus:
+        """The state of this query with the result of a finished run attached.
+
+        The record holds the cache key rather than the result, which is what lets it stay small
+        enough to keep for a day. A result that has since left the query cache cannot be rebuilt
+        from the record, so the query has to run again.
+        """
+        query_status, cache_key = self._load_record()
+        if show_progress and not query_status.complete:
+            query_status.query_progress = self.get_clickhouse_progresses()
+        if query_status.complete and not query_status.error and query_status.results is None:
+            query_status.results = self._read_cached_result(cache_key)
+        return query_status
+
+    def _read_cached_result(self, cache_key: Optional[str]) -> dict:
         entry = QueryCache(team_id=self.team_id, cache_key=cache_key).lookup().entry if cache_key else None
         response = entry.as_full_response() if entry else None
         if response is None:
             raise QueryResultExpiredError("The result expired. Refresh to run the query again.")
         response["is_cached"] = True
         return response
-
-    @staticmethod
-    def _parse_datetime(value: Optional[str]) -> Optional[datetime.datetime]:
-        return datetime.datetime.fromisoformat(value) if value else None
 
     def delete_query_status(self) -> None:
         logger.info("Deleting redis query key %s", self.status_key)
@@ -429,15 +396,22 @@ def enqueue_process_query_task(
     if force:
         cancel_query(team.id, query_id)
 
-    if manager.has_results() and not refresh_requested:
-        # If we've seen this query before return and don't resubmit it.
-        return manager.get_query_status()
+    if not refresh_requested:
+        try:
+            # The same query ID came in again while its run is still going, so join that run.
+            # A finished record decides nothing here: a success is answered by the query cache,
+            # and whether a failure may run again is the failure breaker's call in the query runner.
+            in_flight = manager.get_query_status()
+            if not in_flight.complete:
+                return in_flight
+        except QueryNotFoundError:
+            pass
 
     try:
         if cache_key:
             existing_query_id = manager.get_running_query_by_cache_key(cache_key)
             if existing_query_id:
-                query_status = get_query_status(team.id, existing_query_id, resolve_results=False)
+                query_status = QueryStatusManager(existing_query_id, team.id).get_query_status()
                 if not query_status.complete:
                     # Only deduplicate against a query that is still in progress
                     posthoganalytics.capture(
@@ -506,14 +480,13 @@ def enqueue_process_query_task(
     return query_status
 
 
-def get_query_status(
-    team_id: int, query_id: str, show_progress: bool = False, resolve_results: bool = True
-) -> QueryStatus:
+def get_query_status(team_id: int, query_id: str, show_progress: bool = False) -> QueryStatus:
+    """The status of a query with the result of a finished run attached.
+
+    This is what the poll endpoints answer with. Callers that only need to know whether a query
+    is still running should use `QueryStatusManager.get_query_status` instead.
     """
-    Abstracts away the manager for any caller and returns a QueryStatus object
-    """
-    manager = QueryStatusManager(query_id, team_id)
-    return manager.get_query_status(show_progress=show_progress, resolve_results=resolve_results)
+    return QueryStatusManager(query_id, team_id).get_query_status_with_result(show_progress=show_progress)
 
 
 def record_blocking_query_result(team_id: int, query_id: str, result: dict) -> None:
@@ -531,9 +504,7 @@ def record_blocking_query_result(team_id: int, query_id: str, result: dict) -> N
         error=False,
         end_time=datetime.datetime.now(datetime.UTC),
     )
-    QueryStatusManager(query_id, team_id).store_query_status(
-        query_status, ttl_seconds=settings.BLOCKING_QUERY_STATUS_TTL_SECONDS, cache_key=result.get("cache_key")
-    )
+    _record_blocking_query_status(team_id, query_id, query_status, cache_key=result.get("cache_key"))
 
 
 def record_blocking_query_failure(team_id: int, query_id: str, error: Exception) -> None:
@@ -545,8 +516,26 @@ def record_blocking_query_failure(team_id: int, query_id: str, error: Exception)
         end_time=datetime.datetime.now(datetime.UTC),
         error_message=_user_safe_error_message(error),
     )
-    QueryStatusManager(query_id, team_id).store_query_status(
-        query_status, ttl_seconds=settings.BLOCKING_QUERY_STATUS_TTL_SECONDS
+    _record_blocking_query_status(team_id, query_id, query_status, cache_key=None)
+
+
+def _record_blocking_query_status(
+    team_id: int, query_id: str, query_status: QueryStatus, cache_key: Optional[str]
+) -> None:
+    """Store the outcome under the query ID the client sent.
+
+    The client picks that ID, and an async run of the same query is filed under an ID the client
+    can also see, so the two can name the same record. A run that is still going owns it: the
+    poller is waiting for that run's outcome, and this one would answer with a different result.
+    """
+    manager = QueryStatusManager(query_id, team_id)
+    try:
+        if not manager.get_query_status().complete:
+            return
+    except QueryNotFoundError:
+        pass
+    manager.store_query_status(
+        query_status, ttl_seconds=settings.BLOCKING_QUERY_STATUS_TTL_SECONDS, cache_key=cache_key
     )
 
 
@@ -573,7 +562,7 @@ def cancel_query(team_id: int, query_id: str, dequeue_only: bool = False) -> str
     message = "Query task revoked"
 
     try:
-        query_status = manager.get_query_status(resolve_results=False)
+        query_status = manager.get_query_status()
 
         if query_status.complete:
             return "Query already complete"

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -69,9 +69,9 @@ class QueryStatusManager:
     KEY_PREFIX_RUNNING_QUERIES = "running_queries"
 
     # The status record is a small hash: state, timings, task id, error, and once the query
-    # finishes the cache key of its result. The result itself is never copied here. A poll for a
-    # finished query reads it from the query cache through that key, so the record can stay
-    # small enough to keep for a day while the result lives in the cache tier.
+    # finishes the cache key of its result. A query-runner result is never copied here. A poll
+    # for a finished query reads it from the query cache through that key, so the record can
+    # stay small enough to keep for a day while the result lives in the cache tier.
     _DATETIME_FIELDS = ("start_time", "pickup_time", "end_time")
     _INT_FIELDS = ("insight_id", "dashboard_id")
     _STRING_FIELDS = ("task_id", "error_message", "error_code")
@@ -101,12 +101,13 @@ class QueryStatusManager:
         self,
         query_status: QueryStatus,
         ttl_seconds: Optional[int] = None,
+        cache_key: Optional[str] = None,
     ) -> None:
-        """Write the record. `query_status.results` is never stored; the record points at the
-        result through the cache key it carries."""
+        """Write the record. `results` is stored as given. A query-runner result does not go in
+        it: the caller passes its cache key and the poll reads the result from the query cache."""
         ttl = ttl_seconds if ttl_seconds is not None else settings.ASYNC_QUERY_STATUS_TTL_SECONDS
         query_status.expiration_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=ttl)
-        fields: dict[str, str] = {
+        fields: dict[str | bytes, str] = {
             "complete": "1" if query_status.complete else "0",
             "error": "1" if query_status.error else "0",
         }
@@ -124,7 +125,8 @@ class QueryStatusManager:
                 fields[name] = value.isoformat()
         if query_status.labels is not None:
             fields["labels"] = json.dumps(query_status.labels).decode("utf-8")
-        cache_key = query_status.results.get("cache_key") if isinstance(query_status.results, dict) else None
+        if query_status.results is not None:
+            fields["results"] = json.dumps(query_status.results).decode("utf-8")
         if cache_key:
             fields["cache_key"] = cache_key
         self.redis_client.hset(self.status_key, mapping=fields)
@@ -209,7 +211,10 @@ class QueryStatusManager:
         )
 
         if query_status.complete and not query_status.error and resolve_results:
-            query_status.results = self._load_result(record.get("cache_key"))
+            if record.get("results"):
+                query_status.results = json.loads(record["results"])
+            else:
+                query_status.results = self._load_result(record.get("cache_key"))
 
         if show_progress and not query_status.complete:
             query_status.query_progress = self.get_clickhouse_progresses()
@@ -325,6 +330,7 @@ def execute_process_query(
 
     query_status.error = True  # Assume error in case nothing below ends up working
     query_status.complete = True
+    cache_key: Optional[str] = None
 
     trigger = "chained" if "chained" in (query_status.labels or []) else ""
     if trigger == "chained":
@@ -350,7 +356,7 @@ def execute_process_query(
             results = results.model_dump(by_alias=True)
         logger.info("Got results for team %s query %s", team_id, query_id)
         query_status.error = False
-        query_status.results = results
+        cache_key = results.get("cache_key")
         process_duration = (datetime.datetime.now(datetime.UTC) - query_status.pickup_time) / datetime.timedelta(
             seconds=1
         )
@@ -368,7 +374,6 @@ def execute_process_query(
     except Exception as err:
         from products.access_control.backend.facade.user_access_control import UserAccessControlError
 
-        query_status.results = None  # Clear results in case they are faulty
         is_user_safe_error = isinstance(
             err, APIException | ExposedHogQLError | ExposedCHQueryError | UserAccessControlError
         )
@@ -389,13 +394,10 @@ def execute_process_query(
         # Do not raise here, the task itself did its job and we cannot recover
     finally:
         query_status.end_time = datetime.datetime.now(datetime.UTC)
-        manager.store_query_status(query_status)
-        cache_key = None
+        manager.store_query_status(query_status, cache_key=cache_key)
         try:
-            if query_status.results:
-                cache_key = query_status.results.get("cache_key")
-                if cache_key:
-                    manager.unregister_cache_key_mapping(cache_key)
+            if cache_key:
+                manager.unregister_cache_key_mapping(cache_key)
         except Exception as e:
             capture_exception(e, {"cache_key": cache_key})
 
@@ -528,10 +530,9 @@ def record_blocking_query_result(team_id: int, query_id: str, result: dict) -> N
         complete=True,
         error=False,
         end_time=datetime.datetime.now(datetime.UTC),
-        results=result,
     )
     QueryStatusManager(query_id, team_id).store_query_status(
-        query_status, ttl_seconds=settings.BLOCKING_QUERY_STATUS_TTL_SECONDS
+        query_status, ttl_seconds=settings.BLOCKING_QUERY_STATUS_TTL_SECONDS, cache_key=result.get("cache_key")
     )
 
 

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -2,6 +2,8 @@ import uuid
 import datetime
 from typing import TYPE_CHECKING, Optional, cast
 
+from django.conf import settings
+
 import orjson as json
 import structlog
 import posthoganalytics
@@ -23,6 +25,7 @@ from posthog.direct_query_cancellation import build_direct_query_cancellation_to
 from posthog.errors import ExposedCHQueryError
 from posthog.exceptions import ClickHouseAtCapacity
 from posthog.exceptions_capture import capture_exception
+from posthog.query_cache.cache import QueryCache
 from posthog.renderers import SafeJSONRenderer
 
 if TYPE_CHECKING:
@@ -48,6 +51,10 @@ QUERY_PROCESS_TIME = Histogram(
 
 class QueryNotFoundError(NotFound):
     pass
+
+
+class QueryResultExpiredError(QueryNotFoundError):
+    default_code = "query_result_expired"
 
 
 class QueryRetrievalError(Exception):
@@ -83,12 +90,58 @@ class QueryStatusManager:
     def running_queries_key(self) -> str:
         return f"{self.KEY_PREFIX_RUNNING_QUERIES}:{self.team_id}"
 
-    def store_query_status(self, query_status: QueryStatus):
+    @property
+    def handle_key(self) -> str:
+        return f"{self.KEY_PREFIX_ASYNC_RESULTS}:{self.team_id}:{self.query_id}:handle"
+
+    def store_query_status(self, query_status: QueryStatus, cache_key: Optional[str] = None):
         value = SafeJSONRenderer().render(query_status.model_dump(exclude={"clickhouse_query_progress"}))
         query_status.expiration_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(
             seconds=self.STATUS_TTL_SECONDS
         )
         self.redis_client.set(self.results_key, value, exat=int(query_status.expiration_time.timestamp()))
+        self._store_handle(query_status, cache_key)
+
+    def _store_handle(self, query_status: QueryStatus, cache_key: Optional[str]) -> None:
+        # The status record above carries the result payload, so it is short-lived. This handle
+        # carries only the outcome and the cache key, and it lives as long as the query cache
+        # entry does. A client that polls after the status record is gone (a browser tab that
+        # stayed hidden, an API script that resumed late) can still be served from the cache
+        # instead of getting a 404 for a result that exists.
+        fields = {
+            "complete": "1" if query_status.complete else "0",
+            "error": "1" if query_status.error else "0",
+            "error_message": query_status.error_message or "",
+            "error_code": query_status.error_code or "",
+        }
+        if cache_key:
+            fields["cache_key"] = cache_key
+        self.redis_client.hset(self.handle_key, mapping=fields)
+        self.redis_client.expire(self.handle_key, settings.CACHED_RESULTS_TTL)
+
+    def _status_from_handle(self) -> QueryStatus:
+        raw_handle = self.redis_client.hgetall(self.handle_key)
+        if not raw_handle:
+            raise QueryNotFoundError(f"Query {self.query_id} not found for team {self.team_id}")
+        handle = {key.decode("utf-8"): value.decode("utf-8") for key, value in raw_handle.items()}
+        complete = handle.get("complete") == "1"
+        if complete and handle.get("error") == "1":
+            return QueryStatus(
+                id=self.query_id,
+                team_id=self.team_id,
+                complete=True,
+                error=True,
+                error_message=handle.get("error_message") or None,
+                error_code=handle.get("error_code") or None,
+            )
+        cache_key = handle.get("cache_key")
+        if complete and cache_key:
+            entry = QueryCache(team_id=self.team_id, cache_key=cache_key).lookup().entry
+            response = entry.as_full_response() if entry else None
+            if response is not None:
+                response["is_cached"] = True
+                return QueryStatus(id=self.query_id, team_id=self.team_id, complete=True, error=False, results=response)
+        raise QueryResultExpiredError("The result expired. Refresh to run the query again.")
 
     def _store_clickhouse_query_progress_dict(self, query_progress_dict):
         value = json.dumps(query_progress_dict)
@@ -146,7 +199,7 @@ class QueryStatusManager:
         byte_results = self._get_results()
 
         if not byte_results:
-            raise QueryNotFoundError(f"Query {self.query_id} not found for team {self.team_id}")
+            return self._status_from_handle()
 
         loaded = json.loads(byte_results)
         # Drop unknown keys so a status written by a newer deploy (with extra fields) doesn't fail
@@ -162,6 +215,7 @@ class QueryStatusManager:
         logger.info("Deleting redis query key %s", self.results_key)
         self.redis_client.delete(self.results_key)
         self.redis_client.delete(self.clickhouse_query_status_key)
+        self.redis_client.delete(self.handle_key)
 
     def get_running_query_by_cache_key(self, cache_key: str) -> Optional[str]:
         """Get the query_id of a running query with the given cache_key, if any."""
@@ -397,7 +451,7 @@ def enqueue_process_query_task(
         labels=labels,
     )
     query_tags = get_query_tags().model_dump()
-    manager.store_query_status(query_status)
+    manager.store_query_status(query_status, cache_key=cache_key)
 
     if cache_key:
         try:

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -530,13 +530,18 @@ def _record_blocking_query_status(
     """
     manager = QueryStatusManager(query_id, team_id)
     try:
-        if not manager.get_query_status().complete:
-            return
-    except QueryNotFoundError:
-        pass
-    manager.store_query_status(
-        query_status, ttl_seconds=settings.BLOCKING_QUERY_STATUS_TTL_SECONDS, cache_key=cache_key
-    )
+        try:
+            if not manager.get_query_status().complete:
+                return
+        except QueryNotFoundError:
+            pass
+        manager.store_query_status(
+            query_status, ttl_seconds=settings.BLOCKING_QUERY_STATUS_TTL_SECONDS, cache_key=cache_key
+        )
+    except Exception as e:
+        # The record only exists so a dropped request can be followed up on. A Redis failure here
+        # must not fail a query that succeeded, nor replace the error a failed one is about to raise.
+        capture_exception(e, {"query_id": query_id})
 
 
 def _user_safe_error_message(error: Exception) -> Optional[str]:

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -104,10 +104,10 @@ class QueryStatusManager:
 
     def _store_handle(self, query_status: QueryStatus, cache_key: Optional[str]) -> None:
         # The status record above carries the result payload, so it is short-lived. This handle
-        # carries only the outcome and the cache key, and it lives as long as the query cache
-        # entry does. A client that polls after the status record is gone (a browser tab that
-        # stayed hidden, an API script that resumed late) can still be served from the cache
-        # instead of getting a 404 for a result that exists.
+        # carries only the outcome and the cache key, and it outlives the status record by
+        # ASYNC_QUERY_HANDLE_TTL_SECONDS. A client that polls after the status record is gone
+        # (a browser tab that stayed hidden, an API script that resumed late) can still be
+        # served from the cache instead of getting a 404 for a result that exists.
         fields = {
             "complete": "1" if query_status.complete else "0",
             "error": "1" if query_status.error else "0",
@@ -117,7 +117,7 @@ class QueryStatusManager:
         if cache_key:
             fields["cache_key"] = cache_key
         self.redis_client.hset(self.handle_key, mapping=fields)
-        self.redis_client.expire(self.handle_key, settings.CACHED_RESULTS_TTL)
+        self.redis_client.expire(self.handle_key, settings.ASYNC_QUERY_HANDLE_TTL_SECONDS)
 
     def _status_from_handle(self, resolve_cached_results: bool) -> QueryStatus:
         raw_handle = self.redis_client.hgetall(self.handle_key)

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -558,6 +558,7 @@ def record_blocking_query_failure(team_id: int, query_id: str, error: Exception)
         error=True,
         end_time=datetime.datetime.now(datetime.UTC),
         error_message=_user_safe_error_message(error),
+        error_code=_user_safe_error_code(error),
     )
     _record_blocking_query_status(team_id, query_id, query_status, cache_key=None)
 
@@ -587,6 +588,15 @@ def _user_safe_error_message(error: Exception) -> Optional[str]:
     if isinstance(error, ExposedHogQLError | ExposedCHQueryError | UserAccessControlError):
         return str(error)
     return None
+
+
+def _user_safe_error_code(error: Exception) -> Optional[str]:
+    # As in the async path: only a scalar code means anything to the frontend, which matches on
+    # specific code strings. A compound validation error returns a list or a dict instead.
+    if not isinstance(error, APIException):
+        return None
+    codes = error.get_codes()
+    return codes if isinstance(codes, str) else None
 
 
 def cancel_query(team_id: int, query_id: str, dequeue_only: bool = False) -> str:

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -67,16 +67,22 @@ class QueryStatusManager:
     POLL_INTERVAL_SECONDS = 20
     HEARTBEAT_TTL_SECONDS = POLL_INTERVAL_SECONDS * 3
     KEY_PREFIX_ASYNC_RESULTS = "query_async"
+    # A blocking request files its outcome under the query ID its client chose, and an async run
+    # is filed under an ID the client can read off any response, so one namespace would let a
+    # client's own record answer a poll that is waiting for a different run. Two namespaces make
+    # that impossible, which a check before the write could only make unlikely.
+    KEY_PREFIX_BLOCKING_RESULTS = "query_blocking"
     KEY_PREFIX_RUNNING_QUERIES = "running_queries"
 
-    def __init__(self, query_id: str, team_id: int):
+    def __init__(self, query_id: str, team_id: int, key_prefix: Optional[str] = None):
         self.redis_client = redis.get_client()
         self.query_id = query_id
         self.team_id = team_id
+        self.key_prefix = key_prefix or self.KEY_PREFIX_ASYNC_RESULTS
 
     @property
     def status_key(self) -> str:
-        return f"{self.KEY_PREFIX_ASYNC_RESULTS}:{self.team_id}:{self.query_id}"
+        return f"{self.key_prefix}:{self.team_id}:{self.query_id}"
 
     @property
     def clickhouse_query_status_key(self) -> str:
@@ -223,6 +229,17 @@ class QueryStatusManager:
         self.redis_client.hdel(self.running_queries_key, cache_key)
 
 
+def _result_reached_the_cache(team_id: int, cache_key: Optional[str]) -> bool:
+    """Whether a finished query's result is in the query cache, so the record can point at it.
+
+    This asks the cache rather than restating the rules about what gets cached, which live in the
+    query runner and would go stale here.
+    """
+    if not cache_key:
+        return False
+    return QueryCache(team_id=team_id, cache_key=cache_key).freshness() is not None
+
+
 def _shared_link_user_for(sharing_configuration_id: int, team: "Team") -> Optional["User"]:
     """Rebuild the anonymous viewer of a public share so an async recalculation runs as the same
     principal the request did. None if the share was disabled, expired, or deleted, or the
@@ -324,6 +341,12 @@ def execute_process_query(
         logger.info("Got results for team %s query %s", team_id, query_id)
         query_status.error = False
         cache_key = results.get("cache_key")
+        if not _result_reached_the_cache(team_id, cache_key):
+            # Not every result is cached: a debug or explain response is deliberately skipped, a
+            # store can fail, and an entry can be evicted under the team's cache limit. The record
+            # then has to carry the result, because a cache key would point at nothing.
+            query_status.results = results
+            cache_key = None
         process_duration = (datetime.datetime.now(datetime.UTC) - query_status.pickup_time) / datetime.timedelta(
             seconds=1
         )
@@ -361,7 +384,11 @@ def execute_process_query(
         # Do not raise here, the task itself did its job and we cannot recover
     finally:
         query_status.end_time = datetime.datetime.now(datetime.UTC)
-        manager.store_query_status(query_status, cache_key=cache_key)
+        # A record that carries the result keeps the short life. The day-long one is worth its
+        # size only while it is a pointer, and a copy of a result in the app Redis is what this
+        # design exists to avoid.
+        ttl = None if query_status.results is None else settings.INLINE_RESULT_STATUS_TTL_SECONDS
+        manager.store_query_status(query_status, ttl_seconds=ttl, cache_key=cache_key)
         try:
             if cache_key:
                 manager.unregister_cache_key_mapping(cache_key)
@@ -486,7 +513,15 @@ def get_query_status(team_id: int, query_id: str, show_progress: bool = False) -
     This is what the poll endpoints answer with. Callers that only need to know whether a query
     is still running should use `QueryStatusManager.get_query_status` instead.
     """
-    return QueryStatusManager(query_id, team_id).get_query_status_with_result(show_progress=show_progress)
+    try:
+        return QueryStatusManager(query_id, team_id).get_query_status_with_result(show_progress=show_progress)
+    except QueryResultExpiredError:
+        # The async run is the one this ID names, so its expiry is the answer.
+        raise
+    except QueryNotFoundError:
+        # No async run under this ID, so look where a blocking request records its outcome.
+        blocking = QueryStatusManager(query_id, team_id, key_prefix=QueryStatusManager.KEY_PREFIX_BLOCKING_RESULTS)
+        return blocking.get_query_status_with_result(show_progress=show_progress)
 
 
 def record_blocking_query_result(team_id: int, query_id: str, result: dict) -> None:
@@ -522,19 +557,9 @@ def record_blocking_query_failure(team_id: int, query_id: str, error: Exception)
 def _record_blocking_query_status(
     team_id: int, query_id: str, query_status: QueryStatus, cache_key: Optional[str]
 ) -> None:
-    """Store the outcome under the query ID the client sent.
-
-    The client picks that ID, and an async run of the same query is filed under an ID the client
-    can also see, so the two can name the same record. A run that is still going owns it: the
-    poller is waiting for that run's outcome, and this one would answer with a different result.
-    """
-    manager = QueryStatusManager(query_id, team_id)
+    """Store the outcome in the namespace that belongs to client-chosen query IDs."""
+    manager = QueryStatusManager(query_id, team_id, key_prefix=QueryStatusManager.KEY_PREFIX_BLOCKING_RESULTS)
     try:
-        try:
-            if not manager.get_query_status().complete:
-                return
-        except QueryNotFoundError:
-            pass
         manager.store_query_status(
             query_status, ttl_seconds=settings.BLOCKING_QUERY_STATUS_TTL_SECONDS, cache_key=cache_key
         )

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -572,9 +572,11 @@ def _record_blocking_query_status(
 def _user_safe_error_message(error: Exception) -> Optional[str]:
     # Same rule as the async path: only errors we already show to the user may be stored
     # in the record, everything else stays a generic failure.
+    from products.access_control.backend.facade.user_access_control import UserAccessControlError
+
     if isinstance(error, APIException):
         return str(error.detail)
-    if isinstance(error, ExposedHogQLError | ExposedCHQueryError):
+    if isinstance(error, ExposedHogQLError | ExposedCHQueryError | UserAccessControlError):
         return str(error)
     return None
 

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -6,6 +6,7 @@ from typing import Any
 from posthog.test.base import ClickhouseTestMixin, snapshot_clickhouse_queries
 from unittest.mock import MagicMock, patch
 
+from django.conf import settings
 from django.db import transaction
 from django.test import SimpleTestCase, TestCase
 
@@ -112,6 +113,19 @@ class TestQueryStatusManager(SimpleTestCase):
         with self.assertRaises(QueryResultExpiredError):
             self.manager.get_query_status_with_result()
         assert self.manager.get_query_status().complete is True
+
+    @parameterized.expand(
+        [
+            ("still_running", False, settings.RUNNING_QUERY_STATUS_TTL_SECONDS),
+            ("finished", True, settings.ASYNC_QUERY_STATUS_TTL_SECONDS),
+        ]
+    )
+    def test_a_record_lives_as_long_as_its_state_is_worth_keeping(self, _name, complete, expected_ttl):
+        self.query_status.complete = complete
+
+        self.manager.store_query_status(self.query_status)
+
+        assert get_client().ttl(self.manager.status_key) == expected_ttl
 
     def test_a_blocking_outcome_never_takes_over_a_run_under_the_same_id(self):
         self.manager.store_query_status(QueryStatus(id=self.query_id, team_id=self.team_id, complete=False))

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -70,14 +70,14 @@ class TestQueryStatusManager(SimpleTestCase):
     def test_is_empty(self):
         self.assertRaises(QueryNotFoundError, lambda: self.manager.get_query_status(True))
 
-    def test_never_stores_the_result_payload(self):
+    def test_hands_back_results_stored_as_given(self):
         self.query_status.complete = True
-        self.query_status.results = {"results": [1, 2, 3], "cache_key": "cache_abc"}
+        self.query_status.results = {"object_key": "frames/abc.arrow"}
         self.manager.store_query_status(self.query_status)
 
-        record = {k.decode(): v.decode() for k, v in get_client().hgetall(self.manager.status_key).items()}
-        assert record["cache_key"] == "cache_abc"
-        assert "results" not in record
+        status = self.manager.get_query_status()
+
+        assert status.results == {"object_key": "frames/abc.arrow"}
 
     def test_failed_query_keeps_its_error(self):
         self.query_status.complete = True
@@ -95,14 +95,13 @@ class TestQueryStatusManager(SimpleTestCase):
 
     @parameterized.expand(
         [
-            ("result_without_cache_key", {"results": [1, 2, 3]}),
-            ("cache_entry_gone", {"results": [], "cache_key": "cache_missing"}),
+            ("no_cache_key", None),
+            ("cache_entry_gone", "cache_missing"),
         ]
     )
-    def test_finished_query_without_a_cached_result_is_expired(self, _name, results):
+    def test_finished_query_without_a_cached_result_is_expired(self, _name, cache_key):
         self.query_status.complete = True
-        self.query_status.results = results
-        self.manager.store_query_status(self.query_status)
+        self.manager.store_query_status(self.query_status, cache_key=cache_key)
 
         with self.assertRaises(QueryResultExpiredError):
             self.manager.get_query_status()
@@ -250,8 +249,7 @@ class TestExecuteProcessQuery(TestCase):
         self.manager.store_query_status(query_status)
         query_status.complete = True
         query_status.error = False
-        query_status.results = {"results": "never stored", "cache_key": cache_key}
-        self.manager.store_query_status(query_status)
+        self.manager.store_query_status(query_status, cache_key=cache_key)
 
         status = self.manager.get_query_status()
 

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -1,4 +1,3 @@
-import json
 import uuid
 import datetime
 from typing import Any
@@ -71,14 +70,21 @@ class TestQueryStatusManager(SimpleTestCase):
     def test_is_empty(self):
         self.assertRaises(QueryNotFoundError, lambda: self.manager.get_query_status(True))
 
-    def test_keeps_failure_after_status_record_expires(self):
-        self.manager.store_query_status(self.query_status, cache_key="cache_async_handle_failed")
+    def test_never_stores_the_result_payload(self):
+        self.query_status.complete = True
+        self.query_status.results = {"results": [1, 2, 3], "cache_key": "cache_abc"}
+        self.manager.store_query_status(self.query_status)
+
+        record = {k.decode(): v.decode() for k, v in get_client().hgetall(self.manager.status_key).items()}
+        assert record["cache_key"] == "cache_abc"
+        assert "results" not in record
+
+    def test_failed_query_keeps_its_error(self):
         self.query_status.complete = True
         self.query_status.error = True
         self.query_status.error_message = "Query exceeded memory limit"
         self.query_status.error_code = "clickhouse_memory_limit_exceeded"
         self.manager.store_query_status(self.query_status)
-        get_client().delete(self.manager.results_key)
 
         status = self.manager.get_query_status()
 
@@ -87,18 +93,32 @@ class TestQueryStatusManager(SimpleTestCase):
         assert status.error_message == "Query exceeded memory limit"
         assert status.error_code == "clickhouse_memory_limit_exceeded"
 
-    @parameterized.expand([("finished_but_cache_entry_gone", True), ("never_finished", False)])
-    def test_raises_expired_after_status_record_expires_without_a_result(self, _name, complete):
-        self.manager.store_query_status(self.query_status, cache_key="cache_async_handle_missing")
-        self.query_status.complete = complete
+    @parameterized.expand(
+        [
+            ("payload_without_cache_key", {"results": list(range(2000))}),
+            ("cache_entry_gone", {"results": [], "cache_key": "cache_missing"}),
+        ]
+    )
+    def test_finished_query_without_a_cached_result_is_expired(self, _name, results):
+        self.query_status.complete = True
+        self.query_status.results = results
         self.manager.store_query_status(self.query_status)
-        get_client().delete(self.manager.results_key)
 
         with self.assertRaises(QueryResultExpiredError):
             self.manager.get_query_status()
+        assert self.manager.get_query_status(resolve_results=False).complete is True
 
-    def test_delete_removes_the_handle_too(self):
-        self.manager.store_query_status(self.query_status, cache_key="cache_async_handle_deleted")
+    def test_keeps_a_small_result_reference_without_a_cache_key(self):
+        self.query_status.complete = True
+        self.query_status.results = {"object_key": "frames/abc.arrow", "bucket": "notebook-frames"}
+        self.manager.store_query_status(self.query_status)
+
+        status = self.manager.get_query_status()
+
+        assert status.results == {"object_key": "frames/abc.arrow", "bucket": "notebook-frames"}
+
+    def test_delete_forgets_the_query(self):
+        self.manager.store_query_status(self.query_status)
 
         self.manager.delete_query_status()
 
@@ -220,6 +240,7 @@ class TestAsyncTaskChain(SimpleTestCase):
 
 class TestExecuteProcessQuery(TestCase):
     def setUp(self):
+        get_client().flushall()
         self.user = User.objects.create(email="test@posthog.com")
         self.organization = Organization.objects.create(name="test")
         self.team = Team.objects.create(organization=self.organization)
@@ -229,17 +250,17 @@ class TestExecuteProcessQuery(TestCase):
         self.refresh_requested = False
         self.manager = QueryStatusManager(self.query_id, self.team.id)
 
-    def test_serves_cached_result_after_status_record_expires(self):
-        cache_key = f"cache_async_handle_{self.team.id}"
-        query_status = QueryStatus(id=self.query_id, team_id=self.team.id)
-        self.manager.store_query_status(query_status, cache_key=cache_key)
-        query_status.complete = True
-        query_status.error = False
-        self.manager.store_query_status(query_status)
+    def test_finished_query_reads_its_result_from_the_cache(self):
+        cache_key = f"cache_async_record_{self.team.id}"
         QueryCache(team_id=self.team.id, cache_key=cache_key).store_result(
             response={"results": [{"count": 1}], "cache_key": cache_key, "is_cached": False}, target_age=None
         )
-        get_client().delete(self.manager.results_key)
+        query_status = QueryStatus(id=self.query_id, team_id=self.team.id)
+        self.manager.store_query_status(query_status)
+        query_status.complete = True
+        query_status.error = False
+        query_status.results = {"results": "never stored", "cache_key": cache_key}
+        self.manager.store_query_status(query_status)
 
         status = self.manager.get_query_status()
 
@@ -247,35 +268,25 @@ class TestExecuteProcessQuery(TestCase):
         assert status.error is False
         assert status.results == {"results": [{"count": 1}], "cache_key": cache_key, "is_cached": True}
 
-    @patch("posthog.clickhouse.client.execute_async.redis.get_client")
     @patch("posthog.api.services.query.process_query_dict")
-    def test_execute_process_query(self, mock_process_query_dict, mock_redis_client):
-        mock_redis = MagicMock()
+    def test_execute_process_query(self, mock_process_query_dict):
         task_id = uuid.uuid4()
-        mock_redis.get.return_value = json.dumps(
-            {
-                "id": self.query_id,
-                "team_id": self.team.id,
-                "complete": False,
-                "error": False,
-                "task_id": str(task_id),
-            }
-        ).encode()
-        mock_redis_client.return_value = mock_redis
-
-        mock_process_query_dict.return_value = [float("inf"), float("-inf"), float("nan"), 1.0, "👍"]
+        self.manager.store_query_status(QueryStatus(id=self.query_id, team_id=self.team.id, task_id=str(task_id)))
+        cache_key = f"cache_execute_{self.team.id}"
+        mock_process_query_dict.return_value = {"results": [1.0, "👍"], "cache_key": cache_key, "is_cached": False}
 
         execute_process_query(self.team.id, self.user.id, self.query_id, self.query_json, self.limit_context)
 
-        mock_redis_client.assert_called_once()
         mock_process_query_dict.assert_called_once()
         self.assertEqual(get_query_tags().celery_task_id, task_id)
-
-        # Assert that Redis set method was called with the correct arguments
-        self.assertEqual(mock_redis.set.call_count, 2)  # Once on pickup, once on completion
-        args, kwargs = mock_redis.set.call_args
-        args_loaded = json.loads(args[1])
-        self.assertEqual(args_loaded["results"], [None, None, None, 1.0, "👍"])
+        status = self.manager.get_query_status(resolve_results=False)
+        assert status.complete is True
+        assert status.error is False
+        assert status.pickup_time is not None
+        assert status.end_time is not None
+        record = {k.decode(): v.decode() for k, v in get_client().hgetall(self.manager.status_key).items()}
+        assert record["cache_key"] == cache_key
+        assert "results" not in record
 
     @parameterized.expand(
         [
@@ -285,21 +296,19 @@ class TestExecuteProcessQuery(TestCase):
         ]
     )
     @patch("posthog.clickhouse.client.execute_async.capture_exception")
-    @patch("posthog.clickhouse.client.execute_async.redis.get_client")
     @patch("posthog.api.services.query.process_query_dict")
     def test_execute_process_query_only_captures_non_user_safe_errors(
-        self, _name, error, should_capture, mock_process_query_dict, mock_redis_client, mock_capture_exception
+        self, _name, error, should_capture, mock_process_query_dict, mock_capture_exception
     ):
-        mock_redis = MagicMock()
-        mock_redis.get.return_value = json.dumps(
-            {"id": self.query_id, "team_id": self.team.id, "complete": False, "error": False}
-        ).encode()
-        mock_redis_client.return_value = mock_redis
+        self.manager.store_query_status(QueryStatus(id=self.query_id, team_id=self.team.id))
         mock_process_query_dict.side_effect = error
 
         execute_process_query(self.team.id, self.user.id, self.query_id, self.query_json, self.limit_context)
 
         self.assertEqual(mock_capture_exception.called, should_capture)
+        status = self.manager.get_query_status()
+        assert status.complete is True
+        assert status.error is True
 
     @parameterized.expand(
         [
@@ -309,17 +318,12 @@ class TestExecuteProcessQuery(TestCase):
             ("org_disallows_public_sharing", {}, False, False),
         ]
     )
-    @patch("posthog.clickhouse.client.execute_async.redis.get_client")
     @patch("posthog.api.services.query.process_query_dict")
     def test_shared_link_run_rebuilds_the_viewer_while_the_share_is_live(
-        self, _name, overrides, org_allows_sharing, expect_viewer, mock_process_query_dict, mock_redis_client
+        self, _name, overrides, org_allows_sharing, expect_viewer, mock_process_query_dict
     ):
-        mock_redis = MagicMock()
-        mock_redis.get.return_value = json.dumps(
-            {"id": self.query_id, "team_id": self.team.id, "complete": False, "error": False}
-        ).encode()
-        mock_redis_client.return_value = mock_redis
-        mock_process_query_dict.return_value = []
+        self.manager.store_query_status(QueryStatus(id=self.query_id, team_id=self.team.id))
+        mock_process_query_dict.return_value = {"results": [], "cache_key": None}
         sharing_configuration = SharingConfiguration.objects.create(team=self.team, **{"enabled": True, **overrides})
         if not org_allows_sharing:
             self.organization.available_product_features = [

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -27,6 +27,7 @@ from posthog.clickhouse.client.execute_async import (
     QueryResultExpiredError,
     QueryStatusManager,
     execute_process_query,
+    record_blocking_query_failure,
     record_blocking_query_result,
 )
 from posthog.clickhouse.query_tagging import get_query_tags, tag_queries
@@ -43,6 +44,8 @@ from posthog.models.user import User
 from posthog.query_cache.cache import QueryCache
 from posthog.redis import get_client
 from posthog.shared_link_user import SharedLinkUser
+
+from products.access_control.backend.facade.user_access_control import UserAccessControlError
 
 
 def build_query(sql):
@@ -120,6 +123,24 @@ class TestQueryStatusManager(SimpleTestCase):
             self.query_id, self.team_id, key_prefix=QueryStatusManager.KEY_PREFIX_BLOCKING_RESULTS
         )
         assert blocking.get_query_status().complete is True
+
+    @parameterized.expand(
+        [
+            ("access_control", UserAccessControlError("metrics", "viewer"), True),
+            ("exposed_hogql", ExposedHogQLError("bad query"), True),
+            ("internal", ValueError("something broke"), False),
+        ]
+    )
+    def test_a_blocking_failure_keeps_only_a_user_safe_message(self, _name, error, keeps_message):
+        record_blocking_query_failure(self.team_id, self.query_id, error)
+
+        blocking = QueryStatusManager(
+            self.query_id, self.team_id, key_prefix=QueryStatusManager.KEY_PREFIX_BLOCKING_RESULTS
+        )
+        status = blocking.get_query_status()
+
+        assert status.error is True
+        assert status.error_message == (str(error) if keeps_message else None)
 
     def test_delete_forgets_the_query(self):
         self.manager.store_query_status(self.query_status)

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -95,7 +95,7 @@ class TestQueryStatusManager(SimpleTestCase):
 
     @parameterized.expand(
         [
-            ("payload_without_cache_key", {"results": list(range(2000))}),
+            ("result_without_cache_key", {"results": [1, 2, 3]}),
             ("cache_entry_gone", {"results": [], "cache_key": "cache_missing"}),
         ]
     )
@@ -108,14 +108,14 @@ class TestQueryStatusManager(SimpleTestCase):
             self.manager.get_query_status()
         assert self.manager.get_query_status(resolve_results=False).complete is True
 
-    def test_keeps_a_small_result_reference_without_a_cache_key(self):
+    def test_hands_back_an_explicit_result_reference(self):
         self.query_status.complete = True
-        self.query_status.results = {"object_key": "frames/abc.arrow", "bucket": "notebook-frames"}
-        self.manager.store_query_status(self.query_status)
+        reference = {"object_key": "frames/abc.arrow", "bucket": "notebook-frames"}
+        self.manager.store_query_status(self.query_status, result_reference=reference)
 
         status = self.manager.get_query_status()
 
-        assert status.results == {"object_key": "frames/abc.arrow", "bucket": "notebook-frames"}
+        assert status.results == reference
 
     def test_delete_forgets_the_query(self):
         self.manager.store_query_status(self.query_status)

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 from django.db import transaction
 from django.test import SimpleTestCase, TestCase
 
+from celery.result import EagerResult
 from parameterized import parameterized
 
 from posthog.schema import ClickhouseQueryProgress, QueryStatus
@@ -20,7 +21,7 @@ from posthog.clickhouse.client import (
     execute_async as client,
     sync_execute,
 )
-from posthog.clickhouse.client.async_task_chain import execute_task_chain, task_chain_context
+from posthog.clickhouse.client.async_task_chain import execute_task_chain, kick_off_task, task_chain_context
 from posthog.clickhouse.client.execute_async import (
     QueryNotFoundError,
     QueryResultExpiredError,
@@ -239,6 +240,30 @@ class TestAsyncTaskChain(SimpleTestCase):
 
         chain_mock.assert_called_once_with(*signatures)
         chain_mock.return_value.apply_async.assert_called_once_with()
+
+    def test_dispatch_keeps_the_record_the_task_wrote(self) -> None:
+        get_client().flushall()
+        query_id = "query-run-inline"
+        team_id = 12345
+        cache_key = "cache_run_inline"
+        manager = QueryStatusManager(query_id, team_id)
+
+        # An eager Celery app runs the task inside apply_async. By the time it returns, the worker
+        # has already filed the finished record, which points at the result in the query cache.
+        def run_task_inline(task_id: str) -> EagerResult:
+            manager.store_query_status(QueryStatus(id=query_id, team_id=team_id, complete=True), cache_key=cache_key)
+            return EagerResult(task_id, None, "SUCCESS")
+
+        signature = MagicMock()
+        signature.apply_async.side_effect = run_task_inline
+
+        kick_off_task(manager, QueryStatus(id=query_id, team_id=team_id), signature)
+
+        raw_record = get_client().get(manager.status_key)
+        assert raw_record is not None
+        record = json.loads(raw_record)
+        assert record["complete"] is True
+        assert record["cache_key"] == cache_key
 
 
 class TestExecuteProcessQuery(TestCase):

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -108,15 +108,6 @@ class TestQueryStatusManager(SimpleTestCase):
             self.manager.get_query_status()
         assert self.manager.get_query_status(resolve_results=False).complete is True
 
-    def test_hands_back_an_explicit_result_reference(self):
-        self.query_status.complete = True
-        reference = {"object_key": "frames/abc.arrow", "bucket": "notebook-frames"}
-        self.manager.store_query_status(self.query_status, result_reference=reference)
-
-        status = self.manager.get_query_status()
-
-        assert status.results == reference
-
     def test_delete_forgets_the_query(self):
         self.manager.store_query_status(self.query_status)
 

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 import datetime
 from typing import Any
@@ -25,6 +26,7 @@ from posthog.clickhouse.client.execute_async import (
     QueryResultExpiredError,
     QueryStatusManager,
     execute_process_query,
+    record_blocking_query_result,
 )
 from posthog.clickhouse.query_tagging import get_query_tags, tag_queries
 from posthog.constants import AvailableFeature
@@ -104,8 +106,27 @@ class TestQueryStatusManager(SimpleTestCase):
         self.manager.store_query_status(self.query_status, cache_key=cache_key)
 
         with self.assertRaises(QueryResultExpiredError):
-            self.manager.get_query_status()
-        assert self.manager.get_query_status(resolve_results=False).complete is True
+            self.manager.get_query_status_with_result()
+        assert self.manager.get_query_status().complete is True
+
+    @parameterized.expand(
+        [
+            ("nothing_under_that_id", None, True, False),
+            ("a_run_still_going", {"complete": False}, False, False),
+            ("an_earlier_run_that_failed", {"complete": True, "error": True}, True, False),
+        ]
+    )
+    def test_a_blocking_outcome_never_takes_over_a_run_that_is_still_going(
+        self, _name, existing, expected_complete, expected_error
+    ):
+        if existing is not None:
+            self.manager.store_query_status(QueryStatus(id=self.query_id, team_id=self.team_id, **existing))
+
+        record_blocking_query_result(self.team_id, self.query_id, {"cache_key": "cache_of_the_blocking_run"})
+
+        status = self.manager.get_query_status()
+        assert status.complete is expected_complete
+        assert status.error is expected_error
 
     def test_delete_forgets_the_query(self):
         self.manager.store_query_status(self.query_status)
@@ -113,7 +134,7 @@ class TestQueryStatusManager(SimpleTestCase):
         self.manager.delete_query_status()
 
         with self.assertRaises(QueryNotFoundError) as raised:
-            self.manager.get_query_status()
+            self.manager.get_query_status_with_result()
         assert not isinstance(raised.exception, QueryResultExpiredError)
 
     def test_no_status(self):
@@ -251,7 +272,7 @@ class TestExecuteProcessQuery(TestCase):
         query_status.error = False
         self.manager.store_query_status(query_status, cache_key=cache_key)
 
-        status = self.manager.get_query_status()
+        status = self.manager.get_query_status_with_result()
 
         assert status.complete is True
         assert status.error is False
@@ -268,14 +289,16 @@ class TestExecuteProcessQuery(TestCase):
 
         mock_process_query_dict.assert_called_once()
         self.assertEqual(get_query_tags().celery_task_id, task_id)
-        status = self.manager.get_query_status(resolve_results=False)
+        status = self.manager.get_query_status()
         assert status.complete is True
         assert status.error is False
         assert status.pickup_time is not None
         assert status.end_time is not None
-        record = {k.decode(): v.decode() for k, v in get_client().hgetall(self.manager.status_key).items()}
+        raw_record = get_client().get(self.manager.status_key)
+        assert raw_record is not None
+        record = json.loads(raw_record)
         assert record["cache_key"] == cache_key
-        assert "results" not in record
+        assert record["results"] is None
 
     @parameterized.expand(
         [
@@ -462,26 +485,38 @@ class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
         except Exception as e:
             self.assertEqual(str(e), f"Query {query_id} not found for team {wrong_team}")
 
+    @parameterized.expand(
+        [
+            ("still_running", None, 1),
+            ("finished", False, 2),
+            ("failed", True, 2),
+        ]
+    )
     @patch("posthog.clickhouse.client.execute_process_query")
-    def test_async_query_client_is_lazy(self, execute_process_query_mock):
+    def test_async_query_client_joins_only_a_running_query(
+        self, _name, finished_with_error, expected_runs, execute_process_query_mock
+    ):
         query = build_query("SELECT 4 + 4")
         query_id = uuid.uuid4().hex
+        manager = QueryStatusManager(query_id, self.team.id)
+        client.enqueue_process_query_task(
+            self.team, self.user.id, query, query_id=query_id, _test_only_bypass_celery=True
+        )
+        if finished_with_error is not None:
+            status = manager.get_query_status()
+            status.complete = True
+            status.error = finished_with_error
+            manager.store_query_status(status)
+
+        # The same query ID twice more: joins the run while it is going, starts a new run once it finished
+        client.enqueue_process_query_task(
+            self.team, self.user.id, query, query_id=query_id, _test_only_bypass_celery=True
+        )
         client.enqueue_process_query_task(
             self.team, self.user.id, query, query_id=query_id, _test_only_bypass_celery=True
         )
 
-        # Try the same query again
-        client.enqueue_process_query_task(
-            self.team, self.user.id, query, query_id=query_id, _test_only_bypass_celery=True
-        )
-
-        # Try the same query again (for good measure!)
-        client.enqueue_process_query_task(
-            self.team, self.user.id, query, query_id=query_id, _test_only_bypass_celery=True
-        )
-
-        # Assert that we only called clickhouse once
-        execute_process_query_mock.assert_called_once()
+        self.assertEqual(execute_process_query_mock.call_count, expected_runs)
 
     @patch("posthog.clickhouse.client.execute_process_query")
     def test_async_query_client_is_lazy_but_not_too_lazy(self, execute_process_query_mock):

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -21,7 +21,12 @@ from posthog.clickhouse.client import (
     sync_execute,
 )
 from posthog.clickhouse.client.async_task_chain import execute_task_chain, task_chain_context
-from posthog.clickhouse.client.execute_async import QueryNotFoundError, QueryStatusManager, execute_process_query
+from posthog.clickhouse.client.execute_async import (
+    QueryNotFoundError,
+    QueryResultExpiredError,
+    QueryStatusManager,
+    execute_process_query,
+)
 from posthog.clickhouse.query_tagging import get_query_tags, tag_queries
 from posthog.constants import AvailableFeature
 from posthog.direct_query_cancellation import (
@@ -33,6 +38,7 @@ from posthog.exceptions import ClickHouseAtCapacity, ClickHouseQueryMemoryLimitE
 from posthog.models import Organization, Team
 from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.models.user import User
+from posthog.query_cache.cache import QueryCache
 from posthog.redis import get_client
 from posthog.shared_link_user import SharedLinkUser
 
@@ -64,6 +70,41 @@ class TestQueryStatusManager(SimpleTestCase):
 
     def test_is_empty(self):
         self.assertRaises(QueryNotFoundError, lambda: self.manager.get_query_status(True))
+
+    def test_keeps_failure_after_status_record_expires(self):
+        self.manager.store_query_status(self.query_status, cache_key="cache_async_handle_failed")
+        self.query_status.complete = True
+        self.query_status.error = True
+        self.query_status.error_message = "Query exceeded memory limit"
+        self.query_status.error_code = "clickhouse_memory_limit_exceeded"
+        self.manager.store_query_status(self.query_status)
+        get_client().delete(self.manager.results_key)
+
+        status = self.manager.get_query_status()
+
+        assert status.complete is True
+        assert status.error is True
+        assert status.error_message == "Query exceeded memory limit"
+        assert status.error_code == "clickhouse_memory_limit_exceeded"
+
+    @parameterized.expand([("finished_but_cache_entry_gone", True), ("never_finished", False)])
+    def test_raises_expired_after_status_record_expires_without_a_result(self, _name, complete):
+        self.manager.store_query_status(self.query_status, cache_key="cache_async_handle_missing")
+        self.query_status.complete = complete
+        self.manager.store_query_status(self.query_status)
+        get_client().delete(self.manager.results_key)
+
+        with self.assertRaises(QueryResultExpiredError):
+            self.manager.get_query_status()
+
+    def test_delete_removes_the_handle_too(self):
+        self.manager.store_query_status(self.query_status, cache_key="cache_async_handle_deleted")
+
+        self.manager.delete_query_status()
+
+        with self.assertRaises(QueryNotFoundError) as raised:
+            self.manager.get_query_status()
+        assert not isinstance(raised.exception, QueryResultExpiredError)
 
     def test_no_status(self):
         self.manager.store_query_status(self.query_status)
@@ -187,6 +228,24 @@ class TestExecuteProcessQuery(TestCase):
         self.limit_context = None
         self.refresh_requested = False
         self.manager = QueryStatusManager(self.query_id, self.team.id)
+
+    def test_serves_cached_result_after_status_record_expires(self):
+        cache_key = f"cache_async_handle_{self.team.id}"
+        query_status = QueryStatus(id=self.query_id, team_id=self.team.id)
+        self.manager.store_query_status(query_status, cache_key=cache_key)
+        query_status.complete = True
+        query_status.error = False
+        self.manager.store_query_status(query_status)
+        QueryCache(team_id=self.team.id, cache_key=cache_key).store_result(
+            response={"results": [{"count": 1}], "cache_key": cache_key, "is_cached": False}, target_age=None
+        )
+        get_client().delete(self.manager.results_key)
+
+        status = self.manager.get_query_status()
+
+        assert status.complete is True
+        assert status.error is False
+        assert status.results == {"results": [{"count": 1}], "cache_key": cache_key, "is_cached": True}
 
     @patch("posthog.clickhouse.client.execute_async.redis.get_client")
     @patch("posthog.api.services.query.process_query_dict")

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -109,24 +109,16 @@ class TestQueryStatusManager(SimpleTestCase):
             self.manager.get_query_status_with_result()
         assert self.manager.get_query_status().complete is True
 
-    @parameterized.expand(
-        [
-            ("nothing_under_that_id", None, True, False),
-            ("a_run_still_going", {"complete": False}, False, False),
-            ("an_earlier_run_that_failed", {"complete": True, "error": True}, True, False),
-        ]
-    )
-    def test_a_blocking_outcome_never_takes_over_a_run_that_is_still_going(
-        self, _name, existing, expected_complete, expected_error
-    ):
-        if existing is not None:
-            self.manager.store_query_status(QueryStatus(id=self.query_id, team_id=self.team_id, **existing))
+    def test_a_blocking_outcome_never_takes_over_a_run_under_the_same_id(self):
+        self.manager.store_query_status(QueryStatus(id=self.query_id, team_id=self.team_id, complete=False))
 
         record_blocking_query_result(self.team_id, self.query_id, {"cache_key": "cache_of_the_blocking_run"})
 
-        status = self.manager.get_query_status()
-        assert status.complete is expected_complete
-        assert status.error is expected_error
+        assert self.manager.get_query_status().complete is False
+        blocking = QueryStatusManager(
+            self.query_id, self.team_id, key_prefix=QueryStatusManager.KEY_PREFIX_BLOCKING_RESULTS
+        )
+        assert blocking.get_query_status().complete is True
 
     def test_delete_forgets_the_query(self):
         self.manager.store_query_status(self.query_status)
@@ -278,12 +270,16 @@ class TestExecuteProcessQuery(TestCase):
         assert status.error is False
         assert status.results == {"results": [{"count": 1}], "cache_key": cache_key, "is_cached": True}
 
+    @parameterized.expand([("cached", True), ("not_cached", False)])
     @patch("posthog.api.services.query.process_query_dict")
-    def test_execute_process_query(self, mock_process_query_dict):
+    def test_execute_process_query(self, _name, cached, mock_process_query_dict):
         task_id = uuid.uuid4()
         self.manager.store_query_status(QueryStatus(id=self.query_id, team_id=self.team.id, task_id=str(task_id)))
         cache_key = f"cache_execute_{self.team.id}"
-        mock_process_query_dict.return_value = {"results": [1.0, "👍"], "cache_key": cache_key, "is_cached": False}
+        response = {"results": [1.0, "👍"], "cache_key": cache_key, "is_cached": False}
+        mock_process_query_dict.return_value = response
+        if cached:
+            QueryCache(team_id=self.team.id, cache_key=cache_key).store_result(response=response, target_age=None)
 
         execute_process_query(self.team.id, self.user.id, self.query_id, self.query_json, self.limit_context)
 
@@ -297,8 +293,9 @@ class TestExecuteProcessQuery(TestCase):
         raw_record = get_client().get(self.manager.status_key)
         assert raw_record is not None
         record = json.loads(raw_record)
-        assert record["cache_key"] == cache_key
-        assert record["results"] is None
+        # A cached result is a pointer; one the cache never took has to ride in the record itself.
+        assert record["cache_key"] == (cache_key if cached else None)
+        assert record["results"] == (None if cached else response)
 
     @parameterized.expand(
         [

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -115,7 +115,7 @@ from posthog import settings
 from posthog.api_queries_quota import API_QUERIES_QUOTA_ERRORS_COUNTER, get_api_queries_bytes, next_counter_reset
 from posthog.caching.utils import ThresholdMode, cache_target_age, is_stale, last_refresh_from_cached_result
 from posthog.clickhouse.client.connection import ClickHouseUser, Workload
-from posthog.clickhouse.client.execute_async import QueryNotFoundError, enqueue_process_query_task, get_query_status
+from posthog.clickhouse.client.execute_async import QueryNotFoundError, QueryStatusManager, enqueue_process_query_task
 from posthog.clickhouse.client.limit import (
     get_api_team_rate_limiter,
     get_app_dashboard_queries_rate_limiter,
@@ -1880,9 +1880,9 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
 
     def get_async_query_status(self, *, cache_key: str) -> Optional[QueryStatus]:
         try:
-            query_status = get_query_status(
-                team_id=self.team.pk, query_id=self.query_id or cache_key, resolve_results=False
-            )
+            # State only: this attaches an in-flight status to a cache miss, so it must not
+            # pay for a query cache read on top of the one that just missed.
+            query_status = QueryStatusManager(self.query_id or cache_key, self.team.pk).get_query_status()
             if query_status.complete:
                 return None
             return query_status

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1880,7 +1880,9 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
 
     def get_async_query_status(self, *, cache_key: str) -> Optional[QueryStatus]:
         try:
-            query_status = get_query_status(team_id=self.team.pk, query_id=self.query_id or cache_key)
+            query_status = get_query_status(
+                team_id=self.team.pk, query_id=self.query_id or cache_key, resolve_results=False
+            )
             if query_status.complete:
                 return None
             return query_status

--- a/posthog/settings/schedules.py
+++ b/posthog/settings/schedules.py
@@ -48,6 +48,11 @@ CACHED_RESULTS_TTL = CACHED_RESULTS_TTL_DAYS * 24 * 60 * 60
 ASYNC_QUERY_STATUS_TTL_SECONDS = get_from_env("ASYNC_QUERY_STATUS_TTL_SECONDS", 24 * 60 * 60, type_cast=int)
 BLOCKING_QUERY_STATUS_TTL_SECONDS = get_from_env("BLOCKING_QUERY_STATUS_TTL_SECONDS", 15 * 60, type_cast=int)
 
+# A blocking request only gets a record once it has run this long, because only a request the
+# ingress could have dropped needs one. Blocking requests are most of the query traffic, so
+# recording every one of them would fill the app Redis with records nothing ever reads.
+BLOCKING_QUERY_RECORD_AFTER_SECONDS = get_from_env("BLOCKING_QUERY_RECORD_AFTER_SECONDS", 60, type_cast=int)
+
 # TTL for cache entries written by API keys or OAuth clients outside any insight or dashboard.
 # retention_ttl in posthog/query_cache/cache.py decides which writes get it.
 CACHED_RESULTS_PROGRAMMATIC_TTL = get_from_env("CACHED_RESULTS_PROGRAMMATIC_TTL", 24 * 60 * 60, type_cast=int)

--- a/posthog/settings/schedules.py
+++ b/posthog/settings/schedules.py
@@ -48,6 +48,12 @@ CACHED_RESULTS_TTL = CACHED_RESULTS_TTL_DAYS * 24 * 60 * 60
 ASYNC_QUERY_STATUS_TTL_SECONDS = 24 * 60 * 60
 BLOCKING_QUERY_STATUS_TTL_SECONDS = 15 * 60
 
+# A run that has not finished keeps a short life. The day is for answering a late poll about a
+# finished run, while an unfinished record only holds the next run back: enqueue joins whatever is
+# not complete, so a dispatch that never reaches a worker has to stop blocking the query long
+# before a day is out.
+RUNNING_QUERY_STATUS_TTL_SECONDS = 20 * 60
+
 # A record that carries the result itself, because the result never reached the query cache, keeps
 # a short life. The day-long one is worth its size only while it is a pointer.
 INLINE_RESULT_STATUS_TTL_SECONDS = 20 * 60

--- a/posthog/settings/schedules.py
+++ b/posthog/settings/schedules.py
@@ -40,6 +40,11 @@ COUNT_TILES_WITH_NO_FILTERS_HASH_INTERVAL_SECONDS = get_from_env(
 CACHED_RESULTS_TTL_DAYS = 7
 CACHED_RESULTS_TTL = CACHED_RESULTS_TTL_DAYS * 24 * 60 * 60
 
+# How long a finished async query stays resolvable by its query ID after its status record is
+# gone, by falling back to the query cache. Bounded separately from CACHED_RESULTS_TTL because
+# every async query writes one of these keys to the app Redis.
+ASYNC_QUERY_HANDLE_TTL_SECONDS = get_from_env("ASYNC_QUERY_HANDLE_TTL_SECONDS", 24 * 60 * 60, type_cast=int)
+
 # TTL for cache entries written by API keys or OAuth clients outside any insight or dashboard.
 # retention_ttl in posthog/query_cache/cache.py decides which writes get it.
 CACHED_RESULTS_PROGRAMMATIC_TTL = get_from_env("CACHED_RESULTS_PROGRAMMATIC_TTL", 24 * 60 * 60, type_cast=int)

--- a/posthog/settings/schedules.py
+++ b/posthog/settings/schedules.py
@@ -40,10 +40,13 @@ COUNT_TILES_WITH_NO_FILTERS_HASH_INTERVAL_SECONDS = get_from_env(
 CACHED_RESULTS_TTL_DAYS = 7
 CACHED_RESULTS_TTL = CACHED_RESULTS_TTL_DAYS * 24 * 60 * 60
 
-# How long a finished async query stays resolvable by its query ID after its status record is
-# gone, by falling back to the query cache. Bounded separately from CACHED_RESULTS_TTL because
-# every async query writes one of these keys to the app Redis.
-ASYNC_QUERY_HANDLE_TTL_SECONDS = get_from_env("ASYNC_QUERY_HANDLE_TTL_SECONDS", 24 * 60 * 60, type_cast=int)
+# How long a query stays resolvable by its query ID: the small status record in the app Redis that
+# points a finished query at its result in the query cache. Async queries keep it for a day, because
+# a browser tab can sit in the background that long before it polls again. A blocking request only
+# needs it for the window in which the server can still be finishing a query whose HTTP request
+# was dropped, and blocking requests are far more numerous, so theirs is short.
+ASYNC_QUERY_STATUS_TTL_SECONDS = get_from_env("ASYNC_QUERY_STATUS_TTL_SECONDS", 24 * 60 * 60, type_cast=int)
+BLOCKING_QUERY_STATUS_TTL_SECONDS = get_from_env("BLOCKING_QUERY_STATUS_TTL_SECONDS", 15 * 60, type_cast=int)
 
 # TTL for cache entries written by API keys or OAuth clients outside any insight or dashboard.
 # retention_ttl in posthog/query_cache/cache.py decides which writes get it.

--- a/posthog/settings/schedules.py
+++ b/posthog/settings/schedules.py
@@ -45,13 +45,17 @@ CACHED_RESULTS_TTL = CACHED_RESULTS_TTL_DAYS * 24 * 60 * 60
 # a browser tab can sit in the background that long before it polls again. A blocking request only
 # needs it for the window in which the server can still be finishing a query whose HTTP request
 # was dropped, and blocking requests are far more numerous, so theirs is short.
-ASYNC_QUERY_STATUS_TTL_SECONDS = get_from_env("ASYNC_QUERY_STATUS_TTL_SECONDS", 24 * 60 * 60, type_cast=int)
-BLOCKING_QUERY_STATUS_TTL_SECONDS = get_from_env("BLOCKING_QUERY_STATUS_TTL_SECONDS", 15 * 60, type_cast=int)
+ASYNC_QUERY_STATUS_TTL_SECONDS = 24 * 60 * 60
+BLOCKING_QUERY_STATUS_TTL_SECONDS = 15 * 60
+
+# A record that carries the result itself, because the result never reached the query cache, keeps
+# a short life. The day-long one is worth its size only while it is a pointer.
+INLINE_RESULT_STATUS_TTL_SECONDS = 20 * 60
 
 # A blocking request only gets a record once it has run this long, because only a request the
 # ingress could have dropped needs one. Blocking requests are most of the query traffic, so
 # recording every one of them would fill the app Redis with records nothing ever reads.
-BLOCKING_QUERY_RECORD_AFTER_SECONDS = get_from_env("BLOCKING_QUERY_RECORD_AFTER_SECONDS", 60, type_cast=int)
+BLOCKING_QUERY_RECORD_AFTER_SECONDS = 60
 
 # TTL for cache entries written by API keys or OAuth clients outside any insight or dashboard.
 # retention_ttl in posthog/query_cache/cache.py decides which writes get it.

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -400,7 +400,7 @@ def _process_query_task_failure(
 
     manager = QueryStatusManager(query_id, team_id)
     try:
-        query_status = manager.get_query_status(resolve_results=False)
+        query_status = manager.get_query_status()
     except QueryNotFoundError:
         return
 

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -400,7 +400,7 @@ def _process_query_task_failure(
 
     manager = QueryStatusManager(query_id, team_id)
     try:
-        query_status = manager.get_query_status()
+        query_status = manager.get_query_status(resolve_results=False)
     except QueryNotFoundError:
         return
 


### PR DESCRIPTION
## Problem

Leave an experiment page in a background tab for twenty minutes and every metric card comes back "Query … not found", though the query finished and its result is sitting in the query cache. Any async query polled late does the same.

Blocking queries have a cousin: past the gateway's idle timeout the request is cut with a 504 while the server keeps running the query, so the result lands in the cache and the page shows an error for work that completed.

One cause under both. The status record in the app Redis carried a full copy of the result, so it could only be kept for twenty minutes, and once it expired nothing linked the query ID to the cached result.

## Changes

- A query polled up to a day later now gets its result. The record keeps state, timings, error and the result's cache key, and a poll follows that key into the query cache.
- A result that has left the cache answers 404 with `query_result_expired` and "The result expired. Refresh to run the query again.", where the poll used to claim the query never existed.
- A page whose blocking request the gateway drops now shows the result instead of the gateway error. The request carries a client query ID, the server records the outcome under it, and the page polls that ID.
- An insight whose async run failed can run again straight away. Enqueue joins a record only while its run is still going, so a finished or failed one no longer blocks the next run for the record's lifetime. Whether a failure may run again stays with the failure breaker, which is where that decision already lives.
- Mechanical: the record is master's key and master's single JSON value again, with the cache key stored beside the status, and reading it splits into a state-only accessor and one that attaches the result. Nothing renders differently; only the message above and what a poll returns changed.

**Four choices worth a reviewer's attention.**

1. **Blocking outcomes live under their own key prefix.** The client picks that query ID, and an async run is filed under an ID the client can read off any response, so one namespace let a client's own record answer a poll waiting for a different run. Checking before the write only narrowed that window. A poll reads the async record first, then the blocking one.
2. **The worker asks the cache whether the result actually landed**, rather than restating which responses get cached. Those rules live in the query runner and a second copy here would go stale. It costs one Redis read per finished async query, and when the answer is no the record carries the result itself on the old twenty minute lifetime.
3. **A record for a run still in flight keeps the short life.** The day is for a record that has an answer. Since an async query ID is the insight's cache key, a run that dies without its failure handler would otherwise be joined by every later request for that insight for a whole day.
4. **A blocking request is recorded only once it has run long enough for the gateway to have dropped it.** Blocking requests are most of the query traffic, and the app Redis is the tier this PR's own premise calls constrained.

The `results` field stays and is stored as given, so notebook frames, which keep an S3 pointer there, are untouched; moving them to their own record is #94709. The four lifetimes are plain constants, so no environment variable has to land in charts or secrets first.

> [!NOTE]
> Accepted: for one deploy, an async query a new worker finished and an old web pod serves renders an empty insight, because the old pod does not know to follow the cache key. It lasts until the web pods have rolled and clears itself.

## How did you test this code?

`test_execute_async.py` and `TestQueryRetrieve` cover the record round trip, the expired answer, the task storing a cache key when the cache took the result and the result itself when it did not, how long a record lives against whether its run finished, enqueue joining a running record but rerunning a finished one, and a blocking outcome landing outside the async namespace. Eight Jest cases in `query.test.ts` cover the recovery, including a record written past the time the request itself was allowed to run, and the two kinds of 504 that are answers rather than drops.

Not run: the app in a browser, and the deploy-window case, which needs two versions serving at once.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Claude Opus 5), directed by the assignee; skills: /writing-tests, /writing-code-comments, /writing-user-facing-copy, /writing-pr-descriptions, /improving-drf-endpoints. Origin: a customer report of "Query not found" on an experiment page, traced through access logs to polls arriving after the record expired. No customer material is in the PR. Replaces #94496 and #94595, which retried on the client and could not work because the query endpoint rewrites `force_cache` to compute-if-stale.

Two earlier designs were cut: one dropped the `results` field and added a notebook-specific escape hatch, the other renamed the record key and wrote it as a Redis hash. A subagent review of the second found the enqueue lock and the merge-on-write. Greptile and Graphite then found a check-then-set race and lost uncached results, which choices 1 and 2 above replace. ReviewHog found and fixed six more, including a 504 the application raises itself being mistaken for a dropped request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
