### PR TITLE
feat(rbac): migrate unaffected organizations to most-specific resolution

### DIFF
--- a/products/access_control/backend/facade/most_specific_migration.py
+++ b/products/access_control/backend/facade/most_specific_migration.py
@@ -52,10 +52,11 @@ class MigrationCandidates:
 
     @property
     def unaffected_ids(self) -> list[UUID]:
-        return [org.id for org in self.unchanged] + list(self.without_rules)
+        return [org.id for org in self.unchanged] + self.without_rules
 
 
 def _pending_organizations() -> QuerySet[Organization]:
+    # The column is nullable and NULL means legacy, so exclude True rather than filter False
     return Organization.objects.exclude(uses_most_specific_access_resolution=True)
 
 
@@ -79,7 +80,7 @@ def find_organizations_to_migrate() -> MigrationCandidates:
         )
         for org_id, changes in changes_by_org.items()
     ]
-    divergent = sorted((org for org in evaluated if org.changes > 0), key=lambda org: -org.changes)
+    divergent = sorted((org for org in evaluated if org.changes > 0), key=lambda org: org.changes, reverse=True)
     unchanged = sorted((org for org in evaluated if org.changes == 0), key=lambda org: str(org.id))
 
     organizations_with_rules = AccessControl.objects.values("team__organization_id")

--- a/products/access_control/backend/facade/most_specific_migration.py
+++ b/products/access_control/backend/facade/most_specific_migration.py
@@ -3,16 +3,18 @@ resolution does not affect, and switches them over.
 
 An organization is not affected when it has no access rules, or when every rule resolves
 the same under both resolutions on every team (see `resolution_preview`). Organizations
-that resolve differently, and organizations with rules but no active member to evaluate
-as, are reported and stay on the legacy resolution.
+that resolve differently, and organizations the preview cannot evaluate, are reported and
+stay on the legacy resolution.
 """
 
 from collections import Counter, defaultdict
 from collections.abc import Iterable
+from datetime import datetime
 from itertools import batched
 from uuid import UUID
 
-from django.db.models import QuerySet
+from django.db.models import Exists, OuterRef, QuerySet
+from django.utils import timezone
 
 from posthog.dataclasses import frozen
 from posthog.models.organization import Organization
@@ -45,6 +47,8 @@ class OrganizationRef:
 class MigrationCandidates:
     """Every organization still on the legacy resolution, sorted by what the switch would do."""
 
+    # When the classification started. Rules written after this may invalidate it.
+    found_at: datetime
     divergent: list[OrganizationChanges]
     unchanged: list[OrganizationChanges]
     unevaluated: list[OrganizationRef]
@@ -61,6 +65,7 @@ def _pending_organizations() -> QuerySet[Organization]:
 
 
 def find_organizations_to_migrate() -> MigrationCandidates:
+    found_at = timezone.now()
     names: dict[UUID, str] = {}
     teams_by_org: Counter[UUID] = Counter()
     changes_by_org: defaultdict[UUID, list[ResolutionChange]] = defaultdict(list)
@@ -96,14 +101,29 @@ def find_organizations_to_migrate() -> MigrationCandidates:
         _pending_organizations().exclude(id__in=organizations_with_rules).order_by("id").values_list("id", flat=True)
     )
     return MigrationCandidates(
-        divergent=divergent, unchanged=unchanged, unevaluated=unevaluated, without_rules=without_rules
+        found_at=found_at,
+        divergent=divergent,
+        unchanged=unchanged,
+        unevaluated=unevaluated,
+        without_rules=without_rules,
     )
 
 
-def enable_most_specific_resolution(organization_ids: Iterable[UUID]) -> int:
+def enable_most_specific_resolution(organization_ids: Iterable[UUID], *, rules_unchanged_since: datetime) -> int:
     """Switch the given organizations to the most-specific resolution. Returns the number of
-    rows updated. Batched so one run never holds a long lock on the organization table."""
+    rows updated. Batched so one run never holds a long lock on the organization table.
+
+    An organization whose access rules were written at or after `rules_unchanged_since` is
+    left alone: the classification that approved it no longer describes its rules.
+    """
+    rules_written_since = AccessControl.objects.filter(
+        team__organization_id=OuterRef("id"), updated_at__gte=rules_unchanged_since
+    )
     updated = 0
     for batch in batched(organization_ids, _UPDATE_BATCH_SIZE, strict=False):
-        updated += Organization.objects.filter(id__in=batch).update(uses_most_specific_access_resolution=True)
+        updated += (
+            Organization.objects.filter(id__in=batch)
+            .exclude(Exists(rules_written_since))
+            .update(uses_most_specific_access_resolution=True)
+        )
     return updated

--- a/products/access_control/backend/facade/most_specific_migration.py
+++ b/products/access_control/backend/facade/most_specific_migration.py
@@ -1,10 +1,10 @@
-"""Sweep of organizations still on the legacy access resolution, and the switch for the
-ones the change cannot affect.
+"""Finds the organizations still on the legacy access resolution that the most-specific
+resolution does not affect, and switches them over.
 
