### PR TITLE
feat(stamphog): let a team opt out of the daily digest alone

### DIFF
--- a/docs/internal/ownership-model-proposal.md
+++ b/docs/internal/ownership-model-proposal.md
@@ -143,7 +143,7 @@ Every value is a string starting with `#`, or `false` to mean "no channel, don't
 - `notifications` — where automation posts. It falls back to `slack`, so a team that never separates the two keeps one entry, and `notifications: false` keeps automation out without hiding the team's channel from people.
 
 `notifications` may also be a mapping of producer name to channel, so a team can silence or redirect one bot on its own.
-A `default` key answers for every producer the team does not name; without one, an unnamed producer falls through to `slack`.
+A producer the mapping does not name falls through to `slack`.
 Only a producer the schema knows may be named, so a typo is a lint error rather than an opt-out that never applies.
 
 ```yaml

--- a/docs/internal/ownership-model-proposal.md
+++ b/docs/internal/ownership-model-proposal.md
@@ -142,6 +142,10 @@ Every value is a string starting with `#`, or `false` to mean "no channel, don't
 - `slack` — where the people are. This is the channel a human is pointed at.
 - `notifications` — where automation posts. It falls back to `slack`, so a team that never separates the two keeps one entry, and `notifications: false` keeps automation out without hiding the team's channel from people.
 
+`notifications` may also be a mapping of producer name to channel, so a team can silence or redirect one bot on its own.
+A `default` key answers for every producer the team does not name; without one, an unnamed producer falls through to `slack`.
+Only a producer the schema knows may be named, so a typo is a lint error rather than an opt-out that never applies.
+
 ```yaml
 # owners.yaml (repo root only)
 teams:
@@ -153,6 +157,10 @@ teams:
   quiet-team:
     slack: '#team-quiet'
     notifications: false
+  digest-free-team:
+    slack: '#team-digest-free'
+    notifications:
+      stamphog: false
   some-retired-team:
     slack: false
 ```

--- a/owners.yaml
+++ b/owners.yaml
@@ -26,6 +26,11 @@ teams:
     # PostHog Desktop's channel kept the name it was created under.
     team-posthog-code:
         slack: '#team-desktop'
+    # The derived '#team-replay' is right; the entry exists only to drop the daily
+    # stamphog digest, which the team reads on the PRs themselves.
+    team-replay:
+        notifications:
+            stamphog: false
 rules:
     - match: Dockerfile.llm-analytics
       owners: team-ai-observability

--- a/products/stamphog/backend/logic/channel_resolution.py
+++ b/products/stamphog/backend/logic/channel_resolution.py
@@ -32,8 +32,8 @@ from django.db import router
 from django.db.models import Q
 
 import structlog
-from posthog_owners.resolver import Producer, Purpose, TeamChannel, team_channel, teams_registry
-from posthog_owners.schema import TeamEntry
+from posthog_owners.resolver import Purpose, TeamChannel, team_channel, teams_registry
+from posthog_owners.schema import Producer, TeamEntry
 
 from posthog.dataclasses import frozen
 from posthog.models.integration import Integration, SlackIntegration

--- a/products/stamphog/backend/logic/channel_resolution.py
+++ b/products/stamphog/backend/logic/channel_resolution.py
@@ -32,7 +32,7 @@ from django.db import router
 from django.db.models import Q
 
 import structlog
-from posthog_owners.resolver import Purpose, TeamChannel, team_channel, teams_registry
+from posthog_owners.resolver import Producer, Purpose, TeamChannel, team_channel, teams_registry
 from posthog_owners.schema import TeamEntry
 
 from posthog.dataclasses import frozen
@@ -52,6 +52,8 @@ _OWNERS_FILE_PATH = "owners.yaml"
 # The digest is automation, so it asks the registry where automation posts rather than where the
 # team's people are. That falls back to the people channel when a team never separates the two.
 _CHANNEL_PURPOSE: Purpose = "notifications"
+# Named so a team can keep the daily digest out of its channel while other bots keep posting there.
+_PRODUCER: Producer = "stamphog"
 
 # Slack channel flags that mark a channel as shared beyond this workspace. Routing maps a GitHub
 # team slug onto a Slack channel by name, or by a registry entry. A shared channel with that name
