### PR TITLE
feat(dashboards): add saved filter views

### DIFF
--- a/.agents/skills/managing-dashboards/references/filters-variables-and-overrides.md
+++ b/.agents/skills/managing-dashboards/references/filters-variables-and-overrides.md
@@ -25,6 +25,15 @@ Before you change one layer, define its precedence with every other affected lay
 - Check tiles that opt out of dashboard filters separately from tiles that add their own filters.
 - Apply the same resolved state to dashboard detail, `run_insights`, streaming, export, and the frontend preview.
 
+## Saved filter views
+
+- Store a small shared view list on the dashboard when views do not need separate access rules.
+- Keep saved views distinct from the dashboard's default filters.
+- Apply a selected view through URL filters so users can share and clear it.
+- Let dashboard editors manage views. Let dashboard viewers select views.
+- Hide saved filter views from public, embedded, product-embedded, and export surfaces unless a later contract adds them.
+- Gate both the UI and dashboard mutations during rollout.
+
 ## Failure cases
 
 | Change               | Check                                                                              |

--- a/frontend/src/lib/components/SavedViews/SavedViewsList.tsx
+++ b/frontend/src/lib/components/SavedViews/SavedViewsList.tsx
@@ -1,0 +1,56 @@
+import { IconCheck, IconTrash } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+export interface SavedViewListItem {
+    id: string
+    name: string
+}
+
+export interface SavedViewsListProps<T extends SavedViewListItem> {
+    views: T[]
+    activeViewId?: string | null
+    emptyMessage: string
+    onSelect: (view: T) => void
+    onDelete?: (view: T) => void
+}
+
+export function SavedViewsList<T extends SavedViewListItem>({
+    views,
+    activeViewId,
+    emptyMessage,
+    onSelect,
+    onDelete,
+}: SavedViewsListProps<T>): JSX.Element {
+    if (views.length === 0) {
+        return <div className="px-3 py-3 text-sm text-secondary">{emptyMessage}</div>
+    }
+
+    return (
+        <div className="max-h-64 overflow-y-auto">
+            {views.map((view) => (
+                <div key={view.id} className="flex items-center">
+                    <LemonButton
+                        fullWidth
+                        size="small"
+                        type="tertiary"
+                        className="min-w-0 justify-start rounded-none px-3 hover:!bg-fill-secondary"
+                        sideIcon={activeViewId === view.id ? <IconCheck className="text-success" /> : null}
+                        onClick={() => onSelect(view)}
+                    >
+                        <span className="truncate">{view.name}</span>
+                    </LemonButton>
+                    {onDelete && (
+                        <LemonButton
+                            size="small"
+                            type="tertiary"
+                            icon={<IconTrash />}
+                            tooltip={`Delete ${view.name}`}
+                            aria-label={`Delete ${view.name}`}
+                            onClick={() => onDelete(view)}
+                        />
+                    )}
+                </div>
+            ))}
+        </div>
+    )
+}

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -300,6 +300,7 @@ export const FEATURE_FLAGS = {
     DASHBOARD_AUTO_PREVIEW_LIMIT: 'dashboard-auto-preview-limit', // owner: @pauldambra #team-product-analytics
     DASHBOARD_CUSTOMIZATION: 'dashboard-customization', // owner: @MattPua #team-analytics-platform
     DASHBOARD_EXPORT_NUDGE: 'dashboard-export-nudge', // owner: #team-analytics-platform multivariate=control,test, nudges people who just exported a dashboard toward a recurring subscription
+    DASHBOARD_FILTER_SAVED_VIEWS: 'dashboard-filter-saved-views', // owner: #team-analytics-platform, target organizations for saved filter views within dashboards
     DASHBOARD_LAYOUT_DISCARD_PROMPT: 'dashboard-layout-discard-prompt', // owner: @cory.s #team-analytics-platform
     DASHBOARD_SAVED_VIEWS: 'dashboard-saved-views', // owner: #team-analytics-platform, target organizations for saved dashboard-list views
     DASHBOARD_TEMPLATE_CHOOSER_EXPERIMENT: 'dashboard-template-chooser-experiment', // owner: @mattp #team-analytics-platform multivariate=control,simple,new
@@ -579,7 +580,7 @@ export const FEATURE_FLAGS = {
     WORKFLOWS_ISP_SENDING_HEALTH: 'workflows-isp-sending-health', // owner: #team-workflows
     WORKFLOWS_PUSH_NOTIFICATIONS: 'workflows-push-notifications', // owner: #team-workflows
     XAA_AUTHENTICATION: 'xaa-authentication', // owner: @reecejones #team-platform-features
-} as const
+    } as const
 export type FeatureFlagLookupKey = keyof typeof FEATURE_FLAGS
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/dashboard/DashboardFilterViews.tsx
+++ b/frontend/src/scenes/dashboard/DashboardFilterViews.tsx
@@ -1,0 +1,116 @@
+import { deepEqual } from 'fast-equals'
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+import { useState } from 'react'
+
+import { IconChevronDown, IconPlus } from '@posthog/icons'
+import { LemonButton, LemonDialog, LemonInput, Popover } from '@posthog/lemon-ui'
+
+import { SavedViewsList } from 'lib/components/SavedViews/SavedViewsList'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { LemonField } from 'lib/lemon-ui/LemonField'
+
+import { DashboardFilterView, DashboardPlacement } from '~/types'
+
+import { dashboardLogic } from './dashboardLogic'
+import { searchParamsWithUrlFilters } from './dashboardUtils'
+
+export function DashboardFilterViews(): JSX.Element | null {
+    const enabled = useFeatureFlag('DASHBOARD_FILTER_SAVED_VIEWS')
+    const { dashboard, placement, canEditDashboard, effectiveEditBarFilters, urlFilters } = useValues(dashboardLogic)
+    const { triggerDashboardUpdate } = useActions(dashboardLogic)
+    const [visible, setVisible] = useState(false)
+
+    if (!enabled || !dashboard || placement !== DashboardPlacement.Dashboard) {
+        return null
+    }
+
+    const views = dashboard.customization?.filter_views ?? []
+    const activeView = views.find((view) => deepEqual(view.filters, urlFilters))
+
+    const saveViews = (filterViews: DashboardFilterView[]): void => {
+        triggerDashboardUpdate({ filter_views: filterViews })
+    }
+
+    const selectView = (view: DashboardFilterView): void => {
+        const { currentLocation } = router.values
+        const filters = activeView?.id === view.id ? {} : view.filters
+        router.actions.push(
+            currentLocation.pathname,
+            searchParamsWithUrlFilters(currentLocation.searchParams, filters),
+            currentLocation.hashParams
+        )
+        setVisible(false)
+    }
+
+    const createView = (): void => {
+        LemonDialog.openForm({
+            title: 'Save filter view',
+            initialValues: { name: '' },
+            content: (
+                <LemonField name="name" label="Name">
+                    <LemonInput autoFocus placeholder="Enter a view name" />
+                </LemonField>
+            ),
+            errors: { name: (name) => (!name?.trim() ? 'Enter a view name' : undefined) },
+            onSubmit: ({ name }) =>
+                saveViews([...views, { id: crypto.randomUUID(), name: name.trim(), filters: effectiveEditBarFilters }]),
+            primaryButtonProps: { children: 'Save view' },
+        })
+    }
+
+    const deleteView = (view: DashboardFilterView): void => {
+        LemonDialog.open({
+            title: `Delete “${view.name}”?`,
+            description: 'This removes the view from this dashboard.',
+            primaryButton: {
+                children: 'Delete view',
+                status: 'danger',
+                onClick: () => saveViews(views.filter((candidate) => candidate.id !== view.id)),
+            },
+            secondaryButton: { children: 'Cancel' },
+        })
+    }
+
+    return (
+        <Popover
+            visible={visible}
+            padded={false}
+            onClickOutside={() => setVisible(false)}
+            overlay={
+                <div className="flex w-72 flex-col py-1" data-attr="dashboard-filter-views-popover">
+                    {canEditDashboard && views.length < 20 && (
+                        <LemonButton
+                            fullWidth
+                            size="small"
+                            type="tertiary"
+                            className="justify-start rounded-none px-3"
+                            icon={<IconPlus />}
+                            onClick={createView}
+                        >
+                            Save current filters
+                        </LemonButton>
+                    )}
+                    {canEditDashboard && views.length < 20 && <div className="border-t" />}
+                    <SavedViewsList
+                        views={[...views].sort((left, right) => left.name.localeCompare(right.name))}
+                        activeViewId={activeView?.id}
+                        emptyMessage="No saved filter views yet."
+                        onSelect={selectView}
+                        onDelete={canEditDashboard ? deleteView : undefined}
+                    />
+                </div>
+            }
+        >
+            <LemonButton
+                size="small"
+                type="secondary"
+                data-attr="dashboard-filter-views-picker"
+                sideIcon={<IconChevronDown />}
+                onClick={() => setVisible(!visible)}
+            >
+                {activeView?.name ?? 'Views'}
+            </LemonButton>
+        </Popover>
+    )
+}

