### PR TITLE
fix(workflows): keep the SES tenant sweep inside the account API quota

### DIFF
--- a/docs/internal/workflows-email-sending-tiers.md
+++ b/docs/internal/workflows-email-sending-tiers.md
@@ -8,7 +8,7 @@ Only workflows that send email are subject to the tiers; SMS, push, and webhook 
 ## Where the pieces live
 
 - Tier state: `email_sending_tier`, `email_sending_tier_updated_at` (dwell anchor), `email_sending_tier_demoted_at` (demotion cooldown anchor), and `email_sending_tier_pinned` on `TeamWorkflowsConfig`.
-- Tier movement: a daily Celery sweep (07:15 UTC, after the SES tenant-state reconcile at 07:00) in `products/workflows/backend/services/email_sending_tier.py`.
+- Tier movement: a daily Celery sweep (08:30 UTC, two hours after the SES tenant-state reconcile at 06:30, which is the state it reads) in `products/workflows/backend/services/email_sending_tier.py`.
 - Batch audience cap: `get_hogflow_batch_trigger_limit` in `products/workflows/backend/utils/batch_trigger_limit.py`, applied at batch dispatch and shown in the blast radius preview.
 - Send-time caps: two Valkey token buckets per team in the CDP email worker (`claimTeamSendingBudget` in `nodejs/src/cdp/services/messaging/email.service.ts`).
 - Staff controls: the team's Django admin page (view state, set/pin a tier, recompute now).

--- a/posthog/egress/README.md
+++ b/posthog/egress/README.md
@@ -81,6 +81,13 @@ One scrape is one credit, so those numbers cap a bill as much as a rate; they ar
 Every Firecrawl call runs on a sheddable lane: what gets scraped is derived from user-supplied input and callers can do without the scrape, so nothing in this domain runs `CRITICAL`.
 `FIRECRAWL_API_KEY` authenticates every call as a bearer token; an instance without one makes no request at all (`FirecrawlNotConfigured`).
 
+AWS SES (`ses/`) is metered by AWS per account and region, and one operation is far tighter than the rest: `ListRecommendations` allows roughly one call a second, where `GetTenant` and `GetAccount` allow much more.
+So the domain budgets that one operation, under `ses_recommendations`, keyed by the region that names the metered account.
+`SES_RECOMMENDATIONS_EGRESS_PER_MINUTE_BUDGET` (default 45) holds PostHog under AWS's own ceiling so botocore's retries absorb the drift the counter cannot see.
+Three callers share it, and only the daily tenant reconciliation sweep is big enough to spend the whole quota on its own, so the sweep runs `BATCH` and the reserved floor keeps 40% for the account reputation poller and the Reputation tab.
+The sweep also asks `pace_ses_recommendations_seconds` how long to wait between teams, because a caller that walks every team spends its whole share whether or not the window currently holds headroom.
+This domain has no `transport.py`: SES is reached through boto3 rather than `requests`, so the calls are gated at the provider (`products/workflows/backend/providers/ses.py`) and botocore's adaptive retry mode is the reactive backstop.
+
 ### Priority lanes
 
 Priority (`CRITICAL` / `NORMAL` / `BATCH`) controls how sheddable a call is when the budget gets tight.

--- a/posthog/egress/ses/__init__.py
+++ b/posthog/egress/ses/__init__.py
@@ -1,0 +1,13 @@
+from posthog.egress.ses.limiter import (
+    SESRecommendationsBudgetExhausted,
+    consume_ses_recommendations_sync,
+    pace_ses_recommendations_seconds,
+    ses_recommendations_key,
+)
+
+__all__ = [
+    "SESRecommendationsBudgetExhausted",
+    "consume_ses_recommendations_sync",
+    "pace_ses_recommendations_seconds",
+    "ses_recommendations_key",
+]