-An organization is unaffected when every rule subject resolves the same under both
-resolutions on every team (see `resolution_preview`), or when it has no access rules at all.
-Organizations that resolve differently, and organizations with rules but no active member
-to evaluate as, are reported and left on the legacy resolution.
+An organization is not affected when it has no access rules, or when every rule resolves
+the same under both resolutions on every team (see `resolution_preview`). Organizations
+that resolve differently, and organizations with rules but no active member to evaluate
+as, are reported and stay on the legacy resolution.
 """
 
 from collections.abc import Iterable
@@ -39,8 +39,8 @@ class OrganizationRef:
 
 
 @frozen
-class ResolutionSweep:
-    """Every organization not yet on the most-specific resolution, sorted into buckets."""
+class MigrationCandidates:
+    """Every organization still on the legacy resolution, sorted by what the switch would do."""
 
     divergent: list[OrganizationReadiness]
     unchanged: list[OrganizationReadiness]
@@ -56,7 +56,7 @@ def _pending_organizations() -> QuerySet[Organization]:
     return Organization.objects.exclude(uses_most_specific_access_resolution=True)
 
 
-def sweep_pending_organizations() -> ResolutionSweep:
+def find_organizations_to_migrate() -> MigrationCandidates:
     totals: dict[UUID, dict[str, int]] = {}
     names: dict[UUID, str] = {}
 
@@ -87,14 +87,14 @@ def sweep_pending_organizations() -> ResolutionSweep:
     without_rules = list(
         _pending_organizations().exclude(id__in=organizations_with_rules).order_by("id").values_list("id", flat=True)
     )
-    return ResolutionSweep(
+    return MigrationCandidates(
         divergent=divergent, unchanged=unchanged, unevaluated=unevaluated, without_rules=without_rules
     )
 
 
 def enable_most_specific_resolution(organization_ids: Iterable[UUID]) -> int:
     """Switch the given organizations to the most-specific resolution. Returns the number of
-    rows updated. Batched so one sweep never holds a long lock on the organization table."""
+    rows updated. Batched so one run never holds a long lock on the organization table."""
     ids = list(organization_ids)
     updated = 0
     for start in range(0, len(ids), _UPDATE_BATCH_SIZE):