@@ -235,7 +237,7 @@ def _registry_answer(context: RoutingContext, slug: str, repository: str) -> Tea
     block, which no repository has a reason to write.
     """
     registry = context.registry_by_repo.get(repository) or context.inherited_registry
-    return team_channel(slug, registry, _CHANNEL_PURPOSE)
+    return team_channel(slug, registry, _CHANNEL_PURPOSE, _PRODUCER)
 
 
 def resolve_destination(context: RoutingContext, audience_key: str, repository: str) -> Destination | None:

--- a/products/stamphog/backend/tests/test_digest.py
+++ b/products/stamphog/backend/tests/test_digest.py
@@ -409,6 +409,11 @@ def test_a_repo_with_no_registry_inherits_one(team) -> None:
     "context_kwargs,reason",
     [
         ({"registry_by_repo": {REPO: {AUDIENCE: TeamEntry(notifications=False)}}}, "silenced_by_config"),
+        # A team that silences this digest alone keeps its channel for every other bot.
+        (
+            {"registry_by_repo": {REPO: {AUDIENCE: TeamEntry(slack="#team-apm", notifications={"stamphog": False})}}},
+            "silenced_by_config",
+        ),
         ({"channels_by_name": {}}, "no_channel_of_that_name"),
     ],
 )

--- a/tools/owners/posthog_owners/resolver.py
+++ b/tools/owners/posthog_owners/resolver.py
@@ -15,7 +15,15 @@ from pathlib import Path
 from typing import Literal, Protocol, TypedDict
 
 from .matcher import compile_pattern, normalize_path
-from .schema import UNSET, OwnersFile, TeamEntry, _Unset, parse_owners_file, parse_product_yaml_as_owners
+from .schema import (
+    PRODUCER_DEFAULT_KEY,
+    UNSET,
+    OwnersFile,
+    TeamEntry,
+    _Unset,
+    parse_owners_file,
+    parse_product_yaml_as_owners,
+)
 
 OWNERS_FILENAME = "owners.yaml"
 PRODUCT_FILENAME = "product.yaml"
@@ -40,15 +48,38 @@ class TeamChannel:
 Purpose = Literal["slack", "notifications"]
 DEFAULT_PURPOSE: Purpose = "slack"
 
+# One piece of automation posting on its own behalf, so a team can silence it without silencing
+# every bot. Mirrors ``schema.PRODUCERS``, which is what an ``owners.yaml`` may name.
+Producer = Literal["stamphog"]
 
-def team_channel(slug: str, teams: Mapping[str, TeamEntry], purpose: Purpose = DEFAULT_PURPOSE) -> TeamChannel:
+
+def _producer_channel(value: Mapping[str, str | bool], producer: Producer | None) -> str | bool | None:
+    """One producer's entry in a per-producer ``notifications:`` mapping, else the ``default`` key.
+
+    None means the mapping does not answer for this producer, so the lookup falls through to
+    ``slack`` exactly as an undeclared ``notifications`` does.
+    """
+    if producer is not None and producer in value:
+        return value[producer]
+    return value.get(PRODUCER_DEFAULT_KEY)
+
+
+def team_channel(
+    slug: str,
+    teams: Mapping[str, TeamEntry],
+    purpose: Purpose = DEFAULT_PURPOSE,
+    producer: Producer | None = None,
+) -> TeamChannel:
     """The Slack channel for a team slug and a purpose, else the derived ``#<slug>``.
 
     ``purpose`` is "slack" (where people are) or "notifications" (where automation posts).
     "notifications" falls back to "slack", so a team that never separates automation from people
-    keeps one channel and one entry. A per-producer form, so a team can silence one bot without
-    silencing all of them, is an additive change here later: it widens what a key may hold, and
-    callers keep the call they already make.
+    keeps one channel and one entry.
+
+    ``producer`` names the automation asking, and only matters when the team declared a per-producer
+    ``notifications`` mapping. A mapping that names neither the producer nor ``default`` falls
+    through to ``slack``, so silencing one bot leaves the others where they were. A caller that does
+    not identify itself gets the mapping's ``default``.
 
     A declared ``false`` means the team has no channel for that purpose, which is different from
     having no entry. The first is an answer and stops the lookup; the second falls through.
