### PR TITLE
chore(data-deletion): plan self-service event deletion

### DIFF
--- a/docs/plans/2026-09-03-self-service-event-deletion.md
+++ b/docs/plans/2026-09-03-self-service-event-deletion.md
@@ -1,0 +1,371 @@
+# Self-service event deletion from HogQL
+
+## Context
+
+Customers currently need PostHog staff to translate an event-deletion request into a `DataDeletionRequest` in Django Admin. This creates unnecessary support work and makes customers describe criteria that they can already express precisely in the SQL editor.
+
+The goal is to let an authorized project member write a regular HogQL query, review its result, and submit it as a deletion request. The query must return exactly one column containing event UUIDs. PostHog queues those UUIDs in `adhoc_events_deletion`, and the scheduled `deletes_job` removes the matching events during the weekend deletion window.
+
+The existing backend already provides most of the operational workflow:
+
+- `DataDeletionRequest` records criteria, approval, execution, and verification state.
+- Deferred event removals insert `(team_id, uuid)` rows into `adhoc_events_deletion`.
+- `deletes_job` builds a dictionary from pending queue rows and deletes matching events from every physical events table.
+- The dictionary lookup uses `(team_id, uuid)`, so an event UUID cannot delete an event belonging to a different team.
+- A verification job promotes queued deletion requests after `deletes_job` succeeds.
+
+This plan extends that workflow. It does not introduce a second deletion system.
+
+## Requirements
+
+1. An authorized project member can submit the current SQL editor HogQL query as an event-deletion request.
+2. The submitted query can use regular HogQL features, including joins, CTEs, subqueries, and unions supported by the normal query path.
+3. The query must return exactly one column whose values can be inserted into a ClickHouse `UUID` column.
+4. PostHog stores an immutable query and variable snapshot on the deletion request.
+5. Requests created through the product are clearly distinguishable from requests created in Django Admin.
+6. PostHog executes selection and queue insertion entirely within ClickHouse. Millions of UUIDs must not pass through Python, Postgres, object storage, or a Dagster payload.
+7. Customer-controlled text cannot choose the insertion target, queued team ID, provenance, or ClickHouse settings.
+8. Queue rows identify the deletion request that created them.
+9. Queueing is retry-safe after a timeout or partial distributed failure.
+10. The existing weekend `deletes_job` remains the only process that deletes query-selected events.
+
+## Proposed customer flow
+
+1. The customer writes and runs a HogQL query in the SQL editor.
+2. The customer chooses **Delete matching events** from the existing save menu.
+3. PostHog validates the current query and calculates a preview count.
+4. A confirmation dialog explains that deletion is irreversible and runs during the next deletion window.
+5. Submission creates an immutable `DataDeletionRequest` for the current project and user.
+6. The existing approval workflow approves the request automatically or routes it for operator review.
+7. A Dagster job executes one ClickHouse `INSERT ... SELECT` to queue the selected UUIDs.
+8. The request moves to `queued` only after ClickHouse reports that queueing succeeded.
+9. The weekend `deletes_job` deletes the queued `(team_id, uuid)` keys.
+10. The existing verifier marks the request complete after confirming that the events no longer exist.
+
+The first release should force product-created requests to deferred execution. Customers should not be able to select immediate mutations.
+
+## Store the query on `DataDeletionRequest`
+
+The deletion authority should be an immutable snapshot on `DataDeletionRequest`, not a `DataWarehouseSavedQuery`.
+
+A saved view has independent edit, deletion, and materialization behavior. Referencing it would allow the query to change between review and execution unless the deletion workflow copied it. Storing the snapshot directly provides a smaller and clearer audit boundary.
+
+Add fields equivalent to:
+
+```python
+class DataDeletionRequestOrigin(models.TextChoices):
+    DJANGO_ADMIN = "django_admin"
+    SELF_SERVICE = "self_service"
+
+origin = models.CharField(...)
+hogql_query = models.TextField(blank=True, default="")
+hogql_variables = models.JSONField(blank=True, default=dict)
+```
+
+The exact query representation should match the SQL editor's existing `HogQLQuery` shape. If variable values contain typed query nodes, store the complete serialized variables rather than a flattened value map.
+
+`created_by_staff` already records whether an instance operator created many existing requests. Keep it during rollout for compatibility, but make `origin` the explicit product distinction. Existing rows should migrate to `django_admin` unless another known creation path requires a separate origin.
+
+Changing the query or variables must reset the request to draft, clear approval and cached preview data, and invalidate any compiled-query cache. Approved and later requests remain immutable.
+
+## Query validation
+
+The API accepts regular HogQL but never accepts raw ClickHouse SQL.
+
+Validation uses the normal HogQL parser, resolver, access controls, and compiler with the request's project and submitting user. It must establish:
+
+- The input contains one read-only query.
+- The resolved output has exactly one column.
+- The output is compatible with ClickHouse `UUID`.
+- All variables resolve successfully.
+- The submitting user can access every referenced HogQL resource.
+- The query cannot supply output formatting, an output destination, or execution settings outside the normal HogQL contract.
+
+The query does not need to select syntactically from `events`, and the column does not need to be a direct `events.uuid` AST node. This preserves regular HogQL composition. A customer may derive the final UUID set through joins or unions.
+
+No Python loop needs to validate individual UUID values. ClickHouse query evaluation and insertion into the destination `UUID` column enforce the runtime type. A bad conversion fails the queueing operation.
+
+The preview and queueing paths must compile the same immutable query and variables. Preview may wrap it in `SELECT count()` but must not modify the eventual UUID set with an implicit limit.
+
+## ClickHouse-native queue insertion
+
+The queueing job constructs the outer statement from trusted constants and embeds only parameterized SQL produced by the HogQL compiler:
+
+```sql
+INSERT INTO adhoc_events_deletion
+    (team_id, uuid, source, source_id)
+SELECT
+    %(request_team_id)s,
+    selected.uuid,
+    'data_deletion_request',
+    %(request_id)s
+FROM (
+    /* parameterized SQL emitted by the HogQL compiler */
+) AS selected
+```
+
+The implementation must not interpolate `DataDeletionRequest.hogql_query` into this string. It parses and resolves the stored HogQL, compiles it to a single parameterized `SELECT`, and combines the compiler parameters with trusted outer parameters.
+
+Prefer constructing the wrapper from typed query nodes if the current HogQL/ClickHouse AST supports this statement shape. If `INSERT` is not representable, a small query builder may wrap compiler-owned SQL. That boundary must accept compiled SQL plus parameters, never customer text.
+
+The outer query owns:
+
+- The destination table.
+- The queued `team_id`.
+- The `source` value.
+- The `source_id` value.
+- Workload and resource settings.
+
+The inner query owns only the UUID set.
+
+### Tenant isolation
+
+The outer statement always writes `DataDeletionRequest.team_id`, which came from the authenticated project context. It never reads a team ID from the query result.
+
+`deletes_job` looks up queue entries with the physical event row's `(team_id, uuid)`. If a query for team 100 returns a UUID belonging to team 200, the queue receives `(100, uuid)`. It cannot match the event stored under `(200, uuid)`.
+
+The normal HogQL access layer still restricts what the customer can read. The composite deletion key independently restricts what the request can delete.
+
+No join back to the events table is required. Such a join would add an expensive scan to every large deletion request without improving the composite-key tenant boundary.
+
+## Dedicated ClickHouse principal
+
+Introduce a `data_deletion_request_executor` principal for this operation.
+
+It needs:
+
+- `SELECT` privileges required by supported regular HogQL queries.
+- `INSERT` on `adhoc_events_deletion`.
+- No write privilege on any other table.
+- No event mutation privileges.
+- No DDL privileges.
+- No customer-controlled query settings.
+- No output-file or unapproved external table-function capabilities.
+
+The principal must be separate from the identity used by `deletes_job`, which performs the actual mutations.
+
+A separate user limits the impact of a parser, compiler, or query-composition defect. The executor may append deletion candidates, but it cannot mutate event storage or write elsewhere. Infrastructure must provision equivalent grants in every environment before application code depends on the new principal.
+
+The query should run under an offline workload with server-controlled limits for execution time, memory, bytes read, temporary disk, threads, and concurrency. Settings constraints must prevent the compiled inner query from weakening those limits.
+
+## Queue provenance
+
+Extend `adhoc_events_deletion` with:
+
+```sql
+source LowCardinality(String) DEFAULT 'legacy',
+source_id Nullable(UUID)
+```
+
+Product-created deletion rows use:
+
+```text
+source = data_deletion_request
+source_id = DataDeletionRequest.id
+```
+
+`source` explains which subsystem queued the row. `source_id` identifies the exact request, which already records the actor, project, query, approval, and execution history.
+
+These columns do not participate in the deletion dictionary key. The dictionary continues to use `(team_id, uuid)`.
+
+The ClickHouse migration must ship in a migration-only PR. It also updates the local schema and HCL definitions so local development matches production.
+
+## Retry and consistency semantics
+
+An `INSERT ... SELECT` can have an uncertain result after a connection timeout or a distributed failure. Retrying the immutable request may therefore append duplicate queue rows.
+
+The workflow treats duplicate `(team_id, uuid)` candidates as idempotent:
+
+- `deletes_job` performs a membership lookup rather than one action per queue row.
+- The dictionary input should explicitly collapse duplicate pending keys if the dictionary source does not already guarantee deterministic key selection.
+- Progress and verification counts should count distinct UUIDs for the request.
+- A retry reuses the same `source_id` and immutable query snapshot.
+- The request moves to `queued` only after a successful queueing response.
+- An uncertain failure remains retryable and never marks the request complete.
+
+The implementation must verify how `ReplacingMergeTreeDeleted` and the dictionary handle duplicate active rows before relying on background merges. Correctness should not depend on `OPTIMIZE FINAL` running first.
+
+Queueing fixes the selected UUID set at approval execution time. New events that match the query after queueing are not part of the request. The UI and documentation must state this timing.
+
+## API and authorization
+
+Add a project-nested API under `/api/projects/:team_id/` with generated request and response types. The minimal surface is:
+
+```text
+POST data_deletion_requests/preview
+POST data_deletion_requests
+GET  data_deletion_requests
+GET  data_deletion_requests/:id
+```
+
+The server derives the team through `self.context["get_team"]()` and derives the actor from the authenticated request. The create serializer must not accept operational fields such as `team_id`, `origin`, `created_by`, approval state, status, or execution mode.
+
+The API requires a dedicated destructive permission rather than general SQL-editor access. List and detail queries must filter by the current team. The product API may expose only requests appropriate for customer visibility, while Django Admin continues to expose every origin.
+
+Preview must be rate-limited and use the normal query-cost controls. Creation must guard against replay and double submission. A client-generated idempotency key or a uniqueness constraint over an immutable submission identifier should prevent accidental duplicate requests.
+
+## Approval policy
+
+Self-service submission and approval are separate decisions.
+
+The current workflow can auto-approve small, closed-range event removals and leave larger requests for operator review. Query-backed requests need an equivalent policy based on a fresh preview generated by the approval job, not a count supplied by the browser.
+
+Before launch, decide:
+
+- Whether all self-service requests require manual approval initially.
+- Which count or query-cost threshold permits automatic approval.
+- Whether a maximum count blocks submission entirely.
+- Whether each organization or project needs a concurrent-request limit.
+- Which roles receive the destructive permission.
+
+Regardless of policy, product-created requests always use deferred execution.
+
+## Frontend
+
+Add **Delete matching events** to the SQL editor save menu. Keep the action behind a feature flag during rollout.
+
+The action is available only when:
+
+- The current query has run successfully.
+- The current editor contents match the last successful run.
+- The user has the deletion permission.
+- The result has one UUID-compatible column.
+
+The confirmation dialog shows the query snapshot, match count, selection time, approval expectation, and next deletion window. It requires explicit confirmation and keeps the submit action disabled while the request is in flight.
+
+After submission, navigate to a deletion-request detail surface showing status, selected count, submission time, approval state, queueing state, and expected deletion timing. Do not expose raw queued UUIDs.
+
+## Activity and audit trail
+
+Deletion requests should appear in PostHog's activity log with events for creation, submission, approval, queueing, failure, retry, and completion. Activity payloads should record identifiers and state transitions, not the full query or UUID set.
+
+Django Admin should display and filter by `origin`, `source_id`, actor, project, approval mode, and latest Dagster run. Existing `created_by_staff` information remains visible during migration.
+
+## Delivery sequence
+
+### 1. ClickHouse migration PR
+
+- Add `source` and `source_id` to `adhoc_events_deletion`.
+- Update local schema and HCL definitions.
+- Verify dictionary behavior with duplicate active keys.
+- Keep this PR migration-only.
+
+### 2. Postgres model PR
+
+- Add request origin and immutable HogQL snapshot fields.
+- Define criteria-reset and immutability rules.
+- Add model-level validation for query-backed event removals.
+- Preserve compatibility with existing admin-created requests.
+
+### 3. ClickHouse executor and infrastructure PRs
+
+- Provision the dedicated ClickHouse principal in every environment.
+- Add a credential path for the executor.
+- Compile regular HogQL within the request's team and user context.
+- Execute the server-owned `INSERT ... SELECT` under offline limits.
+- Add provenance and retry-safe queue accounting.
+
+Infrastructure grants should land before application code uses them. Application code should fail closed when the dedicated credentials are absent in cloud environments.
+
+### 4. API PR
+
+- Add preview, create, list, and detail endpoints.
+- Add permission and tenant-scoping checks.
+- Add idempotent submission.
+- Regenerate OpenAPI clients.
+
+### 5. Frontend PR
+
+- Add the SQL editor menu action and confirmation dialog.
+- Add the deletion request status surface.
+- Add feature-flag and permission gates.
+- Document the customer workflow.
+
+### 6. Operational rollout
+
+- Enable the approval, pickup, weekend deletion, and verification automation.
+- Start with manual approval and a restricted cohort.
+- Monitor query resource use, queue growth, failure rates, and deletion latency.
+- Define rollback by disabling submission and pickup while preserving queued audit records.
+- Expand eligibility and auto-approval only after observing the initial workload.
+
+## Test strategy
+
+### Model and API
+
+- A request stores an immutable query and variable snapshot.
+- Product creation assigns the authenticated team, actor, origin, and deferred mode.
+- Cross-team list and detail access fails closed.
+- Customers cannot assign status, approval, origin, execution mode, or team.
+- Criteria edits clear approval and preview state.
+- Duplicate submissions return the existing request.
+
+### HogQL validation
+
+- A direct `SELECT uuid FROM events` query passes.
+- A UUID selected through a CTE, join, subquery, or union passes.
+- Zero or multiple output columns fail.
+- A non-UUID output fails before queueing.
+- Invalid or unresolved HogQL fails.
+- A query referencing a resource unavailable to the submitting user fails.
+- Customer text cannot alter the outer insertion target, team ID, provenance, or settings.
+
+### Queue execution
+
+- The compiled query queues `(request.team_id, uuid)` with request provenance.
+- A UUID originating from another team is still queued under the request team and cannot delete the other team's event.
+- The executor cannot write to event tables or unrelated tables.
+- A large selection stays entirely inside ClickHouse.
+- A retry after partial insertion is idempotent.
+- Duplicate active queue rows produce a valid deletion dictionary.
+- Legacy and native-JSON event tables both lose queued events after `deletes_job`.
+
+### Workflow
+
+- Approval uses a fresh server-generated preview.
+- Product requests cannot enter immediate mode.
+- Queueing success moves the request to `queued`.
+- Queueing failure remains retryable.
+- Weekend deletion followed by verification moves the request to `completed`.
+
+## Documentation
+
+User-facing documentation must explain:
+
+- The required one-column UUID result.
+- Who can submit a deletion request.
+- When the UUID selection becomes fixed.
+- Whether approval is automatic or manual.
+- When deletion normally runs.
+- That deletion is irreversible.
+- Which event copies and derived data the workflow covers.
+
+Operational documentation must cover credential provisioning, resource limits, retries, queue inspection by `source_id`, schedule dependencies, and emergency shutdown.
+
+## Open questions
+
+1. Which product should own the backend and frontend implementation?
+2. Which project role receives the deletion permission?
+3. Do all self-service requests require manual approval for the first release?
+4. What preview count or query-cost thresholds permit automatic approval?
+5. Should the API accept only `HogQLQuery`, or every query node that eventually compiles to one UUID column?
+6. Does the current compiler expose a safe typed representation for wrapping a compiled query in `INSERT ... SELECT`?
+7. Which regular HogQL resources should the dedicated executor principal be able to read?
+8. How should self-hosted deployments provision or fall back when the dedicated principal is unavailable?
+9. Does the queue dictionary need an explicit `GROUP BY team_id, uuid` for retry duplicates?
+10. How long should completed provenance rows remain available before the existing TTL removes them?
+11. Does event deletion also need to remove or rebuild derived data outside the legacy and native-JSON event tables?
+12. What customer-visible cancellation behavior is safe before UUID queueing begins and after it completes?
+
+## Definition of done
+
+- An authorized customer can submit a regular one-column HogQL query without support assistance.
+- The approved query snapshot cannot change before execution.
+- ClickHouse selects and queues millions of UUIDs without transferring them through application memory.
+- Customer input cannot control the queue destination, tenant key, provenance, or resource settings.
+- The executor can write only to `adhoc_events_deletion`.
+- Every queued UUID can be traced to a `DataDeletionRequest`.
+- Retries cannot expand deletion beyond the immutable query and request team.
+- `deletes_job` removes queued events from every active physical event table.
+- The product shows the request's approval, queueing, deletion, and verification state.
+- Documentation and operational controls are ready before the feature flag expands.