--- a/products/access_control/backend/facade/most_specific_migration.py
+++ b/products/access_control/backend/facade/most_specific_migration.py
@@ -7,23 +7,26 @@ that resolve differently, and organizations with rules but no active member to e
 as, are reported and stay on the legacy resolution.
 """
 
+from collections import Counter, defaultdict
 from collections.abc import Iterable
+from itertools import batched
 from uuid import UUID
 
 from django.db.models import QuerySet
 
 from posthog.dataclasses import frozen
 from posthog.models.organization import Organization
-from posthog.models.team.team import Team
 
-from products.access_control.backend.facade.resolution_preview import iter_resolution_changes
+from products.access_control.backend.facade.resolution_preview import ResolutionChange, iter_resolution_changes
 from products.access_control.backend.models.access_control import AccessControl
 
 _UPDATE_BATCH_SIZE = 500
 
 
 @frozen
-class OrganizationReadiness:
+class OrganizationChanges:
+    """How many rules on an organization resolve differently, across its evaluated teams."""
+
     id: UUID
     name: str
     teams: int
@@ -42,14 +45,14 @@ class OrganizationRef:
 class MigrationCandidates:
     """Every organization still on the legacy resolution, sorted by what the switch would do."""
 
-    divergent: list[OrganizationReadiness]
-    unchanged: list[OrganizationReadiness]
+    divergent: list[OrganizationChanges]
+    unchanged: list[OrganizationChanges]
     unevaluated: list[OrganizationRef]
     without_rules: list[UUID]
 
     @property
     def unaffected_ids(self) -> list[UUID]:
-        return [readiness.id for readiness in self.unchanged] + list(self.without_rules)
+        return [org.id for org in self.unchanged] + list(self.without_rules)
 
 
 def _pending_organizations() -> QuerySet[Organization]:
@@ -57,30 +60,34 @@ def _pending_organizations() -> QuerySet[Organization]:
 
 
 def find_organizations_to_migrate() -> MigrationCandidates:
-    totals: dict[UUID, dict[str, int]] = {}
     names: dict[UUID, str] = {}
-
+    teams_by_org: Counter[UUID] = Counter()
+    changes_by_org: defaultdict[UUID, list[ResolutionChange]] = defaultdict(list)
     for team, changes in iter_resolution_changes(only_pending=True):
-        org_id = team.organization_id
-        names[org_id] = team.organization.name
-        counts = totals.setdefault(org_id, {"teams": 0, "changes": 0, "gains": 0, "loses": 0})
-        counts["teams"] += 1
-        counts["changes"] += len(changes)
-        counts["gains"] += sum(1 for change in changes if change.direction == "gains")
-        counts["loses"] += sum(1 for change in changes if change.direction == "loses")
+        names[team.organization_id] = team.organization.name
+        teams_by_org[team.organization_id] += 1
+        changes_by_org[team.organization_id].extend(changes)
 
-    evaluated = [OrganizationReadiness(id=org_id, name=names[org_id], **counts) for org_id, counts in totals.items()]
-    divergent = sorted((r for r in evaluated if r.changes > 0), key=lambda r: -r.changes)
-    unchanged = sorted((r for r in evaluated if r.changes == 0), key=lambda r: str(r.id))
+    evaluated = [
+        OrganizationChanges(
+            id=org_id,
+            name=names[org_id],
+            teams=teams_by_org[org_id],
+            changes=len(changes),
+            gains=sum(change.direction == "gains" for change in changes),
+            loses=sum(change.direction == "loses" for change in changes),
+        )
+        for org_id, changes in changes_by_org.items()
+    ]
+    divergent = sorted((org for org in evaluated if org.changes > 0), key=lambda org: -org.changes)
+    unchanged = sorted((org for org in evaluated if org.changes == 0), key=lambda org: str(org.id))
 
-    organizations_with_rules = Team.objects.filter(id__in=AccessControl.objects.values("team_id")).values(
-        "organization_id"
-    )
+    organizations_with_rules = AccessControl.objects.values("team__organization_id")
     unevaluated = [
         OrganizationRef(id=org_id, name=name)
         for org_id, name in _pending_organizations()
         .filter(id__in=organizations_with_rules)
-        .exclude(id__in=totals.keys())
+        .exclude(id__in=changes_by_org.keys())
         .order_by("id")
         .values_list("id", "name")
     ]
@@ -95,9 +102,7 @@ def find_organizations_to_migrate() -> MigrationCandidates:
 def enable_most_specific_resolution(organization_ids: Iterable[UUID]) -> int:
     """Switch the given organizations to the most-specific resolution. Returns the number of
     rows updated. Batched so one run never holds a long lock on the organization table."""
-    ids = list(organization_ids)
     updated = 0
-    for start in range(0, len(ids), _UPDATE_BATCH_SIZE):
-        batch = ids[start : start + _UPDATE_BATCH_SIZE]
+    for batch in batched(organization_ids, _UPDATE_BATCH_SIZE, strict=False):
         updated += Organization.objects.filter(id__in=batch).update(uses_most_specific_access_resolution=True)
     return updated

--- a/products/access_control/backend/facade/resolution_migration.py
+++ b/products/access_control/backend/facade/resolution_migration.py
@@ -1,0 +1,103 @@
+"""Sweep of organizations still on the legacy access resolution, and the switch for the
+ones the change cannot affect.
+
+An organization is unaffected when every rule subject resolves the same under both
+resolutions on every team (see `resolution_preview`), or when it has no access rules at all.
+Organizations that resolve differently, and organizations with rules but no active member
+to evaluate as, are reported and left on the legacy resolution.
+"""
+
+from collections.abc import Iterable
+from uuid import UUID
+
+from django.db.models import QuerySet
+
+from posthog.dataclasses import frozen
+from posthog.models.organization import Organization
+from posthog.models.team.team import Team
+
+from products.access_control.backend.facade.resolution_preview import iter_resolution_changes
+from products.access_control.backend.models.access_control import AccessControl
+
+_UPDATE_BATCH_SIZE = 500
+
+
+@frozen
+class OrganizationReadiness:
+    id: UUID
+    name: str
+    teams: int
+    changes: int
+    gains: int
+    loses: int
+
+
+@frozen
+class OrganizationRef:
+    id: UUID
+    name: str
+
+
+@frozen
+class ResolutionSweep:
+    """Every organization not yet on the most-specific resolution, sorted into buckets."""
+
+    divergent: list[OrganizationReadiness]
+    unchanged: list[OrganizationReadiness]
+    unevaluated: list[OrganizationRef]
+    without_rules: list[UUID]
+
+    @property
+    def unaffected_ids(self) -> list[UUID]:
+        return [readiness.id for readiness in self.unchanged] + list(self.without_rules)
+
+
+def _pending_organizations() -> QuerySet[Organization]:
+    return Organization.objects.exclude(uses_most_specific_access_resolution=True)
+
+
+def sweep_pending_organizations() -> ResolutionSweep:
+    totals: dict[UUID, dict[str, int]] = {}
+    names: dict[UUID, str] = {}
+
+    for team, changes in iter_resolution_changes(only_pending=True):
+        org_id = team.organization_id
+        names[org_id] = team.organization.name
+        counts = totals.setdefault(org_id, {"teams": 0, "changes": 0, "gains": 0, "loses": 0})
+        counts["teams"] += 1
+        counts["changes"] += len(changes)
+        counts["gains"] += sum(1 for change in changes if change.direction == "gains")
+        counts["loses"] += sum(1 for change in changes if change.direction == "loses")
+
+    evaluated = [OrganizationReadiness(id=org_id, name=names[org_id], **counts) for org_id, counts in totals.items()]
+    divergent = sorted((r for r in evaluated if r.changes > 0), key=lambda r: -r.changes)
+    unchanged = sorted((r for r in evaluated if r.changes == 0), key=lambda r: str(r.id))
+
+    organizations_with_rules = Team.objects.filter(id__in=AccessControl.objects.values("team_id")).values(
+        "organization_id"
+    )
+    unevaluated = [
+        OrganizationRef(id=org_id, name=name)
+        for org_id, name in _pending_organizations()
+        .filter(id__in=organizations_with_rules)
+        .exclude(id__in=totals.keys())
+        .order_by("id")
+        .values_list("id", "name")
+    ]
+    without_rules = list(
+        _pending_organizations().exclude(id__in=organizations_with_rules).order_by("id").values_list("id", flat=True)
+    )
+    return ResolutionSweep(
+        divergent=divergent, unchanged=unchanged, unevaluated=unevaluated, without_rules=without_rules
+    )
+
+
+def enable_most_specific_resolution(organization_ids: Iterable[UUID]) -> int:
+    """Switch the given organizations to the most-specific resolution. Returns the number of
+    rows updated. Batched so one sweep never holds a long lock on the organization table."""
+    ids = list(organization_ids)
+    updated = 0
+    for start in range(0, len(ids), _UPDATE_BATCH_SIZE):
+        batch = ids[start : start + _UPDATE_BATCH_SIZE]
+        updated += Organization.objects.filter(id__in=batch).update(uses_most_specific_access_resolution=True)
+    return updated

--- a/products/access_control/backend/facade/resolution_preview.py
+++ b/products/access_control/backend/facade/resolution_preview.py
@@ -389,8 +389,7 @@ def iter_resolution_changes(
 
     Resolution is evaluated as one acting active member per organization; teams of
     organizations with no active member are skipped. With `only_pending`, organizations
-    already on the most-specific resolution are skipped too: for them the enforced and the
-    most-specific resolution are the same walk, so the comparison is empty by construction.
+    already on the most-specific resolution are skipped too: they are migrated already.
     """
     team_ids = AccessControl.objects.values_list("team_id", flat=True).distinct()
     teams = Team.objects.filter(id__in=team_ids).select_related("organization").order_by("organization_id")

