### PR TITLE
chore(ingestion-consumer): attribute ledger rejections and rebalances

### DIFF
--- a/rust/common/kafka-consumer/src/topic_offset_ledger.rs
+++ b/rust/common/kafka-consumer/src/topic_offset_ledger.rs
@@ -31,7 +31,16 @@ pub enum Rejection {
     /// The work violated the ledger's contract. The partition's window is
     /// unknown after this, so its ledger was reset to a new generation: work
     /// in flight drops as stale, and the next delivery founds a fresh ledger.
-    Violation(LedgerError),
+    Violation {
+        error: LedgerError,
+        /// The generation the rejected work was stamped with.
+        stamp: u64,
+        /// The generation the ledger held when it rejected the work. The
+        /// reset founds `generation + 1`.
+        generation: u64,
+        /// What the partition's window held before the reset discarded it.
+        held: Held,
+    },
 }
 
 /// One batch's settled view of its partition ledger: the frontier after its
@@ -108,9 +117,15 @@ impl TopicOffsetLedger {
         match ledger.charge(offset_charges) {
             Ok(_) => Ok(ledger.held()),
             Err(error) => {
+                let held = ledger.held();
                 *ledger = PartitionOffsetLedger::new(generation + 1);
                 self.generations_version.fetch_add(1, Ordering::Relaxed);
-                Err(Rejection::Violation(error))
+                Err(Rejection::Violation {
+                    error,
+                    stamp,
+                    generation,
+                    held,
+                })
             }
         }
     }
@@ -144,9 +159,15 @@ impl TopicOffsetLedger {
                 generation,
             }),
             Err(error) => {
+                let held = ledger.held();
                 *ledger = PartitionOffsetLedger::new(generation + 1);
                 self.generations_version.fetch_add(1, Ordering::Relaxed);
-                Err(Rejection::Violation(error))
+                Err(Rejection::Violation {
+                    error,
+                    stamp,
+                    generation,
+                    held,
+                })
             }
         }
     }
@@ -528,10 +549,18 @@ mod tests {
         // violation, not a rebalance: the ledger cannot trust its window.
         assert_eq!(
             ledger.charge(&p0, 0, [(Offset(11), Charge::ZERO)]),
-            Err(Rejection::Violation(LedgerError::OffsetNotAboveWindow {
-                offset: Offset(11),
-                next: Offset(12),
-            }))
+            Err(Rejection::Violation {
+                error: LedgerError::OffsetNotAboveWindow {
+                    offset: Offset(11),
+                    next: Offset(12),
+                },
+                stamp: 0,
+                generation: 0,
+                held: Held {
+                    offsets: 2,
+                    charge: Charge::ZERO
+                },
+            })
         );
         assert_eq!(ledger.held(&p0).offsets, 0, "the window is discarded");
         assert_eq!(ledger.generation(&p0), 1);
@@ -562,9 +591,15 @@ mod tests {
 
         assert_eq!(
             ledger.settle(&p0, 0, [Offset(15)]),
-            Err(Rejection::Violation(LedgerError::CompletionUncharged {
-                offset: Offset(15)
-            }))
+            Err(Rejection::Violation {
+                error: LedgerError::CompletionUncharged { offset: Offset(15) },
+                stamp: 0,
+                generation: 0,
+                held: Held {
+                    offsets: 1,
+                    charge: Charge::ZERO
+                },
+            })
         );
         assert_eq!(ledger.held(&p0).offsets, 0);
         assert_eq!(ledger.generation(&p0), 1);

--- a/rust/common/kafka-consumer/src/topic_offset_ledger.rs
+++ b/rust/common/kafka-consumer/src/topic_offset_ledger.rs
@@ -31,14 +31,11 @@ pub enum Rejection {
     /// The work violated the ledger's contract. The partition's window is
     /// unknown after this, so its ledger was reset to a new generation: work
     /// in flight drops as stale, and the next delivery founds a fresh ledger.
+    /// `generation` and `held` describe the ledger before that reset.
     Violation {
         error: LedgerError,
-        /// The generation the rejected work was stamped with.
         stamp: u64,
-        /// The generation the ledger held when it rejected the work. The
-        /// reset founds `generation + 1`.
         generation: u64,
-        /// What the partition's window held before the reset discarded it.
         held: Held,
     },
 }

--- a/rust/ingestion-consumer/src/consumer.rs
+++ b/rust/ingestion-consumer/src/consumer.rs
@@ -781,7 +781,7 @@ impl IngestionConsumer {
         self.ledger_shadow.settle(
             topic_partition,
             partition.generation,
-            partition.charges.iter().map(|(offset, _)| *offset),
+            &partition.charges,
             &partition.span,
         )
     }

--- a/rust/ingestion-consumer/src/consumer.rs
+++ b/rust/ingestion-consumer/src/consumer.rs
@@ -781,7 +781,7 @@ impl IngestionConsumer {
         self.ledger_shadow.settle(
             topic_partition,
             partition.generation,
-            &partition.charges,
+            partition.charges.iter().map(|(offset, _)| *offset),
             &partition.span,
         )
     }

--- a/rust/ingestion-consumer/src/ledger_shadow.rs
+++ b/rust/ingestion-consumer/src/ledger_shadow.rs
@@ -202,19 +202,20 @@ fn frontier_mismatch(
     })
 }
 