--- a/frontend/src/scenes/dashboard/DashboardFilterViews.tsx
+++ b/frontend/src/scenes/dashboard/DashboardFilterViews.tsx
@@ -2,17 +2,15 @@ import { deepEqual } from 'fast-equals'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import posthog from 'posthog-js'
-import { useState } from 'react'
 
-import { IconChevronDown, IconPlus } from '@posthog/icons'
-import { LemonButton, LemonDialog, LemonInput, Popover } from '@posthog/lemon-ui'
+import { LemonDialog, LemonInput } from '@posthog/lemon-ui'
 
-import { SavedViewsList } from 'lib/components/SavedViews/SavedViewsList'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
 import { DashboardFilterView, DashboardPlacement } from '~/types'
 
+import { DashboardFilterViewsButton } from './DashboardFilterViewsButton'
 import { dashboardLogic } from './dashboardLogic'
 import { searchParamsWithUrlFilters } from './dashboardUtils'
 
@@ -20,7 +18,6 @@ export function DashboardFilterViews(): JSX.Element | null {
     const enabled = useFeatureFlag('DASHBOARD_FILTER_SAVED_VIEWS')
     const { dashboard, placement, canEditDashboard, effectiveEditBarFilters, urlFilters } = useValues(dashboardLogic)
     const { triggerDashboardUpdate } = useActions(dashboardLogic)
-    const [visible, setVisible] = useState(false)
 
     if (!enabled || !dashboard || placement !== DashboardPlacement.Dashboard) {
         return null
@@ -52,7 +49,6 @@ export function DashboardFilterViews(): JSX.Element | null {
             searchParamsWithUrlFilters(currentLocation.searchParams, filters),
             currentLocation.hashParams
         )
-        setVisible(false)
     }
 
     const createView = (): void => {
@@ -85,44 +81,13 @@ export function DashboardFilterViews(): JSX.Element | null {
     }
 
     return (
-        <Popover
-            visible={visible}
-            padded={false}
-            onClickOutside={() => setVisible(false)}
-            overlay={
-                <div className="flex w-72 flex-col py-1" data-attr="dashboard-filter-views-popover">
-                    {canEditDashboard && views.length < 20 && (
-                        <LemonButton
-                            fullWidth
-                            size="small"
-                            type="tertiary"
-                            className="justify-start rounded-none px-3"
-                            icon={<IconPlus />}
-                            onClick={createView}
-                        >
-                            Save current filters
-                        </LemonButton>
-                    )}
-                    {canEditDashboard && views.length < 20 && <div className="border-t" />}
-                    <SavedViewsList
-                        views={[...views].sort((left, right) => left.name.localeCompare(right.name))}
-                        activeViewId={activeView?.id}
-                        emptyMessage="No saved filter views yet."
-                        onSelect={selectView}
-                        onDelete={canEditDashboard ? deleteView : undefined}
-                    />
-                </div>
-            }
-        >
-            <LemonButton
-                size="small"
-                type="secondary"
-                data-attr="dashboard-filter-views-picker"
-                sideIcon={<IconChevronDown />}
-                onClick={() => setVisible(!visible)}
-            >
-                {activeView?.name ?? 'Views'}
-            </LemonButton>
-        </Popover>
+        <DashboardFilterViewsButton
+            views={views}
+            activeView={activeView}
+            canEdit={canEditDashboard}
+            onCreate={createView}
+            onSelect={selectView}
+            onDelete={deleteView}
+        />
     )
 }

--- a/frontend/src/scenes/dashboard/DashboardFilterViews.tsx
+++ b/frontend/src/scenes/dashboard/DashboardFilterViews.tsx
@@ -10,9 +10,13 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 
 import { DashboardFilterView, DashboardPlacement } from '~/types'
 
+import {
+    createDashboardFilterView,
+    dashboardFilterViewAnalyticsProperties,
+    dashboardFilterViewSearchParams,
+} from './dashboardFilterViews'
 import { DashboardFilterViewsButton } from './DashboardFilterViewsButton'
 import { dashboardLogic } from './dashboardLogic'
-import { searchParamsWithUrlFilters } from './dashboardUtils'
 
 export function DashboardFilterViews(): JSX.Element | null {
     const enabled = useFeatureFlag('DASHBOARD_FILTER_SAVED_VIEWS')
@@ -32,21 +36,16 @@ export function DashboardFilterViews(): JSX.Element | null {
 
     const selectView = (view: DashboardFilterView): void => {
         const { currentLocation } = router.values
-        const filters = activeView?.id === view.id ? {} : view.filters
         if (activeView?.id !== view.id) {
             posthog.capture('dashboard filter view applied', {
                 dashboard_id: dashboard.id,
                 saved_view_count: views.length,
-                has_date_filter: !!(view.filters.date_from || view.filters.date_to),
-                property_filter_count: view.filters.properties?.length ?? 0,
-                has_breakdown_filter: !!view.filters.breakdown_filter,
-                has_interval_filter: !!view.filters.interval,
-                has_test_account_filter: view.filters.filterTestAccounts !== undefined,
+                ...dashboardFilterViewAnalyticsProperties(view.filters),
             })
         }
         router.actions.push(
             currentLocation.pathname,
-            searchParamsWithUrlFilters(currentLocation.searchParams, filters),
+            dashboardFilterViewSearchParams(currentLocation.searchParams, activeView?.id, view),
             currentLocation.hashParams
         )
     }
@@ -62,7 +61,7 @@ export function DashboardFilterViews(): JSX.Element | null {
             ),
             errors: { name: (name) => (!name?.trim() ? 'Enter a view name' : undefined) },
             onSubmit: ({ name }) =>
-                saveViews([...views, { id: crypto.randomUUID(), name: name.trim(), filters: effectiveEditBarFilters }]),
+                saveViews([...views, createDashboardFilterView(crypto.randomUUID(), name, effectiveEditBarFilters)]),
             primaryButtonProps: { children: 'Save view' },
         })
     }