--- a/products/access_control/backend/facade/resolution_preview.py
+++ b/products/access_control/backend/facade/resolution_preview.py
@@ -6,8 +6,8 @@ rules and every resource that has resource-level rows. Return one change record 
 scope) pair whose level differs. Members are never enumerated: members with the same applicable
 rules resolve identically, so one subject-level record covers all of them.
 
-Read-only. Nothing here changes enforcement. The settings preview page and the divergent-org
-sweep command are the only callers.
+Read-only. Nothing here changes enforcement. The settings preview page and the
+migration command are the only callers.
 """
 
 from collections.abc import Iterator

--- a/products/access_control/backend/facade/resolution_preview.py
+++ b/products/access_control/backend/facade/resolution_preview.py
@@ -382,16 +382,22 @@ def build_resolution_preview(team: Team, user_access_control: UserAccessControl)
     return changes
 
 
-def iter_resolution_changes(organization_id: Optional[str] = None) -> "Iterator[tuple[Team, list[ResolutionChange]]]":
+def iter_resolution_changes(
+    organization_id: Optional[str] = None, *, only_pending: bool = False
+) -> "Iterator[tuple[Team, list[ResolutionChange]]]":
     """Yield (team, changes) for every team with access rules, ordered by organization.
 
     Resolution is evaluated as one acting active member per organization; teams of
