### PR TITLE
feat(replay_vision): stamp the creation-flow arm on the scanner created event

### DIFF
--- a/products/replay_vision/backend/api/scanners.py
+++ b/products/replay_vision/backend/api/scanners.py
@@ -127,10 +127,13 @@ _QUERY_FIELDS_TO_STRIP = ("date_from", "date_to")
 GOAL_FLOW_FLAG = "vision-goal-based-creation-flow"
 
 
-def _goal_flow_enabled(user: User, team: Team) -> bool:
-    """Any variant except control gets the goal-based flow. Never gate this on feature_enabled():
-    it returns True for EVERY variant, control included, which would ship the new flow to the
-    experiment's control group."""
+def _goal_flow_variant(user: User, team: Team) -> str | None:
+    """The user's arm of the creation-flow experiment, or None when the flag is off for them.
+
+    Never sends an exposure event. The frontend already records one when a person opens the editor,
+    which is the point they enter the flow; a second exposure from here would also enroll API-only
+    callers who never see the UI.
+    """
     variant = get_feature_flag_or_none(
         GOAL_FLOW_FLAG,
         str(user.distinct_id),
@@ -138,7 +141,14 @@ def _goal_flow_enabled(user: User, team: Team) -> bool:
         group_properties={"organization": {"id": str(team.organization_id)}},
         send_feature_flag_events=False,
     )
-    return isinstance(variant, str) and variant != "control"
+    return variant if isinstance(variant, str) else None
+
+
+def _goal_flow_enabled(user: User, team: Team) -> bool:
+    """Any variant except control gets the goal-based flow. Never gate this on feature_enabled():
+    it returns True for EVERY variant, control included, which would ship the new flow to the
+    experiment's control group."""
+    return (variant := _goal_flow_variant(user, team)) is not None and variant != "control"
 
 
 def _reject_direct_experiment_exposure(query: dict[str, Any]) -> None:
