### PR TITLE
chore: move the duplicate-PR check into the pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -46,6 +46,7 @@
 **Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous
 
 <!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
+     - No duplicate: when this PR fixes something believed to be live on master, no open PR already fixes it. A broken master attracts parallel agents, so search before opening — `gh pr list --state open --search "<keywords>" --limit 20`, keeping drafts, since most agent PRs start as drafts. Say which PR you found and why this one is still needed, or that the search found nothing.
      - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
      - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -46,7 +46,7 @@
 **Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous
 
 <!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
-     - No duplicate: when this PR fixes something believed to be live on master, no open PR already fixes it. A broken master attracts parallel agents, so search before opening — `gh pr list --state open --search "<keywords>" --limit 20`, keeping drafts, since most agent PRs start as drafts. Say which PR you found and why this one is still needed, or that the search found nothing.
+     - No duplicate: when this PR fixes something believed to be live on master, no open PR already fixes it. A broken master attracts parallel agents, so search before opening — `gh pr list --state open --search "<keywords>" --limit 20`, which lists drafts too, and most agent PRs start as drafts. Say here which PR you found and why this one is still needed, or that the search found nothing.
      - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
      - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,30 +37,6 @@
 - Dev experience feedback: `hogli devex:feedback "<message>"` sends feedback about repo tooling — hogli, the dev stack, tests, CI, migrations, this setup — straight to the devex team as a `hogli_feedback` event (add `-c bug|idea|praise|question`).
   **Local agents must use it too**: when a hogli command or local dev workflow is broken, slow, or confusing, run it — e.g. `hogli devex:feedback -c bug "migrations:run failed with <error>"`. Do not run it from cloud tasks or agent-server sandboxes; the command is a no-op there.
 
-## Starting a task
-
-Several agents work on this repository at the same time, so the change you plan can already be in flight.
-Before you plan the work or write code, look for open PRs that clash with it.
-This matters most for a broken `master`: the break is visible to everyone, so it attracts duplicate PRs.
-
-Search the open PRs by keyword, then look at each candidate:
-
-```bash
-gh pr list --state open --search "<keywords>" --limit 20
-gh pr diff <number> --name-only  # the files it touches
-gh pr diff <number>              # the patch, once a candidate looks like a match
-```
-
-Take the keywords from the error message, the failing test, the symbol, or the feature name.
-Run two or three searches with different words, because another author can describe the same problem differently.
-Keep draft PRs in the results, because most agent PRs start as drafts.
-
-Then act on what you find:
-
-- An open PR already makes this change: do not open a second one. Tell the user the PR number, and continue the work on that PR.
-- An open PR changes the same files for a different reason: keep your diff clear of the overlap when possible, and name the other PR in your PR description.
-- Nothing matches: continue with the work.
-
 ## Commits and Pull Requests
 
 - Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for all commit messages and PR titles.


### PR DESCRIPTION
## Problem

Every agent session on this repo carried about 275 tokens for a duplicate-PR check that applies to a small share of tasks, and agents skipped it anyway.

The check landed in AGENTS.md in #94288. Its trigger reads "before you plan the work or write code". A session that opens with "investigate how X is configured" does neither, so the trigger does not fire. An agent held the rule in context, started the work, and checked only after a human asked whether it had.

The rule itself is sound. Duplicate PRs on a broken master waste review time and CI credits. The placement was wrong.

## Changes

- Agents now answer the duplicate check in the PR body. It becomes a third gate in the template's "Definition of done (agents)" block, next to patch coverage and public artifact.
- The trigger narrows to a fix aimed at a problem believed to be live on master. That is the case the rule was written for.
- AGENTS.md drops the section. Always-on context falls by about 275 tokens. The template gains about 85, charged only when a PR is being written.
- The multi-search procedure goes. Two or three keyword searches plus a full patch read cost thousands of tokens of tool output per task, on every task.

Why the template is the right home:

- Review time and CI credits are both spent at PR creation, so the gate fires where the cost it prevents is incurred.
- A PR title and file list make the search usable. A branch name does not. A broad search hits the result cap and a title-scoped search returns nothing.
- A gate answered in the body leaves a trace. Compliance can be audited across merged PRs. An AGENTS.md rule leaves no trace, which is why its compliance rate is a guess today.

Two earlier options were rejected. A `hogli ci:preflight` advisory fires after the push, once the duplicate work is done. A `post-checkout` hook fires early but has only a branch name to query with.

Documentation only. No code or behavior change.

## How did you test this code?

Nothing to run. The diff is two markdown files.

- `hogli ci:preflight --strict` passes.
- Token counts come from a local cl100k tokenizer. Treat them as approximate, since Claude's tokenizer differs by a small margin.
- The search comparison is measured. Four realistic branch names ran against `gh pr list`. Broad search returned the result cap three times out of four. Title-scoped search returned nothing every time.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 5), from an audit of what #94288 cost per session. Skills invoked: `/writing-pr-descriptions`.

The audit ranked the section sixth of ten in AGENTS.md by size. The five above it apply far more broadly. Removing it beat shrinking it because a rule agents skip does not get cheaper when it gets shorter. It also teaches skimming of the mandatory-skill block beside it.

One note for the reviewer. The description of #94288 says its section was cut to a single bullet before merge. The merged diff keeps the full section, so that claim does not match what landed.

https://claude.ai/code/session_01M6KnoahEzd9uduM4vKURJC