--- a/frontend/src/scenes/dashboard/DashboardFilterViews.tsx
+++ b/frontend/src/scenes/dashboard/DashboardFilterViews.tsx
@@ -1,6 +1,7 @@
 import { deepEqual } from 'fast-equals'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
+import posthog from 'posthog-js'
 import { useState } from 'react'
 
 import { IconChevronDown, IconPlus } from '@posthog/icons'
@@ -35,6 +36,17 @@ export function DashboardFilterViews(): JSX.Element | null {
     const selectView = (view: DashboardFilterView): void => {
         const { currentLocation } = router.values
         const filters = activeView?.id === view.id ? {} : view.filters
+        if (activeView?.id !== view.id) {
+            posthog.capture('dashboard filter view applied', {
+                dashboard_id: dashboard.id,
+                saved_view_count: views.length,
+                has_date_filter: !!(view.filters.date_from || view.filters.date_to),
+                property_filter_count: view.filters.properties?.length ?? 0,
+                has_breakdown_filter: !!view.filters.breakdown_filter,
+                has_interval_filter: !!view.filters.interval,
+                has_test_account_filter: view.filters.filterTestAccounts !== undefined,
+            })
+        }
         router.actions.push(
             currentLocation.pathname,
             searchParamsWithUrlFilters(currentLocation.searchParams, filters),

--- a/frontend/src/scenes/dashboard/DashboardFilterViewsButton.stories.tsx
+++ b/frontend/src/scenes/dashboard/DashboardFilterViewsButton.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+
+import { DashboardFilterView } from '~/types'
+
+import { DashboardFilterViewsButton } from './DashboardFilterViewsButton'
+
+const views: DashboardFilterView[] = [
+    { id: 'enterprise', name: 'Enterprise', filters: { date_from: '-30d' } },
+    { id: 'self-serve', name: 'Self-serve', filters: { date_from: '-7d' } },
+    { id: 'europe', name: 'Europe', filters: { date_from: '-14d' } },
+]
+
+const meta: Meta<typeof DashboardFilterViewsButton> = {
+    title: 'Scenes/Dashboard/Filter views',
+    component: DashboardFilterViewsButton,
+    args: {
+        views,
+        canEdit: true,
+        defaultOpen: true,
+        onCreate: () => {},
+        onSelect: () => {},
+        onDelete: () => {},
+    },
+    parameters: {
+        featureFlags: [FEATURE_FLAGS.DASHBOARD_FILTER_SAVED_VIEWS],
+    },
+}
+
+export default meta
+type Story = StoryObj<typeof DashboardFilterViewsButton>
+
+export const SavedViews: Story = {}
+
+export const ActiveView: Story = {
+    args: {
+        activeView: views[0],
+    },
+}
+
+export const Viewer: Story = {
+    args: {
+        canEdit: false,
+    },
+}
+
+export const Empty: Story = {
+    args: {
+        views: [],
+    },
+}

--- a/frontend/src/scenes/dashboard/DashboardFilterViewsButton.tsx
+++ b/frontend/src/scenes/dashboard/DashboardFilterViewsButton.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react'
+
+import { IconChevronDown, IconPlus } from '@posthog/icons'
+import { LemonButton, Popover } from '@posthog/lemon-ui'
+
+import { SavedViewsList } from 'lib/components/SavedViews/SavedViewsList'
+
+import { DashboardFilterView } from '~/types'
+
+export interface DashboardFilterViewsButtonProps {
+    views: DashboardFilterView[]
+    activeView?: DashboardFilterView
+    canEdit: boolean
+    defaultOpen?: boolean
+    onCreate: () => void
+    onSelect: (view: DashboardFilterView) => void
+    onDelete: (view: DashboardFilterView) => void
+}
+
+export function DashboardFilterViewsButton({
+    views,
+    activeView,
+    canEdit,
+    defaultOpen = false,
+    onCreate,
+    onSelect,
+    onDelete,
+}: DashboardFilterViewsButtonProps): JSX.Element {
+    const [visible, setVisible] = useState(defaultOpen)
+
+    return (
+        <Popover
+            visible={visible}
+            padded={false}
+            onClickOutside={() => setVisible(false)}
+            overlay={
+                <div className="flex w-72 flex-col py-1" data-attr="dashboard-filter-views-popover">
+                    {canEdit && views.length < 20 && (
+                        <LemonButton
+                            fullWidth
+                            size="small"
+                            type="tertiary"
+                            className="justify-start rounded-none px-3"
+                            icon={<IconPlus />}
+                            onClick={onCreate}
+                        >
+                            Save current filters
+                        </LemonButton>
+                    )}
+                    {canEdit && views.length < 20 && <div className="border-t" />}
+                    <SavedViewsList
+                        views={[...views].sort((left, right) => left.name.localeCompare(right.name))}
+                        activeViewId={activeView?.id}
+                        emptyMessage="No saved filter views yet."
+                        onSelect={(view) => {
+                            onSelect(view)
+                            setVisible(false)
+                        }}
+                        onDelete={canEdit ? onDelete : undefined}
+                    />
+                </div>
+            }
+        >
+            <LemonButton
+                size="small"
+                type="secondary"
+                data-attr="dashboard-filter-views-picker"
+                sideIcon={<IconChevronDown />}
+                onClick={() => setVisible(!visible)}
+            >
+                {activeView?.name ?? 'Views'}
+            </LemonButton>
+        </Popover>
+    )
+}

--- a/frontend/src/scenes/dashboard/DashboardFilters.tsx
+++ b/frontend/src/scenes/dashboard/DashboardFilters.tsx
@@ -9,6 +9,7 @@ import { urls } from 'scenes/urls'
 import { DashboardMode, DashboardPlacement } from '~/types'
 
 import { DashboardEditBar } from './DashboardEditBar'
+import { DashboardFilterViews } from './DashboardFilterViews'
 import { DashboardEditSaveCancelButtons } from './DashboardHeaderActions'
 import { dashboardLogic } from './dashboardLogic'
 import { DashboardReloadAction, LastRefreshText } from './DashboardReloadAction'
@@ -74,6 +75,7 @@ export function DashboardFilterBar({ backTo }: DashboardFilterBarProps): JSX.Ele
                             DashboardPlacement.Builtin,
                         ].includes(placement) &&
                             dashboard && <DashboardEditBar />}
+                        <DashboardFilterViews />
                         <DashboardEditActions />
                     </div>
                 </div>

--- a/frontend/src/scenes/dashboard/dashboardFilterViews.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardFilterViews.test.ts
@@ -1,0 +1,88 @@
+import { PropertyFilterType, PropertyOperator } from '~/types'
+
+import {
+    createDashboardFilterView,
+    dashboardFilterViewAnalyticsProperties,
+    dashboardFilterViewSearchParams,
+} from './dashboardFilterViews'
+import { parseURLFilters, SEARCH_PARAM_FILTERS_KEY } from './dashboardUtils'
+
+const propertyFilters = [
+    {
+        key: 'plan',
+        type: PropertyFilterType.Person,
+        operator: PropertyOperator.Exact,
+        value: ['enterprise', 'scale'],
+    },
+    {
+        key: '$browser',
+        type: PropertyFilterType.Event,
+        operator: PropertyOperator.IsNot,
+        value: 'Internet Explorer',
+    },
+]
+
+const combinedFilters = {
+    date_from: '-30d',
+    date_to: '-1d',
+    explicitDate: true,
+    interval: 'week' as const,
+    filterTestAccounts: false,
+    properties: propertyFilters,
+    breakdown_filter: {
+        breakdowns: [
+            { property: '$browser', type: 'event' as const },
+            { property: 'plan', type: 'person' as const },
+            { property: 'company_id', type: 'group' as const, group_type_index: 0 },
+        ],
+        breakdown_limit: 25,
+        breakdown_hide_other_aggregation: true,
+    },
+}
+
+describe('dashboard filter views', () => {
+    it('creates a view without losing any filter type', () => {
+        expect(createDashboardFilterView('view-id', '  Enterprise weekly  ', combinedFilters)).toEqual({
+            id: 'view-id',
+            name: 'Enterprise weekly',
+            filters: combinedFilters,
+        })
+    })
+
+    it.each([
+        ['date range and interval', { date_from: '-90d', date_to: 'now', explicitDate: true, interval: 'month' }],
+        ['person and event properties', { properties: propertyFilters }],
+        ['legacy event breakdown', { breakdown_filter: { breakdown: '$browser', breakdown_type: 'event' } }],
+        ['multiple typed breakdowns', { breakdown_filter: combinedFilters.breakdown_filter }],
+        ['test accounts included', { filterTestAccounts: true }],
+        ['test accounts excluded', { filterTestAccounts: false }],
+        ['all supported filter types', combinedFilters],
+    ])('applies %s through the URL without changing its filter payload', (_, filters) => {
+        const view = createDashboardFilterView('view-id', 'View', filters)
+        const searchParams = dashboardFilterViewSearchParams({ tab: 'overview' }, undefined, view)
+
+        expect(searchParams.tab).toBe('overview')
+        expect(parseURLFilters(searchParams)).toEqual(filters)
+    })
+
+    it('clears the active view without removing unrelated URL state', () => {
+        const view = createDashboardFilterView('view-id', 'View', combinedFilters)
+        const searchParams = dashboardFilterViewSearchParams(
+            { tab: 'overview', [SEARCH_PARAM_FILTERS_KEY]: JSON.stringify(combinedFilters) },
+            view.id,
+            view
+        )
+
+        expect(searchParams).toEqual({ tab: 'overview' })
+    })
+
+    it('describes every applied filter family without capturing values', () => {
+        expect(dashboardFilterViewAnalyticsProperties(combinedFilters)).toEqual({
+            has_date_filter: true,
+            property_filter_count: 2,
+            has_breakdown_filter: true,
+            has_interval_filter: true,
+            has_test_account_filter: true,
+        })
+    })
+})

--- a/frontend/src/scenes/dashboard/dashboardFilterViews.ts
+++ b/frontend/src/scenes/dashboard/dashboardFilterViews.ts
@@ -1,0 +1,35 @@
+import { DashboardFilter, DashboardFilterView } from '~/types'
+
+import { searchParamsWithUrlFilters } from './dashboardUtils'
+
+export interface DashboardFilterViewAnalyticsProperties {
+    has_date_filter: boolean
+    property_filter_count: number
+    has_breakdown_filter: boolean
+    has_interval_filter: boolean
+    has_test_account_filter: boolean
+}
+
+export function createDashboardFilterView(id: string, name: string, filters: DashboardFilter): DashboardFilterView {
+    return { id, name: name.trim(), filters }
+}
+
+export function dashboardFilterViewSearchParams(
+    searchParams: Record<string, unknown>,
+    activeViewId: string | undefined,
+    view: DashboardFilterView
+): Record<string, unknown> {
+    return searchParamsWithUrlFilters(searchParams, activeViewId === view.id ? {} : view.filters)
+}
+
+export function dashboardFilterViewAnalyticsProperties(
+    filters: DashboardFilter
+): DashboardFilterViewAnalyticsProperties {
+    return {
+        has_date_filter: !!(filters.date_from || filters.date_to),
+        property_filter_count: filters.properties?.length ?? 0,
+        has_breakdown_filter: !!filters.breakdown_filter,
+        has_interval_filter: !!filters.interval,
+        has_test_account_filter: filters.filterTestAccounts !== undefined,
+    }
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2768,7 +2768,14 @@ export interface DashboardType<T = InsightModel> extends DashboardBasicType {
     customization?: {
         tile_spacing?: DashboardTileSpacing
         layout_compaction?: 'vertical' | 'horizontal' | 'stable'
+        filter_views?: DashboardFilterView[]
     }
+}
+
+export interface DashboardFilterView {
+    id: string
+    name: string
+    filters: DashboardFilter
 }
 
 export type DashboardTileSpacing = 'tight' | 'condensed' | 'standard' | 'relaxed' | 'wide'

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -776,8 +776,11 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         self.assertEqual(response["attr"], "layout_compaction")
         self.assertEqual(response["detail"], "Tile movement settings aren't available.")
 
+    @patch("products.dashboards.backend.api.dashboard.report_user_action")
     @patch("products.dashboards.backend.api.dashboard.dashboard_filter_saved_views_enabled", return_value=True)
-    def test_dashboard_filter_views_are_saved(self, _mock_enabled: MagicMock) -> None:
+    def test_dashboard_filter_views_are_saved(
+        self, _mock_enabled: MagicMock, mock_report_user_action: MagicMock
+    ) -> None:
         dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
         view_id = "00000000-0000-0000-0000-000000000001"
 
@@ -796,6 +799,21 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
 
         self.assertEqual(updated["customization"]["filter_views"][0]["id"], view_id)
         self.assertEqual(updated["customization"]["filter_views"][0]["filters"]["date_from"], "-30d")
+        created_call = next(
+            call for call in mock_report_user_action.call_args_list if call.args[1] == "dashboard filter view created"
+        )
+        self.assertEqual(
+            created_call.args[2],
+            {
+                "dashboard_id": dashboard_id,
+                "saved_view_count": 1,
+                "has_date_filter": True,
+                "property_filter_count": 0,
+                "has_breakdown_filter": False,
+                "has_interval_filter": False,
+                "has_test_account_filter": False,
+            },
+        )
 
     @patch("products.dashboards.backend.api.dashboard.dashboard_filter_saved_views_enabled", return_value=False)
     def test_dashboard_filter_views_require_feature_flag(self, _mock_enabled: MagicMock) -> None:

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -783,6 +783,25 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
     ) -> None:
         dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
         view_id = "00000000-0000-0000-0000-000000000001"
+        filters = {
+            "date_from": "-30d",
+            "date_to": "-1d",
+            "interval": "week",
+            "filterTestAccounts": False,
+            "properties": [
+                {"key": "plan", "type": "person", "operator": "exact", "value": ["enterprise", "scale"]},
+                {"key": "$browser", "type": "event", "operator": "is_not", "value": "Internet Explorer"},
+            ],
+            "breakdown_filter": {
+                "breakdowns": [
+                    {"property": "$browser", "type": "event"},
+                    {"property": "plan", "type": "person"},
+                    {"property": "company_id", "type": "group", "group_type_index": 0},
+                ],
+                "breakdown_limit": 25,
+                "breakdown_hide_other_aggregation": True,
+            },
+        }
 
         _, updated = self.dashboard_api.update_dashboard(
             dashboard_id,
@@ -791,14 +810,14 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
                     {
                         "id": view_id,
                         "name": "Enterprise",
-                        "filters": {"date_from": "-30d", "properties": []},
+                        "filters": filters,
                     }
                 ]
             },
         )
 
         self.assertEqual(updated["customization"]["filter_views"][0]["id"], view_id)