--- a/docs/plans/2026-09-03-self-service-event-deletion.md
+++ b/docs/plans/2026-09-03-self-service-event-deletion.md
@@ -224,6 +224,27 @@ The initial schema should prefer explicit columns over a serialized model payloa
 
 The HogQL table is read-only. Creating, approving, canceling, or retrying a deletion request continues through authenticated API actions with explicit permissions.
 
+## PostgreSQL capacity and abuse controls
+
+`DataDeletionRequest` inherits from `UUIDModel`, which uses a UUIDv7 primary key. UUIDv7 values are time ordered, so inserts retain substantially better B-tree locality than random UUIDv4 values. The identifier itself is not expected to create material write pressure at deletion-request volumes.
+
+The larger PostgreSQL risks are unbounded request creation, duplicate submissions, large stored queries, inefficient list and pickup queries, and indefinite retention. Apply these controls:
+
+- Rate-limit preview and creation separately per user and team.
+- Limit each team to a small number of active requests across `pending`, `approved`, `in_progress`, and `queued` states.
+- Use an idempotency key for submission so retries and double clicks return the existing request.
+- Cap the serialized HogQL query and variables by byte size before writing them.
+- Reject unnecessary repeated previews of the same unchanged query within a short cache window.
+- Index customer list access by team and creation time.
+- Index Dagster pickup access by status and approval time based on the verified query plan.
+- Avoid indexes on large query or variables fields.
+- Define a retention or archival policy for completed and failed requests while preserving the required audit period.
+- Monitor request creation rate, active rows, table and index size, and slow queries after rollout.
+
+Enforce active-request limits transactionally so concurrent submissions cannot both pass a read-then-create check. Prefer a database-backed quota or locking strategy over an application-only count.
+
+Index design must follow measured access paths. Before adding an index, capture `EXPLAIN` plans for the team-scoped HogQL table, customer list endpoint, approval sweep, pickup sensor, and queued verifier. Add indexes concurrently where required by the migration policy.
+
 ## Approval policy
 
 Self-service submission and approval are separate decisions.
