### PR TITLE
fix(kafka): match the target profile's compression on DLQ replay

### DIFF
--- a/posthog/kafka_client/dlq_replay.py
+++ b/posthog/kafka_client/dlq_replay.py
@@ -252,6 +252,10 @@ def drain_dlq(
         message_max_bytes = max_message_bytes or target.producer_settings.get("max_request_size")
         if message_max_bytes:
             producer_conf["message.max.bytes"] = int(message_max_bytes)
+        # Compress the same way the shared producer does, so a record that fit the target
+        # topic when it was first written still fits on the way back in.
+        if target.producer_settings.get("compression_type"):
+            producer_conf["compression.type"] = target.producer_settings["compression_type"]
         producer = Producer(producer_conf)
 
     replayed = 0

--- a/posthog/kafka_client/test/test_dlq_replay.py
+++ b/posthog/kafka_client/test/test_dlq_replay.py
@@ -224,6 +224,24 @@ class DrainDlqTest(TestCase):
 
         assert producer.conf.get("message.max.bytes") == expected
 
+    @parameterized.expand(
+        [
+            ("from_profile", {"compression_type": "gzip"}, "gzip"),
+            ("unset_when_profile_omits_it", {}, None),
+        ]
+    )
+    def test_producer_compression_type(
+        self,
+        _name: str,
+        producer_settings: dict[str, Any],
+        expected: Optional[str],
+    ) -> None:
+        producer = FakeProducer()
+
+        self._drain([[FakeMessage(b"one")]], producer, producer_settings=producer_settings)
+
+        assert producer.conf.get("compression.type") == expected
+
     def test_delivery_failure_is_reported_and_not_committed(self) -> None:
         producer = FakeProducer(delivery_error="Broker: Message too large")
 


### PR DESCRIPTION
## Problem

- An operator draining a DLQ back into its target topic hits a broker rejection on a record that topic already accepted.
- The broker enforces `max.message.bytes` on the compressed record batch, and capture wrote these records with the target profile's compression.
- The replay producer copied hosts, security, and `message.max.bytes` from the target profile, but not its compression, so it re-sent the records uncompressed and larger.

## Changes

- The replay producer now compresses with the target profile's `compression_type`, so a record that fit the topic when capture wrote it still fits on the way back in.
- A profile that sets no `compression_type` is unaffected. The producer keeps the librdkafka default.
- Nothing a user sees changes. `drain_dlq` backs a management command an operator runs.

> [!NOTE]
> This PR opened with the `message.max.bytes` seeding too. [#95101](https://github.com/PostHog/posthog/pull/95101) landed that, along with a `--max-message-bytes` override, so the rebase onto master leaves only the compression setting.

## How did you test this code?

Two cases added to `DrainDlqTest`, both through the existing `_drain` helper:

- A profile with `compression_type` sets `compression.type` on the producer. Drop the seeding and this fails, which is the regression the fix removes.
- A profile without it leaves `compression.type` unset, so a cluster that never configured compression keeps the current behavior.

Not run: a live produce against a broker holding real DLQ records.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Agent-driven

Authored with PostHog Desktop (Claude). Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
The branch was rebased onto master after [#95101](https://github.com/PostHog/posthog/pull/95101) landed the message-size half of the original fix. The conflict resolution keeps master's `max_message_bytes` flag and its parameterized test, and reduces this PR to the compression setting that is still missing.