--- a/posthog/egress/ses/limiter.py
+++ b/posthog/egress/ses/limiter.py
@@ -1,0 +1,81 @@
+"""SES ListRecommendations egress budget.
+
+AWS meters SESv2 ``ListRecommendations`` account-wide, and it is the tightest quota any SES caller
+here touches: roughly one request per second, against operations like ``GetTenant`` that answer far
+faster. Three callers share it — the account reputation poller, the daily tenant reconciliation
+sweep, and the Reputation tab in the app. The sweep is the only one big enough to spend the whole
+quota on its own, so it takes the sheddable lane and the other two keep a reserved floor.
+
+Importing this module registers the policy as a side effect, so import it (directly or via
+``consume_ses_recommendations_sync``) before using a ``ses_recommendations:...`` limiter key.
+"""
+
+from django.conf import settings
+
+from posthog.egress.limiter.outbound import get_outbound_rate_limiter
+from posthog.egress.limiter.policies import Priority, RatePolicy, register_policy
+from posthog.egress.transport.transport import EgressBudgetExhausted
+
+SES_RECOMMENDATIONS_DOMAIN = "ses_recommendations"
+
+# The quota belongs to the SES account in one region, which is what AWS meters. A deployment holds
+# one set of SES credentials, so the region names that account without the STS call an account id
+# would cost on every gate.
+_SCOPE = "account"
+
+# Only the reconciliation sweep is sheddable. The poller feeds the gauges the SES alerts evaluate
+# and the Reputation tab serves a person waiting on a response, and both spend a handful of calls,
+# so denying either would cost a real answer to save budget they cannot dent.
+_RESERVE: dict[Priority, float] = {Priority.BATCH: 0.40}
+
+# Under AWS's own ceiling of about 60 calls a minute, so botocore's retries absorb the drift our
+# own counter cannot see: clock skew, races between worker processes, and the SES console.
+_DEFAULT_PER_MINUTE_BUDGET = 45
+
+# The fallback counts one process rather than the shared budget. It is left undivided because the
+# consumer that can exhaust this quota is a single sweep running in one process at a time, and
+# shrinking its fallback share would turn a Redis outage into a sweep that reconciles almost
+# nothing. The callers that do run in many processes each spend a few calls, and botocore's
+# adaptive retries remain the backstop.
+_IN_MEMORY_DIVIDER = 1
+
+
+class SESRecommendationsBudgetExhausted(EgressBudgetExhausted):
+    """A sheddable ListRecommendations call was denied before it was sent, so our own shared budget
+    is spent rather than SES having refused the call."""
+
+
+def _ses_recommendations_policy(_key: str) -> RatePolicy:
+    per_minute = int(getattr(settings, "SES_RECOMMENDATIONS_EGRESS_PER_MINUTE_BUDGET", _DEFAULT_PER_MINUTE_BUDGET))
+    return RatePolicy(limits=((per_minute, 60.0),), in_memory_divider=_IN_MEMORY_DIVIDER, reserve=_RESERVE)
+
+
+register_policy(SES_RECOMMENDATIONS_DOMAIN, _ses_recommendations_policy)
+
+
+def ses_recommendations_key() -> str:
+    """Limiter key for the SES account whose ListRecommendations quota every caller draws on."""
+    return f"{SES_RECOMMENDATIONS_DOMAIN}:{_SCOPE}:{settings.SES_REGION}"
+
+
+def consume_ses_recommendations_sync(
+    n: int = 1, *, priority: Priority = Priority.NORMAL, source: str = "unknown"
+) -> bool:
+    """Reserve ``n`` ListRecommendations calls against the account budget. Returns False when the
+    budget (or this priority's reserved floor) is spent, so the caller decides whether to shed."""
+    return get_outbound_rate_limiter().consume_sync(ses_recommendations_key(), n, priority=priority, source=source)
+
+
+def pace_ses_recommendations_seconds(*, priority: Priority = Priority.BATCH) -> float:
+    """Seconds a bulk caller should wait before its next ListRecommendations call.
+
+    Always positive, unlike the facade's own ``pace_seconds``. That answers 0 both while a window
+    still holds headroom and when the limiter store is unreachable, which suits a caller short
+    enough never to spend its share. A caller that walks every team spends the whole window either
+    way, so it holds a steady interval of its own and lets contention slow it further.
+    """
+    key = ses_recommendations_key()
+    policy = _ses_recommendations_policy(key)
+    count, period = policy.limits[0]
+    allowance = max(1, count - policy.reserve_amount(priority, count))
+    return max(get_outbound_rate_limiter().pace_seconds(key, priority=priority), period / allowance)

