### PR TITLE
fix(data-quality): stop the editor's own validation blocking save

### DIFF
--- a/products/data_quality/frontend/dataQualityCheckEditorLogic.test.ts
+++ b/products/data_quality/frontend/dataQualityCheckEditorLogic.test.ts
@@ -447,6 +447,32 @@ describe('dataQualityCheckEditorLogic', () => {
         expect(logic.values.checkFormErrors.customSql).toEqual('Checking query...')
     })
 
+    it('saves a query nobody edited while Monaco validates the one it opened with', async () => {
+        // Monaco validates the query as soon as the editor mounts. That pass used to read as an
+        // edit awaiting validation, so Save did nothing at all for the first moment the modal was up.
+        ;(warehouseSavedQueriesChecksPartialUpdate as jest.Mock).mockResolvedValue(buildCheck())
+        await mountLogic()
+        await openWith(
+            buildCheck({
+                check_type: CheckTypeEnumApi.CustomSql,
+                column_name: '',
+                config: { query: 'SELECT id FROM orders' },
+            }),
+            { description: 'Every order keeps a positive id' }
+        )
+
+        logic.actions.setCustomSqlValidationLoading(true)
+        logic.actions.submitCheckForm()
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(warehouseSavedQueriesChecksPartialUpdate).toHaveBeenCalledWith(
+            '1',
+            'view-1',
+            'check-1',
+            expect.objectContaining({ description: 'Every order keeps a positive id' })
+        )
+    })
+
     it('keeps a Monaco error until an edited query receives a new validation result', async () => {
         await mountLogic()
         await openWith(null, { checkType: 'custom_sql', customSql: 'SELECT * FROM orders' })

--- a/products/data_quality/frontend/dataQualityCheckEditorLogic.test.ts
+++ b/products/data_quality/frontend/dataQualityCheckEditorLogic.test.ts
@@ -448,8 +448,8 @@ describe('dataQualityCheckEditorLogic', () => {
     })
 
     it('saves a query nobody edited while Monaco validates the one it opened with', async () => {
-        // Monaco validates the query as soon as the editor mounts. That pass used to read as an
-        // edit awaiting validation, so Save did nothing at all for the first moment the modal was up.
+        // Monaco validates the query as soon as the editor mounts. That pass is not an edit, so it
+        // must not hold the save while it runs.
         ;(warehouseSavedQueriesChecksPartialUpdate as jest.Mock).mockResolvedValue(buildCheck())
         await mountLogic()
         await openWith(

--- a/products/data_quality/frontend/dataQualityCheckEditorLogic.ts
+++ b/products/data_quality/frontend/dataQualityCheckEditorLogic.ts
@@ -595,7 +595,10 @@ export const dataQualityCheckEditorLogic = kea<dataQualityCheckEditorLogicType>(
         customSqlValidationLoading: [
             false,
             {
-                setCustomSqlValidationLoading: (_, { loading }) => loading,
+                // An edit is what starts the wait, so the editor can only end it. The editor also
+                // validates the query it was opened with, and that pass must not block saving a
+                // check whose query nobody touched.
+                setCustomSqlValidationLoading: (state, { loading }) => (loading ? state : false),
                 openEditor: () => false,
                 setCheckFormValue: (state, { name }) =>
                     name === 'customSql' ? true : name === 'checkType' ? false : state,

--- a/products/data_quality/frontend/dataQualityCheckEditorLogic.ts
+++ b/products/data_quality/frontend/dataQualityCheckEditorLogic.ts
@@ -598,7 +598,7 @@ export const dataQualityCheckEditorLogic = kea<dataQualityCheckEditorLogicType>(
                 // An edit is what starts the wait, so the editor can only end it. The editor also
                 // validates the query it was opened with, and that pass must not block saving a
                 // check whose query nobody touched.
-                setCustomSqlValidationLoading: (state, { loading }) => (loading ? state : false),
+                setCustomSqlValidationLoading: (state, { loading }) => state && loading,
                 openEditor: () => false,
                 setCheckFormValue: (state, { name }) =>
                     name === 'customSql' ? true : name === 'checkType' ? false : state,


### PR DESCRIPTION
## Problem

Anyone editing a custom SQL data quality check gets a dead Save button for the first moment the modal is open. The click produces no request, no toast, and no message.

- The query editor validates the query it was handed as soon as it mounts.
- That pass reports "validating" through the same signal an edit uses.
- The form therefore counts the untouched query as an edit still awaiting a verdict, and refuses to submit.
- The message clears when validation finishes, so nothing is left to explain the dead click.

The window is short, so whether a click lands inside it is a race. That race held master red on [E2E CI Playwright](https://github.com/PostHog/posthog/actions/runs/33847986654) for over two hours. The Data Ops spec edits a check description and saves right after the modal opens, so it aims straight at the window: it failed both attempts on three consecutive runs, then [failed once and passed on retry](https://github.com/PostHog/posthog/actions/runs/33849521419), which is the only reason master reads green now.

## Changes

- A person can now save a check the moment the modal opens, whatever the check type.
- An edit starts the wait for validation, so the editor can only end it.
- A query the person changed still waits for a verdict before it can be saved. That behavior is unchanged.

Nothing looks different. The modal, its fields and its buttons are untouched; only the moment the form accepts a save moves.

## How did you test this code?

Added one kea logic case: opening a custom SQL check and saving while the editor reports validation in flight has to reach the API. On master it records zero calls, which is the same silence the browser shows.

The Playwright suite needs the full E2E stack, so it did not run locally. A full run is dispatched on this branch with retries set to 0, which fails the spec on any single miss instead of hiding it behind a retry.

This PR does not trigger the suite on its own. The E2E workflow's path filter matches `frontend/**` and `products/*/frontend/e2e/**`, but not `products/*/frontend/**`, so a product frontend change skips the suite and is first tested by the master push run after merge. That gap is why the original regression reached master.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) triaged the red master alert, read the failing job logs and the Playwright failure artifacts, and traced the stuck modal to the form's validation gate. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The obvious alternative was to disable the Save button while validation runs. That trades a silent no-op for a button that a hung validation request can disable forever, and it leaves the automatic pass gating a query nobody edited. Treating the edit as the thing that starts the wait keeps the guard where it was intended and removes both failure modes.

https://claude.ai/code/session_01RFamrG1DG3eoBpgUQkB7TE
