### PR TITLE
fix(ci): let a rust image dispatch reach the deploy and alias jobs

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -126,7 +126,10 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 5
         needs: build-images
-        if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && github.ref == 'refs/heads/master'
+        # !cancelled() stops the skipped 'affected' job from cascading a skip through
+        # build-images into this job on workflow_dispatch; the result check keeps the
+        # fail-closed behaviour a bare success() gave.
+        if: ${{ !cancelled() && needs.build-images.result == 'success' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && github.ref == 'refs/heads/master' }}
         strategy:
             # fail-fast false so one missing digest doesn't cancel other deploys
             fail-fast: false
@@ -272,7 +275,7 @@ jobs:
         # gets one. Mirrors the posthog_build alias job in container-images-cd.yml,
         # against ghcr instead of ECR. Best effort: a missing alias delays Freight for
         # that build and never fails the deploy.
-        if: ${{ needs.build-images.result == 'success' && needs.build-images.outputs.digests != '' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && vars.ORDERED_IMAGE_ALIAS_PAUSED != 'true' && github.ref == 'refs/heads/master' }}
+        if: ${{ !cancelled() && needs.build-images.result == 'success' && needs.build-images.outputs.digests != '' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && vars.ORDERED_IMAGE_ALIAS_PAUSED != 'true' && github.ref == 'refs/heads/master' }}
         runs-on: ubuntu-24.04
         timeout-minutes: 10
         continue-on-error: true


### PR DESCRIPTION
## Problem

- A `workflow_dispatch` of the rust image build built and pushed the images but never deployed or aliased them. Run [33807298107](https://github.com/PostHog/posthog/actions/runs/33807298107) shows `deploy` and `publish ordered image aliases` skipped after a successful build.
- On a dispatch the `affected` job is skipped by design. GitHub cascades a skipped dependency through the whole chain unless a job opts out with a status function. `build-images` opts out with `!cancelled()`, so it ran. `deploy` and the alias job did not, so both were skipped.
- This predates #94460 for `deploy`: the dispatch escape hatch has never deployed.

## Changes

- `deploy` and `publish ordered image aliases` now start with `!cancelled() && needs.build-images.result == 'success'`, so a dispatch reaches them and a failed build still fails them closed.
- Push-triggered runs are unchanged: `affected` runs there, so no skip cascades.

## How did you test this code?

- Agent-run: `bin/hogli lint:workflows` passes. `actionlint` is not installed locally, so CI's run is the check.
- Not run: a dispatch. After merge, dispatch the workflow on master with `image-filter: pgcollector,pgapi` and confirm both jobs run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5.1). Skills invoked: authoring-ci-workflows, writing-pr-descriptions.
- Found by inspecting the first dispatch after #94460 landed: the build pushed and the images carry the new annotations, but the alias job never ran.

https://claude.ai/code/session_01Wj8kKEtD9ArrtmTy9kAGp6
