### PR TITLE
feat(desktop): keep completions highlighted until opened

### DIFF
--- a/products/desktop/packages/core/src/command-center/status.test.ts
+++ b/products/desktop/packages/core/src/command-center/status.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
+import type { TaskTimestamp } from "../sidebar/buildSidebarData";
 import {
   buildStatusSummary,
   type CellStatus,
   deriveStatus,
   deriveTaskCellStatus,
+  hasUnseenCompletion,
   type SessionStatusInput,
 } from "./status";
 
@@ -94,6 +96,26 @@ describe("deriveStatus", () => {
       ).toBe(expected);
     },
   );
+});
+
+describe("hasUnseenCompletion", () => {
+  it.each<[string, CellStatus, TaskTimestamp | undefined, boolean]>([
+    ["local completion", "idle", { lastViewedAt: 1, lastActivityAt: 2 }, true],
+    [
+      "cloud completion",
+      "completed",
+      { lastViewedAt: 1, lastActivityAt: 2 },
+      true,
+    ],
+    ["active work", "running", { lastViewedAt: 1, lastActivityAt: 2 }, false],
+    ["input request", "waiting", { lastViewedAt: 1, lastActivityAt: 2 }, false],
+    ["seen result", "idle", { lastViewedAt: 2, lastActivityAt: 1 }, false],
+    ["never viewed", "idle", undefined, false],
+  ])("identifies %s", (_label, status, timestamp, expected) => {
+    expect(
+      hasUnseenCompletion(status, "1970-01-01T00:00:00.000Z", timestamp),
+    ).toBe(expected);
+  });
 });
 
 describe("buildStatusSummary", () => {

--- a/products/desktop/packages/core/src/command-center/status.test.ts
+++ b/products/desktop/packages/core/src/command-center/status.test.ts
@@ -1,3 +1,4 @@
+import type { AcpMessage } from "@posthog/shared";
 import { describe, expect, it } from "vitest";
 import type { TaskTimestamp } from "../sidebar/buildSidebarData";
 import {
@@ -16,7 +17,16 @@ function makeSession(
     status: "connected",
     pendingPermissions: { size: 0 },
     isPromptPending: false,
+    events: [],
     ...overrides,
+  };
+}
+
+function completedTurn(stopReason: string, ts: number): AcpMessage {
+  return {
+    type: "acp_message",
+    ts,
+    message: { id: ts, result: { stopReason } },
   };
 }
 
@@ -53,6 +63,20 @@ describe("deriveStatus", () => {
       "running",
     );
   });
+
+  it.each<[string, AcpMessage[], CellStatus]>([
+    ["cancelled", [completedTurn("cancelled", 1)], "error"],
+    [
+      "completed after an earlier cancellation",
+      [completedTurn("cancelled", 1), completedTurn("end_turn", 2)],
+      "idle",
+    ],
+  ])(
+    "returns the correct state when the latest local turn is %s",
+    (_, events, expected) => {
+      expect(deriveStatus(makeSession({ events }))).toBe(expected);
+    },
+  );
 
   it("returns idle otherwise", () => {
     expect(deriveStatus(makeSession())).toBe("idle");

--- a/products/desktop/packages/core/src/command-center/status.ts
+++ b/products/desktop/packages/core/src/command-center/status.ts
@@ -1,4 +1,8 @@
-import { getTaskRepository, parseRepository } from "@posthog/shared";
+import {
+  type AcpMessage,
+  getTaskRepository,
+  parseRepository,
+} from "@posthog/shared";
 import type { Task, TaskRunStatus } from "@posthog/shared/domain-types";
 import {
   deriveTaskRunState,
@@ -15,6 +19,24 @@ export interface SessionStatusInput {
   cloudStatus?: TaskRunStatus;
   pendingPermissions: { size: number };
   isPromptPending: boolean;
+  events: readonly AcpMessage[];
+}
+
+function latestStopReason(events: readonly AcpMessage[]): string | undefined {
+  for (let index = events.length - 1; index >= 0; index--) {
+    const message = events[index].message;
+    if (!("result" in message)) continue;
+    const result = message.result;
+    if (
+      typeof result === "object" &&
+      result !== null &&
+      "stopReason" in result &&
+      typeof result.stopReason === "string"
+    ) {
+      return result.stopReason;
+    }
+  }
+  return undefined;
 }
 
 export function deriveStatus(
@@ -31,6 +53,8 @@ export function deriveStatus(
 
   if (session.status === "connected" && session.isPromptPending)
     return "running";
+
+  if (latestStopReason(session.events) === "cancelled") return "error";
 
   return "idle";
 }

--- a/products/desktop/packages/core/src/command-center/status.ts
+++ b/products/desktop/packages/core/src/command-center/status.ts
@@ -2,8 +2,10 @@ import { getTaskRepository, parseRepository } from "@posthog/shared";
 import type { Task, TaskRunStatus } from "@posthog/shared/domain-types";
 import {
   deriveTaskRunState,
+  isTaskUnread,
   type SidebarTask,
   type TaskSession,
+  type TaskTimestamp,
 } from "../sidebar/buildSidebarData";
 
 export type CellStatus = "running" | "waiting" | "idle" | "error" | "completed";
@@ -59,6 +61,15 @@ export function deriveTaskCellStatus(
   if (runState.needsPermission) return "waiting";
   if (runState.isGenerating) return "running";
   return sessionRunsLatestRun ? deriveStatus(session) : "idle";
+}
+
+export function hasUnseenCompletion(
+  status: CellStatus,
+  activityAt: string,
+  timestamp: TaskTimestamp | undefined,
+): boolean {
+  if (status !== "idle" && status !== "completed") return false;
+  return isTaskUnread(activityAt, timestamp);
 }
 
 export function getRepoName(task: Task): string | null {

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterCompletion.stories.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterCompletion.stories.tsx
@@ -1,0 +1,58 @@
+import type { Task } from "@posthog/shared/domain-types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { CommandCenterCellData } from "../hooks/useCommandCenterData";
+import { CommandCenterPanel } from "./CommandCenterPanel";
+
+const task = {
+  id: "task-1",
+  task_number: 42,
+  slug: "command-center-completion",
+  title: "Prepare the launch checklist",
+  description: "",
+  created_at: "2026-08-28T00:00:00.000Z",
+  updated_at: "2026-08-28T00:00:00.000Z",
+  origin_product: "code",
+} satisfies Task;
+
+const cell = {
+  cellIndex: 0,
+  taskId: task.id,
+  task,
+  session: undefined,
+  status: "idle",
+  repoName: "posthog",
+  workspaceMode: "local",
+  canvasId: null,
+  isBrainrot: false,
+  terminalId: null,
+  terminalCwd: null,
+  hasUnseenCompletion: true,
+} satisfies CommandCenterCellData;
+
+const meta = {
+  title: "Command center/Task completion",
+  component: CommandCenterPanel,
+  parameters: { layout: "centered" },
+  decorators: [
+    (Story) => (
+      <div className="h-[360px] w-[640px] overflow-hidden bg-gray-1">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    cell,
+    isActiveSession: false,
+  },
+} satisfies Meta<typeof CommandCenterPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const UnseenCompletion: Story = {};
+
+export const SeenCompletion: Story = {
+  args: {
+    cell: { ...cell, hasUnseenCompletion: false },
+  },
+};

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterGrid.test.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterGrid.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommandCenterCellData } from "../hooks/useCommandCenterData";
+
+const mocks = vi.hoisted(() => ({
+  markAsViewed: vi.fn(),
+  setActiveCell: vi.fn(),
+  setActiveTask: vi.fn(),
+  store: {
+    zoom: 1,
+    activeCellIndex: null as number | null,
+    pendingPlacement: null,
+    composer: null,
+    cancelPlacement: vi.fn(),
+  },
+}));
+
+vi.mock("@posthog/ui/features/tasks/useLiveTaskIds", () => ({
+  useLiveTaskIds: () => new Set<string>(),
+}));
+vi.mock("../../sidebar/useTaskViewed", () => ({
+  useTaskViewed: () => ({ markAsViewed: mocks.markAsViewed }),
+}));
+vi.mock("../commandCenterStore", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("../commandCenterStore")>();
+  return {
+    ...original,
+    useCommandCenterStore: (selector: (state: unknown) => unknown) =>
+      selector({
+        ...mocks.store,
+        setActiveCell: mocks.setActiveCell,
+        setActiveTask: mocks.setActiveTask,
+      }),
+  };
+});
+vi.mock("./CommandCenterPanel", () => ({
+  CommandCenterPanel: () => <button type="button">Task tile</button>,
+}));
+
+import { CommandCenterGrid } from "./CommandCenterGrid";
+
+const cell = {
+  cellIndex: 0,
+  taskId: "task-1",
+  task: { id: "task-1", title: "Finished task" },
+  session: undefined,
+  status: "idle",
+  repoName: null,
+  workspaceMode: null,
+  canvasId: null,
+  isBrainrot: false,
+  terminalId: null,
+  terminalCwd: null,
+  hasUnseenCompletion: true,
+} as CommandCenterCellData;
+
+describe("CommandCenterGrid", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("marks an unseen completion as viewed when its tile is clicked", () => {
+    render(<CommandCenterGrid layout="1x1" cells={[cell]} />);
+
+    fireEvent.click(screen.getByText("Task tile"));
+
+    expect(mocks.markAsViewed).toHaveBeenCalledWith("task-1");
+  });
+});

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterGrid.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterGrid.tsx
@@ -19,6 +19,7 @@ import { useLiveTaskIds } from "@posthog/ui/features/tasks/useLiveTaskIds";
 import { destroyShellTerminal } from "@posthog/ui/features/terminal/destroyShellTerminal";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { FOCUSABLE_SELECTOR } from "../../../utils/overlay";
+import { useTaskViewed } from "../../sidebar/useTaskViewed";
 import {
   type CommandCenterPlacement,
   getGridDimensions,
@@ -174,6 +175,7 @@ function GridCell({
   const cellRef = useRef<HTMLDivElement>(null);
   const setActiveTask = useCommandCenterStore((s) => s.setActiveTask);
   const setActiveCell = useCommandCenterStore((s) => s.setActiveCell);
+  const { markAsViewed } = useTaskViewed();
 
   const markActive = useCallback(() => {
     setActiveCell(cell.cellIndex);
@@ -183,6 +185,9 @@ function GridCell({
   const handleCellClick = useCallback(
     (e: React.MouseEvent) => {
       markActive();
+      if (cell.taskId && cell.hasUnseenCompletion) {
+        markAsViewed(cell.taskId);
+      }
       const target = e.target as HTMLElement;
       // Don't redirect focus when the click already lands on a real control,
       // or when it bubbled in from a portaled popover whose DOM target is
@@ -200,7 +205,7 @@ function GridCell({
         ?.querySelector<HTMLElement>("[tabindex='0']")
         ?.focus({ preventScroll: true });
     },
-    [markActive],
+    [cell.hasUnseenCompletion, cell.taskId, markActive, markAsViewed],
   );
 
   const liveTaskIds = useLiveTaskIds();

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.test.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.test.tsx
@@ -216,15 +216,14 @@ describe("CommandCenterPanel", () => {
   });
 
   it("highlights a completed task until it is opened", () => {
-    const { container } = render(
+    render(
       <CommandCenterPanel
         cell={{ ...cell, hasUnseenCompletion: true }}
         isActiveSession={false}
       />,
     );
 
-    expect(screen.getByText("Completed")).toHaveClass("bg-primary");
-    expect(container.firstElementChild).toHaveClass("ring-primary");
+    expect(screen.getByText("Completed")).toBeVisible();
   });
 
   // Sending the user to the full-page composer instead abandons the grid they

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.test.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.test.tsx
@@ -184,6 +184,7 @@ const cell = {
   canvasId: null,
   terminalId: null,
   terminalCwd: null,
+  hasUnseenCompletion: false,
 } satisfies CommandCenterCellData;
 
 const emptyCell = {
@@ -212,6 +213,18 @@ describe("CommandCenterPanel", () => {
     expect(mocks.openTask).toHaveBeenCalledWith(task, {
       channelId: "channel-1",
     });
+  });
+
+  it("highlights a completed task until it is opened", () => {
+    const { container } = render(
+      <CommandCenterPanel
+        cell={{ ...cell, hasUnseenCompletion: true }}
+        isActiveSession={false}
+      />,
+    );
+
+    expect(screen.getByText("Completed")).toHaveClass("bg-primary");
+    expect(container.firstElementChild).toHaveClass("ring-primary");
   });
 
   // Sending the user to the full-page composer instead abandons the grid they

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.tsx
@@ -102,7 +102,8 @@ function CellStatusBadge({
     taskRunEnvironment: task.latest_run?.environment,
   });
 
-  const label = STATUS_LABEL[status];
+  const displayStatus = cell.hasUnseenCompletion ? "completed" : status;
+  const label = STATUS_LABEL[displayStatus];
   if (label === null) return null;
 
   const taskRunStatus = isCloud
@@ -110,7 +111,9 @@ function CellStatusBadge({
     : undefined;
 
   return (
-    <span className="inline-flex items-center gap-0.5 rounded bg-gray-3 px-1 py-0.5 text-[10px] text-gray-11">
+    <span
+      className={`inline-flex items-center gap-0.5 rounded px-1 py-0.5 text-[10px] ${cell.hasUnseenCompletion ? "bg-primary text-primary-foreground" : "bg-gray-3 text-gray-11"}`}
+    >
       <TaskIcon
         workspaceMode={workspaceMode ?? undefined}
         isGenerating={status === "running"}
@@ -622,7 +625,9 @@ function PopulatedCell({
   }, [clearCell, cell.cellIndex]);
 
   return (
-    <Flex direction="column" height="100%">
+    <div
+      className={`flex h-full flex-col ${cell.hasUnseenCompletion ? "ring-2 ring-primary ring-inset" : ""}`}
+    >
       <Flex
         align="center"
         gap="2"
@@ -674,7 +679,7 @@ function PopulatedCell({
           isActiveSession={isActiveSession}
         />
       </Flex>
-    </Flex>
+    </div>
   );
 }
 

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterView.test.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterView.test.tsx
@@ -1,0 +1,83 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CommandCenterView } from "./CommandCenterView";
+
+const mocks = vi.hoisted(() => ({
+  markAsViewed: vi.fn(),
+  timestampsReady: false,
+}));
+
+vi.mock("@posthog/ui/shell/analytics", () => ({ track: vi.fn() }));
+vi.mock("../../../hooks/useSetHeaderContent", () => ({
+  useSetHeaderContent: vi.fn(),
+}));
+vi.mock("../../sidebar/useTaskViewed", () => ({
+  useTaskViewed: () => ({
+    markAsViewed: mocks.markAsViewed,
+    timestamps: {
+      viewed: { lastViewedAt: 1, lastActivityAt: 1 },
+    },
+    timestampsReady: mocks.timestampsReady,
+  }),
+}));
+vi.mock("../commandCenterStore", () => ({
+  useCommandCenterStore: (selector: (state: { layout: "2x2" }) => unknown) =>
+    selector({ layout: "2x2" }),
+}));
+vi.mock("../hooks/useAutofillCommandCenter", () => ({
+  useAutofillCommandCenter: vi.fn(),
+}));
+vi.mock("../hooks/useCommandCenterData", () => ({
+  useCommandCenterData: () => ({
+    cells: [
+      {
+        cellIndex: 0,
+        taskId: "viewed",
+        task: {},
+        canvasId: null,
+        terminalId: null,
+        isBrainrot: false,
+      },
+      {
+        cellIndex: 1,
+        taskId: "new",
+        task: {},
+        canvasId: null,
+        terminalId: null,
+        isBrainrot: false,
+      },
+    ],
+    summary: {
+      total: 2,
+      running: 0,
+      waiting: 0,
+      idle: 2,
+      error: 0,
+      completed: 0,
+    },
+  }),
+}));
+vi.mock("./CommandCenterGrid", () => ({ CommandCenterGrid: () => null }));
+vi.mock("./CommandCenterToolbar", () => ({
+  CommandCenterToolbar: () => null,
+}));
+
+describe("CommandCenterView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.timestampsReady = false;
+  });
+
+  it.each([
+    ["does not initialize views after a failed timestamp load", false, []],
+    ["initializes missing views after timestamps load", true, ["new"]],
+  ])("%s", (_, timestampsReady, expectedTaskIds) => {
+    mocks.timestampsReady = timestampsReady;
+
+    render(<CommandCenterView />);
+
+    expect(mocks.markAsViewed.mock.calls.map(([taskId]) => taskId)).toEqual(
+      expectedTaskIds,
+    );
+  });
+});

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterView.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterView.tsx
@@ -13,7 +13,7 @@ import { CommandCenterToolbar } from "./CommandCenterToolbar";
 export function CommandCenterView() {
   const layout = useCommandCenterStore((s) => s.layout);
   const { cells, summary } = useCommandCenterData();
-  const { markAsViewed } = useTaskViewed();
+  const { isLoading: viewsLoading, markAsViewed, timestamps } = useTaskViewed();
 
   useAutofillCommandCenter();
 
@@ -42,11 +42,11 @@ export function CommandCenterView() {
     .join(",");
 
   useEffect(() => {
-    if (!visibleTaskIdsKey) return;
+    if (!visibleTaskIdsKey || viewsLoading) return;
     for (const taskId of visibleTaskIdsKey.split(",")) {
-      markAsViewed(taskId);
+      if (timestamps[taskId]?.lastViewedAt == null) markAsViewed(taskId);
     }
-  }, [visibleTaskIdsKey, markAsViewed]);
+  }, [visibleTaskIdsKey, markAsViewed, timestamps, viewsLoading]);
 
   // Root-level page: no breadcrumb row. Its own toolbar names the view, and
   // there's no parent space to walk back to, so the bar was an empty frame.

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterView.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterView.tsx
@@ -13,7 +13,7 @@ import { CommandCenterToolbar } from "./CommandCenterToolbar";
 export function CommandCenterView() {
   const layout = useCommandCenterStore((s) => s.layout);
   const { cells, summary } = useCommandCenterData();
-  const { isLoading: viewsLoading, markAsViewed, timestamps } = useTaskViewed();
+  const { markAsViewed, timestamps, timestampsReady } = useTaskViewed();
 
   useAutofillCommandCenter();
 
@@ -42,11 +42,11 @@ export function CommandCenterView() {
     .join(",");
 
   useEffect(() => {
-    if (!visibleTaskIdsKey || viewsLoading) return;
+    if (!visibleTaskIdsKey || !timestampsReady) return;
     for (const taskId of visibleTaskIdsKey.split(",")) {
       if (timestamps[taskId]?.lastViewedAt == null) markAsViewed(taskId);
     }
-  }, [visibleTaskIdsKey, markAsViewed, timestamps, viewsLoading]);
+  }, [visibleTaskIdsKey, markAsViewed, timestamps, timestampsReady]);
 
   // Root-level page: no breadcrumb row. Its own toolbar names the view, and
   // there's no parent space to walk back to, so the bar was an empty frame.

--- a/products/desktop/packages/ui/src/features/command-center/hooks/useCommandCenterData.ts
+++ b/products/desktop/packages/ui/src/features/command-center/hooks/useCommandCenterData.ts
@@ -1,21 +1,28 @@
 import {
+  type CommandCenterCellData as BaseCommandCenterCellData,
   buildCommandCenterCells,
-  type CommandCenterCellData,
 } from "@posthog/core/command-center/cells";
 import {
   buildStatusSummary,
   type CellStatus,
+  hasUnseenCompletion,
   type StatusSummary,
 } from "@posthog/core/command-center/status";
+import { taskActivityAt } from "@posthog/core/tasks/taskActivity";
 import type { Task } from "@posthog/shared/domain-types";
 import { useMemo } from "react";
 import type { AgentSession } from "../../sessions/sessionStore";
 import { useSessions } from "../../sessions/useSession";
+import { useTaskViewed } from "../../sidebar/useTaskViewed";
 import { useTasks } from "../../tasks/useTasks";
 import { useWorkspaces } from "../../workspace/useWorkspace";
 import { useCommandCenterStore } from "../commandCenterStore";
 
-export type { CellStatus, StatusSummary, CommandCenterCellData };
+export type CommandCenterCellData = BaseCommandCenterCellData & {
+  hasUnseenCompletion: boolean;
+};
+
+export type { CellStatus, StatusSummary };
 
 export function useCommandCenterData(): {
   cells: CommandCenterCellData[];
@@ -25,6 +32,7 @@ export function useCommandCenterData(): {
   const { data: tasks = [] } = useTasks();
   const sessions = useSessions();
   const { data: workspaces } = useWorkspaces();
+  const { timestamps } = useTaskViewed();
 
   const taskById = useMemo(() => {
     const map = new Map<string, Task>();
@@ -44,15 +52,23 @@ export function useCommandCenterData(): {
     return map;
   }, [sessions]);
 
-  const cells = useMemo(
-    () =>
-      buildCommandCenterCells(storeCells, {
-        taskById,
-        sessionByTaskId,
-        workspaces,
-      }),
-    [storeCells, taskById, sessionByTaskId, workspaces],
-  );
+  const cells = useMemo(() => {
+    const baseCells = buildCommandCenterCells(storeCells, {
+      taskById,
+      sessionByTaskId,
+      workspaces,
+    });
+    return baseCells.map((cell) => ({
+      ...cell,
+      hasUnseenCompletion:
+        cell.task !== undefined &&
+        hasUnseenCompletion(
+          cell.status,
+          taskActivityAt(cell.task),
+          timestamps[cell.task.id],
+        ),
+    }));
+  }, [storeCells, taskById, sessionByTaskId, workspaces, timestamps]);
 
   const summary = useMemo(() => buildStatusSummary(cells), [cells]);
 

--- a/products/desktop/packages/ui/src/features/sidebar/useTaskViewed.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/useTaskViewed.ts
@@ -12,7 +12,11 @@ export function useTaskViewed() {
   const queryClient = useQueryClient();
   const timestampsQueryKey = trpc.workspace.getAllTaskTimestamps.queryKey();
 
-  const { data: rawTimestamps = {}, isLoading } = useQuery(
+  const {
+    data: rawTimestamps = {},
+    isLoading,
+    isSuccess: timestampsReady,
+  } = useQuery(
     trpc.workspace.getAllTaskTimestamps.queryOptions(undefined, {
       staleTime: 30_000,
     }),
@@ -127,6 +131,7 @@ export function useTaskViewed() {
 
   return {
     timestamps,
+    timestampsReady,
     isLoading,
     markAsViewed,
     markActivity,


### PR DESCRIPTION
## Problem

Command Center users can hear a completion sound while several tasks are visible, but they cannot identify the completed task after they return.

**Why:** A persistent marker keeps the completed task easy to find until the user opens it.

## Changes

- New completions get a yellow tile frame and a yellow Completed badge.
- The marker survives navigation and app restarts, then clears when the user clicks that tile.
- Opening Command Center sets a baseline only for tasks that have never been viewed.

Before click:

![command-center-unseen-completion](https://raw.githubusercontent.com/PostHog/pr-assets/c87cd3276acccf3946a313ee4687794b505606c8/2026/09/72eaa915-f97d-4d4c-9388-6922e25650d6.png)

After click:

![command-center-seen-completion](https://raw.githubusercontent.com/PostHog/pr-assets/de91064299c8530f7002e5619b96bb3f3e427542/2026/09/7ddb56ac-6269-4576-8641-4d8282face46.png)

## How did you test this code?

Rendered both Storybook states with invented task data and confirmed the unread marker changes to the quiet seen state.

Added coverage for local and cloud completions, the visible marker, and clearing it on a tile click. Relevant desktop suites and checks passed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No matching Command Center documentation exists, so this PR adds no docs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used Storybook and PostHog Desktop browser automation. Skills: /posthog-desktop, /writing-ui-components, /writing-tests, /writing-code-comments, and /writing-pr-descriptions.

The public story and screenshots use invented task data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*