### PR TITLE
feat(rbac): add facade helper to set object access controls

### DIFF
--- a/.claude/agents/access-control.md
+++ b/.claude/agents/access-control.md
@@ -442,6 +442,28 @@ accessible_notebooks = user_access_control.filter_queryset_by_access_level(
 )
 ```
 
+### Granting object access from product code
+
+When a product must keep a rule in step with its own state (an assignee, a share link), write the rule through the facade instead of the `AccessControl` model. Product code outside `products/access_control/` cannot import the model.
+
+```python
+from products.access_control.backend.facade import contracts
+from products.access_control.backend.facade.api import set_object_access_control
+
+set_object_access_control(
+    team_id=team.id,
+    input=contracts.SetObjectAccessControlInput(
+        resource="customer_task",
+        resource_id=str(task.id),
+        organization_member_id=assignee_membership.id,
+        access_level="editor",  # None removes the rule
+        created_by_id=actor.id,
+    ),
+)
+```
+
+The helper validates the resource, the level, and that the subject belongs to the team's organization. It does not check whether the actor may change access; the caller decides that. A `UserAccessControl` built before the call keeps its preloaded rows, so build a new one before re-checking the object in the same request.
+
 ### Performance Optimization
 
 For bulk operations, preload access controls:

--- a/products/access_control/backend/facade/api.py
+++ b/products/access_control/backend/facade/api.py
@@ -18,18 +18,27 @@ Do NOT:
 
 from __future__ import annotations
 
+from typing import cast
 from uuid import UUID
 
 from django.shortcuts import get_object_or_404
 
 from posthog.models import OrganizationMembership, PropertyDefinition, Team
+from posthog.scopes import API_SCOPE_OBJECTS, INTERNAL_API_SCOPE_OBJECTS, APIScopeObject
 
 from products.access_control.backend.models.role import Role
 
+from ..models.access_control import AccessControl
 from ..models.property_access_control import PropertyAccessControl
 from ..property_access_control import is_property_access_control_enabled
 from . import contracts
 from .contracts import PropertyAccessLevel
+from .user_access_control import highest_access_level, minimum_access_level, ordered_access_levels
+
+
+class InvalidObjectAccessControlError(Exception):
+    """Raised when an object access control rule names an unknown resource, an access level the
+    resource does not support, or a subject outside the team's organization."""
 
 
 class PropertyDefinitionNotFoundError(Exception):
@@ -229,6 +238,96 @@ def delete_property_access_control(
     ).delete()
     if not deleted:
         raise PropertyAccessControlRuleNotFoundError
+
+
+# --- Object access controls ---
+
+
+def _to_object_rule(rule: AccessControl) -> contracts.ObjectAccessControlRule:
+    assert rule.resource_id is not None
+    return contracts.ObjectAccessControlRule(
+        id=rule.id,
+        resource=rule.resource,
+        resource_id=rule.resource_id,
+        access_level=rule.access_level,
+        organization_member_id=rule.organization_member_id,
+        role_id=rule.role_id,
+    )
+
+
+def _validate_object_access_control(
+    *, organization_id: UUID, input: contracts.SetObjectAccessControlInput
+) -> APIScopeObject:
+    resource = input.resource
+    if resource not in API_SCOPE_OBJECTS or resource in INTERNAL_API_SCOPE_OBJECTS:
+        raise InvalidObjectAccessControlError(f"{resource} is not an access controlled resource.")
+    scoped_resource = cast(APIScopeObject, resource)
+
+    if input.access_level is not None:
+        levels = ordered_access_levels(scoped_resource)
+        if input.access_level not in levels:
+            raise InvalidObjectAccessControlError(
+                f"Invalid access level for {resource}. Must be one of: {', '.join(levels)}."
+            )
+        # `ordered_access_levels` can include levels the settings UI never offers for a resource
+        # (for example "none" on a project), so the bounds apply here as well as in the API.
+        level_index = levels.index(input.access_level)
+        if level_index < levels.index(minimum_access_level(scoped_resource)):
+            raise InvalidObjectAccessControlError(f"Access level is below the minimum for {resource}.")
+        if level_index > levels.index(highest_access_level(scoped_resource)):
+            raise InvalidObjectAccessControlError(f"Access level is above the maximum for {resource}.")
+
+    if (
+        input.organization_member_id is not None
+        and not OrganizationMembership.objects.filter(
+            id=input.organization_member_id, organization_id=organization_id
+        ).exists()
+    ):
+        raise InvalidObjectAccessControlError("organization_member does not belong to this team's organization.")
+    if (
+        input.role_id is not None
+        and not Role.objects.filter(id=input.role_id, organization_id=organization_id).exists()
+    ):
+        raise InvalidObjectAccessControlError("role does not belong to this team's organization.")
+    return scoped_resource
+
+
+def set_object_access_control(
+    *,
+    team_id: int,
+    input: contracts.SetObjectAccessControlInput,
+) -> contracts.ObjectAccessControlRule | None:
+    """Grant, change, or remove one subject's access to one object.
+
+    This is the programmatic counterpart of the `PUT .../access_controls` endpoint, for product code
+    that must keep a rule in step with its own state (for example, the assignee of a work item).
+    It writes the rule only. The caller decides whether the actor may change access, and the
+    caller owns the reverse write when its state changes again.
+
+    A `UserAccessControl` built before this call still holds its preloaded rows. Build a new one
+    or clear its cache before checking the object again in the same request.
+
+    Returns the stored rule, or None when `access_level` is None and the rule was removed.
+    """
+    team = Team.objects.only("id", "organization_id").get(id=team_id)
+    resource = _validate_object_access_control(organization_id=team.organization_id, input=input)
+    lookup = {
+        "team_id": team_id,
+        "resource": resource,
+        "resource_id": input.resource_id,
+        "organization_member_id": input.organization_member_id,
+        "role_id": input.role_id,
+    }
+    if input.access_level is None:
+        AccessControl.objects.filter(**lookup).delete()
+        return None
+
+    rule, _created = AccessControl.objects.update_or_create(
+        **lookup,
+        defaults={"access_level": input.access_level},
+        create_defaults={"access_level": input.access_level, "created_by_id": input.created_by_id},
+    )
+    return _to_object_rule(rule)
 
 
 # --- Convenience for external callers (avoids importing UUID type at call sites) ---

--- a/products/access_control/backend/facade/api.py
+++ b/products/access_control/backend/facade/api.py
@@ -311,19 +311,19 @@ def set_object_access_control(
     """
     team = Team.objects.only("id", "organization_id").get(id=team_id)
     resource = _validate_object_access_control(organization_id=team.organization_id, input=input)
-    lookup = {
-        "team_id": team_id,
+    subject = {
         "resource": resource,
         "resource_id": input.resource_id,
         "organization_member_id": input.organization_member_id,
         "role_id": input.role_id,
     }
     if input.access_level is None:
-        AccessControl.objects.filter(**lookup).delete()
+        AccessControl.objects.filter(team_id=team_id, **subject).delete()
         return None
 
     rule, _created = AccessControl.objects.update_or_create(
-        **lookup,
+        team_id=team_id,
+        **subject,
         defaults={"access_level": input.access_level},
         create_defaults={"access_level": input.access_level, "created_by_id": input.created_by_id},
     )

--- a/products/access_control/backend/facade/contracts.py
+++ b/products/access_control/backend/facade/contracts.py
@@ -69,3 +69,35 @@ class DeletePropertyAccessControlInput:
     property_definition_id: str
     organization_member_id: UUID | None = None
     role_id: UUID | None = None
+
+
+@dataclass(frozen=True)
+class SetObjectAccessControlInput:
+    """Input for granting, changing, or removing one subject's access to one object.
+
+    `access_level=None` removes the rule. Exactly one of `organization_member_id` or `role_id`
+    names the subject.
+    """
+
+    resource: str
+    resource_id: str
+    access_level: str | None
+    organization_member_id: UUID | None = None
+    role_id: UUID | None = None
+    created_by_id: int | None = None
+
+    def __post_init__(self) -> None:
+        if (self.organization_member_id is None) == (self.role_id is None):
+            raise ValueError("Set exactly one of organization_member_id or role_id.")
+
+
+@dataclass(frozen=True)
+class ObjectAccessControlRule:
+    """One object-level access control rule as stored."""
+
+    id: UUID
+    resource: str
+    resource_id: str
+    access_level: str
+    organization_member_id: UUID | None
+    role_id: UUID | None

--- a/products/access_control/backend/tests/test_api.py
+++ b/products/access_control/backend/tests/test_api.py
@@ -1,0 +1,99 @@
+import pytest
+from posthog.test.base import BaseTest
+
+from parameterized import parameterized
+
+from posthog.constants import AvailableFeature
+from posthog.models import User
+from posthog.models.organization import Organization, OrganizationMembership
+
+from products.access_control.backend.facade import contracts
+from products.access_control.backend.facade.api import InvalidObjectAccessControlError, set_object_access_control
+from products.access_control.backend.facade.user_access_control import UserAccessControl
+from products.access_control.backend.models.access_control import AccessControl
+from products.access_control.backend.models.role import Role, RoleMembership
+from products.dashboards.backend.models.dashboard import Dashboard
+
+
+class TestSetObjectAccessControl(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+            {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
+        ]
+        self.organization.save()
+        self.other_user = User.objects.create_and_join(self.organization, "other@posthog.com", "testtest")
+        self.other_membership = OrganizationMembership.objects.get(user=self.other_user, organization=self.organization)
+        self.dashboard = Dashboard.objects.create(team=self.team, created_by=self.user)
+        AccessControl.objects.create(team=self.team, resource="dashboard", resource_id=None, access_level="none")
+
+    def _grant(self, access_level: str | None, **overrides: object) -> contracts.ObjectAccessControlRule | None:
+        input_kwargs: dict = {
+            "resource": "dashboard",
+            "resource_id": str(self.dashboard.id),
+            "access_level": access_level,
+            "organization_member_id": self.other_membership.id,
+        }
+        input_kwargs.update(overrides)
+        return set_object_access_control(
+            team_id=self.team.id, input=contracts.SetObjectAccessControlInput(**input_kwargs)
+        )
+
+    def _other_user_level(self) -> str | None:
+        return UserAccessControl(user=self.other_user, team=self.team).get_user_access_level(self.dashboard)
+
+    def test_grant_update_and_revoke_are_visible_through_user_access_control(self) -> None:
+        assert self._other_user_level() == "none"
+
+        rule = self._grant("viewer")
+        assert rule is not None and rule.access_level == "viewer"
+        assert self._other_user_level() == "viewer"
+
+        updated = self._grant("editor")
+        assert updated is not None and updated.id == rule.id
+        assert self._other_user_level() == "editor"
+
+        assert self._grant(None) is None
+        assert self._other_user_level() == "none"
+        assert self._grant(None) is None
+
+    def test_role_rule_grants_role_members(self) -> None:
+        role = Role.objects.create(name="Sales", organization=self.organization)
+        RoleMembership.objects.create(user=self.other_user, role=role)
+
+        self._grant("viewer", organization_member_id=None, role_id=role.id)
+
+        assert self._other_user_level() == "viewer"
+
+    @parameterized.expand(
+        [
+            ("unknown_resource", {"resource": "not_a_resource"}),
+            ("internal_resource", {"resource": "INTERNAL"}),
+            ("unknown_level", {"access_level": "owner"}),
+            ("level_below_resource_minimum", {"resource": "action", "access_level": "none"}),
+            ("level_above_resource_maximum", {"resource": "activity_log", "access_level": "editor"}),
+        ]
+    )
+    def test_rejects_invalid_rules(self, _name: str, overrides: dict) -> None:
+        with pytest.raises(InvalidObjectAccessControlError):
+            self._grant("viewer", **overrides)
+        assert not AccessControl.objects.filter(resource_id=str(self.dashboard.id)).exists()
+
+    def test_rejects_subjects_from_another_organization(self) -> None:
+        other_org = Organization.objects.create(name="Other")
+        outsider = User.objects.create_and_join(other_org, "outsider@posthog.com", "testtest")
+        outsider_membership = OrganizationMembership.objects.get(user=outsider, organization=other_org)
+        other_org_role = Role.objects.create(name="Outside", organization=other_org)
+
+        with pytest.raises(InvalidObjectAccessControlError):
+            self._grant("viewer", organization_member_id=outsider_membership.id)
+        with pytest.raises(InvalidObjectAccessControlError):
+            self._grant("viewer", organization_member_id=None, role_id=other_org_role.id)
+
+    def test_requires_exactly_one_subject(self) -> None:
+        role = Role.objects.create(name="Sales", organization=self.organization)
+        with pytest.raises(ValueError):
+            self._grant("viewer", organization_member_id=None)
+        with pytest.raises(ValueError):
+            self._grant("viewer", role_id=role.id)

--- a/products/access_control/backend/tests/test_api.py
+++ b/products/access_control/backend/tests/test_api.py
@@ -28,7 +28,9 @@ class TestSetObjectAccessControl(BaseTest):
         self.dashboard = Dashboard.objects.create(team=self.team, created_by=self.user)
         AccessControl.objects.create(team=self.team, resource="dashboard", resource_id=None, access_level="none")
 
-    def _grant(self, access_level: str | None, **overrides: object) -> contracts.ObjectAccessControlRule | None:
+    def _grant(
+        self, access_level: str | None = "viewer", **overrides: object
+    ) -> contracts.ObjectAccessControlRule | None:
         input_kwargs: dict = {
             "resource": "dashboard",
             "resource_id": str(self.dashboard.id),
@@ -77,7 +79,7 @@ class TestSetObjectAccessControl(BaseTest):
     )
     def test_rejects_invalid_rules(self, _name: str, overrides: dict) -> None:
         with pytest.raises(InvalidObjectAccessControlError):
-            self._grant("viewer", **overrides)
+            self._grant(**overrides)
         assert not AccessControl.objects.filter(resource_id=str(self.dashboard.id)).exists()
 
     def test_rejects_subjects_from_another_organization(self) -> None:


### PR DESCRIPTION
## Problem

Product code that wants to keep an access rule in step with its own state (an assignee, a share) has no sanctioned way to write it. The only writers of `AccessControl` rows today are the `PUT .../access_controls` endpoint, which is a DRF `Response`-returning function tied to a serializer, and the org invite flow in `posthog/`, which imports the model directly. An isolated product cannot do either.

Came up reviewing #94196, where customer tasks reimplement "the assignee can see and edit this task" as a custom permission chain because there was no facade function to grant object access instead.

## Changes

- `set_object_access_control(team_id=..., input=SetObjectAccessControlInput(...))` in `products/access_control/backend/facade/api.py`. Upserts one object rule for a member or a role, or deletes it when `access_level` is `None`. Returns the stored rule as a contract DTO.
- Validates the same things the endpoint's serializer does: known non-internal resource, level within the resource's allowed range, subject belongs to the team's organization. Raises `InvalidObjectAccessControlError` otherwise.
- Does **not** check whether the actor may change access. That stays with the caller, since a product syncing its own state (assignment) is not a user editing permissions.

> The endpoint's `upsert_access_control` is left as is for now. Folding it onto this helper is a follow-up once there is a second caller.

## How did you test this code?

Tests in `products/access_control/backend/tests/test_api.py`: grant, change, and revoke are visible through `UserAccessControl`; role rules reach role members; invalid resources, levels, and cross-org subjects are rejected. Not run locally (worktree), relying on CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Added a "Granting object access from product code" section to `.claude/agents/access-control.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code while reviewing #94196. Skills used: `/writing-dataclasses`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`. The only design fork was whether to validate actor permissions inside the helper; it does not, so that a product can write a rule on behalf of a state change without pretending the actor edited permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRKqpCbSBW7uJFPnwzJ7bE