--- a/posthog/egress/test/test_ses_limiter.py
+++ b/posthog/egress/test/test_ses_limiter.py
@@ -1,0 +1,25 @@
+from django.test import SimpleTestCase, override_settings
+
+from posthog.egress.limiter.policies import Priority, resolve_policy
+from posthog.egress.ses.limiter import (
+    SES_RECOMMENDATIONS_DOMAIN,
+    pace_ses_recommendations_seconds,
+    ses_recommendations_key,
+)
+
+
+class TestSesRecommendationsLimiter(SimpleTestCase):
+    def test_the_key_resolves_to_a_registered_policy_that_reads_the_settings_budget(self) -> None:
+        # A key whose domain has no policy raises at the first real call, and the only thing that
+        # registers this one is importing the module, so a moved import breaks every SES caller.
+        with override_settings(SES_REGION="eu-west-1", SES_RECOMMENDATIONS_EGRESS_PER_MINUTE_BUDGET=30):
+            key = ses_recommendations_key()
+            assert key == f"{SES_RECOMMENDATIONS_DOMAIN}:account:eu-west-1"
+            assert resolve_policy(key).limits == ((30, 60.0),)
+
+    def test_a_bulk_caller_is_always_told_to_wait_at_least_its_steady_interval(self) -> None:
+        # The facade answers 0 while a window holds headroom and when its store is unreachable. The
+        # sweep waits on this answer between teams, so a 0 would let it sprint through the quota.
+        with override_settings(SES_RECOMMENDATIONS_EGRESS_PER_MINUTE_BUDGET=60):
+            # 60 a minute less the 40% BATCH floor leaves 36, so a second spread over 36 calls.
+            assert pace_ses_recommendations_seconds(priority=Priority.BATCH) >= 60.0 / 36

--- a/posthog/settings/ses.py
+++ b/posthog/settings/ses.py
@@ -14,6 +14,11 @@ else:
 
 SES_REGION = os.getenv("SES_REGION", "us-east-1")
 
+# Calls a minute PostHog allows itself against the account-wide SESv2 ListRecommendations quota,
+# shared by the reputation poller, the tenant reconciliation sweep, and the Reputation tab. See
+# posthog/egress/ses/limiter.py for how the share is split between them.
+SES_RECOMMENDATIONS_EGRESS_PER_MINUTE_BUDGET = int(os.getenv("SES_RECOMMENDATIONS_EGRESS_PER_MINUTE_BUDGET", "45"))
+
 # Configuration sets referenced by workflow email sends. With tenant attribution, SES requires
 # every resource a send references — the configuration set included, not just the sending
 # identity — to be associated with the tenant, so provisioning associates these with each tenant.

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -254,19 +254,22 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     )
 
     # SES tenant reputation reconciliation - daily at 6:30 AM UTC. EventBridge events are the
-    # real-time path; this sweep catches missed deliveries. Sequential SES API calls per team
-    # with an SES email integration, so kept daily to stay well inside SES API rate limits.
+    # real-time path; this sweep catches missed deliveries. It walks every team with an SES email
+    # integration and paces itself to stay inside the account's shared SES API quota, so its run
+    # time grows with the number of those teams.
     sender.add_periodic_task(
         crontab(hour="6", minute="30"),
         reconcile_ses_tenant_states.s(),
         name="ses tenant reputation reconciliation",
     )
 
