### PR TITLE
fix(desktop): personalize self presence label

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -334,6 +334,26 @@ describe("ChannelItemRow", () => {
     expect(screen.queryByRole("img", { name: "Pinned" })).toBeNull();
   });
 
+  it.each([
+    ["the signed-in user", "u-1", "You were here recently"],
+    ["another user", "u-2", "Ada Lovelace was here recently"],
+  ])("labels recent presence for %s", (_case, uuid, label) => {
+    renderRow(
+      item({
+        ts: Date.now() - 5 * 60_000,
+        authorUser: {
+          id: 1,
+          uuid,
+          email: "ada@example.com",
+          first_name: "Ada",
+          last_name: "Lovelace",
+        },
+      }),
+    );
+
+    expect(screen.getByRole("img", { name: label })).not.toBeNull();
+  });
+
   // A pinned row offering only `move` resolves against the Command Center's
   // `copy` as no drop, so the tile stops accepting it with nothing to show why.
   it.each([{ pinned: false }, { pinned: true }])(

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
@@ -182,11 +182,23 @@ function rowAuthor(
  * so a row that is idle now stays idle until its item changes, and re-rendering
  * it every minute would buy nothing. Only a row with a face to fade subscribes.
  */
-function RowPresence({ item }: { item: ChannelItemModel }) {
+function RowPresence({
+  item,
+  currentUserUuid,
+}: {
+  item: ChannelItemModel;
+  currentUserUuid?: string;
+}) {
   const author = rowAuthor(item);
   if (!author) return null;
   if (presenceTier(item.ts, Date.now()) === "idle") return null;
-  return <ActiveRowPresence item={item} author={author} />;
+  return (
+    <ActiveRowPresence
+      item={item}
+      author={author}
+      isCurrentUser={author.user.uuid === currentUserUuid}
+    />
+  );
 }
 
 /**
@@ -197,9 +209,11 @@ function RowPresence({ item }: { item: ChannelItemModel }) {
 function ActiveRowPresence({
   item,
   author,
+  isCurrentUser,
 }: {
   item: ChannelItemModel;
   author: NonNullable<ReturnType<typeof rowAuthor>>;
+  isCurrentUser: boolean;
 }) {
   const tier = presenceTier(item.ts, useNow());
   if (tier === "idle") return null;
@@ -208,9 +222,13 @@ function ActiveRowPresence({
       user={author.user}
       tier={tier}
       label={
-        tier === "live"
-          ? `${author.label} is working on this`
-          : `${author.label} was here recently`
+        isCurrentUser && tier === "live"
+          ? "You are working on this"
+          : isCurrentUser
+            ? "You were here recently"
+            : tier === "live"
+              ? `${author.label} is working on this`
+              : `${author.label} was here recently`
       }
     />
   );
@@ -251,6 +269,7 @@ export function ChannelItemRowView({
   isSelected = false,
   showPinBadge = true,
   draggable = false,
+  currentUserUuid,
   onClick,
   onDragStart,
   onDragEnd,
@@ -263,6 +282,7 @@ export function ChannelItemRowView({
   isSelected?: boolean;
   showPinBadge?: boolean;
   draggable?: boolean;
+  currentUserUuid?: string;
   onClick?: (e: React.MouseEvent) => void;
   onDragStart?: (e: DragEvent) => void;
   onDragEnd?: (e: DragEvent) => void;
@@ -292,7 +312,7 @@ export function ChannelItemRowView({
         <span className={TRAILING_CLASS}>
           {/* Who's here, ahead of the badges: presence is the row's most
               time-sensitive fact, and it's absent on a quiet row. */}
-          <RowPresence item={item} />
+          <RowPresence item={item} currentUserUuid={currentUserUuid} />
           {/* Badges take the timestamp's slot: identity (pin, source, cloud,
               PR) is what you scan a task list for, and the age is still on the
               preview card. */}
@@ -476,6 +496,7 @@ export function ChannelItemRow({
         isSelected={isSelected}
         showPinBadge={showPinBadge}
         draggable
+        currentUserUuid={currentUser.data?.uuid}
         onDragStart={handleDragStart}
         onDragEnd={onDragEnd}
         onClick={(e) => (onClick ? onClick(e) : actions.open(item))}


### PR DESCRIPTION
## Problem

Self-presence tooltips show the signed-in user's name. This makes the user look like another person.

## Changes

Show “You were here recently” or “You are working on this” for self-presence.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*