@@ -323,6 +344,9 @@ Infrastructure grants should land before application code uses them. Application
 - Customers cannot assign status, approval, origin, execution mode, or team.
 - Criteria edits clear approval and preview state.
 - Duplicate submissions return the existing request.
+- Concurrent submissions cannot exceed the active-request limit.
+- Oversized query or variables payloads fail before persistence.
+- Customer list and Dagster pickup queries use the intended indexes.
 
 ### HogQL validation
 
@@ -381,6 +405,7 @@ Operational documentation must cover credential provisioning, resource limits, r
 11. How long should completed provenance rows remain available before the existing TTL removes them?
 12. Does event deletion also need to remove or rebuild derived data outside the legacy and native-JSON event tables?
 13. What customer-visible cancellation behavior is safe before UUID queueing begins and after it completes?
+14. What per-user rate, per-team rate, active-request limit, payload-size limit, and retention period should apply?
 
 ## Definition of done
 
@@ -394,4 +419,5 @@ Operational documentation must cover credential provisioning, resource limits, r
 - `deletes_job` removes queued events from every active physical event table.
 - The product shows the request's approval, queueing, deletion, and verification state.
 - Customers can inspect their self-service requests through the team-scoped `data_deletion_requests` HogQL table.
+- PostgreSQL controls bound request volume, payload size, duplicate submissions, active work, and retained history.
 - Documentation and operational controls are ready before the feature flag expands.

