### PR TITLE
chore(demo): write demo insights as query, not filters

### DIFF
--- a/products/demo/backend/logic/legacy/app_data_generator.py
+++ b/products/demo/backend/logic/legacy/app_data_generator.py
@@ -4,7 +4,8 @@ from django.utils.timezone import now
 
 from dateutil.relativedelta import relativedelta
 
-from posthog.constants import TREND_FILTER_TYPE_ACTIONS
+from posthog.schema import ActionsNode, DateRange, EventPropertyFilter, FunnelsQuery, InsightVizNode, PropertyOperator
+
 from posthog.models import EventDefinition, Person, PropertyDefinition
 
 from products.actions.backend.models.action import Action
@@ -38,31 +39,22 @@ class AppDataGenerator(DataGenerator):
         insight = Insight.objects.create(
             team=self.team,
             name="Installed App -> Rated App -> Rated App 5 Stars",
-            filters={
-                "actions": [
-                    {
-                        "id": installed_app_action.id,
-                        "name": "Installed App",
-                        "order": 0,
-                        "type": TREND_FILTER_TYPE_ACTIONS,
-                    },
-                    {
-                        "id": rated_app_action.id,
-                        "name": "Rated App",
-                        "order": 1,
-                        "type": TREND_FILTER_TYPE_ACTIONS,
-                    },
-                    {
-                        "id": rated_app_action.id,
-                        "name": "Rated App",
-                        "order": 2,
-                        "type": TREND_FILTER_TYPE_ACTIONS,
-                        "properties": {"app_rating": 5},
-                    },
-                ],
-                "insight": "FUNNELS",
-                "date_from": "yStart",
-            },
+            query=InsightVizNode(
+                source=FunnelsQuery(
+                    series=[
+                        ActionsNode(id=installed_app_action.id, name="Installed App"),
+                        ActionsNode(id=rated_app_action.id, name="Rated App"),
+                        ActionsNode(
+                            id=rated_app_action.id,
+                            name="Rated App",
+                            properties=[
+                                EventPropertyFilter(key="app_rating", value=5, operator=PropertyOperator.EXACT)
+                            ],
+                        ),
+                    ],
+                    dateRange=DateRange(date_from="yStart"),
+                )
+            ).model_dump(),
         )
         DashboardTile.objects.create(insight=insight, dashboard=dashboard)
         dashboard.save()  # to update the insight's filter hash

--- a/products/demo/backend/logic/legacy/revenue_data_generator.py
+++ b/products/demo/backend/logic/legacy/revenue_data_generator.py
@@ -4,7 +4,16 @@ from django.utils.timezone import now
 
 from dateutil.relativedelta import relativedelta
 
-from posthog.constants import TREND_FILTER_TYPE_ACTIONS
+from posthog.schema import (
+    ActionsNode,
+    DateRange,
+    EventPropertyFilter,
+    EventsNode,
+    FunnelsQuery,
+    InsightVizNode,
+    PropertyOperator,
+)
+
 from posthog.models import EventDefinition, Person, PropertyDefinition
 
 from products.actions.backend.models.action import Action
@@ -64,27 +73,21 @@ class RevenueDataGenerator(DataGenerator):
         insight = Insight.objects.create(
             team=self.team,
             name="Entered Free Trial -> Purchase (Premium)",
-            filters={
-                "events": [
-                    {
-                        "id": "$pageview",
-                        "name": "Pageview",
-                        "order": 0,
-                        "type": TREND_FILTER_TYPE_ACTIONS,
-                    }
-                ],
-                "actions": [
-                    {
-                        "id": purchase_action.id,
-                        "name": "Purchase",
-                        "order": 1,
-                        "type": TREND_FILTER_TYPE_ACTIONS,
-                        "properties": {"plan": "premium"},
-                    }
-                ],
-                "insight": "FUNNELS",
-                "date_from": "all",
-            },
+            query=InsightVizNode(
+                source=FunnelsQuery(
+                    series=[
+                        EventsNode(event="$pageview", name="Pageview"),
+                        ActionsNode(
+                            id=purchase_action.id,
+                            name="Purchase",
+                            properties=[
+                                EventPropertyFilter(key="plan", value="premium", operator=PropertyOperator.EXACT)
+                            ],
+                        ),
+                    ],
+                    dateRange=DateRange(date_from="all"),
+                )
+            ).model_dump(),
             short_id="TEST1234",
         )
         DashboardTile.objects.create(insight=insight, dashboard=dashboard)

