### PR TITLE
feat(web-analytics): let a project mint its own heatmap screenshot header value

### DIFF
--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -64,6 +64,7 @@ import { LogsMetricRulesSection } from 'products/logs/frontend/components/LogsMe
 import { LogsRetentionSection } from 'products/logs/frontend/components/LogsRetention/LogsRetentionSection'
 import { LogsSamplingSection } from 'products/logs/frontend/components/LogsSampling/LogsSamplingSection'
 import { LogsFeatureFlagKeys } from 'products/logs/frontend/logsFeatureFlagKeys'
+import { HeatmapScreenshotHeaderSettings } from 'products/web_analytics/frontend/heatmaps/components/HeatmapScreenshotHeaderSettings'
 import { WorkflowsEmailTrackingConsentSettings } from 'products/workflows/frontend/scenes/settings/WorkflowsEmailTrackingConsentSettings'
 import { WorkflowsEngagementEventsSettings } from 'products/workflows/frontend/scenes/settings/WorkflowsEngagementEventsSettings'
 
@@ -800,6 +801,15 @@ export const SETTINGS_MAP: SettingSection[] = [
                 platformSupport: FEATURE_SUPPORT.heatmaps,
                 component: <HeatmapsSettings />,
                 keywords: ['click map', 'scroll', 'rage click', 'mouse', 'touch'],
+            },
+            {
+                id: 'heatmap-screenshot-header',
+                title: 'Screenshot request header',
+                description:
+                    'Heatmap backgrounds are screenshots of your site. This header lets bot protection tell them apart from other headless browsers and permit them.',
+                docsUrl: 'https://posthog.com/docs/toolbar/heatmaps',
+                component: <HeatmapScreenshotHeaderSettings />,
+                keywords: ['waf', 'bot protection', 'firewall', 'cloudflare', 'screenshot', 'blocked', 'allowlist'],
             },
         ],
     },

--- a/frontend/src/scenes/settings/types.ts
+++ b/frontend/src/scenes/settings/types.ts
@@ -173,6 +173,7 @@ export type SettingId =
     | 'feature-previews-coming-soon'
     | 'group-analytics'
     | 'heatmaps'
+    | 'heatmap-screenshot-header'
     | 'hedgehog-mode'
     | 'homepage'
     | 'human-friendly-comparison-periods'

--- a/frontend/src/scenes/team-activity/teamActivityDescriber.tsx
+++ b/frontend/src/scenes/team-activity/teamActivityDescriber.tsx
@@ -160,6 +160,7 @@ const TEAM_PROPERTIES_MAPPING: Record<keyof TeamType, (change: ActivityChange) =
     // API-related tokens
     api_token: createApiTokenHandler('project token', 'set', 'reset'),
     secret_api_token: createApiTokenHandler('Feature Flags secure API key', 'generated', 'rotated'),
