### PR TITLE
fix(experiments): preserve holdout when shipping a variant

### DIFF
--- a/products/feature_flags/backend/facade/api.py
+++ b/products/feature_flags/backend/facade/api.py
@@ -201,7 +201,7 @@ def _roll_out_variant(
             catch_all["description"] = release_condition_description
         groups = [catch_all, *groups]
 
-    return {
+    new_filters = {
         "aggregation_group_type_index": current_filters.get("aggregation_group_type_index"),
         "payloads": current_filters.get("payloads", {}),
         "multivariate": {
@@ -216,6 +216,11 @@ def _roll_out_variant(
         },
         "groups": groups,
     }
+    # A holdout must keep excluding its users after the winner ships — that is its
+    # entire purpose (measuring shipped features against an unexposed baseline).
+    if current_filters.get("holdout"):
+        new_filters["holdout"] = current_filters["holdout"]
+    return new_filters
 
 
 def ship_variant(

--- a/products/feature_flags/backend/test/test_facade.py
+++ b/products/feature_flags/backend/test/test_facade.py
@@ -353,6 +353,27 @@ class TestRollOutVariant:
         assert result["payloads"] == {}
         assert result["aggregation_group_type_index"] is None
 
+    def test_transform_filters_preserves_holdout(self):
+        current_filters = {
+            "groups": [{"properties": [], "rollout_percentage": 100}],
+            "multivariate": {
+                "variants": [
+                    {"key": "control", "rollout_percentage": 50},
+                    {"key": "test", "rollout_percentage": 50},
+                ]
+            },
+            "holdout": {"id": 42, "exclusion_percentage": 5},
+        }
+
+        assert _roll_out_variant(current_filters, "test")["holdout"] == {"id": 42, "exclusion_percentage": 5}
+        assert _roll_out_variant(current_filters, "test", release_to_everyone=True)["holdout"] == {
+            "id": 42,
+            "exclusion_percentage": 5,
+        }
+
+        del current_filters["holdout"]
+        assert "holdout" not in _roll_out_variant(current_filters, "test")
+
     def test_transform_filters_default_does_not_mutate_input(self):
         """Defensive: ensure the function returns a new groups list without mutating caller's filters."""
         original_groups = [{"properties": [], "rollout_percentage": 50}]


### PR DESCRIPTION
## Problem

Shipping a winning variant silently removes the experiment's holdout from the feature flag, so held-out users start seeing the winner. This defeats the purpose of a holdout: measuring shipped features against users who never got them.

The ship transform rebuilds the flag's filters from scratch and does not carry the `holdout` key over.

## Changes

- After shipping a variant, the flag keeps its `holdout` key, so holdout users keep getting the fallback experience.
- Nothing else about shipping changes; flags without a holdout produce identical filters as before.

## How did you test this code?

Added a test asserting `_roll_out_variant` preserves the holdout in both ship modes and adds no key when none is set. It fails on the previous code. Ran the facade test file locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. The bug was found while answering a customer question about holdout lifecycle. Skills invoked: /writing-tests, /writing-pr-descriptions, /wt.
