### PR TITLE
feat(surveys): follow up on survey responses by email

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -4,7 +4,7 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { useEffect, useState } from 'react'
 
-import { IconArchive, IconCopy, IconGraph, IconTrash } from '@posthog/icons'
+import { IconArchive, IconCopy, IconGraph, IconSend, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonDialog, LemonDivider, LemonTag } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
@@ -54,10 +54,15 @@ import {
     AccessControlLevel,
     AccessControlResourceType,
     ActivityScope,
+    PropertyFilterType,
+    PropertyOperator,
     Survey,
     SurveyEventName,
+    SurveyEventProperties,
     SurveyQuestionType,
 } from '~/types'
+
+import { urlForNewWorkflowWithTrigger } from 'products/workflows/frontend/Workflows/workflowTriggerPrefill'
 
 import { SurveyResultsRefreshStatus } from './components/SurveyResultsRefreshStatus'
 import { NEW_SURVEY } from './constants'
@@ -398,15 +403,39 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
                     >
                         <SurveyStatsSummary />
                         <SurveyResponsesByQuestionV2 />
-                        <LemonButton
-                            type="primary"
-                            data-attr="survey-results-explore"
-                            icon={<IconGraph />}
-                            to={surveyAsInsightURL}
-                            className="max-w-40"
-                        >
-                            Explore results
-                        </LemonButton>
+                        <div className="flex flex-wrap gap-2">
+                            <LemonButton
+                                type="primary"
+                                data-attr="survey-results-explore"
+                                icon={<IconGraph />}
+                                to={surveyAsInsightURL}
+                                className="max-w-40"
+                            >
+                                Explore results
+                            </LemonButton>
+                            <LemonButton
+                                type="secondary"
+                                data-attr="survey-results-follow-up"
+                                icon={<IconSend />}
+                                to={urlForNewWorkflowWithTrigger({
+                                    type: 'event',
+                                    filters: {
+                                        events: [{ id: SurveyEventName.SENT, type: 'events', name: 'Survey sent' }],
+                                        properties: [
+                                            {
+                                                key: SurveyEventProperties.SURVEY_ID,
+                                                value: survey.id,
+                                                operator: PropertyOperator.Exact,
+                                                type: PropertyFilterType.Event,
+                                            },
+                                        ],
+                                    },
+                                })}
+                                tooltip="Start a workflow that emails people based on how they answered"
+                            >
+                                Follow up by email
+                            </LemonButton>
+                        </div>
                         {!disableEventsTable &&
                             (isInitialSurveyLoad ? (
                                 <LemonSkeleton />

--- a/products/workflows/frontend/Workflows/WorkflowScene.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowScene.tsx
@@ -34,6 +34,7 @@ import { WorkflowMetrics } from './WorkflowMetrics'
 import { WorkflowRevisions } from './WorkflowRevisions'
 import { WorkflowSceneHeader } from './WorkflowSceneHeader'
 import { WorkflowSceneLogicProps, WorkflowTab, workflowSceneLogic } from './workflowSceneLogic'
+import { TRIGGER_PREFILL_PARAM } from './workflowTriggerPrefill'
 
 export const scene: SceneExport<WorkflowSceneLogicProps> = {
     component: WorkflowScene,
@@ -55,10 +56,11 @@ export function WorkflowScene(props: WorkflowSceneLogicProps): JSX.Element {
     const { searchParams } = useValues(router)
     const templateId = searchParams.templateId as string | undefined
     const editTemplateId = searchParams.editTemplateId as string | undefined
+    const triggerPrefill = searchParams[TRIGGER_PREFILL_PARAM] as string | undefined
 
     const batchJobsLogic = batchWorkflowJobsLogic({ id: workflowSceneProps.id })
 
-    const logic = workflowLogic({ id: props.id, templateId, editTemplateId })
+    const logic = workflowLogic({ id: props.id, templateId, editTemplateId, triggerPrefill })
     // The save/auto-save indicators moved into the WorkflowStatusBar; the scene only needs the
     // workflow itself (for the agent context) and the load state.
     const { workflow, workflowLoading, originalWorkflow, hogFunctionTemplatesById } = useValues(logic)
@@ -164,7 +166,7 @@ export function WorkflowScene(props: WorkflowSceneLogicProps): JSX.Element {
 
     return (
         <SceneContent className="h-full flex flex-col grow" data-attr="workflow-scene">
-            <BindLogic logic={workflowLogic} props={{ id: props.id, templateId, editTemplateId }}>
+            <BindLogic logic={workflowLogic} props={{ id: props.id, templateId, editTemplateId, triggerPrefill }}>
                 <WorkflowSceneHeader {...props} />
                 {/* Only show Logs and Metrics tabs if the workflow has already been created */}
                 {!props.id || props.id === 'new' ? (

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -53,11 +53,13 @@ import { openPublishConfirmDialog } from './PublishImpactDialog'
 import { prepareWorkflowDuplicate } from './workflowDuplication'
 import { workflowSceneLogic } from './workflowSceneLogic'
 import { workflowsLogic } from './workflowsLogic'
+import { parseWorkflowTriggerPrefill } from './workflowTriggerPrefill'
 
 export interface WorkflowLogicProps {
     id?: string
     templateId?: string
     editTemplateId?: string
+    triggerPrefill?: string
 }
 
 export const TRIGGER_NODE_ID = 'trigger_node'
@@ -2994,7 +2996,8 @@ export const workflowLogic = kea<workflowLogicType>([
     path((key) => ['products', 'workflows', 'frontend', 'Workflows', 'workflowLogic', key]),
     props({ id: 'new' } as WorkflowLogicProps),
     key(
-        (props) => `workflow-${props.id || 'new'}-${props.templateId || 'default'}-${props.editTemplateId || 'default'}`
+        (props) =>
+            `workflow-${props.id || 'new'}-${props.templateId || 'default'}-${props.editTemplateId || 'default'}-${props.triggerPrefill || 'default'}`
     ),
     connect(() => ({
         values: [userLogic, ['user'], projectLogic, ['currentProjectId']],
@@ -3079,6 +3082,16 @@ export const workflowLogic = kea<workflowLogicType>([
                             delete (newWorkflow as any).created_by
 
                             return newWorkflow
+                        }
+                        const triggerConfig = parseWorkflowTriggerPrefill(props.triggerPrefill)
+                        if (triggerConfig) {
+                            const prefilled: HogFlow = {
+                                ...NEW_WORKFLOW,
+                                actions: NEW_WORKFLOW.actions.map((action) =>
+                                    action.type === 'trigger' ? { ...action, config: triggerConfig } : action
+                                ),
+                            }
+                            return prefilled
                         }
                         return { ...NEW_WORKFLOW }
                     }

--- a/products/workflows/frontend/Workflows/workflowTriggerPrefill.test.ts
+++ b/products/workflows/frontend/Workflows/workflowTriggerPrefill.test.ts
@@ -1,0 +1,29 @@
+import {
+    TRIGGER_PREFILL_PARAM,
+    type WorkflowTriggerConfig,
+    parseWorkflowTriggerPrefill,
+    urlForNewWorkflowWithTrigger,
+} from './workflowTriggerPrefill'
+
+describe('workflowTriggerPrefill', () => {
+    it('round-trips a trigger config through the URL', () => {
+        const config: WorkflowTriggerConfig = {
+            type: 'batch',
+            filters: { properties: [{ key: 'id', type: 'cohort', value: 7, operator: 'in' }] },
+        }
+
+        const url = urlForNewWorkflowWithTrigger(config)
+        const raw = new URLSearchParams(url.split('?')[1]).get(TRIGGER_PREFILL_PARAM)
+
+        expect(parseWorkflowTriggerPrefill(raw ?? undefined)).toEqual(config)
+    })
+
+    it.each([
+        ['nothing', undefined],
+        ['a non-JSON string', 'not-json'],
+        ['an unknown trigger type', '{"type":"nonsense"}'],
+        ['a batch trigger missing its filters', '{"type":"batch"}'],
+    ])('returns null for %s', (_label, raw) => {
+        expect(parseWorkflowTriggerPrefill(raw)).toBeNull()
+    })
+})

--- a/products/workflows/frontend/Workflows/workflowTriggerPrefill.ts
+++ b/products/workflows/frontend/Workflows/workflowTriggerPrefill.ts
@@ -1,0 +1,26 @@
+import { combineUrl } from 'kea-router'
+
+import { urls } from 'scenes/urls'
+
+import { HogFlowTriggerSchema } from './hogflows/steps/types'
+import type { HogFlowAction } from './hogflows/types'
+
+export type WorkflowTriggerConfig = Extract<HogFlowAction, { type: 'trigger' }>['config']
+
+export const TRIGGER_PREFILL_PARAM = 'trigger'
+
+export function urlForNewWorkflowWithTrigger(config: WorkflowTriggerConfig): string {
+    return combineUrl(urls.workflowNew(), { [TRIGGER_PREFILL_PARAM]: JSON.stringify(config) }).url
+}
+
+export function parseWorkflowTriggerPrefill(raw: string | undefined): WorkflowTriggerConfig | null {
+    if (!raw) {
+        return null
+    }
+    try {
+        const result = HogFlowTriggerSchema.safeParse(JSON.parse(raw))
+        return result.success ? (result.data as WorkflowTriggerConfig) : null
+    } catch {
+        return null
+    }
+}


### PR DESCRIPTION
## Problem

Someone reading survey results can see that 38 people rated the product badly, and can do nothing about it from that page. Closing the loop means leaving surveys, building a workflow from scratch, and rebuilding the same filter by hand.

Workflows has shipped a survey trigger for a while. It reads `$survey_id`, `$survey_completed`, and the per-question response keys, and the template library carries a negative-response template. The surveys frontend never mentions any of it, so the integration is invisible from the product that needs it.

## Changes

- "Follow up by email" on the survey results tab opens a new workflow whose event trigger is already filtered to this survey's responses. It sits next to "Explore results" and appears once the survey has at least one response.
- From there the existing trigger panel narrows by answer, so a detractor sequence and a promoter sequence are a filter apart.
- The new-workflow URL takes a `?trigger=` param carrying a trigger config. The editor validates it against `HogFlowTriggerSchema` and falls back to a blank trigger when it does not parse, so a hand-edited or stale link cannot break the editor.
- Mechanical: the two result buttons now sit in a wrapping flex row, and a `triggerPrefill` prop is threaded from `WorkflowScene` into `workflowLogic`.

The prefill stops at "responses to this survey" rather than preselecting detractors. Which answers deserve a follow-up differs per survey, and the trigger panel already asks that question well.

No screenshot: the button renders only once a survey has responses, and Storybook's survey-results mock does not reliably load them (the sibling `SurveyView` story is `test-skip` for the same reason). The survey Results tab renders, but it settles into the 0-response empty state where this button is correctly hidden. The action is a `LemonButton` matching the "Explore results" button beside it, and the row wraps rather than clipping in a narrow scene. The same button pattern was captured on the actor modal in sibling PR #94912.

## How did you test this code?

Automated only.

- New unit tests cover the round trip from config to URL and back, and four malformed `?trigger=` values. The regression they catch: a bad param reaching `workflowLogic` and either throwing or building a workflow with an invalid trigger, which no existing test covers.
- Ran the jest suite for the prefill module, and a repo-wide `tsgo --noEmit`; no errors in any changed file. The remaining repo type errors are the pre-existing unbuilt `@posthog/quill` cascade, identical on `master`.

Not checked: a browser render of the button in its has-responses state (blocked by the Storybook mock above) and the end-to-end redirect into the prefilled workflow editor. No new test covers the survey button itself, because it renders a URL that the prefill tests already cover on both sides.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code in PostHog Desktop. Skills invoked: `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

This is one of four sibling PRs opening a prefilled workflow from a host product. All four add the same `workflowTriggerPrefill` module and the same `workflowLogic` and `WorkflowScene` hunks, byte for byte, so whichever lands first leaves the rest a clean rebase.

The trigger config here matches what the registered survey trigger builds for itself, so the editor recognises the prefilled config as a survey trigger rather than a raw event trigger.

Public artifact: nothing here draws on non-public material. The survey event and property names come from this repository.

