### PR TITLE
fix(queries): recover a dropped or expired query from the cache

### DIFF
--- a/frontend/src/queries/query.test.ts
+++ b/frontend/src/queries/query.test.ts
@@ -3,7 +3,13 @@ import posthog from 'posthog-js'
 import api, { ApiError } from 'lib/api'
 
 import { useMocks } from '~/mocks/jest'
-import { performQuery, pollForResults, queryExportContext, waitForPageVisible } from '~/queries/query'
+import {
+    QUERY_RESULT_EXPIRED_MESSAGE,
+    performQuery,
+    pollForResults,
+    queryExportContext,
+    waitForPageVisible,
+} from '~/queries/query'
 import { EventsQuery, HogQLQuery, NodeKind, WebStatsBreakdown } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import { PropertyFilterType, PropertyOperator } from '~/types'
@@ -280,6 +286,112 @@ describe('query', () => {
             })
 
             await expect(promise).resolves.toMatchObject({ complete: true, results: ['ok'] })
+        })
+    })
+
+    describe('cache recovery', () => {
+        const query = { kind: NodeKind.EventsQuery, select: ['*'] } as EventsQuery
+        const asyncResponse = { query_status: { id: 'expired-query-id', complete: false } }
+        const cacheMiss = { cache_key: 'k', query_status: null }
+        const cachedAt = (ms: number): Record<string, any> => ({
+            results: ['cached'],
+            is_cached: true,
+            last_refresh: new Date(ms).toISOString(),
+        })
+        const notFound = (): ApiError =>
+            new ApiError('Query expired-query-id not found for team 1', 404, undefined, {
+                detail: 'Query expired-query-id not found for team 1',
+            })
+        let now: number
+
+        beforeEach(() => {
+            now = 1_700_000_000_000
+            jest.spyOn(Date, 'now').mockImplementation(() => now)
+        })
+
+        afterEach(() => {
+            jest.restoreAllMocks()
+        })
+
+        it('serves the cached result when the poll finds its own query gone', async () => {
+            jest.spyOn(api.queryStatus, 'get').mockRejectedValueOnce(notFound())
+            const querySpy = jest
+                .spyOn(api, 'query')
+                .mockResolvedValueOnce(asyncResponse as any)
+                .mockResolvedValueOnce(cachedAt(now) as any)
+            const captureSpy = jest.spyOn(posthog, 'capture')
+
+            await expect(performQuery(query, undefined, 'async')).resolves.toMatchObject({ results: ['cached'] })
+
+            expect(querySpy.mock.calls[1][1]).toMatchObject({ refresh: 'force_cache' })
+            const completed = captureSpy.mock.calls.filter((call) => call[0] === 'query completed')
+            expect(completed[0][1]).toMatchObject({ recovered_from_cache: true, recovered_after_status: 404 })
+        })
+
+        it('reports an expired result when the cache has nothing fresh for a gone query', async () => {
+            jest.spyOn(api.queryStatus, 'get').mockRejectedValueOnce(notFound())
+            jest.spyOn(api, 'query')
+                .mockResolvedValueOnce(asyncResponse as any)
+                .mockResolvedValueOnce(cacheMiss as any)
+            const captureSpy = jest.spyOn(posthog, 'capture')
+
+            await expect(performQuery(query, undefined, 'async')).rejects.toMatchObject({
+                status: 404,
+                detail: QUERY_RESULT_EXPIRED_MESSAGE,
+                code: 'query_result_expired',
+            })
+
+            const failed = captureSpy.mock.calls.filter((call) => call[0] === 'query failed')
+            expect(failed[0][1]).toMatchObject({ cache_recovery_attempted: true, error_status: 404 })
+        })
+
+        it('waits for a blocking request the ingress dropped to land in the cache', async () => {
+            const querySpy = jest
+                .spyOn(api, 'query')
+                .mockRejectedValueOnce(new ApiError('upstream request timeout', 504))
+                .mockImplementationOnce(async () => {
+                    // Nothing cached yet. Jump to just before the server-side limit so the next
+                    // check happens after a short wait instead of the real poll interval.
+                    now += 10 * 60 * 1000 - 10
+                    return cacheMiss as any
+                })
+                .mockImplementationOnce(async () => cachedAt(now) as any)
+            const captureSpy = jest.spyOn(posthog, 'capture')
+
+            await expect(performQuery(query, undefined, 'blocking')).resolves.toMatchObject({ results: ['cached'] })
+
+            expect(querySpy).toHaveBeenCalledTimes(3)
+            expect(querySpy.mock.calls[1][1]).toMatchObject({ refresh: 'force_cache' })
+            const completed = captureSpy.mock.calls.filter((call) => call[0] === 'query completed')
+            expect(completed[0][1]).toMatchObject({ recovered_from_cache: true, recovered_after_status: 504 })
+        })
+
+        it('does not let a stale cache entry stand in for a dropped blocking request', async () => {
+            const startedAt = now
+            const querySpy = jest
+                .spyOn(api, 'query')
+                .mockRejectedValueOnce(new ApiError('upstream request timeout', 504))
+                .mockImplementationOnce(async () => {
+                    now += 10 * 60 * 1000
+                    return cachedAt(startedAt - 60 * 60 * 1000) as any
+                })
+            const captureSpy = jest.spyOn(posthog, 'capture')
+
+            await expect(performQuery(query, undefined, 'blocking')).rejects.toMatchObject({ status: 504 })
+
+            expect(querySpy).toHaveBeenCalledTimes(2)
+            const failed = captureSpy.mock.calls.filter((call) => call[0] === 'query failed')
+            expect(failed[0][1]).toMatchObject({ cache_recovery_attempted: true, error_status: 504 })
+        })
+
+        it('does not wait on the cache when an async submission itself fails', async () => {
+            const querySpy = jest
+                .spyOn(api, 'query')
+                .mockRejectedValueOnce(new ApiError('upstream request timeout', 504))
+
+            await expect(performQuery(query, undefined, 'async')).rejects.toMatchObject({ status: 504 })
+
+            expect(querySpy).toHaveBeenCalledTimes(1)
         })
     })
 

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -64,6 +64,108 @@ export function waitForPageVisible(signal?: AbortSignal): Promise<void> {
 const QUERY_ASYNC_MAX_INTERVAL_SECONDS = 3
 const QUERY_ASYNC_TOTAL_POLL_SECONDS = 10 * 60 + 6 // keep in sync with backend-side timeout (currently 10min) + a small buffer
 export const QUERY_TIMEOUT_ERROR_MESSAGE = 'Query timed out'
+export const QUERY_RESULT_EXPIRED_MESSAGE = 'The result expired. Refresh to run the query again.'
+
+// The server lets a query run for this long (MAX_QUERY_TIMEOUT in posthog/api/query.py). The
+// query keeps running after the ingress or the browser drops the request, so its result can still
+// land in the query cache until then.
+const CACHE_RECOVERY_DEADLINE_MS = 10 * 60 * 1000
+const CACHE_RECOVERY_POLL_INTERVAL_MS = 5_000
+// A cached entry only counts as this request's result if it was written after the request started.
+// Otherwise a stale entry would stand in for a run that failed. The allowance covers clock skew
+// between the browser and the server that stamps last_refresh.
+const CACHE_RECOVERY_CLOCK_SKEW_MS = 60_000
+
+/** What the cache fallback did for one request, reported on the query telemetry events. */
+export interface QueryRecoveryOutcome {
+    attempted: boolean
+    recovered: boolean
+    waitMs: number
+    afterStatus: number | null
+}
+
+function isCacheMissResponse(response: unknown): boolean {
+    return (
+        !!response &&
+        typeof response === 'object' &&
+        'cache_key' in response &&
+        !('results' in response) &&
+        !('result' in response)
+    )
+}
+
+/** The request never produced an answer: dropped by the browser, the network, or the ingress. */
+function isTransportFailure(error: unknown): boolean {
+    const status = (error as { status?: number } | null)?.status
+    const name = (error as { name?: string } | null)?.name
+    return name === 'NetworkError' || status === 0 || status === 502 || status === 503 || status === 504
+}
+
+function blocksOnServer(refresh: RefreshType | undefined): boolean {
+    return refresh !== 'async' && refresh !== 'force_async' && refresh !== 'lazy_async' && refresh !== 'force_cache'
+}
+
+async function fetchFreshCachedResult<N extends DataNode>(
+    queryNode: N,
+    methodOptions: ApiMethodOptions | undefined,
+    filtersOverride: DashboardFilter | null | undefined,
+    variablesOverride: Record<string, HogQLVariable> | null | undefined,
+    limitContext: 'posthog_ai' | undefined,
+    notBeforeMs: number
+): Promise<NonNullable<N['response']> | null> {
+    let response: any
+    try {
+        response = await api.query(queryNode, {
+            requestOptions: methodOptions,
+            refresh: 'force_cache',
+            filtersOverride,
+            variablesOverride,
+            limitContext,
+        })
+    } catch (e) {
+        if (isAbortError(e)) {
+            throw e
+        }
+        return null
+    }
+    if (!response || isCacheMissResponse(response) || isAsyncResponse(response)) {
+        return null
+    }
+    const lastRefresh = typeof response.last_refresh === 'string' ? Date.parse(response.last_refresh) : NaN
+    if (!Number.isNaN(lastRefresh) && lastRefresh < notBeforeMs - CACHE_RECOVERY_CLOCK_SKEW_MS) {
+        return null
+    }
+    return response
+}
+
+async function waitForCachedResult<N extends DataNode>(
+    queryNode: N,
+    methodOptions: ApiMethodOptions | undefined,
+    filtersOverride: DashboardFilter | null | undefined,
+    variablesOverride: Record<string, HogQLVariable> | null | undefined,
+    limitContext: 'posthog_ai' | undefined,
+    requestStartedAtMs: number
+): Promise<NonNullable<N['response']> | null> {
+    const untilMs = requestStartedAtMs + CACHE_RECOVERY_DEADLINE_MS
+    for (;;) {
+        const cached = await fetchFreshCachedResult(
+            queryNode,
+            methodOptions,
+            filtersOverride,
+            variablesOverride,
+            limitContext,
+            requestStartedAtMs
+        )
+        if (cached) {
+            return cached
+        }
+        const remainingMs = untilMs - Date.now()
+        if (remainingMs <= 0) {
+            return null
+        }
+        await delay(Math.min(CACHE_RECOVERY_POLL_INTERVAL_MS, remainingMs), methodOptions?.signal)
+    }
+}
 
 /**
  * Parse error message that may be in ErrorDetail string format.
@@ -181,19 +283,51 @@ async function executeQuery<N extends DataNode>(
      * (stale-while-revalidate: `is_cached` is true *and* an incomplete `query_status` is
      * attached), return the cached results immediately instead of blocking on the recompute.
      */
-    acceptStaleCache = false
+    acceptStaleCache = false,
+    /**
+     * Filled in when the request itself failed but the query cache could still answer. Two cases:
+     * a blocking request the ingress or the browser dropped while the query kept running on the
+     * server, and an async poll that found its query ID gone (the status record is short-lived,
+     * the cached result is not). Absent for poll-only callers, which cannot send queries.
+     */
+    recovery?: QueryRecoveryOutcome
 ): Promise<NonNullable<N['response']>> {
+    const requestStartedAtMs = Date.now()
     if (!pollOnly) {
         const refreshParam: RefreshType = refresh || 'blocking'
 
-        const response = await api.query(queryNode, {
-            requestOptions: methodOptions,
-            clientQueryId: queryId,
-            refresh: refreshParam,
-            filtersOverride,
-            variablesOverride,
-            limitContext,
-        })
+        let response: any
+        try {
+            response = await api.query(queryNode, {
+                requestOptions: methodOptions,
+                clientQueryId: queryId,
+                refresh: refreshParam,
+                filtersOverride,
+                variablesOverride,
+                limitContext,
+            })
+        } catch (e: any) {
+            if (!recovery || !blocksOnServer(refreshParam) || !isTransportFailure(e)) {
+                throw e
+            }
+            const failedAtMs = Date.now()
+            recovery.attempted = true
+            recovery.afterStatus = e?.status ?? 0
+            const cached = await waitForCachedResult(
+                queryNode,
+                methodOptions,
+                filtersOverride,
+                variablesOverride,
+                limitContext,
+                requestStartedAtMs
+            )
+            if (!cached) {
+                throw e
+            }
+            recovery.recovered = true
+            recovery.waitMs = Date.now() - failedAtMs
+            return cached
+        }
 
         if (response.detail) {
             throw new Error(response.detail)
@@ -220,8 +354,35 @@ async function executeQuery<N extends DataNode>(
         }
     }
 
-    const statusResponse = await pollForResults(queryId, methodOptions, setPollResponse)
-    return statusResponse.results
+    try {
+        const statusResponse = await pollForResults(queryId, methodOptions, setPollResponse)
+        return statusResponse.results
+    } catch (e: any) {
+        if (!recovery || pollOnly || e?.status !== 404) {
+            throw e
+        }
+        // The run is over either way, so one cache check answers it: a fresh entry is the result,
+        // anything else means it failed or has since been evicted.
+        const failedAtMs = Date.now()
+        recovery.attempted = true
+        recovery.afterStatus = 404
+        const cached = await fetchFreshCachedResult(
+            queryNode,
+            methodOptions,
+            filtersOverride,
+            variablesOverride,
+            limitContext,
+            requestStartedAtMs
+        )
+        if (cached) {
+            recovery.recovered = true
+            recovery.waitMs = Date.now() - failedAtMs
+            return cached
+        }
+        e.detail = QUERY_RESULT_EXPIRED_MESSAGE
+        e.code = e.code ?? 'query_result_expired'
+        throw e
+    }
 }
 
 // Return data for a given query
@@ -240,6 +401,7 @@ export async function performQuery<N extends DataNode>(
     let response: NonNullable<N['response']>
     const logParams: Record<string, any> = {}
     const startTime = performance.now()
+    const recovery: QueryRecoveryOutcome = { attempted: false, recovered: false, waitMs: 0, afterStatus: null }
 
     try {
         if (isPersonsNode(queryNode)) {
@@ -255,8 +417,14 @@ export async function performQuery<N extends DataNode>(
                 variablesOverride,
                 pollOnly,
                 limitContext,
-                acceptStaleCache
+                acceptStaleCache,
+                pollOnly ? undefined : recovery
             )
+            if (recovery.recovered) {
+                logParams.recovered_from_cache = true
+                logParams.recovery_wait_ms = Math.round(recovery.waitMs)
+                logParams.recovered_after_status = recovery.afterStatus
+            }
             if (isHogQLQuery(queryNode) && response && typeof response === 'object') {
                 logParams.clickhouse_sql = (response as HogQLQueryResponse)?.clickhouse
             }
@@ -302,6 +470,7 @@ export async function performQuery<N extends DataNode>(
                 error_status: error?.status ?? null,
                 error_code: error?.code ?? null,
                 uses_data_warehouse_source: queryUsesDataWarehouse(queryNode),
+                cache_recovery_attempted: recovery.attempted,
                 ...logParams,
             })
         }


### PR DESCRIPTION
## Problem

- A person whose query request is dropped sees an error for a result that exists. Two ways in:
  - A blocking query that runs past 5 minutes. The ingress cuts the request at 300 s (`stream_idle_timeout`, visible in the access logs) while the server allows 10 minutes and the query keeps running to completion. The result lands in the query cache; the page shows a 504.
  - An experiment page refreshed and left in a background tab. Polling pauses while hidden, the server forgets the query ID 20 minutes after it finishes, and the page comes back to "Query … not found" for every metric.
- In both cases one cache-only request would have returned the result.

## Changes

- A dropped blocking request now keeps asking the cache, in cache-only mode, until the server-side query limit, then shows the result when it lands. Nothing recomputes.
- An async poll that finds its query gone asks the cache once. Found: the result renders. Not found: the card says "The result expired. Refresh to run the query again." with code `query_result_expired`, instead of the raw 404.
- Only an entry written after the request started counts, so a stale entry never stands in for a run that failed. A forced refresh keeps waiting for the new result.
- The query telemetry events say what happened: `recovered_from_cache`, `recovery_wait_ms` and `recovered_after_status` on `query completed`, `cache_recovery_attempted` on `query failed`.
- Async submissions that fail, and poll-only callers such as shared dashboards, behave as before.

## How did you test this code?

- Five cases in `frontend/src/queries/query.test.ts`: cached result served after a gone query; expired message when nothing fresh is cached; a dropped blocking request recovered once the result lands; a stale entry rejected and the 504 surfaced; a failed async submission not retried. No existing test covered a failed request being answered from the cache.
- Not run: the app in a browser.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Claude Fable 5.1), directed by the assignee.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-user-facing-copy, /writing-pr-descriptions.
- Origin: a customer report of "Query not found" on an experiment page after the tab sat in the background. Access logs showed the polls arriving after the status record expired while the result was already cached, and separately showed blocking queries cut at 300 s by the ingress. No customer material is in this PR.
- Replaces #94496, which re-sent the query in normal mode and could recompute a heavy query. A server-side alternative, #94537, keeps a durable handle per async query; this client change covers dropped blocking requests too, which that one cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
