### PR TITLE
fix(dashboards): let "no date range override" clear a saved date range

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardFilterEmpty.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardFilterEmpty.test.ts
@@ -1,7 +1,7 @@
 import { DashboardFilter, TileFilters } from '~/queries/schema/schema-general'
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
-import { isDashboardFilterEmpty } from './dashboardFilterEmpty'
+import { clearsSavedDashboardFilter, isDashboardFilterEmpty } from './dashboardFilterEmpty'
 
 describe('isDashboardFilterEmpty', () => {
     const emptyCases: Array<[string, DashboardFilter | TileFilters | null | undefined]> = [
@@ -44,5 +44,26 @@ describe('isDashboardFilterEmpty', () => {
 
     test.each(nonEmptyCases)('returns false for %s', (_, filter) => {
         expect(isDashboardFilterEmpty(filter)).toBe(false)
+    })
+})
+
+describe('clearsSavedDashboardFilter', () => {
+    const SAVED: DashboardFilter = {
+        date_from: '-30d',
+        date_to: null,
+        properties: [{ key: 'email', type: PropertyFilterType.Person, value: 'foo', operator: PropertyOperator.Exact }],
+    }
+
+    const cases: Array<[string, DashboardFilter, DashboardFilter | null, boolean]> = [
+        ['a saved date range switched off', { date_from: null, date_to: null }, SAVED, true],
+        ['saved properties switched off', { properties: [] }, SAVED, true],
+        ['a payload that mentions no filter at all', {}, SAVED, false],
+        ['a filter the dashboard has not saved', { interval: null }, SAVED, false],
+        ['a date range switched off with nothing saved', { date_from: null, date_to: null }, null, false],
+        ['a saved date range replaced rather than switched off', { date_from: '-7d', date_to: null }, SAVED, false],
+    ]
+
+    test.each(cases)('reports %s', (_, filter, savedFilters, expected) => {
+        expect(clearsSavedDashboardFilter(filter, savedFilters)).toBe(expected)
     })
 })

--- a/frontend/src/scenes/dashboard/dashboardFilterEmpty.ts
+++ b/frontend/src/scenes/dashboard/dashboardFilterEmpty.ts
@@ -4,12 +4,53 @@ import { DashboardFilter, TileFilters } from '~/queries/schema/schema-general'
 export function isDashboardFilterEmpty(filter: DashboardFilter | TileFilters | null | undefined): boolean {
     return (
         !filter ||
-        (filter.date_from == null &&
-            filter.date_to == null &&
-            (filter.properties == null || (Array.isArray(filter.properties) && filter.properties.length === 0)) &&
-            filter.breakdown_filter == null &&
-            filter.interval == null &&
-            filter.filterTestAccounts == null &&
+        (isFilterValueEmpty(filter.date_from) &&
+            isFilterValueEmpty(filter.date_to) &&
+            isFilterValueEmpty(filter.properties) &&
+            isFilterValueEmpty(filter.breakdown_filter) &&
+            isFilterValueEmpty(filter.interval) &&
+            isFilterValueEmpty(filter.filterTestAccounts) &&
             !(filter as TileFilters).ignoreDashboardFilters)
     )
+}
+
+const OVERRIDABLE_KEYS = [
+    'date_from',
+    'date_to',
+    'properties',
+    'breakdown_filter',
+    'interval',
+    'filterTestAccounts',
+] as const satisfies readonly (keyof DashboardFilter)[]
+
+function isFilterValueEmpty(value: unknown): boolean {
+    return value == null || (Array.isArray(value) && value.length === 0)
+}
+
+function clearedFilterKeys(filter: DashboardFilter | null | undefined): (keyof DashboardFilter)[] {
+    if (!filter) {
+        return []
+    }
+    return OVERRIDABLE_KEYS.filter((key) => key in filter && isFilterValueEmpty(filter[key]))
+}
+
+/**
+ * True when the override switches a filter off — the `{"date_from": null}` that "no date range override"
+ * produces, rather than a payload that just doesn't mention dates. Both read as empty to
+ * `isDashboardFilterEmpty`, but only this one changes what the dashboard shows, so it has to survive
+ * being written to the URL and passed on.
+ */
+export function clearsDashboardFilter(filter: DashboardFilter | null | undefined): boolean {
+    return clearedFilterKeys(filter).length > 0
+}
+
+/** As `clearsDashboardFilter`, but only counts filters the dashboard has actually saved. */
+export function clearsSavedDashboardFilter(
+    filter: DashboardFilter | null | undefined,
+    savedFilters: DashboardFilter | null | undefined
+): boolean {
+    if (!savedFilters) {
+        return false
+    }
+    return clearedFilterKeys(filter).some((key) => !isFilterValueEmpty(savedFilters[key]))
 }

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -25,19 +25,23 @@ import { teamLogic } from 'scenes/teamLogic'
 
 import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
+import { Mocks } from '~/mocks/utils'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { insightsModel } from '~/models/insightsModel'
 import { examples } from '~/queries/examples'
 import { variableDataLogic } from '~/queries/nodes/DataVisualization/Components/Variables/variableDataLogic'
-import { HogQLVariable, InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
+import { DashboardFilter, HogQLVariable, InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import {
+    AnyPropertyFilter,
     DashboardMode,
     DashboardPlacement,
     DashboardTile,
     DashboardType,
     InsightColor,
     InsightShortId,
+    PropertyFilterType,
+    PropertyOperator,
     QueryBasedInsightModel,
 } from '~/types'
 
@@ -1193,7 +1197,9 @@ describe('dashboardLogic', () => {
         })
 
         describe('url filter overrides', () => {
-            const PROPERTY_OVERRIDE = [{ key: '$browser', value: 'Chrome', type: 'event' }]
+            const PROPERTY_OVERRIDE: AnyPropertyFilter[] = [
+                { key: '$browser', value: 'Chrome', type: PropertyFilterType.Event, operator: PropertyOperator.Exact },
+            ]
 
             const openWithUrlFilters = async (urlFilters: Record<string, any>): Promise<void> => {
                 logic.unmount()
@@ -1229,6 +1235,67 @@ describe('dashboardLogic', () => {
                 }).toFinishAllListeners()
 
                 expect(router.values.searchParams[dashboardUtils.SEARCH_PARAM_FILTERS_KEY]).toBeUndefined()
+            })
+
+            describe('clearing a saved filter', () => {
+                const SAVED_DATE_RANGE = { date_from: '-30d', date_to: null }
+
+                const savedFiltersMock = (savedFilters: DashboardFilter): Mocks => ({
+                    get: {
+                        '/api/environments/:team_id/dashboards/5/': {
+                            ...dashboards[5],
+                            filters: savedFilters,
+                            persisted_filters: savedFilters,
+                        },
+                    },
+                })
+
+                const reopenDashboard = async (): Promise<void> => {
+                    logic.unmount()
+                    router.actions.push('/dashboard/5')
+                    logic = dashboardLogic({ id: 5 })
+                    logic.mount()
+                    await expectLogic(logic).toFinishAllListeners()
+                }
+
+                // Previews route filter state through the URL, and the refresh wipes the intermittent
+                // filters on its way. A cleared filter that the URL can't hold therefore comes straight
+                // back off the dashboard's saved filters.
+                const clearCases: [string, DashboardFilter, () => void, keyof DashboardFilter, unknown][] = [
+                    ['date range', SAVED_DATE_RANGE, () => logic.actions.setDates(null, null), 'date_from', null],
+                    [
+                        'property filter',
+                        { properties: PROPERTY_OVERRIDE },
+                        () => logic.actions.setProperties([]),
+                        'properties',
+                        [],
+                    ],
+                ]
+
+                it.each(clearCases)(
+                    'clearing a saved %s survives the preview refresh',
+                    async (_name, savedFilters, clearFilter, key, expected) => {
+                        useMocks(savedFiltersMock(savedFilters))
+                        await reopenDashboard()
+                        expect(logic.values.effectiveEditBarFilters[key]).toEqual(savedFilters[key])
+
+                        await expectLogic(logic, clearFilter).toFinishAllListeners()
+
+                        expect(logic.values.effectiveEditBarFilters[key]).toEqual(expected)
+                        expect(logic.values.effectiveRefreshFilters[key]).toEqual(expected)
+                    }
+                )
+
+                it('announces a cleared saved filter as an override', async () => {
+                    useMocks(savedFiltersMock(SAVED_DATE_RANGE))
+                    await reopenDashboard()
+
+                    await expectLogic(logic, () => {
+                        logic.actions.setDates(null, null)
+                    }).toFinishAllListeners()
+
+                    expect(logic.values.hasUrlFilters).toBe(true)
+                })
             })
         })
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -137,7 +137,7 @@ import {
     mergeBreakdownColorConfigs,
 } from './dashboardBreakdownColors'
 import { AUTO_REFRESH_INITIAL_INTERVAL_SECONDS } from './dashboardConstants'
-import { isDashboardFilterEmpty } from './dashboardFilterEmpty'
+import { clearsSavedDashboardFilter, isDashboardFilterEmpty } from './dashboardFilterEmpty'
 import {
     BREAKPOINT_COLUMN_COUNTS,
     DASHBOARD_MIN_REFRESH_INTERVAL_MINUTES,
@@ -1032,7 +1032,10 @@ export interface dashboardLogicMeta {
         shouldUseStreaming: (featureFlags: FeatureFlagsSet) => boolean
         canAutoPreview: (insightTiles: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>[]) => boolean
         hasIntermittentFilters: (intermittentFilters: DashboardFilter) => boolean
-        hasUrlFilters: (urlFilters: DashboardFilter) => boolean
+        hasUrlFilters: (
+            urlFilters: DashboardFilter,
+            dashboard: DashboardType<QueryBasedInsightModel<Node<Record<string, any>>>> | null
+        ) => boolean
         showApplyFiltersBanner: (canAutoPreview: boolean, hasIntermittentFilters: boolean) => boolean
         urlFilters: (searchParams: Record<string, any>) => DashboardFilter
         filtersOverrideForLoad: (externalFilters: DashboardFilter, urlFilters: DashboardFilter) => DashboardFilter
@@ -2584,8 +2587,15 @@ export const dashboardLogic = kea<dashboardLogicType>([
         ],
         // An override that constrains nothing still has keys — clearing the last property filter leaves
         // `{"properties":[]}` in the URL. Counting keys reads that as an active override, so the dashboard
-        // announces overrides while showing exactly its saved state.
-        hasUrlFilters: [(s) => [s.urlFilters], (urlFilters: DashboardFilter) => !isDashboardFilterEmpty(urlFilters)],
+        // announces overrides while showing exactly its saved state. Switching off a filter the dashboard
+        // has saved is the other way round: it constrains nothing, yet the dashboard is not showing its
+        // saved state.
+        hasUrlFilters: [
+            (s) => [s.urlFilters, s.dashboard],
+            (urlFilters: DashboardFilter, dashboard: DashboardType<QueryBasedInsightModel> | null) =>
+                !isDashboardFilterEmpty(urlFilters) ||
+                clearsSavedDashboardFilter(urlFilters, dashboard?.persisted_filters),
+        ],
         showApplyFiltersBanner: [
             (s) => [s.canAutoPreview, s.hasIntermittentFilters],
             (canAutoPreview: boolean, hasIntermittentFilters: boolean) => !canAutoPreview && hasIntermittentFilters,
@@ -4828,7 +4838,11 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
             return [
                 currentLocation.pathname,
-                searchParamsWithUrlFilters(currentLocation.searchParams, newUrlFilters),
+                searchParamsWithUrlFilters(
+                    currentLocation.searchParams,
+                    newUrlFilters,
+                    values.dashboard?.persisted_filters
+                ),
                 currentLocation.hashParams,
             ]
         },
@@ -4847,7 +4861,11 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
             return [
                 currentLocation.pathname,
-                searchParamsWithUrlFilters(currentLocation.searchParams, newUrlFilters),
+                searchParamsWithUrlFilters(
+                    currentLocation.searchParams,
+                    newUrlFilters,
+                    values.dashboard?.persisted_filters
+                ),
                 currentLocation.hashParams,
             ]
         },
@@ -4868,7 +4886,11 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
             return [
                 currentLocation.pathname,
-                searchParamsWithUrlFilters(currentLocation.searchParams, newUrlFilters),
+                searchParamsWithUrlFilters(
+                    currentLocation.searchParams,
+                    newUrlFilters,
+                    values.dashboard?.persisted_filters
+                ),
                 currentLocation.hashParams,
             ]
         },
@@ -4887,7 +4909,11 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
             return [
                 currentLocation.pathname,
-                searchParamsWithUrlFilters(currentLocation.searchParams, newUrlFilters),
+                searchParamsWithUrlFilters(
+                    currentLocation.searchParams,
+                    newUrlFilters,
+                    values.dashboard?.persisted_filters
+                ),
                 currentLocation.hashParams,
             ]
         },
@@ -4906,7 +4932,11 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
             return [
                 currentLocation.pathname,
-                searchParamsWithUrlFilters(currentLocation.searchParams, newUrlFilters),
+                searchParamsWithUrlFilters(
+                    currentLocation.searchParams,
+                    newUrlFilters,
+                    values.dashboard?.persisted_filters
+                ),
                 currentLocation.hashParams,
             ]
         },
@@ -4925,7 +4955,11 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
             return [
                 currentLocation.pathname,
-                searchParamsWithUrlFilters(currentLocation.searchParams, newUrlFilters),
+                searchParamsWithUrlFilters(
+                    currentLocation.searchParams,
+                    newUrlFilters,
+                    values.dashboard?.persisted_filters
+                ),
                 currentLocation.hashParams,
             ]
         },

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -32,7 +32,7 @@ import {
 } from '~/types'
 
 import { SHARED_DASHBOARD_AUTO_FORCE_IF_STALE_MINUTES } from './dashboardConstants'
-import { isDashboardFilterEmpty } from './dashboardFilterEmpty'
+import { clearsSavedDashboardFilter, isDashboardFilterEmpty } from './dashboardFilterEmpty'
 
 export function getInsightQueryError(insight: QueryBasedInsightModel): ApiError | null {
     const queryStatus = insight.query_status
@@ -464,13 +464,18 @@ export const encodeURLFilters = (filters: DashboardFilter): Record<string, strin
  * Search params for a dashboard filter change. A filter that constrains nothing drops the param instead
  * of writing an empty one, so clearing the last filter doesn't leave the dashboard looking overridden on
  * its next load. Spreading the encoded filter can't do this — it never removes a key already in the URL.
+ *
+ * An override that switches off one of the dashboard's saved filters is the exception: it constrains
+ * nothing, but the URL is where previews and refreshes read filter state from, so dropping it would put
+ * the saved filter straight back.
  */
 export function searchParamsWithUrlFilters(
     searchParams: Record<string, any>,
-    filters: DashboardFilter
+    filters: DashboardFilter,
+    savedFilters?: DashboardFilter | null
 ): Record<string, any> {
     const nextSearchParams = { ...searchParams }
-    if (isDashboardFilterEmpty(filters)) {
+    if (isDashboardFilterEmpty(filters) && !clearsSavedDashboardFilter(filters, savedFilters)) {
         delete nextSearchParams[SEARCH_PARAM_FILTERS_KEY]
         return nextSearchParams
     }

--- a/frontend/src/scenes/insights/insightSceneLogic.test.ts
+++ b/frontend/src/scenes/insights/insightSceneLogic.test.ts
@@ -11,7 +11,7 @@ import { urls } from 'scenes/urls'
 
 import { useMocks } from '~/mocks/jest'
 import { examples } from '~/queries/examples'
-import { InsightVizNode, NodeKind, ProductKey } from '~/queries/schema/schema-general'
+import { DashboardFilter, InsightVizNode, NodeKind, ProductKey } from '~/queries/schema/schema-general'
 import { setLatestVersionsOnQuery } from '~/queries/utils'
 import { initKeaTests } from '~/test/init'
 import { ActivityScope, InsightShortId, InsightType, ItemMode } from '~/types'
@@ -539,5 +539,19 @@ describe('insightSceneLogic', () => {
         await expectLogic(logic).delay(150)
 
         expect(insightApiCall.mock.calls.length).toEqual(callCountAfterInitialLoad)
+    })
+
+    // A tile link carries the dashboard's filters so the insight opens on what the tile shows. An
+    // override that switches the dashboard's date range off constrains nothing, so it has to be told
+    // apart from a link that never mentioned dates.
+    it.each([
+        ['a cleared date range', { date_from: null, date_to: null }, { date_from: null, date_to: null }],
+        ['an override that constrains nothing', {}, null],
+    ])('keeps %s from a dashboard tile link', async (_name, filtersOverride, expected) => {
+        router.actions.push(urls.insightView(Insight42, 6, undefined, filtersOverride as DashboardFilter))
+        logic = insightSceneLogic()
+        logic.mount()
+
+        await expectLogic(logic).toMatchValues({ filtersOverride: expected })
     })
 })

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -20,7 +20,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
 import { InsightEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { isEmptyObject, isObject } from 'lib/utils/guards'
-import { isDashboardFilterEmpty } from 'scenes/dashboard/dashboardFilterEmpty'
+import { clearsDashboardFilter, isDashboardFilterEmpty } from 'scenes/dashboard/dashboardFilterEmpty'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { createEmptyInsight, insightLogic } from 'scenes/insights/insightLogic'
 import type { insightLogicType } from 'scenes/insights/insightLogic'
@@ -850,8 +850,14 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                     insightMode,
                     itemId,
                     alert_id,
-                    // Only pass filters/variables if overrides exist
-                    filtersOverride && isDashboardFilterEmpty(filtersOverride) ? undefined : filtersOverride,
+                    // Only pass filters/variables if overrides exist. An override that switches a
+                    // dashboard filter off constrains nothing, but still has to reach the insight — a tile
+                    // whose date range was cleared must open on the same data it shows.
+                    filtersOverride &&
+                        isDashboardFilterEmpty(filtersOverride) &&
+                        !clearsDashboardFilter(filtersOverride)
+                        ? undefined
+                        : filtersOverride,
                     variablesOverride && !isEmptyObject(variablesOverride) ? variablesOverride : undefined,
                     tileFiltersOverride && isDashboardFilterEmpty(tileFiltersOverride)
                         ? undefined


### PR DESCRIPTION
## Problem

A dashboard with a saved date range cannot have that range removed. Picking "No date range override" refreshes the tiles, then the picker snaps back to the saved range and the data never changes.

- Switching a filter off produces an override of explicit nulls, such as `{"date_from": null, "date_to": null}`.
- `searchParamsWithUrlFilters` reads that as "no override at all" and deletes the `query_filters` param.
- Previews read filter state from the URL, and `refreshDashboardItems` clears the pending edits on its way, so the saved range comes straight back.
- The same holds for a saved property filter cleared to none.

## Changes

- Picking "No date range override" now clears a saved date range, and the tiles reload without it. Saving persists the cleared state.
- The URL keeps an override that switches a saved filter off, so a link reproduces what the person is looking at.
- The overrides banner appears for a cleared saved filter, so "Discard overrides" is there to put the saved range back.
- An insight opened from a tile keeps the cleared range instead of falling back to the dashboard's saved one.
- `clearsSavedDashboardFilter` in `dashboardFilterEmpty.ts` is the shared rule: a payload with no filter keys stays droppable, and only a key present with an empty value counts as clearing.

Nothing looks different until a filter is switched off, so there is no before-and-after screenshot to take: the picker renders the same label it always did, and the change is which state survives the refresh.

This PR touches `dashboardLogic.tsx`, which [#93590](https://github.com/PostHog/posthog/pull/93590) also touches, in the save path rather than here.

## How did you test this code?

Jest, driven by three groups of new cases. Each failed before the fix and passes after it.

- `dashboardLogic.test.ts`: clearing a saved date range and clearing saved properties both survive the preview refresh, and the cleared state reaches the tile refresh. Catches the reported regression.
- `dashboardLogic.test.ts`: `hasUrlFilters` reports a cleared saved filter, guarding the banner.
- `insightSceneLogic.test.ts`: a tile link keeps a cleared date range, and still drops an override that constrains nothing.
- `dashboardFilterEmpty.test.ts`: six cases fixing the key-absent / key-null boundary the whole fix rests on.

Not run: the app itself. This ran in a sandbox with no dev stack, so the flow was exercised through the kea logic rather than in a browser.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in PostHog Desktop, from a report that a dashboard's global date range could not be removed.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The first diagnosis pass considered making `combineDashboardFilters` treat null differently, but null already wins there. The conflation is one layer up, in the URL encoder, so the fix stays there and the two helpers that decide it now sit next to `isDashboardFilterEmpty`. The insight scene made the same call for the same reason, and was fixed alongside it so a tile and its drill-in cannot disagree.