+    heatmaps_screenshot_secret: createApiTokenHandler('heatmap screenshot header value', 'generated', 'rotated'),
     secret_api_token_backup: (change) => {
         if (change.after === undefined || change.action !== 'deleted') {
             return null

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -856,6 +856,8 @@ export interface TeamType extends TeamBasicType {
     session_recording_trigger_groups?: SessionRecordingTriggerGroupsConfig | null
     surveys_opt_in?: boolean
     heatmaps_opt_in?: boolean
+    /** Value of the X-PostHog-Heatmap-Screenshot header on this project's heatmap renders. Null means the public default. */
+    heatmaps_screenshot_secret?: string | null
     conversations_enabled?: boolean
     conversations_settings?: ConversationsSettings | null
     web_analytics_pre_aggregated_tables_enabled?: boolean

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -1033,6 +1033,7 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
             "api_token",
             "secret_api_token",
             "secret_api_token_backup",
+            "heatmaps_screenshot_secret",
             "created_at",
             "updated_at",
             "ingested_event",
@@ -1061,6 +1062,7 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
             "api_token",
             "secret_api_token",
             "secret_api_token_backup",
+            "heatmaps_screenshot_secret",
             "created_at",
             "updated_at",
             "ingested_event",
@@ -2313,6 +2315,19 @@ class TeamViewSet(
         team = self.get_object()
         validate_secret_token_generation(team, cast(User, request.user))
         team.rotate_secret_token_and_save(user=request.user, is_impersonated_session=is_impersonated(request))
+        return response.Response(TeamSerializer(team, context=self.get_serializer_context()).data)
+
+    @action(
+        methods=["PATCH"],
+        detail=True,
+        # Only ADMIN or higher users are allowed to access this project
+        permission_classes=[TeamMemberStrictManagementPermission],
+    )
+    def rotate_heatmaps_screenshot_secret(self, request: request.Request, id: str, **kwargs) -> response.Response:
+        team = self.get_object()
+        team.rotate_heatmaps_screenshot_secret_and_save(
+            user=request.user, is_impersonated_session=is_impersonated(request)
+        )
         return response.Response(TeamSerializer(team, context=self.get_serializer_context()).data)
 
     @action(

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -787,6 +787,36 @@ def team_api_test_factory():
                 ]
             )
 
+        def test_rotate_heatmaps_screenshot_secret(self):
+            self.organization_membership.level = OrganizationMembership.Level.ADMIN
+            self.organization_membership.save()
+            self.assertIsNone(self.team.heatmaps_screenshot_secret)
+
+            response = self.client.patch(f"/api/environments/{self.team.id}/rotate_heatmaps_screenshot_secret/")
+            self.team.refresh_from_db()
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            first_secret = response.json()["heatmaps_screenshot_secret"]
+            self.assertTrue(first_secret.startswith("phh_"))
+            self.assertEqual(first_secret, self.team.heatmaps_screenshot_secret)
+
+            # Rotating again replaces the value, so a leaked one stops working.
+            response = self.client.patch(f"/api/environments/{self.team.id}/rotate_heatmaps_screenshot_secret/")
+            self.assertNotEqual(response.json()["heatmaps_screenshot_secret"], first_secret)
+
+            # Only the rotate endpoint mints a value, so a caller cannot choose one.
+            self.client.patch(f"/api/environments/{self.team.id}/", {"heatmaps_screenshot_secret": "phh_chosen"})
+            self.team.refresh_from_db()
+            self.assertNotEqual(self.team.heatmaps_screenshot_secret, "phh_chosen")
+
+        def test_rotate_heatmaps_screenshot_secret_insufficient_privileges(self):
+            self.organization_membership.level = OrganizationMembership.Level.MEMBER
+            self.organization_membership.save()
+
+            response = self.client.patch(f"/api/environments/{self.team.id}/rotate_heatmaps_screenshot_secret/")
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+            self.team.refresh_from_db()
+            self.assertIsNone(self.team.heatmaps_screenshot_secret)
+
         def test_rotate_secret_token_insufficient_privileges(self):
             self.organization_membership.level = OrganizationMembership.Level.MEMBER
             self.organization_membership.save()

--- a/posthog/migrations/1322_team_heatmaps_screenshot_secret.py
+++ b/posthog/migrations/1322_team_heatmaps_screenshot_secret.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1321_add_user_facet_settings"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="team",
+            name="heatmaps_screenshot_secret",
+            field=models.CharField(blank=True, max_length=200, null=True),
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1321_add_user_facet_settings
+1322_team_heatmaps_screenshot_secret

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -28,6 +28,7 @@ from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.signals import mutable_receiver, secret_api_token_rotated
 from posthog.models.utils import (
     UUIDTClassicModel,
+    generate_random_token_heatmap_screenshot,
     generate_random_token_project,
     generate_random_token_secret,
     mask_key_value,
@@ -493,6 +494,14 @@ class Team(UUIDTClassicModel):
 
     # Heatmaps
     heatmaps_opt_in = field_access_control(models.BooleanField(null=True, blank=True), "project", "admin")
+    # Value of the X-PostHog-Heatmap-Screenshot header on this team's heatmap renders, so a WAF rule can
+    # allow our screenshots without allowing every headless browser. Null means the team has not minted
+    # one and the render sends the public default instead. Only as strong as a shared secret can be here:
+    # the render service applies the header to every request the page makes, third-party hosts included,
+    # which is why it is rotatable and grants nothing beyond a match on the customer's own WAF rule.
+    heatmaps_screenshot_secret = field_access_control(
+        models.CharField(max_length=200, null=True, blank=True), "project", "admin"
+    )
 
     # Activity logs
     receive_org_level_activity_logs = field_access_control(
@@ -1074,6 +1083,36 @@ class Team(UUIDTClassicModel):
                         field="conversations_settings.widget_public_token",
                         before=mask_key_value(old_token) if old_token else None,
                         after=mask_key_value(new_token),
+                    )
+                ],
+            ),
+        )
+
+    def rotate_heatmaps_screenshot_secret_and_save(self, *, user: "User", is_impersonated_session: bool):
+        """Mint the team's first heatmap screenshot secret, or replace the one it has."""
+        from posthog.models.activity_logging.activity_log import Change, Detail, log_activity
+
+        old_secret = self.heatmaps_screenshot_secret
+        self.heatmaps_screenshot_secret = generate_random_token_heatmap_screenshot()
+        self.save(update_fields=["heatmaps_screenshot_secret"])
+
+        log_activity(
+            organization_id=self.organization_id,
+            team_id=self.pk,
+            user=cast("User", user),
+            was_impersonated=is_impersonated_session,
+            scope="Team",
+            item_id=self.pk,
+            activity="updated",
+            detail=Detail(
+                name=str(self.name),
+                changes=[
+                    Change(
+                        type="Team",
+                        action="created" if old_secret is None else "changed",
+                        field="heatmaps_screenshot_secret",
+                        before=mask_key_value(old_secret) if old_secret else None,
+                        after=mask_key_value(self.heatmaps_screenshot_secret),
                     )
                 ],
             ),

--- a/posthog/models/utils.py
+++ b/posthog/models/utils.py
@@ -164,6 +164,7 @@ def generate_random_token(nbytes: int = 32) -> str:
 PROJECT_API_TOKEN_PREFIX = "phc_"  # "c" standing for "client"
 PERSONAL_API_KEY_PREFIX = "phx_"  # "x" standing for nothing in particular
 SECRET_API_TOKEN_PREFIX = "phs_"  # "s" standing for "secret"; team secret tokens and project secret API keys
+HEATMAP_SCREENSHOT_SECRET_PREFIX = "phh_"  # "h" standing for "heatmap"
 OAUTH_ACCESS_TOKEN_PREFIX = "pha_"  # "a" standing for "access"
 OAUTH_REFRESH_TOKEN_PREFIX = "phr_"  # "r" standing for "refresh"
 
@@ -182,6 +183,11 @@ def generate_random_token_personal() -> str:
 def generate_random_token_secret() -> str:
     # Similar to personal API keys, but for retrieving feature flag definitions for local evaluation.
     return SECRET_API_TOKEN_PREFIX + generate_random_token(35)
+
+
+def generate_random_token_heatmap_screenshot() -> str:
+    # Only ever matched against by a customer WAF rule, so 16 bytes is ample.
+    return HEATMAP_SCREENSHOT_SECRET_PREFIX + generate_random_token(16)
 
 
 def generate_random_oauth_access_token(_request) -> str:

--- a/products/web_analytics/backend/tasks/heatmap_screenshot.py
+++ b/products/web_analytics/backend/tasks/heatmap_screenshot.py
@@ -15,6 +15,7 @@ from celery.exceptions import SoftTimeLimitExceeded
 from prometheus_client import Counter, Gauge, Histogram
 
 from posthog.exceptions_capture import capture_exception
+from posthog.models.team import Team
 from posthog.ph_client import ph_scoped_capture
 from posthog.scoping_audit import skip_team_scope_audit
 from posthog.security.url_validation import is_url_allowed
@@ -28,11 +29,11 @@ logger = structlog.get_logger(__name__)
 # Rides on every render request so a site's WAF can allow our screenshot without allowing headless
 # browsers broadly. The render reaches the site from Browserless' worker fleet, not from PostHog's
 # published egress IPs, so an IP allowlist cannot match it; this header can. The name is a public
-# contract we publish to customers, so a rename breaks every WAF rule that matches it. The value is
-# non-secret: Browserless applies these headers to every request the page makes, including
-# cross-origin subresources.
+# contract we publish to customers, so a rename breaks every WAF rule that matches it.
 HEATMAP_SCREENSHOT_REQUEST_HEADER = "X-PostHog-Heatmap-Screenshot"
-HEATMAP_SCREENSHOT_REQUEST_HEADER_VALUE = "1"
+# Sent by every team that has not minted a secret. It is public, so a rule matching it allows anyone
+# who sends the same header. A team that wants more than that mints a value only it knows.
+HEATMAP_SCREENSHOT_REQUEST_HEADER_DEFAULT_VALUE = "1"
 
 # Reclaim a hung worker rather than letting a stuck render hold an EXPORTS slot for the full retry budget.
 HEATMAP_SCREENSHOT_SOFT_TIME_LIMIT = 600  # seconds
@@ -389,8 +390,12 @@ def _page_status_from(response: requests.Response) -> int | None:
         return None
 
 
+def heatmap_screenshot_header_value(team: Team) -> str:
+    return team.heatmaps_screenshot_secret or HEATMAP_SCREENSHOT_REQUEST_HEADER_DEFAULT_VALUE
+
+
 def _browserless_screenshot(
-    endpoint_url: str, page_url: str, width: int, block_consent_modals: bool
+    endpoint_url: str, page_url: str, width: int, block_consent_modals: bool, header_value: str
 ) -> tuple[bytes, int | None]:
     # Render one width via the Browserless /screenshot REST API. viewport.width sets the captured width;
     # scrollPage triggers lazy-loaded content and blockConsentModals dismisses cookie banners server-side.
@@ -407,7 +412,7 @@ def _browserless_screenshot(
         "gotoOptions": {"waitUntil": "networkidle2", "timeout": 30_000},
         "scrollPage": True,
         "bestAttempt": True,
-        "setExtraHTTPHeaders": {HEATMAP_SCREENSHOT_REQUEST_HEADER: HEATMAP_SCREENSHOT_REQUEST_HEADER_VALUE},
+        "setExtraHTTPHeaders": {HEATMAP_SCREENSHOT_REQUEST_HEADER: header_value},
     }
     # blockConsentModals / blockAds are browserless.io cloud API extensions; the self-hosted OSS
     # image rejects unknown body fields (400 "must NOT have additional properties"), so only send
@@ -565,17 +570,20 @@ def _generate_browserless_screenshots(screenshot: SavedHeatmap, widths: list[int
         widths=pending,
         reused_widths=sorted(already_rendered),
     )
+    header_value = heatmap_screenshot_header_value(screenshot.team)
     count = 0
     for w in pending:
         image_data, page_status = _browserless_screenshot(
-            endpoint_url, screenshot.url, w, screenshot.block_consent_modals
+            endpoint_url, screenshot.url, w, screenshot.block_consent_modals, header_value
         )
         if page_status is not None and not 200 <= page_status < 300:
             raise PageHttpStatusError(
                 f"{_host_of(screenshot.url)} returned {page_status} when we loaded the page, so the capture "
                 f"is a picture of that response. Bot protection often blocks our screenshots. To allow them, "
-                f'add a rule that permits requests carrying the "{HEATMAP_SCREENSHOT_REQUEST_HEADER}: '
-                f'{HEATMAP_SCREENSHOT_REQUEST_HEADER_VALUE}" header, then try again.',
+                # The header value stays out of this string: it is persisted on the snapshot and sent to
+                # error tracking, and a team's minted secret belongs in neither.
+                f'add a rule that permits requests carrying the "{HEATMAP_SCREENSHOT_REQUEST_HEADER}" header, '
+                f"then try again. Project settings, under Heatmaps, holds the value to match.",
                 cause="page_http_status",
             )
         _persist_snapshot(screenshot, w, image_data)

--- a/products/web_analytics/backend/tasks/test/test_heatmap_screenshot.py
+++ b/products/web_analytics/backend/tasks/test/test_heatmap_screenshot.py
@@ -11,6 +11,8 @@ from celery.exceptions import SoftTimeLimitExceeded
 from parameterized import parameterized
 from prometheus_client import REGISTRY
 
+from posthog.models.team import Team
+
 from products.web_analytics.backend.api.heatmaps_utils import MAX_TARGET_WIDTHS, PREWARM_TTL
 from products.web_analytics.backend.models import HeatmapSnapshot, SavedHeatmap
 from products.web_analytics.backend.tasks.heatmap_screenshot import (
@@ -27,6 +29,7 @@ from products.web_analytics.backend.tasks.heatmap_screenshot import (
     _resolve_widths,
     _sanitize_browserless_error,
     generate_heatmap_screenshot,
+    heatmap_screenshot_header_value,
     reap_stale_prewarm_heatmaps,
     report_stuck_heatmap_screenshots,
 )
@@ -286,7 +289,7 @@ class TestBrowserlessScreenshotRequest(SimpleTestCase):
         mock_requests.post.return_value = resp
 
         content, page_status = _browserless_screenshot(
-            "https://host/screenshot?token=t", "https://ex.com", 1024, block_consent_modals=False
+            "https://host/screenshot?token=t", "https://ex.com", 1024, block_consent_modals=False, header_value="1"
         )
 
         assert content == _jpeg(b"img")
@@ -305,7 +308,7 @@ class TestBrowserlessScreenshotRequest(SimpleTestCase):
         mock_requests.post.return_value = _make_response(_jpeg(b"img"))
 
         content, _ = _browserless_screenshot(
-            "https://host/screenshot?token=t", "https://example.com", width, block_consent_modals=True
+            "https://host/screenshot?token=t", "https://example.com", width, block_consent_modals=True, header_value="1"
         )
 
         assert content == _jpeg(b"img")
@@ -333,7 +336,7 @@ class TestBrowserlessScreenshotRequest(SimpleTestCase):
     def test_block_ads_added_to_body_when_enabled(self, mock_requests: MagicMock) -> None:
         mock_requests.post.return_value = _make_response()
         _browserless_screenshot(
-            "https://host/screenshot?token=t", "https://example.com", 1024, block_consent_modals=False
+            "https://host/screenshot?token=t", "https://example.com", 1024, block_consent_modals=False, header_value="1"
         )
         assert mock_requests.post.call_args.kwargs["json"]["blockAds"] is True
 
@@ -348,7 +351,7 @@ class TestBrowserlessScreenshotRequest(SimpleTestCase):
         # so disabling them must omit the keys entirely rather than send false.
         mock_requests.post.return_value = _make_response()
         _browserless_screenshot(
-            "https://host/screenshot?token=t", "https://example.com", 1024, block_consent_modals=False
+            "https://host/screenshot?token=t", "https://example.com", 1024, block_consent_modals=False, header_value="1"
         )
         body = mock_requests.post.call_args.kwargs["json"]
         assert "blockAds" not in body
@@ -369,7 +372,7 @@ class TestBrowserlessScreenshotRequest(SimpleTestCase):
             mock_requests.post.side_effect = Exception("ECONNREFUSED https://host/screenshot?token=secret-token")
 
         with self.assertRaises(BrowserlessError) as ctx:
-            _browserless_screenshot(endpoint, "https://example.com", 1024, block_consent_modals=False)
+            _browserless_screenshot(endpoint, "https://example.com", 1024, block_consent_modals=False, header_value="1")
 
         message = str(ctx.exception)
         # The token must never reach the (API-readable) persisted exception
@@ -392,7 +395,11 @@ class TestBrowserlessScreenshotRequest(SimpleTestCase):
         mock_requests.post.return_value = _make_response(content, content_type=content_type)
         with self.assertRaises(BrowserlessError):
             _browserless_screenshot(
-                "https://host/screenshot?token=t", "https://example.com", 1024, block_consent_modals=False
+                "https://host/screenshot?token=t",
+                "https://example.com",
+                1024,
+                block_consent_modals=False,
+                header_value="1",
             )
 
     @override_settings(HEATMAP_BROWSERLESS_TIMEOUT_MS=180000, HEATMAP_BROWSERLESS_CONNECT_TIMEOUT_MS=30000)
@@ -402,8 +409,20 @@ class TestBrowserlessScreenshotRequest(SimpleTestCase):
         mock_requests.post.return_value = _make_response(_jpeg(b"way over the cap"))
         with self.assertRaises(BrowserlessPermanentError):
             _browserless_screenshot(
-                "https://host/screenshot?token=t", "https://example.com", 1024, block_consent_modals=False
+                "https://host/screenshot?token=t",
+                "https://example.com",
+                1024,
+                block_consent_modals=False,
+                header_value="1",
             )
+
+
+class TestHeatmapScreenshotHeaderValue(SimpleTestCase):
+    def test_team_without_a_secret_sends_the_public_default(self) -> None:
+        assert heatmap_screenshot_header_value(Team(heatmaps_screenshot_secret=None)) == "1"
+
+    def test_team_with_a_secret_sends_it_instead_of_the_default(self) -> None:
+        assert heatmap_screenshot_header_value(Team(heatmaps_screenshot_secret="phh_abc")) == "phh_abc"
 
 
 # Pure-function tests for the Browserless URL helpers — no DB, so they run on SimpleTestCase.

--- a/products/web_analytics/frontend/heatmaps/components/HeatmapScreenshotHeaderSettings.tsx
+++ b/products/web_analytics/frontend/heatmaps/components/HeatmapScreenshotHeaderSettings.tsx
@@ -1,0 +1,88 @@
+import { useActions, useValues } from 'kea'
+import { useState } from 'react'
+
+import { LemonButton, LemonDialog, Link } from '@posthog/lemon-ui'
+
+import api from 'lib/api'
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { teamLogic } from 'scenes/teamLogic'
+
+import {
+    HEATMAP_SCREENSHOT_HEADER,
+    HEATMAP_SCREENSHOT_HEADER_DEFAULT_VALUE,
+    heatmapScreenshotHeaderValue,
+} from '../heatmapScreenshotHeader'
+
+export function HeatmapScreenshotHeaderSettings(): JSX.Element {
+    const { currentTeam, currentTeamId } = useValues(teamLogic)
+    const { loadCurrentTeam } = useActions(teamLogic)
+    const [rotating, setRotating] = useState(false)
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
+
+    const headerValue = heatmapScreenshotHeaderValue(currentTeam)
+    const usesDefault = headerValue === HEATMAP_SCREENSHOT_HEADER_DEFAULT_VALUE
+
+    const rotate = async (): Promise<void> => {
+        setRotating(true)
+        try {
+            await api.update(`api/environments/${currentTeamId}/rotate_heatmaps_screenshot_secret`, {})
+            loadCurrentTeam()
+            lemonToast.success('New header value ready. Update your rule to match it.')
+        } catch {
+            lemonToast.error('Could not generate a new header value. Please try again.')
+        } finally {
+            setRotating(false)
+        }
+    }
+
+    return (
+        <div className="flex flex-col gap-2">
+            <p className="mb-0">
+                The screenshots come from a rendering service, not from PostHog's own IP addresses, so an IP allowlist
+                cannot let them through. Every screenshot request carries the header below. Add a rule to your WAF or
+                bot protection that permits it.
+            </p>
+            <CodeSnippet language={Language.HTTP} thing="header">
+                {`${HEATMAP_SCREENSHOT_HEADER}: ${headerValue}`}
+            </CodeSnippet>
+            <p className="mb-0">
+                {usesDefault
+                    ? 'This project uses the public default value, which anyone can send. Generate a value only this project knows, so your rule permits our screenshots alone.'
+                    : 'This value is private to this project. Rotate it if it leaks. The old value stops working at once, so update your rule straight after.'}
+            </p>
+            <p className="text-secondary mb-0">
+                The rendering service puts the header on every request the page makes, third-party hosts included. Treat
+                the value as a shared secret of modest worth: it permits a page load, and nothing else. Read more in our{' '}
+                <Link to="https://posthog.com/docs/toolbar/heatmaps">heatmaps docs</Link>.
+            </p>
+            <div>
+                <LemonButton
+                    type="secondary"
+                    disabledReason={restrictedReason}
+                    loading={rotating}
+                    onClick={() => {
+                        if (usesDefault) {
+                            void rotate()
+                            return
+                        }
+                        LemonDialog.open({
+                            title: 'Rotate the header value?',
+                            description:
+                                'Screenshots start sending the new value at once. Any rule that matches the current value stops permitting them until you update it.',
+                            primaryButton: { children: 'Rotate value', onClick: () => void rotate() },
+                            secondaryButton: { children: 'Cancel' },
+                        })
+                    }}
+                >
+                    {usesDefault ? 'Generate a value for this project' : 'Rotate value'}
+                </LemonButton>
+            </div>
+        </div>
+    )
+}

--- a/products/web_analytics/frontend/heatmaps/components/heatmapsBrowserLogic.test.ts
+++ b/products/web_analytics/frontend/heatmaps/components/heatmapsBrowserLogic.test.ts
@@ -44,23 +44,30 @@ describe('heatmapsBrowserLogic', () => {
             ['blocked by csp', { framing: 'blocked', blocked_by: 'frame_ancestors' }, 'content security policy'],
             ['blocked by xfo', { framing: 'blocked', blocked_by: 'x_frame_options' }, 'X-Frame-Options'],
         ] as const)('explains why the live preview cannot load when %s', (_name, overrides, expected) => {
-            const message = preflightBannerMessage({ ...base, ...overrides })
+            const message = preflightBannerMessage({ ...base, ...overrides }, '1')
             expect(message).toContain('shop.example.com')
             expect(message).toContain(expected)
         })
 
-        it('reports a non-2xx and points to the screenshot background that carries the header', () => {
-            const message = preflightBannerMessage({
-                ...base,
-                framing: 'unknown',
-                http_status: 429,
-                body_excerpt: 'local_rate_limited',
-            })
+        it.each([
+            ['the public default', '1'],
+            // A project that minted a secret must see its own value, not the default that everyone sends.
+            ['a project secret', 'phh_abc123'],
+        ])('reports a non-2xx and quotes %s in the header to allow', (_name, headerValue) => {
+            const message = preflightBannerMessage(
+                {
+                    ...base,
+                    framing: 'unknown',
+                    http_status: 429,
+                    body_excerpt: 'local_rate_limited',
+                },
+                headerValue
+            )
 
             expect(message).toContain('429')
             expect(message).toContain('local_rate_limited')
             // The published fix is the header, not an IP allowlist that cannot match the render service.
-            expect(message).toContain('X-PostHog-Heatmap-Screenshot: 1')
+            expect(message).toContain(`X-PostHog-Heatmap-Screenshot: ${headerValue}`)
             // The live preview cannot send the header, so the guidance must point at the screenshot
             // background that does, not tell the user to retry the iframe.
             expect(message).toContain('screenshot background')
@@ -75,7 +82,7 @@ describe('heatmapsBrowserLogic', () => {
             // must never be reported as the customer's host refusing us.
             ['a redirect', { ...base, framing: 'unknown', http_status: 301 }],
         ] as const)('stays silent for %s', (_name, preflight) => {
-            expect(preflightBannerMessage(preflight)).toBeNull()
+            expect(preflightBannerMessage(preflight, '1')).toBeNull()
         })
     })
 

--- a/products/web_analytics/frontend/heatmaps/components/heatmapsBrowserLogic.ts
+++ b/products/web_analytics/frontend/heatmaps/components/heatmapsBrowserLogic.ts
@@ -35,10 +35,12 @@ import { objectsEqual } from 'lib/utils/objects'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { hogql } from '~/queries/utils'
+import { TeamPublicType, TeamType } from '~/types'
 
 import { savedPreflightCreate } from 'products/web_analytics/frontend/generated/api'
 import type { HeatmapPreflightResponseApi } from 'products/web_analytics/frontend/generated/api.schemas'
 
+import { HEATMAP_SCREENSHOT_HEADER, heatmapScreenshotHeaderValue } from '../heatmapScreenshotHeader'
 import {
     ReplayIframeData,
     getStoredRecordingBackground,
@@ -67,7 +69,7 @@ function hostOf(url: string): string {
     }
 }
 
-export function preflightBannerMessage(preflight: PagePreflight | null): string | null {
+export function preflightBannerMessage(preflight: PagePreflight | null, headerValue: string): string | null {
     if (!preflight) {
         return null
     }
@@ -80,8 +82,8 @@ export function preflightBannerMessage(preflight: PagePreflight | null): string 
         return (
             `${host} returned ${preflight.http_status} when we tried to load this page.${said} ` +
             `Bot protection often blocks automated loads like this. A screenshot background sends the ` +
-            `"X-PostHog-Heatmap-Screenshot: 1" header, which a bot protection rule can allow. The live ` +
-            `preview cannot send that header, so add the rule and switch to a screenshot background.`
+            `"${HEATMAP_SCREENSHOT_HEADER}: ${headerValue}" header, which a bot protection rule can allow. The ` +
+            `live preview cannot send that header, so add the rule and switch to a screenshot background.`
         )
     }
 
@@ -139,6 +141,7 @@ export interface heatmapsBrowserLogicValues {
     hrefMatchType: HrefMatchType // heatmapDataLogic
     isHeightCapped: boolean // heatmapDataLogic
     widthOverride: number // heatmapDataLogic
+    currentTeam: TeamPublicType | TeamType | null // teamLogic
     currentTeamIdStrict: number | string // teamLogic
     browserSearchResults: string[] | null
     browserSearchResultsLoading: boolean
@@ -317,7 +320,10 @@ export interface heatmapsBrowserLogicActions {
 export interface heatmapsBrowserLogicMeta {
     __keaTypeGenInternalSelectorTypes: {
         currentPagePreflight: (pagePreflight: PagePreflight | null, displayUrl: string | null) => PagePreflight | null
-        preflightMessage: (currentPagePreflight: PagePreflight | null) => string | null
+        preflightMessage: (
+            currentPagePreflight: PagePreflight | null,
+            currentTeam: TeamPublicType | TeamType | null
+        ) => string | null
         iframeBanner: (preflightMessage: string | null, loadTimeoutBanner: IFrameBanner | null) => IFrameBanner | null
         browserUrlSearchOptions: (
             browserSearchResults: string[] | null,
@@ -386,7 +392,7 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
             featureFlagLogic,
             ['featureFlags'],
             teamLogic,
-            ['currentTeamIdStrict'],
+            ['currentTeam', 'currentTeamIdStrict'],
         ],
         actions: [
             heatmapDataLogic({ context: 'in-app' }),
@@ -573,8 +579,11 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
                 pagePreflight?.url === displayUrl ? pagePreflight : null,
         ],
         preflightMessage: [
-            (s) => [s.currentPagePreflight],
-            (currentPagePreflight: PagePreflight | null): string | null => preflightBannerMessage(currentPagePreflight),
+            (s) => [s.currentPagePreflight, s.currentTeam],
+            (
+                currentPagePreflight: PagePreflight | null,
+                currentTeam: TeamPublicType | TeamType | null
+            ): string | null => preflightBannerMessage(currentPagePreflight, heatmapScreenshotHeaderValue(currentTeam)),
         ],
         // Derived rather than pushed into loadTimeoutBanner, because stopTrackingLoading nulls that
         // banner as soon as the iframe fires onload, which a blocked frame does immediately.

--- a/products/web_analytics/frontend/heatmaps/heatmapScreenshotHeader.ts
+++ b/products/web_analytics/frontend/heatmaps/heatmapScreenshotHeader.ts
@@ -1,0 +1,14 @@
+import { TeamPublicType, TeamType } from '~/types'
+
+// Every heatmap screenshot request carries this header, so a bot protection rule can permit our
+// render without permitting headless browsers broadly. The name is a public contract: a rename
+// breaks every customer rule that matches it. Keep both constants in step with
+// products/web_analytics/backend/tasks/heatmap_screenshot.py.
+export const HEATMAP_SCREENSHOT_HEADER = 'X-PostHog-Heatmap-Screenshot'
+export const HEATMAP_SCREENSHOT_HEADER_DEFAULT_VALUE = '1'
+
+/** The header value this project's screenshots carry: its own secret, or the public default. */
+export function heatmapScreenshotHeaderValue(team: TeamType | TeamPublicType | null): string {
+    const secret = team && 'heatmaps_screenshot_secret' in team ? team.heatmaps_screenshot_secret : null
+    return secret ?? HEATMAP_SCREENSHOT_HEADER_DEFAULT_VALUE
+}


### PR DESCRIPTION
## Problem

A team whose site sits behind bot protection can now write a WAF rule that permits PostHog heatmap screenshots and nothing else.

The header that #89722 adds carries the fixed value `1`. That value is public, so any rule that matches it also permits every other request that copies the header. A team that does not want to open that door had no alternative.

Stacked on #89722, which introduces the header.

## Changes

- Settings - Heatmaps holds a new "Screenshot request header" section. It shows the exact header line to match, with a copy button.
- A project admin can mint a value only that project knows, and rotate it later. The button reads "Generate a value for this project" until a value exists, then "Rotate value" behind a confirmation.
- Renders send the project value when one exists. Every other project keeps sending the public default, so nothing changes for a team that does nothing.
- The failure message on a blocked render now names the header and points at project settings for the value. It no longer prints the value, because that message is persisted and sent to error tracking.
- Rotation is written to the project activity log, with the value masked.
- Mechanical: a nullable `heatmaps_screenshot_secret` column on Team, a read-only serializer field, a `rotate_heatmaps_screenshot_secret` action gated to project admins, and a matching `TeamType` field.

The header value is not a credential. The render service puts extra headers on every request the page makes, third parties included, so the value reaches hosts other than the customer's own. It buys a page load and nothing else, which is why rotation exists and why the settings copy says so plainly.

### Before

![before-light-wide](https://raw.githubusercontent.com/PostHog/pr-assets/bb28cb6dd5a20dc9b159ece2472b465628932348/2026/09/0ed679de-8e9f-4a5a-909e-f0c54ec9cc44.png)

### After, no value minted

![after-light-wide](https://raw.githubusercontent.com/PostHog/pr-assets/bb28cb6dd5a20dc9b159ece2472b465628932348/2026/09/10e45a92-b020-4674-87e2-d77189cebaca.png)

### After, value minted

![after-secret-light-wide](https://raw.githubusercontent.com/PostHog/pr-assets/bb28cb6dd5a20dc9b159ece2472b465628932348/2026/09/842732b5-f3f6-4d60-ae53-434be38e0358.png)

<details>
<summary>Dark mode, and a narrow window</summary>

![after-dark-wide](https://raw.githubusercontent.com/PostHog/pr-assets/bb28cb6dd5a20dc9b159ece2472b465628932348/2026/09/6e1a5ba3-bc42-44b3-b800-74bac4bdbac4.png)

![after-light-narrow](https://raw.githubusercontent.com/PostHog/pr-assets/bb28cb6dd5a20dc9b159ece2472b465628932348/2026/09/68dba01f-5457-4ce7-b1bd-1879a6ed4f17.png)

![after-dark-narrow](https://raw.githubusercontent.com/PostHog/pr-assets/bb28cb6dd5a20dc9b159ece2472b465628932348/2026/09/745fbc0c-6c86-4190-8844-5d588204153e.png)

</details>

## How did you test this code?

Run locally by the agent:

- `pytest products/web_analytics/backend/tasks/test/test_heatmap_screenshot.py -k "HeaderValue or BrowserlessScreenshotRequest"` - 16 passed. The two new cases pin that a project with a minted value sends it, and that a project without one still sends `1`. No existing test covered the fallback.
- `jest heatmapsBrowserLogic.test.ts` - 21 passed. The banner case is now parameterised over the default and a minted value, so a banner that hardcodes `1` again fails.
- `manage.py makemigrations --check --dry-run posthog` - no changes detected, so the hand-written migration matches the model.
- `tsgo --noEmit` - no errors in the changed files. It caught the missing activity-log describer entry, which is why one is in the diff.
- `ruff check` / `ruff format` clean. `oxlint` and `oxfmt` clean.
- Screenshots above come from the `SettingsEnvironmentHeatmaps` Storybook story, rendered headless. The minted-value state uses a temporary local edit to the mock team, which is not committed.

Not run here: the two new `test_team.py` cases for the rotate endpoint (admin mints and rotates, member gets 403, a PATCH cannot choose a value). They need Postgres and ClickHouse, which were not both up in this environment. CI runs them.

No end-to-end run against a real WAF or the hosted render service.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The public docs page still tells customers to allowlist the PostHog Cloud US IP addresses. That guidance cannot work, because the render does not come from them. The page lives in `PostHog/posthog.com` and needs a companion change that names the header and the per-project value. Not included here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by the PostHog Slack app from a support thread, and directed by a PostHog engineer there. Reassign if the DRI should be someone else.
- Skills invoked: none beyond the repo conventions in `AGENTS.md` and `.cursor/rules/django-python.mdc`.
- The opt-in design was chosen over minting a value for every project. It needs no backfill, and a team that already matches on the published default keeps working.
- One value per project, with no backup value. PostHog is the only sender, so an old value has no traffic to serve once rotation lands.
- `hogli review` could not run: the Greptile CLI is absent from this environment. The bot review on the PR still runs as usual.
- Nothing from the originating conversation is in the diff or in this description.

