### PR TITLE
fix(data-catalog): (Unbreak master) route metric delete and run jest on tools.yaml

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -168,6 +168,10 @@ jobs:
                         - 'products/**/*.ts'
                         - 'products/**/*.tsx'
                         - 'products/**/*.json'
+                        # Jest reads these at runtime, so they are code here even though the
+                        # rule above treats YAML as docs: the agent-sync suites assert that a
+                        # product's frontend routes every tool the MCP build enables.
+                        - 'products/**/mcp/tools.yaml'
                         # products/desktop is the imported desktop app; it has its own
                         # desktop-* CI and must not drag this suite onto its PRs
                         - '!products/desktop/**'

--- a/products/data_catalog/frontend/dataCatalogAgentSyncLogic.ts
+++ b/products/data_catalog/frontend/dataCatalogAgentSyncLogic.ts
@@ -12,6 +12,7 @@ import { relationshipsLogic } from './relationshipsLogic'
 export const METRIC_TOOLS = [
     'data-catalog-metric-create',
     'data-catalog-metric-update',
+    'data-catalog-metric-delete-execute',
     'data-catalog-metric-approve-execute',
     'data-catalog-metrics-refresh-from-insight-create',
 ]


### PR DESCRIPTION
## Problem

Every PR that touches frontend code fails `Frontend Tests Pass` in the merge queue.

- `dataCatalogAgentSyncLogic.test.ts` reads `products/data_catalog/mcp/tools.yaml` at runtime.
- The test asserts the frontend routes every tool the YAML enables.
- #94168 enabled `data-catalog-metric-delete` with a `confirmed_action`, which the test resolves to `data-catalog-metric-delete-execute`. No routing array lists it.
- Jest never ran on #94168. The `frontend_code` filter gates Jest and treats YAML as docs, so `Frontend Tests Pass` went green having run no tests.

## Changes

- The data catalog metrics list now refreshes after the agent deletes a metric. `METRIC_TOOLS` routes `data-catalog-metric-delete-execute`.
- A change to any `products/*/mcp/tools.yaml` now runs Jest. The `frontend_code` filter lists that path.

> [!NOTE]
> Routing delete through `METRIC_TOOLS` also reaches `openMetricChanged`. When the deleted metric is the one on screen, the scene refetches it and gets a 404. That path did nothing at all before. A dedicated delete route is a product call for the data catalog team.

## How did you test this code?

- `dataCatalogAgentSyncLogic.test.ts` passes locally. The guard case failed before this change and passes after it.
- Not checked: the deleted-metric-on-screen path in a browser.
- Not checked: the filter change against a real tools.yaml-only PR. CI on this PR does not exercise it, because this diff also touches a `.ts` file.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). Skills invoked: `/merging-prs`, `/authoring-ci-workflows`, `/writing-pr-descriptions`.

Found while investigating why PR #91874 kept getting ejected from the merge queue. That stack was ejected three times on this test without touching any data catalog code. The first diagnosis blamed a cancelled workflow run and was wrong; the job list on #94168's queue run showed the Jest jobs skipped, which pointed at the paths filter.
