### PR TITLE
feat(insights): email the people behind a data point

### DIFF
--- a/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
+++ b/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
@@ -4,7 +4,7 @@ import { useActions, useValues } from 'kea'
 import React, { useCallback, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 
-import { IconCollapse, IconExpand } from '@posthog/icons'
+import { IconCollapse, IconExpand, IconSend } from '@posthog/icons'
 import {
     LemonBadge,
     LemonBanner,
@@ -104,6 +104,7 @@ export function PersonsModal({
         searchTerm,
         actorLabel,
         isCohortModalOpen,
+        cohortRedirectsToWorkflow,
         isModalOpen,
         missingActorsCount,
         propertiesTimelineFilterFromUrl,
@@ -384,14 +385,25 @@ export function PersonsModal({
                                 </LemonButton>
                             )}
                             {actors.length > 0 && !isGroupType(actors[0]) && !hasSessions && (
-                                <LemonButton
-                                    onClick={() => setIsCohortModalOpen(true)}
-                                    type="secondary"
-                                    data-attr="person-modal-save-as-cohort"
-                                    disabled={!actors.length}
-                                >
-                                    Save as cohort
-                                </LemonButton>
+                                <>
+                                    <LemonButton
+                                        onClick={() => setIsCohortModalOpen(true)}
+                                        type="secondary"
+                                        data-attr="person-modal-save-as-cohort"
+                                        disabled={!actors.length}
+                                    >
+                                        Save as cohort
+                                    </LemonButton>
+                                    <LemonButton
+                                        onClick={() => setIsCohortModalOpen(true, true)}
+                                        type="secondary"
+                                        icon={<IconSend />}
+                                        data-attr="person-modal-email-actors"
+                                        disabled={!actors.length}
+                                    >
+                                        Email these {actorLabel.plural}
+                                    </LemonButton>
+                                </>
                             )}
                         </div>
                         <div className="flex gap-2">
@@ -429,6 +441,10 @@ export function PersonsModal({
                 onSave={(title) => saveAsCohort(title)}
                 onCancel={() => setIsCohortModalOpen(false)}
                 isOpen={isCohortModalOpen}
+                title={cohortRedirectsToWorkflow ? `Save these ${actorLabel.plural} as a cohort` : undefined}
+                description={
+                    cohortRedirectsToWorkflow ? 'Your new workflow will message everyone in this cohort.' : undefined
+                }
             />
         </>
     )

--- a/frontend/src/scenes/trends/persons-modal/SaveCohortModal.tsx
+++ b/frontend/src/scenes/trends/persons-modal/SaveCohortModal.tsx
@@ -6,13 +6,15 @@ interface Props {
     onSave: (title: string) => void
     onCancel: () => void
     isOpen: boolean
+    title?: string
+    description?: string
 }
 
-export function SaveCohortModal({ onSave, onCancel, isOpen }: Props): JSX.Element {
+export function SaveCohortModal({ onSave, onCancel, isOpen, title = 'New cohort', description }: Props): JSX.Element {
     const [cohortTitle, setCohortTitle] = useState('')
     return (
         <LemonModal
-            title="New cohort"
+            title={title}
             footer={
                 <>
                     <LemonButton type="secondary" onClick={onCancel}>
@@ -33,6 +35,7 @@ export function SaveCohortModal({ onSave, onCancel, isOpen }: Props): JSX.Elemen
             onClose={onCancel}
             isOpen={isOpen}
         >
+            {description && <p className="mb-2 text-secondary">{description}</p>}
             <div className="mb-4">
                 <LemonInput
                     autoFocus

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -61,6 +61,8 @@ import {
     UniversalFilterValue,
 } from '~/types'
 
+import { urlForNewWorkflowWithTrigger } from 'products/workflows/frontend/Workflows/workflowTriggerPrefill'
+
 import type { Noun } from '../../../models/groupsModel'
 import type { InsightQueryNode } from '../../../queries/schema/schema-general'
 import type { GroupType, GroupTypeIndex } from '../../../types'
@@ -179,6 +181,7 @@ export interface personsModalLogicValues {
     insightActorsQueryOptions: InsightActorsQueryOptionsResponse | null
     insightActorsQueryOptionsLoading: boolean
     insightEventsQueryUrl: string | null
+    cohortRedirectsToWorkflow: boolean
     isCohortModalOpen: boolean
     isModalOpen: boolean
     missingActorsCount: number
@@ -268,8 +271,12 @@ export interface personsModalLogicActions {
     saveAsCohort: (cohortName: string) => {
         cohortName: string
     }
-    setIsCohortModalOpen: (isOpen: boolean) => {
+    setIsCohortModalOpen: (
+        isOpen: boolean,
+        redirectToWorkflow?: boolean
+    ) => {
         isOpen: boolean
+        redirectToWorkflow: boolean
     }
     setSearchTerm: (search: string) => {
         search: string
@@ -324,7 +331,10 @@ export const personsModalLogic = kea<personsModalLogicType>([
         saveAsCohort: (cohortName: string) => ({ cohortName }),
         resetActors: () => true,
         closeModal: () => true,
-        setIsCohortModalOpen: (isOpen: boolean) => ({ isOpen }),
+        setIsCohortModalOpen: (isOpen: boolean, redirectToWorkflow: boolean = false) => ({
+            isOpen,
+            redirectToWorkflow,
+        }),
         loadActors: ({ url, clear, offset }: { url?: string | null; clear?: boolean; offset?: number }) => ({
             url,
             clear,
@@ -522,6 +532,13 @@ export const personsModalLogic = kea<personsModalLogicType>([
                 closeModal: () => false,
             },
         ],
+        cohortRedirectsToWorkflow: [
+            false,
+            {
+                setIsCohortModalOpen: (_, { redirectToWorkflow }) => redirectToWorkflow,
+                closeModal: () => false,
+            },
+        ],
     })),
 
     listeners(({ actions, values, props }) => ({
@@ -543,6 +560,27 @@ export const personsModalLogic = kea<personsModalLogicType>([
             }
             const cohort = await api.create('api/cohort', { ...cohortParams, query: values.actorsQuery })
             cohortsModel.actions.cohortCreated(cohort)
+            if (values.cohortRedirectsToWorkflow) {
+                actions.setIsCohortModalOpen(false)
+                actions.closeModal()
+                router.actions.push(
+                    urlForNewWorkflowWithTrigger({
+                        type: 'batch',
+                        filters: {
+                            properties: [
+                                {
+                                    key: 'id',
+                                    type: PropertyFilterType.Cohort,
+                                    value: cohort.id,
+                                    operator: PropertyOperator.In,
+                                    cohort_name: cohort.name,
+                                },
+                            ],
+                        },
+                    })
+                )
+                return
+            }
             lemonToast.success('Cohort saved', {
                 toastId: `cohort-saved-${cohort.id}`,
                 button: {

--- a/products/workflows/frontend/Workflows/WorkflowScene.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowScene.tsx
@@ -34,6 +34,7 @@ import { WorkflowMetrics } from './WorkflowMetrics'
 import { WorkflowRevisions } from './WorkflowRevisions'
 import { WorkflowSceneHeader } from './WorkflowSceneHeader'
 import { WorkflowSceneLogicProps, WorkflowTab, workflowSceneLogic } from './workflowSceneLogic'
+import { TRIGGER_PREFILL_PARAM } from './workflowTriggerPrefill'
 
 export const scene: SceneExport<WorkflowSceneLogicProps> = {
     component: WorkflowScene,
@@ -55,10 +56,11 @@ export function WorkflowScene(props: WorkflowSceneLogicProps): JSX.Element {
     const { searchParams } = useValues(router)
     const templateId = searchParams.templateId as string | undefined
     const editTemplateId = searchParams.editTemplateId as string | undefined
+    const triggerPrefill = searchParams[TRIGGER_PREFILL_PARAM] as string | undefined
 
     const batchJobsLogic = batchWorkflowJobsLogic({ id: workflowSceneProps.id })
 
-    const logic = workflowLogic({ id: props.id, templateId, editTemplateId })
+    const logic = workflowLogic({ id: props.id, templateId, editTemplateId, triggerPrefill })
     // The save/auto-save indicators moved into the WorkflowStatusBar; the scene only needs the
     // workflow itself (for the agent context) and the load state.
     const { workflow, workflowLoading, originalWorkflow, hogFunctionTemplatesById } = useValues(logic)
@@ -164,7 +166,7 @@ export function WorkflowScene(props: WorkflowSceneLogicProps): JSX.Element {
 
     return (
         <SceneContent className="h-full flex flex-col grow" data-attr="workflow-scene">
-            <BindLogic logic={workflowLogic} props={{ id: props.id, templateId, editTemplateId }}>
+            <BindLogic logic={workflowLogic} props={{ id: props.id, templateId, editTemplateId, triggerPrefill }}>
                 <WorkflowSceneHeader {...props} />
                 {/* Only show Logs and Metrics tabs if the workflow has already been created */}
                 {!props.id || props.id === 'new' ? (

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -53,11 +53,13 @@ import { openPublishConfirmDialog } from './PublishImpactDialog'
 import { prepareWorkflowDuplicate } from './workflowDuplication'
 import { workflowSceneLogic } from './workflowSceneLogic'
 import { workflowsLogic } from './workflowsLogic'
+import { parseWorkflowTriggerPrefill } from './workflowTriggerPrefill'
 
 export interface WorkflowLogicProps {
     id?: string
     templateId?: string
     editTemplateId?: string
+    triggerPrefill?: string
 }
 
 export const TRIGGER_NODE_ID = 'trigger_node'
@@ -2994,7 +2996,8 @@ export const workflowLogic = kea<workflowLogicType>([
     path((key) => ['products', 'workflows', 'frontend', 'Workflows', 'workflowLogic', key]),
     props({ id: 'new' } as WorkflowLogicProps),
     key(
-        (props) => `workflow-${props.id || 'new'}-${props.templateId || 'default'}-${props.editTemplateId || 'default'}`
+        (props) =>
+            `workflow-${props.id || 'new'}-${props.templateId || 'default'}-${props.editTemplateId || 'default'}-${props.triggerPrefill || 'default'}`
     ),
     connect(() => ({
         values: [userLogic, ['user'], projectLogic, ['currentProjectId']],
@@ -3079,6 +3082,16 @@ export const workflowLogic = kea<workflowLogicType>([
                             delete (newWorkflow as any).created_by
 
                             return newWorkflow
+                        }
+                        const triggerConfig = parseWorkflowTriggerPrefill(props.triggerPrefill)
+                        if (triggerConfig) {
+                            const prefilled: HogFlow = {
+                                ...NEW_WORKFLOW,
+                                actions: NEW_WORKFLOW.actions.map((action) =>
+                                    action.type === 'trigger' ? { ...action, config: triggerConfig } : action
+                                ),
+                            }
+                            return prefilled
                         }
                         return { ...NEW_WORKFLOW }
                     }

--- a/products/workflows/frontend/Workflows/workflowTriggerPrefill.test.ts
+++ b/products/workflows/frontend/Workflows/workflowTriggerPrefill.test.ts
@@ -1,0 +1,29 @@
+import {
+    TRIGGER_PREFILL_PARAM,
+    type WorkflowTriggerConfig,
+    parseWorkflowTriggerPrefill,
+    urlForNewWorkflowWithTrigger,
+} from './workflowTriggerPrefill'
+
+describe('workflowTriggerPrefill', () => {
+    it('round-trips a trigger config through the URL', () => {
+        const config: WorkflowTriggerConfig = {
+            type: 'batch',
+            filters: { properties: [{ key: 'id', type: 'cohort', value: 7, operator: 'in' }] },
+        }
+
+        const url = urlForNewWorkflowWithTrigger(config)
+        const raw = new URLSearchParams(url.split('?')[1]).get(TRIGGER_PREFILL_PARAM)
+
+        expect(parseWorkflowTriggerPrefill(raw ?? undefined)).toEqual(config)
+    })
+
+    it.each([
+        ['nothing', undefined],
+        ['a non-JSON string', 'not-json'],
+        ['an unknown trigger type', '{"type":"nonsense"}'],
+        ['a batch trigger missing its filters', '{"type":"batch"}'],
+    ])('returns null for %s', (_label, raw) => {
+        expect(parseWorkflowTriggerPrefill(raw)).toBeNull()
+    })
+})

--- a/products/workflows/frontend/Workflows/workflowTriggerPrefill.ts
+++ b/products/workflows/frontend/Workflows/workflowTriggerPrefill.ts
@@ -1,0 +1,26 @@
+import { combineUrl } from 'kea-router'
+
+import { urls } from 'scenes/urls'
+
+import { HogFlowTriggerSchema } from './hogflows/steps/types'
+import type { HogFlowAction } from './hogflows/types'
+
+export type WorkflowTriggerConfig = Extract<HogFlowAction, { type: 'trigger' }>['config']
+
+export const TRIGGER_PREFILL_PARAM = 'trigger'
+
+export function urlForNewWorkflowWithTrigger(config: WorkflowTriggerConfig): string {
+    return combineUrl(urls.workflowNew(), { [TRIGGER_PREFILL_PARAM]: JSON.stringify(config) }).url
+}
+
+export function parseWorkflowTriggerPrefill(raw: string | undefined): WorkflowTriggerConfig | null {
+    if (!raw) {
+        return null
+    }
+    try {
+        const result = HogFlowTriggerSchema.safeParse(JSON.parse(raw))
+        return result.success ? (result.data as WorkflowTriggerConfig) : null
+    } catch {
+        return null
+    }
+}


### PR DESCRIPTION
## Problem

Someone who clicks a point on a trend, a funnel step, or a lifecycle bucket gets the list of people behind it. From there the only things they can do are download a CSV and save a cohort. The highest-intent moment in the product dead-ends.

The actor modal is the most-opened surface in PostHog. Workflows can already message a cohort through its batch trigger, so the capability exists and the two products never meet.

## Changes

- "Email these people" in the actor modal saves the actors as a static cohort, then opens a new workflow whose batch trigger targets that cohort. It sits next to "Save as cohort" and follows the same guards, so it is hidden for groups and for session rows.
- The naming dialog now says what the cohort is for when it was opened this way, instead of the bare "New cohort" title.
- Lifecycle's dormant and resurrecting buckets open this same modal, so win-back messaging is covered without a lifecycle-specific change.
- The new-workflow URL takes a `?trigger=` param carrying a trigger config. The editor validates it against `HogFlowTriggerSchema` and falls back to a blank trigger when it does not parse, so a hand-edited or stale link cannot break the editor.
- Mechanical: optional `title` and `description` props on `SaveCohortModal`, a `cohortRedirectsToWorkflow` reducer on `personsModalLogic`, and a `triggerPrefill` prop threaded from `WorkflowScene` into `workflowLogic`.

The cohort is created before the redirect rather than passing the actors query into the workflow. A batch trigger takes a cohort, and this keeps the audience inspectable and reusable after the fact.

Rendered in Storybook (`Scenes-App/Persons Modal` → `WithResults`). "Email these persons" sits in the modal footer next to "Save as cohort":

![Actor modal with the new Email these persons button](https://raw.githubusercontent.com/PostHog/pr-assets/8dead2a87f9af77c7a65f41bc517ddf130999763/2026/09/56eb7ec3-6258-4013-b62e-d0dc07e48883.png)

The mock people are the story's committed fixture. Not captured: the workflow editor it opens, which needs the running app.

## How did you test this code?

Automated only.

- New unit tests cover the round trip from config to URL and back, and four malformed `?trigger=` values. The regression they catch: a bad param reaching `workflowLogic` and either throwing or building a workflow with an invalid trigger, which no existing test covers.
- Ran the jest suites for the touched modules, and a repo-wide `tsgo --noEmit`; no errors in any changed file. The remaining repo type errors are the pre-existing unbuilt `@posthog/quill` cascade, identical on `master`.

- Rendered the actor modal in Storybook to confirm the button's placement and copy (screenshot above).

Not checked: the end-to-end redirect into the prefilled workflow editor. That needs the running app, which was not available.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code in PostHog Desktop. Skills invoked: `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

This is one of four sibling PRs opening a prefilled workflow from a host product. All four add the same `workflowTriggerPrefill` module and the same `workflowLogic` and `WorkflowScene` hunks, byte for byte, so whichever lands first leaves the rest a clean rebase. The `SaveCohortModal` prop addition is shared with the retention sibling in the same byte-identical way. The cohort-to-batch-trigger builder is inlined per call site rather than shared, to keep each PR independently reviewable; extracting it is worth a follow-up once more than one has landed.

Public artifact: nothing here draws on non-public material.

