### PR TITLE
feat(retention): win back the people who dropped out

### DIFF
--- a/frontend/src/scenes/retention/RetentionModal.tsx
+++ b/frontend/src/scenes/retention/RetentionModal.tsx
@@ -3,6 +3,7 @@ import './RetentionTable.scss'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 
+import { IconSend } from '@posthog/icons'
 import { LemonButton, LemonModal } from '@posthog/lemon-ui'
 
 import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
@@ -41,6 +42,7 @@ export function RetentionModal(): JSX.Element | null {
         insightEventsQueryUrl,
         actorsQuery,
         isCohortModalOpen,
+        cohortRedirectsToWorkflow,
         theme,
         retentionFilter,
         selectedColumnIndex,
@@ -108,14 +110,25 @@ export function RetentionModal(): JSX.Element | null {
                                 </LemonButton>
                             )}
                             {!!people.result?.length && !people.result.some((person) => isGroupType(person.person)) && (
-                                <LemonButton
-                                    onClick={() => setIsCohortModalOpen(true)}
-                                    type="secondary"
-                                    data-attr="retention-person-modal-save-as-cohort"
-                                    disabled={!people.result?.length}
-                                >
-                                    Save as cohort
-                                </LemonButton>
+                                <>
+                                    <LemonButton
+                                        onClick={() => setIsCohortModalOpen(true)}
+                                        type="secondary"
+                                        data-attr="retention-person-modal-save-as-cohort"
+                                        disabled={!people.result?.length}
+                                    >
+                                        Save as cohort
+                                    </LemonButton>
+                                    <LemonButton
+                                        onClick={() => setIsCohortModalOpen(true, true)}
+                                        type="secondary"
+                                        icon={<IconSend />}
+                                        data-attr="retention-person-modal-email-actors"
+                                        disabled={!people.result?.length}
+                                    >
+                                        Email these {aggregationTargetLabel.plural}
+                                    </LemonButton>
+                                </>
                             )}
                         </div>
                         <div className="flex gap-2">
@@ -277,6 +290,12 @@ export function RetentionModal(): JSX.Element | null {
                 onSave={(title) => saveAsCohort(title)}
                 onCancel={() => setIsCohortModalOpen(false)}
                 isOpen={isCohortModalOpen}
+                title={
+                    cohortRedirectsToWorkflow ? `Save these ${aggregationTargetLabel.plural} as a cohort` : undefined
+                }
+                description={
+                    cohortRedirectsToWorkflow ? 'Your new workflow will message everyone in this cohort.' : undefined
+                }
             />
         </>
     )

--- a/frontend/src/scenes/retention/retentionModalLogic.ts
+++ b/frontend/src/scenes/retention/retentionModalLogic.ts
@@ -23,7 +23,9 @@ import {
     RetentionQuery,
 } from '~/queries/schema/schema-general'
 import { isInsightActorsQuery, isLifecycleQuery, isRetentionQuery, isStickinessQuery } from '~/queries/utils'
-import { InsightLogicProps } from '~/types'
+import { InsightLogicProps, PropertyFilterType, PropertyOperator } from '~/types'
+
+import { urlForNewWorkflowWithTrigger } from 'products/workflows/frontend/Workflows/workflowTriggerPrefill'
 
 import type { DataColorTheme } from '../../lib/colors'
 import type { FeatureFlagsSet } from '../../lib/logic/featureFlagLogic'