@@ -715,7 +725,12 @@ class ReplayScannerSerializer(TaggedItemSerializerMixin, UserAccessControlSerial
         report_user_action(
             user,
             "replay_vision_scanner_created",
-            _scanner_lifecycle_properties(scanner),
+            # The experiment arm rides the conversion event so a metric can split by it without
+            # depending on an exposure event reaching the same person. Read from the flag, not from
+            # how this scanner was drafted, so it carries intent to treat: someone in the test arm
+            # who ignores the goal flow still counts as treated, which is what keeps the arms
+            # comparable.
+            {**_scanner_lifecycle_properties(scanner), "creation_flow_variant": _goal_flow_variant(user, team)},
             team=team,
             request=self.context.get("request"),
         )

--- a/products/replay_vision/backend/api/scanners.py
+++ b/products/replay_vision/backend/api/scanners.py
@@ -2,7 +2,7 @@ import json
 from typing import Any, NoReturn, cast
 from uuid import UUID
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, models, transaction
 from django.db.models import CharField, Count, F, IntegerField, OuterRef, Prefetch, Q, QuerySet, Subquery, Sum, Value
 from django.db.models.functions import Coalesce, NullIf
 from django.utils import timezone
@@ -125,6 +125,22 @@ _QUERY_FIELDS_TO_STRIP = ("date_from", "date_to")
 # The goal-based creation flow's flag. Multivariate so it can graduate to an experiment without a
 # rename; server-side so a client/rollout skew cannot half-apply the new flow.
 GOAL_FLOW_FLAG = "vision-goal-based-creation-flow"
+
+
+class ScannerCreationMethod(models.TextChoices):
+    """How a person built a scanner in the UI. Reported once at creation, never stored.
+
+    Shares its values with the `creation_method` property on `replay_vision_scanner_creation_started`,
+    which the app sends when the person picks a path. Same words at both ends, so a report can see
+    who switched paths between starting and saving.
+
+    Separate from the creation-flow experiment arm, which says only which flow a person was offered.
+    Someone offered the AI flow can still fill the form by hand, so this is what says what they did.
+    """
+
+    AI = "ai", "AI draft"
+    TEMPLATE = "template", "Template"
+    SCRATCH = "scratch", "From scratch"
 
 
 def _goal_flow_variant(user: User, team: Team) -> str | None:
@@ -334,6 +350,18 @@ class ReplayScannerSerializer(TaggedItemSerializerMixin, UserAccessControlSerial
         choices=ScannerType.choices,
         help_text="What the scanner does: monitor, classifier, scorer, or summarizer.",
     )
+    creation_method = serializers.ChoiceField(
+        choices=ScannerCreationMethod.choices,
+        required=False,
+        allow_null=True,
+        write_only=True,
+        help_text=(
+            "How the creator built this scanner: from an AI draft, from a template, or from scratch. "
+            "Reported to product analytics at creation and not stored on the scanner. Independent of "
+            "any experiment the creator is in, since a person offered the AI flow can still fill the "
+            "form by hand. Ignored on update."
+        ),
+    )
     scanner_config = serializers.JSONField(
         help_text=(
             "Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, "
@@ -479,6 +507,7 @@ class ReplayScannerSerializer(TaggedItemSerializerMixin, UserAccessControlSerial
             "description",
             "tags",
             "scanner_type",
+            "creation_method",
             "scanner_config",
             "query",
             "sampling_rate",
@@ -713,6 +742,8 @@ class ReplayScannerSerializer(TaggedItemSerializerMixin, UserAccessControlSerial
             )
         # Tags become TaggedItem rows below, not a scanner column.
         tags = validated_data.pop("tags", None)
+        # Telemetry only, so it must not reach the model constructor.
+        creation_method = validated_data.pop("creation_method", None)
         # One transaction so a failed tag write can't leave an untagged scanner behind. Side effects stay outside.
         with transaction.atomic():
             try:
@@ -725,12 +756,16 @@ class ReplayScannerSerializer(TaggedItemSerializerMixin, UserAccessControlSerial
         report_user_action(
             user,
             "replay_vision_scanner_created",
-            # The experiment arm rides the conversion event so a metric can split by it without
-            # depending on an exposure event reaching the same person. Read from the flag, not from
-            # how this scanner was drafted, so it carries intent to treat: someone in the test arm
-            # who ignores the goal flow still counts as treated, which is what keeps the arms
-            # comparable.
-            {**_scanner_lifecycle_properties(scanner), "creation_flow_variant": _goal_flow_variant(user, team)},
+            # Two different questions ride this event. `creation_flow_variant` is the experiment arm,
+            # read from the flag, so it carries intent to treat and keeps the arms comparable: someone
+            # offered the AI flow counts as treated even when they ignore it. `creation_method` is what
+            # the person actually did, which is what says whether AI-built scanners turn out better.
+            # None when the caller is not the app, since only the UI knows how the form was filled.
+            {
+                **_scanner_lifecycle_properties(scanner),
+                "creation_flow_variant": _goal_flow_variant(user, team),
+                "creation_method": creation_method,
+            },
             team=team,
             request=self.context.get("request"),
         )
@@ -740,6 +775,9 @@ class ReplayScannerSerializer(TaggedItemSerializerMixin, UserAccessControlSerial
         # Tags are not a scanner column: keep them out of the before/after getattr diff below.
         # The mixin's update (reached via super()) persists them as TaggedItem rows.
         tags = validated_data.pop("tags", None)
+        # A scanner is built once, so this says nothing about an edit. Dropped here because the UI
+        # PATCHes the whole form back and would otherwise send it into the getattr diff below.
+        validated_data.pop("creation_method", None)
         # Compared as tagify()d names, since that is what set_tags_on_object stores.
         tags_changed = tags is not None and {tagify(t) for t in tags} != set(
             instance.tagged_items.values_list("tag__name", flat=True)

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -1016,6 +1016,34 @@ class TestScannerLifecycleTelemetry(_VisionAPITestCase):
         # Session auth resolves to "web" (the app UI), MCP callers to "mcp".
         self.assertEqual(properties["source"], "web")
 
+    @parameterized.expand([("test_arm", "test"), ("control_arm", "control"), ("flag_off", False)])
+    def test_create_reports_the_experiment_arm(self, _name: str, flag_value: str | bool) -> None:
+        # The creation-flow experiment splits its conversion metric on this property. Dropping it
+        # leaves the metric computable but arm-blind, so the analysis reads as valid and is not.
+        with (
+            patch("products.replay_vision.backend.api.scanners.get_feature_flag_or_none", return_value=flag_value),
+            patch("posthoganalytics.capture") as capture,
+        ):
+            resp = self.client.post(
+                self.scanners_url,
+                data={
+                    "name": f"telemetry-arm-{_name}",
+                    "scanner_type": ScannerType.MONITOR,
+                    "scanner_config": {"prompt": "did checkout complete?"},
+                    "model": ScannerModel.GEMINI_3_8_FLASH,
+                },
+                format="json",
+            )
+
+        self.assertEqual(resp.status_code, 201, resp.json())
+        created = [
+            call for call in capture.call_args_list if call.kwargs.get("event") == "replay_vision_scanner_created"
+        ]
+        # A flag that is off carries no arm, so the metric can exclude the unenrolled rather than
+        # counting them as a third arm.
+        expected = flag_value if isinstance(flag_value, str) else None
+        self.assertEqual(created[0].kwargs["properties"]["creation_flow_variant"], expected)
+
     @parameterized.expand(
         [
             ("disable", True, False, "replay_vision_scanner_disabled"),

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -1044,6 +1044,47 @@ class TestScannerLifecycleTelemetry(_VisionAPITestCase):
         expected = flag_value if isinstance(flag_value, str) else None
         self.assertEqual(created[0].kwargs["properties"]["creation_flow_variant"], expected)
 
+    def test_create_reports_how_the_scanner_was_built(self):
+        # The arm says which flow the person was offered; this says what they did with it. Someone
+        # offered the AI flow can still fill the form by hand, so a metric comparing AI-built against
+        # hand-built scanners needs this and cannot read it off the arm.
+        with patch("posthoganalytics.capture") as capture:
+            resp = self.client.post(
+                self.scanners_url,
+                data={
+                    "name": "telemetry-method",
+                    "scanner_type": ScannerType.MONITOR,
+                    "scanner_config": {"prompt": "did checkout complete?"},
+                    "model": ScannerModel.GEMINI_3_8_FLASH,
+                    "creation_method": "ai",
+                },
+                format="json",
+            )
+
+        self.assertEqual(resp.status_code, 201, resp.json())
+        created = [
+            call for call in capture.call_args_list if call.kwargs.get("event") == "replay_vision_scanner_created"
+        ]
+        self.assertEqual(created[0].kwargs["properties"]["creation_method"], "ai")
+        # Telemetry only: it must not reach the model, whose constructor would reject it.
+        self.assertFalse(hasattr(ReplayScanner.objects.get(id=resp.json()["id"]), "creation_method"))
+
+    def test_update_ignores_how_the_scanner_was_built(self):
+        # The UI PATCHes the whole form back, so an edit resends this. A scanner is built once, and
+        # an unpopped value would land in the edit diff and report a change that never happened.
+        scanner = self._create_scanner()
+
+        with patch("posthoganalytics.capture") as capture:
+            resp = self.client.patch(
+                f"{self.scanners_url}{scanner.id}/",
+                data={"name": "renamed", "creation_method": "template"},
+                format="json",
+            )
+
+        self.assertEqual(resp.status_code, 200, resp.json())
+        edited = [call for call in capture.call_args_list if call.kwargs.get("event") == "replay_vision_scanner_edited"]
+        self.assertNotIn("creation_method", edited[0].kwargs["properties"])
+
     @parameterized.expand(
         [
             ("disable", True, False, "replay_vision_scanner_disabled"),

--- a/products/replay_vision/frontend/generated/api.schemas.ts
+++ b/products/replay_vision/frontend/generated/api.schemas.ts
@@ -732,6 +732,20 @@ export interface VisionSpendSeriesApi {
 }
 
 /**
+ * * `ai` - AI draft
+ * * `template` - Template
+ * * `scratch` - From scratch
+ */
+export type ScannerCreationMethodEnumApi =
+    (typeof ScannerCreationMethodEnumApi)[keyof typeof ScannerCreationMethodEnumApi]
+
+export const ScannerCreationMethodEnumApi = {
+    Ai: 'ai',
+    Template: 'template',
+    Scratch: 'scratch',
+} as const
+
+/**
  * * `focused` - Focused
  * * `balanced` - Balanced
  * * `comprehensive` - Comprehensive
@@ -840,6 +854,12 @@ export interface ReplayScannerApi {
      * * `scorer` - Scorer
      * * `summarizer` - Summarizer */
     scanner_type: ScannerTypeEnumApi
+    /** How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Ignored on update.
+     *
+     * * `ai` - AI draft
+     * * `template` - Template
+     * * `scratch` - From scratch */
+    creation_method?: ScannerCreationMethodEnumApi | null
     /** Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, classifiers add `tags`, scorers add `scale`, summarizers add optional `length`. */
     scanner_config: unknown
     /** Persisted `RecordingsQuery` shape used to pick candidate sessions. `date_from`/`date_to` are stripped on save — the schedule controls time, not the user. */
@@ -958,6 +978,12 @@ export interface PatchedReplayScannerApi {
      * * `scorer` - Scorer
      * * `summarizer` - Summarizer */
     scanner_type?: ScannerTypeEnumApi
+    /** How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Ignored on update.
+     *
+     * * `ai` - AI draft
+     * * `template` - Template
+     * * `scratch` - From scratch */
+    creation_method?: ScannerCreationMethodEnumApi | null
     /** Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, classifiers add `tags`, scorers add `scale`, summarizers add optional `length`. */
     scanner_config?: unknown
     /** Persisted `RecordingsQuery` shape used to pick candidate sessions. `date_from`/`date_to` are stripped on save — the schedule controls time, not the user. */

--- a/products/replay_vision/frontend/generated/api.zod.ts
+++ b/products/replay_vision/frontend/generated/api.zod.ts
@@ -529,6 +529,17 @@ export const VisionScannersCreateBody = /* @__PURE__ */ zod
             .describe(
                 'What the scanner does: monitor, classifier, scorer, or summarizer.\n\n\* `monitor` - Monitor\n\* `classifier` - Classifier\n\* `scorer` - Scorer\n\* `summarizer` - Summarizer'
             ),
+        creation_method: zod
+            .union([
+                zod
+                    .enum(['ai', 'template', 'scratch'])
+                    .describe('\* `ai` - AI draft\n\* `template` - Template\n\* `scratch` - From scratch'),
+                zod.null(),
+            ])
+            .optional()
+            .describe(
+                'How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Ignored on update.\n\n\* `ai` - AI draft\n\* `template` - Template\n\* `scratch` - From scratch'
+            ),
         scanner_config: zod
             .unknown()
             .describe(
@@ -659,6 +670,17 @@ export const VisionScannersPartialUpdateBody = /* @__PURE__ */ zod
             .optional()
             .describe(
                 'What the scanner does: monitor, classifier, scorer, or summarizer.\n\n\* `monitor` - Monitor\n\* `classifier` - Classifier\n\* `scorer` - Scorer\n\* `summarizer` - Summarizer'
+            ),
+        creation_method: zod
+            .union([
+                zod
+                    .enum(['ai', 'template', 'scratch'])
+                    .describe('\* `ai` - AI draft\n\* `template` - Template\n\* `scratch` - From scratch'),
+                zod.null(),
+            ])
+            .optional()
+            .describe(
+                'How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Ignored on update.\n\n\* `ai` - AI draft\n\* `template` - Template\n\* `scratch` - From scratch'
             ),
         scanner_config: zod
             .unknown()

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
@@ -1444,6 +1444,19 @@ describe('replayScannerLogic', () => {
                 goal_length: 'find users who get stuck'.length,
             })
         })
+
+        it('the last path taken is what the save reports', async () => {
+            // Each of these replaces the form, so someone who drafts with AI and then picks a
+            // template saved the template's scanner. Reporting the first path would credit the AI
+            // flow with a scanner it did not produce.
+            await expectLogic(logic, () => {
+                logic.actions.draftScannerFromGoal('find users who get stuck')
+            }).toFinishAllListeners()
+            expect(logic.values.creationMethod).toEqual('ai')
+
+            logic.actions.startFromTemplate('dead_end')
+            expect(logic.values.creationMethod).toEqual('template')
+        })
     })
 
     describe('rebuildExperimentContext', () => {

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -52,7 +52,7 @@ import type {
     ReplayObservationApi,
     TagSuggestionApi,
 } from '../generated/api.schemas'
-import type { ScannerTypeEnumApi } from '../generated/api.schemas'
+import type { ScannerCreationMethodEnumApi, ScannerTypeEnumApi } from '../generated/api.schemas'
 import { OBSERVE_POLL_GRACE_MS, scheduleObservationPoll, shouldPollObservations } from '../logics/observationPolling'
 import { requestObservationRetry } from '../logics/observationRetry'
 import { refreshVisionQuota } from '../logics/visionQuotaLogic'
@@ -294,6 +294,7 @@ export interface replayScannerLogicValues {
     chartDateFrom: string | null
     chartDateTo: string | null
     copyingAllObservations: boolean
+    creationMethod: ScannerCreationMethodEnumApi
     creditLimitState: CreditLimitState
     durationValidationError: string | null
     estimateRequestVersion: number
@@ -799,7 +800,7 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
         copyAllObservationsFinished: true,
     }),
 
-    forms(({ props, actions }) => ({
+    forms(({ props, actions, values }) => ({
         scanner: {
             defaults: newScanner(
                 props.id === 'new' ? currentTemplateKey() : null,
@@ -880,7 +881,13 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                 const body = apiScanner.query == null ? omitQuery(apiScanner) : apiScanner
                 try {
                     if (props.id === 'new') {
-                        const response = await visionScannersCreate(String(teamId), scannerToApiBody(body))
+                        // Telemetry only, and only on create: the API reports it and drops it, so a
+                        // saved scanner can be attributed to how it was built. An edit says nothing
+                        // about that, so the update payload below leaves it out.
+                        const response = await visionScannersCreate(
+                            String(teamId),
+                            scannerToApiBody({ ...body, creation_method: values.creationMethod })
+                        )
                         actions.scannerSaved(scanner)
                         router.actions.replace(urls.replayVision(response.id))
                         // First scheduled results are minutes away, so the copy matches the Overview's
@@ -1023,6 +1030,17 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
             null as DraftScannerResponseApi | null,
             {
                 startFromTemplate: () => null,
+            },
+        ],
+        // How the form standing in front of the user was built, sent with the create request so the
+        // saved scanner can be attributed. Last path taken wins, because each of these replaces the
+        // form: someone who drafts with AI and then picks a template saved the template's scanner.
+        creationMethod: [
+            'scratch' as ScannerCreationMethodEnumApi,
+            {
+                draftScannerFromGoal: () => 'ai' as ScannerCreationMethodEnumApi,
+                startFromTemplate: (_, { templateKey }) =>
+                    (templateKey ? 'template' : 'scratch') as ScannerCreationMethodEnumApi,
             },
         ],
         // Which tag's cohort is being created, so tag rows can show a per-row spinner.

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -55833,6 +55833,20 @@ export namespace Schemas {
     }
 
     /**
+     * * `ai` - AI draft
+     * * `template` - Template
+     * * `scratch` - From scratch
+     */
+    export type ScannerCreationMethodEnum = typeof ScannerCreationMethodEnum[keyof typeof ScannerCreationMethodEnum];
+
+
+    export const ScannerCreationMethodEnum = {
+      Ai: 'ai',
+      Template: 'template',
+      Scratch: 'scratch',
+    } as const;
+
+    /**
      * * `google` - Google
      */
     export type ScannerProviderEnum = typeof ScannerProviderEnum[keyof typeof ScannerProviderEnum];
@@ -55870,6 +55884,12 @@ export namespace Schemas {
        * * `scorer` - Scorer
        * * `summarizer` - Summarizer */
       scanner_type: ScannerTypeEnum;
+      /** How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Ignored on update.
+       *
+       * * `ai` - AI draft
+       * * `template` - Template
+       * * `scratch` - From scratch */
+      creation_method?: ScannerCreationMethodEnum | null;
       /** Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, classifiers add `tags`, scorers add `scale`, summarizers add optional `length`. */
       scanner_config: unknown;
       /** Persisted `RecordingsQuery` shape used to pick candidate sessions. `date_from`/`date_to` are stripped on save — the schedule controls time, not the user. */
@@ -65782,6 +65802,12 @@ export namespace Schemas {
        * * `scorer` - Scorer
        * * `summarizer` - Summarizer */
       scanner_type?: ScannerTypeEnum;
+      /** How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Ignored on update.
+       *
+       * * `ai` - AI draft
+       * * `template` - Template
+       * * `scratch` - From scratch */
+      creation_method?: ScannerCreationMethodEnum | null;
       /** Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, classifiers add `tags`, scorers add `scale`, summarizers add optional `length`. */
       scanner_config?: unknown;
       /** Persisted `RecordingsQuery` shape used to pick candidate sessions. `date_from`/`date_to` are stripped on save — the schedule controls time, not the user. */

--- a/services/mcp/src/generated/replay_vision/api.ts
+++ b/services/mcp/src/generated/replay_vision/api.ts
@@ -299,6 +299,17 @@ export const VisionScannersCreateBody = () => zod
             .describe(
                 'What the scanner does: monitor, classifier, scorer, or summarizer.\n\n\* `monitor` - Monitor\n\* `classifier` - Classifier\n\* `scorer` - Scorer\n\* `summarizer` - Summarizer'
             ),
+        creation_method: zod
+            .union([
+                zod
+                    .enum(['ai', 'template', 'scratch'])
+                    .describe('\* `ai` - AI draft\n\* `template` - Template\n\* `scratch` - From scratch'),
+                zod.null(),
+            ])
+            .optional()
+            .describe(
+                'How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Ignored on update.\n\n\* `ai` - AI draft\n\* `template` - Template\n\* `scratch` - From scratch'
+            ),
         scanner_config: zod
             .unknown()
             .describe(
@@ -450,6 +461,17 @@ export const VisionScannersPartialUpdateBody = () => zod
             .optional()
             .describe(
                 'What the scanner does: monitor, classifier, scorer, or summarizer.\n\n\* `monitor` - Monitor\n\* `classifier` - Classifier\n\* `scorer` - Scorer\n\* `summarizer` - Summarizer'
+            ),
+        creation_method: zod
+            .union([
+                zod
+                    .enum(['ai', 'template', 'scratch'])
+                    .describe('\* `ai` - AI draft\n\* `template` - Template\n\* `scratch` - From scratch'),
+                zod.null(),
+            ])
+            .optional()
+            .describe(
+                'How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Ignored on update.\n\n\* `ai` - AI draft\n\* `template` - Template\n\* `scratch` - From scratch'
             ),
         scanner_config: zod
             .unknown()

--- a/services/mcp/src/tools/generated/replay_vision.ts
+++ b/services/mcp/src/tools/generated/replay_vision.ts
@@ -250,6 +250,9 @@ const visionScannersCreate = (): ToolBase<ReturnType<typeof VisionScannersCreate
         if (params.scanner_type !== undefined) {
             body['scanner_type'] = params.scanner_type
         }
+        if (params.creation_method !== undefined) {
+            body['creation_method'] = params.creation_method
+        }
         if (params.scanner_config !== undefined) {
             body['scanner_config'] = params.scanner_config
         }
@@ -761,6 +764,9 @@ const visionScannersUpdate = (): ToolBase<ReturnType<typeof VisionScannersUpdate
         }
         if (params.scanner_type !== undefined) {
             body['scanner_type'] = params.scanner_type
+        }
+        if (params.creation_method !== undefined) {
+            body['creation_method'] = params.creation_method
         }
         if (params.scanner_config !== undefined) {
             body['scanner_config'] = params.scanner_config

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/vision-scanners-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/vision-scanners-create.json
@@ -2,6 +2,19 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "A Replay Vision scanner: its type, targeting query, and AI configuration.",
     "properties": {
+        "creation_method": {
+            "anyOf": [
+                {
+                    "description": "* `ai` - AI draft\n* `template` - Template\n* `scratch` - From scratch",
+                    "enum": ["ai", "template", "scratch"],
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Ignored on update.\n\n* `ai` - AI draft\n* `template` - Template\n* `scratch` - From scratch"
+        },
         "credit_limit": {
             "anyOf": [
                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/vision-scanners-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/vision-scanners-update.json
@@ -1,6 +1,19 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "creation_method": {
+            "anyOf": [
+                {
+                    "description": "* `ai` - AI draft\n* `template` - Template\n* `scratch` - From scratch",
+                    "enum": ["ai", "template", "scratch"],
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Ignored on update.\n\n* `ai` - AI draft\n* `template` - Template\n* `scratch` - From scratch"
+        },
         "credit_limit": {
             "anyOf": [
                 {


### PR DESCRIPTION
## Problem

The creation-flow experiment cannot split its conversion metric by arm, because the event that marks the conversion does not say which arm the person was in.

- `replay_vision_scanner_created` is the conversion event. None of the 8,861 fired in the last 30 days carry the flag.
- `report_user_action` defaults to `send_feature_flags=False`, and this call does not override it.
- That leaves exposure events as the only attribution path. Those fire when a person opens the editor in the app, and 967 people did that in 30 days against 4,714 who created a scanner, so a large share of conversions belong to people the exposure never covered.

## Changes

- `replay_vision_scanner_created` now carries `creation_flow_variant`, so an experiment metric can split conversions by arm.
- The value is read from the flag, not from how the scanner was drafted. It means intent to treat: a person in the test arm who ignores the goal flow still counts as treated, which is what keeps the arms comparable.
- A flag that is off records no arm, so a metric can exclude the unenrolled rather than counting them as a third arm.
- No exposure event is sent from this path. The frontend already records one when a person opens the editor, and a second from here would enroll API-only callers who never see the UI.
- Mechanical: `_goal_flow_enabled` now reads the variant through the new `_goal_flow_variant` helper instead of calling the flag itself. Same gate, same arguments, one place that names them.

Nothing a person sees changes. This adds one property to an internal analytics event.

## How did you test this code?

Added `test_create_reports_the_experiment_arm` to `TestScannerLifecycleTelemetry`, parameterized over the test arm, the control arm, and the flag being off.

It catches a regression that is invisible without it: drop the property and the metric still computes, but it is arm-blind, so the experiment analysis reads as valid and is not. The existing `test_create_reports_config_choices` covers the other properties on this event and needs no change. This case is separate because it patches the flag, which that test does not.

Not run locally. This machine's disk is full, so Postgres would not start. `ruff` and `mypy` pass. CI runs the suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code in PostHog Desktop, while checking whether the goal-based creation flow was ready to run as an experiment.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/improving-drf-endpoints`.

Two other options were dropped. Passing `send_feature_flags=True` on the capture would evaluate every flag for the user on a request path. Threading a field from the frontend would report which flow the person actually used, which measures treatment received rather than intent to treat, and the arms stop being comparable once anyone crosses over.

The property is named `creation_flow_variant` rather than `creation_flow`, which already exists in this project on `in-app heatmap created` with the value `wizard`. That one names a UI flow; this one names an experiment arm.

Public artifact: the event volumes quoted above come from PostHog's own project and describe our internal instrumentation, not a customer's data.
