### PR TITLE
fix(mcp-store): keep disabled servers inactive

### DIFF
--- a/products/mcp_store/backend/catalog_sync.py
+++ b/products/mcp_store/backend/catalog_sync.py
@@ -161,10 +161,11 @@ def _update_template(template: MCPServerTemplate, entry: CatalogEntry, skip_prob
     changed = [f for f in _CONTENT_FIELDS if getattr(template, f) != _entry_field_value(entry, f)]
     for f in changed:
         setattr(template, f, _entry_field_value(entry, f))
-    if entry.disabled and template.is_active:
-        template.is_active = False
-        changed.append("is_active")
-        logger.warning("mcp_catalog_sync.deactivated_disabled_entry", url=entry.url)
+    if entry.disabled:
+        if template.is_active:
+            template.is_active = False
+            changed.append("is_active")
+            logger.warning("mcp_catalog_sync.deactivated_disabled_entry", url=entry.url)
     elif "auth_type" in changed and template.is_active:
         # The row was vetted and activated under the old auth model — e.g. an
         # oauth→api_key flip would route new installs through the API-key branch

--- a/products/mcp_store/backend/test/test_catalog_sync.py
+++ b/products/mcp_store/backend/test/test_catalog_sync.py
@@ -290,23 +290,36 @@ class TestSyncMCPCatalog(TestCase):
         assert counts.created == 1
         assert MCPServerTemplate.objects.get(url=_entry().url).is_active is False
 
-    def test_disabled_entry_deactivates_existing_template(self):
+    @patch(
+        "products.mcp_store.backend.oauth_credentials.get_instance_settings",
+        return_value={"SLACK_APP_CLIENT_ID": "slack-client", "SLACK_APP_CLIENT_SECRET": "slack-secret"},
+    )
+    def test_disabled_entry_remains_inactive_across_syncs(self, _settings):
+        entry = _entry(disabled=True, oauth_credentials_source="slack_app")
         template = MCPServerTemplate.objects.create(
             name="Linear",
-            url=_entry().url,
+            url=entry.url,
             description="Manage Linear issues.",
             auth_type="oauth",
             category="dev",
             icon_domain="linear.app",
             is_active=True,
         )
+        probe_result = ProbeResult(
+            reachable=True,
+            speaks_mcp=True,
+            auth_flavor="oauth_shared",
+            authorize_endpoint_ok=True,
+        )
 
-        with patch("products.mcp_store.backend.catalog_sync.probe_mcp_server") as probe_mock:
-            counts = sync_mcp_catalog(entries=[_entry(disabled=True)])
+        with patch("products.mcp_store.backend.catalog_sync.probe_mcp_server", return_value=probe_result) as probe_mock:
+            first_counts = sync_mcp_catalog(entries=[entry])
+            second_counts = sync_mcp_catalog(entries=[entry])
 
         probe_mock.assert_not_called()
         template.refresh_from_db()
-        assert counts.updated == 1
+        assert first_counts.updated == 1
+        assert second_counts.unchanged == 1
         assert template.is_active is False
 
     def test_warns_on_active_row_missing_from_catalog(self):


### PR DESCRIPTION
## Problem

A disabled MCP server with catalog-managed OAuth credentials can reappear after a recurring catalog sync.

Refs #93867

## Changes

- Disabled entries now bypass credential probing regardless of their stored activation state.
- No UI changes.

Before:

```mermaid
flowchart LR
    A[Sync disabled active server] --> B[Deactivate]
    B --> C[Next sync]
    C --> D[Probe configured credentials]
    D --> E[Reactivate]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,C phBlue;
    class B phYellow;
    class D,E phRed;
```

After:

```mermaid
flowchart LR
    A[Sync disabled server] --> B{Active}
    B -->|Yes| C[Deactivate]
    B -->|No| D[Leave inactive]
    C --> D
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phBlue;
    class B phYellow;
    class C phRed;
    class D phYellow;
```

## How did you test this code?

Added coverage that syncs a sourced disabled server twice and confirms it remains inactive without probing. The MCP catalog suite and strict preflight pass.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Existing documentation already states that disabled entries remain inactive.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used GitHub and local repository tools. Skills: `stacking-prs`, `writing-pr-descriptions`, `adding-mcp-store-servers`, `writing-tests`, and `run-posthog`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*