--- a/docs/plans/2026-09-03-self-service-event-deletion.md
+++ b/docs/plans/2026-09-03-self-service-event-deletion.md
@@ -28,6 +28,7 @@ This plan extends that workflow. It does not introduce a second deletion system.
 8. Queue rows identify the deletion request that created them.
 9. Queueing is retry-safe after a timeout or partial distributed failure.
 10. The existing weekend `deletes_job` remains the only process that deletes query-selected events.
+11. Customers can query their product-created deletion requests through a team-scoped, read-only HogQL table.
 
 ## Proposed customer flow
 
@@ -64,7 +65,9 @@ hogql_variables = models.JSONField(blank=True, default=dict)
 
 The exact query representation should match the SQL editor's existing `HogQLQuery` shape. If variable values contain typed query nodes, store the complete serialized variables rather than a flattened value map.
 
-`created_by_staff` already records whether an instance operator created many existing requests. Keep it during rollout for compatibility, but make `origin` the explicit product distinction. Existing rows should migrate to `django_admin` unless another known creation path requires a separate origin.
+Keep `created_by_staff` as a permanent, independent audit field. It records whether the actor was PostHog staff, while `origin` records which surface created the request. A PostHog employee acting as a customer through the product therefore creates a request with `origin = self_service` and `created_by_staff = true`.
+
+The product creation path derives `created_by_staff` from the authenticated actor and never accepts it from the request body. Existing rows should migrate to `origin = django_admin` only after confirming that Django Admin was their only creation path.
 
 Changing the query or variables must reset the request to draft, clear approval and cached preview data, and invalidate any compiled-query cache. Approved and later requests remain immutable.
 
