### PR TITLE
fix(posthog-ai): cap eval temporal worker graceful shutdown

### DIFF
--- a/products/posthog_ai/eval_harness/harness/temporal_env.py
+++ b/products/posthog_ai/eval_harness/harness/temporal_env.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import asyncio
 import logging
+import datetime as dt
 import threading
 
 from django.conf import settings
@@ -22,6 +23,12 @@ from products.tasks.backend.facade.temporal import (
 )
 
 logger = logging.getLogger(__name__)
+
+# This worker serves one throwaway eval run, so it has nothing worth draining for
+# minutes on shutdown. Cap the graceful drain below the join timeout in stop() so a
+# slow in-flight activity does not leave the worker thread hanging past teardown.
+WORKER_GRACEFUL_SHUTDOWN_TIMEOUT = dt.timedelta(seconds=5)
+WORKER_STOP_JOIN_TIMEOUT_SECONDS = 15
 
 
 def temporal_client_target(env: WorkflowEnvironment) -> tuple[str, str]:
@@ -139,6 +146,7 @@ class TemporalWorkerThread:
             activities=TASKS_ACTIVITIES + NOTEBOOK_ACTIVITIES,  # type: ignore[arg-type]
             max_concurrent_workflow_tasks=self._max_concurrent_workflow_tasks,
             max_concurrent_activities=self._max_concurrent_activities,
+            graceful_shutdown_timeout=WORKER_GRACEFUL_SHUTDOWN_TIMEOUT,
             enable_combined_metrics_server=False,
         )
         logger.info("Eval temporal worker created")
@@ -152,10 +160,13 @@ class TemporalWorkerThread:
     def stop(self) -> None:
         self._loop.call_soon_threadsafe(self._stop_event.set)
         if self._thread is not None:
-            self._thread.join(timeout=10)
+            self._thread.join(timeout=WORKER_STOP_JOIN_TIMEOUT_SECONDS)
             if self._thread.is_alive():
                 # The loop is still running the worker; closing it now would raise.
                 # Leak it rather than risk a RuntimeError masking the real teardown.
-                logger.warning("Eval temporal worker thread did not join in 10s; leaving its loop open")
+                logger.warning(
+                    "Eval temporal worker thread did not join in %ds; leaving its loop open",
+                    WORKER_STOP_JOIN_TIMEOUT_SECONDS,
+                )
                 return
         self._loop.close()


### PR DESCRIPTION
## Problem

A person running the PostHog AI eval harness with Modal sandboxes sees the run end with a wall of `asyncio.exceptions.CancelledError: Task cancelled, timeout graceful shutdown exceeded`, after `respond_activity_task_completed` retries against a refused connection.

Why: the harness's `TemporalWorkerThread` uses `create_worker`'s default graceful shutdown timeout of 5 minutes. During teardown the local Temporal dev server shuts down, so in-flight activity completions hit connection refused and the Rust worker retries until the 5-minute drain elapses. The core then cancels the task, which is the `CancelledError` above. Meanwhile `stop()` only joins the worker thread for 10s, so it gives up, logs a warning, and leaks the worker loop.

## Changes

- Give the throwaway per-run eval worker a short graceful shutdown timeout (5s) so teardown does not stall for minutes on a server that is already gone.
- Raise `stop()`'s thread join timeout to 15s (above the drain) so the loop closes cleanly instead of leaking.

Both changes are confined to `products/posthog_ai/eval_harness/harness/temporal_env.py`.

## How did you test this code?

No new test. The graceful timeout flows into the Rust Temporal worker core, which only exercises against a live Temporal server; a unit test here would mirror the implementation (change-detector). Verified: `ruff check` and `ruff format` clean on the edited file; AST parses; the existing `test_sandboxed_harness.py` module collects (21 tests) so the edited module imports under Django setup. I did not run a full Modal eval run.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

skip-inkeep-docs

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools/agent: Claude Code via PostHog Desktop.
- Skills invoked: `/writing-code-comments`, `/writing-tests`.
- No duplicate: searched open PRs for "eval harness temporal worker graceful shutdown" and "graceful_shutdown_timeout"; none found.
- Public artifact: the diff and this description contain only code and reasoning from the repository. The reported error log line was provided by the user as task context; it is paraphrased, not quoted from any private thread.
- Decisions: capped the timeout rather than reordering teardown (server-before-worker), because the worker's purpose is a single throwaway run and a long drain has no value there.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
