### PR TITLE
feat(notebooks): stop offering new canvases

### DIFF
--- a/frontend/src/scenes/hog-functions/metrics/HogFunctionEventEstimates.tsx
+++ b/frontend/src/scenes/hog-functions/metrics/HogFunctionEventEstimates.tsx
@@ -1,11 +1,10 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonLabel, LemonSelect, SpinnerOverlay } from '@posthog/lemon-ui'
+import { LemonLabel, SpinnerOverlay } from '@posthog/lemon-ui'
 
 import { Sparkline } from 'lib/components/Sparkline'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
-import { base64Encode } from 'lib/utils/base64'
 import { urls } from 'scenes/urls'
 
 import { Query } from '~/queries/Query/Query'
@@ -34,20 +33,6 @@ export function HogFunctionEventEstimates(): JSX.Element | null {
     }
 
     const insightUrl = urls.insightNew({ type: InsightType.SQL, query: dataTableNode })
-
-    const canvasContent = {
-        type: 'doc',
-        content: [
-            {
-                type: 'ph-query',
-                attrs: {
-                    query: dataTableNode,
-                },
-            },
-        ],
-    }
-
-    const canvasUrl = urls.canvas() + '#🦔=' + base64Encode(JSON.stringify(canvasContent))
 
     return (
         <div className="relative p-3 rounded border deprecated-space-y-2 bg-surface-primary">
@@ -95,22 +80,9 @@ export function HogFunctionEventEstimates(): JSX.Element | null {
                 {showEventsList ? (
                     <>
                         <div className="flex justify-end items-start">
-                            <LemonSelect
-                                placeholder="Open in..."
-                                onChange={(target) => {
-                                    if (target === 'insight') {
-                                        // Open a new tab
-                                        window.open(insightUrl, '_blank')
-                                    } else if (target === 'canvas') {
-                                        // Open a new tab
-                                        window.open(canvasUrl, '_blank')
-                                    }
-                                }}
-                                options={[
-                                    { label: 'New insight', value: 'insight' },
-                                    { label: 'New canvas', value: 'canvas' },
-                                ]}
-                            />
+                            <LemonButton type="secondary" size="small" to={insightUrl} targetBlank>
+                                New insight
+                            </LemonButton>
                         </div>
                         <div className="flex overflow-y-auto flex-col flex-1 rounded border max-h-200">
                             {eventsDataTableNode && (

--- a/frontend/src/scenes/notebooks/Notebook/NotebookShareModal.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookShareModal.tsx
@@ -7,7 +7,6 @@ import { LemonBanner, LemonButton, LemonDivider, LemonModal } from '@posthog/lem
 
 import { SHARING_MODAL_WIDTH, SharingModalContent } from 'lib/components/Sharing/SharingModal'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
-import { base64Encode } from 'lib/utils/base64'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { urls } from 'scenes/urls'
 
@@ -31,13 +30,12 @@ export function NotebookShareModal({ shortId }: NotebookShareModalProps): JSX.El
 }
 
 function OpenNotebookShareModal({ shortId }: NotebookShareModalProps): JSX.Element {
-    const { content, isLocalOnly, isShareModalOpen } = useValues(notebookLogic({ shortId }))
+    const { isLocalOnly, isShareModalOpen } = useValues(notebookLogic({ shortId }))
     const { closeShareModal } = useActions(notebookLogic({ shortId }))
     const externalSharingEnabled = useFeatureFlag('NOTEBOOK_SHARING')
     const [interestTracked, setInterestTracked] = useState(false)
 
     const notebookUrl = urls.absolute(urls.currentProject(urls.notebook(shortId)))
-    const canvasUrl = urls.absolute(urls.canvas()) + `#🦔=${base64Encode(JSON.stringify(content))}`
 
     const trackInterest = (): void => {
         posthog.capture('pressed interested in notebook sharing', { url: notebookUrl })
@@ -81,31 +79,12 @@ function OpenNotebookShareModal({ shortId }: NotebookShareModalProps): JSX.Eleme
                         >
                             {notebookUrl}
                         </LemonButton>
-
-                        <LemonDivider className="my-4" />
                     </>
                 ) : (
                     <LemonBanner type="info">
                         <p>This notebook cannot be shared directly with others as it is only visible to you.</p>
                     </LemonBanner>
                 )}
-
-                <h3>Template link</h3>
-                <p>
-                    The link below will open a Canvas with the contents of this notebook, allowing the receiver to view
-                    it, edit it or create their own notebook without affecting this one.
-                </p>
-                <LemonButton
-                    type="secondary"
-                    fullWidth
-                    center
-                    truncate
-                    sideIcon={<IconCopy />}
-                    onClick={() => void copyToClipboard(canvasUrl, 'canvas link')}
-                    title={canvasUrl}
-                >
-                    {canvasUrl}
-                </LemonButton>
 
                 {!isLocalOnly &&
                     (externalSharingEnabled ? (

--- a/frontend/src/scenes/notebooks/NotebooksScene.tsx
+++ b/frontend/src/scenes/notebooks/NotebooksScene.tsx
@@ -1,13 +1,8 @@
-import { router } from 'kea-router'
-
-import { IconEllipsis } from '@posthog/icons'
-import { LemonButton, LemonMenu, Tooltip, lemonToast } from '@posthog/lemon-ui'
+import { LemonButton } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { Shortcut } from 'lib/components/Shortcuts/Shortcut'
 import { keyBinds } from 'lib/components/Shortcuts/shortcuts'
-import { base64Encode } from 'lib/utils/base64'
-import { getTextFromFile, selectFiles } from 'lib/utils/file-utils'
 import { notebooksTableLogic } from 'scenes/notebooks/NotebooksTable/notebooksTableLogic'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
@@ -34,72 +29,28 @@ export function NotebooksScene(): JSX.Element {
                     type: 'notebook',
                 }}
                 actions={
-                    <>
-                        <LemonMenu
-                            items={[
-                                {
-                                    label: 'Load from JSON',
-                                    onClick: () => {
-                                        void selectFiles({
-                                            contentType: 'application/json',
-                                            multiple: false,
-                                        })
-                                            .then(async (files) => {
-                                                if (!files.length) {
-                                                    return
-                                                }
-                                                const text = await getTextFromFile(files[0])
-                                                const data = JSON.parse(text)
-                                                if (data.type !== 'doc') {
-                                                    throw new Error('Not a notebook')
-                                                }
-
-                                                // Looks like a notebook
-                                                router.actions.push(
-                                                    urls.canvas(),
-                                                    {},
-                                                    {
-                                                        '🦔': base64Encode(text),
-                                                    }
-                                                )
-                                            })
-                                            .catch((e) => {
-                                                lemonToast.error(e.message)
-                                            })
-                                    },
-                                },
-                            ]}
+                    <AccessControlAction
+                        resourceType={AccessControlResourceType.Notebook}
+                        minAccessLevel={AccessControlLevel.Editor}
+                    >
+                        <Shortcut
+                            name="NewNotebook"
+                            keybind={[keyBinds.new]}
+                            intent="New notebook"
+                            interaction="click"
+                            scope={Scene.Notebooks}
                         >
-                            <LemonButton icon={<IconEllipsis />} size="small" />
-                        </LemonMenu>
-                        <Tooltip title="Like a Notebook but all your exploration is persisted to the URL for easy sharing.">
-                            <LemonButton size="small" data-attr="new-canvas" to={urls.canvas()} type="secondary">
-                                New canvas
-                            </LemonButton>
-                        </Tooltip>
-                        <AccessControlAction
-                            resourceType={AccessControlResourceType.Notebook}
-                            minAccessLevel={AccessControlLevel.Editor}
-                        >
-                            <Shortcut
-                                name="NewNotebook"
-                                keybind={[keyBinds.new]}
-                                intent="New notebook"
-                                interaction="click"
-                                scope={Scene.Notebooks}
+                            <LemonButton
+                                size="small"
+                                data-attr="new-notebook"
+                                to={urls.notebook('new')}
+                                type="primary"
+                                tooltip="New notebook"
                             >
-                                <LemonButton
-                                    size="small"
-                                    data-attr="new-notebook"
-                                    to={urls.notebook('new')}
-                                    type="primary"
-                                    tooltip="New notebook"
-                                >
-                                    New notebook
-                                </LemonButton>
-                            </Shortcut>
-                        </AccessControlAction>
-                    </>
+                                New notebook
+                            </LemonButton>
+                        </Shortcut>
+                    </AccessControlAction>
                 }
             />
 


### PR DESCRIPTION
## Problem

- Canvases are going away, but pulling the whole surface at once would break every canvas link people already shared.
- This is step one of two. It closes the door on new canvases and leaves the existing ones readable.
- Step two removes the scene and the route. Draft: #94979.

## Changes

- The Notebooks scene drops the "New canvas" button and the overflow menu that opened one from a JSON file.
- The notebook share modal drops its "Template link" section. That link handed the reader a new canvas.
- The hog function "Matching events" panel drops "New canvas". "New insight" is now a button, because the dropdown had one option left.
- Nothing else changes. The `/canvas` scene, its route, and `urls.canvas()` all stay.

> [!NOTE]
> A shared canvas link still opens and still renders. "Save as Notebook" inside a canvas still works, so anyone who wants to keep a canvas has a way out before step two lands.

One path survives on purpose: a person who types `/canvas` by hand still gets a blank canvas. No product surface leads there any more. Blocking it would mean branching the route on whether the URL carries content, which risks the shared links this step exists to protect.

No screenshots. The local dev stack serves a different worktree, so this branch never rendered. Each change is a removal from a surface the diff shows in full.

## How did you test this code?

- Ran the jest suites for notebooks and hog functions.
- Ran `tsgo --noEmit`. It reports no error in any touched file. The failures it does report are missing local modules and predate this branch.
- Not checked: the running app, for the reason above.
- No new tests. The change removes three controls, and the existing notebook suites cover the surfaces that keep them company.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No page under `docs/` describes the notebook canvas.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this PR. Session: https://claude.ai/code/session_01TPVus93NDqexg7ELvK8cQy

Skills invoked: `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

This PR started as the full removal in #94979. The requester then asked to split it, so the creation entry points land first and the scene comes out later. #94979 keeps the rest of that work and needs a rebase once this one merges.

The three files here are byte-identical to their state in #94979, so the two PRs will not fight over them.

Canvas content never reaches a server or localStorage. `loadNotebook` returns early when the mode is not `notebook`, the autosave is gated on `isLocalOnly`, and the `localContent` reducer sets `persist: props.mode !== 'canvas'`. A canvas lives only in its URL fragment, which is why step two has to consider the shared links and step one does not.

The claim that canvases are unused comes from the requester. No usage query backs it here.

No duplicate: `gh pr list --state open --search "canvas notebooks remove"` returned no other PR in this area.

Public artifact: the diff deletes code from this repository. Nothing in the branch, the commit message, or this description comes from outside the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPVus93NDqexg7ELvK8cQy