@@ -66,6 +68,7 @@ export interface retentionModalLogicValues {
     canOpenPersonModal: boolean
     exploreUrl: string | null
     insightEventsQueryUrl: string | null
+    cohortRedirectsToWorkflow: boolean
     isCohortModalOpen: boolean
     selectedBreakdownValue: number | string | null
     selectedColumnIndex: number | null
@@ -97,8 +100,12 @@ export interface retentionModalLogicActions {
     saveAsCohort: (cohortName: string) => {
         cohortName: string
     }
-    setIsCohortModalOpen: (isOpen: boolean) => {
+    setIsCohortModalOpen: (
+        isOpen: boolean,
+        redirectToWorkflow?: boolean
+    ) => {
         isOpen: boolean
+        redirectToWorkflow: boolean
     }
 }
 
@@ -179,7 +186,10 @@ export const retentionModalLogic = kea<retentionModalLogicType>([
         }),
         closeModal: true,
         saveAsCohort: (cohortName: string) => ({ cohortName }),
-        setIsCohortModalOpen: (isOpen: boolean) => ({ isOpen }),
+        setIsCohortModalOpen: (isOpen: boolean, redirectToWorkflow: boolean = false) => ({
+            isOpen,
+            redirectToWorkflow,
+        }),
     })),
     reducers({
         selectedInterval: [
@@ -203,6 +213,14 @@ export const retentionModalLogic = kea<retentionModalLogicType>([
             {
                 openModal: (_, { columnIndex }: { columnIndex?: number | null }) => columnIndex ?? null,
                 closeModal: () => null,
+            },
+        ],
+        cohortRedirectsToWorkflow: [
+            false,
+            {
+                setIsCohortModalOpen: (_, { redirectToWorkflow }: { redirectToWorkflow: boolean }) =>
+                    redirectToWorkflow,
+                closeModal: () => false,
             },
         ],
         isCohortModalOpen: [
@@ -367,6 +385,27 @@ export const retentionModalLogic = kea<retentionModalLogicType>([
             }
             const cohort = await api.create('api/cohort', { ...cohortParams, query: values.actorsQuery })
             cohortsModel.actions.cohortCreated(cohort)
+            if (values.cohortRedirectsToWorkflow) {
+                actions.setIsCohortModalOpen(false)
+                actions.closeModal()
+                router.actions.push(
+                    urlForNewWorkflowWithTrigger({
+                        type: 'batch',
+                        filters: {
+                            properties: [
+                                {
+                                    key: 'id',
+                                    type: PropertyFilterType.Cohort,
+                                    value: cohort.id,
+                                    operator: PropertyOperator.In,
+                                    cohort_name: cohort.name,
+                                },
+                            ],
+                        },
+                    })
+                )
+                return
+            }
             lemonToast.success('Cohort saved', {
                 toastId: `cohort-saved-${cohort.id}`,
                 button: {

--- a/frontend/src/scenes/trends/persons-modal/SaveCohortModal.tsx
+++ b/frontend/src/scenes/trends/persons-modal/SaveCohortModal.tsx
@@ -6,13 +6,15 @@ interface Props {
     onSave: (title: string) => void
     onCancel: () => void
     isOpen: boolean
+    title?: string
+    description?: string
 }
 
-export function SaveCohortModal({ onSave, onCancel, isOpen }: Props): JSX.Element {
+export function SaveCohortModal({ onSave, onCancel, isOpen, title = 'New cohort', description }: Props): JSX.Element {
     const [cohortTitle, setCohortTitle] = useState('')
     return (
         <LemonModal
-            title="New cohort"
+            title={title}
             footer={
                 <>
                     <LemonButton type="secondary" onClick={onCancel}>
@@ -33,6 +35,7 @@ export function SaveCohortModal({ onSave, onCancel, isOpen }: Props): JSX.Elemen
             onClose={onCancel}
             isOpen={isOpen}
         >
+            {description && <p className="mb-2 text-secondary">{description}</p>}
             <div className="mb-4">
                 <LemonInput
                     autoFocus

--- a/products/workflows/frontend/Workflows/WorkflowScene.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowScene.tsx
@@ -34,6 +34,7 @@ import { WorkflowMetrics } from './WorkflowMetrics'
 import { WorkflowRevisions } from './WorkflowRevisions'
 import { WorkflowSceneHeader } from './WorkflowSceneHeader'
 import { WorkflowSceneLogicProps, WorkflowTab, workflowSceneLogic } from './workflowSceneLogic'
+import { TRIGGER_PREFILL_PARAM } from './workflowTriggerPrefill'
 
 export const scene: SceneExport<WorkflowSceneLogicProps> = {
     component: WorkflowScene,
@@ -55,10 +56,11 @@ export function WorkflowScene(props: WorkflowSceneLogicProps): JSX.Element {
     const { searchParams } = useValues(router)
     const templateId = searchParams.templateId as string | undefined
     const editTemplateId = searchParams.editTemplateId as string | undefined
+    const triggerPrefill = searchParams[TRIGGER_PREFILL_PARAM] as string | undefined
 
     const batchJobsLogic = batchWorkflowJobsLogic({ id: workflowSceneProps.id })
 
-    const logic = workflowLogic({ id: props.id, templateId, editTemplateId })
+    const logic = workflowLogic({ id: props.id, templateId, editTemplateId, triggerPrefill })
     // The save/auto-save indicators moved into the WorkflowStatusBar; the scene only needs the
     // workflow itself (for the agent context) and the load state.
     const { workflow, workflowLoading, originalWorkflow, hogFunctionTemplatesById } = useValues(logic)
@@ -164,7 +166,7 @@ export function WorkflowScene(props: WorkflowSceneLogicProps): JSX.Element {
 
     return (
         <SceneContent className="h-full flex flex-col grow" data-attr="workflow-scene">
-            <BindLogic logic={workflowLogic} props={{ id: props.id, templateId, editTemplateId }}>
+            <BindLogic logic={workflowLogic} props={{ id: props.id, templateId, editTemplateId, triggerPrefill }}>
                 <WorkflowSceneHeader {...props} />
                 {/* Only show Logs and Metrics tabs if the workflow has already been created */}
                 {!props.id || props.id === 'new' ? (

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -53,11 +53,13 @@ import { openPublishConfirmDialog } from './PublishImpactDialog'
 import { prepareWorkflowDuplicate } from './workflowDuplication'
 import { workflowSceneLogic } from './workflowSceneLogic'
 import { workflowsLogic } from './workflowsLogic'
+import { parseWorkflowTriggerPrefill } from './workflowTriggerPrefill'
 
 export interface WorkflowLogicProps {
     id?: string
     templateId?: string
     editTemplateId?: string
+    triggerPrefill?: string
 }
 
 export const TRIGGER_NODE_ID = 'trigger_node'
@@ -2994,7 +2996,8 @@ export const workflowLogic = kea<workflowLogicType>([
     path((key) => ['products', 'workflows', 'frontend', 'Workflows', 'workflowLogic', key]),
     props({ id: 'new' } as WorkflowLogicProps),
     key(
-        (props) => `workflow-${props.id || 'new'}-${props.templateId || 'default'}-${props.editTemplateId || 'default'}`
+        (props) =>
+            `workflow-${props.id || 'new'}-${props.templateId || 'default'}-${props.editTemplateId || 'default'}-${props.triggerPrefill || 'default'}`
     ),
     connect(() => ({
         values: [userLogic, ['user'], projectLogic, ['currentProjectId']],
@@ -3079,6 +3082,16 @@ export const workflowLogic = kea<workflowLogicType>([
                             delete (newWorkflow as any).created_by
 
                             return newWorkflow
+                        }
+                        const triggerConfig = parseWorkflowTriggerPrefill(props.triggerPrefill)
+                        if (triggerConfig) {
+                            const prefilled: HogFlow = {
+                                ...NEW_WORKFLOW,
+                                actions: NEW_WORKFLOW.actions.map((action) =>
+                                    action.type === 'trigger' ? { ...action, config: triggerConfig } : action
+                                ),
+                            }
+                            return prefilled
                         }
                         return { ...NEW_WORKFLOW }
                     }

--- a/products/workflows/frontend/Workflows/workflowTriggerPrefill.test.ts
+++ b/products/workflows/frontend/Workflows/workflowTriggerPrefill.test.ts
@@ -1,0 +1,29 @@
+import {
+    TRIGGER_PREFILL_PARAM,
+    type WorkflowTriggerConfig,
+    parseWorkflowTriggerPrefill,
+    urlForNewWorkflowWithTrigger,
+} from './workflowTriggerPrefill'
+
+describe('workflowTriggerPrefill', () => {
+    it('round-trips a trigger config through the URL', () => {
+        const config: WorkflowTriggerConfig = {
+            type: 'batch',
+            filters: { properties: [{ key: 'id', type: 'cohort', value: 7, operator: 'in' }] },
+        }
+
+        const url = urlForNewWorkflowWithTrigger(config)
+        const raw = new URLSearchParams(url.split('?')[1]).get(TRIGGER_PREFILL_PARAM)
+
+        expect(parseWorkflowTriggerPrefill(raw ?? undefined)).toEqual(config)
+    })
+
+    it.each([
+        ['nothing', undefined],
+        ['a non-JSON string', 'not-json'],
+        ['an unknown trigger type', '{"type":"nonsense"}'],
+        ['a batch trigger missing its filters', '{"type":"batch"}'],
+    ])('returns null for %s', (_label, raw) => {
+        expect(parseWorkflowTriggerPrefill(raw)).toBeNull()
+    })
+})

--- a/products/workflows/frontend/Workflows/workflowTriggerPrefill.ts
+++ b/products/workflows/frontend/Workflows/workflowTriggerPrefill.ts
@@ -1,0 +1,26 @@
+import { combineUrl } from 'kea-router'
+
+import { urls } from 'scenes/urls'
+
+import { HogFlowTriggerSchema } from './hogflows/steps/types'
+import type { HogFlowAction } from './hogflows/types'
+
+export type WorkflowTriggerConfig = Extract<HogFlowAction, { type: 'trigger' }>['config']
+
+export const TRIGGER_PREFILL_PARAM = 'trigger'
+
+export function urlForNewWorkflowWithTrigger(config: WorkflowTriggerConfig): string {
+    return combineUrl(urls.workflowNew(), { [TRIGGER_PREFILL_PARAM]: JSON.stringify(config) }).url
+}
+
+export function parseWorkflowTriggerPrefill(raw: string | undefined): WorkflowTriggerConfig | null {
+    if (!raw) {
+        return null
+    }
+    try {
+        const result = HogFlowTriggerSchema.safeParse(JSON.parse(raw))
+        return result.success ? (result.data as WorkflowTriggerConfig) : null
+    } catch {
+        return null
+    }
+}


### PR DESCRIPTION
## Problem

A retention chart shows exactly which weekly cohort stopped coming back. Clicking the cell lists those people, and from there the only things a person can do are export a CSV and save a cohort. Winning them back means leaving the insight and rebuilding the audience by hand.

Find dormant users, message them, measure the return is the canonical growth loop, and PostHog owns both ends of it. Today it breaks in the middle. The re-engagement template already sits in the workflows library.

## Changes

- "Email these people" in the retention modal saves that cell's actors as a static cohort, then opens a new workflow whose batch trigger targets that cohort. It sits next to "Save as cohort" and follows the same guards, so it is hidden when the rows are groups.
- The naming dialog now says what the cohort is for when it was opened this way, instead of the bare "New cohort" title.
- The new-workflow URL takes a `?trigger=` param carrying a trigger config. The editor validates it against `HogFlowTriggerSchema` and falls back to a blank trigger when it does not parse, so a hand-edited or stale link cannot break the editor.
- Mechanical: optional `title` and `description` props on `SaveCohortModal`, a `cohortRedirectsToWorkflow` reducer on `retentionModalLogic`, and a `triggerPrefill` prop threaded from `WorkflowScene` into `workflowLogic`.

The cohort is a static snapshot of the cell, so the audience matches what the person clicked and stays inspectable after the workflow runs.

No screenshot: the retention modal has no Storybook story, and the full app was not available to open the modal from a live insight. The action is a `LemonButton` matching its "Save as cohort" sibling in the same footer row, and the identical button was captured on the actor modal in the sibling PR #94912.

## How did you test this code?

Automated only.

- New unit tests cover the round trip from config to URL and back, and four malformed `?trigger=` values. The regression they catch: a bad param reaching `workflowLogic` and either throwing or building a workflow with an invalid trigger, which no existing test covers.
- Ran the jest suites for the touched modules, and a repo-wide `tsgo --noEmit`; no errors in any changed file. The remaining repo type errors are the pre-existing unbuilt `@posthog/quill` cascade, identical on `master`.

Not checked: no browser render of the retention modal (no story exists), and no end-to-end redirect into the prefilled workflow editor. Both need the running app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code in PostHog Desktop. Skills invoked: `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

This is one of four sibling PRs opening a prefilled workflow from a host product. All four add the same `workflowTriggerPrefill` module and the same `workflowLogic` and `WorkflowScene` hunks, byte for byte, so whichever lands first leaves the rest a clean rebase. The `SaveCohortModal` prop addition is shared with the actor-modal sibling in the same byte-identical way. The cohort-to-batch-trigger builder is inlined per call site rather than shared, to keep each PR independently reviewable; extracting it is worth a follow-up once more than one has landed.

The lifecycle half of this idea needs no code here, because lifecycle buckets open the actor modal covered by the sibling PR.

Public artifact: nothing here draws on non-public material.

