### PR TITLE
feat(inbox): choose where copied report links open

### DIFF
--- a/products/desktop/docs/DEEP-LINKS.md
+++ b/products/desktop/docs/DEEP-LINKS.md
@@ -100,8 +100,8 @@ An **https** bridge also exists for links sent outside the app (e.g. comment Sla
 
 Open Self-driving, or a specific report inside it.
 
-The report "Copy link" action shares the browser-accessible web URL
-(`<instance>/project/<projectId>/inbox/<reportId>`), not this app-only scheme.
+The report "Copy link" action lets users copy this app-only scheme or the
+browser-accessible web URL (`<instance>/project/<projectId>/inbox/<reportId>`).
 The web report can still hand off to Desktop where appropriate.
 
 | Segment | Required | Description |

--- a/products/desktop/packages/ui/src/features/canvas/utils/copyCanvasLink.ts
+++ b/products/desktop/packages/ui/src/features/canvas/utils/copyCanvasLink.ts
@@ -10,11 +10,10 @@ import { canvasShareUrl } from "@posthog/ui/utils/posthogLinks";
  * Copy a canvas's shareable https link (`<instance>/code/canvas/<channelId>/
  * <dashboardId>`) to the clipboard, toasting success or failure. Shared by every
  * "Copy link" affordance (canvas toolbar, dashboards grid) so the link format
- * and feedback stay in one place. Unlike the inbox/scout copy actions — which
- * copy the raw `<scheme>://` deep link — this copies an https link that resolves
- * to a web interstitial, so it opens for anyone whether or not they have the
- * desktop app. Inbox links likewise use browser-accessible PostHog URLs; scout
- * links still copy their raw app scheme.
+ * and feedback stay in one place. This copies an https link that resolves to a
+ * web interstitial, so it opens for anyone whether or not they have the desktop
+ * app. Inbox users choose between web and Desktop links; scout links copy their
+ * raw app scheme.
  */
 export async function copyCanvasLink(
   channelId: string,

--- a/products/desktop/packages/ui/src/features/inbox/AGENTS.md
+++ b/products/desktop/packages/ui/src/features/inbox/AGENTS.md
@@ -100,7 +100,7 @@ Ready and pending-input report details offer Resolve and Dismiss beside the othe
 
 List cards should prefer fields already present in the list response. Fetching per-card secondary data is acceptable only for small, clearly bounded adornments; avoid new N+1 request patterns without a batching plan.
 
-Report rows expose the same primary actions through a right-click menu. Reviewer data stays lazy until its submenu opens. Copy link is the menu's only link action; opening a report remains the row's primary interaction.
+Report rows expose the same primary actions through a right-click menu. Reviewer data stays lazy until its submenu opens. Copy link lets users choose a web or Desktop link; opening a report remains the row's primary interaction.
 
 ## Backend Contracts
 

--- a/products/desktop/packages/ui/src/features/inbox/components/DismissedReportDetail.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/DismissedReportDetail.tsx
@@ -4,17 +4,16 @@ import {
   LinkIcon,
   MagnifyingGlassIcon,
 } from "@phosphor-icons/react";
-import { Button } from "@posthog/quill";
+import { Button, Spinner } from "@posthog/quill";
 import type { SignalReport } from "@posthog/shared/types";
 import { InboxDetailFrame } from "@posthog/ui/features/inbox/components/InboxDetailFrame";
+import { InboxReportCopyLinkMenu } from "@posthog/ui/features/inbox/components/InboxReportCopyLinkMenu";
 import { InboxReportDetailGate } from "@posthog/ui/features/inbox/components/InboxReportDetailGate";
 import {
   type InboxBackTarget,
   useInboxBackTarget,
 } from "@posthog/ui/features/inbox/hooks/useInboxBackTarget";
 import { useInboxRestoreReport } from "@posthog/ui/features/inbox/hooks/useInboxRestoreReport";
-import { copyInboxReportLink } from "@posthog/ui/features/inbox/utils/copyInboxReportLink";
-import { Spinner } from "@radix-ui/themes";
 import { useNavigate } from "@tanstack/react-router";
 
 interface DismissedReportDetailProps {
@@ -82,15 +81,20 @@ function DismissedReportDetailContent({
       primaryAction={
         <>
           {canRestore && <RestoreReportButton report={report} />}
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => copyInboxReportLink(report)}
-            title="Copy a deep link to this report"
-          >
-            <LinkIcon size={12} />
-          </Button>
+          <InboxReportCopyLinkMenu
+            report={report}
+            trigger={
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                aria-label="Copy link"
+                title="Copy link"
+              >
+                <LinkIcon size={12} />
+              </Button>
+            }
+          />
         </>
       }
       summarySection={{ Icon: FileTextIcon, title: "Summary" }}
@@ -118,7 +122,7 @@ function RestoreReportButton({ report }: { report: SignalReport }) {
       }
     >
       {restore.isPending ? (
-        <Spinner size="1" />
+        <Spinner className="size-3.5" />
       ) : (
         <ArrowCounterClockwiseIcon size={12} />
       )}

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxReportContextMenu.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxReportContextMenu.test.tsx
@@ -242,7 +242,7 @@ describe("InboxReportContextMenu", () => {
     expect(mocks.openDismissDialog).toHaveBeenCalledWith("already_fixed");
   });
 
-  it("wires restore and copy link actions", async () => {
+  it("wires the restore action", async () => {
     const user = userEvent.setup();
     const report = makeReport({ status: "suppressed" });
     openMenu(report);
@@ -252,10 +252,20 @@ describe("InboxReportContextMenu", () => {
     // the row and unmounts this menu, so a mutation callback could be skipped.
     expect(mocks.trackAction).toHaveBeenCalledWith("restore");
     expect(mocks.restore).toHaveBeenCalledWith(report.id);
+  });
 
-    fireEvent.contextMenu(screen.getByText("Report one"));
-    await user.click(screen.getByText("Copy link"));
-    expect(mocks.copyLink).toHaveBeenCalledWith(report);
+  it.each(["web", "desktop"] as const)("copies the %s link", async (target) => {
+    const user = userEvent.setup();
+    const report = makeReport({ status: "suppressed" });
+    openMenu(report);
+
+    await user.hover(screen.getByText("Copy link"));
+    fireEvent.click(
+      await screen.findByText(
+        target === "web" ? "Copy web link" : "Copy desktop link",
+      ),
+    );
+    expect(mocks.copyLink).toHaveBeenCalledWith(report, target);
     expect(mocks.trackAction).toHaveBeenCalledWith("copy_link");
   });
 });

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxReportContextMenuContent.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxReportContextMenuContent.tsx
@@ -2,8 +2,10 @@ import {
   ArrowCounterClockwiseIcon,
   CheckCircleIcon,
   CopyIcon,
+  DesktopIcon,
   EyeSlashIcon,
   GitPullRequestIcon,
+  GlobeIcon,
   UsersThreeIcon,
 } from "@phosphor-icons/react";
 import { extractRepoSelectionRepository } from "@posthog/core/inbox/artefacts";
@@ -210,15 +212,34 @@ export function InboxReportContextMenuContent({
         )}
         <ContextMenuSeparator />
         <ContextMenuGroup>
-          <ContextMenuItem
-            onClick={() => {
-              fireAction("copy_link");
-              copyInboxReportLink(report);
-            }}
-          >
-            <CopyIcon size={14} />
-            Copy link
-          </ContextMenuItem>
+          <ContextMenuSub>
+            <ContextMenuSubTrigger openOnHover>
+              <CopyIcon size={14} />
+              Copy link
+            </ContextMenuSubTrigger>
+            <ContextMenuSubContent className="min-w-44">
+              <ContextMenuItem
+                data-attr="inbox-copy-web-link"
+                onClick={() => {
+                  fireAction("copy_link");
+                  copyInboxReportLink(report, "web");
+                }}
+              >
+                <GlobeIcon size={14} />
+                Copy web link
+              </ContextMenuItem>
+              <ContextMenuItem
+                data-attr="inbox-copy-desktop-link"
+                onClick={() => {
+                  fireAction("copy_link");
+                  copyInboxReportLink(report, "desktop");
+                }}
+              >
+                <DesktopIcon size={14} />
+                Copy desktop link
+              </ContextMenuItem>
+            </ContextMenuSubContent>
+          </ContextMenuSub>
         </ContextMenuGroup>
       </ContextMenuContent>
       {resolve.dialog}

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxReportCopyLinkMenu.stories.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxReportCopyLinkMenu.stories.tsx
@@ -1,0 +1,33 @@
+import { LinkIcon } from "@phosphor-icons/react";
+import { Button } from "@posthog/quill";
+import { InboxReportCopyLinkMenu } from "@posthog/ui/features/inbox/components/InboxReportCopyLinkMenu";
+import { inboxStoryReport } from "@posthog/ui/features/inbox/components/inboxStoryFixtures";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { within } from "storybook/test";
+
+const meta: Meta<typeof InboxReportCopyLinkMenu> = {
+  title: "Inbox/Reports/Copy link menu",
+  component: InboxReportCopyLinkMenu,
+  args: {
+    report: inboxStoryReport(),
+    trigger: (
+      <Button type="button" variant="outline" size="sm">
+        <LinkIcon size={12} />
+        Copy link
+      </Button>
+    ),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof InboxReportCopyLinkMenu>;
+
+export const Closed: Story = {};
+
+export const Open: Story = {
+  play: async ({ canvas, canvasElement, userEvent }): Promise<void> => {
+    await userEvent.click(canvas.getByRole("button", { name: "Copy link" }));
+    const body = within(canvasElement.ownerDocument.body);
+    await body.findByText("Copy desktop link");
+  },
+};

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxReportCopyLinkMenu.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxReportCopyLinkMenu.tsx
@@ -1,0 +1,47 @@
+import { DesktopIcon, GlobeIcon } from "@phosphor-icons/react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@posthog/quill";
+import type { SignalReport } from "@posthog/shared/types";
+import { copyInboxReportLink } from "@posthog/ui/features/inbox/utils/copyInboxReportLink";
+import type { ReactElement } from "react";
+
+interface InboxReportCopyLinkMenuProps {
+  report: SignalReport;
+  trigger: ReactElement;
+}
+
+export function InboxReportCopyLinkMenu({
+  report,
+  trigger,
+}: InboxReportCopyLinkMenuProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger render={trigger} />
+      <DropdownMenuContent
+        align="end"
+        side="bottom"
+        sideOffset={6}
+        className="min-w-44"
+      >
+        <DropdownMenuItem
+          data-attr="inbox-copy-web-link"
+          onClick={() => copyInboxReportLink(report, "web")}
+        >
+          <GlobeIcon size={13} />
+          Copy web link
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          data-attr="inbox-copy-desktop-link"
+          onClick={() => copyInboxReportLink(report, "desktop")}
+        >
+          <DesktopIcon size={13} />
+          Copy desktop link
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportDetailActions.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportDetailActions.tsx
@@ -14,6 +14,9 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   Popover,
   PopoverContent,
@@ -27,6 +30,7 @@ import {
 import type { SignalReport } from "@posthog/shared/types";
 import { useTaskChannels } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { useChannelReportsEnabled } from "@posthog/ui/features/feature-flags/useChannelReportsEnabled";
+import { InboxReportCopyLinkMenu } from "@posthog/ui/features/inbox/components/InboxReportCopyLinkMenu";
 import { RefundReportDialog } from "@posthog/ui/features/inbox/components/RefundReportDialog";
 import { ReportChatToggle } from "@posthog/ui/features/inbox/components/ReportChatToggle";
 import { useCreateCanvasReport } from "@posthog/ui/features/inbox/hooks/useCreateCanvasReport";
@@ -132,10 +136,30 @@ export function ReportDetailActions({
         }
       />
       <DropdownMenuContent align="end" side="bottom" sideOffset={6}>
-        <DropdownMenuItem onClick={() => copyInboxReportLink(report)}>
-          <LinkIcon size={13} />
-          Copy link
-        </DropdownMenuItem>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <LinkIcon size={13} />
+            Copy link
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent
+            side="right"
+            sideOffset={4}
+            className="min-w-44"
+          >
+            <DropdownMenuItem
+              data-attr="inbox-copy-web-link"
+              onClick={() => copyInboxReportLink(report, "web")}
+            >
+              Copy web link
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              data-attr="inbox-copy-desktop-link"
+              onClick={() => copyInboxReportLink(report, "desktop")}
+            >
+              Copy desktop link
+            </DropdownMenuItem>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
         {refund.canRefund && !isResolved && (
           <DropdownMenuItem
             disabled={refund.disabledReason !== null}
@@ -207,23 +231,21 @@ export function ReportDetailActions({
             Dismiss
           </Button>
         )}
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                type="button"
-                variant="outline"
-                size="icon-xs"
-                className="h-7 w-7"
-                aria-label="Copy link"
-                onClick={() => copyInboxReportLink(report)}
-              />
-            }
-          >
-            <LinkIcon size={13} />
-          </TooltipTrigger>
-          <TooltipContent>Copy link</TooltipContent>
-        </Tooltip>
+        <InboxReportCopyLinkMenu
+          report={report}
+          trigger={
+            <Button
+              type="button"
+              variant="outline"
+              size="icon-xs"
+              className="h-7 w-7"
+              aria-label="Copy link"
+              title="Copy link"
+            >
+              <LinkIcon size={13} />
+            </Button>
+          }
+        />
         {refund.canRefund && (
           <Tooltip>
             <TooltipTrigger

--- a/products/desktop/packages/ui/src/features/inbox/utils/copyInboxReportLink.test.ts
+++ b/products/desktop/packages/ui/src/features/inbox/utils/copyInboxReportLink.test.ts
@@ -23,12 +23,27 @@ describe("copyInboxReportLink", () => {
     });
   });
 
-  it("copies the browser-accessible report URL", async () => {
-    await copyInboxReportLink({ id: "report-1" });
-
-    expect(writeText).toHaveBeenCalledWith(
+  it.each([
+    [
+      "web",
       "https://us.posthog.com/project/2/inbox/report-1",
-    );
-    expect(toast.success).toHaveBeenCalledWith("Link copied");
-  });
+      "Web link copied",
+    ],
+    [
+      "desktop",
+      "posthog-code-dev://inbox/report-1/Example-report",
+      "Desktop link copied",
+    ],
+  ] as const)(
+    "copies the %s report link",
+    async (target, expectedUrl, successCopy) => {
+      await copyInboxReportLink(
+        { id: "report-1", title: "Example report" },
+        target,
+      );
+
+      expect(writeText).toHaveBeenCalledWith(expectedUrl);
+      expect(toast.success).toHaveBeenCalledWith(successCopy);
+    },
+  );
 });

--- a/products/desktop/packages/ui/src/features/inbox/utils/copyInboxReportLink.ts
+++ b/products/desktop/packages/ui/src/features/inbox/utils/copyInboxReportLink.ts
@@ -1,22 +1,29 @@
+import { buildInboxDeeplink } from "@posthog/shared/deeplink";
 import type { SignalReport } from "@posthog/shared/types";
 import { toast } from "@posthog/ui/primitives/toast";
 import { inboxReportUrl } from "@posthog/ui/utils/posthogLinks";
 
-/**
- * Copy the report's browser-accessible PostHog URL. Shared by every inbox
- * detail surface so links still work when the recipient has no Desktop app.
- */
+export type InboxReportLinkTarget = "web" | "desktop";
+
 export async function copyInboxReportLink(
-  report: Pick<SignalReport, "id">,
+  report: Pick<SignalReport, "id" | "title">,
+  target: InboxReportLinkTarget = "web",
 ): Promise<void> {
-  const url = inboxReportUrl(report.id);
+  const url =
+    target === "desktop"
+      ? buildInboxDeeplink(report.id, report.title, {
+          isDevBuild: import.meta.env.DEV,
+        })
+      : inboxReportUrl(report.id);
   if (!url) {
     toast.error("Couldn't build a shareable link");
     return;
   }
   try {
     await navigator.clipboard.writeText(url);
-    toast.success("Link copied");
+    toast.success(
+      target === "desktop" ? "Desktop link copied" : "Web link copied",
+    );
   } catch {
     toast.error("Couldn't copy link");
   }


### PR DESCRIPTION
## Problem

Desktop Inbox users cannot choose whether a copied report link opens in the web app or Desktop.

## Changes

- **Copy link** now opens a menu with web and Desktop choices.
- Web links remain safe to share. Desktop links use the existing app scheme.

Closed:

![inbox-copy-link-closed](https://raw.githubusercontent.com/PostHog/pr-assets/7e7efb71f63b80aff602266a84bf1fd43bbcca8b/2026/09/cbb1804a-e3ef-4267-938e-2833616aa1e3.png)

Open:

![inbox-copy-link-open](https://raw.githubusercontent.com/PostHog/pr-assets/7e7efb71f63b80aff602266a84bf1fd43bbcca8b/2026/09/ef26d7c8-8d35-4b2d-9b7a-030a15331c97.png)

## How did you test this code?

Added coverage for both choices and confirmed that each writes the correct URL. Rendered the closed and open Storybook states and checked both labels.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the Desktop deep-link guide.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used the desktop, UI component, user-facing copy, test, Storybook, and PR-description skills. The screenshots contain only invented Storybook data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
