### PR TITLE
fix(notebooks): give frame materialization its own status record

### DIFF
--- a/products/notebooks/backend/frame_status.py
+++ b/products/notebooks/backend/frame_status.py
@@ -1,0 +1,77 @@
+"""Status of a frame materialization job, kept in the app Redis.
+
+A materialize job runs on a Temporal worker and writes its frame to the object store, so
+its result never enters the query cache. This record is what the data-plane status
+endpoint polls: running, failed with a message, or done with the object key to presign.
+A second key maps a running job's query hash to its id so an identical concurrent
+request joins the job instead of starting another scan.
+"""
+
+import json
+from dataclasses import asdict
+
+from posthog.dataclasses import frozen
+from posthog.redis import get_client
+
+# Longer than the kernel's object poll deadline, so a job that finishes late still has a
+# record for the poll to find.
+STATUS_TTL_SECONDS = 20 * 60
+
+
+@frozen
+class FrameStatus:
+    query_id: str
+    team_id: int
+    complete: bool = False
+    error: bool = False
+    error_message: str | None = None
+    # Where the frame landed. The bucket travels with the key: a status outlives the deploy
+    # that changes NOTEBOOKS_FRAME_STORE_S3_BUCKET, and the key alone does not say where the
+    # object went.
+    object_key: str | None = None
+    bucket: str | None = None
+
+
+def _status_key(team_id: int, query_id: str) -> str:
+    return f"notebook_frame:{team_id}:{query_id}:status"
+
+
+def _running_key(team_id: int, query_hash: str) -> str:
+    return f"notebook_frame:{team_id}:running:{query_hash}"
+
+
+def store_frame_status(status: FrameStatus) -> None:
+    get_client().set(_status_key(status.team_id, status.query_id), json.dumps(asdict(status)), ex=STATUS_TTL_SECONDS)
+
+
+def get_frame_status(team_id: int, query_id: str) -> FrameStatus | None:
+    raw = get_client().get(_status_key(team_id, query_id))
+    if raw is None:
+        return None
+    payload = json.loads(raw)
+    return FrameStatus(
+        query_id=query_id,
+        team_id=team_id,
+        complete=bool(payload.get("complete")),
+        error=bool(payload.get("error")),
+        error_message=payload.get("error_message"),
+        object_key=payload.get("object_key"),
+        bucket=payload.get("bucket"),
+    )
+
+
+def delete_frame_status(team_id: int, query_id: str) -> None:
+    get_client().delete(_status_key(team_id, query_id))
+
+
+def register_running_frame(team_id: int, query_hash: str, query_id: str) -> None:
+    get_client().set(_running_key(team_id, query_hash), query_id, ex=STATUS_TTL_SECONDS)
+
+
+def get_running_frame(team_id: int, query_hash: str) -> str | None:
+    query_id = get_client().get(_running_key(team_id, query_hash))
+    return query_id.decode("utf-8") if query_id else None
+
+
+def unregister_running_frame(team_id: int, query_hash: str) -> None:
+    get_client().delete(_running_key(team_id, query_hash))

--- a/products/notebooks/backend/sql_v2_data_plane.py
+++ b/products/notebooks/backend/sql_v2_data_plane.py
@@ -13,6 +13,10 @@ and the SQL editor use), so no web worker ever waits on ClickHouse:
   background thread polls this — invisible to the user, who already waits on the
   run callback or the page response.
 