-/// What a rejected charge or settlement can say about the offsets it carried.
-/// The two stages know different things, so each reports its own fields.
 #[derive(Debug, Clone, Copy)]
 enum RejectedSlice {
-    /// The offsets the charge delivered, in delivery order. A charge holds
-    /// its slice, so it names exactly what it submitted to the ledger.
+    /// Exactly the offsets the charge submitted to the ledger.
     Charged {
         first: Option<i64>,
         last: Option<i64>,
         offsets: usize,
     },
-    /// The batch's delivered span for the partition, which is what the commit
-    /// path submits.
+    /// The batch's delivered span for the partition, not the settled slice.
+    /// A generation change mid-batch drops the old generation's charges but
+    /// leaves the span whole, so the span can cover offsets the settlement
+    /// never submitted. The settled offsets are an iterator the happy path
+    /// does not collect, so the span is the closest description available.
+    /// The error names the offending offset.
     Settled { first: i64, last: i64 },
 }
 
@@ -227,11 +228,6 @@ impl RejectedSlice {
         }
     }
 
-    /// The span can cover more offsets than the settlement submitted: a
-    /// generation change mid-batch drops the old generation's charges but
-    /// leaves the span whole. The settled offsets are not retained, so the
-    /// span is reported as the batch's span and never as the settled slice.
-    /// The error names the offending offset.
     fn settled(span: &OffsetSpan) -> Self {
         Self::Settled {
             first: span.first,
@@ -242,9 +238,8 @@ impl RejectedSlice {
 
 /// Count one charge or settlement the ledger rejected. A stale slice is
 /// expected around a rebalance; a violation is a bug in the accounting.
-///
-/// Both callers build `slice` inside their error arm, so the happy path pays
-/// nothing for the detail.
+/// Callers must build `slice` inside their error arm so the happy path pays
+/// nothing for it.
 fn count_rejection(
     stage: &'static str,
     topic_partition: &TopicPartition,
@@ -267,8 +262,8 @@ fn count_rejection(
                 "kind" => error.kind()
             )
             .increment(1);
-            // The two stages name their offsets differently, and a tracing
-            // field name is fixed at the call site, so each gets its own call.
+            // A tracing field name is fixed at the call site, so each variant
+            // needs its own `warn!`.
             match slice {
                 RejectedSlice::Charged {
                     first,

--- a/rust/ingestion-consumer/src/ledger_shadow.rs
+++ b/rust/ingestion-consumer/src/ledger_shadow.rs
@@ -63,28 +63,29 @@ impl LedgerShadow {
         };
         match ledger.charge(topic_partition, stamp, charges.iter().copied()) {
             Ok(held) => set_held_gauges(&topic_partition.topic, topic_partition.partition, held),
-            Err(rejection) => count_rejection("charge", topic_partition, rejection),
+            Err(rejection) => count_rejection("charge", topic_partition, rejection, charges),
         }
     }
 
-    /// Settle one batch's slice of a partition: complete its offsets and
-    /// compare the frontier with the commit the batch submits. Returns the
-    /// settlement, or `None` when the ledger rejected the slice. The window
-    /// holds the offsets until `drain`.
+    /// Settle one batch's slice of a partition: complete the offsets it
+    /// charged and compare the frontier with the commit the batch submits.
+    /// Returns the settlement, or `None` when the ledger rejected the slice.
+    /// The window holds the offsets until `drain`.
     pub(crate) fn settle(
         &self,
         topic_partition: &TopicPartition,
         stamp: u64,
-        offsets: impl IntoIterator<Item = Offset>,
+        charges: &[(Offset, Charge)],
         span: &OffsetSpan,
     ) -> Option<Settlement> {
         let Some(ledger) = &self.ledger else {
             return None;
         };
+        let offsets = charges.iter().map(|(offset, _)| *offset);
         let settlement = match ledger.settle(topic_partition, stamp, offsets) {
             Ok(settlement) => settlement,
             Err(rejection) => {
-                count_rejection("settle", topic_partition, rejection);
+                count_rejection("settle", topic_partition, rejection, charges);
                 return None;
             }
         };
@@ -194,23 +195,45 @@ fn frontier_mismatch(
 
 /// Count one charge or settlement the ledger rejected. A stale slice is
 /// expected around a rebalance; a violation is a bug in the accounting.
-fn count_rejection(stage: &'static str, topic_partition: &TopicPartition, rejection: Rejection) {
+///
+/// `charges` is the rejected slice in delivery order. It is read only to
+/// describe a violation, so the happy path pays nothing for the detail.
+fn count_rejection(
+    stage: &'static str,
+    topic_partition: &TopicPartition,
+    rejection: Rejection,
+    charges: &[(Offset, Charge)],
+) {
     match rejection {
         Rejection::Stale { .. } => {
             counter!("ingestion_consumer_ledger_stale_slices_total", "stage" => stage).increment(1);
         }
-        Rejection::Violation(error) => {
+        Rejection::Violation {
+            error,
+            stamp,
+            generation,
+            held,
+        } => {
             counter!(
                 "ingestion_consumer_ledger_errors_total",
                 "stage" => stage,
                 "kind" => error.kind()
             )
             .increment(1);
+            let first = charges.first().map(|(offset, _)| offset.0);
+            let last = charges.last().map(|(offset, _)| offset.0);
             warn!(
                 stage,
                 topic = %topic_partition.topic,
                 partition = topic_partition.partition,
                 error = %error,
+                kind = error.kind(),
+                batch_generation = stamp,
+                ledger_generation = generation,
+                slice_first = ?first,
+                slice_last = ?last,
+                slice_offsets = charges.len(),
+                depth = held.offsets,
                 "Offset ledger rejected a slice and reset its partition"
             );
         }
@@ -280,12 +303,12 @@ mod tests {
 
         assert!(
             shadow
-                .settle(&reassigned, 0, [Offset(10)], &span(10, 10))
+                .settle(&reassigned, 0, &charges(&[10]), &span(10, 10))
                 .is_none(),
             "the stale batch settles nothing against the new ledger"
         );
         let settlement = shadow
-            .settle(&live, 0, [Offset(20)], &span(20, 20))
+            .settle(&live, 0, &charges(&[20]), &span(20, 20))
             .expect("the live batch settles");
         assert_eq!(settlement.frontier, Some(Offset(21)));
         shadow.drain(&live);
@@ -301,7 +324,7 @@ mod tests {
         shadow.charge(&held, 0, &charges(&[10, 11]));
 
         let settlement = shadow
-            .settle(&held, 0, [Offset(11)], &span(11, 11))
+            .settle(&held, 0, &charges(&[11]), &span(11, 11))
             .expect("the batch settles");
         assert_eq!(settlement.frontier, None);
         shadow.drain(&held);
@@ -314,7 +337,9 @@ mod tests {
         let shadow = LedgerShadow::new(None);
         let p0 = tp("events", 0);
         shadow.charge(&p0, 0, &charges(&[10]));
-        assert!(shadow.settle(&p0, 0, [Offset(10)], &span(10, 10)).is_none());
+        assert!(shadow
+            .settle(&p0, 0, &charges(&[10]), &span(10, 10))
+            .is_none());
         shadow.drain(&p0);
 
         assert_eq!(shadow.generations_version(), 0);
@@ -328,11 +353,11 @@ mod tests {
         shadow.charge(&p0, 0, &charges(&[10, 11]));
 
         // Only offset 11 completes: the frontier stays behind the commit.
-        shadow.settle(&p0, 0, [Offset(11)], &span(10, 11));
+        shadow.settle(&p0, 0, &charges(&[11]), &span(10, 11));
         assert_eq!(shadow.mismatched.lock().unwrap().get(&p0), Some(&0));
 
         // Offset 10 completes and the frontier catches up.
-        shadow.settle(&p0, 0, [Offset(10)], &span(10, 11));
+        shadow.settle(&p0, 0, &charges(&[10]), &span(10, 11));
         assert!(shadow.mismatched.lock().unwrap().is_empty());
     }
 
@@ -374,10 +399,10 @@ mod tests {
 
         // The batch in flight from before the reset settles as stale, and the
         // next delivery under the new generation founds a fresh ledger.
-        shadow.settle(&p0, 0, [Offset(10)], &span(10, 10));
+        shadow.settle(&p0, 0, &charges(&[10]), &span(10, 10));
         shadow.charge(&p0, 1, &charges(&[11]));
         assert_eq!(ledger.held(&p0).offsets, 1);
-        shadow.settle(&p0, 1, [Offset(11)], &span(11, 11));
+        shadow.settle(&p0, 1, &charges(&[11]), &span(11, 11));
         shadow.drain(&p0);
         assert_eq!(
             ledger.held(&p0).offsets,
@@ -393,12 +418,12 @@ mod tests {
         shadow.charge(&p0, 0, &charges(&[10]));
 
         // Settling an offset the ledger never charged resets the partition.
-        shadow.settle(&p0, 0, [Offset(15)], &span(15, 15));
+        shadow.settle(&p0, 0, &charges(&[15]), &span(15, 15));
         assert_eq!(ledger.held(&p0).offsets, 0, "the window is discarded");
         assert_eq!(ledger.generation(&p0), 1);
 
         shadow.charge(&p0, 1, &charges(&[11]));
-        shadow.settle(&p0, 1, [Offset(11)], &span(11, 11));
+        shadow.settle(&p0, 1, &charges(&[11]), &span(11, 11));
         shadow.drain(&p0);
         assert_eq!(
             ledger.held(&p0).offsets,

--- a/rust/ingestion-consumer/src/ledger_shadow.rs
+++ b/rust/ingestion-consumer/src/ledger_shadow.rs
@@ -202,33 +202,40 @@ fn frontier_mismatch(
     })
 }
 
-/// What a rejected slice covered, for the warning that reports it. A charge
-/// still owns its slice and reports the offsets it counted; a settlement
-/// hands its offsets to the ledger, so it reports the span the batch commits
-/// and no count.
+/// What a rejected charge or settlement can say about the offsets it carried.
+/// The two stages know different things, so each reports its own fields.
 #[derive(Debug, Clone, Copy)]
-struct RejectedSlice {
-    first: Option<i64>,
-    last: Option<i64>,
-    offsets: Option<usize>,
+enum RejectedSlice {
+    /// The offsets the charge delivered, in delivery order. A charge holds
+    /// its slice, so it names exactly what it submitted to the ledger.
+    Charged {
+        first: Option<i64>,
+        last: Option<i64>,
+        offsets: usize,
+    },
+    /// The batch's delivered span for the partition, which is what the commit
+    /// path submits.
+    Settled { first: i64, last: i64 },
 }
 
 impl RejectedSlice {
-    /// A charged slice, in delivery order.
     fn charged(charges: &[(Offset, Charge)]) -> Self {
-        Self {
+        Self::Charged {
             first: charges.first().map(|(offset, _)| offset.0),
             last: charges.last().map(|(offset, _)| offset.0),
-            offsets: Some(charges.len()),
+            offsets: charges.len(),
         }
     }
 
-    /// A settled slice, described by the batch's offset span.
+    /// The span can cover more offsets than the settlement submitted: a
+    /// generation change mid-batch drops the old generation's charges but
+    /// leaves the span whole. The settled offsets are not retained, so the
+    /// span is reported as the batch's span and never as the settled slice.
+    /// The error names the offending offset.
     fn settled(span: &OffsetSpan) -> Self {
-        Self {
-            first: Some(span.first),
-            last: Some(span.last),
-            offsets: None,
+        Self::Settled {
+            first: span.first,
+            last: span.last,
         }
     }
 }
@@ -260,20 +267,41 @@ fn count_rejection(
                 "kind" => error.kind()
             )
             .increment(1);
-            warn!(
-                stage,
-                topic = %topic_partition.topic,
-                partition = topic_partition.partition,
-                error = %error,
-                kind = error.kind(),
-                batch_generation = stamp,
-                ledger_generation = generation,
-                slice_first = ?slice.first,
-                slice_last = ?slice.last,
-                slice_offsets = ?slice.offsets,
-                depth = held.offsets,
-                "Offset ledger rejected a slice and reset its partition"
-            );
+            // The two stages name their offsets differently, and a tracing
+            // field name is fixed at the call site, so each gets its own call.
+            match slice {
+                RejectedSlice::Charged {
+                    first,
+                    last,
+                    offsets,
+                } => warn!(
+                    stage,
+                    topic = %topic_partition.topic,
+                    partition = topic_partition.partition,
+                    error = %error,
+                    kind = error.kind(),
+                    batch_generation = stamp,
+                    ledger_generation = generation,
+                    depth = held.offsets,
+                    slice_first = ?first,
+                    slice_last = ?last,
+                    slice_offsets = offsets,
+                    "Offset ledger rejected a slice and reset its partition"
+                ),
+                RejectedSlice::Settled { first, last } => warn!(
+                    stage,
+                    topic = %topic_partition.topic,
+                    partition = topic_partition.partition,
+                    error = %error,
+                    kind = error.kind(),
+                    batch_generation = stamp,
+                    ledger_generation = generation,
+                    depth = held.offsets,
+                    batch_first = first,
+                    batch_last = last,
+                    "Offset ledger rejected a slice and reset its partition"
+                ),
+            }
         }
     }
 }

--- a/rust/ingestion-consumer/src/ledger_shadow.rs
+++ b/rust/ingestion-consumer/src/ledger_shadow.rs
@@ -63,29 +63,38 @@ impl LedgerShadow {
         };
         match ledger.charge(topic_partition, stamp, charges.iter().copied()) {
             Ok(held) => set_held_gauges(&topic_partition.topic, topic_partition.partition, held),
-            Err(rejection) => count_rejection("charge", topic_partition, rejection, charges),
+            Err(rejection) => count_rejection(
+                "charge",
+                topic_partition,
+                rejection,
+                RejectedSlice::charged(charges),
+            ),
         }
     }
 
-    /// Settle one batch's slice of a partition: complete the offsets it
-    /// charged and compare the frontier with the commit the batch submits.
-    /// Returns the settlement, or `None` when the ledger rejected the slice.
-    /// The window holds the offsets until `drain`.
+    /// Settle one batch's slice of a partition: complete its offsets and
+    /// compare the frontier with the commit the batch submits. Returns the
+    /// settlement, or `None` when the ledger rejected the slice. The window
+    /// holds the offsets until `drain`.
     pub(crate) fn settle(
         &self,
         topic_partition: &TopicPartition,
         stamp: u64,
-        charges: &[(Offset, Charge)],
+        offsets: impl IntoIterator<Item = Offset>,
         span: &OffsetSpan,
     ) -> Option<Settlement> {
         let Some(ledger) = &self.ledger else {
             return None;
         };
-        let offsets = charges.iter().map(|(offset, _)| *offset);
         let settlement = match ledger.settle(topic_partition, stamp, offsets) {
             Ok(settlement) => settlement,
             Err(rejection) => {
-                count_rejection("settle", topic_partition, rejection, charges);
+                count_rejection(
+                    "settle",
+                    topic_partition,
+                    rejection,
+                    RejectedSlice::settled(span),
+                );
                 return None;
             }
         };
@@ -193,16 +202,47 @@ fn frontier_mismatch(
     })
 }
 
+/// What a rejected slice covered, for the warning that reports it. A charge
+/// still owns its slice and reports the offsets it counted; a settlement
+/// hands its offsets to the ledger, so it reports the span the batch commits
+/// and no count.
+#[derive(Debug, Clone, Copy)]
+struct RejectedSlice {
+    first: Option<i64>,
+    last: Option<i64>,
+    offsets: Option<usize>,
+}
+
+impl RejectedSlice {
+    /// A charged slice, in delivery order.
+    fn charged(charges: &[(Offset, Charge)]) -> Self {
+        Self {
+            first: charges.first().map(|(offset, _)| offset.0),
+            last: charges.last().map(|(offset, _)| offset.0),
+            offsets: Some(charges.len()),
+        }
+    }
+
+    /// A settled slice, described by the batch's offset span.
+    fn settled(span: &OffsetSpan) -> Self {
+        Self {
+            first: Some(span.first),
+            last: Some(span.last),
+            offsets: None,
+        }
+    }
+}
+
 /// Count one charge or settlement the ledger rejected. A stale slice is
 /// expected around a rebalance; a violation is a bug in the accounting.
 ///
-/// `charges` is the rejected slice in delivery order. It is read only to
-/// describe a violation, so the happy path pays nothing for the detail.
+/// Both callers build `slice` inside their error arm, so the happy path pays
+/// nothing for the detail.
 fn count_rejection(
     stage: &'static str,
     topic_partition: &TopicPartition,
     rejection: Rejection,
-    charges: &[(Offset, Charge)],
+    slice: RejectedSlice,
 ) {
     match rejection {
         Rejection::Stale { .. } => {
@@ -220,8 +260,6 @@ fn count_rejection(
                 "kind" => error.kind()
             )
             .increment(1);
-            let first = charges.first().map(|(offset, _)| offset.0);
-            let last = charges.last().map(|(offset, _)| offset.0);
             warn!(
                 stage,
                 topic = %topic_partition.topic,
@@ -230,9 +268,9 @@ fn count_rejection(
                 kind = error.kind(),
                 batch_generation = stamp,
                 ledger_generation = generation,
-                slice_first = ?first,
-                slice_last = ?last,
-                slice_offsets = charges.len(),
+                slice_first = ?slice.first,
+                slice_last = ?slice.last,
+                slice_offsets = ?slice.offsets,
                 depth = held.offsets,
                 "Offset ledger rejected a slice and reset its partition"
             );
@@ -303,12 +341,12 @@ mod tests {
 
         assert!(
             shadow
-                .settle(&reassigned, 0, &charges(&[10]), &span(10, 10))
+                .settle(&reassigned, 0, [Offset(10)], &span(10, 10))
                 .is_none(),
             "the stale batch settles nothing against the new ledger"
         );
         let settlement = shadow
-            .settle(&live, 0, &charges(&[20]), &span(20, 20))
+            .settle(&live, 0, [Offset(20)], &span(20, 20))
             .expect("the live batch settles");
         assert_eq!(settlement.frontier, Some(Offset(21)));
         shadow.drain(&live);
@@ -324,7 +362,7 @@ mod tests {
         shadow.charge(&held, 0, &charges(&[10, 11]));
 
         let settlement = shadow
-            .settle(&held, 0, &charges(&[11]), &span(11, 11))
+            .settle(&held, 0, [Offset(11)], &span(11, 11))
             .expect("the batch settles");
         assert_eq!(settlement.frontier, None);
         shadow.drain(&held);
@@ -337,9 +375,7 @@ mod tests {
         let shadow = LedgerShadow::new(None);
         let p0 = tp("events", 0);
         shadow.charge(&p0, 0, &charges(&[10]));
-        assert!(shadow
-            .settle(&p0, 0, &charges(&[10]), &span(10, 10))
-            .is_none());
+        assert!(shadow.settle(&p0, 0, [Offset(10)], &span(10, 10)).is_none());
         shadow.drain(&p0);
 
         assert_eq!(shadow.generations_version(), 0);
@@ -353,11 +389,11 @@ mod tests {
         shadow.charge(&p0, 0, &charges(&[10, 11]));
 
         // Only offset 11 completes: the frontier stays behind the commit.
-        shadow.settle(&p0, 0, &charges(&[11]), &span(10, 11));
+        shadow.settle(&p0, 0, [Offset(11)], &span(10, 11));
         assert_eq!(shadow.mismatched.lock().unwrap().get(&p0), Some(&0));
 
         // Offset 10 completes and the frontier catches up.
-        shadow.settle(&p0, 0, &charges(&[10]), &span(10, 11));
+        shadow.settle(&p0, 0, [Offset(10)], &span(10, 11));
         assert!(shadow.mismatched.lock().unwrap().is_empty());
     }
 
@@ -399,10 +435,10 @@ mod tests {
 
         // The batch in flight from before the reset settles as stale, and the
         // next delivery under the new generation founds a fresh ledger.
-        shadow.settle(&p0, 0, &charges(&[10]), &span(10, 10));
+        shadow.settle(&p0, 0, [Offset(10)], &span(10, 10));
         shadow.charge(&p0, 1, &charges(&[11]));
         assert_eq!(ledger.held(&p0).offsets, 1);
-        shadow.settle(&p0, 1, &charges(&[11]), &span(11, 11));
+        shadow.settle(&p0, 1, [Offset(11)], &span(11, 11));
         shadow.drain(&p0);
         assert_eq!(
             ledger.held(&p0).offsets,
@@ -418,12 +454,12 @@ mod tests {
         shadow.charge(&p0, 0, &charges(&[10]));
 
         // Settling an offset the ledger never charged resets the partition.
-        shadow.settle(&p0, 0, &charges(&[15]), &span(15, 15));
+        shadow.settle(&p0, 0, [Offset(15)], &span(15, 15));
         assert_eq!(ledger.held(&p0).offsets, 0, "the window is discarded");
         assert_eq!(ledger.generation(&p0), 1);
 
         shadow.charge(&p0, 1, &charges(&[11]));
-        shadow.settle(&p0, 1, &charges(&[11]), &span(11, 11));
+        shadow.settle(&p0, 1, [Offset(11)], &span(11, 11));
         shadow.drain(&p0);
         assert_eq!(
             ledger.held(&p0).offsets,

--- a/rust/ingestion-consumer/src/order_sentinel.rs
+++ b/rust/ingestion-consumer/src/order_sentinel.rs
@@ -632,6 +632,22 @@ impl SentinelContext {
     }
 }
 
+/// The partitions in `tpl` as `topic:partition` names, sorted by topic and
+/// then by partition number. A rebalance log line carries the set itself,
+/// because a count cannot say whether a given partition moved.
+fn partition_names(tpl: &TopicPartitionList) -> Vec<String> {
+    let mut partitions: Vec<(String, i32)> = tpl
+        .elements()
+        .iter()
+        .map(|element| (element.topic().to_owned(), element.partition()))
+        .collect();
+    partitions.sort_unstable();
+    partitions
+        .into_iter()
+        .map(|(topic, partition)| format!("{topic}:{partition}"))
+        .collect()
+}
+
 impl ClientContext for SentinelContext {
     /// Fired on a librdkafka thread every `statistics.interval.ms`; disabled
     /// when that is 0.
@@ -645,7 +661,11 @@ impl ConsumerContext for SentinelContext {
         match rebalance {
             Rebalance::Revoke(tpl) => {
                 counter!("ingestion_consumer_rebalances_total", "event" => "revoke").increment(1);
-                info!(partitions = tpl.count(), "Rebalance: partitions revoked");
+                info!(
+                    partitions = tpl.count(),
+                    topic_partitions = ?partition_names(tpl),
+                    "Rebalance: partitions revoked"
+                );
                 self.commit_sentinel
                     .forget_partitions(tpl.elements().iter().map(|e| (e.topic(), e.partition())));
                 self.forget_ledger_partitions(tpl);
@@ -665,7 +685,11 @@ impl ConsumerContext for SentinelContext {
     fn post_rebalance(&self, _consumer: &BaseConsumer<Self>, rebalance: &Rebalance) {
         if let Rebalance::Assign(tpl) = rebalance {
             counter!("ingestion_consumer_rebalances_total", "event" => "assign").increment(1);
-            info!(partitions = tpl.count(), "Rebalance: partitions assigned");
+            info!(
+                partitions = tpl.count(),
+                topic_partitions = ?partition_names(tpl),
+                "Rebalance: partitions assigned"
+            );
             // An assign list names partitions that start a new assignment, so
             // any surviving ledger for them is stale. The revoke callback
             // normally dropped it already; this covers losses with no revoke
@@ -1012,5 +1036,18 @@ mod tests {
         assert!(sentinel
             .note_sent("t:a", &[msg_at(0, 101)], SendKind::Fresh)
             .is_empty());
+    }
+
+    #[test]
+    fn partition_names_sort_by_topic_then_partition_number() {
+        let mut tpl = TopicPartitionList::new();
+        tpl.add_partition("overflow", 2);
+        tpl.add_partition("events", 10);
+        tpl.add_partition("events", 9);
+
+        assert_eq!(
+            partition_names(&tpl),
+            vec!["events:9", "events:10", "overflow:2"]
+        );
     }
 }

--- a/rust/ingestion-consumer/src/order_sentinel.rs
+++ b/rust/ingestion-consumer/src/order_sentinel.rs
@@ -633,10 +633,10 @@ impl SentinelContext {
 }
 
 fn partition_names(tpl: &TopicPartitionList) -> Vec<String> {
-    let mut partitions: Vec<(String, i32)> = tpl
-        .elements()
+    let elements = tpl.elements();
+    let mut partitions: Vec<(&str, i32)> = elements
         .iter()
-        .map(|element| (element.topic().to_owned(), element.partition()))
+        .map(|element| (element.topic(), element.partition()))
         .collect();
     partitions.sort_unstable();
     partitions

--- a/rust/ingestion-consumer/src/order_sentinel.rs
+++ b/rust/ingestion-consumer/src/order_sentinel.rs
@@ -632,9 +632,6 @@ impl SentinelContext {
     }
 }
 
-/// The partitions in `tpl` as `topic:partition` names, sorted by topic and
-/// then by partition number. A rebalance log line carries the set itself,
-/// because a count cannot say whether a given partition moved.
 fn partition_names(tpl: &TopicPartitionList) -> Vec<String> {
     let mut partitions: Vec<(String, i32)> = tpl
         .elements()


### PR DESCRIPTION
## Problem

On 2026-09-04 an overflow consumer pod logged `Offset ledger rejected a slice and reset its partition` for partition 73, 93 ms after a `Rebalance: partitions assigned` line. That rebalance line carried only `partitions=5`, so nobody could tell whether partition 73 was in the assigned set. The rejection warning named only the stage, the topic-partition, and the error text, so the duplicate-delivery question could not be answered from the logs at all.

Anyone reading these logs after the fact hits the same wall today.

## Changes

- The revoke and assign rebalance lines now carry `topic_partitions`, the sorted `topic:partition` list, next to the existing `partitions` count. A reader can now say whether a named partition moved.
- The ledger violation warning now carries `batch_generation` (the stamp the rejected work was buffered under), `ledger_generation` (what the ledger held when it rejected), `depth` (the window depth discarded by the reset), and `kind` (the same label the error counter uses).
- The two stages name their offsets separately, because they know different things. A rejected charge holds its slice and reports `slice_first`, `slice_last`, and `slice_offsets`. A rejected settlement reports `batch_first` and `batch_last`, the batch's delivered span for the partition, and no count. The span is not the settled slice: a generation change mid-batch clears the old generation's charges but leaves the span whole, so it can cover offsets the settlement never submitted.
- Stale rejections stay silent. They are expected around a rebalance and are already counted.
- Mechanical: `Rejection::Violation` becomes a struct variant so the crate reports the stamp, generation, and pre-reset window depth it already had at hand. The settle interface is unchanged.

Every new field is derived inside the failure arm. The per-message and per-batch happy paths are untouched, in line with the rule that debug detail is derived lazily at the failure site.

## How did you test this code?

Automated tests, run locally through flox:

- `cargo test -p ingestion-consumer -p common-kafka-consumer` passes (unit and integration targets).
- `cargo clippy -p ingestion-consumer -p common-kafka-consumer --all-targets -- -D warnings` is clean.
- `cargo fmt` applied to both crates.

Test changes:

- `partition_names_sort_by_topic_then_partition_number` catches the sort bug a plain string sort would introduce, where `events:10` would order before `events:9`.
- The two `Rejection::Violation` assertions in `topic_offset_ledger.rs` now pin the stamp, the generation, and the window depth the reset discarded. Without them the crate could report the post-reset window (always empty) and no test would notice.

Not tested: the rendered log output in a running consumer. There is no log-capture harness in these crates, so the field values themselves are covered only through the crate-level assertions above.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior, API, or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Repo skills consulted: `writing-code-comments` (comment gate, no change-history notes, no em-dash), plus the PR template and `writing-pr-descriptions` rules in AGENTS.md.

Design decision worth a reviewer's attention: the violation context could have been threaded from the caller by re-reading `held()` before every charge and settle. That would have put a lock acquisition on the happy path for data only a failure needs, so the crate returns it inside `Rejection::Violation` instead, computed in the error arm it was already in.

Review rounds shaped the settle path twice. An earlier revision passed the charged slice into `LedgerShadow::settle` so the warning could describe it; that coupled settle to a slice the call site only holds incidentally, so it was reverted. The follow-up then had settle describe its offsets from the batch span, which review caught as misleading across a generation change. The span now reports under its own field names rather than posing as the rejected slice.

No open PR covers this; `gh pr list --search "offset ledger"` surfaced only adjacent ledger work (#94950 deletes the old commit computation and may conflict textually in `consumer.rs`).

Nothing in this diff, its commits, or this description carries material from the session that is not already in this repository. The incident is described by the log lines the code itself emits.

