### PR TITLE
chore(devex): run e2e for product frontend changes

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -133,7 +133,10 @@ jobs:
                       shouldRun:
                         # Any change that could affect E2E behavior triggers a run.
                         - playwright/**
-                        - 'products/*/frontend/e2e/**'
+                        # The whole product frontend, not only the specs it owns: it compiles
+                        # into the same bundle the suite drives. tools/playwright_area_map.json
+                        # narrows the run from here.
+                        - 'products/*/frontend/**'
                         - .github/workflows/ci-e2e-playwright.yml
                         - 'ee/**'
                         - 'posthog/!(temporal/**)/**'


### PR DESCRIPTION
## Problem

Anyone who changes a product frontend and nothing else gets no E2E run on their PR. The break first appears on master, after merge, where it blocks everyone.

The E2E trigger filter lists `products/*/frontend/e2e/**`, the specs a product owns, but not the product frontend itself. That frontend compiles into the same bundle the suite drives, so a change there reaches every spec.

[#92893](https://github.com/PostHog/posthog/pull/92893) is what that costs. It changed five files, all under `products/data_quality/frontend/`, so the workflow never started. The race it shipped [held master red for over two hours](https://github.com/PostHog/posthog/actions/runs/33847986654), and [#94936](https://github.com/PostHog/posthog/pull/94936) fixes it.

The selector already expects these paths. `tools/playwright_spec_selection.py:212` maps `products/<name>/frontend/` to that product's specs, and reports `unmapped_product` for one with no mapping. `tools/playwright_area_map.json` carries 20 such mappings, including `products/data_quality/frontend/** -> data-quality-overview.spec.ts`. None of it can run on a PR that touches nothing else.

## Changes

- One filter entry widens from `products/*/frontend/e2e/**` to `products/*/frontend/**`, so the suite starts on a product frontend change.
- The 20 mapped products get a narrowed run. `products/data_quality/frontend/**` selects one spec.
- The other 54 fall closed to the full suite, the same treatment an unmapped `frontend/src/scenes/` scene already gets. That is the cost of this PR, and the `unmapped_product` telemetry says which products to map next.

Drafts still skip the suite, so this changes nothing for a draft PR.

> [!NOTE]
> A path filter that skips tests makes a claim about the import graph. `docs/internal/ci-things-already-tried.md` records the backend version of the same mistake and the revert that followed. Here the claim was that a product frontend cannot affect the browser suite, which is false.

## How did you test this code?

`bin/hogli lint:workflows` passes all 9 checks, and `tools/test_playwright_spec_selection.py` passes. `actionlint` reports the same 21 pre-existing shellcheck findings as master, all in a step this PR does not touch.

The filter itself is only exercised by a real PR event, so it is unverified until this PR runs. Its own diff matches `.github/workflows/ci-e2e-playwright.yml`, which is in the map's `force_full` list, so this PR runs the full suite rather than a narrowed one.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) found this while triaging the red master alert that [#94936](https://github.com/PostHog/posthog/pull/94936) fixes. Skills invoked: `/authoring-ci-workflows`, `/writing-pr-descriptions`.

The history was checked before writing this. Across 200 commits to the workflow, back to September 2025, one commit touched a `products` filter line: [#60190](https://github.com/PostHog/posthog/pull/60190) added the `e2e/**` entry in June 2026. So the wider glob was never present and never removed, and this is not a revert of a past decision.

Filling in the 54 missing spec mappings would avoid the full-suite cost, but picking specs for a product nobody mapped is guesswork. The `unmapped_product` category exists to drive that with data instead.

https://claude.ai/code/session_01RFamrG1DG3eoBpgUQkB7TE
