### PR TITLE
feat(desktop): add Dev Cloud region

### DIFF
--- a/products/desktop/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.test.ts
+++ b/products/desktop/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.test.ts
@@ -41,23 +41,23 @@ vi.mock("@posthog/agent/pi/rpc-client", () => ({
 }));
 
 describe("DesktopPiRpcClientFactory", () => {
-  it("routes Pi through the shared host auth proxy", async () => {
+  it("routes Dev Cloud Pi sessions through the hosted development gateway", async () => {
     const auth = {
       getOAuthCredentials: vi.fn(async () => ({
         access: "access-token",
         refresh: "refresh-token",
         expires: 1,
-        region: "eu" as const,
+        region: "dev-cloud" as const,
       })),
       getState: vi.fn(() => ({ currentProjectId: 1 })),
       getValidAccessToken: vi.fn(async () => ({
         accessToken: "access-token",
-        apiHost: "https://eu.posthog.com",
+        apiHost: "https://app.dev.posthog.dev",
       })),
     } as unknown as AgentAuth;
     const authProxy = {
       start: vi.fn(async (url: string) =>
-        url === "https://eu.posthog.com"
+        url === "https://app.dev.posthog.dev"
           ? "http://127.0.0.1:5678"
           : "http://127.0.0.1:1234",
       ),
@@ -112,19 +112,19 @@ describe("DesktopPiRpcClientFactory", () => {
       }),
     ).resolves.toBe(client);
     expect(authProxy.start).toHaveBeenCalledWith(
-      getLlmGatewayUrl(getCloudUrlFromRegion("eu")),
+      getLlmGatewayUrl(getCloudUrlFromRegion("dev-cloud")),
       {
         "x-posthog-property-task_id": "task-1",
         "x-posthog-property-$ai_session_id": "task-1",
         "X-PostHog-Project-Id": "1",
       },
     );
-    expect(authProxy.start).toHaveBeenCalledWith("https://eu.posthog.com");
+    expect(authProxy.start).toHaveBeenCalledWith("https://app.dev.posthog.dev");
     expect(createLocalRuntimeMcpServers).toHaveBeenCalledWith("/workspace");
     expect(createPiRpcClient).toHaveBeenCalledWith({
       enrichment: {
         apiUrl: "http://127.0.0.1:5678",
-        publicApiUrl: "https://eu.posthog.com",
+        publicApiUrl: "https://app.dev.posthog.dev",
         projectId: 1,
         apiKey: "posthog-code-auth-proxy",
       },
@@ -150,7 +150,7 @@ describe("DesktopPiRpcClientFactory", () => {
       },
       taskContext: {
         projectId: 1,
-        apiHost: "https://eu.posthog.com",
+        apiHost: "https://app.dev.posthog.dev",
         taskId: "task-1",
         cwd: "/workspace",
         environment: "local",
@@ -159,7 +159,7 @@ describe("DesktopPiRpcClientFactory", () => {
         channelMode: true,
       },
       providerOptions: {
-        region: "eu",
+        region: "dev-cloud",
         baseUrl: "http://127.0.0.1:1234",
         apiKey: "posthog-code-auth-proxy",
       },

--- a/products/desktop/apps/web/src/web-host-router.ts
+++ b/products/desktop/apps/web/src/web-host-router.ts
@@ -14,6 +14,7 @@ import { cloudTaskRouter } from "@posthog/host-router/routers/cloud-task.router"
 import { dashboardsRouter } from "@posthog/host-router/routers/dashboards.router";
 import { publicProcedure, router } from "@posthog/host-trpc/trpc";
 import {
+  CLOUD_REGIONS,
   type CloudRegion,
   getCloudUrlFromRegion,
   tabsSnapshotSchema,
@@ -140,9 +141,7 @@ const agentStubRouter = router({
   // Called by resetSessionService() on logout/project switch.
   resetAll: publicProcedure.mutation(() => undefined),
   getPiModelCatalog: publicProcedure
-    .input(
-      z.object({ apiHost: z.string(), region: z.enum(["us", "eu", "dev"]) }),
-    )
+    .input(z.object({ apiHost: z.string(), region: z.enum(CLOUD_REGIONS) }))
     .query(async ({ input }) => {
       const auth = resolveService<AuthService>(AUTH_SERVICE);
       const { accessToken } = await auth.getValidAccessToken();

--- a/products/desktop/docs/LOCAL-DEVELOPMENT.md
+++ b/products/desktop/docs/LOCAL-DEVELOPMENT.md
@@ -1,18 +1,28 @@
-# Connecting the Desktop App to a Local PostHog Instance
+# Connect PostHog Desktop to a development environment
 
-This guide walks you through running the desktop app's dev build against a local PostHog instance (localhost:8010).
+Development builds can connect to a local PostHog instance or the hosted Dev Cloud deployment.
+
+| Choice | PostHog host | Use it for |
+| --- | --- | --- |
+| Local development | `http://localhost:8010` | Local backend changes and local test data |
+| Dev Cloud | `https://app.dev.posthog.dev` | Code deployed to the shared development environment |
+
+Production builds show only US Cloud and EU Cloud. The two development choices appear only in development builds. `VITE_POSTHOG_API_HOST` does not select the data backend. It controls the separate analytics and feature flag client.
 
 ## Prerequisites
 
-- A running local PostHog instance at `http://localhost:8010` ([PostHog local development docs](https://posthog.com/handbook/engineering/developing-locally))
+- For Local development, a running PostHog instance at `http://localhost:8010` ([PostHog local development docs](https://posthog.com/handbook/engineering/developing-locally))
+- For Dev Cloud, access to `https://app.dev.posthog.dev`
 - Node.js 22+
 - pnpm 10+
 
-## 1. Set up the OAuth application in PostHog
+## Local development setup
+
+### 1. Set up the OAuth application in PostHog
 
 The desktop app authenticates with PostHog via OAuth. Your local PostHog instance needs an OAuth application registered for the app to connect to it.
 
-### Option A: Generate demo data (easiest)
+#### Option A: Generate demo data
 
 PostHog's demo data generator creates a pre-configured OAuth application with the correct client ID:
 
@@ -25,22 +35,22 @@ This creates an OAuth application with:
 - **Client ID**: `DC5uRLVbGI02YQ82grxgnK6Qn12SXWpCqdPb60oZ`
 - **Redirect URIs**: includes `http://localhost:8237/callback` and `http://localhost:8239/callback`
 
-### Option B: Create the OAuth application manually via Django admin
+#### Option B: Create the OAuth application manually via Django admin
 
 1. Go to http://localhost:8010/admin/posthog/oauthapplication/
 2. Click **Add OAuth Application**
 3. Set these fields:
    - **Name**: `PostHog Desktop` (or whatever you like)
-   - **Client ID**: `DC5uRLVbGI02YQ82grxgnK6Qn12SXWpCqdPb60oZ` — this must match the `POSTHOG_DEV_CLIENT_ID` in the app's source
+   - **Client ID**: `DC5uRLVbGI02YQ82grxgnK6Qn12SXWpCqdPb60oZ`. This must match `POSTHOG_DEV_CLIENT_ID` in the app source.
    - **Client type**: `Public` (the app is an Electron desktop app)
    - **Authorization grant type**: `Authorization code`
    - **Redirect URIs**: `http://localhost:8237/callback http://localhost:8239/callback`
    - **Algorithm**: `RS256`
 4. Save
 
-> **Important**: The Client ID must be exactly `DC5uRLVbGI02YQ82grxgnK6Qn12SXWpCqdPb60oZ` — this is hardcoded in the app as the Dev region client ID (see `apps/code/src/shared/constants/oauth.ts`).
+> **Important**: The client ID must be exactly `DC5uRLVbGI02YQ82grxgnK6Qn12SXWpCqdPb60oZ`. The value is defined in `packages/shared/src/oauth.ts`.
 
-## 2. Configure RSA keys in PostHog
+### 2. Configure RSA keys in PostHog
 
 OAuth token signing requires an RSA private key. In your PostHog repo:
 
@@ -58,7 +68,7 @@ openssl genrsa 2048 | openssl pkcs8 -topk8 -nocrypt -outform PEM | \
 # Add to your PostHog .env as OIDC_RSA_PRIVATE_KEY="<generated_key>"
 ```
 
-## 3. Clone and run the app
+## Run the app
 
 Already working in the posthog/posthog monorepo? Skip the clone: the app lives at `products/desktop`. Note it needs Node 22 (see `.node-version`), not the Node version the monorepo's flox environment provides, so switch with your version manager first.
 
@@ -79,20 +89,21 @@ cp .env.example .env
 pnpm dev
 ```
 
-## 4. Connect to your local instance
+## Connect
 
-1. When the app opens, select the **Dev** region on the login screen (in addition to US & EU, the dev build shows a Dev option that points to `localhost:8010`)
-2. This will redirect you to your local PostHog instance for OAuth authorization
+1. Select **Local development** for `localhost:8010`, or select **Dev Cloud** for `app.dev.posthog.dev`.
+2. Desktop opens the selected PostHog host for OAuth authorization.
 3. Authorize the application and select the project/organization access level
-4. You'll be redirected back to the app, now connected to your local PostHog
+4. PostHog redirects to Desktop on its existing localhost callback port.
 
 ## How it works
 
-The dev build includes a "Dev" cloud region that maps to:
-- **API URL**: `http://localhost:8010`
-- **OAuth Client ID**: `DC5uRLVbGI02YQ82grxgnK6Qn12SXWpCqdPb60oZ`
+The development build has two separate region values:
 
-This is defined in `apps/code/src/shared/constants/oauth.ts`. The Dev region only appears when running the dev build (`pnpm dev`), not in production releases.
+- `dev` remains Local development at `http://localhost:8010` and uses its existing OAuth client ID.
+- `dev-cloud` connects to `https://app.dev.posthog.dev` and uses its dedicated OAuth client ID.
+
+Keeping both values preserves stored Local development sessions. Dev Cloud agent requests use `https://gateway.dev.posthog.dev`.
 
 ## Dev console commands
 
@@ -127,8 +138,8 @@ pnpm dev
 `node scripts/use-local-posthog.mjs` auto-reads the project API key from the
 surrounding monorepo checkout (or pass it:
 `node scripts/use-local-posthog.mjs phc_xxx`, or set `POSTHOG_DIR`). This
-only affects the analytics/flags client — the data API still uses the **Dev**
-region you pick at login.
+only affects the analytics/flags client. The data API still uses the **Local development**
+choice you pick at login.
 
 > One-off override without changing `.env`: the dev build exposes the client on
 > `window.posthog`, so you can run

--- a/products/desktop/packages/agent/src/pi/rpc-client.ts
+++ b/products/desktop/packages/agent/src/pi/rpc-client.ts
@@ -11,6 +11,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import type { McpConfig } from "@posthog/harness/extensions/mcp/config";
 import type {
+  CloudRegion,
   McpServerConnection,
   McpToolPermissionDecision,
   McpToolPermissionRequest,
@@ -49,7 +50,7 @@ export type PiRpcClient = RpcClient & {
 };
 
 export interface PiRpcProviderOptions {
-  region?: "us" | "eu" | "dev";
+  region?: CloudRegion;
   apiKey: string;
   baseUrl?: string;
   headers?: Record<string, string>;

--- a/products/desktop/packages/core/src/auth/auth.test.ts
+++ b/products/desktop/packages/core/src/auth/auth.test.ts
@@ -1,6 +1,10 @@
 import type { RootLogger } from "@posthog/di/logger";
 import type { IPowerManager } from "@posthog/platform/power-manager";
-import { NotAuthenticatedError, OAUTH_SCOPE_VERSION } from "@posthog/shared";
+import {
+  type CloudRegion,
+  NotAuthenticatedError,
+  OAUTH_SCOPE_VERSION,
+} from "@posthog/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthService } from "./auth";
 import type {
@@ -130,13 +134,14 @@ describe("AuthService", () => {
   function seedStoredSession(
     overrides: {
       refreshToken?: string;
+      cloudRegion?: CloudRegion;
       selectedProjectId?: number | null;
       scopeVersion?: number;
     } = {},
   ) {
     sessionPort.saveCurrent({
       refreshTokenEncrypted: overrides.refreshToken ?? "stored-refresh-token",
-      cloudRegion: "us",
+      cloudRegion: overrides.cloudRegion ?? "us",
       selectedProjectId: overrides.selectedProjectId ?? null,
       scopeVersion: overrides.scopeVersion ?? OAUTH_SCOPE_VERSION,
     });
@@ -471,51 +476,59 @@ describe("AuthService", () => {
     });
   });
 
-  it("restores an authenticated session by refreshing the stored refresh token", async () => {
-    seedStoredSession({ selectedProjectId: 42 });
-    oauthFlow.refreshToken.mockResolvedValue(
-      mockTokenResponse({
-        accessToken: "new-access-token",
-        refreshToken: "rotated-refresh-token",
-      }),
-    );
-    stubAuthFetch({
-      orgs: {
-        "org-1": {
-          name: "Org 1",
-          projects: [
-            { id: 42, name: "Project 42" },
-            { id: 84, name: "Project 84" },
-          ],
+  it.each(["us", "dev", "dev-cloud"] as const)(
+    "restores an authenticated stored %s session",
+    async (cloudRegion) => {
+      seedStoredSession({ cloudRegion, selectedProjectId: 42 });
+      oauthFlow.refreshToken.mockResolvedValue(
+        mockTokenResponse({
+          accessToken: "new-access-token",
+          refreshToken: "rotated-refresh-token",
+        }),
+      );
+      stubAuthFetch({
+        orgs: {
+          "org-1": {
+            name: "Org 1",
+            projects: [
+              { id: 42, name: "Project 42" },
+              { id: 84, name: "Project 84" },
+            ],
+          },
         },
-      },
-    });
+      });
 
-    await service.initialize();
+      await service.initialize();
 
-    expect(service.getState()).toMatchObject({
-      status: "authenticated",
-      bootstrapComplete: true,
-      cloudRegion: "us",
-      orgProjectsMap: {
-        "org-1": {
-          orgName: "Org 1",
-          projects: [
-            { id: 42, name: "Project 42" },
-            { id: 84, name: "Project 84" },
-          ],
+      expect(service.getState()).toMatchObject({
+        status: "authenticated",
+        bootstrapComplete: true,
+        cloudRegion,
+        orgProjectsMap: {
+          "org-1": {
+            orgName: "Org 1",
+            projects: [
+              { id: 42, name: "Project 42" },
+              { id: 84, name: "Project 84" },
+            ],
+          },
         },
-      },
-      currentOrgId: "org-1",
-      currentProjectId: 42,
-      desktopAccess: { projectId: 42, status: "allowed", reason: null },
-      needsScopeReauth: false,
-    });
+        currentOrgId: "org-1",
+        currentProjectId: 42,
+        desktopAccess: { projectId: 42, status: "allowed", reason: null },
+        needsScopeReauth: false,
+      });
 
-    expect(sessionPort.getCurrent()?.refreshTokenEncrypted).toBe(
-      "rotated-refresh-token",
-    );
-  });
+      expect(oauthFlow.refreshToken).toHaveBeenCalledWith(
+        "stored-refresh-token",
+        cloudRegion,
+      );
+      expect(sessionPort.getCurrent()).toMatchObject({
+        refreshTokenEncrypted: "rotated-refresh-token",
+        cloudRegion,
+      });
+    },
+  );
 
   it("keeps the existing refresh token when the server does not rotate it", async () => {
     seedStoredSession({ refreshToken: "existing-refresh-token" });

--- a/products/desktop/packages/core/src/auth/oauth.schemas.test.ts
+++ b/products/desktop/packages/core/src/auth/oauth.schemas.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { cloudRegion } from "./oauth.schemas";
+
+describe("cloudRegion", () => {
+  it.each(["dev", "dev-cloud"] as const)(
+    "accepts a serialized %s region",
+    (region) => {
+      const serialized = JSON.stringify(region);
+      expect(cloudRegion.parse(JSON.parse(serialized))).toBe(region);
+    },
+  );
+});

--- a/products/desktop/packages/core/src/auth/oauth.schemas.ts
+++ b/products/desktop/packages/core/src/auth/oauth.schemas.ts
@@ -1,6 +1,7 @@
+import { CLOUD_REGIONS } from "@posthog/shared";
 import { z } from "zod";
 
-export const cloudRegion = z.enum(["us", "eu", "dev"]);
+export const cloudRegion = z.enum(CLOUD_REGIONS);
 export type CloudRegion = z.infer<typeof cloudRegion>;
 
 /**

--- a/products/desktop/packages/core/src/integrations/schemas.ts
+++ b/products/desktop/packages/core/src/integrations/schemas.ts
@@ -1,6 +1,7 @@
+import { CLOUD_REGIONS } from "@posthog/shared";
 import { z } from "zod";
 
-export const cloudRegion = z.enum(["us", "eu", "dev"]);
+export const cloudRegion = z.enum(CLOUD_REGIONS);
 export type CloudRegion = z.infer<typeof cloudRegion>;
 
 export const startIntegrationFlowInput = z.object({

--- a/products/desktop/packages/harness/src/extensions/posthog-provider/gateway.test.ts
+++ b/products/desktop/packages/harness/src/extensions/posthog-provider/gateway.test.ts
@@ -12,6 +12,9 @@ describe("getGatewayBaseUrl", () => {
     expect(getGatewayBaseUrl("us")).toBe("https://gateway.us.posthog.com");
     expect(getGatewayBaseUrl("eu")).toBe("https://gateway.eu.posthog.com");
     expect(getGatewayBaseUrl("dev")).toBe("http://localhost:3308");
+    expect(getGatewayBaseUrl("dev-cloud")).toBe(
+      "https://gateway.dev.posthog.dev",
+    );
   });
 });
 
@@ -25,6 +28,9 @@ describe("getLlmGatewayUrl", () => {
     );
     expect(getLlmGatewayUrl("dev")).toBe(
       `http://localhost:3308/${GATEWAY_PRODUCT}`,
+    );
+    expect(getLlmGatewayUrl("dev-cloud")).toBe(
+      `https://gateway.dev.posthog.dev/${GATEWAY_PRODUCT}`,
     );
   });
 });
@@ -54,7 +60,7 @@ describe("resolveRegion", () => {
     expect(resolveRegion()).toBe("eu");
   });
 
-  it.each(["us", "eu", "dev"] as const)(
+  it.each(["us", "eu", "dev", "dev-cloud"] as const)(
     "accepts %s from the environment",
     (region) => {
       process.env.POSTHOG_REGION = region;

--- a/products/desktop/packages/harness/src/extensions/posthog-provider/gateway.ts
+++ b/products/desktop/packages/harness/src/extensions/posthog-provider/gateway.ts
@@ -6,6 +6,7 @@ const GATEWAY_HOSTS: Record<CloudRegion, string> = {
   us: "https://gateway.us.posthog.com",
   eu: "https://gateway.eu.posthog.com",
   dev: "http://localhost:3308",
+  "dev-cloud": "https://gateway.dev.posthog.dev",
 };
 
 export function getGatewayBaseUrl(region: CloudRegion): string {
@@ -25,7 +26,12 @@ export function resolveExplicitRegion(
   explicit?: CloudRegion,
 ): CloudRegion | undefined {
   const candidate = explicit ?? process.env.POSTHOG_REGION;
-  if (candidate === "us" || candidate === "eu" || candidate === "dev") {
+  if (
+    candidate === "us" ||
+    candidate === "eu" ||
+    candidate === "dev" ||
+    candidate === "dev-cloud"
+  ) {
     return candidate;
   }
   return undefined;

--- a/products/desktop/packages/harness/src/extensions/posthog-provider/oauth.test.ts
+++ b/products/desktop/packages/harness/src/extensions/posthog-provider/oauth.test.ts
@@ -120,7 +120,7 @@ describe("buildAuthorizeUrl", () => {
   });
 
   it("routes each region to its own cloud host", () => {
-    for (const region of ["us", "eu", "dev"] as const) {
+    for (const region of ["us", "eu", "dev", "dev-cloud"] as const) {
       const url = buildAuthorizeUrl(region, "c", getRedirectUri());
       expect(url.origin).toBe(new URL(getCloudUrlFromRegion(region)).origin);
       expect(url.searchParams.get("client_id")).toBe(

--- a/products/desktop/packages/harness/src/extensions/posthog-provider/oauth.ts
+++ b/products/desktop/packages/harness/src/extensions/posthog-provider/oauth.ts
@@ -187,8 +187,8 @@ const REGION_LOGIN_OPTIONS: { id: CloudRegion; label: string }[] = [
 
 /**
  * Prompts the user to pick their PostHog region via the login callbacks'
- * selector. `dev` is intentionally not offered here; it stays reachable only
- * through an explicit `POSTHOG_REGION=dev`.
+ * selector. Development regions are intentionally not offered here; they stay
+ * reachable only through an explicit `POSTHOG_REGION`.
  */
 async function selectRegion(
   callbacks: OAuthLoginCallbacks,

--- a/products/desktop/packages/harness/src/extensions/posthog-provider/provider.test.ts
+++ b/products/desktop/packages/harness/src/extensions/posthog-provider/provider.test.ts
@@ -1,4 +1,5 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
+import type { CloudRegion } from "@posthog/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getLlmGatewayUrl } from "./gateway";
 import {
@@ -255,7 +256,7 @@ describe("resolvePosthogProvider", () => {
 });
 
 describe("model classification", () => {
-  const byId = (region: "us" | "eu" | "dev") =>
+  const byId = (region: CloudRegion) =>
     new Map(fallbackModelConfigs(region).map((model) => [model.id, model]));
 
   it("routes Claude models through anthropic-messages on the product base", () => {

--- a/products/desktop/packages/shared/src/index.ts
+++ b/products/desktop/packages/shared/src/index.ts
@@ -274,6 +274,7 @@ export {
 } from "./reasoning-effort";
 export { REFUND_REASON_OPTIONS } from "./refund-reasons";
 export {
+  CLOUD_REGIONS,
   type CloudRegion,
   REGION_LABELS,
 } from "./regions";

--- a/products/desktop/packages/shared/src/oauth.ts
+++ b/products/desktop/packages/shared/src/oauth.ts
@@ -3,13 +3,15 @@ import type { CloudRegion } from "./regions";
 export const POSTHOG_US_CLIENT_ID = "HCWoE0aRFMYxIxFNTTwkOORn5LBjOt2GVDzwSw5W";
 export const POSTHOG_EU_CLIENT_ID = "AIvijgMS0dxKEmr5z6odvRd8Pkh5vts3nPTzgzU9";
 export const POSTHOG_DEV_CLIENT_ID = "DC5uRLVbGI02YQ82grxgnK6Qn12SXWpCqdPb60oZ";
+export const POSTHOG_DEV_CLOUD_CLIENT_ID =
+  "7D6O76iHBMAioX5bLy4smEJ7qehtanmBRYOAQoEw";
 
 // Explicit scopes instead of "*". Mirrors scopes_supported at
 // /.well-known/oauth-authorization-server (OAUTH_SCOPES_SUPPORTED in the API's
 // services/mcp/src/lib/oauth-scopes.generated.ts), plus privileged llm_gateway:read
 // which the advertised set excludes. The LLM gateway requires that scope; it is
-// granted only because this app's OAuth ceiling is seeded to
-// ["@default", "llm_gateway:read"] in US + EU.
+// granted only because each hosted Desktop OAuth app has a ceiling of
+// ["@default", "llm_gateway:read"].
 //
 // That generated file also exports OAUTH_SCOPES_HIDDEN (batch_import_support,
 // query_performance, wizard_session). Never copy those in: they are staff-only
@@ -18,7 +20,7 @@ export const POSTHOG_DEV_CLIENT_ID = "DC5uRLVbGI02YQ82grxgnK6Qn12SXWpCqdPb60oZ";
 //
 // Deploy-order guardrail: NEVER ship a non-"*" OAUTH_SCOPES set (or bump
 // OAUTH_SCOPE_VERSION off a build that still requests "*") until that ceiling is
-// seeded in both regions. A non-empty ceiling rejects scope=* at /authorize, and
+// seeded in every hosted region. A non-empty ceiling rejects scope=* at /authorize, and
 // an empty/unseeded ceiling rejects privileged llm_gateway:read. #3411 shipped
 // the explicit list bundled with loops without seeding; prod login broke and was
 // reverted in #3668. Keep this comment when regenerating the list.
@@ -252,5 +254,7 @@ export function getOauthClientIdFromRegion(region: CloudRegion): string {
       return POSTHOG_EU_CLIENT_ID;
     case "dev":
       return POSTHOG_DEV_CLIENT_ID;
+    case "dev-cloud":
+      return POSTHOG_DEV_CLOUD_CLIENT_ID;
   }
 }

--- a/products/desktop/packages/shared/src/regions.test.ts
+++ b/products/desktop/packages/shared/src/regions.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   getOauthClientIdFromRegion,
   POSTHOG_DEV_CLIENT_ID,
+  POSTHOG_DEV_CLOUD_CLIENT_ID,
   POSTHOG_EU_CLIENT_ID,
   POSTHOG_US_CLIENT_ID,
 } from "./oauth";
-import { formatRegionBadge, REGION_LABELS } from "./regions";
+import { CLOUD_REGIONS, formatRegionBadge, REGION_LABELS } from "./regions";
 import { getCloudUrlFromRegion } from "./urls";
 
 describe("getCloudUrlFromRegion", () => {
@@ -13,6 +14,9 @@ describe("getCloudUrlFromRegion", () => {
     expect(getCloudUrlFromRegion("us")).toBe("https://us.posthog.com");
     expect(getCloudUrlFromRegion("eu")).toBe("https://eu.posthog.com");
     expect(getCloudUrlFromRegion("dev")).toBe("http://localhost:8010");
+    expect(getCloudUrlFromRegion("dev-cloud")).toBe(
+      "https://app.dev.posthog.dev",
+    );
   });
 });
 
@@ -21,6 +25,9 @@ describe("getOauthClientIdFromRegion", () => {
     expect(getOauthClientIdFromRegion("us")).toBe(POSTHOG_US_CLIENT_ID);
     expect(getOauthClientIdFromRegion("eu")).toBe(POSTHOG_EU_CLIENT_ID);
     expect(getOauthClientIdFromRegion("dev")).toBe(POSTHOG_DEV_CLIENT_ID);
+    expect(getOauthClientIdFromRegion("dev-cloud")).toBe(
+      POSTHOG_DEV_CLOUD_CLIENT_ID,
+    );
   });
 
   it("uses a different client id per region", () => {
@@ -28,12 +35,24 @@ describe("getOauthClientIdFromRegion", () => {
       getOauthClientIdFromRegion("us"),
       getOauthClientIdFromRegion("eu"),
       getOauthClientIdFromRegion("dev"),
+      getOauthClientIdFromRegion("dev-cloud"),
     ]);
-    expect(ids.size).toBe(3);
+    expect(ids.size).toBe(CLOUD_REGIONS.length);
   });
 });
 
 describe("formatRegionBadge", () => {
+  it("labels the two development targets with their hosts", () => {
+    expect(REGION_LABELS.dev).toMatchObject({
+      label: "Local development",
+      hint: "localhost:8010",
+    });
+    expect(REGION_LABELS["dev-cloud"]).toMatchObject({
+      label: "Dev Cloud",
+      hint: "app.dev.posthog.dev",
+    });
+  });
+
   it("combines the flag and label for a region", () => {
     expect(formatRegionBadge("us")).toBe(
       `${REGION_LABELS.us.flag} ${REGION_LABELS.us.label}`,
@@ -41,7 +60,7 @@ describe("formatRegionBadge", () => {
   });
 
   it("formats every known region without throwing", () => {
-    for (const region of ["us", "eu", "dev"] as const) {
+    for (const region of CLOUD_REGIONS) {
       expect(formatRegionBadge(region)).toContain(REGION_LABELS[region].label);
     }
   });

--- a/products/desktop/packages/shared/src/regions.ts
+++ b/products/desktop/packages/shared/src/regions.ts
@@ -1,4 +1,5 @@
-export type CloudRegion = "us" | "eu" | "dev";
+export const CLOUD_REGIONS = ["us", "eu", "dev", "dev-cloud"] as const;
+export type CloudRegion = (typeof CLOUD_REGIONS)[number];
 
 interface RegionLabel {
   flag: string;
@@ -21,6 +22,11 @@ export const REGION_LABELS: Record<CloudRegion, RegionLabel> = {
     flag: "🛠️",
     label: "Local development",
     hint: "localhost:8010",
+  },
+  "dev-cloud": {
+    flag: "🧪",
+    label: "Dev Cloud",
+    hint: "app.dev.posthog.dev",
   },
 };
 

--- a/products/desktop/packages/shared/src/urls.ts
+++ b/products/desktop/packages/shared/src/urls.ts
@@ -8,5 +8,7 @@ export function getCloudUrlFromRegion(region: CloudRegion): string {
       return "https://eu.posthog.com";
     case "dev":
       return "http://localhost:8010";
+    case "dev-cloud":
+      return "https://app.dev.posthog.dev";
   }
 }

--- a/products/desktop/packages/ui/src/features/auth/OAuthControls.tsx
+++ b/products/desktop/packages/ui/src/features/auth/OAuthControls.tsx
@@ -5,7 +5,7 @@ import { useOAuthFlow } from "./useOAuthFlow";
 
 interface OAuthControlsProps {
   onAuthInitiated?: (region: CloudRegion) => void;
-  /** Defaults to the dev build, which is the only place a local instance is worth offering. */
+  /** Defaults to the dev build, where development targets are available. */
   includeDevRegion?: boolean;
 }
 

--- a/products/desktop/packages/ui/src/features/auth/RegionSelect.stories.tsx
+++ b/products/desktop/packages/ui/src/features/auth/RegionSelect.stories.tsx
@@ -52,6 +52,6 @@ export const SignInBlock: StoryObj = {
   render: () => <SignInCardPreview includeDevRegion={false} />,
 };
 
-export const WithDevRegion: StoryObj = {
+export const WithDevelopmentRegions: StoryObj = {
   render: () => <SignInCardPreview includeDevRegion={true} />,
 };

--- a/products/desktop/packages/ui/src/features/auth/RegionSelect.test.ts
+++ b/products/desktop/packages/ui/src/features/auth/RegionSelect.test.ts
@@ -6,7 +6,7 @@ describe("getSelectableRegions", () => {
     { includeDevRegion: false, expected: ["us", "eu"] },
     {
       includeDevRegion: true,
-      expected: ["us", "eu", "dev", "dev-cloud"],
+      expected: ["us", "eu", "dev-cloud", "dev"],
     },
   ])(
     "returns the regions available when development regions are $includeDevRegion",

--- a/products/desktop/packages/ui/src/features/auth/RegionSelect.test.ts
+++ b/products/desktop/packages/ui/src/features/auth/RegionSelect.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { getSelectableRegions } from "./RegionSelect";
+
+describe("getSelectableRegions", () => {
+  it.each([
+    { includeDevRegion: false, expected: ["us", "eu"] },
+    {
+      includeDevRegion: true,
+      expected: ["us", "eu", "dev", "dev-cloud"],
+    },
+  ])(
+    "returns the regions available when development regions are $includeDevRegion",
+    ({ includeDevRegion, expected }) => {
+      expect(getSelectableRegions(includeDevRegion)).toEqual(expected);
+    },
+  );
+});

--- a/products/desktop/packages/ui/src/features/auth/RegionSelect.tsx
+++ b/products/desktop/packages/ui/src/features/auth/RegionSelect.tsx
@@ -13,18 +13,26 @@ interface RegionSelectProps {
   region: CloudRegion;
   onRegionChange: (region: CloudRegion) => void;
   disabled?: boolean;
-  /** Host decides whether the local "dev" region is offered (e.g. dev builds). */
+  /** Host decides whether development regions are offered. */
   includeDevRegion?: boolean;
 }
 
-const CLOUD_REGIONS: CloudRegion[] = ["us", "eu"];
+const PRODUCTION_REGIONS: CloudRegion[] = ["us", "eu"];
+const DEVELOPMENT_REGIONS: CloudRegion[] = ["dev", "dev-cloud"];
+
+export function getSelectableRegions(includeDevRegion: boolean): CloudRegion[] {
+  return includeDevRegion
+    ? [...PRODUCTION_REGIONS, ...DEVELOPMENT_REGIONS]
+    : PRODUCTION_REGIONS;
+}
 
 function RegionOptionLabel({ region }: { region: CloudRegion }) {
-  const { flag, label } = REGION_LABELS[region];
+  const { flag, hint, label } = REGION_LABELS[region];
   return (
     <span className="flex items-center gap-2">
       <span className="shrink-0 leading-none">{flag}</span>
-      <span>{label}</span>
+      <span className="font-medium">{label}</span>
+      <span className="text-(--gray-10) text-xs">{hint}</span>
     </span>
   );
 }
@@ -35,9 +43,7 @@ export function RegionSelect({
   disabled = false,
   includeDevRegion = false,
 }: RegionSelectProps) {
-  const offered: CloudRegion[] = includeDevRegion
-    ? [...CLOUD_REGIONS, "dev"]
-    : CLOUD_REGIONS;
+  const offered = getSelectableRegions(includeDevRegion);
 
   return (
     <div className="flex items-center justify-center gap-2">
@@ -51,7 +57,7 @@ export function RegionSelect({
         }
         items={offered.map((candidate) => ({
           value: candidate,
-          label: REGION_LABELS[candidate].label,
+          label: `${REGION_LABELS[candidate].label} - ${REGION_LABELS[candidate].hint}`,
         }))}
       >
         {/* Fixed width so switching regions never reflows the row beneath the button. */}
@@ -59,7 +65,7 @@ export function RegionSelect({
           size="sm"
           disabled={disabled}
           aria-label="Data region"
-          className="w-[176px]"
+          className="w-[280px]"
         >
           <SelectValue>
             <RegionOptionLabel region={region} />

--- a/products/desktop/packages/ui/src/features/auth/RegionSelect.tsx
+++ b/products/desktop/packages/ui/src/features/auth/RegionSelect.tsx
@@ -18,7 +18,7 @@ interface RegionSelectProps {
 }
 
 const PRODUCTION_REGIONS: CloudRegion[] = ["us", "eu"];
-const DEVELOPMENT_REGIONS: CloudRegion[] = ["dev", "dev-cloud"];
+const DEVELOPMENT_REGIONS: CloudRegion[] = ["dev-cloud", "dev"];
 
 export function getSelectableRegions(includeDevRegion: boolean): CloudRegion[] {
   return includeDevRegion

--- a/products/desktop/packages/workspace-server/src/db/repositories/auth-preference-repository.ts
+++ b/products/desktop/packages/workspace-server/src/db/repositories/auth-preference-repository.ts
@@ -1,3 +1,4 @@
+import type { CloudRegion } from "@posthog/shared";
 import { and, eq } from "drizzle-orm";
 import { inject, injectable } from "inversify";
 import { DATABASE_SERVICE } from "../identifiers";
@@ -13,27 +14,24 @@ export type NewAuthOrgProjectPreference =
 
 export interface PersistAuthPreferenceInput {
   accountKey: string;
-  cloudRegion: "us" | "eu" | "dev";
+  cloudRegion: CloudRegion;
   lastSelectedProjectId: number | null;
   lastSelectedOrgId: string | null;
 }
 
 export interface PersistAuthOrgProjectPreferenceInput {
   accountKey: string;
-  cloudRegion: "us" | "eu" | "dev";
+  cloudRegion: CloudRegion;
   orgId: string;
   lastSelectedProjectId: number;
 }
 
 export interface IAuthPreferenceRepository {
-  get(
-    accountKey: string,
-    cloudRegion: "us" | "eu" | "dev",
-  ): AuthPreference | null;
+  get(accountKey: string, cloudRegion: CloudRegion): AuthPreference | null;
   save(input: PersistAuthPreferenceInput): AuthPreference;
   getOrgProject(
     accountKey: string,
-    cloudRegion: "us" | "eu" | "dev",
+    cloudRegion: CloudRegion,
     orgId: string,
   ): AuthOrgProjectPreference | null;
   saveOrgProject(
@@ -54,10 +52,7 @@ export class AuthPreferenceRepository implements IAuthPreferenceRepository {
     return this.databaseService.db;
   }
 
-  get(
-    accountKey: string,
-    cloudRegion: "us" | "eu" | "dev",
-  ): AuthPreference | null {
+  get(accountKey: string, cloudRegion: CloudRegion): AuthPreference | null {
     return (
       this.db
         .select()
@@ -110,7 +105,7 @@ export class AuthPreferenceRepository implements IAuthPreferenceRepository {
 
   getOrgProject(
     accountKey: string,
-    cloudRegion: "us" | "eu" | "dev",
+    cloudRegion: CloudRegion,
     orgId: string,
   ): AuthOrgProjectPreference | null {
     return (

--- a/products/desktop/packages/workspace-server/src/db/repositories/auth-session-repository.ts
+++ b/products/desktop/packages/workspace-server/src/db/repositories/auth-session-repository.ts
@@ -1,5 +1,4 @@
-type CloudRegion = "us" | "eu" | "dev";
-
+import type { CloudRegion } from "@posthog/shared";
 import { eq } from "drizzle-orm";
 import { inject, injectable } from "inversify";
 import { DATABASE_SERVICE } from "../identifiers";

--- a/products/desktop/packages/workspace-server/src/db/schema.ts
+++ b/products/desktop/packages/workspace-server/src/db/schema.ts
@@ -134,7 +134,7 @@ export const suspensions = sqliteTable("suspensions", {
 export const authSessions = sqliteTable("auth_sessions", {
   id: integer().primaryKey(),
   refreshTokenEncrypted: text().notNull(),
-  cloudRegion: text({ enum: ["us", "eu", "dev"] }).notNull(),
+  cloudRegion: text({ enum: ["us", "eu", "dev", "dev-cloud"] }).notNull(),
   selectedProjectId: integer(),
   scopeVersion: integer().notNull(),
   createdAt: createdAt(),
@@ -175,7 +175,7 @@ export const authPreferences = sqliteTable(
   "auth_preferences",
   {
     accountKey: text().notNull(),
-    cloudRegion: text({ enum: ["us", "eu", "dev"] }).notNull(),
+    cloudRegion: text({ enum: ["us", "eu", "dev", "dev-cloud"] }).notNull(),
     lastSelectedProjectId: integer(),
     lastSelectedOrgId: text(),
     createdAt: createdAt(),
@@ -193,7 +193,7 @@ export const authOrgProjectPreferences = sqliteTable(
   "auth_org_project_preferences",
   {
     accountKey: text().notNull(),
-    cloudRegion: text({ enum: ["us", "eu", "dev"] }).notNull(),
+    cloudRegion: text({ enum: ["us", "eu", "dev", "dev-cloud"] }).notNull(),
     orgId: text().notNull(),
     lastSelectedProjectId: integer().notNull(),
     createdAt: createdAt(),

--- a/products/desktop/packages/workspace-server/src/services/agent/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/schemas.ts
@@ -1,5 +1,5 @@
 import type { RequestPermissionRequest } from "@agentclientprotocol/sdk";
-import { BEDROCK_GATEWAY_VARIANTS } from "@posthog/shared";
+import { BEDROCK_GATEWAY_VARIANTS, CLOUD_REGIONS } from "@posthog/shared";
 import { effortLevelSchema } from "@posthog/shared/domain-types";
 import { z } from "zod";
 import { USER_AGENT_INSTRUCTIONS_MAX_LENGTH } from "../os/schemas";
@@ -390,7 +390,7 @@ export const listSessionsOutput = z.array(sessionInfoSchema);
 
 export const getPiModelCatalogInput = z.object({
   apiHost: z.string(),
-  region: z.enum(["us", "eu", "dev"]),
+  region: z.enum(CLOUD_REGIONS),
 });
 
 export const getPiModelCatalogOutput = z.array(piModelCatalogEntrySchema);


### PR DESCRIPTION
## Problem

Desktop developers cannot sign in to the shared Dev Cloud deployment without changing the local-only development region.

**Why:** Deployed OAuth integrations (such as Slack) need a hosted test path while existing Local development sessions keep using localhost.

## Changes

- Development builds show Dev Cloud above Local development. Production builds still show only US and EU.
- The new region uses a dedicated OAuth client and routes API and agent traffic through the Dev Cloud hosts.
- Region schemas, stored authentication, IPC, and agent RPC contracts accept `dev-cloud`. The existing `dev` value stays unchanged.

![Dev Cloud listed before Local development](https://raw.githubusercontent.com/PostHog/pr-assets/2614f31bc879311b74860942f3bb037bc739a85c/2026/09/65d9868b-6c36-4b94-85de-1964efa3f94a.png)

## How did you test this code?

- The development app showed both development choices and started Dev Cloud OAuth on the existing localhost callback port.
- Relevant automated tests cover mappings, build visibility, serialization, stored-session restoration, and agent routing. Full Desktop lint and typecheck passed.
- Authenticated project, MCP server, and agent checks remain untested because this VM has no Dev Cloud browser session.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the local-development guide to explain Local development, Dev Cloud, and the separate analytics host setting.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used the Desktop development build, Storybook, and GitHub tooling. Invoked skills: `posthog-desktop`, `writing-tests`, `writing-user-facing-copy`, `test-electron-app`, and `writing-pr-descriptions`.

The final design adds a separate hosted region and keeps the existing local region compatible.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