@@ -56,7 +87,8 @@ def team_channel(slug: str, teams: Mapping[str, TeamEntry], purpose: Purpose = D
     entry = teams.get(slug)
     if entry is not None:
         candidates = (entry.notifications, entry.slack) if purpose == "notifications" else (entry.slack,)
-        for value in candidates:
+        for candidate in candidates:
+            value = _producer_channel(candidate, producer) if isinstance(candidate, Mapping) else candidate
             if value is not None:
                 # Schema only admits `false`; any bool means "no channel".
                 return TeamChannel(channel=value if isinstance(value, str) else None, declared=True)

--- a/tools/owners/posthog_owners/resolver.py
+++ b/tools/owners/posthog_owners/resolver.py
@@ -15,15 +15,7 @@ from pathlib import Path
 from typing import Literal, Protocol, TypedDict
 
 from .matcher import compile_pattern, normalize_path
-from .schema import (
-    PRODUCER_DEFAULT_KEY,
-    UNSET,
-    OwnersFile,
-    TeamEntry,
-    _Unset,
-    parse_owners_file,
-    parse_product_yaml_as_owners,
-)
+from .schema import UNSET, OwnersFile, Producer, TeamEntry, _Unset, parse_owners_file, parse_product_yaml_as_owners
 
 OWNERS_FILENAME = "owners.yaml"
 PRODUCT_FILENAME = "product.yaml"
@@ -33,9 +25,9 @@ PRODUCT_FILENAME = "product.yaml"
 class TeamChannel:
     """Where a team's Slack messages go, and how that was decided.
 
-    ``declared`` separates an explicit ``teams:`` entry from the derived ``#<slug>``: a caller
-    routing real messages usually treats a declaration as a decision to honor and a derivation as
-    a guess to verify, and cannot tell them apart from ``channel`` alone.
+    ``declared`` separates an answer for this purpose and producer from the derived ``#<slug>``: a
+    caller routing real messages usually treats a declaration as a decision to honor and a
+    derivation as a guess to verify, and cannot tell them apart from ``channel`` alone.
     """
 
     channel: str | None
@@ -47,21 +39,6 @@ class TeamChannel:
 # resolving to the channel where people are.
 Purpose = Literal["slack", "notifications"]
 DEFAULT_PURPOSE: Purpose = "slack"
-
-# One piece of automation posting on its own behalf, so a team can silence it without silencing
-# every bot. Mirrors ``schema.PRODUCERS``, which is what an ``owners.yaml`` may name.
-Producer = Literal["stamphog"]
-
-
-def _producer_channel(value: Mapping[str, str | bool], producer: Producer | None) -> str | bool | None:
-    """One producer's entry in a per-producer ``notifications:`` mapping, else the ``default`` key.
-
-    None means the mapping does not answer for this producer, so the lookup falls through to
-    ``slack`` exactly as an undeclared ``notifications`` does.
-    """
-    if producer is not None and producer in value:
-        return value[producer]
-    return value.get(PRODUCER_DEFAULT_KEY)
 
 
 def team_channel(
@@ -77,9 +54,8 @@ def team_channel(
     keeps one channel and one entry.
 
     ``producer`` names the automation asking, and only matters when the team declared a per-producer
-    ``notifications`` mapping. A mapping that names neither the producer nor ``default`` falls
-    through to ``slack``, so silencing one bot leaves the others where they were. A caller that does
-    not identify itself gets the mapping's ``default``.
+    ``notifications`` mapping. A mapping that does not name the producer falls through to ``slack``,
+    so silencing one bot leaves the others where they were.
 
     A declared ``false`` means the team has no channel for that purpose, which is different from
     having no entry. The first is an answer and stops the lookup; the second falls through.
@@ -88,7 +64,10 @@ def team_channel(
     if entry is not None:
         candidates = (entry.notifications, entry.slack) if purpose == "notifications" else (entry.slack,)
         for candidate in candidates:
-            value = _producer_channel(candidate, producer) if isinstance(candidate, Mapping) else candidate
+            if isinstance(candidate, Mapping):
+                value = candidate.get(producer) if producer is not None else None
+            else:
+                value = candidate
             if value is not None:
                 # Schema only admits `false`; any bool means "no channel".
                 return TeamChannel(channel=value if isinstance(value, str) else None, declared=True)

--- a/tools/owners/posthog_owners/schema.py
+++ b/tools/owners/posthog_owners/schema.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TypeGuard
+from typing import Literal, TypeGuard, get_args
 
 import yaml
 
@@ -25,11 +25,11 @@ _TOP_LEVEL_KEYS = {"version", "owners", "status", "inherit", "rules", "teams"}
 _RULE_KEYS = {"match", "owners", "status", "inherit"}
 _TEAMS_ENTRY_KEYS = {"slack", "notifications"}
 # Automation that posts to a team's notifications channel and can be silenced on its own. A
-# producer must be listed here to be nameable in `notifications:`, so a typo is a lint error
-# rather than an opt-out that quietly never applies.
-PRODUCERS = frozenset({"stamphog"})
-# The key a per-producer mapping uses for every producer it does not name.
-PRODUCER_DEFAULT_KEY = "default"
+# producer must be named here to be nameable in `notifications:`. Lint reports a typo where lint
+# runs; where it does not, an unreadable mapping silences rather than posts (see _validate_teams).
+Producer = Literal["stamphog"]
+PRODUCERS = frozenset(get_args(Producer))
+_KNOWN_PRODUCERS = ", ".join(sorted(PRODUCERS))
 
 
 @dataclass(frozen=True)
@@ -40,9 +40,8 @@ class TeamEntry:
     to ``slack`` when a team never separates the two.
 
     ``notifications`` may also be a mapping of producer name to channel, so a team can silence or
-    redirect one bot without doing it to all of them. A ``default`` key in that mapping answers for
-    every producer the team does not name; without one, an unnamed producer falls through to
-    ``slack``.
+    redirect one bot without doing it to all of them. A producer the mapping does not name falls
+    through to ``slack``.
 
     ``None`` means the key was not declared, which is not the same as ``False``. The first falls
     through to the next step of the lookup; the second is a decision that there is no channel.
@@ -123,28 +122,24 @@ def _is_valid_slack(raw: object) -> TypeGuard[str | bool]:
     return raw is False or (isinstance(raw, str) and raw.startswith("#"))
 
 
-def _validate_producer_map(value: object, where: str, key: str, errors: list[str]) -> dict[str, str | bool] | None:
-    """A per-producer ``notifications`` mapping, or None when the value is not one.
-
-    Returns None for anything that is not a mapping so the caller can go on to the scalar form and
-    report one error for a value that is neither.
-    """
-    if not isinstance(value, dict):
-        return None
-    known = ", ".join(sorted([*PRODUCERS, PRODUCER_DEFAULT_KEY]))
+def _validate_producer_map(
+    value: dict[object, object], where: str, key: str, errors: list[str]
+) -> dict[str, str | bool]:
+    """The producers a ``notifications:`` mapping names, without the entries it rejects."""
     if key != "notifications":
         errors.append(f"{where}: '{key}' takes a single channel, not a per-producer mapping")
         return {}
+    if not value:
+        errors.append(f"{where}: '{key}' mapping names no producer")
+        return {}
     declared: dict[str, str | bool] = {}
     for producer, raw in value.items():
-        if not isinstance(producer, str) or (producer not in PRODUCERS and producer != PRODUCER_DEFAULT_KEY):
-            errors.append(f"{where}: unknown producer '{producer}' (known: {known})")
+        if not isinstance(producer, str) or producer not in PRODUCERS:
+            errors.append(f"{where}: unknown producer '{producer}' (known: {_KNOWN_PRODUCERS})")
         elif _is_valid_slack(raw):
             declared[producer] = raw
         else:
             errors.append(f"{where}: '{producer}' must be a string starting with '#' or false")
-    if not declared:
-        errors.append(f"{where}: '{key}' mapping declares no producer")
     return declared
 
 
@@ -174,11 +169,15 @@ def _validate_teams(value: object, errors: list[str]) -> dict[str, TeamEntry]:
         for key, raw in entry.items():
             if not isinstance(key, str) or key not in _TEAMS_ENTRY_KEYS:
                 errors.append(f"{where}: unknown field '{key}'")
-                continue
-            per_producer = _validate_producer_map(raw, where, key, errors)
-            if per_producer is not None:
+            elif isinstance(raw, dict):
+                per_producer = _validate_producer_map(raw, where, key, errors)
                 if per_producer:
                     declared[key] = per_producer
+                elif key == "notifications":
+                    # A mapping we could not read silences the producer. Dropping the key would
+                    # post to the channel the team asked to be left out of, and a repo we read
+                    # this file from over the API runs no lint of ours.
+                    declared[key] = False
             elif _is_valid_slack(raw):
                 declared[key] = raw
             else:

--- a/tools/owners/posthog_owners/schema.py
+++ b/tools/owners/posthog_owners/schema.py
@@ -7,6 +7,7 @@ treated as empty), every other field ignored.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TypeGuard
@@ -23,6 +24,12 @@ CHANGEME_SLUG = "team-CHANGEME"
 _TOP_LEVEL_KEYS = {"version", "owners", "status", "inherit", "rules", "teams"}
 _RULE_KEYS = {"match", "owners", "status", "inherit"}
 _TEAMS_ENTRY_KEYS = {"slack", "notifications"}
+# Automation that posts to a team's notifications channel and can be silenced on its own. A
+# producer must be listed here to be nameable in `notifications:`, so a typo is a lint error
+# rather than an opt-out that quietly never applies.
+PRODUCERS = frozenset({"stamphog"})
+# The key a per-producer mapping uses for every producer it does not name.
+PRODUCER_DEFAULT_KEY = "default"
 
 
 @dataclass(frozen=True)
@@ -32,12 +39,17 @@ class TeamEntry:
     ``slack`` is where people are. ``notifications`` is where automation posts, and it falls back
     to ``slack`` when a team never separates the two.
 
+    ``notifications`` may also be a mapping of producer name to channel, so a team can silence or
+    redirect one bot without doing it to all of them. A ``default`` key in that mapping answers for
+    every producer the team does not name; without one, an unnamed producer falls through to
+    ``slack``.
+
     ``None`` means the key was not declared, which is not the same as ``False``. The first falls
     through to the next step of the lookup; the second is a decision that there is no channel.
     """
 
     slack: str | bool | None = None
-    notifications: str | bool | None = None
+    notifications: str | bool | Mapping[str, str | bool] | None = None
 
 
 class _Unset:
@@ -111,6 +123,31 @@ def _is_valid_slack(raw: object) -> TypeGuard[str | bool]:
     return raw is False or (isinstance(raw, str) and raw.startswith("#"))
 
 
+def _validate_producer_map(value: object, where: str, key: str, errors: list[str]) -> dict[str, str | bool] | None:
+    """A per-producer ``notifications`` mapping, or None when the value is not one.
+
+    Returns None for anything that is not a mapping so the caller can go on to the scalar form and
+    report one error for a value that is neither.
+    """
+    if not isinstance(value, dict):
+        return None
+    known = ", ".join(sorted([*PRODUCERS, PRODUCER_DEFAULT_KEY]))
+    if key != "notifications":
+        errors.append(f"{where}: '{key}' takes a single channel, not a per-producer mapping")
+        return {}
+    declared: dict[str, str | bool] = {}
+    for producer, raw in value.items():
+        if not isinstance(producer, str) or (producer not in PRODUCERS and producer != PRODUCER_DEFAULT_KEY):
+            errors.append(f"{where}: unknown producer '{producer}' (known: {known})")
+        elif _is_valid_slack(raw):
+            declared[producer] = raw
+        else:
+            errors.append(f"{where}: '{producer}' must be a string starting with '#' or false")
+    if not declared:
+        errors.append(f"{where}: '{key}' mapping declares no producer")
+    return declared
+
+
 def _validate_teams(value: object, errors: list[str]) -> dict[str, TeamEntry]:
     """Validate the root-only ``teams:`` registry, a mapping of team slug to its channels.
 
@@ -133,10 +170,15 @@ def _validate_teams(value: object, errors: list[str]) -> dict[str, TeamEntry]:
         if not isinstance(entry, dict):
             errors.append(f"{where}: entry must be a mapping with a {known_keys} key")
             continue
-        declared: dict[str, str | bool] = {}
+        declared: dict[str, str | bool | Mapping[str, str | bool]] = {}
         for key, raw in entry.items():
             if not isinstance(key, str) or key not in _TEAMS_ENTRY_KEYS:
                 errors.append(f"{where}: unknown field '{key}'")
+                continue
+            per_producer = _validate_producer_map(raw, where, key, errors)
+            if per_producer is not None:
+                if per_producer:
+                    declared[key] = per_producer
             elif _is_valid_slack(raw):
                 declared[key] = raw
             else:

--- a/tools/owners/tests/test_owners.py
+++ b/tools/owners/tests/test_owners.py
@@ -282,6 +282,10 @@ def test_teams_registry_is_root_only(tmp_path: Path) -> None:
         ("teams:\n  team-a: '#a'\n", "entry must be a mapping"),
         ("teams:\n  '@alice':\n    slack: '#a'\n", "not @handles"),
         ("teams:\n  123:\n    slack: '#a'\n", "slug must be a string"),
+        ("teams:\n  team-a:\n    slack:\n      stamphog: false\n", "takes a single channel"),
+        ("teams:\n  team-a:\n    notifications:\n      nosuchbot: false\n", "unknown producer 'nosuchbot'"),
+        ("teams:\n  team-a:\n    notifications:\n      stamphog: 'no-hash'\n", "'stamphog' must be a string"),
+        ("teams:\n  team-a:\n    notifications: {}\n", "mapping declares no producer"),
     ],
 )
 def test_teams_registry_invalid_shapes(tmp_path: Path, teams_yaml: str, needle: str) -> None:
@@ -313,6 +317,28 @@ def test_team_channel_falls_back_by_purpose(
     # a derived #<slug> that may not exist, and conflating a silenced automation channel with a
     # team that has no channel at all would take the people channel down with it.
     resolved = team_channel("team-a", {"team-a": entry}, purpose)
+    assert (resolved.channel, resolved.declared) == (channel, declared)
+
+
+@pytest.mark.parametrize(
+    "notifications,producer,channel,declared",
+    [
+        # Silencing one producer leaves every other reader on the people channel, which is the
+        # whole point of the per-producer form over `notifications: false`.
+        ({"stamphog": False}, "stamphog", None, True),
+        ({"stamphog": False}, None, "#team-a", True),
+        ({"stamphog": "#bots-a"}, "stamphog", "#bots-a", True),
+        # `default` answers for a producer the team did not name.
+        ({"default": False}, "stamphog", None, True),
+        ({"default": "#bots-a", "stamphog": False}, "stamphog", None, True),
+        ({"default": "#bots-a", "stamphog": False}, None, "#bots-a", True),
+    ],
+)
+def test_team_channel_resolves_per_producer(
+    notifications: dict[str, str | bool], producer: str | None, channel: str | None, declared: bool
+) -> None:
+    entry = TeamEntry(slack="#team-a", notifications=notifications)
+    resolved = team_channel("team-a", {"team-a": entry}, "notifications", producer)
     assert (resolved.channel, resolved.declared) == (channel, declared)
 
 

--- a/tools/owners/tests/test_owners.py
+++ b/tools/owners/tests/test_owners.py
@@ -285,7 +285,7 @@ def test_teams_registry_is_root_only(tmp_path: Path) -> None:
         ("teams:\n  team-a:\n    slack:\n      stamphog: false\n", "takes a single channel"),
         ("teams:\n  team-a:\n    notifications:\n      nosuchbot: false\n", "unknown producer 'nosuchbot'"),
         ("teams:\n  team-a:\n    notifications:\n      stamphog: 'no-hash'\n", "'stamphog' must be a string"),
-        ("teams:\n  team-a:\n    notifications: {}\n", "mapping declares no producer"),
+        ("teams:\n  team-a:\n    notifications: {}\n", "mapping names no producer"),
     ],
 )
 def test_teams_registry_invalid_shapes(tmp_path: Path, teams_yaml: str, needle: str) -> None:
@@ -328,14 +328,13 @@ def test_team_channel_falls_back_by_purpose(
         ({"stamphog": False}, "stamphog", None, True),
         ({"stamphog": False}, None, "#team-a", True),
         ({"stamphog": "#bots-a"}, "stamphog", "#bots-a", True),
-        # `default` answers for a producer the team did not name.
-        ({"default": False}, "stamphog", None, True),
-        ({"default": "#bots-a", "stamphog": False}, "stamphog", None, True),
-        ({"default": "#bots-a", "stamphog": False}, None, "#bots-a", True),
+        # A scalar answers every producer, so naming one must not move the channel.
+        ("#bots-a", "stamphog", "#bots-a", True),
+        (False, "stamphog", None, True),
     ],
 )
 def test_team_channel_resolves_per_producer(
-    notifications: dict[str, str | bool], producer: str | None, channel: str | None, declared: bool
+    notifications: str | bool | dict[str, str | bool], producer: str | None, channel: str | None, declared: bool
 ) -> None:
     entry = TeamEntry(slack="#team-a", notifications=notifications)
     resolved = team_channel("team-a", {"team-a": entry}, "notifications", producer)
@@ -346,6 +345,15 @@ def test_team_channel_derives_for_an_unregistered_slug() -> None:
     assert team_channel("team-b", {"team-a": TeamEntry(slack="#a")}, "notifications") == team_channel(
         "team-b", {}, "notifications"
     )
