### PR TITLE
fix(batch-exports): treat Redshift database permission error as non-retryable

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -1601,7 +1601,16 @@ async def check_and_raise_redshift_copy_error(
     error matches a known S3 read/access marker, raising the more generic `RedshiftS3CopyError` that
     points at the likely culprits (role read access or bucket region). Any other COPY error returns
     unchanged so it keeps its original message and retry behaviour.
+
+    Redshift can also report a missing permission to create temporary tables as an `InternalError_`.
+    We translate that specific diagnostic to `InsufficientPrivilege`, which the activity treats as
+    non-retryable.
     """
+    # this is a database permissions issue, not an S3 one
+    diagnostics = (str(err), err.diag.message_primary or "", err.diag.message_detail or "")
+    if any("permission denied to create temporary tables" in text.lower() for text in diagnostics):
+        raise psycopg.errors.InsufficientPrivilege(str(err)) from err
+
     if isinstance(authorization, AWSCredentials):
         probe_keys = [manifest_key, *files_uploaded[:1]]
         if await is_s3_read_access_denied(
@@ -1620,7 +1629,6 @@ async def check_and_raise_redshift_copy_error(
         "S3ServiceException",
         "Forbidden",
     )
-    diagnostics = (str(err), err.diag.message_primary or "", err.diag.message_detail or "")
     if any(marker in text for text in diagnostics for marker in markers):
         raise RedshiftS3CopyError(bucket) from err
 

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_redshift_utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_redshift_utils.py
@@ -273,14 +273,21 @@ async def test_check_and_raise_redshift_copy_error_credentials(denied):
 
 
 @pytest.mark.parametrize(
-    "error,should_raise",
+    "error,expected_error",
     [
-        (_FakeInternalError("COPY with MANIFEST parameter requires full path of an S3 object"), True),
-        (_FakeInternalError("copy failed", detail="S3ServiceException: Access Denied"), True),
-        (_FakeInternalError("syntax error at or near 'foo'"), False),
+        (
+            _FakeInternalError("COPY with MANIFEST parameter requires full path of an S3 object"),
+            RedshiftS3CopyError,
+        ),
+        (_FakeInternalError("copy failed", detail="S3ServiceException: Access Denied"), RedshiftS3CopyError),
+        (
+            _FakeInternalError('permission denied to create temporary tables in database "my_data"'),
+            psycopg.errors.InsufficientPrivilege,
+        ),
+        (_FakeInternalError("syntax error at or near 'foo'"), None),
     ],
 )
-async def test_check_and_raise_redshift_copy_error_iam_role(error, should_raise):
+async def test_check_and_raise_redshift_copy_error_iam_role(error, expected_error):
     """IAM role auth can't be probed, so we translate only recognised S3 read/access failures."""
     call = check_and_raise_redshift_copy_error(
         error,
@@ -290,8 +297,8 @@ async def test_check_and_raise_redshift_copy_error_iam_role(error, should_raise)
         manifest_key="prefix/manifest.json",
         files_uploaded=["prefix/file-0.parquet.zst"],
     )
-    if should_raise:
-        with pytest.raises(RedshiftS3CopyError):
+    if expected_error is not None:
+        with pytest.raises(expected_error):
             await call
     else:
         await call  # should not raise


### PR DESCRIPTION
## Problem

If there is a permissions error when creating temporary tables in Redshift, a `psycopg.errors.InternalError_` is raised, but we don't treat this as non-retryable.

## Changes

In this case raise a `psycopg.errors.InsufficientPrivilege` error, which will be treated as non-retryable.

## How did you test this code?

Added a new test. Relying on existing test suite to pass.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None needed.

## 🤖 Agent context

Co-authored with PostHog Desktop using GPT-5.6-Sol

**Autonomy:** Human-driven (agent-assisted)

