### PR TITLE
fix(pgcollector): install rustls crypto provider and enable TLS for pgapi

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8987,14 +8987,17 @@ dependencies = [
  "reqwest 0.12.28",
  "rmcp",
  "rust_decimal",
+ "rustls 0.23.37",
  "schemars 1.2.1",
  "serde",
  "serde_json",
  "tokio",
  "tokio-postgres",
+ "tokio-postgres-rustls",
  "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/rust/pgapi/Cargo.toml
+++ b/rust/pgapi/Cargo.toml
@@ -21,14 +21,17 @@ regex = { workspace = true }
 reqwest = { workspace = true }
 rmcp = { version = "3", features = ["server", "macros", "transport-streamable-http-server"] }
 rust_decimal = { version = "1", features = ["db-tokio-postgres"] }
+rustls = { workspace = true }
 schemars = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
+tokio-postgres-rustls = "0.13"
 tower-http = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+webpki-roots = "1"
 
 [lints]
 workspace = true

--- a/rust/pgapi/src/db.rs
+++ b/rust/pgapi/src/db.rs
@@ -19,7 +19,7 @@ pub struct Db {
 impl Db {
     pub async fn connect(url: &str) -> Result<Self> {
         let mut cfg: tokio_postgres::Config = url.parse().context("parsing PGAPI_DATABASE_URL")?;
-        cfg.ssl_mode(Self::tls_policy(url));
+        cfg.ssl_mode(tokio_postgres::config::SslMode::Require);
         let tls_cfg = rustls::ClientConfig::builder()
             .with_root_certificates(rustls::RootCertStore {
                 roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
@@ -51,18 +51,6 @@ impl Db {
             .await
             .context("stats database unreachable")?;
         Ok(db)
-    }
-
-    fn tls_policy(url: &str) -> tokio_postgres::config::SslMode {
-        use tokio_postgres::config::SslMode;
-        let lower = url.to_ascii_lowercase();
-        if lower.contains("sslmode=disable") {
-            SslMode::Disable
-        } else if lower.contains("sslmode=prefer") {
-            SslMode::Prefer
-        } else {
-            SslMode::Require
-        }
     }
 
     pub async fn ping(&self) -> bool {

--- a/rust/pgapi/src/db.rs
+++ b/rust/pgapi/src/db.rs
@@ -6,7 +6,6 @@ use chrono::{DateTime, Utc};
 use deadpool_postgres::{Manager, ManagerConfig, Pool, RecyclingMethod};
 use serde_json::{json, Map, Value};
 use tokio_postgres::types::{ToSql, Type};
-use tokio_postgres::NoTls;
 
 /// Serialised-response ceiling for raw SQL. Row count is bounded by LIMIT; this bounds
 /// bytes so a wide or `repeat()`-style query can't exhaust the pod's memory.
@@ -20,9 +19,15 @@ pub struct Db {
 impl Db {
     pub async fn connect(url: &str) -> Result<Self> {
         let cfg: tokio_postgres::Config = url.parse().context("parsing PGAPI_DATABASE_URL")?;
+        let tls_cfg = rustls::ClientConfig::builder()
+            .with_root_certificates(rustls::RootCertStore {
+                roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+            })
+            .with_no_client_auth();
+        let tls = tokio_postgres_rustls::MakeRustlsConnect::new(tls_cfg);
         let mgr = Manager::from_config(
             cfg,
-            NoTls,
+            tls,
             ManagerConfig {
                 recycling_method: RecyclingMethod::Fast,
             },

--- a/rust/pgapi/src/db.rs
+++ b/rust/pgapi/src/db.rs
@@ -18,7 +18,8 @@ pub struct Db {
 
 impl Db {
     pub async fn connect(url: &str) -> Result<Self> {
-        let cfg: tokio_postgres::Config = url.parse().context("parsing PGAPI_DATABASE_URL")?;
+        let mut cfg: tokio_postgres::Config = url.parse().context("parsing PGAPI_DATABASE_URL")?;
+        cfg.ssl_mode(Self::tls_policy(url));
         let tls_cfg = rustls::ClientConfig::builder()
             .with_root_certificates(rustls::RootCertStore {
                 roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
@@ -50,6 +51,18 @@ impl Db {
             .await
             .context("stats database unreachable")?;
         Ok(db)
+    }
+
+    fn tls_policy(url: &str) -> tokio_postgres::config::SslMode {
+        use tokio_postgres::config::SslMode;
+        let lower = url.to_ascii_lowercase();
+        if lower.contains("sslmode=disable") {
+            SslMode::Disable
+        } else if lower.contains("sslmode=prefer") {
+            SslMode::Prefer
+        } else {
+            SslMode::Require
+        }
     }
 
     pub async fn ping(&self) -> bool {

--- a/rust/pgapi/src/main.rs
+++ b/rust/pgapi/src/main.rs
@@ -81,6 +81,10 @@ pub struct AppState {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install rustls CryptoProvider");
+
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| "info,tokio_postgres=warn".into()),

--- a/rust/pgcollector/src/main.rs
+++ b/rust/pgcollector/src/main.rs
@@ -42,6 +42,10 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install rustls CryptoProvider");
+
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| "info,tokio_postgres=warn".into()),


### PR DESCRIPTION
## Problem

pgcollector and pgapi both crash on startup in dev, blocking the first deploy of both services.

- pgcollector panics before any TLS connection: rustls requires a process-level `CryptoProvider` but none is installed.
- pgapi is rejected by the stats database with `no pg_hba.conf entry ... no encryption` because it connects with `NoTls`.

## Changes

- pgcollector installs the `aws_lc_rs` crypto provider at the top of `main()`, matching every other Rust service in the repo.
- pgapi adds `rustls`, `tokio-postgres-rustls`, and `webpki-roots` as dependencies, replaces the `NoTls` connector with a `MakeRustlsConnect` using Mozilla root CAs, and installs the same crypto provider.
- The `Cargo.lock` diff is pgapi gaining three crates already present in the workspace. No other crate is affected.

## How did you test this code?

- `cargo check -p pgcollector -p pgapi`, `cargo clippy`, and `cargo fmt --check` all pass.
- Not run: an actual deployment. The next Kargo promotion will exercise both fixes end to end.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 4.6). Skills invoked: `/writing-pr-descriptions`.
Diagnosed from Kargo promotion logs and runtime errors the user shared.
The `aws_lc_rs` provider was chosen over `ring` because the workspace `rustls` dependency already selects `aws_lc_rs` to match the `clickhouse` crate's feature set.

https://claude.ai/code/session_018mk53g7s2h8LME92fxbdNv