### PR TITLE
fix(tasks): restore harness package in local sandbox image build

### DIFF
--- a/products/tasks/backend/logic/services/docker_sandbox.py
+++ b/products/tasks/backend/logic/services/docker_sandbox.py
@@ -81,9 +81,10 @@ _AGENT_VERSION_LABEL = "com.posthog.sandbox.agent-version"
 AGENT_SERVER_PORT = 47821  # Arbitrary high port unlikely to conflict with dev servers
 
 # posthog-code workspace packages staged into a local sandbox image build. @posthog/agent
-# needs shared, git and enricher; git needs shared. Both the path check and the copy read
-# this tuple, so a package named here but absent from the checkout fails the build outright.
-_LOCAL_SANDBOX_PACKAGES = ("agent", "shared", "git", "enricher")
+# needs harness, shared, git and enricher (its tsup build copies harness dist assets); git
+# needs shared. Both the path check and the copy read this tuple, so a package named here
+# but absent from the checkout fails the build outright.
+_LOCAL_SANDBOX_PACKAGES = ("agent", "harness", "shared", "git", "enricher")
 # Streamlit sandboxes expose their auth proxy (not the agent-server) on this port; the
 # host-published port maps to it so connect_info can reach the app across processes.
 

--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-local
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-local
@@ -11,6 +11,7 @@ COPY local-workspace/patches /local-workspace/patches
 COPY local-workspace/packages/agent/package.json /local-workspace/packages/agent/package.json
 COPY local-workspace/packages/enricher/package.json /local-workspace/packages/enricher/package.json
 COPY local-workspace/packages/git/package.json /local-workspace/packages/git/package.json
+COPY local-workspace/packages/harness/package.json /local-workspace/packages/harness/package.json
 COPY local-workspace/packages/shared/package.json /local-workspace/packages/shared/package.json
 
 RUN --mount=type=cache,id=posthog-sandbox-local-pnpm,target=/pnpm/store,sharing=locked \


### PR DESCRIPTION
## Problem

A developer running a cloud task on a local Docker sandbox with the default `claude` model (`claude-sonnet-5`, effort `high`) gets "Agent-server failed to start" every time. The agent-server inside `posthog-sandbox-base-local` was built before `claude-sonnet-5` supported `high`, so it exits at startup with `POSTHOG_CODE_REASONING_EFFORT 'high' is not supported for claude model 'claude-sonnet-5'`.

The image never picked up the current agent sources because `@posthog/harness` was dropped from the workspace staged into the image build, while `@posthog/agent` depends on it (its tsup build copies harness dist assets).

## Changes

- Stage `@posthog/harness` in the local sandbox image build again (constant and Dockerfile COPY), so the agent-server builds from current sources. Mechanical revert of the harness removal; nothing user-visible beyond the boot succeeding.

## How did you test this code?

- Rebuilt `posthog-sandbox-base-local` from current sources; the built `models.js` now lists `claude-sonnet-5: EXTENDED_EFFORT_LEVELS` (includes `high`).
- Booted the image's agent-server with `MODEL=claude-sonnet-5`, `REASONING_EFFORT=high`: it passes validation and starts session init (previously it exited at the validation check).
- `products/tasks/backend/logic/services/test_docker_sandbox.py` passes (67 tests). Existing fixtures already bind to `_LOCAL_SANDBOX_PACKAGES`, so no test change was needed.
- Not checked: an end-to-end desktop run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) - assignee: thmsobrmlr

- Agent: Claude Code (PostHog Desktop). Skills invoked: /writing-tests, /writing-pr-descriptions.
- Root-caused by decrypting the Temporal activity-failure payload, which carried the in-sandbox agent-server log line naming the unsupported reasoning effort.
- The harness removal being reverted was itself a fix for an earlier layout where harness did not exist; harness now exists under products/desktop and is a real dependency of @posthog/agent.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*