--- a/products/demo/backend/logic/legacy/web_data_generator.py
+++ b/products/demo/backend/logic/legacy/web_data_generator.py
@@ -8,7 +8,8 @@ from django.utils.timezone import now
 
 from dateutil.relativedelta import relativedelta
 
-from posthog.constants import TREND_FILTER_TYPE_ACTIONS
+from posthog.schema import ActionsNode, FunnelsQuery, InsightVizNode
+
 from posthog.models import Person, PropertyDefinition
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.utils import UUIDT
@@ -78,29 +79,15 @@ class WebDataGenerator(DataGenerator):
             team=self.team,
             name="Hogflix signup -> watching movie",
             description="Shows a conversion funnel from sign up to watching a movie.",
-            filters={
-                "actions": [
-                    {
-                        "id": homepage.id,
-                        "name": "Hogflix homepage view",
-                        "order": 0,
-                        "type": TREND_FILTER_TYPE_ACTIONS,
-                    },
-                    {
-                        "id": user_signed_up.id,
-                        "name": "Hogflix signed up",
-                        "order": 1,
-                        "type": TREND_FILTER_TYPE_ACTIONS,
-                    },
-                    {
-                        "id": user_paid.id,
-                        "name": "Hogflix paid",
-                        "order": 2,
-                        "type": TREND_FILTER_TYPE_ACTIONS,
-                    },
-                ],
-                "insight": "FUNNELS",
-            },
+            query=InsightVizNode(
+                source=FunnelsQuery(
+                    series=[
+                        ActionsNode(id=homepage.id, name="Hogflix homepage view"),
+                        ActionsNode(id=user_signed_up.id, name="Hogflix signed up"),
+                        ActionsNode(id=user_paid.id, name="Hogflix paid"),
+                    ],
+                )
+            ).model_dump(),
         )
         DashboardTile.objects.create(insight=insight, dashboard=dashboard)
         dashboard.save()  # to update the insight's filter hash


### PR DESCRIPTION
## Problem

Every new demo project minted insight rows that carry only the legacy `filters` format, with no `query`. The legacy insight removal deletes the read-time conversion that papers over those rows, so demo projects would create insights the platform can no longer read. Three demo data generators (app, web, revenue) built their funnels with a legacy `filters` dict instead of a `query`.

## Changes

- Demo projects now create their three starter funnels as `query` insights, readable after legacy conversion goes away.
- The app, web and revenue generators write an `InsightVizNode`/`FunnelsQuery` instead of a `filters` dict.
- Same series, same property filters, same date ranges as before. The hedgebox generator already used `query`.

Mechanical: import swaps only. No user-facing surface changes beyond the stored row shape.

## How did you test this code?

- Validated the schema nodes construct and `model_dump()` cleanly in a Django shell.
- Ran the old `filter_to_query` converter on the original filter dicts and confirmed the output matches the hand-written queries (node kinds, `exact` event-property filters, `date_from` passthrough).
- `hogli test products/demo/backend/test/` passes, including `test_matrix_manager`, which runs the generators.
- Not run: an end-to-end demo-project render in a browser. The stored row shape matches what the converters produce.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. `skip-inkeep-docs`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Co-authored by Claude Code. Skills invoked: `/writing-pr-descriptions`. The hedgebox generator was already on `query`, so this change covers only the three legacy generators. The old-style `{"app_rating": 5}` dict shorthand was mapped to an `exact` `EventPropertyFilter` by tracing `clean_entity_properties` in the legacy converter, to keep semantics identical.