+An object-delivery request (`delivery: "object"`) runs as a Temporal materialize job
+instead. Its status is the notebook-owned `frame_status` record, and the poll answers
+with a 302 to a presigned URL for the frame.
+
 Wired in posthog/urls.py at internal/notebooks/data_plane/query/.
 """
 
@@ -34,7 +38,7 @@ from posthog.clickhouse.client.execute_async import QueryNotFoundError, enqueue_
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.models import Team, User
 
-from products.notebooks.backend import frame_store
+from products.notebooks.backend import frame_status, frame_store
 from products.notebooks.backend.models import Notebook
 from products.notebooks.backend.sql_v2 import (
     DELIVERY_INLINE,
@@ -190,7 +194,7 @@ def notebook_sql_v2_data_plane(request: HttpRequest) -> HttpResponse:
                     "notebook_frame_materialize_enqueue_failed", notebook_short_id=claims.notebook_short_id
                 )
                 return JsonResponse({"error": "Query could not be scheduled."}, status=500)
-            return JsonResponse({"query_id": status.id, "delivery": DELIVERY_OBJECT_RELAY}, status=202)
+            return JsonResponse({"query_id": status.query_id, "delivery": DELIVERY_OBJECT_RELAY}, status=202)
         if frame_store_configured:
             # The environment is provisioned but this user is outside the rollout, which is
             # the expected state for most users while the flag ramps. Counted, not logged:
@@ -253,6 +257,10 @@ def notebook_sql_v2_data_plane_status(request: HttpRequest, query_id: str) -> Ht
     if isinstance(claims, JsonResponse):
         return claims
 
+    frame = frame_status.get_frame_status(claims.team_id, query_id)
+    if frame is not None:
+        return _frame_status_response(frame, claims.team_id, query_id)
+
     try:
         status = get_query_status(team_id=claims.team_id, query_id=query_id)
     except QueryNotFoundError:
@@ -264,26 +272,26 @@ def notebook_sql_v2_data_plane_status(request: HttpRequest, query_id: str) -> Ht
         return JsonResponse({"error": status.error_message or "Query execution failed."}, status=400)
 
     results: dict[str, Any] = status.results or {}
-
-    object_key = results.get("object_key")
-    if object_key:
-        # Object delivery: the status carries a pointer, not rows. The token was verified
-        # above; presign_get additionally refuses keys outside this team's prefix. The
-        # presigned URL is a bearer secret — it must never be logged.
-        try:
-            # Sign against the bucket the writer recorded. A status written before a bucket
-            # change still points at the old bucket, and signing it against the new one
-            # would 404 every frame materialized in the window before that deploy.
-            recorded_bucket = results.get("bucket")
-            presigned_url = frame_store.presign_get(
-                str(object_key), claims.team_id, bucket=str(recorded_bucket) if recorded_bucket else None
-            )
-        except frame_store.FrameStoreError:
-            logger.exception("notebook_frame_presign_failed", team_id=claims.team_id, query_id=query_id)
-            return JsonResponse({"error": "The frame download could not be prepared. Try re-running."}, status=500)
-        return HttpResponseRedirect(presigned_url)
-
     columns = [str(column) for column in (results.get("columns") or [])]
     types = [[str(name), str(type_name)] for name, type_name in (results.get("types") or [])]
     payload = _rows_to_arrow_bytes(columns, results.get("results") or [], types)
     return HttpResponse(payload, content_type=ARROW_STREAM_CONTENT_TYPE)
+
+
+def _frame_status_response(frame: frame_status.FrameStatus, team_id: int, query_id: str) -> HttpResponse:
+    if not frame.complete:
+        return JsonResponse({"status": "running"}, status=202)
+    if frame.error or frame.object_key is None:
+        return JsonResponse({"error": frame.error_message or "Query execution failed."}, status=400)
+    # Object delivery: the status carries a pointer, not rows. The caller verified the token;
+    # presign_get additionally refuses keys outside this team's prefix. The presigned URL is
+    # a bearer secret — it must never be logged.
+    try:
+        # Sign against the bucket the writer recorded. A status written before a bucket
+        # change still points at the old bucket, and signing it against the new one
+        # would 404 every frame materialized in the window before that deploy.
+        presigned_url = frame_store.presign_get(frame.object_key, team_id, bucket=frame.bucket)
+    except frame_store.FrameStoreError:
+        logger.exception("notebook_frame_presign_failed", team_id=team_id, query_id=query_id)
+        return JsonResponse({"error": "The frame download could not be prepared. Try re-running."}, status=500)
+    return HttpResponseRedirect(presigned_url)

--- a/products/notebooks/backend/temporal/frame_materialize.py
+++ b/products/notebooks/backend/temporal/frame_materialize.py
@@ -4,9 +4,9 @@ The data plane dispatches this for `delivery: "object"` requests (whole-frame py
 inputs): the activity prints the HogQL through the guarded executor (team database +
 access controls), executes it over the ClickHouse HTTP interface with `FORMAT ArrowStream`,
 and relays the raw response bytes into one object-store multipart upload — no pyarrow
-decode in the worker, memory bounded by the part buffer. The existing async-query status
-machinery carries a pointer (`{"object_key": ...}`) instead of rows; the status endpoint
-turns it into a 302 to a presigned GET.
+decode in the worker, memory bounded by the part buffer. The job's status record
+(`frame_status`) carries the object key instead of rows; the status endpoint turns it into
+a 302 to a presigned GET.
 
 Load protection mirrors the Celery async path (`process_query_task`): a Redis Lua
 concurrency limiter gates activity starts (global + per-team), slot exhaustion and
@@ -48,8 +48,6 @@ import structlog
 from prometheus_client import Counter, Histogram
 from temporalio import activity, common, exceptions, workflow
 
-from posthog.schema import QueryStatus
-
 from posthog.hogql import ast
 from posthog.hogql.constants import HogQLGlobalSettings, LimitContext
 from posthog.hogql.context import HogQLContext
@@ -67,7 +65,6 @@ from posthog.clickhouse.client.connection import (
     make_ch_pool,
 )
 from posthog.clickhouse.client.execute import kill_switch_overrides
-from posthog.clickhouse.client.execute_async import QueryNotFoundError, QueryStatusManager, get_query_status
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded, ConcurrencySlot, RateLimit
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.clickhouse.workload import Workload
@@ -91,7 +88,7 @@ from posthog.temporal.common.clickhouse import (
 )
 
 from products.access_control.backend.facade.user_access_control import UserAccessControl
-from products.notebooks.backend import frame_store
+from products.notebooks.backend import frame_status, frame_store
 
 logger = structlog.get_logger(__name__)
 
@@ -251,7 +248,6 @@ class FrameMaterializeInputs:
     # after printing through the guarded HogQL executor — never handed to ClickHouse raw.
     query: str
     query_hash: str
-    cache_key: str
     # Resolved from the per-user flag in the web process, because the worker has no request
     # user to evaluate it against. Defaulted so a history recorded before this field existed
     # decodes to the streaming path on the interactive pool, which keeps in-flight runs
@@ -721,30 +717,31 @@ def _execute_insert_to_s3(team: Team, user: User | None, query: str, key: str) -
 
 
 def _finalize_status(
-    manager: QueryStatusManager,
     inputs: FrameMaterializeInputs,
     *,
-    results: dict[str, object] | None = None,
+    object_key: str | None = None,
     error_message: str | None = None,
 ) -> None:
-    """Write the terminal query status and release the dedup mapping."""
-    try:
-        status = manager.get_query_status()
-        if status.complete:
-            # First terminal write wins. A slow zombie attempt (one that outlived its Temporal
-            # deadline while a retry — or mark-failed — already finalized) must not overwrite
-            # what the user has seen: not a success flipping a recorded failure, and not a late
-            # error clobbering a genuinely-materialized frame that still exists at the key.
-            return
-    except QueryNotFoundError:
-        status = QueryStatus(id=inputs.query_id, team_id=inputs.team_id)
-    status.complete = True
-    status.error = error_message is not None
-    status.error_message = error_message
-    status.results = results
-    status.end_time = dt.datetime.now(dt.UTC)
-    manager.store_query_status(status)
-    manager.unregister_cache_key_mapping(inputs.cache_key)
+    """Write the terminal frame status and release the dedup mapping."""
+    existing = frame_status.get_frame_status(inputs.team_id, inputs.query_id)
+    if existing is not None and existing.complete:
+        # First terminal write wins. A slow zombie attempt (one that outlived its Temporal
+        # deadline while a retry — or mark-failed — already finalized) must not overwrite
+        # what the user has seen: not a success flipping a recorded failure, and not a late
+        # error clobbering a genuinely-materialized frame that still exists at the key.
+        return
+    frame_status.store_frame_status(
+        frame_status.FrameStatus(
+            query_id=inputs.query_id,
+            team_id=inputs.team_id,
+            complete=True,
+            error=error_message is not None,
+            error_message=error_message,
+            object_key=object_key,
+            bucket=settings.NOTEBOOKS_FRAME_STORE_S3_BUCKET if object_key else None,
+        )
+    )
+    frame_status.unregister_running_frame(inputs.team_id, inputs.query_hash)
 
 
 class MidStreamQueryError(Exception):
@@ -851,7 +848,6 @@ def materialize_frame(inputs: FrameMaterializeInputs) -> str:
         pool="offline" if pool_offline else "online",
         mode=mode,
     ).inc()
-    manager = QueryStatusManager(inputs.query_id, inputs.team_id)
     team = Team.objects.get(id=inputs.team_id)
     user = User.objects.filter(id=inputs.user_id).first() if inputs.user_id else None
     key = frame_store.build_frame_key(inputs.team_id, inputs.notebook_short_id, inputs.query_hash)
@@ -860,16 +856,12 @@ def materialize_frame(inputs: FrameMaterializeInputs) -> str:
     started_at = dt.datetime.now(dt.UTC)
     activity_started = time.perf_counter()
 
-    try:
-        status = manager.get_query_status()
-        if status.complete:
-            if status.error:
-                raise exceptions.ApplicationError("Materialization already failed", non_retryable=True)
-            return key  # a previous attempt already finished (e.g. retry after a lost ack)
-        status.pickup_time = started_at
-        manager.store_query_status(status)
-    except QueryNotFoundError:
-        pass  # status expired mid-flight; still produce the object so the run can be retried
+    # A missing status expired mid-flight; still produce the object so the run can be retried.
+    existing = frame_status.get_frame_status(inputs.team_id, inputs.query_id)
+    if existing is not None and existing.complete:
+        if existing.error:
+            raise exceptions.ApplicationError("Materialization already failed", non_retryable=True)
+        return key  # a previous attempt already finished (e.g. retry after a lost ack)
 
     with tags_context(
         product=Product.NOTEBOOKS,
@@ -967,7 +959,7 @@ def materialize_frame(inputs: FrameMaterializeInputs) -> str:
         except ExposedHogQLError as exc:
             # User-safe and terminal: surface the message through the poll, don't retry —
             # a bad query cannot succeed on a second attempt.
-            _finalize_status(manager, inputs, error_message=str(exc))
+            _finalize_status(inputs, error_message=str(exc))
             FRAME_MATERIALIZATIONS_FINISHED_COUNTER.labels(outcome="failed", mode=mode).inc()
             raise exceptions.ApplicationError(str(exc), non_retryable=True) from exc
         except FrameTooLargeError as exc:
@@ -981,7 +973,7 @@ def materialize_frame(inputs: FrameMaterializeInputs) -> str:
                 query_id=inputs.query_id,
                 error=str(exc),
             )
-            _finalize_status(manager, inputs, error_message=_RESULT_SIZE_MESSAGE)
+            _finalize_status(inputs, error_message=_RESULT_SIZE_MESSAGE)
             FRAME_MATERIALIZATIONS_FINISHED_COUNTER.labels(outcome="failed", mode=mode).inc()
             raise exceptions.ApplicationError(_RESULT_SIZE_MESSAGE, non_retryable=True) from exc
         except (
@@ -995,7 +987,7 @@ def materialize_frame(inputs: FrameMaterializeInputs) -> str:
             message = (
                 _RESULT_SIZE_MESSAGE if isinstance(exc, ClickHouseTooManyRowsOrBytesError) else _RESOURCE_BUDGET_MESSAGE
             )
-            _finalize_status(manager, inputs, error_message=message)
+            _finalize_status(inputs, error_message=message)
             FRAME_MATERIALIZATIONS_FINISHED_COUNTER.labels(outcome="failed", mode=mode).inc()
             raise exceptions.ApplicationError(message, non_retryable=True) from exc
         except (
@@ -1030,7 +1022,7 @@ def materialize_frame(inputs: FrameMaterializeInputs) -> str:
                 query_id=inputs.query_id,
                 error_type=type(exc).__name__,
             )
-            _finalize_status(manager, inputs, error_message=message)
+            _finalize_status(inputs, error_message=message)
             FRAME_MATERIALIZATIONS_FINISHED_COUNTER.labels(outcome="failed", mode=mode).inc()
             raise exceptions.ApplicationError(message, non_retryable=True) from exc
         except ExposedCHQueryError as exc:
@@ -1042,7 +1034,7 @@ def materialize_frame(inputs: FrameMaterializeInputs) -> str:
             # ExposedCHQueryError), so consult the shared code table first: the same failure
             # must read the same way whichever transport produced it.
             message = _MID_STREAM_MESSAGES_BY_CODE.get(exc.code, "") or str(exc)
-            _finalize_status(manager, inputs, error_message=message)
+            _finalize_status(inputs, error_message=message)
             FRAME_MATERIALIZATIONS_FINISHED_COUNTER.labels(outcome="failed", mode=mode).inc()
             raise exceptions.ApplicationError(message, non_retryable=True) from exc
         except InternalCHQueryError as exc:
@@ -1071,7 +1063,7 @@ def materialize_frame(inputs: FrameMaterializeInputs) -> str:
                 query_id=inputs.query_id,
                 exception_code=exc.code,
             )
-            _finalize_status(manager, inputs, error_message=message)
+            _finalize_status(inputs, error_message=message)
             FRAME_MATERIALIZATIONS_FINISHED_COUNTER.labels(outcome="failed", mode=mode).inc()
             raise exceptions.ApplicationError(message, non_retryable=True) from exc
         except frame_store.FrameStoreError as exc:
@@ -1113,13 +1105,11 @@ def materialize_frame(inputs: FrameMaterializeInputs) -> str:
                 error=exception_message,
             )
             message = _MID_STREAM_MESSAGES_BY_CODE.get(exception_code, _MID_STREAM_ERROR_MESSAGE)
-            _finalize_status(manager, inputs, error_message=message)
+            _finalize_status(inputs, error_message=message)
             FRAME_MATERIALIZATIONS_FINISHED_COUNTER.labels(outcome="failed", mode=mode).inc()
             raise exceptions.ApplicationError(message, non_retryable=True) from exc
 
-    # The bucket travels with the key: a status outlives the deploy that changes
-    # NOTEBOOKS_FRAME_STORE_S3_BUCKET, and the key alone does not say where the object went.
-    _finalize_status(manager, inputs, results={"object_key": key, "bucket": settings.NOTEBOOKS_FRAME_STORE_S3_BUCKET})
+    _finalize_status(inputs, object_key=key)
     FRAME_MATERIALIZATIONS_FINISHED_COUNTER.labels(outcome="succeeded", mode=mode).inc()
     FRAME_OBJECT_BYTES_HISTOGRAM.observe(object_bytes)
     FRAME_MATERIALIZE_SECONDS_HISTOGRAM.observe((dt.datetime.now(dt.UTC) - started_at).total_seconds())
@@ -1154,14 +1144,11 @@ def materialize_frame(inputs: FrameMaterializeInputs) -> str:
 
 def mark_frame_materialize_failed(inputs: FrameMaterializeInputs) -> None:
     """Terminal-state safety net once the materialize activity exhausts its retries."""
-    manager = QueryStatusManager(inputs.query_id, inputs.team_id)
-    try:
-        if manager.get_query_status().complete:
-            manager.unregister_cache_key_mapping(inputs.cache_key)
-            return  # the activity already wrote a terminal state (e.g. a user-safe error)
-    except QueryNotFoundError:
-        pass
-    _finalize_status(manager, inputs, error_message="The frame could not be materialized. Try re-running the cell.")
+    existing = frame_status.get_frame_status(inputs.team_id, inputs.query_id)
+    if existing is not None and existing.complete:
+        frame_status.unregister_running_frame(inputs.team_id, inputs.query_hash)
+        return  # the activity already wrote a terminal state (e.g. a user-safe error)
+    _finalize_status(inputs, error_message="The frame could not be materialized. Try re-running the cell.")
     # The effective transport, not the requested one: a run that fell back to streaming must
     # not land in the ch_writes bucket, or the rollout comparison counts its failures twice over.
     mode = "ch_writes" if _resolve_writer(inputs).ch_writes else "streaming"
@@ -1225,12 +1212,12 @@ def enqueue_frame_materialization(
     query: str,
     ch_writes: bool = False,
     _test_only_inline: bool = False,
-) -> QueryStatus:
+) -> frame_status.FrameStatus:
     """Register a materialize job for `query` and dispatch the workflow; returns its status.
 
     Dedup happens here: identical concurrent materializations (same team + user + query)