-        self.assertEqual(updated["customization"]["filter_views"][0]["filters"]["date_from"], "-30d")
+        self.assertEqual(updated["customization"]["filter_views"][0]["filters"], filters)
         created_call = next(
             call for call in mock_report_user_action.call_args_list if call.args[1] == "dashboard filter view created"
         )
@@ -808,10 +827,10 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
                 "dashboard_id": dashboard_id,
                 "saved_view_count": 1,
                 "has_date_filter": True,
-                "property_filter_count": 0,
-                "has_breakdown_filter": False,
-                "has_interval_filter": False,
-                "has_test_account_filter": False,
+                "property_filter_count": 2,
+                "has_breakdown_filter": True,
+                "has_interval_filter": True,
+                "has_test_account_filter": True,
             },
         )
 

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -776,6 +776,40 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         self.assertEqual(response["attr"], "layout_compaction")
         self.assertEqual(response["detail"], "Tile movement settings aren't available.")
 
+    @patch("products.dashboards.backend.api.dashboard.dashboard_filter_saved_views_enabled", return_value=True)
+    def test_dashboard_filter_views_are_saved(self, _mock_enabled: MagicMock) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+        view_id = "00000000-0000-0000-0000-000000000001"
+
+        _, updated = self.dashboard_api.update_dashboard(
+            dashboard_id,
+            {
+                "filter_views": [
+                    {
+                        "id": view_id,
+                        "name": "Enterprise",
+                        "filters": {"date_from": "-30d", "properties": []},
+                    }
+                ]
+            },
+        )
+
+        self.assertEqual(updated["customization"]["filter_views"][0]["id"], view_id)
+        self.assertEqual(updated["customization"]["filter_views"][0]["filters"]["date_from"], "-30d")
+
+    @patch("products.dashboards.backend.api.dashboard.dashboard_filter_saved_views_enabled", return_value=False)
+    def test_dashboard_filter_views_require_feature_flag(self, _mock_enabled: MagicMock) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+
+        _, response = self.dashboard_api.update_dashboard(
+            dashboard_id,
+            {"filter_views": []},
+            expected_status=status.HTTP_400_BAD_REQUEST,
+        )
+
+        self.assertEqual(response["attr"], "filter_views")
+        self.assertEqual(response["detail"], "Dashboard filter views aren't available.")
+
     @patch("products.dashboards.backend.api.dashboard.dashboard_customization_enabled", return_value=True)
     def test_dashboard_tile_spacing_requires_a_known_preset(self, _mock_enabled: MagicMock):
         dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -121,7 +121,11 @@ from products.dashboards.backend.api.widget_openapi_serializers import (
 from products.dashboards.backend.constants import DASHBOARD_GRID_COLUMN_COUNT, MAX_WIDGETS_BATCH_SIZE
 from products.dashboards.backend.facade.api import DashboardTileBasicSerializer
 from products.dashboards.backend.facade.enums import PrivilegeLevel, RestrictionLevel
-from products.dashboards.backend.feature_flags import dashboard_customization_enabled, dashboard_widgets_enabled
+from products.dashboards.backend.feature_flags import (
+    dashboard_customization_enabled,
+    dashboard_filter_saved_views_enabled,
+    dashboard_widgets_enabled,
+)
 from products.dashboards.backend.models.dashboard import (
     DASHBOARD_GRID_COMPACTION_MODES,
     DASHBOARD_GRID_SPACING_GAPS,
@@ -1209,6 +1213,11 @@ class DashboardCustomizationSerializer(serializers.Serializer):
             "to the left, and stable preserves positions while moving colliding tiles."
         ),
     )
