### PR TITLE
chore(devex): cache the VR CLI install and give it a real budget

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -966,6 +966,16 @@ jobs:
 
             # Visual Review: create run + upload snapshots directly from the test job.
             # Completion happens in handle-screenshots so the baseline lands in the same commit as PNGs.
+            # Shares the entry ci-storybook.yml writes, keyed on the same lockfile. A miss
+            # only means the install downloads the tree, which is what it does today.
+            - name: Restore VR CLI npm cache
+              if: always() && (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push')
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: ~/.npm
+                  key: npm-vr-cli-${{ runner.os }}-${{ hashFiles('**/products/visual_review/cli/package-lock.json') }}
+                  restore-keys: npm-vr-cli-${{ runner.os }}-
+
             - name: Install VR CLI
               if: always() && (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push')
               run: cd products/visual_review/cli && npm ci && npm run build && npm link
@@ -1254,6 +1264,14 @@ jobs:
               with:
                   node-version-file: .nvmrc
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
+
+            # Shares the entry ci-storybook.yml writes, keyed on the same lockfile.
+            - name: Restore VR CLI npm cache
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: ~/.npm
+                  key: npm-vr-cli-${{ runner.os }}-${{ hashFiles('**/products/visual_review/cli/package-lock.json') }}
+                  restore-keys: npm-vr-cli-${{ runner.os }}-
 
             - name: Install VR CLI
               run: cd products/visual_review/cli && npm ci && npm run build && npm link

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -308,7 +308,10 @@ jobs:
     vr-setup:
         name: Create Visual Review run
         runs-on: ubuntu-latest
-        timeout-minutes: 5
+        # The VR CLI install dominates this job, and it runs against a cold npm cache
+        # whenever the restore misses. vr-complete allows the same budget for the same
+        # install.
+        timeout-minutes: 15
         needs: [changes, build-storybook, select-stories]
         # A status function is required because select-stories is skipped on forced-full
         # PRs and master pushes, and GitHub would otherwise cascade that skip to this job.
@@ -365,8 +368,28 @@ jobs:
                   node-version-file: .nvmrc
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
+            # The CLI is a standalone npm package outside the pnpm workspace, so no other
+            # job warms its tarballs. Without this cache, every run downloads the whole
+            # dependency tree, which includes the sharp binaries and the test toolchain
+            # that the build never uses.
+            - name: Restore VR CLI npm cache
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: ~/.npm
+                  key: npm-vr-cli-${{ runner.os }}-${{ hashFiles('vr-cli/products/visual_review/cli/package-lock.json') }}
+                  restore-keys: npm-vr-cli-${{ runner.os }}-
+
             - name: Install VR CLI
               run: cd vr-cli/products/visual_review/cli && npm ci && npm run build
+
+            - name: Save VR CLI npm cache
+              # vr-setup is the only writer because it precedes every other job that
+              # installs the CLI, and they all key on the same lockfile hash.
+              if: github.ref == 'refs/heads/master'
+              uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: ~/.npm
+                  key: npm-vr-cli-${{ runner.os }}-${{ hashFiles('vr-cli/products/visual_review/cli/package-lock.json') }}
 
             - name: Create VR run
               id: create
@@ -827,6 +850,14 @@ jobs:
               with:
                   node-version-file: .nvmrc
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
+
+            # Reads the cache that vr-setup writes. This job never saves it.
+            - name: Restore VR CLI npm cache
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: ~/.npm
+                  key: npm-vr-cli-${{ runner.os }}-${{ hashFiles('vr-cli/products/visual_review/cli/package-lock.json') }}
+                  restore-keys: npm-vr-cli-${{ runner.os }}-
 
             - name: Install VR CLI
               run: cd vr-cli/products/visual_review/cli && npm ci && npm run build

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -602,6 +602,18 @@ jobs:
                       products/visual_review/frontend/generated/api.schemas.ts
                   sparse-checkout-cone-mode: false
 
+            # Every shard installs the CLI, so this is the highest-volume reader of the
+            # entry vr-setup writes. Restore only: a save here would race the other
+            # shards for one key. npm stores its cache by content, so the entry moves
+            # between the runner home and the container home without a rewrite.
+            - name: Restore VR CLI npm cache
+              if: always() && needs.vr-setup.outputs.run_id != ''
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: ~/.npm
+                  key: npm-vr-cli-${{ runner.os }}-${{ hashFiles('**/products/visual_review/cli/package-lock.json') }}
+                  restore-keys: npm-vr-cli-${{ runner.os }}-
+
             - name: Install VR CLI
               if: always() && needs.vr-setup.outputs.run_id != ''
               run: cd vr-cli/products/visual_review/cli && npm ci && npm run build

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -376,20 +376,22 @@ jobs:
               uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
               with:
                   path: ~/.npm
-                  key: npm-vr-cli-${{ runner.os }}-${{ hashFiles('vr-cli/products/visual_review/cli/package-lock.json') }}
+                  key: npm-vr-cli-${{ runner.os }}-${{ hashFiles('**/products/visual_review/cli/package-lock.json') }}
                   restore-keys: npm-vr-cli-${{ runner.os }}-
 
             - name: Install VR CLI
               run: cd vr-cli/products/visual_review/cli && npm ci && npm run build
 
             - name: Save VR CLI npm cache
-              # vr-setup is the only writer because it precedes every other job that
-              # installs the CLI, and they all key on the same lockfile hash.
+              # The only writer for every VR CLI install, here and in
+              # ci-e2e-playwright.yml. They key on the same lockfile, so one entry serves
+              # them all and no two jobs save the same content at once. A job that finds
+              # no entry downloads the dependency tree instead.
               if: github.ref == 'refs/heads/master'
               uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
               with:
                   path: ~/.npm
-                  key: npm-vr-cli-${{ runner.os }}-${{ hashFiles('vr-cli/products/visual_review/cli/package-lock.json') }}
+                  key: npm-vr-cli-${{ runner.os }}-${{ hashFiles('**/products/visual_review/cli/package-lock.json') }}
 
             - name: Create VR run
               id: create
@@ -856,7 +858,7 @@ jobs:
               uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
               with:
                   path: ~/.npm
-                  key: npm-vr-cli-${{ runner.os }}-${{ hashFiles('vr-cli/products/visual_review/cli/package-lock.json') }}
+                  key: npm-vr-cli-${{ runner.os }}-${{ hashFiles('**/products/visual_review/cli/package-lock.json') }}
                   restore-keys: npm-vr-cli-${{ runner.os }}-
 
             - name: Install VR CLI


### PR DESCRIPTION
## Problem

Two things go wrong around the VR CLI install, and they are scoped differently.

**A PR can go red for nothing in its diff.** The Visual Review setup job installs the CLI from the npm registry, then gets 5 minutes to finish. When the install crosses the wall, GitHub cancels the job, and the gate fails closed on a cancelled dependency. Over the last 400 Storybook runs, 37 of the 163 jobs that reached the install were cancelled at the wall. That is 23% of the jobs that did real work. Merge-queue branches and master pushes are both in the sample, so it also kicks PRs out of the queue and reds master. [One example](https://github.com/PostHog/posthog/actions/runs/33854560506/job/100966559328).

That budget was never sized for this job. [#51670](https://github.com/PostHog/posthog/pull/51670) set every job in the file to 5 minutes as a blanket sweep. [#52036](https://github.com/PostHog/posthog/pull/52036) added the install five days later, and [#54416](https://github.com/PostHog/posthog/pull/54416) reshaped the job and carried the 5 forward.

**Nothing caches the install, anywhere.** The CLI is a standalone npm package outside the pnpm workspace, so no other job warms its tarballs. It installs at five sites across two workflows, and every one downloads the whole dependency tree every time.

Measured per site, install step only, successful steps, from the GitHub API:

| site | runner | n | p50 | max |
| --- | --- | --- | --- | --- |
| `ci-storybook` `vr-setup` | ubuntu-latest | 93 | 108s | 283s |
| `ci-storybook` `vr-complete` | ubuntu-latest | 33 | 226s | 303s |
| `ci-e2e-playwright` `playwright` | depot-8vcpu | 69 | 325s | 602s |
| `ci-e2e-playwright` `vr-complete` | ubuntu-latest | 35 | 340s | 603s |

`visual-regression` is the highest-volume site and is not in the table, because its install runs inside the shard job rather than as its own job. A forced-full Storybook run fans out to 16 shards, so it pays the install 16 times.

## Changes

- A PR no longer goes red because the VR CLI install ran long. `vr-setup` gets 15 minutes, matching `vr-complete`, which runs the identical install.
- All five install sites restore a shared npm cache, so the install stops refetching the tree.
- Only `vr-setup` writes the cache. Every other site restores. That keeps one writer, which the pnpm cache in this file already does, and it keeps 16 matrix shards off a single key.
- The key hashes the CLI lockfile through a glob that resolves in either checkout layout, so one entry serves both workflows.

Nothing user-facing changes.

> [!NOTE]
> The two halves have different scopes. The timeout change is specific to `vr-setup`, the only site hitting a wall. The E2E jobs keep their budgets, because neither is timing out.

The cache is the part worth reading. The timeout change is one number.

## How did you test this code?

`bin/hogli lint:workflows` passes. `actionlint` reports the same 31 findings on these two files as master, all in steps this PR does not touch.

The distributions above come from the GitHub API over the last 400 Storybook runs and 300 E2E runs, reading each job's `Install VR CLI` step.

Two candidate causes for the E2E sites being roughly three times slower are ruled out by that data. It is not contention with the Docker stack, because `ci-e2e-playwright` `vr-complete` runs no stack, uses the same sparse checkout as the Storybook jobs, and is the slowest site. It is not runner class, because the 8-vCPU Depot job is also three times the 2-vCPU Storybook job. The one remaining command difference is the trailing `npm link` that only the E2E variant runs. That stays unproven, because the global prefix in this sandbox is read-only and the step could not be isolated locally.

The durations pile up near 300s and 600s rather than spreading out. Those line up with npm's default 300s fetch timeout and one retry, which points at registry fetches rather than CPU. That is the path a warm cache removes, but it is an inference from the shape of the distribution, not a measurement of npm's internals.

Not verified: the size of the saving. A cache hit needs a master run to write the entry first, so the effect only shows after this merges. The timeout change stands on its own if the cache turns out to save little.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) picked this up after the job cancelled an unrelated PR. Skills invoked: `/authoring-ci-workflows`, `/writing-code-comments`, `/writing-pr-descriptions`.

The rejected alternative was to shrink the install instead of caching it. The job runs `tsc` and then one CLI command, so the test toolchain it installs is dead weight: `@rolldown`, `@esbuild`, `lightningcss`, `vitest` and `vite` account for roughly 43 MB of a 103 MB tree. Dropping them needs `npm ci --omit=dev`, which also drops `typescript` and breaks the build. Splitting the manifest to separate build deps from test deps is a product change with no measured payoff yet, so this PR caches instead.

A cache miss takes the path every job takes today, so an unrebased branch is unaffected by this edit.

`docs/internal/ci-things-already-tried.md` records no prior attempt at either change.

https://claude.ai/code/session_01RFamrG1DG3eoBpgUQkB7TE
