### PR TITLE
feat(propdefs): warm dedup caches lazily from postgres

### DIFF
--- a/rust/property-defs-rs/src/cache_warming.rs
+++ b/rust/property-defs-rs/src/cache_warming.rs
@@ -25,6 +25,8 @@ use crate::{
 pub struct WarmingLimits {
     pub eventprops_per_team: i64,
     pub propdefs_per_team: i64,
+    // Rows per event-property statement; see the config field for why chunking matters.
+    pub chunk_size: i64,
 }
 
 impl WarmingLimits {
@@ -32,6 +34,7 @@ impl WarmingLimits {
         Self {
             eventprops_per_team: config.cache_warming_eventprops_per_team_limit,
             propdefs_per_team: config.cache_warming_propdefs_per_team_limit,
+            chunk_size: config.cache_warming_chunk_size.max(1),
         }
     }
 }
@@ -157,9 +160,18 @@ pub async fn run_warming_worker(
 /// group name while Postgres stores the resolved index, and they are a sliver of
 /// write volume.
 ///
-/// Loaded rows describe successful past writes, so inserting them satisfies the same
-/// invariant as the optimistic insert on the write path: `Some` property types only
-/// enter the cache when the row is known non-null in Postgres.
+/// The event-property scan is keyset-paginated: with the COALESCE prefix pinned by
+/// equality, ORDER BY (event, property) is the index order, so each chunk resumes
+/// the same range scan where the previous one stopped and every statement stays
+/// bounded to seconds even on the largest teams.
+///
+/// A row the cache already covers is not re-inserted. The live write path races
+/// this scan, and its optimistic inserts can be fresher than the query snapshot
+/// (a property typed after the scan started); overwriting would downgrade that
+/// entry and cost a redundant no-op upsert later. Loaded rows describe successful
+/// past writes, so what does get inserted satisfies the same invariant as the
+/// write path: `Some` property types only enter the cache when the row is known
+/// non-null in Postgres.
 pub async fn warm_team(
     pool: &PgPool,
     cache: &Cache,
@@ -168,21 +180,52 @@ pub async fn warm_team(
     limits: WarmingLimits,
 ) -> Result<(u64, u64), sqlx::Error> {
     let mut eventprops: u64 = 0;
-    let mut rows = sqlx::query_as::<_, (String, String)>(
-        r#"SELECT event, property FROM posthog_eventproperty
-           WHERE COALESCE(project_id, team_id::bigint) = $1 LIMIT $2"#,
-    )
-    .bind(project_id)
-    .bind(limits.eventprops_per_team)
-    .fetch(pool);
-    while let Some((event, property)) = rows.try_next().await? {
-        cache.insert(Update::EventProperty(EventProperty {
-            team_id,
-            project_id,
-            event,
-            property,
-        }));
-        eventprops += 1;
+    let mut keyset: Option<(String, String)> = None;
+    loop {
+        let remaining = limits.eventprops_per_team - eventprops as i64;
+        if remaining <= 0 {
+            break;
+        }
+        let chunk_limit = limits.chunk_size.min(remaining);
+        let query = if let Some((last_event, last_property)) = keyset.take() {
+            sqlx::query_as::<_, (String, String)>(
+                r#"SELECT event, property FROM posthog_eventproperty
+                   WHERE COALESCE(project_id, team_id::bigint) = $1
+                     AND (event, property) > ($3, $4)
+                   ORDER BY event, property LIMIT $2"#,
+            )
+            .bind(project_id)
+            .bind(chunk_limit)
+            .bind(last_event)
+            .bind(last_property)
+        } else {
+            sqlx::query_as::<_, (String, String)>(
+                r#"SELECT event, property FROM posthog_eventproperty
+                   WHERE COALESCE(project_id, team_id::bigint) = $1
+                   ORDER BY event, property LIMIT $2"#,
+            )
+            .bind(project_id)
+            .bind(chunk_limit)
+        };
+
+        let rows = query.fetch_all(pool).await?;
+        let chunk_rows = rows.len() as i64;
+        keyset = rows.last().cloned();
+        for (event, property) in rows {
+            let update = Update::EventProperty(EventProperty {
+                team_id,
+                project_id,
+                event,
+                property,
+            });
+            if !cache.covers(&update) {
+                cache.insert(update);
+            }
+            eventprops += 1;
+        }
+        if chunk_rows < chunk_limit {
+            break;
+        }
     }
     metrics::counter!(CACHE_WARMING_ROWS, &[("cache", "eventprops")]).increment(eventprops);
 
@@ -206,7 +249,7 @@ pub async fn warm_team(
         // An unparseable stored type warms as untyped: the first typed sighting then
         // re-issues one upsert, which the DB guard no-ops. Never lossy.
         let property_type: Option<PropertyValueType> = property_type.and_then(|s| s.parse().ok());
-        cache.insert(Update::Property(PropertyDefinition {
+        let update = Update::Property(PropertyDefinition {
             team_id,
             project_id,
             name,
@@ -214,7 +257,10 @@ pub async fn warm_team(
             property_type,
             event_type,
             group_type_index: None,
-        }));
+        });
+        if !cache.covers(&update) {
+            cache.insert(update);
+        }
         propdefs += 1;
     }
     metrics::counter!(CACHE_WARMING_ROWS, &[("cache", "propdefs")]).increment(propdefs);

--- a/rust/property-defs-rs/src/cache_warming.rs
+++ b/rust/property-defs-rs/src/cache_warming.rs
@@ -1,0 +1,223 @@
+use std::sync::{Arc, Mutex};
+
+use ahash::AHashSet;
+use futures::TryStreamExt;
+use sqlx::PgPool;
+use tokio::sync::{mpsc, Semaphore};
+use tracing::{info, warn};
+
+use crate::{
+    config::Config,
+    metrics_consts::{CACHE_WARMING_ROWS, CACHE_WARMING_TEAMS, CACHE_WARMING_TEAM_TIME},
+    types::{EventProperty, PropertyDefinition, PropertyParentType, PropertyValueType, Update},
+    update_cache::Cache,
+};
+
+// Lazy per-team cache warming. The consumed topic is partitioned by team, so the set
+// of teams a pod serves is exactly the set whose events arrive; there is nothing to
+// enumerate up front. The first event of a team after boot enqueues it here, and a
+// background worker streams the team's existing definition rows from Postgres into
+// the dedup caches. Until that finishes the team's lookups miss and write no-op
+// upserts, exactly as they would without warming, so the warm never blocks the
+// pipeline and cannot affect correctness - it only converts future misses to hits.
+
+#[derive(Clone, Copy)]
+pub struct WarmingLimits {
+    pub eventprops_per_team: i64,
+    pub propdefs_per_team: i64,
+}
+
+impl WarmingLimits {
+    pub fn from_config(config: &Config) -> Self {
+        Self {
+            eventprops_per_team: config.cache_warming_eventprops_per_team_limit,
+            propdefs_per_team: config.cache_warming_propdefs_per_team_limit,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct WarmTarget {
+    team_id: i32,
+    project_id: i64,
+}
+
+/// Shared warming state: the fleet of producer loops feeds it, one worker drains it.
+pub struct Warming {
+    // Teams enqueued or already warmed this process lifetime. A failed warm removes its
+    // team so a later event can retry it.
+    seen: Mutex<AHashSet<i32>>,
+    tx: mpsc::Sender<WarmTarget>,
+}
+
+impl Warming {
+    pub fn new(queue_depth: usize) -> (Arc<Self>, mpsc::Receiver<WarmTarget>) {
+        let (tx, rx) = mpsc::channel(queue_depth);
+        (
+            Arc::new(Self {
+                seen: Mutex::new(AHashSet::new()),
+                tx,
+            }),
+            rx,
+        )
+    }
+
+    fn notice(&self, team_id: i32, project_id: i64) {
+        if !self.seen.lock().unwrap().insert(team_id) {
+            return;
+        }
+        let target = WarmTarget {
+            team_id,
+            project_id,
+        };
+        if self.tx.try_send(target).is_err() {
+            // Full queue: forget the team so a later event re-enqueues it.
+            self.seen.lock().unwrap().remove(&team_id);
+            metrics::counter!(CACHE_WARMING_TEAMS, &[("result", "queue_full")]).increment(1);
+        }
+    }
+
+    fn forget(&self, team_id: i32) {
+        self.seen.lock().unwrap().remove(&team_id);
+    }
+}
+
+/// Per-producer-loop handle. The local set absorbs the per-event check without any
+/// shared-state contention; the shared set only sees each team once per loop.
+pub struct TeamWarmer {
+    local_seen: AHashSet<i32>,
+    shared: Arc<Warming>,
+}
+
+impl TeamWarmer {
+    pub fn new(shared: Arc<Warming>) -> Self {
+        Self {
+            local_seen: AHashSet::new(),
+            shared,
+        }
+    }
+
+    pub fn notice(&mut self, team_id: i32, project_id: i64) {
+        if self.local_seen.insert(team_id) {
+            self.shared.notice(team_id, project_id);
+        }
+    }
+}
+
+/// Drains the warming queue, running at most `concurrency` team warms at a time.
+pub async fn run_warming_worker(
+    mut rx: mpsc::Receiver<WarmTarget>,
+    warming: Arc<Warming>,
+    pool: PgPool,
+    cache: Arc<Cache>,
+    limits: WarmingLimits,
+    concurrency: usize,
+) {
+    let semaphore = Arc::new(Semaphore::new(concurrency.max(1)));
+    while let Some(target) = rx.recv().await {
+        let permit = semaphore.clone().acquire_owned().await;
+        let Ok(permit) = permit else {
+            return;
+        };
+        let warming = warming.clone();
+        let pool = pool.clone();
+        let cache = cache.clone();
+        tokio::spawn(async move {
+            let _permit = permit;
+            let timer = common_metrics::timing_guard(CACHE_WARMING_TEAM_TIME, &[]);
+            match warm_team(&pool, &cache, target.team_id, target.project_id, limits).await {
+                Ok((eventprops, propdefs)) => {
+                    timer.label("result", "completed").fin();
+                    metrics::counter!(CACHE_WARMING_TEAMS, &[("result", "completed")]).increment(1);
+                    info!(
+                        team_id = target.team_id,
+                        eventprops, propdefs, "warmed dedup caches for team"
+                    );
+                }
+                Err(e) => {
+                    timer.label("result", "failed").fin();
+                    metrics::counter!(CACHE_WARMING_TEAMS, &[("result", "failed")]).increment(1);
+                    warn!(
+                        team_id = target.team_id,
+                        "cache warming failed, team will retry on a later event: {e}"
+                    );
+                    // Retry on the next sighting of this team.
+                    warming.forget(target.team_id);
+                }
+            }
+        });
+    }
+}
+
+/// Streams a team's existing definition rows into the dedup caches.
+///
+/// Bounded by the per-team limits: rows past the cap belong to teams whose keyspace
+/// cannot fit a cache anyway, so a partial warm captures the recurring subset and
+/// stops. Group-typed property definitions are skipped - their cache key wants the
+/// group name while Postgres stores the resolved index, and they are a sliver of
+/// write volume.
+///
+/// Loaded rows describe successful past writes, so inserting them satisfies the same
+/// invariant as the optimistic insert on the write path: `Some` property types only
+/// enter the cache when the row is known non-null in Postgres.
+pub async fn warm_team(
+    pool: &PgPool,
+    cache: &Cache,
+    team_id: i32,
+    project_id: i64,
+    limits: WarmingLimits,
+) -> Result<(u64, u64), sqlx::Error> {
+    let mut eventprops: u64 = 0;
+    let mut rows = sqlx::query_as::<_, (String, String)>(
+        r#"SELECT event, property FROM posthog_eventproperty
+           WHERE COALESCE(project_id, team_id::bigint) = $1 LIMIT $2"#,
+    )
+    .bind(project_id)
+    .bind(limits.eventprops_per_team)
+    .fetch(pool);
+    while let Some((event, property)) = rows.try_next().await? {
+        cache.insert(Update::EventProperty(EventProperty {
+            team_id,
+            project_id,
+            event,
+            property,
+        }));
+        eventprops += 1;
+    }
+    metrics::counter!(CACHE_WARMING_ROWS, &[("cache", "eventprops")]).increment(eventprops);
+
+    let mut propdefs: u64 = 0;
+    let mut rows = sqlx::query_as::<_, (String, Option<String>, i16)>(
+        r#"SELECT name, property_type, type FROM posthog_propertydefinition
+           WHERE COALESCE(project_id, team_id::bigint) = $1
+             AND group_type_index IS NULL LIMIT $2"#,
+    )
+    .bind(project_id)
+    .bind(limits.propdefs_per_team)
+    .fetch(pool);
+    while let Some((name, property_type, parent_type)) = rows.try_next().await? {
+        let event_type = match parent_type {
+            1 => PropertyParentType::Event,
+            2 => PropertyParentType::Person,
+            3 => PropertyParentType::Group,
+            4 => PropertyParentType::Session,
+            _ => continue,
+        };
+        // An unparseable stored type warms as untyped: the first typed sighting then
+        // re-issues one upsert, which the DB guard no-ops. Never lossy.
+        let property_type: Option<PropertyValueType> = property_type.and_then(|s| s.parse().ok());
+        cache.insert(Update::Property(PropertyDefinition {
+            team_id,
+            project_id,
+            name,
+            is_numerical: matches!(property_type, Some(PropertyValueType::Numeric)),
+            property_type,
+            event_type,
+            group_type_index: None,
+        }));
+        propdefs += 1;
+    }
+    metrics::counter!(CACHE_WARMING_ROWS, &[("cache", "propdefs")]).increment(propdefs);
+
+    Ok((eventprops, propdefs))
+}

--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -41,11 +41,28 @@ pub struct Config {
     pub cache_warming_concurrency: usize,
 
     // Per-team row caps. Teams with more rows than this get a partial warm: the remainder
-    // of their keyspace recurs too rarely to cache, so reading it buys nothing.
-    #[envconfig(default = "2000000")]
+    // of their keyspace recurs too rarely to cache, so reading it buys nothing. Sized so
+    // legitimate large teams (a few million event-property pairs) warm fully and only the
+    // pathological cardinality outliers truncate.
+    #[envconfig(default = "3000000")]
     pub cache_warming_eventprops_per_team_limit: i64,
-    #[envconfig(default = "1000000")]
+    #[envconfig(default = "250000")]
     pub cache_warming_propdefs_per_team_limit: i64,
+
+    // Event-property rows fetched per statement. The COALESCE predicate rules out
+    // index-only scans (an expression index cannot satisfy them), so every warmed row
+    // pays a heap fetch and an uncapped scan of a large cold team runs for minutes.
+    // Keyset-paginated chunks keep each statement bounded to seconds, release the
+    // warming connection between chunks, and pin the planner to the index (the ORDER BY
+    // makes the LIMIT-driven seq-scan flip on very large teams impossible).
+    #[envconfig(default = "100000")]
+    pub cache_warming_chunk_size: i64,
+
+    // Backstop only; chunking is what bounds statement runtime. Kills a runaway warm
+    // query, freeing the connection; the team retries on a later event, cheaper for the
+    // pages the first attempt already faulted in.
+    #[envconfig(default = "120")]
+    pub cache_warming_statement_timeout_secs: u64,
 
     // Teams waiting to be warmed. When the queue is full a team is dropped and re-noticed
     // on a later event, so a deep rebalance cannot pile up unbounded work.

--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -23,6 +23,35 @@ pub struct Config {
     #[envconfig(default = "300")]
     pub pg_max_lifetime_secs: u64,
 
+    // === Cache warming ===
+    // Lazily backfill the dedup caches from Postgres the first time a team's events arrive
+    // after boot. A fresh pod otherwise re-discovers what Postgres holds by issuing hours of
+    // no-op upserts; warming replaces that with a bounded read per team.
+    #[envconfig(default = "false")]
+    pub cache_warming_enabled: bool,
+
+    // Read-only connection string for warming queries, e.g. an Aurora reader endpoint.
+    // Empty falls back to database_url. Warming reads must not compete with batch writes
+    // for the writer pool, so this gets its own pool either way.
+    #[envconfig(default = "")]
+    pub database_read_url: String,
+
+    // Teams warmed at the same time. Also sizes the warming connection pool.
+    #[envconfig(default = "2")]
+    pub cache_warming_concurrency: usize,
+
+    // Per-team row caps. Teams with more rows than this get a partial warm: the remainder
+    // of their keyspace recurs too rarely to cache, so reading it buys nothing.
+    #[envconfig(default = "2000000")]
+    pub cache_warming_eventprops_per_team_limit: i64,
+    #[envconfig(default = "1000000")]
+    pub cache_warming_propdefs_per_team_limit: i64,
+
+    // Teams waiting to be warmed. When the queue is full a team is dropped and re-noticed
+    // on a later event, so a deep rebalance cannot pile up unbounded work.
+    #[envconfig(default = "10000")]
+    pub cache_warming_queue_depth: usize,
+
     #[envconfig(nested = true)]
     pub kafka: KafkaConfig,
 

--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -13,6 +13,7 @@ use metrics_consts::{
 use types::{Event, Update};
 
 use ahash::AHashSet;
+use cache_warming::TeamWarmer;
 use tokio::sync::mpsc::error::TrySendError;
 use tracing::{error, info, warn};
 use update_cache::Cache;
@@ -25,6 +26,7 @@ use crate::{
 pub mod api;
 pub mod app_context;
 pub mod batch_ingestion;
+pub mod cache_warming;
 pub mod config;
 pub mod group_type_resolver;
 pub mod measuring_channel;
@@ -147,6 +149,7 @@ pub async fn update_producer_loop(
     config: Config,
     consumer: SingleTopicConsumer,
     shared_cache: Arc<Cache>,
+    mut warmer: Option<TeamWarmer>,
     channel: MeasuringSender<Update>,
     handle: lifecycle::Handle,
 ) {
@@ -221,6 +224,10 @@ pub async fn update_producer_loop(
             {
                 skipped_due_to_team_filter.increment(1);
                 continue;
+            }
+
+            if let Some(warmer) = warmer.as_mut() {
+                warmer.notice(event.team_id, event.project_id);
             }
 
             let updates = event.into_updates_with(

--- a/rust/property-defs-rs/src/main.rs
+++ b/rust/property-defs-rs/src/main.rs
@@ -161,8 +161,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         } else {
             &config.database_read_url
         };
+        let statement_timeout_ms = config.cache_warming_statement_timeout_secs * 1000;
         let warm_pool = PgPoolOptions::new()
             .max_connections(config.cache_warming_concurrency.max(1) as u32)
+            .after_connect(move |conn, _meta| {
+                Box::pin(async move {
+                    sqlx::Executor::execute(
+                        &mut *conn,
+                        format!("SET statement_timeout = {statement_timeout_ms}").as_str(),
+                    )
+                    .await?;
+                    Ok(())
+                })
+            })
             .connect_lazy(read_url)?;
         let (warming, rx) = Warming::new(config.cache_warming_queue_depth);
         tokio::spawn(run_warming_worker(

--- a/rust/property-defs-rs/src/main.rs
+++ b/rust/property-defs-rs/src/main.rs
@@ -6,6 +6,7 @@ use lifecycle::{ComponentOptions, Manager};
 use property_defs_rs::{
     api::v1::{query::Manager as QueryManager, routing::apply_routes},
     app_context::AppContext,
+    cache_warming::{run_warming_worker, TeamWarmer, Warming, WarmingLimits},
     config::Config,
     measuring_channel::measuring_channel,
     metrics_buckets::bucket_overrides,
@@ -152,6 +153,32 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Start the lifecycle monitor before spawning components
     let guard = manager.monitor_background();
 
+    // Lazy per-team cache warming (see cache_warming.rs). Reads go to a dedicated pool,
+    // preferably a reader endpoint, so they never compete with batch writes.
+    let warming = if config.cache_warming_enabled {
+        let read_url = if config.database_read_url.is_empty() {
+            &config.database_url
+        } else {
+            &config.database_read_url
+        };
+        let warm_pool = PgPoolOptions::new()
+            .max_connections(config.cache_warming_concurrency.max(1) as u32)
+            .connect_lazy(read_url)?;
+        let (warming, rx) = Warming::new(config.cache_warming_queue_depth);
+        tokio::spawn(run_warming_worker(
+            rx,
+            warming.clone(),
+            warm_pool,
+            cache.clone(),
+            WarmingLimits::from_config(&config),
+            config.cache_warming_concurrency,
+        ));
+        info!("Cache warming enabled");
+        Some(warming)
+    } else {
+        None
+    };
+
     // Spawn N producer loops (Kafka consumers -> channel)
     for _ in 0..config.worker_loop_count {
         let h = producer_handle.clone();
@@ -159,6 +186,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             config.clone(),
             consumer.clone(),
             cache.clone(),
+            warming.clone().map(TeamWarmer::new),
             tx.clone(),
             h,
         ));

--- a/rust/property-defs-rs/src/metrics_consts.rs
+++ b/rust/property-defs-rs/src/metrics_consts.rs
@@ -84,3 +84,9 @@ pub const V2_PROP_DEFS_DROPPED_UNCACHED: &str = "propdefs_v2_propdefs_dropped_un
 // target table. Stripped rows stay in the shared dedup cache on purpose, so the dead
 // tenant's events stop re-issuing the same failing write.
 pub const V2_BATCH_ROWS_DROPPED_FK: &str = "propdefs_v2_batch_rows_dropped_fk";
+
+// Cache warming: lazy per-team backfill of the dedup caches from a Postgres
+// reader, so a fresh pod stops re-writing definitions Postgres already has.
+pub const CACHE_WARMING_TEAMS: &str = "prop_defs_cache_warming_teams";
+pub const CACHE_WARMING_ROWS: &str = "prop_defs_cache_warming_rows";
+pub const CACHE_WARMING_TEAM_TIME: &str = "prop_defs_cache_warming_team_ms";

--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -130,6 +130,24 @@ impl fmt::Display for PropertyValueType {
     }
 }
 
+// Inverse of the Display impl above, which is the form batch writes store in
+// posthog_propertydefinition.property_type. Unknown strings are an error; the
+// caller decides whether to treat the row as untyped.
+impl FromStr for PropertyValueType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DateTime" => Ok(PropertyValueType::DateTime),
+            "String" => Ok(PropertyValueType::String),
+            "Numeric" => Ok(PropertyValueType::Numeric),
+            "Boolean" => Ok(PropertyValueType::Boolean),
+            "Duration" => Ok(PropertyValueType::Duration),
+            _ => Err(()),
+        }
+    }
+}
+
 // The grouptypemapping table uses i32's, but we get group types by name, so we have to resolve them before DB writes, sigh
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
 pub enum GroupType {

--- a/rust/property-defs-rs/src/update_cache.rs
+++ b/rust/property-defs-rs/src/update_cache.rs
@@ -198,7 +198,23 @@ impl Cache {
     /// cold at eviction time and the cache degrades to FIFO: live keys cycle
     /// out and each cycle costs a useless definition upsert against Postgres.
     pub fn contains_key(&self, key: &Update) -> bool {
-        let (covered, hits, misses) = match key {
+        let (covered, hits, misses) = self.coverage(key);
+        if covered {
+            hits.increment(1);
+        } else {
+            misses.increment(1);
+        }
+        covered
+    }
+
+    /// As `contains_key`, but without touching the hit/miss counters. For cache
+    /// warming, whose lookups say nothing about pipeline dedup effectiveness.
+    pub fn covers(&self, key: &Update) -> bool {
+        self.coverage(key).0
+    }
+
+    fn coverage(&self, key: &Update) -> (bool, &Counter, &Counter) {
+        match key {
             Update::Event(def) => {
                 let lookup = EventDefKeyRef {
                     team_id: def.team_id,
@@ -235,13 +251,7 @@ impl Cache {
                 };
                 (covered, &self.propdefs.hits, &self.propdefs.misses)
             }
-        };
-        if covered {
-            hits.increment(1);
-        } else {
-            misses.increment(1);
         }
-        covered
     }
 
     pub fn insert(&self, key: Update) {

--- a/rust/property-defs-rs/tests/cache_warming.rs
+++ b/rust/property-defs-rs/tests/cache_warming.rs
@@ -1,0 +1,103 @@
+use std::sync::Arc;
+
+use sqlx::PgPool;
+
+use property_defs_rs::{
+    batch_ingestion::process_batch,
+    cache_warming::{warm_team, WarmingLimits},
+    config::Config,
+    types::{EventProperty, PropertyDefinition, PropertyParentType, PropertyValueType, Update},
+    update_cache::Cache,
+};
+
+fn test_lifecycle_handle() -> lifecycle::Handle {
+    let mut manager = lifecycle::Manager::builder("test").build();
+    manager.register("consumer", lifecycle::ComponentOptions::new())
+}
+
+const TEAM: i32 = 111;
+const PROJECT: i64 = 111;
+
+fn event_prop(event: &str, property: &str) -> Update {
+    Update::EventProperty(EventProperty {
+        team_id: TEAM,
+        project_id: PROJECT,
+        event: event.to_string(),
+        property: property.to_string(),
+    })
+}
+
+fn prop(name: &str, property_type: Option<PropertyValueType>) -> Update {
+    Update::Property(PropertyDefinition {
+        team_id: TEAM,
+        project_id: PROJECT,
+        name: name.to_string(),
+        is_numerical: matches!(property_type, Some(PropertyValueType::Numeric)),
+        property_type,
+        event_type: PropertyParentType::Event,
+        group_type_index: None,
+    })
+}
+
+fn limits(eventprops: i64, propdefs: i64) -> WarmingLimits {
+    WarmingLimits {
+        eventprops_per_team: eventprops,
+        propdefs_per_team: propdefs,
+    }
+}
+
+// A warmed cache must answer exactly like the cache of the pod that wrote the
+// rows: existing rows are covered (including the type-upgrade semantics of
+// property definitions), unknown rows still miss.
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn test_warm_team_covers_previously_written_rows(db: PgPool) {
+    let config = Config::init_with_defaults().unwrap();
+    let writer_cache = Arc::new(Cache::new(1000, 1000, 1000));
+    let batch = vec![
+        event_prop("$pageview", "plan"),
+        event_prop("$pageview", "browser"),
+        prop("plan", Some(PropertyValueType::String)),
+        prop("misc", None),
+    ];
+    process_batch(&config, writer_cache, &db, batch, &test_lifecycle_handle()).await;
+
+    let warmed = Cache::new(1000, 1000, 1000);
+    let (eventprops, propdefs) = warm_team(&db, &warmed, TEAM, PROJECT, limits(100, 100))
+        .await
+        .unwrap();
+    assert_eq!(eventprops, 2);
+    assert_eq!(propdefs, 2);
+
+    assert!(warmed.contains_key(&event_prop("$pageview", "plan")));
+    assert!(warmed.contains_key(&event_prop("$pageview", "browser")));
+    assert!(!warmed.contains_key(&event_prop("$pageview", "unseen")));
+
+    // A typed stored row can never change again, so both variants are covered.
+    assert!(warmed.contains_key(&prop("plan", Some(PropertyValueType::String))));
+    assert!(warmed.contains_key(&prop("plan", None)));
+
+    // An untyped stored row covers untyped resends but must let a typed
+    // sighting through to fill the NULL type.
+    assert!(warmed.contains_key(&prop("misc", None)));
+    assert!(!warmed.contains_key(&prop("misc", Some(PropertyValueType::Boolean))));
+}
+
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn test_warm_team_respects_per_team_limits(db: PgPool) {
+    let config = Config::init_with_defaults().unwrap();
+    let writer_cache = Arc::new(Cache::new(1000, 1000, 1000));
+    let batch = vec![
+        event_prop("$pageview", "a"),
+        event_prop("$pageview", "b"),
+        event_prop("$pageview", "c"),
+        event_prop("$pageview", "d"),
+    ];
+    process_batch(&config, writer_cache, &db, batch, &test_lifecycle_handle()).await;
+
+    let warmed = Cache::new(1000, 1000, 1000);
+    let (eventprops, _) = warm_team(&db, &warmed, TEAM, PROJECT, limits(2, 100))
+        .await
+        .unwrap();
+    assert_eq!(eventprops, 2, "the per-team cap must truncate the warm");
+    assert_eq!(warmed.eventprops_len(), 2);
+}

--- a/rust/property-defs-rs/tests/cache_warming.rs
+++ b/rust/property-defs-rs/tests/cache_warming.rs
@@ -39,10 +39,12 @@ fn prop(name: &str, property_type: Option<PropertyValueType>) -> Update {
     })
 }
 
+// chunk_size 2 so every test walks the keyset pagination, boundaries included.
 fn limits(eventprops: i64, propdefs: i64) -> WarmingLimits {
     WarmingLimits {
         eventprops_per_team: eventprops,
         propdefs_per_team: propdefs,
+        chunk_size: 2,
     }
 }
 
@@ -80,6 +82,53 @@ async fn test_warm_team_covers_previously_written_rows(db: PgPool) {
     // sighting through to fill the NULL type.
     assert!(warmed.contains_key(&prop("misc", None)));
     assert!(!warmed.contains_key(&prop("misc", Some(PropertyValueType::Boolean))));
+}
+
+// Five rows through chunk_size 2 exercise the keyset continuation across full
+// chunks, a partial final chunk, and the boundary rows between chunks.
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn test_warm_team_chunks_cover_all_rows(db: PgPool) {
+    let config = Config::init_with_defaults().unwrap();
+    let writer_cache = Arc::new(Cache::new(1000, 1000, 1000));
+    let props = ["a", "b", "c", "d", "e"];
+    let batch = props
+        .iter()
+        .map(|p| event_prop("$pageview", p))
+        .collect::<Vec<_>>();
+    process_batch(&config, writer_cache, &db, batch, &test_lifecycle_handle()).await;
+
+    let warmed = Cache::new(1000, 1000, 1000);
+    let (eventprops, _) = warm_team(&db, &warmed, TEAM, PROJECT, limits(100, 100))
+        .await
+        .unwrap();
+    assert_eq!(eventprops, 5);
+    for p in props {
+        assert!(warmed.contains_key(&event_prop("$pageview", p)));
+    }
+}
+
+// The live write path races the warm scan and can be fresher than the query
+// snapshot: a property typed by the pipeline must not be downgraded by a stale
+// untyped row read from Postgres.
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn test_warm_team_does_not_downgrade_fresher_cache_state(db: PgPool) {
+    let config = Config::init_with_defaults().unwrap();
+    let writer_cache = Arc::new(Cache::new(1000, 1000, 1000));
+    let batch = vec![prop("misc", None)];
+    process_batch(&config, writer_cache, &db, batch, &test_lifecycle_handle()).await;
+
+    let warmed = Cache::new(1000, 1000, 1000);
+    let typed = prop("misc", Some(PropertyValueType::String));
+    warmed.insert(typed.clone());
+
+    warm_team(&db, &warmed, TEAM, PROJECT, limits(100, 100))
+        .await
+        .unwrap();
+
+    assert!(
+        warmed.contains_key(&typed),
+        "the stale untyped row must not overwrite the typed entry"
+    );
 }
 
 #[sqlx::test(migrations = "./tests/test_migrations")]

--- a/rust/property-defs-rs/tests/producer_loop.rs
+++ b/rust/property-defs-rs/tests/producer_loop.rs
@@ -70,6 +70,7 @@ async fn test_producer_flushes_a_partial_batch_when_events_stop_arriving() {
         config.clone(),
         consumer,
         cache,
+        None,
         tx,
         handle.clone(),
     ));


### PR DESCRIPTION
## Problem

A freshly deployed pod re-writes definitions Postgres already holds for hours: its dedup caches boot empty, and the fleet spends 6-12 hours re-learning its keyspace through no-op upserts.

- Measured in prod-US, the post-deploy re-learning ramps account for most of this service's wasted write volume.
- The caches are in-memory only, and this service deploys several times a week.

Stacked on #94453; the top layer of stack #94454.

## Changes

Nothing user-visible changes; a redeployed fleet stops re-writing known definitions within minutes instead of hours.

- Each team warms on the first sighting of its events after boot. The topic is partitioned by team, so arriving traffic enumerates a pod's teams exactly; there is no assignment or partitioner plumbing.
- A background worker streams the team's existing eventproperty and propertydefinition rows from Postgres into the caches, at most 2 teams at a time.
- Reads use a dedicated pool pointed at `DATABASE_READ_URL` (an Aurora reader endpoint), never the writer pool, with a statement-timeout backstop.
- The event-property scan is keyset-paginated in 100k-row chunks. The COALESCE predicate rules out index-only scans, so every row pays a heap fetch; chunking bounds each statement to seconds (measured 0.08-2.2s per chunk in prod), pins the planner to the index, and releases the connection between chunks.
- Per-team caps (3M eventprops, 250k propdefs) truncate pathological-cardinality tenants whose keyspace cannot fit a cache anyway; every legitimate team measured warms fully.
- Warming skips rows the cache already covers, so a stale query snapshot cannot downgrade an entry the live write path refreshed mid-scan. `Cache::covers` is the metrics-free variant of the lookup, keeping warming out of the pipeline hit/miss counters.
- Warming never blocks the pipeline: until a team's warm finishes, its lookups miss and write no-op upserts exactly as before. A failed warm retries on the team's next event; a full queue drops and re-notices.
- Off by default behind `CACHE_WARMING_ENABLED`. Rollout needs a charts change setting it plus `DATABASE_READ_URL`.

The riskiest part is the warm-vs-live-write race handling in `warm_team`; the discovery, queue, and worker plumbing is mechanical.

## How did you test this code?

- Four DB-backed tests in `tests/cache_warming.rs` (sqlx test databases with the real migrations): a warmed cache answers identically to the writer's cache including the type-upgrade rule; keyset chunking covers all rows across chunk boundaries; per-team caps truncate; a stale untyped row does not downgrade a typed cache entry.
- Query shape and costs verified against prod-US via EXPLAIN ANALYZE: per-100k chunk 0.08s warm to 2.2s cold; the largest legitimate team (~2.7M rows) warms in ~1.6s warm / 1-4 min cold; capped whales are bounded by chunks plus the statement timeout.
- Not run locally: warming under real Kafka traffic; the flag stays off until the charts change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Third layer of the dedup-cache work (#94452 recency, #94453 identity keys). Authored with Claude Code; the chunking design and caps came from prod-US EXPLAIN ANALYZE probes via Metabase, and the per-team size distribution from a table sample. Skills invoked: /stacking-prs, /writing-tests, /writing-code-comments, /writing-pr-descriptions, /query-clickhouse-via-metabase. The single-statement first draft was replaced with keyset chunks after probes showed whale-team scans exceeding 120s; the coverage check replaced unconditional inserts after reviewing the warm-vs-live race.
