### PR TITLE
feat(signals): default scout Slack reports to threads

### DIFF
--- a/docs/internal/signals-scout-slack-delivery.md
+++ b/docs/internal/signals-scout-slack-delivery.md
@@ -18,6 +18,7 @@ The setting stays the same when you change the channel, direct-message
 recipients, or Slack workspace. Finding messages and report update notes always
 use one message.
 
-If Slack rate-limits a report reply, delivery waits for the `Retry-After` period
-and tries that reply one more time. A reply that still fails is logged without
-posting the report lead again.
+If Slack rate-limits a report reply, delivery schedules a separate task after
+the `Retry-After` period. The delay is at most one hour. Each task continues
+from the section that Slack rejected, so it does not block a delivery worker or
+post the report lead again.

--- a/docs/internal/signals-scout-slack-delivery.md
+++ b/docs/internal/signals-scout-slack-delivery.md
@@ -1,0 +1,23 @@
+# Signals scout Slack delivery
+
+A Signals scout can send its output to one Slack channel or to as many as five
+people by direct message. Configure this in the scout settings or in
+`output_destinations.slack` through the API.
+
+Set either `channel` or `users`. The `integration_id` must identify a Slack
+integration in the same PostHog project.
+
+## Report threads
+
+`thread_reports` is `true` by default. A threaded report puts a short lead in
+the channel and splits the other summary sections into replies. An explicit
+`false` keeps the report in one message. Slack can truncate a long summary in
+this mode.
+
+The setting stays the same when you change the channel, direct-message
+recipients, or Slack workspace. Finding messages and report update notes always
+use one message.
+
+If Slack rate-limits a report reply, delivery waits for the `Retry-After` period
+and tries that reply one more time. A reply that still fails is logged without
+posting the report lead again.

--- a/products/replay_vision/backend/tests/test_scanner_scouts_api.py
+++ b/products/replay_vision/backend/tests/test_scanner_scouts_api.py
@@ -58,7 +58,7 @@ class TestScannerScoutCreate(_VisionAPITestCase):
         with team_scope(self.team.id):
             config = SignalScoutConfig.objects.get(skill_name="signals-scout-daily-digest")
         assert config.output_destinations == {
-            "slack": {"integration_id": integration.id, "channel": "CSCOUTS|#scout-findings", "thread_reports": False}
+            "slack": {"integration_id": integration.id, "channel": "CSCOUTS|#scout-findings", "thread_reports": True}
         }
 
     def test_a_scout_can_be_created_with_a_model_pin(self) -> None:

--- a/products/replay_vision/frontend/generated/api.schemas.ts
+++ b/products/replay_vision/frontend/generated/api.schemas.ts
@@ -1721,7 +1721,7 @@ export interface SignalScoutSlackDestinationApi {
      * @items.pattern ^[UW][A-Z0-9]{4,}\s*(\|.*)?$
      */
     users?: string[] | null
-    /** When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. Off by default, and it does not change how findings post. */
+    /** When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post. */
     thread_reports?: boolean
 }
 

--- a/products/replay_vision/frontend/generated/api.schemas.ts
+++ b/products/replay_vision/frontend/generated/api.schemas.ts
@@ -1721,7 +1721,7 @@ export interface SignalScoutSlackDestinationApi {
      * @items.pattern ^[UW][A-Z0-9]{4,}\s*(\|.*)?$
      */
     users?: string[] | null
-    /** When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post. */
+    /** When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post. */
     thread_reports?: boolean
 }
 

--- a/products/replay_vision/frontend/generated/api.zod.ts
+++ b/products/replay_vision/frontend/generated/api.zod.ts
@@ -960,7 +960,7 @@ export const visionScannersScoutsCreateBodyConfigOneOutputDestinationsOneSlackOn
 )
 export const visionScannersScoutsCreateBodyConfigOneOutputDestinationsOneSlackOneUsersMax = 5
 
-export const visionScannersScoutsCreateBodyConfigOneOutputDestinationsOneSlackOneThreadReportsDefault = false
+export const visionScannersScoutsCreateBodyConfigOneOutputDestinationsOneSlackOneThreadReportsDefault = true
 export const visionScannersScoutsCreateBodyConfigOneRunCronScheduleMax = 100
 
 export const visionScannersScoutsCreateBodyConfigOneModelMax = 200
@@ -1051,7 +1051,7 @@ export const VisionScannersScoutsCreateBody = /* @__PURE__ */ zod
                                             visionScannersScoutsCreateBodyConfigOneOutputDestinationsOneSlackOneThreadReportsDefault
                                         )
                                         .describe(
-                                            "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. Off by default, and it does not change how findings post."
+                                            "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post."
                                         ),
                                 }),
                                 zod.null(),

--- a/products/replay_vision/frontend/generated/api.zod.ts
+++ b/products/replay_vision/frontend/generated/api.zod.ts
@@ -1051,7 +1051,7 @@ export const VisionScannersScoutsCreateBody = /* @__PURE__ */ zod
                                             visionScannersScoutsCreateBodyConfigOneOutputDestinationsOneSlackOneThreadReportsDefault
                                         )
                                         .describe(
-                                            "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post."
+                                            "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post."
                                         ),
                                 }),
                                 zod.null(),

--- a/products/signals/backend/scout_harness/serializers.py
+++ b/products/signals/backend/scout_harness/serializers.py
@@ -2294,8 +2294,8 @@ class SignalScoutSlackDestinationSerializer(serializers.Serializer):
             "When true, post a report as a thread: a short lead in the channel and the rest split "
             "into replies at the summary's section labels, which can be Markdown headings or bold "
             "labels. Keeps a long summary from being clipped at Slack's section limit. On by "
-            "default; set it false to post the whole report as one message. It does not change how "
-            "findings post."
+            "default; set it false to post a single message, which can truncate a long summary. "
+            "It does not change how findings post."
         ),
     )
 

--- a/products/signals/backend/scout_harness/serializers.py
+++ b/products/signals/backend/scout_harness/serializers.py
@@ -2289,12 +2289,13 @@ class SignalScoutSlackDestinationSerializer(serializers.Serializer):
 
     thread_reports = serializers.BooleanField(
         required=False,
-        default=False,
+        default=True,
         help_text=(
             "When true, post a report as a thread: a short lead in the channel and the rest split "
             "into replies at the summary's section labels, which can be Markdown headings or bold "
-            "labels. Keeps a long summary from being clipped at Slack's section limit. Off by "
-            "default, and it does not change how findings post."
+            "labels. Keeps a long summary from being clipped at Slack's section limit. On by "
+            "default; set it false to post the whole report as one message. It does not change how "
+            "findings post."
         ),
     )
 

--- a/products/signals/backend/scout_harness/serializers.py
+++ b/products/signals/backend/scout_harness/serializers.py
@@ -2246,6 +2246,15 @@ SLACK_MEMBER_TARGET_ERROR = (
 )
 
 
+_SCOUT_SLACK_THREAD_REPORTS_HELP = (
+    "When true, post a report as a thread: a short lead in the channel and the rest split "
+    "into replies at the summary's section labels, which can be Markdown headings or bold "
+    "labels. Keeps a long summary from being clipped at Slack's section limit. On by "
+    "default; set it false to post a single message, which can truncate a long summary. "
+    "It does not change how findings post."
+)
+
+
 class SignalScoutSlackDestinationSerializer(serializers.Serializer):
     integration_id = serializers.IntegerField(
         min_value=1,
@@ -2290,13 +2299,7 @@ class SignalScoutSlackDestinationSerializer(serializers.Serializer):
     thread_reports = serializers.BooleanField(
         required=False,
         default=True,
-        help_text=(
-            "When true, post a report as a thread: a short lead in the channel and the rest split "
-            "into replies at the summary's section labels, which can be Markdown headings or bold "
-            "labels. Keeps a long summary from being clipped at Slack's section limit. On by "
-            "default; set it false to post a single message, which can truncate a long summary. "
-            "It does not change how findings post."
-        ),
+        help_text=_SCOUT_SLACK_THREAD_REPORTS_HELP,
     )
 
     def validate_users(self, value: list[str] | None) -> list[str] | None:
@@ -2323,6 +2326,13 @@ class SignalScoutSlackDestinationSerializer(serializers.Serializer):
         return attrs
 
 
+class SignalScoutSlackDestinationUpdateSerializer(SignalScoutSlackDestinationSerializer):
+    thread_reports = serializers.BooleanField(
+        required=False,
+        help_text=_SCOUT_SLACK_THREAD_REPORTS_HELP,
+    )
+
+
 class SignalScoutWebhookDestinationSerializer(serializers.Serializer):
     hog_function_id = serializers.CharField(
         help_text=(
@@ -2346,6 +2356,14 @@ class SignalScoutOutputDestinationsSerializer(serializers.Serializer):
             "omitted means no webhook. Unlike Slack, Signals does not deliver this itself: the "
             "reference lives here so the owning product can manage the destination's lifecycle."
         ),
+    )
+
+
+class SignalScoutOutputDestinationsUpdateSerializer(SignalScoutOutputDestinationsSerializer):
+    slack = SignalScoutSlackDestinationUpdateSerializer(
+        required=False,
+        allow_null=True,
+        help_text="Slack destination for each emitted scout finding or report. Null or omitted disables Slack delivery.",
     )
 
 
@@ -2901,7 +2919,7 @@ class SignalScoutConfigUpdateSerializer(serializers.ModelSerializer):
             "apart. Set null to return to the rolling interval schedule."
         ),
     )