-    join the in-flight job through the async manager's running-query mapping instead of
-    stacking ClickHouse load.
+    join the in-flight job through the running-frame mapping instead of stacking
+    ClickHouse load.
 
     The hash folds in `user_id`: the printed SQL applies the enqueuing user's access
     controls, so two differently-permissioned users in one team must NOT share a job or an
@@ -1240,27 +1227,23 @@ def enqueue_frame_materialization(
     per-user within the team.
     """
     query_hash = hashlib.sha256(f"{user_id}:{query}".encode()).hexdigest()
-    cache_key = f"notebook-frame:{team.id}:{query_hash}"
     query_id = uuid.uuid4().hex
-    manager = QueryStatusManager(query_id, team.id)
 
     try:
-        existing_query_id = manager.get_running_query_by_cache_key(cache_key)
+        existing_query_id = frame_status.get_running_frame(team.id, query_hash)
         if existing_query_id:
-            existing_status = get_query_status(team.id, existing_query_id)
-            if not existing_status.complete:
+            existing = frame_status.get_frame_status(team.id, existing_query_id)
+            if existing is not None and not existing.complete:
                 FRAME_MATERIALIZATION_DEDUP_COUNTER.inc()
-                return existing_status
-            # The mapped job finished — clean up the stale mapping and enqueue a new one.
-            manager.unregister_cache_key_mapping(cache_key)
-    except QueryNotFoundError:
-        manager.unregister_cache_key_mapping(cache_key)
+                return existing
+            # The mapped job finished or expired — clean up the stale mapping and enqueue a new one.
+            frame_status.unregister_running_frame(team.id, query_hash)
     except Exception as exc:
-        capture_exception(exc, {"cache_key": cache_key})
+        capture_exception(exc, {"team_id": team.id, "query_hash": query_hash})
 
-    query_status = QueryStatus(id=query_id, team_id=team.id, start_time=dt.datetime.now(dt.UTC))
-    manager.store_query_status(query_status)
-    manager.register_cache_key_mapping(cache_key)
+    status = frame_status.FrameStatus(query_id=query_id, team_id=team.id)
+    frame_status.store_frame_status(status)
+    frame_status.register_running_frame(team.id, query_hash, query_id)
 
     inputs = FrameMaterializeInputs(
         query_id=query_id,
@@ -1269,7 +1252,6 @@ def enqueue_frame_materialization(
         user_id=user_id,
         query=query,
         query_hash=query_hash,
-        cache_key=cache_key,
         ch_writes=ch_writes,
     )
     if _test_only_inline:
@@ -1288,9 +1270,9 @@ def enqueue_frame_materialization(
         except Exception:
             # Dispatch failed (e.g. Temporal briefly unreachable). Roll back the status and
             # dedup mapping so identical re-runs don't dedup onto a job that will never run
-            # — otherwise every retry polls a dead query_id until the 20-minute TTL.
-            manager.delete_query_status()
-            manager.unregister_cache_key_mapping(cache_key)
+            # — otherwise every retry polls a dead query_id until the record's TTL.
+            frame_status.delete_frame_status(team.id, query_id)
+            frame_status.unregister_running_frame(team.id, query_hash)
             raise
 
-    return manager.get_query_status()
+    return status

--- a/products/notebooks/backend/test/test_frame_materialize.py
+++ b/products/notebooks/backend/test/test_frame_materialize.py
@@ -15,20 +15,17 @@ from temporalio.client import WorkflowFailureError
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
-from posthog.schema import QueryStatus
-
 from posthog.hogql.database.database import Database
 from posthog.hogql.parser import parse_select
 
 from posthog.clickhouse.client.execute import _KILL_SWITCH_SETTINGS, KillSwitchLevel
-from posthog.clickhouse.client.execute_async import QueryStatusManager
 from posthog.errors import ExposedCHQueryError, InternalCHQueryError
 from posthog.exceptions import ClickHouseQueryMemoryLimitExceeded, ClickHouseQuerySizeExceeded, ClickHouseQueryTimeOut
 from posthog.storage import object_storage
 from posthog.storage.object_storage import ObjectStorageError
 from posthog.temporal.common.clickhouse import ClickHouseMemoryLimitExceededError, ClickHouseTooManyRowsOrBytesError
 
-from products.notebooks.backend import frame_store
+from products.notebooks.backend import frame_status, frame_store
 from products.notebooks.backend.models import Notebook
 from products.notebooks.backend.temporal import frame_materialize
 
@@ -51,7 +48,7 @@ def _per_query_memory_error() -> ClickHouseQueryMemoryLimitExceeded:
 
 def _registered_inputs(
     team_id: int, notebook_short_id: str, user_id: int, query: str = "select 1", ch_writes: bool = False
-) -> tuple["frame_materialize.FrameMaterializeInputs", QueryStatusManager]:
+) -> frame_materialize.FrameMaterializeInputs:
     query_id = uuid.uuid4().hex
     inputs = frame_materialize.FrameMaterializeInputs(
         query_id=query_id,
@@ -60,13 +57,17 @@ def _registered_inputs(
         user_id=user_id,
         query=query,
         query_hash="abc123",
-        cache_key=f"notebook-frame:{team_id}:abc123",
         ch_writes=ch_writes,
     )
-    manager = QueryStatusManager(query_id, team_id)
-    manager.store_query_status(QueryStatus(id=query_id, team_id=team_id))
-    manager.register_cache_key_mapping(inputs.cache_key)
-    return inputs, manager
+    frame_status.store_frame_status(frame_status.FrameStatus(query_id=query_id, team_id=team_id))
+    frame_status.register_running_frame(team_id, inputs.query_hash, query_id)
+    return inputs
+
+
+def _status(inputs: frame_materialize.FrameMaterializeInputs) -> frame_status.FrameStatus:
+    status = frame_status.get_frame_status(inputs.team_id, inputs.query_id)
+    assert status is not None
+    return status
 
 
 class TestFrameMaterializeEnqueue(APIBaseTest):
@@ -93,8 +94,8 @@ class TestFrameMaterializeEnqueue(APIBaseTest):
             first = self._enqueue(user_id=101, query=query, _test_only_inline=True)
             same_user_again = self._enqueue(user_id=101, query=query, _test_only_inline=True)
             other_user = self._enqueue(user_id=202, query=query, _test_only_inline=True)
-        self.assertEqual(first.id, same_user_again.id)  # same user + query → dedup join
-        self.assertNotEqual(first.id, other_user.id)  # different user → separate job
+        self.assertEqual(first.query_id, same_user_again.query_id)  # same user + query → dedup join
+        self.assertNotEqual(first.query_id, other_user.query_id)  # different user → separate job
 
     def test_failed_dispatch_lets_the_retry_enqueue_a_fresh_job(self):
         # A Temporal dispatch failure must roll back the status + dedup mapping. Otherwise a
@@ -109,7 +110,7 @@ class TestFrameMaterializeEnqueue(APIBaseTest):
             self._enqueue(user_id=self.user.id, query=query, _test_only_inline=True)
         run.assert_called_once()
 
-    def _registered_inputs(self) -> tuple["frame_materialize.FrameMaterializeInputs", QueryStatusManager]:
+    def _registered_inputs(self) -> frame_materialize.FrameMaterializeInputs:
         return _registered_inputs(self.team.id, self.notebook.short_id, self.user.id)
 
     @parameterized.expand(
@@ -133,7 +134,7 @@ class TestFrameMaterializeEnqueue(APIBaseTest):
         # A deterministic ClickHouse budget failure must be non-retryable and carry a
         # user-facing message — not retried to the schedule bound and finalized with the
         # generic 'try re-running' fallback.
-        inputs, manager = self._registered_inputs()
+        inputs = self._registered_inputs()
 
         with (
             patch.object(frame_materialize, "_print_clickhouse_sql", return_value=_printed_sql()),
@@ -144,7 +145,7 @@ class TestFrameMaterializeEnqueue(APIBaseTest):
                 frame_materialize.materialize_frame(inputs)
 
         self.assertTrue(caught.exception.non_retryable)
-        status = manager.get_query_status()
+        status = _status(inputs)
         self.assertTrue(status.complete and status.error)
         self.assertIn(expected_message, status.error_message or "")
 
@@ -153,7 +154,7 @@ class TestFrameMaterializeEnqueue(APIBaseTest):
         # the body cleanly with exception text appended instead of tearing the read. Without
         # the Arrow EOS-marker check that corrupt object would be stored, the status
         # finalized as succeeded, and the poll would 302 the kernel to garbage.
-        inputs, manager = self._registered_inputs()
+        inputs = self._registered_inputs()
         body_without_eos = b"\xff\xff\xff\xff" + b"x" * 4096 + b"Code: 241. DB::Exception: Memory limit exceeded"
 
         with self.settings(OBJECT_STORAGE_ENABLED=True):
@@ -172,7 +173,7 @@ class TestFrameMaterializeEnqueue(APIBaseTest):
                     frame_materialize.materialize_frame(inputs)
 
             self.assertTrue(caught.exception.non_retryable)
-            status = manager.get_query_status()
+            status = _status(inputs)
             self.assertTrue(status.complete and status.error)
             self.assertIn("materialization limits", status.error_message or "")
             # The corrupt bytes were written to the deterministic key and must not survive.
@@ -191,7 +192,7 @@ class TestFrameMaterializeEnqueue(APIBaseTest):
         ]
     )
     def test_stream_failure_stays_retryable(self, _name, query_log_result):
-        inputs, manager = self._registered_inputs()
+        inputs = self._registered_inputs()
 
         with (
             patch.object(frame_materialize, "_print_clickhouse_sql", return_value=_printed_sql()),
@@ -205,7 +206,7 @@ class TestFrameMaterializeEnqueue(APIBaseTest):
                 frame_materialize.materialize_frame(inputs)
 
         lookup.assert_called_once()
-        status = manager.get_query_status()
+        status = _status(inputs)
         self.assertFalse(status.complete)  # not finalized — Temporal retries per policy
 
 
@@ -222,7 +223,7 @@ class TestFrameMaterializeCHWrites(APIBaseTest):
         # output_format_arrow_string_as_string / the UUID stringification, which would
         # hand pandas raw bytes.
         frame_uuid = "018e0e7a-1111-2222-3333-444444444444"
-        inputs, manager = _registered_inputs(
+        inputs = _registered_inputs(
             self.team.id,
             self.notebook.short_id,
             self.user.id,
@@ -236,11 +237,11 @@ class TestFrameMaterializeCHWrites(APIBaseTest):
             returned_key = frame_materialize.materialize_frame(inputs)
 
         self.assertEqual(returned_key, key)
-        status = manager.get_query_status()
+        status = _status(inputs)
         self.assertTrue(status.complete and not status.error)
         # The bucket is recorded next to the key so the status survives a bucket change:
         # the poll signs against what the writer used, not whatever the setting says later.
-        self.assertEqual(status.results, {"object_key": key, "bucket": settings.NOTEBOOKS_FRAME_STORE_S3_BUCKET})
+        self.assertEqual((status.object_key, status.bucket), (key, settings.NOTEBOOKS_FRAME_STORE_S3_BUCKET))
 
         import pyarrow as pa  # noqa: PLC0415 — keeps the heavy dep off the module import path
 
@@ -256,7 +257,7 @@ class TestFrameMaterializeCHWrites(APIBaseTest):
         # write a valid (header-only) Arrow object for a zero-row INSERT INTO s3, or stat_frame
         # would see no object → retry → generic failure. Guards against a CH version/setting
         # change (or a switch away from ArrowStream) that stops emitting the empty object.
-        inputs, manager = _registered_inputs(
+        inputs = _registered_inputs(
             self.team.id,
             self.notebook.short_id,
             self.user.id,
@@ -269,7 +270,7 @@ class TestFrameMaterializeCHWrites(APIBaseTest):
         with self.settings(OBJECT_STORAGE_ENABLED=True):
             frame_materialize.materialize_frame(inputs)
 
-        status = manager.get_query_status()
+        status = _status(inputs)
         self.assertTrue(status.complete and not status.error)
 
         import pyarrow as pa  # noqa: PLC0415 — keeps the heavy dep off the module import path
@@ -359,7 +360,7 @@ class TestFrameMaterializeCHWrites(APIBaseTest):
         ]
     )
     def test_insert_error_maps_to_terminal_or_retryable(self, _name, error, terminal, expected_message):
-        inputs, manager = _registered_inputs(self.team.id, self.notebook.short_id, self.user.id, ch_writes=True)
+        inputs = _registered_inputs(self.team.id, self.notebook.short_id, self.user.id, ch_writes=True)
 
         with (
             patch.object(frame_materialize, "_print_clickhouse_sql", return_value=_printed_sql()),
@@ -369,7 +370,7 @@ class TestFrameMaterializeCHWrites(APIBaseTest):
             with self.assertRaises(exceptions.ApplicationError if terminal else type(error)) as caught:
                 frame_materialize.materialize_frame(inputs)
 
-        status = manager.get_query_status()
+        status = _status(inputs)
         if terminal:
             self.assertTrue(caught.exception.non_retryable)
             self.assertTrue(status.complete and status.error)
@@ -381,7 +382,7 @@ class TestFrameMaterializeCHWrites(APIBaseTest):
         # max_result_bytes bounds results returned to a client, not an INSERT's sink — the
         # post-write size check is the only output cap on this path. Removing it as
         # "redundant" would let a huge-per-row query persist an unbounded object.
-        inputs, manager = _registered_inputs(self.team.id, self.notebook.short_id, self.user.id, ch_writes=True)
+        inputs = _registered_inputs(self.team.id, self.notebook.short_id, self.user.id, ch_writes=True)
         key = frame_store.build_frame_key(inputs.team_id, inputs.notebook_short_id, inputs.query_hash)
 
         with (
@@ -398,7 +399,7 @@ class TestFrameMaterializeCHWrites(APIBaseTest):
 
         delete_frame.assert_called_once_with(key)
         self.assertTrue(caught.exception.non_retryable)
-        status = manager.get_query_status()
+        status = _status(inputs)
         self.assertTrue(status.complete and status.error)
         self.assertIn("too large", status.error_message or "")
 
@@ -431,7 +432,6 @@ async def test_exhausted_retries_stop_at_three_scans_and_finalize_the_status():
         user_id=1,
         query="select 1",
         query_hash="abc123",
-        cache_key="notebook-frame:1:abc123",
     )
     task_queue = str(uuid.uuid4())
 


### PR DESCRIPTION
## Problem

Notebook frame materialization stores its job status in the async query status record, the Redis entry that `/query/<id>/` polls for async queries. A frame job is not a query result: it runs on Temporal, writes its output to S3, and only needs to report running, failed, or done with an object key. It borrowed the query record because that record had a free-form `results` field to put the key in. So two unrelated things write the same Redis keys with different meanings, and any change to the query record has to be checked against notebooks, which is what happened in #94537.

## Changes

Frame jobs keep a small record of their own in the app Redis, in a new `frame_status` module under notebooks, with the dedup mapping for identical in-flight frames next to it. The data-plane status endpoint reads the frame record first and falls back to the query record for inline deliveries; the kernel gets the same 202, 400 and 302 answers as before. `FrameMaterializeInputs` loses its `cache_key` field: the worker derives the dedup key from the team and query hash, and Temporal ignores the extra field in older histories. The rest is mechanical. Status manager calls become calls into the new module, and the frame tests read the new record.

During a deploy, a frame finished by an old worker and polled by a new web pod comes back empty, and the reverse runs to the kernel's deadline. Both clear with a re-run, and object delivery is behind the `notebooks-frame-store` flag, so there is no compat code.

## How did you test this code?

The existing frame and data-plane endpoint tests exercise the new record end to end: the 302 to a presigned URL, a failure as a 400, identical in-flight frames sharing a job, and rollback after a failed dispatch. No new tests. A live Temporal worker was not exercised.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Claude Fable 5.1), directed by the assignee; skills: /writing-dataclasses, /writing-tests, /writing-code-comments, /writing-pr-descriptions. Split out of #94537 after its review kept hitting the shared record. It was briefly the base of a stack under that PR and is now independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