-    # Workflow email trust tiers - daily at 7:15 AM UTC, after the tenant reconciliation above.
-    # Promotion is intentionally slow (a team must hold a tier for days), so a daily pass is enough.
-    # Demotions do not wait for it: the staff suspension action recomputes the team directly.
+    # Workflow email trust tiers - daily at 8:30 AM UTC. It reads the tenant state the sweep above
+    # writes, so it starts two hours later: that is room for the sweep to finish, and for a retry
+    # after a partial run, before the tiers are computed from what it stored. Promotion is
+    # intentionally slow (a team must hold a tier for days), so a daily pass is enough. Demotions
+    # do not wait for it: the staff suspension action recomputes the team directly.
     sender.add_periodic_task(
-        crontab(hour="7", minute="15"),
+        crontab(hour="8", minute="30"),
         recompute_workflows_email_sending_tiers.s(),
         name="workflows email sending tier recomputation",
     )

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -264,10 +264,12 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     )
 
     # Workflow email trust tiers - daily at 8:30 AM UTC. It reads the tenant state the sweep above
-    # writes, so it starts two hours later: that is room for the sweep to finish, and for a retry
-    # after a partial run, before the tiers are computed from what it stored. Promotion is
-    # intentionally slow (a team must hold a tier for days), so a daily pass is enough. Demotions
-    # do not wait for it: the staff suspension action recomputes the team directly.
+    # writes, so it starts two hours later. The gap is a margin, not a bound: nothing couples the
+    # two jobs, and a team the sweep did not reach keeps the state it already had, which the tier
+    # logic treats as advisory (an unknown reputation impact reads the same as a clean one).
+    # Promotion is intentionally slow (a team must hold a tier for days), so a daily pass is
+    # enough. Demotions do not wait for it: the staff suspension action recomputes the team
+    # directly.
     sender.add_periodic_task(
         crontab(hour="8", minute="30"),
         recompute_workflows_email_sending_tiers.s(),

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -2195,7 +2195,7 @@ def _fetch_aws_tenant_reputation(team_id: int) -> dict[str, Any] | None:
     if cached is not None:
         return cached["value"]
     try:
-        raw = SESProvider().get_tenant_reputation(team_id)
+        raw = SESProvider(source="reputation_tab").get_tenant_reputation(team_id)
     except Exception:
         logger.exception("Failed to fetch SES tenant reputation", team_id=team_id)
         cache.set(cache_key, {"value": None}, AWS_TENANT_REPUTATION_ERROR_CACHE_SECONDS)

--- a/products/workflows/backend/providers/ses.py
+++ b/products/workflows/backend/providers/ses.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime, timedelta
 from functools import cached_property
 from itertools import batched
 from time import monotonic
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from django.conf import settings
 
@@ -18,6 +18,8 @@ from botocore.exceptions import BotoCoreError, ClientError
 from rest_framework import exceptions
 
 from posthog.dataclasses import frozen
+from posthog.egress.limiter.policies import Priority
+from posthog.egress.ses.limiter import SESRecommendationsBudgetExhausted, consume_ses_recommendations_sync
 
 if TYPE_CHECKING:
     from types_boto3_ses.client import SESClient
@@ -45,6 +47,18 @@ METRIC_CALL_WORST_CASE_SECONDS = METRIC_CONNECT_TIMEOUT_SECONDS + METRIC_READ_TI
 # The budget covers every call the breakdown makes, ranking included, and a call starts only with
 # its worst case still inside it — so the ceiling holds even when SES answers slowly.
 METRIC_QUERY_BUDGET_SECONDS = 20
+
+# AWS meters ListRecommendations at about one request a second account-wide, so a throttled call
+# has to wait out most of a second before it can succeed. botocore's legacy default gives up long
+# before that: five attempts of roughly half a second of exponential backoff, exhausted in about
+# two seconds while the quota is still full. Adaptive mode adds the client-side rate limiter a
+# per-second quota needs, which learns the rate from the throttling responses it gets back.
+SES_API_RETRY_MODE: Literal["adaptive"] = "adaptive"
+SES_API_MAX_ATTEMPTS = 6
+
+# The most ListRecommendations returns in one page, which is the AWS ceiling for PageSize. Asking
+# for it makes a listing cost as few calls against the shared quota as AWS allows.
+RECOMMENDATIONS_PAGE_SIZE = 100
 
 
 @frozen
@@ -200,7 +214,13 @@ class SESProvider:
     ses_v2_client: "SESV2Client"
     ses_v2_metrics_client: "SESV2Client"
 
-    def __init__(self):
+    def __init__(self, *, priority: Priority = Priority.NORMAL, source: str = "unknown"):
+        # ListRecommendations draws on one account-wide budget shared by every caller, so a caller
+        # declares how sheddable it is and where the calls come from. Only the BATCH lane is ever
+        # denied; see _iter_open_recommendations.
+        self.egress_priority = priority
+        self.egress_source = source
+
         # Initialize the boto3 clients
         self.sts_client = boto3.client(
             "sts",
@@ -219,6 +239,7 @@ class SESProvider:
             aws_access_key_id=settings.SES_ACCESS_KEY_ID,
             aws_secret_access_key=settings.SES_SECRET_ACCESS_KEY,
             region_name=settings.SES_REGION,
+            config=Config(retries={"mode": SES_API_RETRY_MODE, "max_attempts": SES_API_MAX_ATTEMPTS}),
         )
         # Separate client for the metric fan-out only, so bounding it cannot slow identity and
         # tenant calls, which are allowed to take longer.
@@ -295,8 +316,18 @@ class SESProvider:
         STATUS check exists for RESOURCE_ARN-filtered calls: AWS documents STATUS as combinable
         only with IMPACT or TYPE, so tenant-scoped listings must drop FIXED entries client-side.
         """
-        kwargs: dict[str, Any] = {"Filter": finding_filter} if finding_filter else {}
+        kwargs: dict[str, Any] = {"PageSize": RECOMMENDATIONS_PAGE_SIZE}
+        if finding_filter:
+            kwargs["Filter"] = finding_filter
         while True:
+            if not consume_ses_recommendations_sync(priority=self.egress_priority, source=self.egress_source):
+                # A non-sheddable lane proceeds and lets SES's own throttling be the backstop, the
+                # rule the egress transport applies too. It asks for a few calls, and either a
+                # person is waiting on the answer or the SES alerts are.
+                if self.egress_priority is Priority.BATCH:
+                    raise SESRecommendationsBudgetExhausted(
+                        "SES ListRecommendations egress budget exhausted; another caller holds the account quota"
+                    )
             page = self.ses_v2_client.list_recommendations(**kwargs)
             for recommendation in page.get("Recommendations", []):
                 if recommendation.get("Status") == "OPEN":

--- a/products/workflows/backend/tasks/ses_account_reputation.py
+++ b/products/workflows/backend/tasks/ses_account_reputation.py
@@ -22,7 +22,7 @@ def poll_ses_account_reputation() -> None:
     forever and nothing would fire.
     """
     try:
-        reputation = SESProvider().get_account_reputation()
+        reputation = SESProvider(source="ses_account_reputation_poll").get_account_reputation()
     except Exception:
         # Regions without SES access (self-hosted, dev) land here every tick; a stale
         # last_poll_timestamp is the alertable signal for genuine poller breakage in cloud.

--- a/products/workflows/backend/tasks/ses_tenant_state.py
+++ b/products/workflows/backend/tasks/ses_tenant_state.py
@@ -1,6 +1,10 @@
+import time
+
 from celery import shared_task
 from structlog import get_logger
 
+from posthog.egress.limiter.policies import Priority
+from posthog.egress.ses.limiter import SESRecommendationsBudgetExhausted, pace_ses_recommendations_seconds
 from posthog.models.integration import Integration
 from posthog.scoping_audit import skip_team_scope_audit
 from posthog.tasks.utils import CeleryQueue
@@ -42,15 +46,26 @@ def reconcile_ses_tenant_states() -> None:
         .order_by("team_id")
     )
     # One provider for the whole sweep: a fresh SESProvider per team would rebuild its boto3