-    output_destinations = SignalScoutOutputDestinationsSerializer(
+    output_destinations = SignalScoutOutputDestinationsUpdateSerializer(
         required=False,
         help_text="Destinations that receive each finding or report this scout emits. Pass an empty object to disable delivery.",
     )
@@ -2961,6 +2979,16 @@ class SignalScoutConfigUpdateSerializer(serializers.ModelSerializer):
         return _validate_write_scopes(value)
 
     def update(self, instance: SignalScoutConfig, validated_data: dict) -> SignalScoutConfig:
+        output_destinations = validated_data.get("output_destinations")
+        current_slack = instance.output_destinations.get("slack") if instance.output_destinations else None
+        incoming_slack = output_destinations.get("slack") if output_destinations else None
+        if (
+            isinstance(current_slack, dict)
+            and current_slack.get("thread_reports") is False
+            and isinstance(incoming_slack, dict)
+            and "thread_reports" not in incoming_slack
+        ):
+            incoming_slack["thread_reports"] = False
         # Re-anchor the coordinator's cron due-check only when the schedule actually changes —
         # an emit/enabled-only save must not defer an already-overdue scheduled run.
         schedule_fields = ("run_interval_minutes", "run_cron_schedule")

--- a/products/signals/backend/scout_harness/slack_delivery.py
+++ b/products/signals/backend/scout_harness/slack_delivery.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 import uuid
 from dataclasses import dataclass
 from typing import Literal
@@ -129,6 +130,16 @@ def get_scout_slack_destination(output_destinations: object) -> ScoutSlackDestin
 def slack_api_error_code(exc: SlackApiError) -> str | None:
     error_code = exc.response.get("error") if exc.response else None
     return error_code if isinstance(error_code, str) else None
+
+
+def _slack_retry_after_seconds(exc: Exception) -> int | None:
+    """Return Slack's bounded retry delay for a rate-limited request."""
+    if not isinstance(exc, SlackApiError) or slack_api_error_code(exc) != "ratelimited" or exc.response is None:
+        return None
+    try:
+        return min(max(int(exc.response.headers.get("Retry-After", "1")), 1), 30)
+    except (TypeError, ValueError):
+        return 1
 
 
 def _post_scout_slack_reply(
@@ -537,22 +548,41 @@ def _post_scout_report_thread_replies(
     delivery still succeeds rather than re-posting the lead on retry."""
     if not isinstance(thread_ts, str) or not thread_ts:
         return
+
+    def _post_reply(index: int, blocks: list[dict]) -> None:
+        client.chat_postMessage(  # type: ignore[attr-defined]
+            channel=channel_id,
+            thread_ts=thread_ts,
+            blocks=blocks,
+            text=fallback,
+            # Slack rejects a client_msg_id that is not a UUID, and this loop swallows the
+            # error, so a plain `id:index` string costs every reply silently. The `reply`
+            # infix keeps the derivation clear of the one the DM fan-out uses for extra
+            # recipients (`<delivery_id>:<index>`), which would otherwise collide.
+            client_msg_id=str(uuid.uuid5(uuid.NAMESPACE_OID, f"{delivery_id}:reply:{index}")),
+            unfurl_links=False,
+            unfurl_media=False,
+        )
+
     for index, blocks in enumerate(reply_blocks):
         try:
-            client.chat_postMessage(  # type: ignore[attr-defined]
-                channel=channel_id,
-                thread_ts=thread_ts,
-                blocks=blocks,
-                text=fallback,
-                # Slack rejects a client_msg_id that is not a UUID, and this loop swallows the
-                # error, so a plain `id:index` string costs every reply silently. The `reply`
-                # infix keeps the derivation clear of the one the DM fan-out uses for extra
-                # recipients (`<delivery_id>:<index>`), which would otherwise collide.
-                client_msg_id=str(uuid.uuid5(uuid.NAMESPACE_OID, f"{delivery_id}:reply:{index}")),
-                unfurl_links=False,
-                unfurl_media=False,
-            )
-        except Exception:
+            _post_reply(index, blocks)
+        except Exception as exc:
+            retry_after = _slack_retry_after_seconds(exc)
+            if retry_after is not None:
+                time.sleep(retry_after)
+                try:
+                    _post_reply(index, blocks)
+                    continue
+                except Exception:
+                    logger.warning(
+                        "scout_slack_report_thread_reply_failed",
+                        channel=channel_id,
+                        delivery_id=delivery_id,
+                        chunk_index=index,
+                        exc_info=True,
+                    )
+                    continue
             logger.warning(
                 "scout_slack_report_thread_reply_failed",
                 channel=channel_id,

--- a/products/signals/backend/scout_harness/slack_delivery.py
+++ b/products/signals/backend/scout_harness/slack_delivery.py
@@ -87,7 +87,7 @@ class ScoutSlackDestination:
     # or one or more members to DM individually (`U…|@name`) — Slack's chat.postMessage accepts
     # either id as its `channel` argument, opening the DM for a member id.
     targets: tuple[str, ...]
-    thread_reports: bool = False
+    thread_reports: bool = True
 
 
 class ScoutSlackPermanentDeliveryError(RuntimeError):
@@ -106,7 +106,8 @@ def get_scout_slack_destination(output_destinations: object) -> ScoutSlackDestin
     integration_id = slack.get("integration_id")
     if not isinstance(integration_id, int) or isinstance(integration_id, bool) or integration_id < 1:
         return None
-    thread_reports = slack.get("thread_reports") is True
+    # Threading is the default, so only an explicit `false` turns it off.
+    thread_reports = slack.get("thread_reports") is not False
     channel = slack.get("channel")
     if isinstance(channel, str) and channel.strip():
         return ScoutSlackDestination(

--- a/products/signals/backend/scout_harness/slack_delivery.py
+++ b/products/signals/backend/scout_harness/slack_delivery.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -61,6 +62,7 @@ _PERMANENT_SLACK_ERROR_CODES = frozenset(
 # with one of these when it cannot reach one. Neither code is permanent, so a chart Slack cannot
 # fetch would otherwise retry and then drop a report that used to post as text.
 _BLOCK_REJECTION_ERROR_CODES = frozenset({"invalid_blocks", "invalid_blocks_format"})
+_SCOUT_SLACK_REPLY_PACE_SECONDS = 1
 
 ScoutSlackOutputType = Literal["finding", "report"]
 ScoutSlackReplyRetryScheduler = Callable[[int, list[list[dict]], int, str, str], None]
@@ -572,25 +574,32 @@ def _post_scout_report_thread_replies(
 
     for index, blocks in enumerate(reply_blocks):
         chunk_index = chunk_offset + index
+        if index:
+            # Slack allows roughly one message per second per channel. Keep the bounded reply fan-out
+            # in this worker, but do not send it as one burst that consumes a retry per section.
+            time.sleep(_SCOUT_SLACK_REPLY_PACE_SECONDS)
         try:
             _post_reply(chunk_index, blocks)
         except Exception as exc:
-            if isinstance(exc, SlackApiError) and slack_api_error_code(exc) == "ratelimited":
-                schedule_retry(
-                    _slack_retry_after_seconds(exc) or 60,
-                    reply_blocks[index:],
-                    chunk_index,
-                    thread_ts,
-                    fallback,
-                )
-                return
+            error_code = slack_api_error_code(exc) if isinstance(exc, SlackApiError) else None
             logger.warning(
                 "scout_slack_report_thread_reply_failed",
                 channel=channel_id,
                 delivery_id=delivery_id,
                 chunk_index=chunk_index,
+                error_code=error_code,
                 exc_info=True,
             )
+            if error_code in _PERMANENT_SLACK_ERROR_CODES:
+                continue
+            schedule_retry(
+                _slack_retry_after_seconds(exc) or 60,
+                reply_blocks[index:],
+                chunk_index,
+                thread_ts,
+                fallback,
+            )
+            return
 
 
 def _post_scout_report_lead_message(

--- a/products/signals/backend/scout_harness/slack_delivery.py
+++ b/products/signals/backend/scout_harness/slack_delivery.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import time
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
 from urllib.parse import quote
@@ -63,6 +63,7 @@ _PERMANENT_SLACK_ERROR_CODES = frozenset(
 _BLOCK_REJECTION_ERROR_CODES = frozenset({"invalid_blocks", "invalid_blocks_format"})
 
 ScoutSlackOutputType = Literal["finding", "report"]
+ScoutSlackReplyRetryScheduler = Callable[[int, list[list[dict]], int, str, str], None]
 
 # Each member gets an individual DM (a group DM would need the `mpim:write` scope the Slack app
 # doesn't request), so this bounds the per-output Slack API fan-out.
@@ -133,13 +134,16 @@ def slack_api_error_code(exc: SlackApiError) -> str | None:
 
 
 def _slack_retry_after_seconds(exc: Exception) -> int | None:
-    """Return Slack's bounded retry delay for a rate-limited request."""
+    """Return Slack's retry delay, bounded by the delivery task's one-hour limit."""
     if not isinstance(exc, SlackApiError) or slack_api_error_code(exc) != "ratelimited" or exc.response is None:
         return None
+    headers = exc.response.headers or {}
+    raw_value = headers.get("Retry-After") or headers.get("retry-after")
     try:
-        return min(max(int(exc.response.headers.get("Retry-After", "1")), 1), 30)
+        retry_after = int(raw_value) if raw_value is not None else None
     except (TypeError, ValueError):
-        return 1
+        return None
+    return min(retry_after, 3600) if retry_after is not None and retry_after > 0 else None
 
 
 def _post_scout_slack_reply(
@@ -541,6 +545,8 @@ def _post_scout_report_thread_replies(
     delivery_id: str,
     reply_blocks: list[list[dict]],
     fallback: str,
+    schedule_retry: ScoutSlackReplyRetryScheduler,
+    chunk_offset: int = 0,
 ) -> None:
     """Post the remaining summary chunks as threaded replies under an already-delivered lead.
 
@@ -565,29 +571,24 @@ def _post_scout_report_thread_replies(
         )
 
     for index, blocks in enumerate(reply_blocks):
+        chunk_index = chunk_offset + index
         try:
-            _post_reply(index, blocks)
+            _post_reply(chunk_index, blocks)
         except Exception as exc:
-            retry_after = _slack_retry_after_seconds(exc)
-            if retry_after is not None:
-                time.sleep(retry_after)
-                try:
-                    _post_reply(index, blocks)
-                    continue
-                except Exception:
-                    logger.warning(
-                        "scout_slack_report_thread_reply_failed",
-                        channel=channel_id,
-                        delivery_id=delivery_id,
-                        chunk_index=index,
-                        exc_info=True,
-                    )
-                    continue
+            if isinstance(exc, SlackApiError) and slack_api_error_code(exc) == "ratelimited":
+                schedule_retry(
+                    _slack_retry_after_seconds(exc) or 60,
+                    reply_blocks[index:],
+                    chunk_index,
+                    thread_ts,
+                    fallback,
+                )
+                return
             logger.warning(
                 "scout_slack_report_thread_reply_failed",
                 channel=channel_id,
                 delivery_id=delivery_id,
-                chunk_index=index,
+                chunk_index=chunk_index,
                 exc_info=True,
             )
 
@@ -638,6 +639,7 @@ def post_scout_report_to_slack(
     delivery_id: str,
     integration_id: int,
     channel: str,
+    schedule_thread_reply_retry: ScoutSlackReplyRetryScheduler,
     edit_note: str | None = None,
     thread_reports: bool = False,
 ) -> None:
@@ -754,6 +756,7 @@ def post_scout_report_to_slack(
             delivery_id=delivery_id,
             reply_blocks=messages.reply_blocks,
             fallback=messages.fallback,
+            schedule_retry=schedule_thread_reply_retry,
         )
 
     _post_scout_slack_reply(

--- a/products/signals/backend/scout_harness/views.py
+++ b/products/signals/backend/scout_harness/views.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import uuid
 import dataclasses
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -1825,11 +1826,38 @@ def _upsert_scout_config(
     if created or not tunables:
         return config, created
 
+    update_data = tunables
+    request_data = getattr(request, "data", {})
+    if isinstance(request_data, Mapping):
+        nested_config = request_data.get("config")
+        raw_config = nested_config if isinstance(nested_config, Mapping) else request_data
+        raw_destinations = raw_config.get("output_destinations")
+        raw_slack = raw_destinations.get("slack") if isinstance(raw_destinations, Mapping) else None
+        thread_reports_was_supplied = isinstance(raw_slack, Mapping) and "thread_reports" in raw_slack
+
+        incoming_destinations = tunables.get("output_destinations")
+        incoming_slack = incoming_destinations.get("slack") if isinstance(incoming_destinations, dict) else None
+        current_slack = config.output_destinations.get("slack") if config.output_destinations else None
+        if (
+            not thread_reports_was_supplied
+            and isinstance(incoming_destinations, dict)
+            and isinstance(incoming_slack, dict)
+            and isinstance(current_slack, dict)
+            and current_slack.get("thread_reports") is False
+        ):
+            update_data = {
+                **tunables,
+                "output_destinations": {
+                    **incoming_destinations,
+                    "slack": {**incoming_slack, "thread_reports": False},
+                },
+            }
+
     # The coordinator or another caller may have won the create race. Apply only
     # fields supplied by this request so omitted settings remain untouched.
     update = SignalScoutConfigUpdateSerializer(
         config,
-        data=tunables,
+        data=update_data,
         partial=True,
         context=serializer_context,
     )

--- a/products/signals/backend/tasks.py
+++ b/products/signals/backend/tasks.py
@@ -197,6 +197,7 @@ def deliver_scout_slack_thread_replies(
     chunk_offset: int,
     attempt: int = 1,
     report_id: str | None = None,
+    report_revision: str | None = None,
 ) -> None:
     """Continue a rate-limited report thread without holding or retrying the lead-message worker."""
     team = Team.objects.only("project_id").get(id=team_id)
@@ -234,12 +235,13 @@ def deliver_scout_slack_thread_replies(
                 "chunk_offset": offset,
                 "attempt": attempt + 1,
                 **({"report_id": report_id} if report_id is not None else {}),
+                **({"report_revision": report_revision} if report_revision is not None else {}),
             },
             countdown=countdown,
         )
 
     if report_id is not None:
-        report = SignalReport.objects.filter(id=report_id, team_id=team_id).only("status").first()
+        report = SignalReport.objects.filter(id=report_id, team_id=team_id).only("status", "updated_at").first()
         if report is None:
             logger.info("scout_slack_report_thread_reply_report_missing", team_id=team_id, report_id=report_id)
             return
@@ -249,6 +251,13 @@ def deliver_scout_slack_thread_replies(
                 team_id=team_id,
                 report_id=report_id,
                 report_status=report.status,
+            )
+            return
+        if report_revision is not None and report.updated_at.isoformat() != report_revision:
+            logger.info(
+                "scout_slack_report_thread_reply_report_changed",
+                team_id=team_id,
+                report_id=report_id,
             )
             return
         if _newer_report_delivery_queued(report_id, delivery_id, integration_id, channel):
@@ -362,6 +371,7 @@ def deliver_scout_slack_output(
                         "fallback": fallback,
                         "chunk_offset": offset,
                         "report_id": output_id,
+                        "report_revision": report.updated_at.isoformat(),
                     },
                     countdown=countdown,
                 )

--- a/products/signals/backend/tasks.py
+++ b/products/signals/backend/tasks.py
@@ -16,6 +16,7 @@ from posthog.egress.github.transport import GitHubEgressBudgetExhausted, GitHubR
 from posthog.event_usage import groups
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team
+from posthog.models.integration import SlackIntegration
 from posthog.models.organization import BillingPeriod
 from posthog.models.scoping import with_team_scope
 from posthog.ph_client import ph_scoped_capture
@@ -43,6 +44,10 @@ from products.signals.backend.scout_harness.slack_delivery import (
     DELIVERABLE_REPORT_STATUSES,
     ScoutSlackOutputType,
     ScoutSlackPermanentDeliveryError,
+    _ensure_dm_recipient_eligible,
+    _post_scout_report_thread_replies,
+    _slack_channel_id,
+    _slack_integration_for_project,
     clear_latest_scout_report_delivery,
     mark_latest_scout_report_delivery,
     post_scout_emission_to_slack,
@@ -174,6 +179,76 @@ def _scout_slack_retry_countdown(exc: Exception, retries: int) -> int:
 
 
 @shared_task(
+    name="products.signals.backend.tasks.deliver_scout_slack_thread_replies",
+    ignore_result=True,
+    acks_late=True,
+    reject_on_worker_lost=True,
+)
+@with_team_scope(canonical=True)
+def deliver_scout_slack_thread_replies(
+    team_id: int,
+    integration_id: int,
+    channel: str,
+    thread_ts: str,
+    delivery_id: str,
+    reply_blocks: list[list[dict]],
+    fallback: str,
+    chunk_offset: int,
+    attempt: int = 1,
+) -> None:
+    """Continue a rate-limited report thread without holding or retrying the lead-message worker."""
+    team = Team.objects.only("project_id").get(id=team_id)
+    integration = _slack_integration_for_project(integration_id=integration_id, project_id=team.project_id)
+    slack = SlackIntegration(integration)
+    channel_id = _slack_channel_id(channel)
+    _ensure_dm_recipient_eligible(slack, channel_id)
+
+    def _schedule_retry(
+        countdown: int,
+        blocks: list[list[dict]],
+        offset: int,
+        retry_thread_ts: str,
+        retry_fallback: str,
+    ) -> None:
+        if attempt >= _SCOUT_SLACK_MAX_RETRIES:
+            logger.warning(
+                "scout_slack_report_thread_reply_exhausted",
+                team_id=team_id,
+                integration_id=integration_id,
+                channel=channel_id,
+                delivery_id=delivery_id,
+                chunk_index=offset,
+                attempts=attempt,
+            )
+            return
+        deliver_scout_slack_thread_replies.apply_async(
+            kwargs={
+                "team_id": team_id,
+                "integration_id": integration_id,
+                "channel": channel,
+                "thread_ts": retry_thread_ts,
+                "delivery_id": delivery_id,
+                "reply_blocks": blocks,
+                "fallback": retry_fallback,
+                "chunk_offset": offset,
+                "attempt": attempt + 1,
+            },
+            countdown=countdown,
+        )
+
+    _post_scout_report_thread_replies(
+        slack.client,
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+        delivery_id=delivery_id,
+        reply_blocks=reply_blocks,
+        fallback=fallback,
+        schedule_retry=_schedule_retry,
+        chunk_offset=chunk_offset,
+    )
+
+
+@shared_task(
     name="products.signals.backend.tasks.deliver_scout_slack_output",
     ignore_result=True,
     bind=True,
@@ -230,12 +305,35 @@ def deliver_scout_slack_output(
                     report_status=report.status,
                 )
                 return
+
+            def _schedule_thread_reply_retry(
+                countdown: int,
+                blocks: list[list[dict]],
+                offset: int,
+                thread_ts: str,
+                fallback: str,
+            ) -> None:
+                deliver_scout_slack_thread_replies.apply_async(
+                    kwargs={
+                        "team_id": team_id,
+                        "integration_id": integration_id,
+                        "channel": channel,
+                        "thread_ts": thread_ts,
+                        "delivery_id": delivery_id,
+                        "reply_blocks": blocks,
+                        "fallback": fallback,
+                        "chunk_offset": offset,
+                    },
+                    countdown=countdown,
+                )
+
             post_scout_report_to_slack(
                 report,
                 run,
                 delivery_id=delivery_id,
                 integration_id=integration_id,
                 channel=channel,
+                schedule_thread_reply_retry=_schedule_thread_reply_retry,
                 edit_note=edit_note,
                 thread_reports=thread_reports,
             )

--- a/products/signals/backend/tasks.py
+++ b/products/signals/backend/tasks.py
@@ -45,6 +45,7 @@ from products.signals.backend.scout_harness.slack_delivery import (
     ScoutSlackOutputType,
     ScoutSlackPermanentDeliveryError,
     _ensure_dm_recipient_eligible,
+    _newer_report_delivery_queued,
     _post_scout_report_thread_replies,
     _slack_channel_id,
     _slack_integration_for_project,
@@ -195,13 +196,13 @@ def deliver_scout_slack_thread_replies(
     fallback: str,
     chunk_offset: int,
     attempt: int = 1,
+    report_id: str | None = None,
 ) -> None:
     """Continue a rate-limited report thread without holding or retrying the lead-message worker."""
     team = Team.objects.only("project_id").get(id=team_id)
     integration = _slack_integration_for_project(integration_id=integration_id, project_id=team.project_id)
     slack = SlackIntegration(integration)
     channel_id = _slack_channel_id(channel)
-    _ensure_dm_recipient_eligible(slack, channel_id)
 
     def _schedule_retry(
         countdown: int,
@@ -232,9 +233,46 @@ def deliver_scout_slack_thread_replies(
                 "fallback": retry_fallback,
                 "chunk_offset": offset,
                 "attempt": attempt + 1,
+                **({"report_id": report_id} if report_id is not None else {}),
             },
             countdown=countdown,
         )
+
+    if report_id is not None:
+        report = SignalReport.objects.filter(id=report_id, team_id=team_id).only("status").first()
+        if report is None:
+            logger.info("scout_slack_report_thread_reply_report_missing", team_id=team_id, report_id=report_id)
+            return
+        if report.status not in DELIVERABLE_REPORT_STATUSES:
+            logger.info(
+                "scout_slack_report_thread_reply_report_not_surfaced",
+                team_id=team_id,
+                report_id=report_id,
+                report_status=report.status,
+            )
+            return
+        if _newer_report_delivery_queued(report_id, delivery_id, integration_id, channel):
+            logger.info(
+                "scout_slack_report_thread_reply_yielded_to_newer_delivery",
+                team_id=team_id,
+                report_id=report_id,
+                delivery_id=delivery_id,
+            )
+            return
+
+    try:
+        _ensure_dm_recipient_eligible(slack, channel_id)
+    except ScoutSlackPermanentDeliveryError:
+        raise
+    except Exception as exc:
+        _schedule_retry(
+            _scout_slack_retry_countdown(exc, attempt - 1),
+            reply_blocks,
+            chunk_offset,
+            thread_ts,
+            fallback,
+        )
+        return
 
     _post_scout_report_thread_replies(
         slack.client,
@@ -323,6 +361,7 @@ def deliver_scout_slack_output(
                         "reply_blocks": blocks,
                         "fallback": fallback,
                         "chunk_offset": offset,
+                        "report_id": output_id,
                     },
                     countdown=countdown,
                 )

--- a/products/signals/backend/test/test_scout_create_api.py
+++ b/products/signals/backend/test/test_scout_create_api.py
@@ -70,7 +70,7 @@ class TestSignalScoutCreateAPI(APIBaseTest):
         assert config.emit is False
         assert config.run_cron_schedule == "30 9 * * 1-5"
         assert config.output_destinations == {
-            "slack": {**payload["config"]["output_destinations"]["slack"], "thread_reports": False}
+            "slack": {**payload["config"]["output_destinations"]["slack"], "thread_reports": True}
         }
         assert response.json()["config"]["description"] == payload["description"]
 

--- a/products/signals/backend/test/test_scout_create_api.py
+++ b/products/signals/backend/test/test_scout_create_api.py
@@ -106,6 +106,42 @@ class TestSignalScoutCreateAPI(APIBaseTest):
         assert config.enabled is False
         assert config.emit is False
 
+    def test_matching_definition_retry_preserves_omitted_slack_thread_opt_out(self) -> None:
+        integration = Integration.objects.create(team=self.team, kind=Integration.IntegrationKind.SLACK)
+        payload = self._payload()
+        first = self.client.post(
+            self._url(),
+            data={
+                **payload,
+                "config": {
+                    "output_destinations": {
+                        "slack": {
+                            "integration_id": integration.id,
+                            "channel": "COLD|#old",
+                            "thread_reports": False,
+                        }
+                    }
+                },
+            },
+            format="json",
+        )
+        assert first.status_code == status.HTTP_201_CREATED, first.json()
+
+        response = self.client.post(
+            self._url(),
+            data={
+                **payload,
+                "config": {
+                    "output_destinations": {"slack": {"integration_id": integration.id, "channel": "CNEW|#new"}}
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        config = SignalScoutConfig.all_teams.get(team=self.team, skill_name=payload["name"])
+        assert config.output_destinations["slack"]["thread_reports"] is False
+
     @parameterized.expand(
         [
             # The create form sends an empty list by default, so a repeat of someone else's scout

--- a/products/signals/backend/test/test_scout_harness_api.py
+++ b/products/signals/backend/test/test_scout_harness_api.py
@@ -3495,6 +3495,34 @@ class TestScoutHarnessConfigAPI(APIBaseTest):
         assert config.emit is True
         assert config.run_interval_minutes == 120
 
+    def test_create_upsert_preserves_omitted_slack_thread_opt_out(self) -> None:
+        self._make_skill("signals-scout-fresh")
+        integration = Integration.objects.create(team=self.team, kind=Integration.IntegrationKind.SLACK)
+        SignalScoutConfig.objects.create(
+            team=self.team,
+            skill_name="signals-scout-fresh",
+            output_destinations={
+                "slack": {
+                    "integration_id": integration.id,
+                    "channel": "COLD|#old",
+                    "thread_reports": False,
+                }
+            },
+        )
+
+        response = self.client.post(
+            self._list_url(),
+            data={
+                "skill_name": "signals-scout-fresh",
+                "output_destinations": {"slack": {"integration_id": integration.id, "channel": "CNEW|#new"}},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        config = SignalScoutConfig.objects.get(team=self.team, skill_name="signals-scout-fresh")
+        assert config.output_destinations["slack"]["thread_reports"] is False
+
     _CAP_PATCH = "products.signals.backend.scout_harness.views.MAX_ENABLED_SCOUTS_PER_TEAM"
 
     def test_create_disabled_config_is_allowed_at_team_cap(self) -> None:

--- a/products/signals/backend/test/test_scout_harness_api.py
+++ b/products/signals/backend/test/test_scout_harness_api.py
@@ -2817,7 +2817,7 @@ class TestScoutHarnessConfigAPI(APIBaseTest):
         # A partial update skips the `thread_reports` default, so the flag reaches the reader
         # through the response only and the stored destination keeps the shape it was sent in.
         assert response.json()["output_destinations"] == {
-            "slack": {**destination["slack"], "users": None, "thread_reports": False},
+            "slack": {**destination["slack"], "users": None, "thread_reports": True},
             "webhook": None,
         }
         config.refresh_from_db()
@@ -2837,7 +2837,7 @@ class TestScoutHarnessConfigAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         # Reads render both target keys, null when unset; the stored JSON keeps only what was sent.
         assert response.json()["output_destinations"] == {
-            "slack": {**destination["slack"], "channel": None, "thread_reports": False},
+            "slack": {**destination["slack"], "channel": None, "thread_reports": True},
             "webhook": None,
         }
         config.refresh_from_db()

--- a/products/signals/backend/test/test_scout_harness_api.py
+++ b/products/signals/backend/test/test_scout_harness_api.py
@@ -2843,6 +2843,30 @@ class TestScoutHarnessConfigAPI(APIBaseTest):
         config.refresh_from_db()
         assert config.output_destinations == destination
 
+    def test_partial_update_slack_destination_preserves_explicit_thread_opt_out(self) -> None:
+        integration = Integration.objects.create(team=self.team, kind=Integration.IntegrationKind.SLACK)
+        config = SignalScoutConfig.objects.create(
+            team=self.team,
+            skill_name="signals-scout-foo",
+            output_destinations={
+                "slack": {
+                    "integration_id": integration.id,
+                    "channel": "CSCOUTS|#scout-findings",
+                    "thread_reports": False,
+                }
+            },
+        )
+
+        response = self.client.patch(
+            self._detail_url(str(config.id)),
+            data={"output_destinations": {"slack": {"integration_id": integration.id, "users": ["U0123ABC456|@andy"]}}},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        config.refresh_from_db()
+        assert config.output_destinations["slack"]["thread_reports"] is False
+
     @parameterized.expand(
         [
             ("missing_integration_scope", ["signal_scout:write"], status.HTTP_403_FORBIDDEN, "integration:read"),

--- a/products/signals/backend/test/test_scout_slack_delivery.py
+++ b/products/signals/backend/test/test_scout_slack_delivery.py
@@ -76,10 +76,10 @@ class TestGetScoutSlackDestination(SimpleTestCase):
     @parameterized.expand(
         [
             ("explicit_true", {"thread_reports": True}, True),
-            ("omitted_defaults_off", {}, False),
+            ("omitted_defaults_on", {}, True),
             ("explicit_false", {"thread_reports": False}, False),
-            # Only a real boolean True turns threading on; a truthy non-bool stays off.
-            ("truthy_non_bool_stays_off", {"thread_reports": "yes"}, False),
+            # Only a real boolean False turns threading off; a falsy non-bool stays on.
+            ("falsy_non_bool_stays_on", {"thread_reports": "no"}, True),
         ]
     )
     def test_parses_thread_reports(self, _name: str, extra: dict, expected: bool) -> None:

--- a/products/signals/backend/test/test_scout_slack_delivery.py
+++ b/products/signals/backend/test/test_scout_slack_delivery.py
@@ -410,7 +410,10 @@ class TestScoutSlackDelivery(BaseTest):
         fake_client = MagicMock()
         fake_client.chat_postMessage.return_value = {"ts": "1785418710.000600"}
 
-        with patch("products.signals.backend.scout_harness.slack_delivery.SlackIntegration") as slack_integration:
+        with (
+            patch("products.signals.backend.scout_harness.slack_delivery.SlackIntegration") as slack_integration,
+            patch("products.signals.backend.scout_harness.slack_delivery.time.sleep") as sleep,
+        ):
             slack_integration.return_value.client = fake_client
             deliver_scout_slack_output.run(
                 self.team.id,
@@ -441,6 +444,7 @@ class TestScoutSlackDelivery(BaseTest):
         assert "Second" not in first_reply["blocks"][0]["text"]
         assert "Second" in second_reply["blocks"][0]["text"]
         assert calls[3].kwargs["blocks"][0]["type"] == "context"
+        sleep.assert_called_once_with(1)
 
     def test_threaded_report_without_section_labels_posts_a_single_message(self) -> None:
         # Headings and bold labels are the seams threading splits on. A summary with neither has
@@ -514,6 +518,7 @@ class TestScoutSlackDelivery(BaseTest):
         assert apply_async.call_args.kwargs["countdown"] == 120
         retry_kwargs = apply_async.call_args.kwargs["kwargs"]
         assert retry_kwargs["report_id"] == str(report.id)
+        assert retry_kwargs["report_revision"] == report.updated_at.isoformat()
         assert retry_kwargs["chunk_offset"] == 0
         assert len(retry_kwargs["reply_blocks"]) == 2
         assert "First body" in retry_kwargs["reply_blocks"][0][0]["text"]
@@ -525,7 +530,7 @@ class TestScoutSlackDelivery(BaseTest):
 
         assert _slack_retry_after_seconds(error) == 3600
 
-    @parameterized.expand([("suppressed",), ("newer_delivery",)])
+    @parameterized.expand([("suppressed",), ("newer_delivery",), ("edited",)])
     def test_delayed_thread_replies_revalidate_report(self, state: str) -> None:
         report = SignalReport.objects.create(
             team=self.team,
@@ -536,12 +541,16 @@ class TestScoutSlackDelivery(BaseTest):
         integration = Integration.objects.create(team=self.team, kind=Integration.IntegrationKind.SLACK)
         delivery_id = "01864f4c-6957-7d3f-8d85-1d775e527265"
         channel = "CSCOUTS|#scout-findings"
+        report_revision = report.updated_at.isoformat()
         if state == "suppressed":
             SignalReport.objects.filter(id=report.id).update(status=SignalReport.Status.SUPPRESSED)
-        else:
+        elif state == "newer_delivery":
             mark_latest_scout_report_delivery(
                 str(report.id), "0d1b6f3a-1d3f-4a6f-9d2c-7b3e2f1a9c44", integration.id, channel
             )
+        else:
+            report.title = "Redacted"
+            report.save()
 
         with patch("products.signals.backend.tasks.SlackIntegration") as slack_integration:
             deliver_scout_slack_thread_replies.run(
@@ -554,6 +563,7 @@ class TestScoutSlackDelivery(BaseTest):
                 "stale",
                 0,
                 report_id=str(report.id),
+                report_revision=report_revision,
             )
 
         slack_integration.return_value.client.chat_postMessage.assert_not_called()
@@ -586,13 +596,52 @@ class TestScoutSlackDelivery(BaseTest):
                 "remaining",
                 0,
                 report_id=str(report.id),
+                report_revision=report.updated_at.isoformat(),
             )
 
         assert apply_async.call_args.kwargs["countdown"] == 120
         retry_kwargs = apply_async.call_args.kwargs["kwargs"]
         assert retry_kwargs["report_id"] == str(report.id)
+        assert retry_kwargs["report_revision"] == report.updated_at.isoformat()
         assert retry_kwargs["attempt"] == 2
         slack_integration.return_value.client.chat_postMessage.assert_not_called()
+
+    def test_thread_reply_transport_failure_schedules_a_retry(self) -> None:
+        emission = self._make_emission()
+        report = SignalReport.objects.create(
+            team=self.team,
+            status=SignalReport.Status.READY,
+            title="Checkout failures",
+            summary="Lead line.\n\n## First\nFirst body.\n\n## Second\nSecond body.",
+        )
+        integration = Integration.objects.create(team=self.team, kind=Integration.IntegrationKind.SLACK)
+        fake_client = MagicMock()
+        fake_client.chat_postMessage.side_effect = [
+            {"ts": "1785418710.000800"},
+            ConnectionError("Slack unavailable"),
+            {"ts": "1785418710.000801"},
+        ]
+
+        with (
+            patch("products.signals.backend.scout_harness.slack_delivery.SlackIntegration") as slack_integration,
+            patch("products.signals.backend.tasks.deliver_scout_slack_thread_replies.apply_async") as apply_async,
+        ):
+            slack_integration.return_value.client = fake_client
+            deliver_scout_slack_output.run(
+                self.team.id,
+                "report",
+                str(report.id),
+                str(emission.scout_run_id),
+                "01864f4c-6957-7d3f-8d85-1d775e527265",
+                integration.id,
+                "CSCOUTS|#scout-findings",
+                thread_reports=True,
+            )
+
+        assert apply_async.call_args.kwargs["countdown"] == 60
+        retry_kwargs = apply_async.call_args.kwargs["kwargs"]
+        assert retry_kwargs["chunk_offset"] == 0
+        assert len(retry_kwargs["reply_blocks"]) == 2
 
     def test_reply_posted_regardless_of_ai_approval(self) -> None:
         # The Slack follow-up invite is unconditional — no AI-approval gate on scout output.

--- a/products/signals/backend/test/test_scout_slack_delivery.py
+++ b/products/signals/backend/test/test_scout_slack_delivery.py
@@ -24,6 +24,7 @@ from products.signals.backend.scout_harness.slack_delivery import (
     ScoutSlackDestination,
     ScoutSlackPermanentDeliveryError,
     _latest_report_delivery_key,
+    _slack_retry_after_seconds,
     get_scout_slack_destination,
     mark_latest_scout_report_delivery,
     post_scout_emission_to_slack,
@@ -473,7 +474,7 @@ class TestScoutSlackDelivery(BaseTest):
         assert "second one" in markdown_texts[0]
         assert calls[1].kwargs["blocks"][0]["type"] == "context"
 
-    def test_threaded_report_retries_a_rate_limited_reply(self) -> None:
+    def test_threaded_report_schedules_a_rate_limited_reply(self) -> None:
         emission = self._make_emission()
         report = SignalReport.objects.create(
             team=self.team,
@@ -483,18 +484,16 @@ class TestScoutSlackDelivery(BaseTest):
         )
         integration = Integration.objects.create(team=self.team, kind=Integration.IntegrationKind.SLACK)
         fake_client = MagicMock()
-        rate_limited = FakeSlackResponse({"error": "ratelimited"}, headers={"Retry-After": "2"})
+        rate_limited = FakeSlackResponse({"error": "ratelimited"}, headers={"retry-after": "120"})
         fake_client.chat_postMessage.side_effect = [
             {"ts": "1785418710.000800"},
             SlackApiError(message="rate limited", response=rate_limited),
             {"ts": "1785418710.000801"},
-            {"ts": "1785418710.000802"},
-            {"ts": "1785418710.000803"},
         ]
 
         with (
             patch("products.signals.backend.scout_harness.slack_delivery.SlackIntegration") as slack_integration,
-            patch("products.signals.backend.scout_harness.slack_delivery.time.sleep") as sleep,
+            patch("products.signals.backend.tasks.deliver_scout_slack_thread_replies.apply_async") as apply_async,
         ):
             slack_integration.return_value.client = fake_client
             deliver_scout_slack_output.run(
@@ -508,12 +507,18 @@ class TestScoutSlackDelivery(BaseTest):
                 thread_reports=True,
             )
 
-        sleep.assert_called_once_with(2)
-        first_attempt = fake_client.chat_postMessage.call_args_list[1].kwargs
-        retry = fake_client.chat_postMessage.call_args_list[2].kwargs
-        assert retry == first_attempt
-        assert "First body" in retry["blocks"][0]["text"]
-        assert fake_client.chat_postMessage.call_count == 5
+        assert apply_async.call_args.kwargs["countdown"] == 120
+        retry_kwargs = apply_async.call_args.kwargs["kwargs"]
+        assert retry_kwargs["chunk_offset"] == 0
+        assert len(retry_kwargs["reply_blocks"]) == 2
+        assert "First body" in retry_kwargs["reply_blocks"][0][0]["text"]
+        assert fake_client.chat_postMessage.call_count == 3
+
+    def test_thread_reply_retry_after_is_bounded_to_one_hour(self) -> None:
+        response = FakeSlackResponse({"error": "ratelimited"}, headers={"Retry-After": "7200"})
+        error = SlackApiError(message="rate limited", response=response)
+
+        assert _slack_retry_after_seconds(error) == 3600
 
     def test_reply_posted_regardless_of_ai_approval(self) -> None:
         # The Slack follow-up invite is unconditional — no AI-approval gate on scout output.

--- a/products/signals/backend/test/test_scout_slack_delivery.py
+++ b/products/signals/backend/test/test_scout_slack_delivery.py
@@ -473,6 +473,48 @@ class TestScoutSlackDelivery(BaseTest):
         assert "second one" in markdown_texts[0]
         assert calls[1].kwargs["blocks"][0]["type"] == "context"
 
+    def test_threaded_report_retries_a_rate_limited_reply(self) -> None:
+        emission = self._make_emission()
+        report = SignalReport.objects.create(
+            team=self.team,
+            status=SignalReport.Status.READY,
+            title="Checkout failures",
+            summary="Lead line.\n\n## First\nFirst body.\n\n## Second\nSecond body.",
+        )
+        integration = Integration.objects.create(team=self.team, kind=Integration.IntegrationKind.SLACK)
+        fake_client = MagicMock()
+        rate_limited = FakeSlackResponse({"error": "ratelimited"}, headers={"Retry-After": "2"})
+        fake_client.chat_postMessage.side_effect = [
+            {"ts": "1785418710.000800"},
+            SlackApiError(message="rate limited", response=rate_limited),
+            {"ts": "1785418710.000801"},
+            {"ts": "1785418710.000802"},
+            {"ts": "1785418710.000803"},
+        ]
+
+        with (
+            patch("products.signals.backend.scout_harness.slack_delivery.SlackIntegration") as slack_integration,
+            patch("products.signals.backend.scout_harness.slack_delivery.time.sleep") as sleep,
+        ):
+            slack_integration.return_value.client = fake_client
+            deliver_scout_slack_output.run(
+                self.team.id,
+                "report",
+                str(report.id),
+                str(emission.scout_run_id),
+                "01864f4c-6957-7d3f-8d85-1d775e527265",
+                integration.id,
+                "CSCOUTS|#scout-findings",
+                thread_reports=True,
+            )
+
+        sleep.assert_called_once_with(2)
+        first_attempt = fake_client.chat_postMessage.call_args_list[1].kwargs
+        retry = fake_client.chat_postMessage.call_args_list[2].kwargs
+        assert retry == first_attempt
+        assert "First body" in retry["blocks"][0]["text"]
+        assert fake_client.chat_postMessage.call_count == 5
+
     def test_reply_posted_regardless_of_ai_approval(self) -> None:
         # The Slack follow-up invite is unconditional — no AI-approval gate on scout output.
         self.organization.is_ai_data_processing_approved = False

--- a/products/signals/backend/test/test_scout_slack_delivery.py
+++ b/products/signals/backend/test/test_scout_slack_delivery.py
@@ -30,7 +30,11 @@ from products.signals.backend.scout_harness.slack_delivery import (
     post_scout_emission_to_slack,
 )
 from products.signals.backend.scout_harness.slack_delivery_queue import queue_configured_scout_slack_delivery
-from products.signals.backend.tasks import deliver_scout_slack_output, enqueue_scout_slack_delivery
+from products.signals.backend.tasks import (
+    deliver_scout_slack_output,
+    deliver_scout_slack_thread_replies,
+    enqueue_scout_slack_delivery,
+)
 
 
 class FakeSlackResponse(dict):
@@ -509,6 +513,7 @@ class TestScoutSlackDelivery(BaseTest):
 
         assert apply_async.call_args.kwargs["countdown"] == 120
         retry_kwargs = apply_async.call_args.kwargs["kwargs"]
+        assert retry_kwargs["report_id"] == str(report.id)
         assert retry_kwargs["chunk_offset"] == 0
         assert len(retry_kwargs["reply_blocks"]) == 2
         assert "First body" in retry_kwargs["reply_blocks"][0][0]["text"]
@@ -519,6 +524,75 @@ class TestScoutSlackDelivery(BaseTest):
         error = SlackApiError(message="rate limited", response=response)
 
         assert _slack_retry_after_seconds(error) == 3600
+
+    @parameterized.expand([("suppressed",), ("newer_delivery",)])
+    def test_delayed_thread_replies_revalidate_report(self, state: str) -> None:
+        report = SignalReport.objects.create(
+            team=self.team,
+            status=SignalReport.Status.READY,
+            title="Checkout failures",
+            summary="Checkout failed",
+        )
+        integration = Integration.objects.create(team=self.team, kind=Integration.IntegrationKind.SLACK)
+        delivery_id = "01864f4c-6957-7d3f-8d85-1d775e527265"
+        channel = "CSCOUTS|#scout-findings"
+        if state == "suppressed":
+            SignalReport.objects.filter(id=report.id).update(status=SignalReport.Status.SUPPRESSED)
+        else:
+            mark_latest_scout_report_delivery(
+                str(report.id), "0d1b6f3a-1d3f-4a6f-9d2c-7b3e2f1a9c44", integration.id, channel
+            )
+
+        with patch("products.signals.backend.tasks.SlackIntegration") as slack_integration:
+            deliver_scout_slack_thread_replies.run(
+                self.team.id,
+                integration.id,
+                channel,
+                "1785418710.000800",
+                delivery_id,
+                [[{"type": "markdown", "text": "stale"}]],
+                "stale",
+                0,
+                report_id=str(report.id),
+            )
+
+        slack_integration.return_value.client.chat_postMessage.assert_not_called()
+
+    def test_delayed_dm_thread_replies_retry_recipient_lookup_failure(self) -> None:
+        report = SignalReport.objects.create(
+            team=self.team,
+            status=SignalReport.Status.READY,
+            title="Checkout failures",
+            summary="Checkout failed",
+        )
+        integration = Integration.objects.create(team=self.team, kind=Integration.IntegrationKind.SLACK)
+        error = SlackApiError(
+            message="rate limited",
+            response=FakeSlackResponse({"error": "ratelimited"}, headers={"retry-after": "120"}),
+        )
+
+        with (
+            patch("products.signals.backend.tasks.SlackIntegration") as slack_integration,
+            patch.object(deliver_scout_slack_thread_replies, "apply_async") as apply_async,
+        ):
+            slack_integration.return_value.get_user_by_id.side_effect = error
+            deliver_scout_slack_thread_replies.run(
+                self.team.id,
+                integration.id,
+                "U123ABC45|@andy",
+                "1785418710.000800",
+                "01864f4c-6957-7d3f-8d85-1d775e527265",
+                [[{"type": "markdown", "text": "remaining"}]],
+                "remaining",
+                0,
+                report_id=str(report.id),
+            )
+
+        assert apply_async.call_args.kwargs["countdown"] == 120
+        retry_kwargs = apply_async.call_args.kwargs["kwargs"]
+        assert retry_kwargs["report_id"] == str(report.id)
+        assert retry_kwargs["attempt"] == 2
+        slack_integration.return_value.client.chat_postMessage.assert_not_called()
 
     def test_reply_posted_regardless_of_ai_approval(self) -> None:
         # The Slack follow-up invite is unconditional — no AI-approval gate on scout output.

--- a/products/signals/backend/test/test_signal_scout_models.py
+++ b/products/signals/backend/test/test_signal_scout_models.py
@@ -121,7 +121,7 @@ class TestSignalScoutModels(_ScoutTeamScopedTestMixin, BaseTest):
             integration_id=17,
             channel="CSCOUTS|#scout-findings",
             edit_note=None,
-            thread_reports=False,
+            thread_reports=True,
         )
 
     def test_record_emit_enqueues_dm_destination_per_recipient(self) -> None:
@@ -164,7 +164,7 @@ class TestSignalScoutModels(_ScoutTeamScopedTestMixin, BaseTest):
                 integration_id=17,
                 channel="U1|@andy",
                 edit_note=None,
-                thread_reports=False,
+                thread_reports=True,
             ),
             call(
                 team_id=self.team.id,
@@ -176,7 +176,7 @@ class TestSignalScoutModels(_ScoutTeamScopedTestMixin, BaseTest):
                 integration_id=17,
                 channel="U2|@robbie",
                 edit_note=None,
-                thread_reports=False,
+                thread_reports=True,
             ),
         ]
 

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -2451,6 +2451,38 @@ export interface SignalScoutConfigCreateApi {
  */
 export type PatchedSignalScoutConfigUpdateApiStructuredOutputSchema = { [key: string]: unknown } | null
 
+export interface SignalScoutSlackDestinationUpdateApi {
+    /**
+     * ID of the Slack integration whose bot posts this scout's findings and reports.
+     * @minimum 1
+     */
+    integration_id: number
+    /**
+     * Slack channel target in the channel picker's `channel_id|#channel-name` format. Null while choosing a channel; no messages are sent until a channel or user is set.
+     * @maxLength 255
+     * @nullable
+     */
+    channel?: string | null
+    /**
+     * Slack members to send output to as direct messages, each in `member_id|@display-name` format (a bare member ID like `U0123ABC456` also works). Each member gets their own DM from the PostHog app; at most 5. Set either this or `channel`, not both. Useful for personal scouts where a DM beats a channel.
+     * @minItems 1
+     * @maxItems 5
+     * @nullable
+     * @items.maxLength 255
+     * @items.pattern ^[UW][A-Z0-9]{4,}\s*(\|.*)?$
+     */
+    users?: string[] | null
+    /** When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post. */
+    thread_reports?: boolean
+}
+
+export interface SignalScoutOutputDestinationsUpdateApi {
+    /** Slack destination for each emitted scout finding or report. Null or omitted disables Slack delivery. */
+    slack?: SignalScoutSlackDestinationUpdateApi | null
+    /** The CDP destination another product provisioned for this scout's reports. Null or omitted means no webhook. Unlike Slack, Signals does not deliver this itself: the reference lives here so the owning product can manage the destination's lifecycle. */
+    webhook?: SignalScoutWebhookDestinationApi | null
+}
+
 /**
  * Editable display name, schedule, enablement, and emit posture for one scout config.
  */
@@ -2477,7 +2509,7 @@ export interface PatchedSignalScoutConfigUpdateApi {
      */
     run_cron_schedule?: string | null
     /** Destinations that receive each finding or report this scout emits. Pass an empty object to disable delivery. */
-    output_destinations?: SignalScoutOutputDestinationsApi
+    output_destinations?: SignalScoutOutputDestinationsUpdateApi
     /**
      * Optional JSON Schema (draft 2020-12) describing ONE structured record this scout produces via `scout-record-output` — e.g. a per-report quality judgment (`{"type": "object", "properties": {"verdict": {"enum": ["good", "bad", "unsure"]}, "reason": {"type": "string"}}, "required": ["verdict", "reason"]}`). The root must be `"type": "object"`. Setting a schema turns the structured-output channel on: the run prompt renders the schema and every submitted record is validated against it and recorded in the project as a `$scout_structured_output` event, queryable like any event. The channel also requires emit — a dry-run scout has nowhere to record to. Cardinality is the scout's call (one record per run, one per judged entity, ...). Null = channel off. Setting a schema requires skill-authoring authorization (the `llm_skill:write` scope and skill editor access) since the scout reads it verbatim in its prompt; clearing it needs only the config write. Records validate against the schema in force when the run was dispatched.
      * @nullable

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -1999,7 +1999,7 @@ export interface SignalScoutSlackDestinationApi {
      * @items.pattern ^[UW][A-Z0-9]{4,}\s*(\|.*)?$
      */
     users?: string[] | null
-    /** When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. Off by default, and it does not change how findings post. */
+    /** When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post. */
     thread_reports?: boolean
 }
 

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -1999,7 +1999,7 @@ export interface SignalScoutSlackDestinationApi {
      * @items.pattern ^[UW][A-Z0-9]{4,}\s*(\|.*)?$
      */
     users?: string[] | null
-    /** When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post. */
+    /** When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post. */
     thread_reports?: boolean
 }
 

--- a/products/signals/frontend/generated/api.zod.ts
+++ b/products/signals/frontend/generated/api.zod.ts
@@ -499,7 +499,7 @@ export const SignalsScoutCreateBody = /* @__PURE__ */ zod
                                             signalsScoutCreateBodyConfigOneOutputDestinationsOneSlackOneThreadReportsDefault
                                         )
                                         .describe(
-                                            "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post."
+                                            "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post."
                                         ),
                                 }),
                                 zod.null(),
@@ -699,7 +699,7 @@ export const SignalsScoutConfigCreateBody = /* @__PURE__ */ zod
                                 .boolean()
                                 .default(signalsScoutConfigCreateBodyOutputDestinationsOneSlackOneThreadReportsDefault)
                                 .describe(
-                                    "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post."
+                                    "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post."
                                 ),
                         }),
                         zod.null(),
@@ -887,7 +887,7 @@ export const SignalsScoutConfigUpdateBody = /* @__PURE__ */ zod
                                 .boolean()
                                 .default(signalsScoutConfigUpdateBodyOutputDestinationsOneSlackOneThreadReportsDefault)
                                 .describe(
-                                    "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post."
+                                    "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post."
                                 ),
                         }),
                         zod.null(),

--- a/products/signals/frontend/generated/api.zod.ts
+++ b/products/signals/frontend/generated/api.zod.ts
@@ -391,7 +391,7 @@ export const signalsScoutCreateBodyConfigOneOutputDestinationsOneSlackOneUsersIt
 )
 export const signalsScoutCreateBodyConfigOneOutputDestinationsOneSlackOneUsersMax = 5
 
-export const signalsScoutCreateBodyConfigOneOutputDestinationsOneSlackOneThreadReportsDefault = false
+export const signalsScoutCreateBodyConfigOneOutputDestinationsOneSlackOneThreadReportsDefault = true
 export const signalsScoutCreateBodyConfigOneRunCronScheduleMax = 100
 
 export const signalsScoutCreateBodyConfigOneModelMax = 200
@@ -499,7 +499,7 @@ export const SignalsScoutCreateBody = /* @__PURE__ */ zod
                                             signalsScoutCreateBodyConfigOneOutputDestinationsOneSlackOneThreadReportsDefault
                                         )
                                         .describe(
-                                            "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. Off by default, and it does not change how findings post."
+                                            "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post."
                                         ),
                                 }),
                                 zod.null(),
@@ -636,7 +636,7 @@ export const signalsScoutConfigCreateBodyOutputDestinationsOneSlackOneUsersItemR
 )
 export const signalsScoutConfigCreateBodyOutputDestinationsOneSlackOneUsersMax = 5
 
-export const signalsScoutConfigCreateBodyOutputDestinationsOneSlackOneThreadReportsDefault = false
+export const signalsScoutConfigCreateBodyOutputDestinationsOneSlackOneThreadReportsDefault = true
 export const signalsScoutConfigCreateBodyRunCronScheduleMax = 100
 
 export const signalsScoutConfigCreateBodyModelMax = 200
@@ -699,7 +699,7 @@ export const SignalsScoutConfigCreateBody = /* @__PURE__ */ zod
                                 .boolean()
                                 .default(signalsScoutConfigCreateBodyOutputDestinationsOneSlackOneThreadReportsDefault)
                                 .describe(
-                                    "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. Off by default, and it does not change how findings post."
+                                    "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post."
                                 ),
                         }),
                         zod.null(),
@@ -811,7 +811,7 @@ export const signalsScoutConfigUpdateBodyOutputDestinationsOneSlackOneUsersItemR
 )
 export const signalsScoutConfigUpdateBodyOutputDestinationsOneSlackOneUsersMax = 5
 
-export const signalsScoutConfigUpdateBodyOutputDestinationsOneSlackOneThreadReportsDefault = false
+export const signalsScoutConfigUpdateBodyOutputDestinationsOneSlackOneThreadReportsDefault = true
 export const signalsScoutConfigUpdateBodyModelMax = 200
 
 export const signalsScoutConfigUpdateBodyTagsMax = 10
@@ -887,7 +887,7 @@ export const SignalsScoutConfigUpdateBody = /* @__PURE__ */ zod
                                 .boolean()
                                 .default(signalsScoutConfigUpdateBodyOutputDestinationsOneSlackOneThreadReportsDefault)
                                 .describe(
-                                    "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. Off by default, and it does not change how findings post."
+                                    "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post."
                                 ),
                         }),
                         zod.null(),

--- a/products/signals/frontend/generated/api.zod.ts
+++ b/products/signals/frontend/generated/api.zod.ts
@@ -811,7 +811,6 @@ export const signalsScoutConfigUpdateBodyOutputDestinationsOneSlackOneUsersItemR
 )
 export const signalsScoutConfigUpdateBodyOutputDestinationsOneSlackOneUsersMax = 5
 
-export const signalsScoutConfigUpdateBodyOutputDestinationsOneSlackOneThreadReportsDefault = true
 export const signalsScoutConfigUpdateBodyModelMax = 200
 
 export const signalsScoutConfigUpdateBodyTagsMax = 10
@@ -885,7 +884,7 @@ export const SignalsScoutConfigUpdateBody = /* @__PURE__ */ zod
                                 ),
                             thread_reports: zod
                                 .boolean()
-                                .default(signalsScoutConfigUpdateBodyOutputDestinationsOneSlackOneThreadReportsDefault)
+                                .optional()
                                 .describe(
                                     "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post."
                                 ),

--- a/products/signals/frontend/inbox/components/config/scouts/ScoutSlackDestination.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutSlackDestination.tsx
@@ -77,7 +77,7 @@ export function ScoutSlackDestination({
             slack: {
                 integration_id: selectedIntegration.id,
                 channel,
-                thread_reports: destination?.thread_reports ?? false,
+                thread_reports: destination?.thread_reports ?? true,
             },
         })
     }
@@ -207,7 +207,7 @@ export function ScoutSlackDestination({
                             {configuredIntegration && hasChannel ? (
                                 <LemonSwitch
                                     size="small"
-                                    checked={destination?.thread_reports ?? false}
+                                    checked={destination?.thread_reports ?? true}
                                     onChange={setThreadReports}
                                     disabledReason={disabledReason}
                                     label="Post reports as a thread"

--- a/products/signals/frontend/inbox/components/config/scouts/ScoutSlackDestination.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutSlackDestination.tsx
@@ -47,6 +47,7 @@ export function ScoutSlackDestination({
     const hasChannel = Boolean(destination?.channel)
     const hasUsers = Boolean(destination?.users?.length)
     const hasTarget = hasChannel || hasUsers
+    const threadReports = destination?.thread_reports ?? true
 
     // The toggle is view state only: switching it must never write, or an exploratory click would
     // wipe a live destination. The saved target is replaced only when a new target is picked.
@@ -56,7 +57,7 @@ export function ScoutSlackDestination({
     const selectWorkspace = (integrationId: number): void => {
         // Switching workspace clears the target, so pin the toggle to the mode the user was in.
         setPendingMode(mode)
-        onChange({ slack: { integration_id: integrationId, channel: null } })
+        onChange({ slack: { integration_id: integrationId, channel: null, thread_reports: threadReports } })
     }
 
     const selectMode = (nextMode: SlackTargetMode): void => {
@@ -77,7 +78,7 @@ export function ScoutSlackDestination({
             slack: {
                 integration_id: selectedIntegration.id,
                 channel,
-                thread_reports: destination?.thread_reports ?? true,
+                thread_reports: threadReports,
             },
         })
     }
@@ -110,11 +111,17 @@ export function ScoutSlackDestination({
             // Removing the last recipient empties the saved destination; without pinning the mode
             // the toggle would fall back to its channel default and swap the picker mid-edit.
             setPendingMode('dm')
-            onChange({ slack: { integration_id: selectedIntegration.id, channel: null } })
+            onChange({
+                slack: { integration_id: selectedIntegration.id, channel: null, thread_reports: threadReports },
+            })
             return
         }
         onChange({
-            slack: { integration_id: selectedIntegration.id, users: users.slice(0, MAX_DM_RECIPIENTS) },
+            slack: {
+                integration_id: selectedIntegration.id,
+                users: users.slice(0, MAX_DM_RECIPIENTS),
+                thread_reports: threadReports,
+            },
         })
     }
 
@@ -207,7 +214,7 @@ export function ScoutSlackDestination({
                             {configuredIntegration && hasChannel ? (
                                 <LemonSwitch
                                     size="small"
-                                    checked={destination?.thread_reports ?? true}
+                                    checked={threadReports}
                                     onChange={setThreadReports}
                                     disabledReason={disabledReason}
                                     label="Post reports as a thread"

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -68903,7 +68903,7 @@ export namespace Schemas {
          * @items.pattern ^[UW][A-Z0-9]{4,}\s*(\|.*)?$
          */
       users?: string[] | null;
-      /** When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post. */
+      /** When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post. */
       thread_reports?: boolean;
     }
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -68903,7 +68903,7 @@ export namespace Schemas {
          * @items.pattern ^[UW][A-Z0-9]{4,}\s*(\|.*)?$
          */
       users?: string[] | null;
-      /** When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. Off by default, and it does not change how findings post. */
+      /** When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post. */
       thread_reports?: boolean;
     }
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -68882,7 +68882,7 @@ export namespace Schemas {
      */
     export type PatchedSignalScoutConfigUpdateStructuredOutputSchema = { [key: string]: unknown } | null;
 
-    export interface SignalScoutSlackDestination {
+    export interface SignalScoutSlackDestinationUpdate {
       /**
          * ID of the Slack integration whose bot posts this scout's findings and reports.
          * @minimum 1
@@ -68912,9 +68912,9 @@ export namespace Schemas {
       hog_function_id: string;
     }
 
-    export interface SignalScoutOutputDestinations {
+    export interface SignalScoutOutputDestinationsUpdate {
       /** Slack destination for each emitted scout finding or report. Null or omitted disables Slack delivery. */
-      slack?: SignalScoutSlackDestination | null;
+      slack?: SignalScoutSlackDestinationUpdate | null;
       /** The CDP destination another product provisioned for this scout's reports. Null or omitted means no webhook. Unlike Slack, Signals does not deliver this itself: the reference lives here so the owning product can manage the destination's lifecycle. */
       webhook?: SignalScoutWebhookDestination | null;
     }
@@ -68957,7 +68957,7 @@ export namespace Schemas {
          */
       run_cron_schedule?: string | null;
       /** Destinations that receive each finding or report this scout emits. Pass an empty object to disable delivery. */
-      output_destinations?: SignalScoutOutputDestinations;
+      output_destinations?: SignalScoutOutputDestinationsUpdate;
       /**
          * Optional JSON Schema (draft 2020-12) describing ONE structured record this scout produces via `scout-record-output` — e.g. a per-report quality judgment (`{"type": "object", "properties": {"verdict": {"enum": ["good", "bad", "unsure"]}, "reason": {"type": "string"}}, "required": ["verdict", "reason"]}`). The root must be `"type": "object"`. Setting a schema turns the structured-output channel on: the run prompt renders the schema and every submitted record is validated against it and recorded in the project as a `$scout_structured_output` event, queryable like any event. The channel also requires emit — a dry-run scout has nowhere to record to. Cardinality is the scout's call (one record per run, one per judged entity, ...). Null = channel off. Setting a schema requires skill-authoring authorization (the `llm_skill:write` scope and skill editor access) since the scout reads it verbatim in its prompt; clearing it needs only the config write. Records validate against the schema in force when the run was dispatched.
          * @nullable
@@ -78803,6 +78803,38 @@ export namespace Schemas {
       readonly sessions_without_user: number;
       /** Trailing window the counts cover, in days. */
       readonly window_days: number;
+    }
+
+    export interface SignalScoutSlackDestination {
+      /**
+         * ID of the Slack integration whose bot posts this scout's findings and reports.
+         * @minimum 1
+         */
+      integration_id: number;
+      /**
+         * Slack channel target in the channel picker's `channel_id|#channel-name` format. Null while choosing a channel; no messages are sent until a channel or user is set.
+         * @maxLength 255
+         * @nullable
+         */
+      channel?: string | null;
+      /**
+         * Slack members to send output to as direct messages, each in `member_id|@display-name` format (a bare member ID like `U0123ABC456` also works). Each member gets their own DM from the PostHog app; at most 5. Set either this or `channel`, not both. Useful for personal scouts where a DM beats a channel.
+         * @minItems 1
+         * @maxItems 5
+         * @nullable
+         * @items.maxLength 255
+         * @items.pattern ^[UW][A-Z0-9]{4,}\s*(\|.*)?$
+         */
+      users?: string[] | null;
+      /** When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post. */
+      thread_reports?: boolean;
+    }
+
+    export interface SignalScoutOutputDestinations {
+      /** Slack destination for each emitted scout finding or report. Null or omitted disables Slack delivery. */
+      slack?: SignalScoutSlackDestination | null;
+      /** The CDP destination another product provisioned for this scout's reports. Null or omitted means no webhook. Unlike Slack, Signals does not deliver this itself: the reference lives here so the owning product can manage the destination's lifecycle. */
+      webhook?: SignalScoutWebhookDestination | null;
     }
 
     /**

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -543,7 +543,7 @@ export const signalsScoutCreateBodyConfigOneOutputDestinationsOneSlackOneUsersIt
 )
 export const signalsScoutCreateBodyConfigOneOutputDestinationsOneSlackOneUsersMax = 5
 
-export const signalsScoutCreateBodyConfigOneOutputDestinationsOneSlackOneThreadReportsDefault = false
+export const signalsScoutCreateBodyConfigOneOutputDestinationsOneSlackOneThreadReportsDefault = true
 export const signalsScoutCreateBodyConfigOneRunCronScheduleMax = 100
 
 export const signalsScoutCreateBodyConfigOneModelMax = 200
@@ -649,7 +649,7 @@ export const SignalsScoutCreateBody = () => zod
                                             signalsScoutCreateBodyConfigOneOutputDestinationsOneSlackOneThreadReportsDefault
                                         )
                                         .describe(
-                                            "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. Off by default, and it does not change how findings post."
+                                            "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post."
                                         ),
                                 }),
                                 zod.null(),
@@ -785,7 +785,7 @@ export const signalsScoutConfigCreateBodyOutputDestinationsOneSlackOneUsersItemR
 )
 export const signalsScoutConfigCreateBodyOutputDestinationsOneSlackOneUsersMax = 5
 
-export const signalsScoutConfigCreateBodyOutputDestinationsOneSlackOneThreadReportsDefault = false
+export const signalsScoutConfigCreateBodyOutputDestinationsOneSlackOneThreadReportsDefault = true
 export const signalsScoutConfigCreateBodyRunCronScheduleMax = 100
 
 export const signalsScoutConfigCreateBodyModelMax = 200
@@ -848,7 +848,7 @@ export const SignalsScoutConfigCreateBody = () => zod
                                 .boolean()
                                 .default(signalsScoutConfigCreateBodyOutputDestinationsOneSlackOneThreadReportsDefault)
                                 .describe(
-                                    "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. Off by default, and it does not change how findings post."
+                                    "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post."
                                 ),
                         }),
                         zod.null(),
@@ -969,7 +969,7 @@ export const signalsScoutConfigUpdateBodyOutputDestinationsOneSlackOneUsersItemR
 )
 export const signalsScoutConfigUpdateBodyOutputDestinationsOneSlackOneUsersMax = 5
 
-export const signalsScoutConfigUpdateBodyOutputDestinationsOneSlackOneThreadReportsDefault = false
+export const signalsScoutConfigUpdateBodyOutputDestinationsOneSlackOneThreadReportsDefault = true
 export const signalsScoutConfigUpdateBodyModelMax = 200
 
 export const signalsScoutConfigUpdateBodyTagsMax = 10
@@ -1045,7 +1045,7 @@ export const SignalsScoutConfigUpdateBody = () => zod
                                 .boolean()
                                 .default(signalsScoutConfigUpdateBodyOutputDestinationsOneSlackOneThreadReportsDefault)
                                 .describe(
-                                    "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. Off by default, and it does not change how findings post."
+                                    "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post."
                                 ),
                         }),
                         zod.null(),

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -969,7 +969,6 @@ export const signalsScoutConfigUpdateBodyOutputDestinationsOneSlackOneUsersItemR
 )
 export const signalsScoutConfigUpdateBodyOutputDestinationsOneSlackOneUsersMax = 5
 
-export const signalsScoutConfigUpdateBodyOutputDestinationsOneSlackOneThreadReportsDefault = true
 export const signalsScoutConfigUpdateBodyModelMax = 200
 
 export const signalsScoutConfigUpdateBodyTagsMax = 10
@@ -1043,7 +1042,7 @@ export const SignalsScoutConfigUpdateBody = () => zod
                                 ),
                             thread_reports: zod
                                 .boolean()
-                                .default(signalsScoutConfigUpdateBodyOutputDestinationsOneSlackOneThreadReportsDefault)
+                                .optional()
                                 .describe(
                                     "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post."
                                 ),

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -649,7 +649,7 @@ export const SignalsScoutCreateBody = () => zod
                                             signalsScoutCreateBodyConfigOneOutputDestinationsOneSlackOneThreadReportsDefault
                                         )
                                         .describe(
-                                            "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post."
+                                            "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post."
                                         ),
                                 }),
                                 zod.null(),
@@ -848,7 +848,7 @@ export const SignalsScoutConfigCreateBody = () => zod
                                 .boolean()
                                 .default(signalsScoutConfigCreateBodyOutputDestinationsOneSlackOneThreadReportsDefault)
                                 .describe(
-                                    "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post."
+                                    "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post."
                                 ),
                         }),
                         zod.null(),
@@ -1045,7 +1045,7 @@ export const SignalsScoutConfigUpdateBody = () => zod
                                 .boolean()
                                 .default(signalsScoutConfigUpdateBodyOutputDestinationsOneSlackOneThreadReportsDefault)
                                 .describe(
-                                    "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post."
+                                    "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post."
                                 ),
                         }),
                         zod.null(),

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/scout-config-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/scout-config-create.json
@@ -64,8 +64,8 @@
                                     "type": "number"
                                 },
                                 "thread_reports": {
-                                    "default": false,
-                                    "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. Off by default, and it does not change how findings post.",
+                                    "default": true,
+                                    "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post.",
                                     "type": "boolean"
                                 },
                                 "users": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/scout-config-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/scout-config-create.json
@@ -65,7 +65,7 @@
                                 },
                                 "thread_reports": {
                                     "default": true,
-                                    "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post.",
+                                    "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post.",
                                     "type": "boolean"
                                 },
                                 "users": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/scout-config-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/scout-config-update.json
@@ -72,7 +72,6 @@
                                     "type": "number"
                                 },
                                 "thread_reports": {
-                                    "default": true,
                                     "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post.",
                                     "type": "boolean"
                                 },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/scout-config-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/scout-config-update.json
@@ -73,7 +73,7 @@
                                 },
                                 "thread_reports": {
                                     "default": true,
-                                    "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post.",
+                                    "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post.",
                                     "type": "boolean"
                                 },
                                 "users": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/scout-config-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/scout-config-update.json
@@ -72,8 +72,8 @@
                                     "type": "number"
                                 },
                                 "thread_reports": {
-                                    "default": false,
-                                    "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. Off by default, and it does not change how findings post.",
+                                    "default": true,
+                                    "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post.",
                                     "type": "boolean"
                                 },
                                 "users": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/scout-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/scout-create.json
@@ -71,8 +71,8 @@
                                             "type": "number"
                                         },
                                         "thread_reports": {
-                                            "default": false,
-                                            "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. Off by default, and it does not change how findings post.",
+                                            "default": true,
+                                            "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post.",
                                             "type": "boolean"
                                         },
                                         "users": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/scout-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/scout-create.json
@@ -72,7 +72,7 @@
                                         },
                                         "thread_reports": {
                                             "default": true,
-                                            "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post.",
+                                            "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post.",
                                             "type": "boolean"
                                         },
                                         "users": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-config-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-config-create.json
@@ -64,8 +64,8 @@
                                     "type": "number"
                                 },
                                 "thread_reports": {
-                                    "default": false,
-                                    "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. Off by default, and it does not change how findings post.",
+                                    "default": true,
+                                    "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post.",
                                     "type": "boolean"
                                 },
                                 "users": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-config-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-config-create.json
@@ -65,7 +65,7 @@
                                 },
                                 "thread_reports": {
                                     "default": true,
-                                    "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post.",
+                                    "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post.",
                                     "type": "boolean"
                                 },
                                 "users": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-config-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-config-update.json
@@ -72,7 +72,6 @@
                                     "type": "number"
                                 },
                                 "thread_reports": {
-                                    "default": true,
                                     "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post.",
                                     "type": "boolean"
                                 },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-config-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-config-update.json
@@ -73,7 +73,7 @@
                                 },
                                 "thread_reports": {
                                     "default": true,
-                                    "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post.",
+                                    "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post a single message, which can truncate a long summary. It does not change how findings post.",
                                     "type": "boolean"
                                 },
                                 "users": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-config-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-config-update.json
@@ -72,8 +72,8 @@
                                     "type": "number"
                                 },
                                 "thread_reports": {
-                                    "default": false,
-                                    "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. Off by default, and it does not change how findings post.",
+                                    "default": true,
+                                    "description": "When true, post a report as a thread: a short lead in the channel and the rest split into replies at the summary's section labels, which can be Markdown headings or bold labels. Keeps a long summary from being clipped at Slack's section limit. On by default; set it false to post the whole report as one message. It does not change how findings post.",
                                     "type": "boolean"
                                 },
                                 "users": {


### PR DESCRIPTION
## Problem

A scout report lands in Slack as one long message, so a channel gets a wall of text and a summary past Slack's section limit is clipped. Threading already fixes both, but the destination toggle starts off, so a team only gets it after finding the switch. Threading is the better default: the channel shows a short lead, and the report's sections sit in the thread.

## Changes

- A scout that posts reports to Slack now threads them by default. The channel gets the lead, and each section of the summary becomes a reply.
- The "Post reports as a thread" switch in the scout's Slack destination starts on. Turning it off posts one message, which Slack can truncate when the summary is long.
- The create API and MCP field `thread_reports` defaults to `true`. PATCH keeps an omitted value unchanged.
- The config reader treats a missing `thread_reports` as on, so only an explicit `false` turns threading off. This is what reaches scouts whose stored destination never carried the key.
- A scout whose stored destination holds an explicit `false` keeps posting single messages. The new default reaches new destinations and stored legacy destinations that never carried the key.
- Findings are unchanged. Threading applies to reports only.
- The generated OpenAPI types, Zod schemas, and MCP clients are mechanical, from `hogli build:openapi`.

Nothing new renders in the UI. The only visible difference is the existing switch starting in the on position, so there is no before-and-after screenshot to add.

## How did you test this code?

Ran the backend suites that cover the default: `test_scout_slack_delivery.py`, `test_scout_harness_api.py`, `test_scout_create_api.py`, `test_signal_scout_models.py`, `test_scout_report_api.py`, `test_scout_inactivity.py`, and `products/replay_vision/backend/tests/test_scanner_scouts_api.py`.

The parser cases in `test_scout_slack_delivery.py` catch the regression that matters here: a destination with no `thread_reports` key must now thread, and a non-boolean value must not silently turn threading off. The rest of the test edits move expectations from `False` to `True`.

Not run: the frontend Jest and Playwright suites, and no manual click-through in the app. The dev stack in this sandbox ran Postgres, Redis, and ClickHouse only.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update\n\nAdded `docs/internal/signals-scout-slack-delivery.md` with the destination, threading, truncation, and retry behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack request to flip the scout "post in threads" default. Skills invoked: `/writing-pr-descriptions`.

The one judgment call: whether the reader should treat an absent `thread_reports` key as on. A partial update stores the destination in the shape it was sent, so many stored destinations have no key at all. Leaving the reader on `is True` would have kept those scouts unthreaded and made the new default reach almost nobody, so the reader now flips to off only on an explicit `false`. The `ScoutSlackDestination` dataclass default moved with it. The Celery task and delivery function keep their `False` parameter defaults, because every call site passes the value and an old worker must still accept a payload without the kwarg.

No customer data, session material, or internal context is in this diff.

Source: [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1788511987487889)\n\n---\n*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