+    filter_views = serializers.ListField(
+        child=serializers.DictField(),
+        required=False,
+        help_text="Named dashboard filter sets available to dashboard viewers.",
+    )
 
 
 class DashboardMetadataSerializer(DashboardBasicSerializer):
@@ -1259,7 +1268,7 @@ class DashboardMetadataSerializer(DashboardBasicSerializer):
         return filters_override_requested_by_client(request, dashboard, is_shared=is_shared)
 
     @extend_schema_field(DashboardCustomizationSerializer)
-    def get_customization(self, dashboard: Dashboard) -> dict[str, str]:
+    def get_customization(self, dashboard: Dashboard) -> dict[str, Any]:
         customization = _normalize_dashboard_customization(dashboard.customization)
         tile_spacing = customization.get("tile_spacing")
         layout_compaction = customization.get("layout_compaction")
@@ -1268,6 +1277,13 @@ class DashboardMetadataSerializer(DashboardBasicSerializer):
             result["tile_spacing"] = tile_spacing
         if isinstance(layout_compaction, str) and layout_compaction in DASHBOARD_GRID_COMPACTION_MODES:
             result["layout_compaction"] = layout_compaction
+        filter_views = customization.get("filter_views")
+        if (
+            isinstance(filter_views, list)
+            and not self.context.get("is_shared")
+            and dashboard_filter_saved_views_enabled(team=dashboard.team)
+        ):
+            result["filter_views"] = filter_views
         return result
 
     def get_variables(self, dashboard: Dashboard) -> dict | None:
@@ -1530,6 +1546,30 @@ class DashboardSerializer(DashboardMetadataSerializer):
             return normalize_dashboard_filters_properties(request_filters)
         except ValueError as error:
             raise serializers.ValidationError({"properties": str(error)}) from error
+
+    @classmethod
+    def _validated_filter_views(cls, value: Any) -> list[dict[str, Any]]:
+        if not isinstance(value, list) or len(value) > 20:
+            raise serializers.ValidationError("Filter views must be a list with at most 20 entries.")
+        validated: list[dict[str, Any]] = []
+        seen_ids: set[str] = set()
+        for item in value:
+            if not isinstance(item, dict):
+                raise serializers.ValidationError("Each filter view must be an object.")
+            try:
+                view_id = str(uuid.UUID(str(item.get("id", ""))))
+            except ValueError as error:
+                raise serializers.ValidationError("Each filter view must have a valid ID.") from error
+            name = item.get("name")
+            if not isinstance(name, str) or not name.strip() or len(name.strip()) > 80:
+                raise serializers.ValidationError("Each filter view must have a name with 80 characters or fewer.")
+            if view_id in seen_ids:
+                raise serializers.ValidationError("Filter view IDs must be unique.")
+            seen_ids.add(view_id)
+            validated.append(
+                {"id": view_id, "name": name.strip(), "filters": cls._validated_filters(item.get("filters"))}
+            )
+        return validated
 
     @monitor(feature=Feature.DASHBOARD, endpoint="dashboard", method="POST")
     def create(self, validated_data: dict, *args: Any, **kwargs: Any) -> Dashboard:
@@ -1814,6 +1854,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
         validated_data.pop("use_template", None)  # Remove attribute if present
         grid_spacing = validated_data.pop("grid_spacing", None)
         layout_compaction = validated_data.pop("layout_compaction", None)
+        filter_views = self.initial_data.get("filter_views")
         if grid_spacing is not None and not dashboard_customization_enabled(
             team=instance.team, user=cast(User, self.context["request"].user)
         ):
@@ -1822,11 +1863,16 @@ class DashboardSerializer(DashboardMetadataSerializer):
             team=instance.team, user=cast(User, self.context["request"].user)
         ):
             raise serializers.ValidationError({"layout_compaction": "Tile movement settings aren't available."})
-        if grid_spacing is not None or layout_compaction is not None:
+        if filter_views is not None:
+            if not dashboard_filter_saved_views_enabled(team=instance.team):
+                raise serializers.ValidationError({"filter_views": "Dashboard filter views aren't available."})
+            filter_views = self._validated_filter_views(filter_views)
+        if grid_spacing is not None or layout_compaction is not None or filter_views is not None:
             validated_data["customization"] = {
                 **_normalize_dashboard_customization(instance.customization),
                 **({"tile_spacing": grid_spacing} if grid_spacing is not None else {}),
                 **({"layout_compaction": layout_compaction} if layout_compaction is not None else {}),
+                **({"filter_views": filter_views} if filter_views is not None else {}),
             }
 
         being_undeleted = instance.deleted and "deleted" in validated_data and not validated_data["deleted"]

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -186,6 +186,17 @@ def _effective_layout_compaction(customization: Any) -> str:
     return layout_compaction if layout_compaction in DASHBOARD_GRID_COMPACTION_MODES else "vertical"
 
 
+def _filter_view_analytics_properties(filters: dict[str, Any]) -> dict[str, bool | int]:
+    properties = filters.get("properties")
+    return {
+        "has_date_filter": bool(filters.get("date_from") or filters.get("date_to")),
+        "property_filter_count": len(properties) if isinstance(properties, list) else 0,
+        "has_breakdown_filter": bool(filters.get("breakdown_filter")),
+        "has_interval_filter": bool(filters.get("interval")),
+        "has_test_account_filter": filters.get("filterTestAccounts") is not None,
+    }
+
+
 logger = structlog.get_logger(__name__)
 
 DASHBOARD_TILE_ERROR_TYPE = "DashboardTileError"
@@ -1855,6 +1866,12 @@ class DashboardSerializer(DashboardMetadataSerializer):
         grid_spacing = validated_data.pop("grid_spacing", None)
         layout_compaction = validated_data.pop("layout_compaction", None)
         filter_views = self.initial_data.get("filter_views")
+        previous_filter_view_ids = {
+            str(view.get("id"))
+            for view in _normalize_dashboard_customization(instance.customization).get("filter_views", [])
+            if isinstance(view, dict)
+        }
+        created_filter_views: list[dict[str, Any]] = []
         if grid_spacing is not None and not dashboard_customization_enabled(
             team=instance.team, user=cast(User, self.context["request"].user)
         ):
@@ -1867,6 +1884,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
             if not dashboard_filter_saved_views_enabled(team=instance.team):
                 raise serializers.ValidationError({"filter_views": "Dashboard filter views aren't available."})
             filter_views = self._validated_filter_views(filter_views)
