### PR TITLE
fix(pgcollector): switch from rustls to native-tls for Postgres TLS

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3866,21 +3866,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
- "der_derive",
- "flagset",
  "pem-rfc7468",
  "zeroize",
-]
-
-[[package]]
-name = "der_derive"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -4680,12 +4667,6 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
 ]
-
-[[package]]
-name = "flagset"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flatbuffers"
@@ -8981,24 +8962,23 @@ dependencies = [
  "futures-util",
  "humantime",
  "jsonwebtoken",
+ "native-tls",
  "once_cell",
+ "postgres-native-tls",
  "prometheus",
  "regex",
  "reqwest 0.12.28",
  "rmcp",
  "rust_decimal",
  "rustls 0.23.37",
- "rustls-native-certs 0.8.3",
  "schemars 1.2.1",
  "serde",
  "serde_json",
  "tokio",
  "tokio-postgres",
- "tokio-postgres-rustls",
  "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
- "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -9018,23 +8998,22 @@ dependencies = [
  "glob",
  "humantime-serde",
  "include_dir",
+ "native-tls",
  "once_cell",
+ "postgres-native-tls",
  "prometheus",
  "regex",
  "rust_decimal",
  "rustls 0.23.37",
- "rustls-native-certs 0.8.3",
  "serde",
  "serde_json",
  "serde_yaml",
  "shellexpand",
  "tokio",
  "tokio-postgres",
- "tokio-postgres-rustls",
  "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
- "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -9266,6 +9245,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postgres-native-tls"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef4de47bb81477e0c3deaf153a1b10ae176484713ff1640969f4cb96b653ebc"
+dependencies = [
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-postgres",
 ]
 
 [[package]]
@@ -13043,27 +13034,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tls_codec"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
-dependencies = [
- "tls_codec_derive",
- "zeroize",
-]
-
-[[package]]
-name = "tls_codec_derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13135,21 +13105,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "whoami 2.1.3",
-]
-
-[[package]]
-name = "tokio-postgres-rustls"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d684bad428a0f2481f42241f821db42c54e2dc81d8c00db8536c506b0a0144"
-dependencies = [
- "const-oid 0.9.6",
- "ring 0.17.14",
- "rustls 0.23.37",
- "tokio",
- "tokio-postgres",
- "tokio-rustls 0.26.4",
- "x509-cert",
 ]
 
 [[package]]
@@ -14702,18 +14657,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "x509-cert"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
-dependencies = [
- "const-oid 0.9.6",
- "der",
- "spki",
- "tls_codec",
 ]
 
 [[package]]

--- a/rust/pgapi/Cargo.toml
+++ b/rust/pgapi/Cargo.toml
@@ -21,18 +21,17 @@ regex = { workspace = true }
 reqwest = { workspace = true }
 rmcp = { version = "3", features = ["server", "macros", "transport-streamable-http-server"] }
 rust_decimal = { version = "1", features = ["db-tokio-postgres"] }
+native-tls = "0.2"
+postgres-native-tls = "0.5"
 rustls = { workspace = true }
-rustls-native-certs = "0.8"
 schemars = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
-tokio-postgres-rustls = "0.13"
 tower-http = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-webpki-roots = "1"
 
 [lints]
 workspace = true