+
+
+def test_an_unreadable_producer_map_registers_as_silence(tmp_path: Path) -> None:
+    # Dropping the key instead would fall through to the derived channel, so a typo in a repo our
+    # lint never reads would post the digest the team asked to be left out of.
+    text = "version: 1\nowners: []\nteams:\n  team-a:\n    notifications:\n      stamphogg: false\n"
+    file, errors = parse_owners_file(text, path=tmp_path / "owners.yaml", directory="")
+    assert any("unknown producer" in e for e in errors)
+    assert file is not None and file.teams == {"team-a": TeamEntry(notifications=False)}
 
 
 def test_teams_registry_pins_file_as_non_simple(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

A team that would rather not get the weekday stamphog digest has only one lever today: `notifications: false` in the root `owners.yaml`. That also silences every other bot routing through the registry, so the digest and the rest go together. The replay team follows its reviews on the PRs themselves and would like to turn just the digest off.

## Changes

- A team can now turn off the daily stamphog digest and keep its channel for every other automation. The replay team is the first entry.
- A `teams:` entry may now name one producer: `notifications: {stamphog: false}` covers that producer alone.
- A producer the mapping does not name falls through to `slack`, as an undeclared `notifications` does today.
- Only a producer the schema knows may be named, so a typo fails `owners:lint` rather than becoming an opt-out that never applies.
- `team_channel` takes an optional `producer`, and stamphog passes `"stamphog"`. Every other caller keeps the call it already makes.

Nothing user-visible changes in the product UI.

## How did you test this code?

- `tools/owners` suite passes locally (114 tests), including new cases for per-producer resolution and the new schema errors.
- New stamphog case: a team that opts out of stamphog alone leaves its merges unclaimed, so a later declaration still picks up the backlog.
- Not run: the stamphog digest tests need the test database, which this worktree's shared schema is mid-migration. CI covers them.
- `hogli owners:lint` passes with the new `team-replay` entry.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`docs/internal/ownership-model-proposal.md` documents the mapping form.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Skills invoked: `/writing-pr-descriptions`, `/shepherd-pr`, `/simplify`, `/code-review`.

The resolver docstring already described this extension and its shape, so the change follows it: widen what the `notifications` key may hold rather than add a second key. `Producer` and the validator's `PRODUCERS` derive from one Literal, so adding a bot is a one-line edit. A `default` key was drafted and cut: with one producer it duplicates the scalar form.