+            created_filter_views = [view for view in filter_views if view["id"] not in previous_filter_view_ids]
         if grid_spacing is not None or layout_compaction is not None or filter_views is not None:
             validated_data["customization"] = {
                 **_normalize_dashboard_customization(instance.customization),
@@ -1943,6 +1961,18 @@ class DashboardSerializer(DashboardMetadataSerializer):
                 self._deep_duplicate_tiles(instance, existing_tile, user_access_control)
 
         if "request" in self.context:
+            for created_filter_view in created_filter_views:
+                report_user_action(
+                    user,
+                    "dashboard filter view created",
+                    {
+                        "dashboard_id": instance.id,
+                        "saved_view_count": len(filter_views),
+                        **_filter_view_analytics_properties(created_filter_view["filters"]),
+                    },
+                    team=instance.team,
+                    request=self.context["request"],
+                )
             if layout_compaction is not None and layout_compaction != previous_layout_compaction:
                 report_user_action(
                     user,

--- a/products/dashboards/backend/feature_flags.py
+++ b/products/dashboards/backend/feature_flags.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 DASHBOARD_WIDGETS_FLAG = "dashboard-widgets"
 DASHBOARD_CUSTOMIZATION_FLAG = "dashboard-customization"
 DASHBOARD_SAVED_VIEWS_FLAG = "dashboard-saved-views"
+DASHBOARD_FILTER_SAVED_VIEWS_FLAG = "dashboard-filter-saved-views"
 
 
 def widget_flag_enabled(flag: str, *, team: Team, user: User | None = None) -> bool:
@@ -46,3 +47,7 @@ def dashboard_customization_enabled(*, team: Team, user: User | None = None) -> 
 
 def dashboard_saved_views_enabled(*, team: Team) -> bool:
     return widget_flag_enabled(DASHBOARD_SAVED_VIEWS_FLAG, team=team)
+
+
+def dashboard_filter_saved_views_enabled(*, team: Team) -> bool:
+    return widget_flag_enabled(DASHBOARD_FILTER_SAVED_VIEWS_FLAG, team=team)

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -452,6 +452,8 @@ export const LayoutCompactionEnumApi = {
     Stable: 'stable',
 } as const
 
+export type DashboardCustomizationApiFilterViewsItem = { [key: string]: unknown }
+
 export interface DashboardCustomizationApi {
     /** Named tile density preset.
      *
@@ -467,6 +469,8 @@ export interface DashboardCustomizationApi {
      * * `horizontal` - horizontal
      * * `stable` - stable */
     layout_compaction?: LayoutCompactionEnumApi
+    /** Named dashboard filter sets available to dashboard viewers. */
+    filter_views?: DashboardCustomizationApiFilterViewsItem[]
 }
 
 /**

--- a/products/dashboards/frontend/saved-views/DashboardSavedViews.tsx
+++ b/products/dashboards/frontend/saved-views/DashboardSavedViews.tsx
@@ -127,6 +127,7 @@ export function DashboardSavedViews(): JSX.Element | null {
     } = useValues(savedViewsLogic)
     const {
         loadSavedViews,
+        ensureSavedViewsLoaded,
         loadMoreSavedViews,
         loadMoreSavedViewsSuccess,
         savedViewCreated,
@@ -418,6 +419,7 @@ export function DashboardSavedViews(): JSX.Element | null {
             }}
             onManageViews={manageSavedViews}
             onLoadMore={loadMoreSavedViews}
+            onOpen={ensureSavedViewsLoaded}
             onRetryLoad={loadSavedViews}
         />
     )

--- a/products/dashboards/frontend/saved-views/SavedDashboardViewsPicker.stories.tsx
+++ b/products/dashboards/frontend/saved-views/SavedDashboardViewsPicker.stories.tsx
@@ -94,6 +94,7 @@ export const Default: Story = {
         onSelectView: () => undefined,
         onManageViews: () => undefined,
         onLoadMore: () => undefined,
+        onOpen: () => undefined,
         onRetryLoad: () => undefined,
     },
 }
@@ -140,6 +141,7 @@ export const UnsavedChanges: Story = {
         onSelectView: () => undefined,
         onManageViews: () => undefined,
         onLoadMore: () => undefined,
+        onOpen: () => undefined,
         onRetryLoad: () => undefined,
     },
 }
@@ -163,6 +165,7 @@ export const ReadOnly: Story = {
         onSelectView: () => undefined,
         onManageViews: () => undefined,
         onLoadMore: () => undefined,
+        onOpen: () => undefined,
         onRetryLoad: () => undefined,
     },
 }

--- a/products/dashboards/frontend/saved-views/SavedDashboardViewsPicker.tsx
+++ b/products/dashboards/frontend/saved-views/SavedDashboardViewsPicker.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { IconCheck, IconChevronDown, IconPeople, IconPlus, IconUser } from '@posthog/icons'
 import { LemonButton, LemonSkeleton, Popover } from '@posthog/lemon-ui'
 
+import { SavedViewsList } from 'lib/components/SavedViews/SavedViewsList'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 
 import type {
@@ -172,33 +173,15 @@ export function SavedDashboardViewsPicker({
                                 ]}
                             />
                             <div className="max-h-64 overflow-y-auto">
-                                {selectedSavedViews.length === 0 ? (
-                                    <div className="px-3 py-3 text-sm text-secondary">{emptyScopeMessage}</div>
-                                ) : (
-                                    selectedSavedViews.map((view) => (
-                                        <LemonButton
-                                            key={view.id}
-                                            fullWidth
-                                            size="small"
-                                            type="tertiary"
-                                            className="justify-start rounded-none px-3 hover:!bg-fill-secondary"
-                                            sideIcon={
-                                                activeSavedView?.id === view.id ? (
-                                                    <IconCheck className="text-success" />
-                                                ) : null
-                                            }
-                                            onClick={() => {
-                                                onSelectView(view)
-                                                closePicker()
-                                            }}
-                                            tooltip={
-                                                activeSavedView?.id === view.id ? 'Clear selected view' : undefined
-                                            }
-                                        >
-                                            <span className="truncate">{view.name}</span>
-                                        </LemonButton>
-                                    ))
-                                )}
+                                <SavedViewsList
+                                    views={selectedSavedViews}
+                                    activeViewId={activeSavedView?.id}
+                                    emptyMessage={emptyScopeMessage}
+                                    onSelect={(view) => {
+                                        onSelectView(view)
+                                        closePicker()
+                                    }}
+                                />
                                 {hasMore && (
                                     <div className="border-t p-2">
                                         <LemonButton

--- a/products/dashboards/frontend/saved-views/SavedDashboardViewsPicker.tsx
+++ b/products/dashboards/frontend/saved-views/SavedDashboardViewsPicker.tsx
@@ -30,6 +30,7 @@ export interface SavedDashboardViewsPickerProps {
     onSelectView: (view: DashboardListSavedView) => void
     onManageViews: () => void
     onLoadMore: (scope: DashboardSavedViewScope) => void
+    onOpen: () => void
     onRetryLoad: () => void
 }
 
@@ -51,6 +52,7 @@ export function SavedDashboardViewsPicker({
     onSelectView,
     onManageViews,
     onLoadMore,
+    onOpen,
     onRetryLoad,
 }: SavedDashboardViewsPickerProps): JSX.Element {
     const [scope, setScope] = useState<DashboardSavedViewScope>(activeSavedView?.scope ?? 'private')
@@ -230,6 +232,9 @@ export function SavedDashboardViewsPicker({
                 onClick={() => {
                     if (!visible && activeSavedView) {
                         setScope(activeSavedView.scope ?? 'team')
+                    }
+                    if (!visible) {
+                        onOpen()
                     }
                     setVisible(!visible)
                 }}

--- a/products/dashboards/frontend/saved-views/dashboardSavedViewsLogic.test.ts
+++ b/products/dashboards/frontend/saved-views/dashboardSavedViewsLogic.test.ts
@@ -60,6 +60,7 @@ describe('dashboardSavedViewsLogic', () => {
 
         const logic = dashboardSavedViewsLogic({ teamId: 1 })
         logic.mount()
+        logic.actions.ensureSavedViewsLoaded()
 
         await expectLogic(logic)
             .toFinishAllListeners()
@@ -94,7 +95,7 @@ describe('dashboardSavedViewsLogic', () => {
         logic.unmount()
     })
 
-    it('loads saved views when the feature flag becomes enabled', async () => {
+    it('does not load saved views until the picker opens', async () => {
         featureFlagLogic.actions.setFeatureFlags([], {})
         dashboardSavedViewsList.mockImplementation(async () => page([], null))
         const logic = dashboardSavedViewsLogic({ teamId: 1 })
@@ -103,6 +104,26 @@ describe('dashboardSavedViewsLogic', () => {
         featureFlagLogic.actions.setFeatureFlags([], { [FEATURE_FLAGS.DASHBOARD_SAVED_VIEWS]: true })
 
         await expectLogic(logic).toFinishAllListeners().toMatchValues({ dashboardSavedViewsEnabled: true })
+        expect(dashboardSavedViewsList).not.toHaveBeenCalled()
+
+        logic.actions.ensureSavedViewsLoaded()
+
+        await expectLogic(logic).toFinishAllListeners().toMatchValues({ savedViewsLoaded: true })
+        expect(dashboardSavedViewsList).toHaveBeenCalledTimes(2)
+
+        logic.unmount()
+    })
+
+    it('does not reload saved views when the picker opens again', async () => {
+        dashboardSavedViewsList.mockImplementation(async () => page([], null))
+        const logic = dashboardSavedViewsLogic({ teamId: 1 })
+        logic.mount()
+
+        logic.actions.ensureSavedViewsLoaded()
+        await expectLogic(logic).toFinishAllListeners().toMatchValues({ savedViewsLoaded: true })
+        logic.actions.ensureSavedViewsLoaded()
+        await expectLogic(logic).toFinishAllListeners()
+
         expect(dashboardSavedViewsList).toHaveBeenCalledTimes(2)
 
         logic.unmount()
@@ -133,6 +154,7 @@ describe('dashboardSavedViewsLogic', () => {
         })
         const logic = dashboardSavedViewsLogic({ teamId: 1 })
         logic.mount()
+        logic.actions.ensureSavedViewsLoaded()
         await expectLogic(logic).toFinishAllListeners()
 
         logic.actions.loadMoreSavedViewsFailure('Could not load more saved views', new ApiError(undefined, 403))
@@ -151,6 +173,7 @@ describe('dashboardSavedViewsLogic', () => {
         dashboardSavedViewsList.mockImplementation(async () => page([], null))
         const logic = dashboardSavedViewsLogic({ teamId: 1 })
         logic.mount()
+        logic.actions.ensureSavedViewsLoaded()
         await expectLogic(logic).toFinishAllListeners()
         dashboardsLogic.actions.setFilters({ pinned: true, tags: ['product'] })
         logic.actions.setActiveSavedViewId('private-1')
@@ -174,6 +197,7 @@ describe('dashboardSavedViewsLogic', () => {
         dashboardsLogic.actions.setFilters({ pinned: true })
         const logic = dashboardSavedViewsLogic({ teamId: 1 })
         logic.mount()
+        logic.actions.ensureSavedViewsLoaded()
 
         await expectLogic(logic).toFinishAllListeners().toMatchValues({ activeSavedViewId: 'private-1' })
 

--- a/products/dashboards/frontend/saved-views/dashboardSavedViewsLogic.ts
+++ b/products/dashboards/frontend/saved-views/dashboardSavedViewsLogic.ts
@@ -1,5 +1,5 @@
 import { deepEqual as isEqual } from 'fast-equals'
-import { MakeLogicType, actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { MakeLogicType, actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import posthog from 'posthog-js'
 
 import { ApiError } from 'lib/api-error'
@@ -47,6 +47,7 @@ export interface dashboardSavedViewsLogicValues {
     savedViewsAvailable: boolean
     savedViewsLoadError: boolean
     savedViewsLoadMoreFailed: boolean
+    savedViewsLoaded: boolean
     savedViewsLoading: boolean
     savedViewsNextCursors: DashboardSavedViewCursors
 }
@@ -69,6 +70,9 @@ export interface dashboardSavedViewsLogicActions {
         flags: string[]
         variants: Record<string, boolean | string>
     } // featureFlagLogic
+    ensureSavedViewsLoaded: () => {
+        value: true
+    }
     loadMoreSavedViews: (scope: DashboardSavedViewScope) => {
         scope: DashboardSavedViewScope
     }
@@ -166,6 +170,7 @@ export const dashboardSavedViewsLogic = kea<dashboardSavedViewsLogicType>([
         actions: [featureFlagLogic, ['setFeatureFlags'], dashboardsLogic, ['setCurrentTab', 'setFilters', 'setSearch']],
     })),
     actions({
+        ensureSavedViewsLoaded: true,
         loadSavedViews: true,
         loadSavedViewsSuccess: (pages: DashboardSavedViewsPage[]) => ({ pages }),
         loadSavedViewsFailure: (message: string, errorObject: unknown) => ({ message, errorObject }),
@@ -220,6 +225,12 @@ export const dashboardSavedViewsLogic = kea<dashboardSavedViewsLogicType>([
                 loadSavedViewsSuccess: () => false,
             },
         ],
+        savedViewsLoaded: [
+            false,
+            {
+                loadSavedViewsSuccess: () => true,
+            },
+        ],
         savedViewsLoadMoreFailed: [
             false,
             {
@@ -264,6 +275,11 @@ export const dashboardSavedViewsLogic = kea<dashboardSavedViewsLogicType>([
         ],
     })),
     listeners(({ actions, props, values }) => ({
+        ensureSavedViewsLoaded: () => {
+            if (!values.savedViewsLoaded && !values.savedViewsLoading) {
+                actions.loadSavedViews()
+            }
+        },
         loadSavedViewsSuccess: ({ pages }) => {
             const views = pages.flatMap((page) => page.views)
             if (values.activeSavedViewId && views.some((view) => view.id === values.activeSavedViewId)) {
@@ -284,12 +300,11 @@ export const dashboardSavedViewsLogic = kea<dashboardSavedViewsLogicType>([
             }
         },
         setFeatureFlags: () => {
-            if (values.dashboardSavedViewsEnabled && !values.savedViewsLoading) {
+            if (values.dashboardSavedViewsEnabled) {
                 if (values.currentTab === DashboardsTab.Pinned) {
                     actions.setCurrentTab(DashboardsTab.All)
                     actions.setFilters({ pinned: true })
                 }
-                actions.loadSavedViews()
             }
         },
         loadSavedViews: async (_, breakpoint) => {
@@ -334,9 +349,4 @@ export const dashboardSavedViewsLogic = kea<dashboardSavedViewsLogicType>([
             }
         },
     })),
-    afterMount(({ actions, values }) => {
-        if (values.dashboardSavedViewsEnabled) {
-            actions.loadSavedViews()
-        }
-    }),
 ])

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -20615,6 +20615,8 @@ export namespace Schemas {
       Stable: 'stable',
     } as const;
 
+    export type DashboardCustomizationFilterViewsItem = { [key: string]: unknown };
+
     export interface DashboardCustomization {
       /** Named tile density preset.
        *
@@ -20630,6 +20632,8 @@ export namespace Schemas {
        * * `horizontal` - horizontal
        * * `stable` - stable */
       layout_compaction?: LayoutCompactionEnum;
+      /** Named dashboard filter sets available to dashboard viewers. */
+      filter_views?: DashboardCustomizationFilterViewsItem[];
     }
 
     /**


### PR DESCRIPTION
## Problem

- Dashboard viewers rebuild the same filter combinations when they switch between common views.
- **Why:** Named views make repeated dashboard analysis faster and make filtered links easier to share.

## Changes

- Dashboard viewers can switch between named filter views from the filter bar.
- Dashboard editors can save and delete up to 20 shared views.
- Selected views use URL filters. The dashboard default remains unchanged.
- Analytics track successful view creation and view application without filter names or values.
- A reusable saved-view list now serves dashboard lists and dashboard filter views.
- The `dashboard-filter-saved-views` flag gates the UI and API mutations by organization.

```mermaid
flowchart LR
    A[Set filters] --> B[Use dashboard]
    B --> C[Rebuild filters later]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,C phYellow;
    class B phBlue;
```

```mermaid
flowchart LR
    A[Set filters] --> B[Save named view]
    B --> C[Select view later]
    C --> D[Share filtered URL]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,D phYellow;
    class B,C phBlue;
```

- Storybook covers empty, populated, active, and viewer-only saved-view states.

## How did you test this code?

- Storybook covers flag-on empty, populated, active, and viewer-only states.
- Frontend tests apply date, interval, property, breakdown, and test-account filters.
- Frontend tests preserve unrelated URL state and clear an active view safely.
- Saved-view logic tests confirm page load sends no saved-view request.
- Saved-view logic tests confirm the first open loads once and later opens reuse the result.
- Backend tests preserve the complete saved filter payload.
- Analytics tests cover creation and application metadata without filter values.
- Focused frontend and backend suites pass.
- CI preflight passes and regenerates the affected API types.
- The full frontend type check reached the environment memory limit after workspace dependencies built.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- The managing-dashboard skill now defines saved filter-view state, access, placement, and rollout rules.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex implemented the user-directed feature.
- Skills used: /managing-dashboards, /instrument-feature-flags, /instrument-product-analytics, /writing-ui-components, /writing-kea-logics, /writing-tests, /writing-user-facing-copy, and /writing-pr-descriptions.
- The design stores a small ordered list in dashboard customization instead of private or team-scoped resources.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*


