### PR TITLE
fix(data-warehouse): catch a wrong JSON key file before the API rejects it

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
@@ -266,6 +266,32 @@ function webhookResultHasNoPendingInputs(webhookResult: WebhookCreateResult | nu
 // than the status code itself, so don't let it stand in for a message the source wrote.
 const GENERIC_SERVER_ERROR_DETAIL = 'A server error occurred.'
 
+// A wrong-but-valid JSON file (a client config instead of a service account key, say) parses
+// fine, so the API is left rejecting it by naming its own config fields. Check the keys the
+// source declared while the file is still in hand.
+export function missingUploadedFileKeys(parsed: unknown, keys: '*' | string[]): string[] {
+    if (keys === '*') {
+        return []
+    }
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return [...keys]
+    }
+    const record = parsed as Record<string, unknown>
+    return keys.filter((key) => record[key] === undefined || record[key] === null || record[key] === '')
+}
+
+// Carries the failed submit out of the form without the outer handler mistaking it for an API
+// error; the toast has already said what to do, so nothing else reports it.
+export class UnusableUploadedFileError extends Error {
+    constructor(fieldName: string) {
+        super(`Uploaded "${fieldName}" file is missing the keys this source requires`)
+        this.name = 'UnusableUploadedFileError'
+    }
+}
+
+export const WRONG_UPLOADED_FILE_MESSAGE =
+    'This JSON file is missing the fields PostHog needs. Upload the key file exactly as it was generated, without editing its contents.'
+
 export function resolveConnectErrorMessage(e: any): string {
     const detail = e?.detail === GENERIC_SERVER_ERROR_DETAIL ? undefined : e?.detail
     const apiMessage = e?.data?.message ?? detail
@@ -3934,14 +3960,16 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                         const payloadKeys = (values.selectedConnector?.fields ?? []).map((n) => ({
                             name: n.name,
                             type: n.type,
+                            fileKeys: n.type === 'file-upload' ? n.fileFormat.keys : ([] as string[]),
                         }))
 
                         const fieldPayload: Record<string, any> = {
                             source_type: values.selectedConnector.name,
                         }
 
-                        for (const { name, type } of payloadKeys) {
+                        for (const { name, type, fileKeys } of payloadKeys) {
                             if (type === 'file-upload') {
+                                let parsedFile: unknown
                                 try {
                                     // Assumes we're loading a JSON file
                                     const loadedFile: string = await new Promise((resolve, reject) => {
@@ -3951,13 +3979,21 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                                             reject(fileReader.error ?? new Error(`Failed to read the "${name}" file`))
                                         fileReader.readAsText(payload['payload'][name][0])
                                     })
-                                    fieldPayload[name] = JSON.parse(loadedFile)
+                                    parsedFile = JSON.parse(loadedFile)
                                 } catch (e: any) {
                                     posthog.captureException(e)
-                                    return lemonToast.error(
+                                    lemonToast.error(
                                         `The "${name}" file is not valid — it must be a readable JSON file.`
                                     )
+                                    // Returning here would resolve the submit, so the wizard would go
+                                    // on to discover schemas for a source it never updated.
+                                    throw e
                                 }
+                                if (missingUploadedFileKeys(parsedFile, fileKeys).length > 0) {
+                                    lemonToast.error(WRONG_UPLOADED_FILE_MESSAGE)
+                                    throw new UnusableUploadedFileError(name)
+                                }
+                                fieldPayload[name] = parsedFile
                             } else {
                                 fieldPayload[name] = payload['payload'][name]
                             }

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardValidation.test.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardValidation.test.ts
@@ -1,7 +1,7 @@
 import type { SourceFieldConfig } from '~/queries/schema/schema-general'
 
 import { findOauthBranch, normalizeMultiValue } from '../../shared/components/forms/IntegrationAccountSelector'
-import { getErrorsForFields } from './sourceWizardLogic'
+import { getErrorsForFields, missingUploadedFileKeys } from './sourceWizardLogic'
 
 const REPOSITORIES_FIELD: SourceFieldConfig = {
     type: 'oauth-account-select',
@@ -112,6 +112,26 @@ describe('source wizard multi-value fields', () => {
             [['a/b'], 'legacy/repo', ['a/b']],
         ])('value %p with legacy %p normalizes to %p', (value, legacy, expected) => {
             expect(normalizeMultiValue(value, legacy)).toEqual(expected)
+        })
+    })
+    describe('missingUploadedFileKeys', () => {
+        const SERVICE_ACCOUNT_KEYS = ['project_id', 'private_key', 'client_email']
+
+        // Uploading the wrong JSON is the common mistake here: it parses, so the only thing that
+        // catches it is the declared key list.
+        it.each([
+            [{ project_id: 'p', private_key: 'k', client_email: 'e' }, []],
+            [{ project_info: { project_id: 'p' } }, SERVICE_ACCOUNT_KEYS],
+            [{ project_id: 'p', private_key: '', client_email: 'e' }, ['private_key']],
+            [{ project_id: 'p', private_key: null, client_email: 'e' }, ['private_key']],
+            [[{ project_id: 'p' }], SERVICE_ACCOUNT_KEYS],
+            ['not an object', SERVICE_ACCOUNT_KEYS],
+        ])('reports %p as missing %p', (parsed, expected) => {
+            expect(missingUploadedFileKeys(parsed, SERVICE_ACCOUNT_KEYS)).toEqual(expected)
+        })
+
+        it('accepts any shape when the source declares no specific keys', () => {
+            expect(missingUploadedFileKeys({ anything: true }, '*')).toEqual([])
         })
     })
 })


### PR DESCRIPTION
## Problem

Connecting Firebase means uploading a service account JSON key. Upload the wrong JSON — a client config file, an app config file, anything that parses — and the wizard sent it to the API, which answered by listing the config field names it could not find. That reads as a bug report about our internals, and it says nothing about which file to pick instead.

Firebase was the source people hit this on, but BigQuery and Google Play Console take the same kind of key file and behave the same way.

## Changes

- Uploading a JSON file that isn't the key file now fails immediately, in the wizard, with a message saying the file is missing fields PostHog needs and to upload the key file as it was generated. No round trip, and no list of internal field names.
- The check reads the keys each source already declares on its upload field, so it stays right as sources are added.

Mechanical: the parsed file is held in a local before it goes into the payload, so the check has something to look at.

## How did you test this code?

Added unit tests for the key check covering a good key file, a wrong-but-valid JSON, blank and null values, a JSON array, a bare string, and a source that declares no specific keys. They catch a regression nothing covered before: today any parseable JSON passes the wizard.

Ran the touched Jest suite locally — it passes. Frontend lint and format run clean.

I did not click through the wizard in a browser; the repo's typecheck currently fails on unrelated unbuilt workspace packages, and no error in it points at the files here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Came out of triaging a day of failed data-warehouse source creations. The failure behind this one was an internal validation error reaching users, so it got a fix. Most of the messages in that set were already clear and actionable and were left alone.

The fix lands in shared wizard code rather than under one source, because the upload field, its declared keys, and the parse step are all shared — three sources use them and behave identically.

Searched open PRs for the source module, the upload path, and phrases from the message. Nothing already covers it.

Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-ui-components`, `/writing-code-comments`, `/writing-pr-descriptions`.

Public artifact: the failures came from analytics on real setup attempts. Nothing from them appears in the diff or here — the tests use invented values and assert on our own wording.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
