### PR TITLE
fix(desktop): keep referenced files names in copied chat text

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/AgentMessage.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/AgentMessage.test.tsx
@@ -15,6 +15,10 @@ vi.mock("@posthog/ui/shell/themeStore", () => ({
     selector({ isDarkMode: false }),
 }));
 
+vi.mock("../../../sidebar/useCwd", () => ({
+  useCwd: () => undefined,
+}));
+
 import { AgentMessage } from "./AgentMessage";
 
 const MERMAID_FENCE = "```mermaid\ngraph TD; A-->B\n```";
@@ -25,5 +29,15 @@ describe("AgentMessage", () => {
 
     expect(await screen.findByTestId("mermaid-svg")).toBeInTheDocument();
     expect(screen.queryByText("graph TD; A-->B")).toBeNull();
+  });
+
+  it("renders inline file references as selectable text, not buttons", () => {
+    render(<AgentMessage content="See `src/app/AgentMessage.tsx:12` here." />);
+
+    const chip = screen.getByText("AgentMessage.tsx:12");
+    // Chromium drops <button> text from document selections, so a native
+    // <button> chip would vanish from text copied out of chat output.
+    expect(chip.closest("button")).toBeNull();
+    expect(chip.tagName).toBe("SPAN");
   });
 });

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/AgentMessage.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/AgentMessage.test.tsx
@@ -35,8 +35,6 @@ describe("AgentMessage", () => {
     render(<AgentMessage content="See `src/app/AgentMessage.tsx:12` here." />);
 
     const chip = screen.getByText("AgentMessage.tsx:12");
-    // Chromium drops <button> text from document selections, so a native
-    // <button> chip would vanish from text copied out of chat output.
     expect(chip.closest("button")).toBeNull();
     expect(chip.tagName).toBe("SPAN");
   });

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/fileLinkChips.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/fileLinkChips.tsx
@@ -65,9 +65,6 @@ export function InlineFileLink({
 
   const tooltipText = resolvedPath ?? text;
 
-  // A <span>, not a <button>: Chromium leaves <button> text out of document
-  // selections, so copying chat output that contains these chips dropped every
-  // file reference from the pasted text.
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLSpanElement>) => {
       if (event.key === "Enter" || event.key === " ") {

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/fileLinkChips.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/fileLinkChips.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { KeyboardEvent, ReactNode } from "react";
 import { useCallback, useMemo } from "react";
 import { Tooltip } from "../../../../primitives/Tooltip";
 import { usePendingScrollStore } from "../../../code-editor/pendingScrollStore";
@@ -65,17 +65,33 @@ export function InlineFileLink({
 
   const tooltipText = resolvedPath ?? text;
 
+  // A <span>, not a <button>: Chromium leaves <button> text out of document
+  // selections, so copying chat output that contains these chips dropped every
+  // file reference from the pasted text.
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLSpanElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        handleClick();
+      }
+    },
+    [handleClick],
+  );
+
   return (
     <Tooltip content={tooltipText}>
-      <button
-        type="button"
+      {/* biome-ignore lint/a11y/useSemanticElements: a <button> is not selectable in Chromium, which breaks copy of selected chat text */}
+      <span
+        role="button"
+        tabIndex={taskId ? 0 : undefined}
         onClick={taskId ? handleClick : undefined}
-        disabled={!taskId}
-        className={`m-0 inline border-0 bg-transparent p-0 font-[inherit] text-[length:inherit] text-foreground ${taskId ? "cursor-pointer underline underline-offset-2" : ""}`}
+        onKeyDown={taskId ? handleKeyDown : undefined}
+        aria-disabled={taskId ? undefined : true}
+        className={`m-0 inline border-0 bg-transparent p-0 font-[inherit] text-[length:inherit] text-foreground outline-none focus-visible:underline ${taskId ? "cursor-pointer underline underline-offset-2" : ""}`}
       >
         {filename}
         {lineSuffix ? `:${lineSuffix}` : ""}
-      </button>
+      </span>
     </Tooltip>
   );
 }


### PR DESCRIPTION
## Problem

If a file reference was included in the chat, it was not included when the chat message was copied, due to it being a `<button>`

## Changes

- Turned the file reference into a clickable `<span>` instead.


## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by an agent in a PostHog Desktop session (pi coding agent).
- Skills invoked: the posthog-desktop scoping skill and /writing-pr-descriptions.
- Decision: keep the visible chip text (filename plus line) as the copied text. Rendering the full path in pastes would need a custom copy handler and diverges from what the reader selects, so it stays out of this fix.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