-    organizations with no active member are skipped.
+    organizations with no active member are skipped. With `only_pending`, organizations
+    already on the most-specific resolution are skipped too: for them the enforced and the
+    most-specific resolution are the same walk, so the comparison is empty by construction.
     """
     team_ids = AccessControl.objects.values_list("team_id", flat=True).distinct()
     teams = Team.objects.filter(id__in=team_ids).select_related("organization").order_by("organization_id")
     if organization_id is not None:
         teams = teams.filter(organization_id=organization_id)
+    if only_pending:
+        teams = teams.exclude(organization__uses_most_specific_access_resolution=True)
 
     acting_membership_by_org: dict[str, Optional[OrganizationMembership]] = {}
     for team in teams.iterator():

--- a/products/access_control/backend/management/commands/migrate_to_most_specific_access.py
+++ b/products/access_control/backend/management/commands/migrate_to_most_specific_access.py
@@ -2,56 +2,58 @@ from typing import Any
 
 from django.core.management.base import BaseCommand
 
-from products.access_control.backend.facade.resolution_migration import (
-    ResolutionSweep,
+from products.access_control.backend.facade.most_specific_migration import (
+    MigrationCandidates,
     enable_most_specific_resolution,
-    sweep_pending_organizations,
+    find_organizations_to_migrate,
 )
 
 
 class Command(BaseCommand):
     help = (
-        "Switch organizations that the most-specific access resolution cannot affect over to it: "
-        "those whose access rules resolve the same under both resolutions, and those with no "
-        "rules. Organizations that resolve differently, and organizations with rules but no "
-        "active member to evaluate as, are reported and left on the legacy resolution. "
-        "Organizations already on the most-specific resolution are skipped."
+        "Switch organizations that the most-specific access resolution does not affect over to it: "
+        "those with no access rules, and those whose rules resolve the same under both resolutions. "
+        "Organizations that resolve differently, and organizations with rules but no active member "
+        "to evaluate as, are reported and stay on the legacy resolution. Organizations already on "
+        "the most-specific resolution are skipped."
     )
 
     def add_arguments(self, parser: Any) -> None:
         parser.add_argument("--dry-run", action="store_true", help="Report only, migrate nothing")
 
     def handle(self, *args: Any, **options: Any) -> None:
-        sweep = sweep_pending_organizations()
-        self._report(sweep)
+        candidates = find_organizations_to_migrate()
+        self._report(candidates)
 
-        unaffected_ids = sweep.unaffected_ids
+        unaffected_ids = candidates.unaffected_ids
         if options["dry_run"]:
             self.stdout.write(f"Dry run: {len(unaffected_ids)} organizations would be migrated")
             return
         updated = enable_most_specific_resolution(unaffected_ids)
         self.stdout.write(f"Migrated {updated} organizations")
 
-    def _report(self, sweep: ResolutionSweep) -> None:
-        self.stdout.write(f"{len(sweep.divergent)} organizations resolve differently (left on the legacy resolution)")
-        for readiness in sweep.divergent:
+    def _report(self, candidates: MigrationCandidates) -> None:
+        self.stdout.write(
+            f"{len(candidates.divergent)} organizations resolve differently (stay on the legacy resolution)"
+        )
+        for readiness in candidates.divergent:
             self.stdout.write(
                 f"{readiness.id}\t{readiness.name}\tteams={readiness.teams}\t"
                 f"changes={readiness.changes}\tgains={readiness.gains}\tloses={readiness.loses}"
             )
 
         self.stdout.write("")
-        self.stdout.write(f"{len(sweep.unchanged)} organizations with rules where nothing changes")
-        for readiness in sweep.unchanged:
+        self.stdout.write(f"{len(candidates.unchanged)} organizations with rules where nothing changes")
+        for readiness in candidates.unchanged:
             self.stdout.write(f"{readiness.id}\t{readiness.name}\tteams={readiness.teams}")
 
         self.stdout.write("")
         self.stdout.write(
-            f"{len(sweep.unevaluated)} organizations could not be evaluated (no active member, left on the legacy resolution)"
+            f"{len(candidates.unevaluated)} organizations could not be evaluated (no active member, stay on the legacy resolution)"
         )
-        for ref in sweep.unevaluated:
+        for ref in candidates.unevaluated:
             self.stdout.write(f"{ref.id}\t{ref.name}")
 
         self.stdout.write("")
-        self.stdout.write(f"{len(sweep.without_rules)} organizations with no access rules")
+        self.stdout.write(f"{len(candidates.without_rules)} organizations with no access rules")
         self.stdout.write("")

--- a/products/access_control/backend/management/commands/migrate_to_most_specific_access.py
+++ b/products/access_control/backend/management/commands/migrate_to_most_specific_access.py
@@ -10,13 +10,7 @@ from products.access_control.backend.facade.most_specific_migration import (
 
 
 class Command(BaseCommand):
-    help = (
-        "Switch organizations that the most-specific access resolution does not affect over to it: "
-        "those with no access rules, and those whose rules resolve the same under both resolutions. "
-        "Organizations that resolve differently, and organizations with rules but no active member "
-        "to evaluate as, are reported and stay on the legacy resolution. Organizations already on "
-        "the most-specific resolution are skipped."
-    )
+    help = "Switch organizations that the most-specific access resolution does not affect over to it"
 
     def add_arguments(self, parser: Any) -> None:
         parser.add_argument("--dry-run", action="store_true", help="Report only, migrate nothing")
@@ -36,16 +30,15 @@ class Command(BaseCommand):
         self.stdout.write(
             f"{len(candidates.divergent)} organizations resolve differently (stay on the legacy resolution)"
         )
-        for readiness in candidates.divergent:
+        for org in candidates.divergent:
             self.stdout.write(
-                f"{readiness.id}\t{readiness.name}\tteams={readiness.teams}\t"
-                f"changes={readiness.changes}\tgains={readiness.gains}\tloses={readiness.loses}"
+                f"{org.id}\t{org.name}\tteams={org.teams}\tchanges={org.changes}\tgains={org.gains}\tloses={org.loses}"
             )
 
         self.stdout.write("")
         self.stdout.write(f"{len(candidates.unchanged)} organizations with rules where nothing changes")
-        for readiness in candidates.unchanged:
-            self.stdout.write(f"{readiness.id}\t{readiness.name}\tteams={readiness.teams}")
+        for org in candidates.unchanged:
+            self.stdout.write(f"{org.id}\t{org.name}\tteams={org.teams}")
 
         self.stdout.write("")
         self.stdout.write(

--- a/products/access_control/backend/management/commands/migrate_to_most_specific_access.py
+++ b/products/access_control/backend/management/commands/migrate_to_most_specific_access.py
@@ -23,8 +23,12 @@ class Command(BaseCommand):
         if options["dry_run"]:
             self.stdout.write(f"Dry run: {len(unaffected_ids)} organizations would be migrated")
             return
-        updated = enable_most_specific_resolution(unaffected_ids)
+        updated = enable_most_specific_resolution(unaffected_ids, rules_unchanged_since=candidates.found_at)
         self.stdout.write(f"Migrated {updated} organizations")
+        if updated < len(unaffected_ids):
+            self.stdout.write(
+                f"{len(unaffected_ids) - updated} organizations skipped because their rules changed during the run"
+            )
 
     def _report(self, candidates: MigrationCandidates) -> None:
         self.stdout.write(

--- a/products/access_control/backend/management/commands/migrate_to_most_specific_access.py
+++ b/products/access_control/backend/management/commands/migrate_to_most_specific_access.py
@@ -2,60 +2,56 @@ from typing import Any
 
 from django.core.management.base import BaseCommand
 
-from posthog.models.organization import Organization
-
-from products.access_control.backend.facade.resolution_preview import iter_resolution_changes
-from products.access_control.backend.models.access_control import AccessControl
+from products.access_control.backend.facade.resolution_migration import (
+    ResolutionSweep,
+    enable_most_specific_resolution,
+    sweep_pending_organizations,
+)
 
 
 class Command(BaseCommand):
     help = (
-        "Report readiness for most-specific access resolution across organizations that have access "
-        "rules: those that resolve differently first, then those where nothing changes, then those "
-        "that could not be evaluated (no active member to resolve as). Organizations with no rules "
-        "cannot resolve differently and are omitted. Read-only for now; migration comes later, so "
-        "--dry-run and a plain run print the same report."
+        "Switch organizations that the most-specific access resolution cannot affect over to it: "
+        "those whose access rules resolve the same under both resolutions, and those with no "
+        "rules. Organizations that resolve differently, and organizations with rules but no "
+        "active member to evaluate as, are reported and left on the legacy resolution. "
+        "Organizations already on the most-specific resolution are skipped."
     )
 
     def add_arguments(self, parser: Any) -> None:
         parser.add_argument("--dry-run", action="store_true", help="Report only, migrate nothing")
 
     def handle(self, *args: Any, **options: Any) -> None:
-        totals: dict[Any, dict[str, int]] = {}
-        names: dict[Any, str] = {}
+        sweep = sweep_pending_organizations()
+        self._report(sweep)
 
-        for team, changes in iter_resolution_changes():
-            org_id = team.organization_id
-            names[org_id] = team.organization.name
-            counts = totals.setdefault(org_id, {"teams": 0, "changes": 0, "gains": 0, "loses": 0})
-            counts["teams"] += 1
-            counts["changes"] += len(changes)
-            counts["gains"] += sum(1 for change in changes if change.direction == "gains")
-            counts["loses"] += sum(1 for change in changes if change.direction == "loses")
+        unaffected_ids = sweep.unaffected_ids
+        if options["dry_run"]:
+            self.stdout.write(f"Dry run: {len(unaffected_ids)} organizations would be migrated")
+            return
+        updated = enable_most_specific_resolution(unaffected_ids)
+        self.stdout.write(f"Migrated {updated} organizations")
 
-        divergent = {org_id: counts for org_id, counts in totals.items() if counts["changes"] > 0}
-        unchanged = {org_id: counts for org_id, counts in totals.items() if counts["changes"] == 0}
-
-        self.stdout.write(f"{len(divergent)} organizations resolve differently")
-        for org_id, counts in sorted(divergent.items(), key=lambda item: -item[1]["changes"]):
+    def _report(self, sweep: ResolutionSweep) -> None:
+        self.stdout.write(f"{len(sweep.divergent)} organizations resolve differently (left on the legacy resolution)")
+        for readiness in sweep.divergent:
             self.stdout.write(
-                f"{org_id}\t{names[org_id]}\tteams={counts['teams']}\t"
-                f"changes={counts['changes']}\tgains={counts['gains']}\tloses={counts['loses']}"
+                f"{readiness.id}\t{readiness.name}\tteams={readiness.teams}\t"
+                f"changes={readiness.changes}\tgains={readiness.gains}\tloses={readiness.loses}"
             )
 
         self.stdout.write("")
-        self.stdout.write(f"{len(unchanged)} organizations where nothing changes")
-        for org_id, counts in sorted(unchanged.items(), key=lambda item: str(item[0])):
-            self.stdout.write(f"{org_id}\t{names[org_id]}\tteams={counts['teams']}")
+        self.stdout.write(f"{len(sweep.unchanged)} organizations with rules where nothing changes")
+        for readiness in sweep.unchanged:
+            self.stdout.write(f"{readiness.id}\t{readiness.name}\tteams={readiness.teams}")
 
-        # Organizations with rules that yielded no evaluation: no active member to resolve as
-        unevaluated = dict(
-            Organization.objects.filter(teams__id__in=AccessControl.objects.values("team_id"))
-            .exclude(id__in=totals.keys())
-            .distinct()
-            .values_list("id", "name")
-        )
         self.stdout.write("")
-        self.stdout.write(f"{len(unevaluated)} organizations could not be evaluated (no active member)")
-        for org_id, name in sorted(unevaluated.items(), key=lambda item: str(item[0])):
-            self.stdout.write(f"{org_id}\t{name}")
+        self.stdout.write(
+            f"{len(sweep.unevaluated)} organizations could not be evaluated (no active member, left on the legacy resolution)"
+        )
+        for ref in sweep.unevaluated:
+            self.stdout.write(f"{ref.id}\t{ref.name}")
+
+        self.stdout.write("")
+        self.stdout.write(f"{len(sweep.without_rules)} organizations with no access rules")
+        self.stdout.write("")

--- a/products/access_control/backend/tests/test_migrate_to_most_specific_access.py
+++ b/products/access_control/backend/tests/test_migrate_to_most_specific_access.py
@@ -59,7 +59,7 @@ class TestMigrateToMostSpecificAccess(BaseUserAccessControlTest):
             )
         }
 
-    def test_migrates_only_organizations_the_change_cannot_affect(self):
+    def test_migrates_only_organizations_the_change_does_not_affect(self):
         out = StringIO()
         call_command("migrate_to_most_specific_access", stdout=out)
 

--- a/products/access_control/backend/tests/test_migrate_to_most_specific_access.py
+++ b/products/access_control/backend/tests/test_migrate_to_most_specific_access.py
@@ -9,6 +9,10 @@ from posthog.models.organization import Organization
 from posthog.models.team.team import Team
 from posthog.models.user import User
 
+from products.access_control.backend.facade.most_specific_migration import (
+    enable_most_specific_resolution,
+    find_organizations_to_migrate,
+)
 from products.access_control.backend.models.access_control import AccessControl
 from products.access_control.backend.tests.test_user_access_control import BaseUserAccessControlTest
 from products.dashboards.backend.models.dashboard import Dashboard
@@ -16,7 +20,7 @@ from products.dashboards.backend.models.dashboard import Dashboard
 
 @pytest.mark.ee
 class TestMigrateToMostSpecificAccess(BaseUserAccessControlTest):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         # self.organization resolves differently: the resource-level editor row beats the
         # object's own viewer row under the legacy resolution only
@@ -59,7 +63,7 @@ class TestMigrateToMostSpecificAccess(BaseUserAccessControlTest):
             )
         }
 
-    def test_migrates_only_organizations_the_change_does_not_affect(self):
+    def test_migrates_only_organizations_the_change_does_not_affect(self) -> None:
         out = StringIO()
         call_command("migrate_to_most_specific_access", stdout=out)
 
@@ -72,7 +76,7 @@ class TestMigrateToMostSpecificAccess(BaseUserAccessControlTest):
         assert f"{self.organization.id}\t{self.organization.name}\tteams=1\tchanges=1" in out.getvalue()
         assert f"{self.unevaluated_organization.id}\tNo member org" in out.getvalue()
 
-    def test_dry_run_reports_but_migrates_nothing(self):
+    def test_dry_run_reports_but_migrates_nothing(self) -> None:
         out = StringIO()
         call_command("migrate_to_most_specific_access", "--dry-run", stdout=out)
 
@@ -84,7 +88,22 @@ class TestMigrateToMostSpecificAccess(BaseUserAccessControlTest):
         }
         assert "would be migrated" in out.getvalue()
 
-    def test_skips_organizations_already_on_most_specific_resolution(self):
+    def test_rules_written_after_the_classification_block_the_switch(self) -> None:
+        candidates = find_organizations_to_migrate()
+        team = self.unchanged_organization.teams.get()
+        AccessControl.objects.create(team=team, resource="insight", access_level="editor")
+
+        updated = enable_most_specific_resolution(candidates.unaffected_ids, rules_unchanged_since=candidates.found_at)
+
+        assert updated == 1  # only "No rules org"
+        assert self._resolution_flags() == {
+            self.organization.name: False,
+            "Unchanged org": False,
+            "No member org": False,
+            "No rules org": True,
+        }
+
+    def test_skips_organizations_already_on_most_specific_resolution(self) -> None:
         self.unchanged_organization.uses_most_specific_access_resolution = True
         self.unchanged_organization.save()
         out = StringIO()

--- a/products/access_control/backend/tests/test_migrate_to_most_specific_access.py
+++ b/products/access_control/backend/tests/test_migrate_to_most_specific_access.py
@@ -1,0 +1,88 @@
+from io import StringIO
+
+import pytest
+
+from django.core.management import call_command
+
+from posthog.constants import AvailableFeature
+from posthog.models.organization import Organization
+from posthog.models.team.team import Team
+from posthog.models.user import User
+
+from products.access_control.backend.models.access_control import AccessControl
+from products.access_control.backend.tests.test_user_access_control import BaseUserAccessControlTest
+from products.dashboards.backend.models.dashboard import Dashboard
+
+
+@pytest.mark.ee
+class TestMigrateToMostSpecificAccess(BaseUserAccessControlTest):
+    def setUp(self):
+        super().setUp()
+        # self.organization resolves differently: the resource-level editor row beats the
+        # object's own viewer row under the legacy resolution only
+        self.organization.uses_most_specific_access_resolution = False
+        self.organization.save()
+        dashboard = Dashboard.objects.create(team=self.team, created_by=self.user, name="Growth KPIs")
+        self._create_access_control(resource="dashboard", resource_id=str(dashboard.id), access_level="viewer")
+        self._create_access_control(resource="dashboard", access_level="editor")
+
+        self.unchanged_organization = self._create_legacy_organization("Unchanged org")
+        team = Team.objects.create(organization=self.unchanged_organization, name="Unchanged team")
+        User.objects.create_and_join(self.unchanged_organization, "unchanged@posthog.com", "testtest")
+        AccessControl.objects.create(team=team, resource="dashboard", access_level="viewer")
+
+        self.unevaluated_organization = self._create_legacy_organization("No member org")
+        team = Team.objects.create(organization=self.unevaluated_organization, name="No member team")
+        AccessControl.objects.create(team=team, resource="dashboard", access_level="viewer")
+
+        self.organization_without_rules = self._create_legacy_organization("No rules org")
+
+    def _create_legacy_organization(self, name: str) -> Organization:
+        return Organization.objects.create(
+            name=name,
+            uses_most_specific_access_resolution=False,
+            available_product_features=[
+                {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL}
+            ],
+        )
+
+    def _resolution_flags(self) -> dict[str, bool]:
+        return {
+            org.name: bool(org.uses_most_specific_access_resolution)
+            for org in Organization.objects.filter(
+                id__in=[
+                    self.organization.id,
+                    self.unchanged_organization.id,
+                    self.unevaluated_organization.id,
+                    self.organization_without_rules.id,
+                ]
+            )
+        }
+
+    def test_migrates_only_organizations_the_change_cannot_affect(self):
+        out = StringIO()
+        call_command("migrate_to_most_specific_access", stdout=out)
+
+        assert self._resolution_flags() == {
+            self.organization.name: False,
+            "Unchanged org": True,
+            "No member org": False,
+            "No rules org": True,
+        }
+        assert f"{self.organization.id}\t{self.organization.name}\tteams=1\tchanges=1" in out.getvalue()
+        assert f"{self.unevaluated_organization.id}\tNo member org" in out.getvalue()
+
+    def test_dry_run_reports_but_migrates_nothing(self):
+        out = StringIO()
+        call_command("migrate_to_most_specific_access", "--dry-run", stdout=out)
+
+        assert all(flag is False for flag in self._resolution_flags().values())
+        assert "would be migrated" in out.getvalue()
+
+    def test_skips_organizations_already_on_most_specific_resolution(self):
+        self.unchanged_organization.uses_most_specific_access_resolution = True
+        self.unchanged_organization.save()
+        out = StringIO()
+        call_command("migrate_to_most_specific_access", stdout=out)
+
+        assert "Unchanged org" not in out.getvalue()

--- a/products/access_control/backend/tests/test_migrate_to_most_specific_access.py
+++ b/products/access_control/backend/tests/test_migrate_to_most_specific_access.py
@@ -48,7 +48,7 @@ class TestMigrateToMostSpecificAccess(BaseUserAccessControlTest):
 
     def _resolution_flags(self) -> dict[str, bool]:
         return {
-            org.name: bool(org.uses_most_specific_access_resolution)
+            org.name: org.uses_most_specific_access_resolution
             for org in Organization.objects.filter(
                 id__in=[
                     self.organization.id,
@@ -76,7 +76,12 @@ class TestMigrateToMostSpecificAccess(BaseUserAccessControlTest):
         out = StringIO()
         call_command("migrate_to_most_specific_access", "--dry-run", stdout=out)
 
-        assert all(flag is False for flag in self._resolution_flags().values())
+        assert self._resolution_flags() == {
+            self.organization.name: False,
+            "Unchanged org": False,
+            "No member org": False,
+            "No rules org": False,
+        }
         assert "would be migrated" in out.getvalue()
 
     def test_skips_organizations_already_on_most_specific_resolution(self):


### PR DESCRIPTION
## Problem

For most organizations there is no difference between the old and the new most-specific access control resolution, for example if they have no object overrides or role-based permissions.

The `migrate_to_most_specific_access` command only reported the organizations that resolve differently. It did not migrate the organizations that do not.

The command also crashed before printing its last section, because the query for organizations with rules used an invalid field lookup.

## Changes

- The command switches the organizations that the change does not affect to the most-specific resolution. These are organizations with no access rules, and organizations with rules that resolve the same under both resolutions.
- The command does not switch organizations that resolve differently, or organizations with rules but no active member. It lists them in the report.
- The switch skips an organization whose access rules were written after the classification started, and the command reports how many it skipped. A rule change during the run cannot get an organization switched on a stale answer. Rule deletions in that window are not fenced.
- `--dry-run` prints the same report and the number of organizations that a normal run switches.
- The command skips organizations that already use the most-specific resolution. For these organizations the two resolutions are the same walk, so the comparison is always empty.
- Mechanical: the classification and the batched update moved from the command into `facade/most_specific_migration.py` (`find_organizations_to_migrate`). The command only prints and dispatches.

> [!NOTE]
> Organizations with rules but without the access control entitlement count as unaffected. 

## How did you test this code?

- New `test_migrate_to_most_specific_access.py` sets up one organization per bucket and asserts which ones flip. It catches a run that switches a divergent or unevaluated organization, and a dry run that writes.
- One case pins that an organization already on the new precedence is not reported, which the old command did (it compared the walk against itself and printed "nothing changes").
- One case pins that a rule written between classification and update blocks the switch.
- Verified end to end on a dev database: one seeded organization per bucket, plus one without the access control entitlement, migrated exactly as the report predicted.
- Ran locally: this file.

## Automatic notifications

- [ ] Publish to changelog?

> [!NOTE]
> The preview drops object rules on resources it cannot load, so this command must not run before #95386 (stacked on top) lands. That PR fixes the preview and makes such organizations count as not evaluable.

## Docs update

Not yet. 