@@ -198,11 +201,28 @@ GET  data_deletion_requests
 GET  data_deletion_requests/:id
 ```
 
-The server derives the team through `self.context["get_team"]()` and derives the actor from the authenticated request. The create serializer must not accept operational fields such as `team_id`, `origin`, `created_by`, approval state, status, or execution mode.
+The server derives the team through `self.context["get_team"]()` and derives the actor and `created_by_staff` from the authenticated request. The create serializer must not accept operational fields such as `team_id`, `origin`, `created_by`, `created_by_staff`, approval state, status, or execution mode.
 
 The API requires a dedicated destructive permission rather than general SQL-editor access. List and detail queries must filter by the current team. The product API may expose only requests appropriate for customer visibility, while Django Admin continues to expose every origin.
 
 Preview must be rate-limited and use the normal query-cost controls. Creation must guard against replay and double submission. A client-generated idempotency key or a uniqueness constraint over an immutable submission identifier should prevent accidental duplicate requests.
+
+## HogQL table for deletion requests
+
+Expose product-created deletion requests as a team-scoped HogQL table named `data_deletion_requests`. This lets customers inspect and report on their requests without adding a separate product-only reporting API.
+
+The table must:
+
+- Apply the current HogQL team scope before returning rows.
+- Expose only `origin = self_service` requests.
+- Use the normal HogQL resource access controls.
+- Exclude internal notes, approval comments, Dagster identifiers, and other operator-only metadata.
+- Expose stable customer-facing fields such as request ID, status, query, selected count, creator, creation time, approval time, queue time, completion time, and failure state.
+- Preserve `created_by_staff` so an employee acting through the product remains identifiable without changing the creation origin.
+
+The initial schema should prefer explicit columns over a serialized model payload. Field names and status values become a customer-facing query contract once released.
+
+The HogQL table is read-only. Creating, approving, canceling, or retrying a deletion request continues through authenticated API actions with explicit permissions.
 
 ## Approval policy
 
@@ -239,7 +259,7 @@ After submission, navigate to a deletion-request detail surface showing status, 
 
 Deletion requests should appear in PostHog's activity log with events for creation, submission, approval, queueing, failure, retry, and completion. Activity payloads should record identifiers and state transitions, not the full query or UUID set.
 
-Django Admin should display and filter by `origin`, `source_id`, actor, project, approval mode, and latest Dagster run. Existing `created_by_staff` information remains visible during migration.
+Django Admin should display and filter by `origin`, `created_by_staff`, `source_id`, actor, project, approval mode, and latest Dagster run. The two provenance dimensions remain separate throughout the request lifecycle.
 
 ## Delivery sequence
 
@@ -255,6 +275,7 @@ Django Admin should display and filter by `origin`, `source_id`, actor, project,
 - Add request origin and immutable HogQL snapshot fields.
 - Define criteria-reset and immutability rules.
 - Add model-level validation for query-backed event removals.
+- Keep `created_by_staff` and populate it independently from the creation origin.
 - Preserve compatibility with existing admin-created requests.
 
 ### 3. ClickHouse executor and infrastructure PRs
@@ -270,6 +291,7 @@ Infrastructure grants should land before application code uses them. Application
 ### 4. API PR
 
 - Add preview, create, list, and detail endpoints.
+- Register the team-scoped, read-only `data_deletion_requests` HogQL table.
 - Add permission and tenant-scoping checks.
 - Add idempotent submission.
 - Regenerate OpenAPI clients.
@@ -294,8 +316,10 @@ Infrastructure grants should land before application code uses them. Application
 ### Model and API
 
 - A request stores an immutable query and variable snapshot.
-- Product creation assigns the authenticated team, actor, origin, and deferred mode.
+- Product creation assigns the authenticated team, actor, staff status, origin, and deferred mode.
+- A staff user acting through the product produces `origin = self_service` and `created_by_staff = true`.
 - Cross-team list and detail access fails closed.
+- The HogQL table returns only self-service requests for the current team and omits operator-only fields.
 - Customers cannot assign status, approval, origin, execution mode, or team.
 - Criteria edits clear approval and preview state.
 - Duplicate submissions return the existing request.
@@ -345,17 +369,18 @@ Operational documentation must cover credential provisioning, resource limits, r
 ## Open questions
 
 1. Which product should own the backend and frontend implementation?
-2. Which project role receives the deletion permission?
-3. Do all self-service requests require manual approval for the first release?
-4. What preview count or query-cost thresholds permit automatic approval?
-5. Should the API accept only `HogQLQuery`, or every query node that eventually compiles to one UUID column?
-6. Does the current compiler expose a safe typed representation for wrapping a compiled query in `INSERT ... SELECT`?
-7. Which regular HogQL resources should the dedicated executor principal be able to read?
-8. How should self-hosted deployments provision or fall back when the dedicated principal is unavailable?
-9. Does the queue dictionary need an explicit `GROUP BY team_id, uuid` for retry duplicates?
-10. How long should completed provenance rows remain available before the existing TTL removes them?
-11. Does event deletion also need to remove or rebuild derived data outside the legacy and native-JSON event tables?
-12. What customer-visible cancellation behavior is safe before UUID queueing begins and after it completes?
+2. Should the HogQL table expose all self-service requests for the team or only requests visible to the querying user?
+3. Which project role receives the deletion permission?
+4. Do all self-service requests require manual approval for the first release?
+5. What preview count or query-cost thresholds permit automatic approval?
+6. Should the API accept only `HogQLQuery`, or every query node that eventually compiles to one UUID column?
+7. Does the current compiler expose a safe typed representation for wrapping a compiled query in `INSERT ... SELECT`?
+8. Which regular HogQL resources should the dedicated executor principal be able to read?
+9. How should self-hosted deployments provision or fall back when the dedicated principal is unavailable?
+10. Does the queue dictionary need an explicit `GROUP BY team_id, uuid` for retry duplicates?
+11. How long should completed provenance rows remain available before the existing TTL removes them?
+12. Does event deletion also need to remove or rebuild derived data outside the legacy and native-JSON event tables?
+13. What customer-visible cancellation behavior is safe before UUID queueing begins and after it completes?
 
 ## Definition of done
 
@@ -368,4 +393,5 @@ Operational documentation must cover credential provisioning, resource limits, r
 - Retries cannot expand deletion beyond the immutable query and request team.
 - `deletes_job` removes queued events from every active physical event table.
 - The product shows the request's approval, queueing, deletion, and verification state.
+- Customers can inspect their self-service requests through the team-scoped `data_deletion_requests` HogQL table.
 - Documentation and operational controls are ready before the feature flag expands.


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- For each change a person can notice, say what they will now see or do differently, not only the code path that does it. Mark the rest as mechanical so a reviewer knows nothing user-visible is hiding in it. -->

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - No duplicate: when this PR fixes something believed to be live on master, no open PR already fixes it. A broken master attracts parallel agents, so search before opening — `gh pr list --state open --search "<keywords>" --limit 20`, which lists drafts too, and most agent PRs start as drafts. Say here which PR you found and why this one is still needed, or that the search found nothing.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the palette and role mapping.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
