### PR TITLE
fix(data-warehouse): clarify the error when a Cloudflare API token is rejected

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/source.py
@@ -124,11 +124,11 @@ Create an API token in the [Cloudflare dashboard](https://dash.cloudflare.com/pr
         if status is None or status == 429 or status >= 500:
             return (
                 False,
-                "Couldn't reach Cloudflare to verify your API token. Please try again in a moment.",
+                "Couldn't reach Cloudflare to verify your API token. Try again in a moment.",
             )
         return (
             False,
-            "Invalid Cloudflare API token. Please check the token has read permissions and hasn't been revoked.",
+            "Your Cloudflare API token was rejected. Create a new token with read permissions in your Cloudflare dashboard, then reconnect.",
         )
 
     def source_for_pipeline(self, config: CloudflareSourceConfig, inputs: SourceInputs) -> SourceResponse:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/tests/test_cloudflare_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/tests/test_cloudflare_source.py
@@ -64,8 +64,8 @@ class TestCloudflareSource:
         "mock_return, expected_valid, expected_substring",
         [
             ((True, 200), True, None),
-            ((False, 401), False, "Invalid Cloudflare API token"),
-            ((False, 403), False, "Invalid Cloudflare API token"),
+            ((False, 401), False, "was rejected"),
+            ((False, 403), False, "was rejected"),
             ((False, None), False, "Couldn't reach Cloudflare"),
             ((False, 500), False, "Couldn't reach Cloudflare"),
             ((False, 429), False, "Couldn't reach Cloudflare"),


### PR DESCRIPTION
## Problem

- A person connecting a Cloudflare source who enters a token PostHog can't authenticate with sees "Invalid Cloudflare API token. Please check the token has read permissions and hasn't been revoked." The message leads with a fragment, uses "Please" twice across this validation path, and never says where to go to fix the token, so people retry the same bad token.
- The failure is one users hit repeatedly during onboarding — a wrong or under-scoped token blocks the connection with no clear path forward.

## Changes

- The rejected-token message now reads "Your Cloudflare API token was rejected. Create a new token with read permissions in your Cloudflare dashboard, then reconnect." — it names what happened and the exact next step, in the second person.
- The transient-failure message (Cloudflare unreachable, 429, or 5xx) drops "Please" to match the same voice: "Couldn't reach Cloudflare to verify your API token. Try again in a moment."
- Mechanical: the source's test asserts on the new substring for the 401/403 cases.

## How did you test this code?

- Ran `test_validate_credentials` for the Cloudflare source (6 cases, all pass) and `ruff` over the touched files. No manual UI testing was done.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Themed from Replay Vision observations of the data-warehouse new-source onboarding flow, where connecting Cloudflare repeatedly failed on token validation. Only the two `validate_credentials` strings on the onboarding path were changed; the sync-path error strings and connection behavior are untouched. No customer data or session content is included — the wording follows the source-wizard copy conventions and the sibling sources' phrasing.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
