### PR TITLE
fix(replay-vision): make the digest chart guidance reachable

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/scannerScout.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerScout.ts
@@ -138,6 +138,24 @@ ${focus.skip}
 - Do not restate an unchanged issue from a previous run. Include a recurring one only when it materially worsened, recovered, relapsed, gained useful new evidence, or now needs a different action. This suppresses stale bullets, never the digest itself.
 - Scanners with \`emits_signals: true\` already push one per-session finding into this inbox, and the fleet's replay-vision scout watches cross-scanner aggregates. Don't restate what either already filed; cite it and add only what your window adds.
 
+## Charts, when the shape is the point
+
+Decide this while you write the summary, not after: a bullet whose point is a trajectory or a spread
+reads faster as a chart than as a sentence. \`scout-emit-report\` and \`scout-edit-report\` both take
+\`charts\`, and each entry is \`{ chart_id, title, query, caption?, size? }\` where \`chart_id\` is your
+own slug and \`query\` is an insight query node of the kind \`execute-sql\` and the insight tools produce.
+
+- Attach one when a number's trajectory or spread carries the point, and place it in the summary with
+  \`[label](chart:<chart_id>)\` so it renders next to the bullet it belongs to.
+- A number you have now tracked across several runs (a rate that moved again today) is exactly this
+  case: pull the daily series and chart the trajectory instead of narrating it run by run. Writing
+  "X fell from 98% to 93%" in prose is the case this bullet is for, so chart it rather than say it.
+- Run the query before attaching it, and keep the chart only if it came back with more than one row.
+  That check is what "looking at" a chart means here; a single row is the one-bar chart below.
+- Skip it when a single number says the same thing. A chart of one bar is noise, and a quiet window
+  needs no chart at all.
+- The chart must answer the bullet it sits under.
+
 ## File your digest — every run, exactly once
 
 Every successful run leaves exactly one report for the date, and it is the digest: never one report per finding, and never a run that files nothing.
@@ -156,21 +174,6 @@ ${focus.shape ?? DEFAULT_REPORT_SHAPE}
 
 ${focus.quietVerdict ?? DEFAULT_QUIET_VERDICT} ${focus.priority}
 These are watcher findings: \`repository=NO_REPO\`. Set \`actionability\` by what the report asks of its reader. \`requires_human_input\` only when someone has to decide or act on what you found: it lands in the inbox awaiting input, and a digest that reports a quiet day does not belong in that queue. Otherwise \`immediately_actionable\`, which surfaces the report without asking anything of anyone. Never \`not_actionable\`: it suppresses the report, which empties the scanner's digest card and stops delivery, so a quiet day reads as a run that never happened. After writing, stash the report id under \`${scannerId}:report:<your skill_name>:<today>\` — that pointer, not the title, is how the next run finds this report.
-
-## Charts, when the shape is the point
-
-A rate moving over weeks, a distribution shifting, a mix of tags: those are read faster as a chart
-than as a sentence. \`scout-emit-report\` and \`scout-edit-report\` both take \`charts\`, and each entry is
-\`{ chart_id, title, query, caption?, size? }\` where \`chart_id\` is your own slug and \`query\` is an
-insight query node of the kind \`execute-sql\` and the insight tools produce.
-
-- Attach one when a number's trajectory or spread carries the point, and place it in the summary with
-  \`[label](chart:<chart_id>)\` so it renders next to the bullet it belongs to.
-- A number you have now tracked across several runs (a rate that moved again today) is exactly this
-  case: pull the daily series and chart the trajectory instead of narrating it run by run.
-- Skip it when a single number says the same thing. A chart of one bar is noise, and a quiet window
-  needs no chart at all.
-- The chart must answer the bullet it sits under. Never attach one you have not looked at.
 
 ## Memory
 

--- a/products/replay_vision/frontend/replay_scanners/scannerScout.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerScout.ts
@@ -143,18 +143,19 @@ ${focus.skip}
 Decide this while you write the summary, not after: a bullet whose point is a trajectory or a spread
 reads faster as a chart than as a sentence. \`scout-emit-report\` and \`scout-edit-report\` both take
 \`charts\`, and each entry is \`{ chart_id, title, query, caption?, size? }\` where \`chart_id\` is your
-own slug and \`query\` is an insight query node of the kind \`execute-sql\` and the insight tools produce.
+own slug and \`query\` is an \`InsightVizNode\`, a \`DataVisualizationNode\` over a \`HogQLQuery\`, or a
+\`SavedInsightNode\`. Any other kind is refused when you write.
 
 - Attach one when a number's trajectory or spread carries the point, and place it in the summary with
   \`[label](chart:<chart_id>)\` so it renders next to the bullet it belongs to.
-- A number you have now tracked across several runs (a rate that moved again today) is exactly this
-  case: pull the daily series and chart the trajectory instead of narrating it run by run. Writing
-  "X fell from 98% to 93%" in prose is the case this bullet is for, so chart it rather than say it.
-- Run the query before attaching it, and keep the chart only if it came back with more than one row.
-  That check is what "looking at" a chart means here; a single row is the one-bar chart below.
+- A number you have tracked across several runs is exactly this case. Writing "X fell from 98% to
+  93%" in prose is the sentence to replace: pull the daily series and chart it instead.
+- Attach a query you already ran this session, and keep the chart only if the SQL behind it returned
+  more than one row. That check is what "looking at" a chart means here.
 - Skip it when a single number says the same thing. A chart of one bar is noise, and a quiet window
   needs no chart at all.
 - The chart must answer the bullet it sits under.
+- \`charts\` replaces the report's whole set, so when you edit a report send every chart you want kept.
 
 ## File your digest — every run, exactly once
 


### PR DESCRIPTION
## Problem

Scanner digests almost never attach a chart. Across the whole fleet over 7 days, **16 of 618 digest reports carried one (2.6%)**, and only 9 of 401 scouts have ever attached one. The capability works, so this is the prompt not being reachable.

One digest wrote "scanner success fell from 98% to 93%" in prose. That is the exact case the chart guidance describes, and it still got narrated.

Reading the section back, three things push a scout away from charting:

- It ended with "Never attach one you have not looked at." A scout cannot look at a rendered chart, so read literally the rule sets a precondition it can never satisfy. The compliant move is to skip.
- Three of its four bullets were constraints and one was an invitation, so under uncertainty every cue pointed at "no chart".
- It sat *after* the filing instructions, so a scout reached it having already composed the report it was about to file.

## Changes

- Digests should start attaching charts where a bullet's point is a trajectory or a spread. Nothing else about a digest changes.
- The unsatisfiable precondition becomes a check a scout can actually run: run the query first and keep the chart only if it returned more than one row. That still rules out the one-bar chart the old line was protecting against.
- The section moves above "File your digest" and opens with "Decide this while you write the summary, not after", so the choice happens during composition rather than after the report is written.
- The trajectory bullet now names the prose form it replaces, using the 98%-to-93% shape as the example.

> [!NOTE]
> This only affects scouts created from here on. A scout's body is snapshotted into its skill at creation, so the 401 existing scouts keep the old wording and the 2.6% will not move on its own. Backfilling them is deliberately not in this PR: scout bodies are user-editable, and rewriting them would silently discard any customization a team has made.

## How did you test this code?

- Rendered the template through `scannerScoutTemplates` and asserted on the output: the charts section now precedes `## File your digest`, the old precondition is gone, and the new row check and prose example are present.
- `scannerScout` suites: 17 passed across 3 files. `tsc --noEmit` clean.
- Not measured yet: whether uptake actually improves. The 2.6% baseline above is the thing to re-measure once new scouts have run for a week.

## Automatic notifications

- [ ] Publish changelog?

## Docs update

None. The template is its own documentation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code in Tue's session, after measuring chart uptake across both regions.
- The diagnosis is a reading of the prompt, not a proven cause. The confirming evidence would be what the 9 charting scouts have in common, which is still unmeasured.
- `scannerScout.ts` is the single source for this template now — the Python port went with the migration command in #92983, so there is no second copy to keep in sync.
