### PR TITLE
feat(customer-analytics): add Stripe link to account useful links

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6229,29 +6229,29 @@ snapshots:
     scenes-app-customer-analytics-accounts--feature-gate-off--light:
         hash: v1.k794b7964.e8b91bf6a0dd1b5d31064f4cbb94e9791e999c210831c455a498d0c7cc7e6bbb.IkZPJrJz33sKS8zzKwoy8V3s0GvmKpe5EGYTCIljhLs
     scenes-app-customer-analytics-accounts--row-expanded-conversations--dark:
-        hash: v1.k794b7964.bc44c4751057dc02225b68a4346ab8b3de201c9fc0753ae3343c9155c11d7d7c.7rkYDKhJNy6YMfcm4t5bgSOKJIzmsU5YfufOKgfvBcQ
+        hash: v1.k794b7964.28471d9337f14b772cfe89b267cd6e8ee0af6d9c056829cdbed4f6002ceb0f69.-Ag1Nr1iECryl7-Y6awXl0Vko7ApVJUAiZxpD6gE9S8
     scenes-app-customer-analytics-accounts--row-expanded-conversations--light:
-        hash: v1.k794b7964.1c90a60a6f06c07f82bfe0a83877eeff9ba5eeafa3ad9d7cfb403df7495d6bdf.y4eZZzVpCP6q_c2kMHVAB7RsByV7ITi5x4y3LhV8e9k
+        hash: v1.k794b7964.4a269ddfd195a52ee4e4ee900d9b33ca23ca417119e9a981727c3d555b84c0ad.0seDk14GuoEOGh25pb7azihedQf5P4ykGyBY2aFkR_M
     scenes-app-customer-analytics-accounts--row-expanded-empty--dark:
-        hash: v1.k794b7964.8d9465c3188fab66f5b2ea033dc1d6668bd5de795b8811e99fca09de839f4896.4IHVJmASpKvBBlqeOgzD9RPPqmuO0a30CyzeiQYfg50
+        hash: v1.k794b7964.e26fa4e54eab3ae9089c88549743a71d5647a2b1a9ea59329670f65736f7c3e3.D83ROyLmN1qnXFrUnHwIxmI43D1Wx1ng3YFP0xGGIG0
     scenes-app-customer-analytics-accounts--row-expanded-empty--light:
-        hash: v1.k794b7964.e5df21b2dfc2524f2456e2452cacc0086d1ac3605fe7a36de5cdb4940b4ca11d.fqwdsEPpn_LPQYC5w0Oh5W_1o3w85VjWslOSIsr7ASw
+        hash: v1.k794b7964.d0c7cf851a7d0d02b354b9dbb0415a3520f5fa441687b0f6c22ec0dd540fff2c.KrxRllCdcGjUwupry7nEYDFjvQ1a4EirAq2nJpid3f0
     scenes-app-customer-analytics-accounts--row-expanded-feature-requests--dark:
-        hash: v1.k794b7964.cb06da092218f23ea59f7343e56b659cb9628b05a73f90a6a23676291a63a308.uTWz6x-QW1dWdZN-YdmPXRI0oE-1DogVYcge2yCGK6U
+        hash: v1.k794b7964.5763aba8a69cfabd27fa35d9c257f9b34ef0ec0c5fc9ea0fb04f8f24b6fb99fb.vE84W00tlPWei24OhvFK9QMol-BYY3a88jkXlRmyfc0
     scenes-app-customer-analytics-accounts--row-expanded-feature-requests--light:
-        hash: v1.k794b7964.f0f0578420641a90e8f695fcf722c1a019f95e1a0abbf6720388332363b7e070.5KgxFIYNv58VzKghCJWXqB1De23EHUKikGVjnA_3Uf8
+        hash: v1.k794b7964.64a789d465c72848d4636af9b8285621b0c6d52773fcf807f2acda2fac8564ad.LOlyA-ERhmFyj_kuJ6O5ytfReKYFaf6i2kSPL7SrFTU
     scenes-app-customer-analytics-accounts--row-expanded-links-disabled--dark:
-        hash: v1.k794b7964.b18c0d31c49773263d715ad6484593c0de8d724e932c8f0bd21fceb1000c3ec3.CM4Zw-HP7kOfH-i6R1zPPk_Ncb4yQfMj9aXDxxpGDE8
+        hash: v1.k794b7964.98273ded9eab6ee15a348dee6d75024d6a43c3454d735d5498c3bd7407c301a1.n4AeBhdPn7iCbsutgSjml8OwwKGVRHGRQ3pjsVnOFL0
     scenes-app-customer-analytics-accounts--row-expanded-links-disabled--light:
-        hash: v1.k794b7964.9386895c47574e53cb68bc8ae7f1719a39adf30da685de1a739187eaf1320f6c.GV9GJja8R_rTkrScMHgG0so-41JMELpSr17GwcIaNys
+        hash: v1.k794b7964.1c005ce13c47e11cacadf35f6b53d3873e02605672edc4aa56956f46586209b8.-QGC5z3_B--rJpbLNrUZB9cM8znB8wW8FsJpdVyUsfE
     scenes-app-customer-analytics-accounts--row-expanded-usage-not-found--dark:
-        hash: v1.k794b7964.fe7e23195dccbfa191e8f7b5f04fffbe19de72ae341370782776b72acd28230e.LP13YCcQAZ9pRgAE8nsq7HgAe5CYXfxoDgczD8TsmHU
+        hash: v1.k794b7964.f445ec51405294a7e1fe387bd0954c9499b912f9f9f5675bd54af7d3f42e1bc0.6ryzyVK3ajRA3clhtKz-GlFhv14tJcG6RU-ioWKP1_Q
     scenes-app-customer-analytics-accounts--row-expanded-usage-not-found--light:
-        hash: v1.k794b7964.771b34831c25ea548ee80ab2d6a8207754ea8ed7105c18515afa76db88e2c000.SFNWruc03ghKq3EoRc06R-qLvwj9h-6O69OYGmNWkG8
+        hash: v1.k794b7964.0b205d5623ec4ae0bc4fb606845322bcc18beeaf7b6f0954dbf5670ac972e56d.q83dxrVG2zLbR6T4bop2VlZxrqqz6dxdLcWLvQk_fQk
     scenes-app-customer-analytics-accounts--row-expanded-with-note--dark:
-        hash: v1.k794b7964.05713b54ad9cf3836789543e3a5f87dca1e1d0e669ab34f62366ba28f7d3cca1.sa1189qTJs0JIycSx9L-7SMT-ZRyFbk0zdRVmsz2P24
+        hash: v1.k794b7964.e4c9a4f5fa70c9d812972d49a61b3364d782c4a7993b28802d46063a11e01906.qAeMvIE_-M57FFA0T97nilxqOt1Li5_5hblANFeh9nU
     scenes-app-customer-analytics-accounts--row-expanded-with-note--light:
-        hash: v1.k794b7964.be9cb6321f85a9a345a43097044f167d0c1af73b32239d381e981e63d00f0bd2.juVLg0CcEGHNdX6BuKTCvZMSMP200h_yudnSK8x89EY
+        hash: v1.k794b7964.ae995eb9195d6badc128fe351cc31528f9730ea03c8c61a85098134f46e3bcf4.vl18MUmsu2699D97TPUISdp-Xl9Yi5Lmut2suQEYRDg
     scenes-app-customer-analytics-dashboard--b-2-b-mode-with-groups-enabled--dark:
         hash: v1.k794b7964.cf03f6a65f846aec287042028193b834c567f01226d2e91f6389df5af935530d.bXzRv9MkU0nXN-4tvGbenagVaJuhFr86goke8HVYFJY
     scenes-app-customer-analytics-dashboard--b-2-b-mode-with-groups-enabled--light:

--- a/products/customer_analytics/frontend/components/Accounts/AccountNotebooksExpansion.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountNotebooksExpansion.tsx
@@ -4,6 +4,7 @@ import posthog from 'posthog-js'
 import {
     IconCloud,
     IconCopy,
+    IconCreditCard,
     IconDatabase,
     IconGlobe,
     IconGraph,
@@ -76,6 +77,7 @@ const LINK_ICONS: Record<string, JSX.Element> = {
     metabase: <IconDatabase />,
     slack: <IconSlack />,
     'billing-admin': <IconReceipt />,
+    stripe: <IconCreditCard />,
     salesforce: <IconCloud />,
 }
 

--- a/products/customer_analytics/frontend/components/Accounts/accountLinksLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountLinksLogic.ts
@@ -20,6 +20,9 @@ const ORGANIZATION_GROUP_TYPE_INDEX = 0
 const REVENUE_DASHBOARD_ID = 259114
 const BILLING_ADMIN_ORIGIN = 'https://billing.posthog.com'
 const SLACK_ARCHIVES_ORIGIN = 'https://posthog.slack.com/archives'
+// Append a Stripe customer id to deep-link to that customer in the Stripe dashboard. Links to
+// live mode — the account model carries no live-vs-test signal to pick the /test/ path.
+const STRIPE_DASHBOARD_ORIGIN = 'https://dashboard.stripe.com/customers'
 
 export interface AccountLinksLogicProps {
     accountId: string
@@ -244,6 +247,7 @@ export const accountLinksLogic = kea<accountLinksLogicType>([
                 const usageDashboardLink = account?.properties?.usage_dashboard_link ?? null
                 const metabaseLink = account?.properties?.metabase_link ?? null
                 const sfdcId = account?.properties?.sfdc_id ?? null
+                const stripeCustomerId = account?.properties?.stripe_customer_id ?? null
                 const backUrl =
                     removeProjectIdIfPresent(currentLocation.pathname) + currentLocation.search + currentLocation.hash
                 return [
@@ -300,6 +304,13 @@ export const accountLinksLogic = kea<accountLinksLogicType>([
                         to: billingId ? `${BILLING_ADMIN_ORIGIN}/admin/billing/customer/${billingId}/change/` : null,
                         targetBlank: true,
                         disabledReason: billingId ? null : 'No billing ID set',
+                    },
+                    {
+                        key: 'stripe',
+                        label: 'Stripe',
+                        to: stripeCustomerId ? `${STRIPE_DASHBOARD_ORIGIN}/${stripeCustomerId}` : null,
+                        targetBlank: true,
+                        disabledReason: stripeCustomerId ? null : 'No Stripe customer ID set',
                     },
                     {
                         key: 'salesforce',


### PR DESCRIPTION
## Problem

A person viewing an account in Customer analytics holds the account's Stripe customer ID but has no way to open that customer in Stripe. Reaching the Stripe record means copying the ID and searching for it by hand.

## Changes

- Expanding an account now shows a "Stripe" entry in the Useful links sidebar that opens the customer in the Stripe dashboard in a new tab.
- The link is disabled with "No Stripe customer ID set" when the account has no synced `stripe_customer_id`, matching the other links.
- The link targets live mode (`dashboard.stripe.com/customers/<id>`). The account model carries no live-vs-test signal, so a test-mode customer would need the `/test/` path we cannot derive today.
- `stripe_customer_id` stays read-only (synced from the Stripe warehouse source); it is not added to the link editor.
- Mechanical: a `STRIPE_DASHBOARD_ORIGIN` constant, a link entry in `accountLinksLogic`, and an `IconCreditCard` entry in the link icon map. The entry reuses the existing `customer analytics account link clicked` event with `link_key: 'stripe'`.

This follows the exact shape of the existing Salesforce link.

PR #88133 adds an admin panel link to the same two files for a different reason; whichever merges second resolves a small addition in `accountLinksLogic.ts` and the link icon map.

## How did you test this code?

No test added. The entry is a plain URL-template link identical to five untested sibling links (Salesforce, Slack, Billing admin, Metabase, Usage dashboard); the only tested link, `organization`, is tested because it builds a URL with `combineUrl` and `backUrl`. A mirror test would be redundant coverage.

Not run: the app was not started and the sidebar was not rendered in a browser. The repo-wide `typescript:check` reports pre-existing failures in other products (revenue_analytics, session_summaries, workflows) from stale generated types; none touch the two changed files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by PostHog Desktop (Claude). Skills invoked: `/writing-ui-components`, `/writing-tests`, `/writing-pr-descriptions`.

Decisions across the session: kept `stripe_customer_id` read-only rather than adding it to the link editor, per the driver. Chose the live-mode Stripe URL because no live-vs-test signal exists on the account model. Declined a unit test under the test gate because the link mirrors untested siblings.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