--- a/rust/pgapi/src/db.rs
+++ b/rust/pgapi/src/db.rs
@@ -20,24 +20,11 @@ impl Db {
     pub async fn connect(url: &str) -> Result<Self> {
         let mut cfg: tokio_postgres::Config = url.parse().context("parsing PGAPI_DATABASE_URL")?;
         cfg.ssl_mode(tokio_postgres::config::SslMode::Require);
-        let mut roots = rustls::RootCertStore::empty();
-        let native = rustls_native_certs::load_native_certs();
-        for err in &native.errors {
-            tracing::warn!(error = %err, "failed to load a native certificate");
-        }
-        for cert in native.certs {
-            if let Err(e) = roots.add(cert) {
-                tracing::warn!(error = %e, "failed to add a native certificate to root store");
-            }
-        }
-        if roots.is_empty() {
-            tracing::info!("no native certs found, falling back to webpki-roots");
-            roots.roots = webpki_roots::TLS_SERVER_ROOTS.to_vec();
-        }
-        let tls_cfg = rustls::ClientConfig::builder()
-            .with_root_certificates(roots)
-            .with_no_client_auth();
-        let tls = tokio_postgres_rustls::MakeRustlsConnect::new(tls_cfg);
+        let connector = native_tls::TlsConnector::builder()
+            .danger_accept_invalid_certs(true)
+            .build()
+            .context("building TLS connector")?;
+        let tls = postgres_native_tls::MakeTlsConnector::new(connector);
         let mgr = Manager::from_config(
             cfg,
             tls,

--- a/rust/pgcollector/Cargo.toml
+++ b/rust/pgcollector/Cargo.toml
@@ -24,19 +24,18 @@ once_cell = { workspace = true }
 prometheus = "0.13"
 regex = { workspace = true }
 rust_decimal = { version = "1", features = ["db-tokio-postgres"] }
+native-tls = "0.2"
+postgres-native-tls = "0.5"
 rustls = { workspace = true }
-rustls-native-certs = "0.8"
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = "0.9"
 shellexpand = "3"
 tokio = { workspace = true }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
-tokio-postgres-rustls = "0.13"
 toml = "0.8"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-webpki-roots = "1"
 
 [lints]
 workspace = true

--- a/rust/pgcollector/src/pg.rs
+++ b/rust/pgcollector/src/pg.rs
@@ -20,25 +20,12 @@ pub fn tls_policy(url: &str) -> tokio_postgres::config::SslMode {
     }
 }
 
-pub fn tls_connector() -> tokio_postgres_rustls::MakeRustlsConnect {
-    let mut roots = rustls::RootCertStore::empty();
-    let native = rustls_native_certs::load_native_certs();
-    for err in &native.errors {
-        tracing::warn!(error = %err, "failed to load a native certificate");
-    }
-    for cert in native.certs {
-        if let Err(e) = roots.add(cert) {
-            tracing::warn!(error = %e, "failed to add a native certificate to root store");
-        }
-    }
-    if roots.is_empty() {
-        tracing::info!("no native certs found, falling back to webpki-roots");
-        roots.roots = webpki_roots::TLS_SERVER_ROOTS.to_vec();
-    }
-    let tls_cfg = rustls::ClientConfig::builder()
-        .with_root_certificates(roots)
-        .with_no_client_auth();
-    tokio_postgres_rustls::MakeRustlsConnect::new(tls_cfg)
+pub fn tls_connector() -> postgres_native_tls::MakeTlsConnector {
+    let connector = native_tls::TlsConnector::builder()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .expect("failed to build TLS connector");
+    postgres_native_tls::MakeTlsConnector::new(connector)
 }
 
 pub async fn connect(


### PR DESCRIPTION
## Problem

pgcollector and pgapi crash-loop on startup with `UnknownIssuer` when connecting to RDS Aurora.
rustls always verifies the server certificate, but RDS does not send intermediate CAs in the TLS handshake.
The system CA store has the Amazon root, not the RDS-specific intermediate, so rustls cannot build the chain.

Every other Rust service uses sqlx with native-tls (OpenSSL), which encrypts without verifying — those connect fine.

## Changes

- Replace `tokio-postgres-rustls` with `postgres-native-tls` in both pgcollector and pgapi.
- Remove `rustls-native-certs` and `webpki-roots` (no longer needed for Postgres TLS; `rustls` stays for the AWS SDK and reqwest).
- Connections are encrypted without cert verification, matching the security posture of every other service in the stack.
- Lockfile shrinks: drops `tokio-postgres-rustls`, `x509-cert`, `tls_codec`, `der_derive`, `flagset`.

## How did you test this code?

- `cargo check -p pgcollector -p pgapi` — compiles cleanly.
- `cargo clippy -p pgcollector -p pgapi` — no warnings.
- `cargo fmt` — no changes needed.
- Not tested against a live RDS instance from this environment. Deployment to dev will be the integration test.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, session below.
Diagnosed the root cause by examining Loki logs, the charts repo's external-secret template, and the shared database library.
The native-certs PR (#94808) confirmed the system CA store loads without errors — the issue is a missing RDS intermediate, not a missing root.
Invoked `/writing-pr-descriptions`.

https://claude.ai/code/session_018mk53g7s2h8LME92fxbdNv