### PR TITLE
fix(experiments): Quiet noisy rows in the experiment history feed

### DIFF
--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.feature-flag.test.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.feature-flag.test.tsx
@@ -29,6 +29,22 @@ describe('the activity log logic', () => {
             expect(logic.values.humanizedActivity).toHaveLength(0)
         })
 
+        it('keeps the generic row for a describable change the handler cannot narrate', async () => {
+            const logic = await featureFlagsTestSetup('test flag', 'updated', [
+                {
+                    type: ActivityScope.FEATURE_FLAG,
+                    action: 'changed',
+                    field: 'filters',
+                    before: { groups: [{ properties: [], rollout_percentage: 50 }] },
+                    after: {},
+                },
+            ])
+
+            const actual = logic.values.humanizedActivity
+            expect(actual).toHaveLength(1)
+            expect(render(<>{actual[0].description}</>).container).toHaveTextContent('peter updated')
+        })
+
         it('can handle change of key', async () => {
             const logic = await featureFlagsTestSetup('test flag', 'updated', [
                 {

--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.feature-flag.test.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.feature-flag.test.tsx
@@ -15,6 +15,20 @@ describe('the activity log logic', () => {
             `/api/projects/${MOCK_TEAM_ID}/feature_flags/7/activity/`
         )
 
+        it('drops an entry whose only change is the version bump', async () => {
+            const logic = await featureFlagsTestSetup('test flag', 'updated', [
+                {
+                    type: ActivityScope.FEATURE_FLAG,
+                    action: 'changed',
+                    field: 'version',
+                    before: 1,
+                    after: 2,
+                },
+            ])
+
+            expect(logic.values.humanizedActivity).toHaveLength(0)
+        })
+
         it('can handle change of key', async () => {
             const logic = await featureFlagsTestSetup('test flag', 'updated', [
                 {

--- a/frontend/src/scenes/experiments/activity-descriptions/experimentChangeDescription.tsx
+++ b/frontend/src/scenes/experiments/activity-descriptions/experimentChangeDescription.tsx
@@ -39,6 +39,8 @@ export const nameOrLinkToExperiment = (name: string | null, id?: string): JSX.El
 type AllowedExperimentFields = Pick<
     Experiment,
     | 'conclusion'
+    | 'conclusion_comment'
+    | 'status'
     | 'start_date'
     | 'end_date'
     | 'metrics'
@@ -306,6 +308,15 @@ export const getExperimentChangeDescription = (
         .with({ field: 'excluded_variants' }, () => {
             // The change is described by the `parameters` matcher, which the backend keeps
             // mirrored while `parameters` is deprecated — avoid a duplicate line.
+            return null
+        })
+        .with({ field: 'status' }, () => {
+            // Status only moves together with a lifecycle change (launch, stop, pause), and those
+            // already produce their own descriptions, so an "updated status" clause adds nothing.
+            return null
+        })
+        .with({ field: 'conclusion_comment' }, () => {
+            // The describer renders the comment text as the row's extended description instead.
             return null
         })
         .otherwise(({ field, action }) => {

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.test.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.test.tsx
@@ -437,5 +437,29 @@ describe('experimentActivityDescriber', () => {
             const extended = render(<>{result.extendedDescription}</>).container.textContent
             expect(extended).toContain('Variant B lifted signups by 4%.')
         })
+
+        it('keeps a row for a comment-only conclusion removal', () => {
+            const result = experimentActivityDescriber(
+                baseLogItem({
+                    activity: 'updated',
+                    detail: {
+                        name: 'Checkout funnel',
+                        changes: [
+                            {
+                                type: ActivityScope.EXPERIMENT,
+                                action: 'changed',
+                                field: 'conclusion_comment',
+                                before: 'Variant B lifted signups.',
+                                after: null,
+                            },
+                        ],
+                        merge: null,
+                        trigger: null,
+                    },
+                })
+            )
+            expect(textOf(result)).toContain('removed the conclusion comment')
+            expect(result.extendedDescription).toBeUndefined()
+        })
     })
 })

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.test.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.test.tsx
@@ -410,6 +410,7 @@ describe('experimentActivityDescriber', () => {
             const text = textOf(result)
             expect(text).toContain('launched experiment')
             expect(text).not.toContain('status')
+            expect(text).not.toContain(': on')
         })
 
         it('keeps a row for a comment-only conclusion edit', () => {

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.test.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.test.tsx
@@ -328,4 +328,113 @@ describe('experimentActivityDescriber', () => {
             expect(text).not.toContain('running time calculation')
         })
     })
+
+    describe('lifecycle entries', () => {
+        it('describes a stop entry without narrating status or the conclusion comment', () => {
+            const result = experimentActivityDescriber(
+                baseLogItem({
+                    activity: 'updated',
+                    detail: {
+                        name: 'Checkout funnel',
+                        changes: [
+                            {
+                                type: ActivityScope.EXPERIMENT,
+                                action: 'created',
+                                field: 'end_date',
+                                before: null,
+                                after: '2026-06-18T14:25:34Z',
+                            },
+                            {
+                                type: ActivityScope.EXPERIMENT,
+                                action: 'changed',
+                                field: 'status',
+                                before: 'running',
+                                after: 'complete',
+                            },
+                            {
+                                type: ActivityScope.EXPERIMENT,
+                                action: 'created',
+                                field: 'conclusion',
+                                before: null,
+                                after: 'won',
+                            },
+                            {
+                                type: ActivityScope.EXPERIMENT,
+                                action: 'created',
+                                field: 'conclusion_comment',
+                                before: null,
+                                after: 'Variant B lifted signups.',
+                            },
+                        ],
+                        merge: null,
+                        trigger: null,
+                    },
+                })
+            )
+            const text = textOf(result)
+            expect(text).toContain('stopped experiment')
+            expect(text).toContain('completed it as')
+            expect(text).not.toContain('status')
+            expect(text).not.toContain('conclusion comment')
+            const extended = render(<>{result.extendedDescription}</>).container.textContent
+            expect(extended).toContain('Variant B lifted signups.')
+        })
+
+        it('drops the status clause from a launch entry', () => {
+            const result = experimentActivityDescriber(
+                baseLogItem({
+                    activity: 'updated',
+                    detail: {
+                        name: 'Checkout funnel',
+                        changes: [
+                            {
+                                type: ActivityScope.EXPERIMENT,
+                                action: 'created',
+                                field: 'start_date',
+                                before: null,
+                                after: '2026-06-18T14:25:34Z',
+                            },
+                            {
+                                type: ActivityScope.EXPERIMENT,
+                                action: 'changed',
+                                field: 'status',
+                                before: 'draft',
+                                after: 'running',
+                            },
+                        ],
+                        merge: null,
+                        trigger: null,
+                    },
+                })
+            )
+            const text = textOf(result)
+            expect(text).toContain('launched experiment')
+            expect(text).not.toContain('status')
+        })
+
+        it('keeps a row for a comment-only conclusion edit', () => {
+            const result = experimentActivityDescriber(
+                baseLogItem({
+                    activity: 'updated',
+                    detail: {
+                        name: 'Checkout funnel',
+                        changes: [
+                            {
+                                type: ActivityScope.EXPERIMENT,
+                                action: 'changed',
+                                field: 'conclusion_comment',
+                                before: 'Variant B lifted signups.',
+                                after: 'Variant B lifted signups by 4%.',
+                            },
+                        ],
+                        merge: null,
+                        trigger: null,
+                    },
+                })
+            )
+            expect(textOf(result)).toContain('changed the conclusion')
+            const extended = render(<>{result.extendedDescription}</>).container.textContent
+            expect(extended).toContain('Variant B lifted signups by 4%.')
+        })
+    })
 })

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -100,6 +100,10 @@ const humanizeExperimentChange = (
 }
 
 const appendPreposition = (item: string | JSX.Element): string | JSX.Element => {
+    // A part that ends with a colon already introduces the experiment name.
+    if (extractText(item).trimEnd().endsWith(':')) {
+        return item
+    }
     const preposition = getPreposition(item)
     return typeof item === 'string' ? (
         `${item} ${preposition}`

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -325,13 +325,17 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
                 updateLogDetail.type !== 'holdout' &&
                 updateLogDetail.type !== 'saved_metric_config'
 
-            const conclusionCommentAfter = isExperiment
-                ? changes.find((change) => change.field === 'conclusion_comment')?.after
+            const conclusionCommentChange = isExperiment
+                ? changes.find((change) => change.field === 'conclusion_comment')
                 : undefined
             const conclusionComment =
-                typeof conclusionCommentAfter === 'string' && conclusionCommentAfter.trim()
-                    ? conclusionCommentAfter
+                typeof conclusionCommentChange?.after === 'string' && conclusionCommentChange.after.trim()
+                    ? conclusionCommentChange.after
                     : undefined
+            const conclusionCommentRemoved =
+                !conclusionComment &&
+                typeof conclusionCommentChange?.before === 'string' &&
+                Boolean(conclusionCommentChange.before.trim())
 
             let listParts: (string | JSX.Element)[]
             if (changes.length === 0) {
@@ -356,12 +360,15 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
             }
 
             if (isExperiment && changes.length > 0 && listParts.length === 0) {
-                if (!conclusionComment) {
+                if (conclusionComment) {
+                    // A comment-only edit still gets a row; the comment renders below it.
+                    listParts = ['changed the conclusion']
+                } else if (conclusionCommentRemoved) {
+                    listParts = ['removed the conclusion comment']
+                } else {
                     // humanize() skips log items with a null description
                     return { description: null }
                 }
-                // A comment-only edit still gets a row; the comment renders below it.
-                listParts = ['changed the conclusion']
             }
 
             if (isExperiment && changes.length > 0 && listParts.length > 0) {

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -321,6 +321,14 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
                 updateLogDetail.type !== 'holdout' &&
                 updateLogDetail.type !== 'saved_metric_config'
 
+            const conclusionCommentAfter = isExperiment
+                ? changes.find((change) => change.field === 'conclusion_comment')?.after
+                : undefined
+            const conclusionComment =
+                typeof conclusionCommentAfter === 'string' && conclusionCommentAfter.trim()
+                    ? conclusionCommentAfter
+                    : undefined
+
             let listParts: (string | JSX.Element)[]
             if (changes.length === 0) {
                 listParts = ['updated']
@@ -344,8 +352,12 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
             }
 
             if (isExperiment && changes.length > 0 && listParts.length === 0) {
-                // humanize() skips log items with a null description
-                return { description: null }
+                if (!conclusionComment) {
+                    // humanize() skips log items with a null description
+                    return { description: null }
+                }
+                // A comment-only edit still gets a row; the comment renders below it.
+                listParts = ['changed the conclusion']
             }
 
             if (isExperiment && changes.length > 0 && listParts.length > 0) {
@@ -366,6 +378,9 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
                         suffix={suffix}
                     />
                 ),
+                extendedDescription: conclusionComment ? (
+                    <blockquote className="border-l-2 pl-2 text-secondary">{conclusionComment}</blockquote>
+                ) : undefined,
             }
         })
         .otherwise(() => {

--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -53,6 +53,11 @@ const getRuntimeLabel = (runtime: string): string => {
     }
 }
 
+// Shared handler for fields the feed deliberately never describes. EXCLUDED_FLAG_FIELDS is
+// derived by identity from this function, so excluded fields stay distinguishable from
+// describable fields whose handler returned null for one particular change.
+const excludedFieldHandler = (): null => null
+
 const featureFlagActionsMapping: Record<
     keyof FeatureFlagType,
     (change?: ActivityChange, logItem?: ActivityLogItem) => ChangeMapping | null
@@ -377,27 +382,33 @@ const featureFlagActionsMapping: Record<
         return { description: changes }
     },
     // fields that are excluded on the backend
-    id: () => null,
-    created_at: () => null,
-    created_by: () => null,
-    updated_at: () => null,
-    experiment_set: () => null,
-    experiment_set_metadata: () => null,
-    features: () => null,
-    usage_dashboard: () => null,
-    can_edit: () => null,
-    has_enriched_analytics: () => null,
-    surveys: () => null,
-    user_access_level: () => null,
-    is_remote_configuration: () => null,
-    has_encrypted_payloads: () => null,
-    status: () => null,
-    version: () => null,
-    last_modified_by: () => null,
-    last_called_at: () => null,
-    is_used_in_replay_settings: () => null,
-    _create_in_folder: () => null,
+    id: excludedFieldHandler,
+    created_at: excludedFieldHandler,
+    created_by: excludedFieldHandler,
+    updated_at: excludedFieldHandler,
+    experiment_set: excludedFieldHandler,
+    experiment_set_metadata: excludedFieldHandler,
+    features: excludedFieldHandler,
+    usage_dashboard: excludedFieldHandler,
+    can_edit: excludedFieldHandler,
+    has_enriched_analytics: excludedFieldHandler,
+    surveys: excludedFieldHandler,
+    user_access_level: excludedFieldHandler,
+    is_remote_configuration: excludedFieldHandler,
+    has_encrypted_payloads: excludedFieldHandler,
+    status: excludedFieldHandler,
+    version: excludedFieldHandler,
+    last_modified_by: excludedFieldHandler,
+    last_called_at: excludedFieldHandler,
+    is_used_in_replay_settings: excludedFieldHandler,
+    _create_in_folder: excludedFieldHandler,
 }
+
+const EXCLUDED_FLAG_FIELDS = new Set(
+    Object.keys(featureFlagActionsMapping).filter(
+        (field) => featureFlagActionsMapping[field as keyof FeatureFlagType] === excludedFieldHandler
+    )
+)
 
 const getActorName = (logItem: ActivityLogItem): JSX.Element => {
     const userName = userNameForLogItem(logItem)
@@ -499,17 +510,14 @@ export function flagActivityDescriber(logItem: ActivityLogItem, asNotification?:
             </>
         )
 
-        let hasIndescribableChange = false
         for (const change of logItem.detail.changes || []) {
             if (!change?.field) {
-                hasIndescribableChange = true
                 continue // feature flag updates have to have a "field" to be described
             }
 
             const fieldHandler = featureFlagActionsMapping[change.field as keyof FeatureFlagType]
             if (!fieldHandler) {
                 console.error({ field: change.field, change }, 'No activity describer found for feature flag field')
-                hasIndescribableChange = true
             }
             const possibleLogItem = fieldHandler ? fieldHandler(change, logItem) : null
             if (possibleLogItem) {
@@ -529,10 +537,15 @@ export function flagActivityDescriber(logItem: ActivityLogItem, asNotification?:
             }
         }
 
-        if ((logItem.detail.changes || []).length > 0 && !hasIndescribableChange) {
-            // Every change maps to an excluded field, which happens when a save only bumps the
+        const updateChanges = logItem.detail.changes || []
+        if (
+            updateChanges.length > 0 &&
+            updateChanges.every((change) => change.field && EXCLUDED_FLAG_FIELDS.has(change.field))
+        ) {
+            // Every change is to an excluded field, which happens when a save only bumps the
             // optimistic-concurrency `version`. The fallback would render a contentless
-            // "updated <flag>" row, so drop the entry instead.
+            // "updated <flag>" row, so drop the entry instead. A describable change whose
+            // handler produced no text still falls through to the generic fallback.
             return { description: null }
         }
     }

--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -499,14 +499,17 @@ export function flagActivityDescriber(logItem: ActivityLogItem, asNotification?:
             </>
         )
 
+        let hasIndescribableChange = false
         for (const change of logItem.detail.changes || []) {
             if (!change?.field) {
+                hasIndescribableChange = true
                 continue // feature flag updates have to have a "field" to be described
             }
 
             const fieldHandler = featureFlagActionsMapping[change.field as keyof FeatureFlagType]
             if (!fieldHandler) {
                 console.error({ field: change.field, change }, 'No activity describer found for feature flag field')
+                hasIndescribableChange = true
             }
             const possibleLogItem = fieldHandler ? fieldHandler(change, logItem) : null
             if (possibleLogItem) {
@@ -524,6 +527,13 @@ export function flagActivityDescriber(logItem: ActivityLogItem, asNotification?:
             return {
                 description: <SentenceList listParts={changes} prefix={getActorName(logItem)} suffix={changeSuffix} />,
             }
+        }
+
+        if ((logItem.detail.changes || []).length > 0 && !hasIndescribableChange) {
+            // Every change maps to an excluded field, which happens when a save only bumps the
+            // optimistic-concurrency `version`. The fallback would render a contentless
+            // "updated <flag>" row, so drop the entry instead.
+            return { description: null }
         }
     }
 


### PR DESCRIPTION
## Problem

Lifecycle rows in the experiment History tab carry fallback noise:

- Every launch reads "launched experiment:, updated status for X" since `status` became a stored field in the pause/resume work.
- Stop entries append "updated conclusion comment" instead of showing the comment, which is the most readable thing in the feed.
- Flag saves that only bump the optimistic-concurrency `version` render as contentless "updated \<flag\>" rows in the merged feed.

Follow-up to #93583, which cleaned up the running-time drift rows and added the row-drop plumbing.

## Changes

| Entry | Before | After |
|---|---|---|
| Launch | launched experiment:, updated status for X | launched experiment: X |
| Stop | stopped experiment, completed it as Won:, updated status for X | stopped experiment, completed it as Won: X, comment quoted below the row |
| Comment-only edit | updated conclusion comment for X | changed the conclusion for X, comment quoted below |
| Version-only flag save | updated \<flag\> | row dropped |

- `status` changes describe to null. It only moves together with a lifecycle change that already has its own wording.
- The conclusion comment renders in the existing extended description slot (same mechanism insights use for query details), so it shows as a quoted block under the row instead of a clause in the sentence.
- The flag describer drops an updated entry when every change maps to an excluded field. Entries with unknown fields still fall back to the generic row, so nothing legitimate is hidden.
- Parts ending with a colon no longer get a preposition appended. Suppressing the status clause made "launched experiment:" the last part, which rendered as "launched experiment: on X".

No screenshots: the output is describer text, shown in the table above and asserted by the jest render tests.

## How did you test this code?

- Extended `experimentActivityDescriber.test.tsx` with a stop entry (end_date + status + conclusion + comment in one entry), a launch entry, and a comment-only edit. They catch the fallback clauses reappearing, the comment block disappearing, and the ": on" wording.
- Added a version-only case to `activityLogLogic.feature-flag.test.tsx`. It catches the contentless "updated" row coming back.
- Compared the fixtures against a production dogfood experiment feed: its stop, launch, and version-only entries match the tested shapes.
- Not run: anything beyond the two jest files and the frontend typecheck.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session resuming a handoff from the #93583 work. Skills invoked: /writing-tests, /writing-code-comments, /writing-user-facing-copy, /writing-pr-descriptions. The open decision from the handoff (suppress vs render the conclusion comment) resolved to render, using the extended description slot rather than inline text.
