### PR TITLE
fix(mixpanel): re-fetch the day when an export stream is cut short

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mixpanel/mixpanel.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mixpanel/mixpanel.py
@@ -258,6 +258,15 @@ def _request(
     return _check_response(response, url, logger)
 
 
+class MixpanelExportTruncatedError(Exception):
+    """The export stream ended in a line that isn't an event.
+
+    Mixpanel commits a 200 before it starts streaming, so a server-side abort can only be
+    signalled inside the body: it appends a plain-text marker (`terminated early`) after the
+    JSONL rows instead of failing the request. That leaves a partial day, which is the same
+    situation as a dropped connection and is re-fetched the same way."""
+
+
 # The export body is read lazily while iterating `iter_lines`, i.e. outside `_request`'s
 # retry. A connection dropped mid-day surfaces there (`requests` wraps the underlying
 # `IncompleteRead` as `ChunkedEncodingError`), so it must be retried separately or a single
@@ -267,6 +276,7 @@ _STREAM_RETRYABLE_ERRORS = (
     requests.exceptions.ChunkedEncodingError,
     requests.ConnectionError,
     requests.ReadTimeout,
+    MixpanelExportTruncatedError,
 )
 
 
@@ -294,7 +304,13 @@ def _stream_export_day(
                 for line in response.iter_lines():
                     if not line:
                         continue
-                    batch.append(_flatten_event(orjson.loads(line)))
+                    try:
+                        event = orjson.loads(line)
+                    except orjson.JSONDecodeError as e:
+                        raise MixpanelExportTruncatedError(
+                            f"Mixpanel export: stream for {from_date} ended with a line that is not an event"
+                        ) from e
+                    batch.append(_flatten_event(event))
                     if len(batch) >= CHUNK_SIZE:
                         yield batch
                         batch = []

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mixpanel/test_mixpanel.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mixpanel/test_mixpanel.py
@@ -411,6 +411,35 @@ class TestExportStreamRetry:
         # Cursor only advances once the day finally completes.
         assert [s.from_date for s in manager.saved] == ["2024-01-02"]
 
+    def test_retries_day_when_stream_ends_in_a_non_event_line(self) -> None:
+        manager = FakeManager()
+        day = date(2024, 1, 1)
+        truncated = FakeResponse(lines=[self._line("i1"), b"terminated early"])
+        succeeding = FakeResponse(lines=[self._line("i1"), self._line("i2")])
+        with (
+            patch.object(mp, "_request", side_effect=[truncated, succeeding]) as mock_request,
+            patch.object(mp.time, "sleep") as mock_sleep,
+        ):
+            batches = list(
+                mp._iter_export(
+                    "us",
+                    "u",
+                    "s",
+                    "123",
+                    LOGGER,
+                    manager,  # type: ignore[arg-type]
+                    start_date=day,
+                    end_date=day,
+                    api_version=MIXPANEL_API_VERSION_V1,
+                )
+            )
+
+        rows = [row for batch in batches for row in batch]
+        assert [r["$insert_id"] for r in rows] == ["i1", "i2"]
+        assert mock_request.call_count == 2
+        mock_sleep.assert_called_once()
+        assert [s.from_date for s in manager.saved] == ["2024-01-02"]
+
     def test_gives_up_after_max_attempts(self) -> None:
         manager = FakeManager()
         day = date(2024, 1, 1)


### PR DESCRIPTION
## Problem

- A Mixpanel event sync fails outright when Mixpanel cuts a raw export short, and the message a user sees is `JSONDecodeError: invalid literal: line 1 column 1 (char 0)` ([error tracking issue](https://us.posthog.com/project/2/error_tracking/01a0694c-10fe-7913-a4ff-05993166cc8b)).
- Mixpanel commits a 200 before it starts streaming, so it can only signal a server-side abort inside the body. It appends a plain-text marker (`terminated early`) after the JSONL rows.
- The export day loop decodes every non-empty line as an event, so that marker raises a decode error and stops the sync.
- The loop already re-fetches a day whose download drops mid-stream, but a decode error was not in its retryable set.

## Changes

- A truncated export now costs a re-fetch of the day instead of a failed sync, so the run finishes with the full day.
- A line that is not an event raises `MixpanelExportTruncatedError`, which joins the mid-stream retryable errors.
- The day is re-fetched from the start, up to five attempts. Merge dedupes the re-emitted rows on `$insert_id`, as it already does for a dropped connection.
- If the truncation persists past those attempts, the error names the day instead of pointing at a JSON column offset.
- Any undecodable line counts as truncation, rather than a match on the marker text. Mixpanel has more than one error string, and matching one of them would leave the rest crashing.
- Skipping the bad line was the other option. It advances the cursor past a day that is missing events, so it trades a loud failure for silent data loss.
- The message carries no line content, because export rows hold customer event data.

## How did you test this code?

- Added one regression test: an export stream that ends in a non-event line re-fetches the day and yields both rows. With the fix reverted it reproduces the reported crash at `mixpanel.py:297`.
- Ran the Mixpanel source unit tests in this sandbox.
- Not run: anything against a live Mixpanel project, and the dev stack.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing setting or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from PostHog error tracking with Claude Code, using the PostHog MCP tools to read the issue and its representative event.
- Skills invoked: `/writing-pr-descriptions`.
- The decision that shaped the diff: orjson reports "invalid literal" only for a line that starts a bare word, which pointed at Mixpanel's `terminated early` marker rather than a malformed event. That ruled out a `NonRetryableErrors` entry, since the condition is upstream and transient rather than a credential or config problem.
- Nothing in this PR carries material from the triage session. The test uses the public Mixpanel marker string and invented insert ids.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
