### PR TITLE
fix(stripe): stop retrying a customer-scoped invalid_request_error with no detail

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/source.py
@@ -312,6 +312,12 @@ If automatic creation failed with a permissions error, the fix depends on how yo
             "Integration not found": "The linked Stripe integration no longer exists. Please reconnect your Stripe account.",
             "Stripe access token not found": "Stripe OAuth access token is missing. Please reconnect your Stripe account.",
             "Your Stripe OAuth connection has expired or been revoked. Please reconnect your Stripe account.": "Your Stripe OAuth connection has expired or been revoked. Please reconnect your Stripe account.",
+            # Stripe's own `invalid_request_error` body with no usable detail, seen when listing a
+            # specific customer's nested resources (e.g. payment methods). It is a 400-class error,
+            # so retrying replays the identical request against the same customer and fails
+            # identically every time. Stripe's own message isn't actionable, so surface a message
+            # that points at the account rather than showing the raw string.
+            "error_details_unknown": "Stripe rejected a request for one of your resources without a specific reason. Check your Stripe account for any restrictions or contact Stripe support, then try again.",
         }
 
     def get_retryable_errors(self) -> set[str]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
@@ -238,6 +238,10 @@ class TestStripeSource:
             # A publishable key was used where a secret/restricted key is required — matched on the
             # stable message text, ignoring the request id prefix.
             "Request req_abc123: This API call cannot be made with a publishable API key. Please use a secret API key. You can find a list of your API keys at https://dashboard.stripe.com/account/apikeys.",
+            # A 400-class InvalidRequestError with no usable Stripe-provided detail, raised when
+            # listing a specific customer's nested resources — every retry replays the same request
+            # against the same customer and fails identically.
+            "Request req_abc123: error_details_unknown",
         ],
     )
     def test_non_retryable_errors_match_permission_failures(self, observed_error):


### PR DESCRIPTION
## Problem

A Stripe warehouse sync keeps retrying and failing when Stripe rejects a per-customer nested resource lookup (e.g. listing a customer's payment methods) with an `invalid_request_error` that carries no usable detail in its message.

- Stripe returns this as a 400-class error, so every retry replays the identical request against the same customer and fails the same way.
- The sync currently treats it as retryable, so it keeps failing until the retry budget is exhausted and is reported to error tracking each time: [issue](https://us.posthog.com/project/2/error_tracking/01a0699b-a7e0-7940-8ae9-6ad0be8dd546).

## Changes

- Add the error's stable message text to `StripeSource.get_non_retryable_errors()` so the schema stops retrying and disables with an actionable message instead of Stripe's raw, non-descriptive string.
- Add a parameterized test case asserting the message is recognized as non-retryable.

## How did you test this code?

Ran the existing `TestStripeSource` suite (`pytest products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py -k TestStripeSource`), 47 passed including the new case. Did not run the broader test suite or exercise a live sync.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal retry classification, no documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to confirm the exception originates in `products/warehouse_sources/backend/temporal/data_imports/sources/stripe/stripe.py`, then read the surrounding `get_rows` nested-resource loop and `source.py`'s existing `get_non_retryable_errors` patterns to match its style. Confirmed no open PR already addresses this error before opening this one.