-    # clients (and re-resolve credentials) thousands of times.
-    provider = SESProvider()
+    # clients (and re-resolve credentials) thousands of times. It runs on the sheddable lane,
+    # because a daily backstop can wait while a person or an alert cannot.
+    provider = SESProvider(priority=Priority.BATCH, source="ses_tenant_reconciliation")
     synced = 0
     failed = 0
+    shed = 0
     for team_id in team_ids.iterator(chunk_size=500):
+        # Each team costs at least one ListRecommendations call, and that quota is account-wide at
+        # about one call a second. Walking the teams as fast as Postgres serves them holds the whole
+        # quota for the length of the sweep, which throttles the reputation poller and the
+        # Reputation tab instead. Waiting between teams keeps the sweep inside its own share.
+        time.sleep(pace_ses_recommendations_seconds(priority=Priority.BATCH))
         try:
             sync_ses_tenant_state(team_id, provider=provider, verify_team=False)
             synced += 1
+        except SESRecommendationsBudgetExhausted:
+            # Another caller took the headroom this interval counted on. The next team waits again,
+            # and EventBridge stays the real-time path, so one skipped team costs a day at most.
+            shed += 1
         except Exception:
             failed += 1
             logger.exception("SES tenant reconciliation failed for team", team_id=team_id)
