### PR TITLE
feat(kafka): let DLQ replay pass extra producer settings

### DIFF
--- a/posthog/kafka_client/dlq_replay.py
+++ b/posthog/kafka_client/dlq_replay.py
@@ -192,6 +192,7 @@ def drain_dlq(
     max_messages_per_second: Optional[float] = None,
     max_message_bytes: Optional[int] = None,
     unassigned_timeout_seconds: float = 60.0,
+    producer_config: Optional[dict[str, Any]] = None,
     should_stop: Callable[[], bool] = lambda: False,
     log: Callable[[str], None] = print,
 ) -> dict[str, int]:
@@ -212,7 +213,8 @@ def drain_dlq(
     caller can stop the run after the current batch commits, rather than abandoning it
     mid-flight. A run that holds no
     partitions for unassigned_timeout_seconds gives up, so a spare member of an
-    over-subscribed group exits instead of polling forever.
+    over-subscribed group exits instead of polling forever. producer_config merges extra
+    librdkafka producer settings over the defaults, for tuning past a broker size limit.
     """
     source = get_profile_settings(topic=source_topic)
     target = get_profile_settings(topic=target_topic)
@@ -252,6 +254,9 @@ def drain_dlq(
         message_max_bytes = max_message_bytes or target.producer_settings.get("max_request_size")
         if message_max_bytes:
             producer_conf["message.max.bytes"] = int(message_max_bytes)
+        # Applied last, so an operator can tune batch.size or compression.type to get past
+        # a broker "message too large" rejection.
+        producer_conf.update(producer_config or {})
         producer = Producer(producer_conf)
 
     replayed = 0

--- a/posthog/kafka_client/test/test_dlq_replay.py
+++ b/posthog/kafka_client/test/test_dlq_replay.py
@@ -6,6 +6,8 @@ from typing import Any, Optional
 from unittest import TestCase
 from unittest.mock import patch
 
+from django.core.management.base import CommandError
+
 from confluent_kafka import KafkaError, KafkaException
 from parameterized import parameterized
 
@@ -16,6 +18,7 @@ from posthog.kafka_client.dlq_replay import (
     build_replay_headers,
     drain_dlq,
 )
+from posthog.management.commands.replay_kafka_dlq import _parse_producer_config
 
 REBALANCE_IN_PROGRESS = KafkaError.REBALANCE_IN_PROGRESS  # type: ignore[attr-defined]
 TIMED_OUT = KafkaError._TIMED_OUT  # type: ignore[attr-defined]
@@ -232,6 +235,20 @@ class DrainDlqTest(TestCase):
         assert result == {"replayed": 0, "exhausted": 0, "skipped": 0, "errors": 1}
         assert consumer.commits == 0
 
+    def test_producer_config_overrides_the_defaults(self) -> None:
+        producer = FakeProducer()
+
+        self._drain(
+            [[FakeMessage(b"one")]],
+            producer,
+            producer_settings={"max_request_size": 4_000_000},
+            producer_config={"batch.size": "131072", "acks": "1", "message.max.bytes": "8000000"},
+        )
+
+        assert producer.conf["batch.size"] == "131072"
+        assert producer.conf["acks"] == "1"
+        assert producer.conf["message.max.bytes"] == "8000000"
+
     def test_batch_of_exhausted_messages_still_commits(self) -> None:
         producer = FakeProducer()
         at_cap = [(REPLAY_COUNT_HEADER, b"2")]
@@ -353,3 +370,15 @@ class ThrottleDelayTest(TestCase):
         self, _name: str, produced: int, rate: Optional[float], elapsed: float, expected: float
     ) -> None:
         self.assertAlmostEqual(_throttle_delay(produced, rate, elapsed), expected, places=6)
+
+
+class ParseProducerConfigTest(TestCase):
+    def test_parses_pairs_and_keeps_equals_in_the_value(self) -> None:
+        parsed = _parse_producer_config(["batch.size=131072", "sasl.password=a=b=c"])
+
+        assert parsed == {"batch.size": "131072", "sasl.password": "a=b=c"}
+
+    @parameterized.expand([("no_equals", "batch.size"), ("empty_key", "=gzip")])
+    def test_rejects_malformed_pair(self, _name: str, pair: str) -> None:
+        with self.assertRaises(CommandError):
+            _parse_producer_config([pair])

--- a/posthog/management/commands/replay_kafka_dlq.py
+++ b/posthog/management/commands/replay_kafka_dlq.py
@@ -31,6 +31,16 @@ def resolve_pipeline(
     return dataclasses.replace(DLQ_REPLAY_PIPELINES[pipeline], **overrides)
 
 
+def _parse_producer_config(pairs: list[str]) -> dict[str, str]:
+    config: dict[str, str] = {}
+    for pair in pairs:
+        key, sep, value = pair.partition("=")
+        if not sep or not key.strip():
+            raise CommandError(f"--producer-config expects key=value, got {pair!r}")
+        config[key.strip()] = value.strip()
+    return config
+
+
 class Command(BaseCommand):
     help = "Replay a Kafka DLQ topic back into its target topic using a consumer group."
 
@@ -72,6 +82,17 @@ class Command(BaseCommand):
             default=None,
             help="Largest record to produce, in bytes; unset uses KAFKA_<PROFILE>_PRODUCER_MAX_REQUEST_SIZE, then 1 MiB",
         )
+        parser.add_argument(
+            "--producer-config",
+            action="append",
+            default=[],
+            metavar="KEY=VALUE",
+            help=(
+                "Extra librdkafka producer setting, repeatable. Use for a broker "
+                "'message too large' rejection, e.g. --producer-config batch.size=131072 "
+                "or --producer-config compression.type=gzip"
+            ),
+        )
         parser.add_argument("--dry-run", action="store_true", help="Count without producing or committing")
 
     def handle(self, *args: Any, **options: Any) -> None:
@@ -106,6 +127,7 @@ class Command(BaseCommand):
             skip_team_ids=options["skip_team_ids"],
             max_messages_per_second=options["max_messages_per_second"],
             max_message_bytes=options["max_message_bytes"],
+            producer_config=_parse_producer_config(options["producer_config"]),
             should_stop=lambda: stop_requested["value"],
             log=lambda message: self.stdout.write(message),
         )


### PR DESCRIPTION
## Problem

An operator draining `ingestion-traces-dlq` back into `ingestion-traces` hits `MSG_SIZE_TOO_LARGE` when a produce batch exceeds the target topic's `max.message.bytes`, and the replay command gives no way to tune around it.

The producer config was fixed in code (`acks=all` and the resolved brokers), so getting past the broker limit meant editing and redeploying. This follows up [#94428](https://github.com/PostHog/posthog/pull/94428), which added the consumer-group replay command.

## Changes

- The replay command now takes a repeatable `--producer-config key=value`, so an operator can set `batch.size=131072` or `compression.type=gzip` to get a rejected batch under the topic limit without a code change.
- The parsed pairs merge over the producer defaults, so an override wins; a pair without `=` is rejected with a clear error rather than silently ignored.

> [!NOTE]
> This tunes the producer only. A single record larger than the target topic's `max.message.bytes` is rejected by the broker regardless, and needs the topic limit raised or that record skipped.

## How did you test this code?

Author is an agent (PostHog Desktop). Ran the unit suite for the command and logic module.

Added two groups of cases:
- The passthrough reaches the `Producer` constructor and an override beats the default. Catches a wiring regression that would silently drop `--producer-config`, leaving an operator still blocked on the same error.
- The parser keeps an `=` inside a value and rejects a pair with no `=` or an empty key. Catches a parse regression that would accept `batch.size` as a no-op.

Not run: a live produce against a broker with a lowered `max.message.bytes`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Desktop (Claude). Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
The work came from an operator hitting `MSG_SIZE_TOO_LARGE` mid-replay and asking whether the max message size was tunable.
A dedicated `--message-max-bytes` flag was considered and rejected: raising the producer's `message.max.bytes` builds larger batches the broker rejects more, so the wrong lever. A general passthrough lets the operator reach `batch.size`/`compression.type`, which are the levers that help.
Branched off master because the base command PR ([#94428](https://github.com/PostHog/posthog/pull/94428)) already merged.
