### PR TITLE
fix(postgres): stop retrying a database that isn't accepting connections

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -764,6 +764,19 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 "Enable hot_standby on the replica and restart it, or point this source at the primary "
                 "database, then re-enable the sync."
             ),
+            # SQLSTATE 57P03 with the message "database <name> is not currently accepting connections":
+            # the server is up (it answered with a FATAL) but the target database has datallowconn
+            # turned off, or a managed provider has paused/suspended it (e.g. an inactive Supabase
+            # project). Deterministic until the customer restores it, so a whole-activity retry re-hits
+            # the same refusal — distinct from the transient "the database system is not yet accepting
+            # connections" startup refusal kept retryable in postgres.py (which reads "not yet", not "not
+            # currently"). Match the stable phrase and exclude the volatile database name.
+            "is not currently accepting connections": (
+                "The database you selected to sync isn't accepting new connections right now — this "
+                "usually means it's paused or set to disallow connections (managed providers such as "
+                "Supabase pause inactive projects). Resume or reactivate the database, then re-enable "
+                "the sync."
+            ),
             # A single recovery conflict ("conflict with recovery") is transient and retried in-process,
             # so it stays retryable. This abort is only raised once those retries are exhausted — by then
             # the condition is sustained and a whole-activity retry just re-reads from offset 0 into the

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -444,6 +444,11 @@ class TestPostgresSourceNonRetryableErrors:
             # hit a plan limit. Account-level state only the customer can lift, so retrying re-hits
             # the same refusal — must not keep retrying. Host/port are invented, not a real value.
             'connection failed: connection to server at "db.example.com", port 5432 failed: Your account has restrictions: planLimitReached. Please contact your provider to resolve account restrictions.',
+            # The target database has datallowconn off, or a managed provider paused/suspended it
+            # (SQLSTATE 57P03). Permanent until the customer restores it, so it must not keep retrying.
+            # Distinct from the transient "not yet accepting connections" startup refusal above (which
+            # reads "not yet", not "not currently"). Host/db are invented, not a real value.
+            'connection failed: connection to server at "db.example.com", port 5432 failed: FATAL:  database "postgres" is not currently accepting connections',
         ],
     )
     def test_permanent_connection_errors_are_non_retryable(self, source, error_msg):
@@ -497,6 +502,22 @@ class TestPostgresSourceNonRetryableErrors:
         assert matches, "connect timeout must be classified non-retryable"
         assert matches[0] is not None, "connect timeout must surface an actionable message, not raw driver text"
         assert "firewall" in matches[0].lower()
+
+    def test_database_not_accepting_connections_surfaces_actionable_message(self, source):
+        # A paused/disallowed database must stop retrying and tell the customer to restore it,
+        # rather than storing the raw driver text (which echoes the host, IP, and database name).
+        # Mirror the finalizer's first-match selection so a future reorder that shadows it with an
+        # earlier None-valued key is caught. Host/db are invented, not a real value.
+        error_msg = 'connection failed: connection to server at "db.example.com", port 5432 failed: FATAL:  database "postgres" is not currently accepting connections'
+        matches = [
+            friendly
+            for pattern, friendly in source.get_non_retryable_errors().items()
+            if error_message_matches(error_msg, [pattern])
+        ]
+        assert matches, "a database not accepting connections must be classified non-retryable"
+        assert matches[0] is not None, "a database not accepting connections must surface an actionable message"
+        assert "re-enable the sync" in matches[0].lower()
+        assert "db.example.com" not in matches[0]
 
     def test_plan_limit_restriction_surfaces_actionable_message(self, source):
         # A proxy plan-limit refusal must stop retrying and explain how to lift the restriction,


### PR DESCRIPTION
## Problem

A Postgres or Supabase sync whose source database stops accepting new connections retried on every scheduled run and never recovered. The customer read the raw driver line in the sync error panel, with their host, IP, and database name in it, and no next step.

- The database answers the connection with `FATAL: database "..." is not currently accepting connections` (SQLSTATE 57P03). Connections are disabled on that database, or a managed provider paused it. An inactive Supabase project is the common case.
- This is permanent until the customer restores the database, but the message was unclassified, so it fell through to the transient bucket and kept retrying.
- The pattern burned repeated jobs on an affected team across a day, and the class was seen on a Supabase source.

## Changes

- The sync now stops after a short bounded retry and shows an actionable message: the database isn't accepting connections, resume or reactivate it, then re-enable the sync.
- Classifies `is not currently accepting connections` as non-retryable in the Postgres source, inherited by Supabase and other Postgres-derived sources.
- The match is on the stable phrase, excluding the volatile database name. It stays distinct from the transient "not yet accepting connections" startup refusal, which is still retryable.

## How did you test this code?

- Extended `test_permanent_connection_errors_are_non_retryable` with the paused/disallowed-connections case, and added `test_database_not_accepting_connections_surfaces_actionable_message` for the message content and host redaction.
- The existing `test_transient_connection_errors_are_retryable` still passes, which guards against a match colliding with the transient "not yet accepting" refusal.
- Ran the Postgres connection-classification tests locally. Did not run the full DB-backed suite.

Related open PR #85517 touches the same file for a different reason (naming transient connection drops once retries are exhausted). It does not classify this message, so there is no overlap.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triage of data-warehouse sync failure classes. This class was a Postgres/Supabase connection refusal that was retried forever and surfaced as raw driver text.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/writing-user-facing-copy` (voice for the error string), `/writing-code-comments`.

The customer-facing string carries no source values. The test fixture uses an invented host and a generic database name (`db.example.com`, `"postgres"`). The failure was surfaced from an internal sync-failure summary; the committed message and fixture are written fresh and contain no customer material.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