-    logger.info("SES tenant reconciliation finished", synced=synced, failed=failed)
+    logger.info("SES tenant reconciliation finished", synced=synced, failed=failed, shed=shed)

--- a/products/workflows/backend/test/test_ses_provider.py
+++ b/products/workflows/backend/test/test_ses_provider.py
@@ -14,7 +14,14 @@ import dns.resolver
 from botocore.exceptions import ClientError
 from parameterized import parameterized
 
-from products.workflows.backend.providers.ses import METRIC_QUERY_BUDGET_SECONDS, SESProvider
+from posthog.egress.limiter.policies import Priority
+from posthog.egress.ses.limiter import SESRecommendationsBudgetExhausted
+
+from products.workflows.backend.providers.ses import (
+    METRIC_QUERY_BUDGET_SECONDS,
+    METRIC_READ_TIMEOUT_SECONDS,
+    SESProvider,
+)
 
 TEST_DOMAIN = "test.posthog.com"
 
@@ -47,6 +54,22 @@ class TestSESProvider(TestCase):
         ses_provider = SESProvider()
         if TEST_DOMAIN in ses_provider.ses_client.list_identities()["Identities"]:
             ses_provider.delete_identity(TEST_DOMAIN)
+
+    def test_the_sesv2_client_retries_throttling_with_the_adaptive_limiter(self):
+        # SES meters ListRecommendations per second, so botocore's legacy default gives up while the
+        # quota is still full. Nothing else observable catches this config going missing again.
+        assert self.mock_boto3_client is not None
+        self.mock_boto3_client.reset_mock()
+        SESProvider()
+
+        # The metrics client is the other sesv2 client, told to give up fast to bound a web request.
+        config = next(
+            call.kwargs["config"]
+            for call in self.mock_boto3_client.call_args_list
+            if call.args[0] == "sesv2" and call.kwargs["config"].read_timeout != METRIC_READ_TIMEOUT_SECONDS
+        )
+        assert config.retries["mode"] == "adaptive"
+        assert config.retries["max_attempts"] > 1
 
     def test_init_with_valid_credentials(self):
         with override_settings(
@@ -579,6 +602,22 @@ class TestGetAccountReputation(TestCase):
         first_call, second_call = self.mock_client.list_recommendations.call_args_list
         assert first_call.kwargs["Filter"] == {"STATUS": "OPEN"}
         assert second_call.kwargs["NextToken"] == "page-2"
+
+    @parameterized.expand([("batch", Priority.BATCH, True), ("normal", Priority.NORMAL, False)])
+    def test_a_spent_budget_sheds_only_the_bulk_lane(self, _name, priority, expect_shed):
+        # The reconciliation sweep must give the quota back when another caller needs it, while the
+        # poller and the Reputation tab proceed and let SES's own throttling be the backstop.
+        provider = SESProvider(priority=priority)
+        self.mock_client.get_account.return_value = {"EnforcementStatus": "HEALTHY"}
+        self.mock_client.list_recommendations.return_value = {"Recommendations": []}
+
+        with patch("products.workflows.backend.providers.ses.consume_ses_recommendations_sync", return_value=False):
+            if expect_shed:
+                with pytest.raises(SESRecommendationsBudgetExhausted):
+                    provider.get_account_reputation()
+                self.mock_client.list_recommendations.assert_not_called()
+            else:
+                assert provider.get_account_reputation() == {"enforcement_status": "HEALTHY", "findings": []}
 
     def test_missing_enforcement_status_fails_the_poll(self):
         self.mock_client.get_account.return_value = {}

--- a/products/workflows/backend/test/test_ses_tenant_state.py
+++ b/products/workflows/backend/test/test_ses_tenant_state.py
@@ -5,6 +5,10 @@ from django.utils import timezone
 
 from parameterized import parameterized
 
+from posthog.egress.ses.limiter import SESRecommendationsBudgetExhausted
+from posthog.models.integration import Integration
+from posthog.models.team import Team
+
 from products.workflows.backend.models.team_workflows_config import TeamWorkflowsConfig
 from products.workflows.backend.services.ses_tenant_state import (
     PROVIDER_PAUSE_REASON,
@@ -12,6 +16,7 @@ from products.workflows.backend.services.ses_tenant_state import (
     apply_ses_tenant_state,
     sync_ses_tenant_state,
 )
+from products.workflows.backend.tasks.ses_tenant_state import reconcile_ses_tenant_states
 
 
 class TestApplySesTenantState(BaseTest):
@@ -183,3 +188,33 @@ class TestSyncSesTenantState(BaseTest):
 
         provider.get_tenant_reputation.assert_not_called()
         assert not TeamWorkflowsConfig.objects.filter(team_id=self.team.id + 99_999).exists()
+
+
+class TestReconcileSesTenantStates(BaseTest):
+    def _team_with_ses_integration(self) -> Team:
+        team = Team.objects.create(organization=self.organization)
+        Integration.objects.create(team=team, kind="email", config={"provider": "ses"}, created_by=self.user)
+        return team
+
+    def test_the_sweep_waits_between_teams_and_carries_on_past_a_shed_one(self) -> None:
+        # Unpaced, the sweep holds the account's ListRecommendations quota for its whole run and
+        # throttles the reputation poller. And a team it has to give up on must not end the run:
+        # the teams after it would go a day without reconciliation.
+        first, second = self._team_with_ses_integration(), self._team_with_ses_integration()
+
+        with (
+            patch("products.workflows.backend.tasks.ses_tenant_state.time.sleep") as sleep,
+            patch(
+                "products.workflows.backend.tasks.ses_tenant_state.pace_ses_recommendations_seconds",
+                return_value=2.5,
+            ),
+            patch("products.workflows.backend.tasks.ses_tenant_state.SESProvider"),
+            patch(
+                "products.workflows.backend.tasks.ses_tenant_state.sync_ses_tenant_state",
+                side_effect=[SESRecommendationsBudgetExhausted("spent"), None],
+            ) as sync,
+        ):
+            reconcile_ses_tenant_states()
+
+        assert [c.args[0] for c in sync.call_args_list] == [first.id, second.id]
+        assert sleep.call_args_list == [((2.5,),), ((2.5,),)]


### PR DESCRIPTION
## Problem

Nobody with an SES email integration could see their project's sending reputation for about 20 minutes each morning, and the SES alerts went blind for about 50 minutes.

- The daily SES tenant reconciliation sweep walks every team that has an SES email integration, one team at a time, with no pacing.
- Each team costs at least one `ListRecommendations` call. AWS meters that operation account-wide at roughly one call a second, which is far tighter than the SES operations around it.
- The sweep therefore holds the whole quota for the length of its run. Every other caller on the same account gets `TooManyRequestsException`.
- Two callers share that quota: the account reputation poller that feeds the SES alert gauges, and the Reputation tab in the app.
- The poller catches every exception and returns, so a throttled tick pushes no gauges. Pushgateway gauges never expire, so `posthog_ses_account_reputation_last_poll_timestamp_seconds` froze and the staleness alert fired.
- The shared `sesv2` client carried no retry config, so it kept botocore's legacy default: five attempts of roughly half a second of backoff, exhausted in about two seconds while a per-second quota is still full.

## Changes

- The Reputation tab and the SES alert gauges keep working while the sweep runs, because the sweep now gives the quota back instead of holding it.
- A new egress domain (`posthog/egress/ses/`) budgets `ListRecommendations` per SES account and region, at 45 calls a minute by default (`SES_RECOMMENDATIONS_EGRESS_PER_MINUTE_BUDGET`).
- The sweep runs on the `BATCH` lane, which reserves 40% of every window for the poller and the tab. It is the only lane that gets denied.
- The sweep waits between teams. Its own share is about 27 calls a minute, so roughly 2.2 seconds per team.
- The shared `sesv2` client now retries with botocore's adaptive mode, which is a client-side rate limiter that learns from the throttling responses it gets. The metrics client keeps its own bounded config.
- `ListRecommendations` asks for AWS's maximum page size, so a listing costs as few calls as AWS allows.
- The email sending tier recomputation moves from 7:15 to 8:30 UTC. It reads the tenant state the sweep writes, and two hours leaves room for the sweep to finish and for a retry after a partial run.

The design point worth a reviewer's attention: `pace_ses_recommendations_seconds` returns a positive interval, unlike the egress facade's own `pace_seconds`. The facade answers 0 both while a window holds headroom and when Redis is unreachable. A caller that walks every team spends its whole share either way, so the sweep holds a steady interval of its own and lets contention slow it further. Without that floor a Redis blip would let the sweep sprint through the quota again.

> [!NOTE]
> The sweep's run time now grows with the number of teams that have an SES integration, at about 2.2 seconds each. Watch `SES tenant reconciliation finished` against the 8:30 UTC tier job. The `shed` count in that log line is new and reports teams the sweep gave up on because another caller held the quota.

Nothing in the UI changes. The remaining edits are mechanical: a `source` label on the two other `SESProvider` call sites, and a doc line that already named the wrong reconcile time.

## How did you test this code?

Automated only. This runs in a sandbox, so no SES account was called and none of this was exercised against AWS.

- `posthog/egress/test/test_ses_limiter.py`: the domain's policy is registered only as an import side effect, so a moved import would raise `No outbound rate policy registered` on the first real SES call. The second case pins the positive pacing floor, which is the property the sweep depends on and which a refactor toward the plain facade would silently drop.
- `test_ses_provider.py`: a new case asserts the shared `sesv2` client gets a throttle-aware retry config. The missing config is the shipped bug, and nothing else observable catches its removal. A parameterized case covers the lane rule: `BATCH` raises and makes no call when the budget is spent, `NORMAL` proceeds.
- `test_ses_tenant_state.py`: one case covers the sweep waiting between teams and carrying on past a shed team. Unpaced it starves the poller again, and a shed team that ended the run would cost every team after it a day of reconciliation.
- Not run: anything that needs a live SES account, and the frontend suites, because no frontend code changed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`docs/internal/workflows-email-sending-tiers.md` now names the real reconcile time and the new tier schedule.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app from a Slack thread, after an SES reputation poller staleness alert. The requester asked for the schedule gap, the pacing, and the retry config specifically.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Two decisions changed during the session. The reported 6:45 UTC tier schedule turned out to be 7:15, so the gap was 45 minutes rather than 15; the 8:30 target still holds. And the pacing first went in as a plain sleep interval, then moved onto the egress limiter, because AGENTS.md routes third-party calls that need rate limiting through `posthog/egress/`. The floor interval stayed, for the Redis-outage reason in Changes. This domain has no `transport.py`: SES is reached through boto3 rather than `requests`, so the calls are gated at the provider.

Two of the five suggestions raised in the thread are deliberately not here. Decoupling the poll timestamp gauge from the findings call would change what the SES alerts mean, which is its own decision. Spreading teams across the day instead of pacing one sweep is a larger change than the quota problem needs.

Public artifact check: nothing here carries material from the session that is not already in this repository. No fixtures or sample data were added.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07CR2K1H6G/p1788505764396969?thread_ts=1788505764.396969&cid=C07CR2K1H6G)*
