### PR TITLE
feat(autoresearch): balance frontend Jest shards

### DIFF
--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -353,6 +353,8 @@ const config: Config = {
     // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
     // watchPathIgnorePatterns: [],
 
+    testSequencer: '<rootDir>/jest.test-sequencer.js',
+
     // Whether to use watchman for file crawling
     // watchman: true,
 }

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -162,9 +162,6 @@ jest.mock('posthog-js/dist/element-inference', () => ({
 
 // Mock posthog-js to avoid issues in tests
 jest.mock('posthog-js', () => {
-    // Get the actual module to preserve type exports (enums, etc.)
-    const actual = jest.requireActual('posthog-js')
-
     const mock: Record<string, any> = {
         capture: jest.fn(),
         captureException: jest.fn(),
@@ -200,8 +197,25 @@ jest.mock('posthog-js', () => {
     }
     mock.init = jest.fn(() => mock)
 
-    // Return mock functions but preserve actual type exports
-    return { ...actual, __esModule: true, default: mock, posthog: mock }
+    let actual: Record<PropertyKey, unknown> | undefined
+
+    return new Proxy(
+        {
+            __esModule: true,
+            default: mock,
+            posthog: mock,
+        },
+        {
+            get: (target, property, receiver) => {
+                if (Reflect.has(target, property)) {
+                    return Reflect.get(target, property, receiver)
+                }
+
+                actual ??= jest.requireActual('posthog-js')
+                return actual[property]
+            },
+        }
+    )
 })
 
 jest.mock('@tiptap/extension-code-block-lowlight', () => {

--- a/frontend/jest.test-sequencer.js
+++ b/frontend/jest.test-sequencer.js
@@ -1,0 +1,32 @@
+const Sequencer = require('@jest/test-sequencer').default
+const fs = require('fs')
+
+const TEST_CASE_PATTERN = /\b(?:it|test)(?:\.(?:each|only|skip|todo|concurrent))*\s*\(/g
+const TEST_CASE_WEIGHT = 10_000
+
+const testWeight = (test) => {
+    const size = test.context.hasteFS.getSize(test.path) ?? 0
+    const testCases = fs.readFileSync(test.path, 'utf8').match(TEST_CASE_PATTERN)?.length ?? 0
+    return size + testCases * TEST_CASE_WEIGHT
+}
+
+class SizeBalancedSequencer extends Sequencer {
+    shard(tests, { shardCount, shardIndex }) {
+        const shards = Array.from({ length: shardCount }, () => [])
+        const shardWeights = new Array(shardCount).fill(0)
+        const testWeights = new Map(tests.map((test) => [test.path, testWeight(test)]))
+        const sortedTests = [...tests].sort((first, second) => {
+            return testWeights.get(second.path) - testWeights.get(first.path) || first.path.localeCompare(second.path)
+        })
+
+        for (const test of sortedTests) {
+            const shard = shardWeights.indexOf(Math.min(...shardWeights))
+            shards[shard].push(test)
+            shardWeights[shard] += testWeights.get(test.path)
+        }
+
+        return shards[shardIndex - 1]
+    }
+}
+
+module.exports = SizeBalancedSequencer


### PR DESCRIPTION
## Problem

Frontend developers wait for the slowest Jest shard after the other shards finish.

**Why:** Better shard balance reduces feedback time without removing tests or weakening assertions.

## Changes

- Jest shards now balance files by source size and static test-case count.
- The Jest setup loads real PostHog SDK exports only when a test needs them.
- This change has no user-visible effect.
- Created with Autoresearch.

## How did you test this code?

- Ran all four CI-style Jest shards.
- Ran frontend lint, format checks, TypeScript checks, and CI preflight.
- Confirmed that the sequencer assigns each test file once.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This change only affects test execution.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used the `/querying-posthog-data`, `/diagnosing-ci-and-merge-bottlenecks`, and `/writing-pr-descriptions` skills.

The research tested several models and kept the best stable shard model. It rejected changes that failed or increased run time.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
