### PR TITLE
feat(autoresearch): speed up SQL editor Jest tests

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
@@ -12,8 +12,6 @@ import { insightsApi } from 'scenes/insights/utils/api'
 import { getMarkdownNotebookMarkdown } from 'scenes/notebooks/Notebook/markdownNotebookV2'
 import { NotebookNodeType } from 'scenes/notebooks/types'
 import { defaultNotebookContent } from 'scenes/notebooks/utils'
-import { sceneLogic } from 'scenes/sceneLogic'
-import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { useMocks } from '~/mocks/jest'
@@ -216,6 +214,13 @@ function createMonacoWithModel(model: any): any {
     return monaco
 }
 
+async function runDebouncedAction(action: () => void): Promise<void> {
+    jest.useFakeTimers()
+    action()
+    await jest.advanceTimersByTimeAsync(600)
+    jest.useRealTimers()
+}
+
 describe('sqlEditorLogic', () => {
     let logic: ReturnType<typeof sqlEditorLogic.build>
     let editorRootLogic: ReturnType<typeof editorSceneLogic.build> | undefined
@@ -295,11 +300,8 @@ describe('sqlEditorLogic', () => {
         })
 
         initKeaTests()
-        teamLogic.mount()
-        sceneLogic.mount()
         databaseLogic = databaseTableListLogic()
         databaseLogic.mount()
-        await expectLogic(teamLogic).toFinishAllListeners()
     })
 
     afterEach(() => {
@@ -1514,8 +1516,7 @@ describe('sqlEditorLogic', () => {
                 outputActiveTab: OutputTab.Visualization,
             })
 
-            logic.actions.setQueryInput('SELECT 2')
-            await new Promise((resolve) => setTimeout(resolve, 600))
+            await runDebouncedAction(() => logic.actions.setQueryInput('SELECT 2'))
 
             expect(router.values.hashParams.q).toEqual('SELECT 2')
             expect(router.values.hashParams.output_tab).toEqual(OutputTab.Visualization)
@@ -2009,8 +2010,7 @@ describe('sqlEditorLogic', () => {
 
             await expectLogic(logic).toDispatchActions(['setEditorSource', 'createTab', 'updateTab'])
 
-            logic.actions.setQueryInput('SELECT 2')
-            await new Promise((resolve) => setTimeout(resolve, 600))
+            await runDebouncedAction(() => logic.actions.setQueryInput('SELECT 2'))
 
             expect(router.values.searchParams.source).toBeUndefined()
             expect(router.values.hashParams.q).toEqual('SELECT 2')
@@ -2051,8 +2051,7 @@ describe('sqlEditorLogic', () => {
 
             await expectLogic(logic).toDispatchActions(['setEditorSource', 'createTab', 'updateTab'])
 
-            logic.actions.setQueryInput('SELECT 2')
-            await new Promise((resolve) => setTimeout(resolve, 600))
+            await runDebouncedAction(() => logic.actions.setQueryInput('SELECT 2'))
 
             expect(router.values.searchParams.source).toBeUndefined()
             expect(router.values.hashParams.q).toEqual('SELECT 2')
@@ -2117,8 +2116,7 @@ describe('sqlEditorLogic', () => {
             expect(logic.values.sourceQuery.source.connectionId).toEqual('conn-123')
             expect(router.values.hashParams.c).toEqual('conn-123')
 
-            logic.actions.setQueryInput('SELECT 2')
-            await new Promise((resolve) => setTimeout(resolve, 600))
+            await runDebouncedAction(() => logic.actions.setQueryInput('SELECT 2'))
 
             expect(router.values.hashParams.q).toEqual('SELECT 2')
             expect(router.values.hashParams.c).toEqual('conn-123')
@@ -2140,8 +2138,7 @@ describe('sqlEditorLogic', () => {
             expect(logic.values.sendRawQueryEnabled).toEqual(true)
             expect(String(router.values.hashParams.raw)).toEqual('1')
 
-            logic.actions.setQueryInput('SELECT 2')
-            await new Promise((resolve) => setTimeout(resolve, 600))
+            await runDebouncedAction(() => logic.actions.setQueryInput('SELECT 2'))
 
             expect(router.values.hashParams.q).toEqual('SELECT 2')
             expect(router.values.hashParams.c).toEqual('conn-123')

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
@@ -216,9 +216,12 @@ function createMonacoWithModel(model: any): any {
 
 async function runDebouncedAction(action: () => void): Promise<void> {
     jest.useFakeTimers()
-    action()
-    await jest.advanceTimersByTimeAsync(600)
-    jest.useRealTimers()
+    try {
+        action()
+        await jest.advanceTimersByTimeAsync(600)
+    } finally {
+        jest.useRealTimers()
+    }
 }
 
 describe('sqlEditorLogic', () => {


### PR DESCRIPTION
## Problem

🤖 Robot-authored: Frontend contributors wait while SQL editor tests repeat setup and real debounce delays.

## Changes

- SQL editor tests no longer mount unrelated shared logic.
- Debounce checks advance fake timers instead of waiting for wall-clock time.
- Nothing changes in the product UI or behavior.

## How did you test this code?

- Ran the SQL editor Jest file in serial mode.
- Ran `uv run hogli ci:preflight --fix`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This test-only change does not change documented behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used engineering analytics and local Jest measurements. Invoked skills: `/diagnosing-ci-and-merge-bottlenecks` and `/writing-pr-descriptions`.

Created with Autoresearch.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*