### PR TITLE
feat(ingestion-consumer): deduplicate redelivered offsets instead of resetting the partition

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2922,7 +2922,9 @@ name = "common-kafka-consumer"
 version = "0.1.0"
 dependencies = [
  "metrics",
+ "metrics-util",
  "rdkafka",
+ "tracing",
 ]
 
 [[package]]

--- a/rust/common/kafka-consumer/Cargo.toml
+++ b/rust/common/kafka-consumer/Cargo.toml
@@ -10,3 +10,7 @@ workspace = true
 [dependencies]
 metrics = { workspace = true }
 rdkafka = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+metrics-util = { workspace = true }

--- a/rust/common/kafka-consumer/README.md
+++ b/rust/common/kafka-consumer/README.md
@@ -20,5 +20,6 @@ Kafka consumption primitives shared by stateful services.
 | `kafka_consumer_ledger_uncommitted_offsets` (gauge) | `topic`, `partition` | Offsets the partition's window holds. |
 | `kafka_consumer_ledger_uncommitted_events` (gauge) | `topic`, `partition` | Events those offsets carry. |
 | `kafka_consumer_ledger_uncommitted_bytes` (gauge) | `topic`, `partition` | Bytes those offsets carry (payload plus key plus headers). |
+| `kafka_consumer_ledger_deduplicated_total` (counter) | `topic`, `partition` | Redelivered offsets the window already held. The ledger charges them once and the caller drops the repeated messages. |
 | `kafka_consumer_ledger_stale_slices_total` (counter) | `stage` | Charges and settlements dropped because their partition was reassigned while they were in flight; a few around a rebalance are expected. |
 | `kafka_consumer_ledger_errors_total` (counter) | `stage`, `kind` | Contract violations in the accounting; must stay 0. A violation resets that partition's ledger and the consumer keeps running. |

--- a/rust/common/kafka-consumer/src/accumulator.rs
+++ b/rust/common/kafka-consumer/src/accumulator.rs
@@ -103,6 +103,70 @@ impl<K: Hash + Eq + Clone, M> Accumulator<K, M> {
         self.message_count
     }
 
+    /// Drop, from one partition, as many messages at each offset as
+    /// `offsets` asks for, together with any group they leave empty. A poll
+    /// can hold the same offset more than once, so removal counts copies
+    /// rather than matching every message at that offset; the copies met
+    /// first go. Returns the lowest and highest offset the partition still
+    /// holds, or `None` when it holds nothing.
+    ///
+    /// Linear over the poll, for callers that learn only after collection
+    /// that a message must not be dispatched. The collection path itself
+    /// never calls it.
+    pub fn remove_offsets(
+        &mut self,
+        partition: Partition,
+        offsets: &HashMap<Offset, usize>,
+    ) -> Option<(Offset, Offset)> {
+        let mut wanted = offsets.clone();
+        let mut removed = 0;
+        for group in &mut self.groups {
+            if group.partition != partition {
+                continue;
+            }
+            let before = group.messages.len();
+            group
+                .messages
+                .retain(|message| match wanted.get_mut(&message.offset) {
+                    Some(copies) if *copies > 0 => {
+                        *copies -= 1;
+                        false
+                    }
+                    _ => true,
+                });
+            removed += before - group.messages.len();
+        }
+        if removed > 0 {
+            self.message_count -= removed;
+            self.groups.retain(|group| !group.is_empty());
+            self.reindex();
+        }
+        let mut bounds: Option<(Offset, Offset)> = None;
+        for group in self.groups.iter().filter(|g| g.partition == partition) {
+            for message in &group.messages {
+                bounds = Some(match bounds {
+                    None => (message.offset, message.offset),
+                    Some((first, last)) => (first.min(message.offset), last.max(message.offset)),
+                });
+            }
+        }
+        bounds
+    }
+
+    /// Rebuild the key index after group positions moved.
+    fn reindex(&mut self) {
+        self.group_index_by_key.clear();
+        for (index, group) in self.groups.iter().enumerate() {
+            let Some(key) = group.key.clone() else {
+                continue;
+            };
+            self.group_index_by_key
+                .entry(group.partition)
+                .or_default()
+                .insert(key, index);
+        }
+    }
+
     pub fn into_groups(self) -> Vec<Group<K, M>> {
         self.groups
     }
@@ -156,6 +220,75 @@ mod tests {
         );
         let bodies: Vec<i64> = groups[0].messages.iter().map(|m| m.message).collect();
         assert_eq!(bodies, vec![0, 2]);
+    }
+
+    #[test]
+    fn removing_offsets_drops_the_messages_and_the_groups_they_empty() {
+        let mut acc = Accumulator::default();
+        push(&mut acc, 0, 0, Some("a"));
+        push(&mut acc, 0, 1, Some("b"));
+        push(&mut acc, 0, 2, Some("a"));
+        push(&mut acc, 1, 1, Some("a"));
+
+        let bounds = acc.remove_offsets(
+            Partition(0),
+            &HashMap::from([(Offset(1), 1), (Offset(2), 1)]),
+        );
+
+        assert_eq!(bounds, Some((Offset(0), Offset(0))));
+        assert_eq!(acc.message_count(), 2);
+        // Key "a" on partition 0 still groups later messages, so the index
+        // has to follow the group that moved.
+        push(&mut acc, 0, 3, Some("a"));
+        let groups = acc.into_groups();
+        let shapes: Vec<(Partition, Option<&str>, Vec<Offset>)> = groups
+            .iter()
+            .map(|g| (g.partition, g.key, offsets(g)))
+            .collect();
+        assert_eq!(
+            shapes,
+            vec![
+                (Partition(0), Some("a"), vec![Offset(0), Offset(3)]),
+                (Partition(1), Some("a"), vec![Offset(1)]),
+            ]
+        );
+    }
+
+    #[test]
+    fn removing_every_offset_of_a_partition_reports_no_bounds() {
+        let mut acc = Accumulator::default();
+        push(&mut acc, 0, 0, Some("a"));
+        push(&mut acc, 1, 7, None);
+
+        let bounds = acc.remove_offsets(Partition(0), &HashMap::from([(Offset(0), 1)]));
+
+        assert_eq!(bounds, None);
+        assert_eq!(acc.message_count(), 1, "other partitions are untouched");
+    }
+
+    #[test]
+    fn removing_offsets_drops_only_as_many_copies_as_asked() {
+        let mut acc = Accumulator::default();
+        push(&mut acc, 0, 4, Some("a"));
+        push(&mut acc, 0, 4, Some("a"));
+        push(&mut acc, 0, 5, Some("a"));
+
+        let bounds = acc.remove_offsets(Partition(0), &HashMap::from([(Offset(4), 1)]));
+
+        assert_eq!(bounds, Some((Offset(4), Offset(5))));
+        assert_eq!(acc.message_count(), 2, "one copy of offset 4 stays");
+    }
+
+    #[test]
+    fn removing_offsets_a_partition_never_held_changes_nothing() {
+        let mut acc = Accumulator::default();
+        push(&mut acc, 0, 4, Some("a"));
+        push(&mut acc, 0, 6, Some("a"));
+
+        let bounds = acc.remove_offsets(Partition(0), &HashMap::from([(Offset(5), 1)]));
+
+        assert_eq!(bounds, Some((Offset(4), Offset(6))));
+        assert_eq!(acc.message_count(), 2);
     }
 
     #[test]

--- a/rust/common/kafka-consumer/src/lib.rs
+++ b/rust/common/kafka-consumer/src/lib.rs
@@ -12,6 +12,8 @@ pub use accumulator::{Accumulator, Group, GroupMessage, PolledMessage};
 pub use assignment_epoch::AssignmentEpoch;
 pub use charge::Charge;
 pub use config::ConsumerConfigBuilder;
-pub use partition_offset_ledger::{Held, LedgerError, PartitionOffsetLedger, TakenFrontier};
-pub use topic_offset_ledger::{Rejection, TopicOffsetLedger, TopicPartition};
+pub use partition_offset_ledger::{
+    Charged, Held, LedgerError, PartitionOffsetLedger, TakenFrontier,
+};
+pub use topic_offset_ledger::{ChargeOutcome, Rejection, TopicOffsetLedger, TopicPartition};
 pub use types::{GroupCompletion, Offset, Partition};

--- a/rust/common/kafka-consumer/src/partition_offset_ledger.rs
+++ b/rust/common/kafka-consumer/src/partition_offset_ledger.rs
@@ -17,8 +17,10 @@ struct Slot {
 /// rather than reasoning about that state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LedgerError {
-    /// A charge delivered an offset that is not above every offset already
-    /// recorded.
+    /// A charge delivered an offset the window cannot place: below its base,
+    /// or on a slot that only fills an offset gap. A repeat of an offset the
+    /// window still holds is not this error; see
+    /// [`PartitionOffsetLedger::charge`].
     OffsetNotAboveWindow { offset: Offset, next: Offset },
     /// A completion arrived before any delivery was charged.
     CompletionBeforeDelivery { offset: Offset },
@@ -77,6 +79,18 @@ pub struct TakenFrontier {
     pub gap_offset_count: usize,
 }
 
+/// What one charge did: the charge of the offsets it recorded, and the
+/// offsets it recognised as already recorded.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Charged {
+    /// Charge of the offsets this call added to the window. A recognised
+    /// repeat adds nothing.
+    pub charge: Charge,
+    /// Offsets the window already holds, in the order the slice repeated
+    /// them. Empty on every charge that only delivers new offsets.
+    pub duplicates: Vec<Offset>,
+}
+
 /// What a window holds: the offsets charged and not yet drained by
 /// `take_frontier`, and the charge they carry.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -97,12 +111,13 @@ pub struct Held {
 ///
 /// A ledger lives for one partition assignment: create it on assign, drop it
 /// on revoke. Kafka redelivers a partition from its committed offset after a
-/// rebalance, so a ledger kept across assignments sees the redelivery as
-/// duplicate delivery and rejects it. Completions from a previous
+/// rebalance, and the new assignment must process that redelivery, so a
+/// ledger kept across assignments would take it for a repeat of work it still
+/// holds and tell the caller to drop it. Completions from a previous
 /// assignment's in-flight work must be discarded before they reach the new
-/// ledger; it never charged those offsets and rejects them too. Both come
-/// back as a [`LedgerError`]: the ledger never panics, so an owner holding
-/// it under a lock stays usable.
+/// ledger; it never charged those offsets and rejects them as a
+/// [`LedgerError`]. The ledger never panics, so an owner holding it under a
+/// lock stays usable.
 #[derive(Debug)]
 pub struct PartitionOffsetLedger {
     /// The partition generation this ledger was founded under. The owner
@@ -140,22 +155,35 @@ impl PartitionOffsetLedger {
         self.generation
     }
 
-    /// Record offsets in delivery order and return their total charge. An
-    /// offset gap (transaction control records) never blocks the frontier and
-    /// carries no charge.
+    /// Record offsets in delivery order and return the charge they added,
+    /// together with the offsets the window already held. An offset gap
+    /// (transaction control records) never blocks the frontier and carries no
+    /// charge.
     ///
-    /// Fails when an offset is not above every offset already recorded.
-    /// Duplicate or out-of-order delivery is a caller bug, and recording it
-    /// would corrupt the commit accounting.
+    /// An offset that lands on a slot the window holds for a real delivery
+    /// repeats an offset this ledger already accounts for, whether the slot
+    /// is complete or not. The window keeps the slot it has, adds no charge,
+    /// and returns the offset as a duplicate. The caller must drop the
+    /// repeated message, because the window's charge states what the owner
+    /// holds.
+    ///
+    /// Fails when an offset is below the window's base, or lands on gap
+    /// filler. The window recorded no delivery in either place, so it cannot
+    /// tell a repeat from a message it never saw, and accounting for it
+    /// either way would corrupt the commit accounting.
     pub fn charge(
         &mut self,
         offset_charges: impl IntoIterator<Item = (Offset, Charge)>,
-    ) -> Result<Charge, LedgerError> {
-        let mut total = Charge::ZERO;
+    ) -> Result<Charged, LedgerError> {
+        let mut charged = Charged::default();
         for (offset, charge) in offset_charges {
             let base_offset = *self.base_offset.get_or_insert(offset);
             let next_offset = base_offset + self.slots.len();
             if offset < next_offset {
+                if self.holds_delivery(offset, base_offset) {
+                    charged.duplicates.push(offset);
+                    continue;
+                }
                 return Err(LedgerError::OffsetNotAboveWindow {
                     offset,
                     next: next_offset,
@@ -175,10 +203,20 @@ impl PartitionOffsetLedger {
                 charge,
                 delivered: true,
             });
-            total += charge;
+            charged.charge += charge;
             self.held_charge += charge;
         }
-        Ok(total)
+        Ok(charged)
+    }
+
+    /// Whether the window holds `offset` for a real delivery. False below the
+    /// base and on gap filler. Only offsets below the window's next offset
+    /// reach this.
+    fn holds_delivery(&self, offset: Offset, base_offset: Offset) -> bool {
+        usize::try_from(offset - base_offset)
+            .ok()
+            .and_then(|slot_index| self.slots.get(slot_index))
+            .is_some_and(|slot| slot.delivered)
     }
 
     /// Mark delivered offsets complete in any order.
@@ -299,9 +337,100 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_delivery_is_rejected() {
+    fn a_repeat_of_an_uncompleted_offset_is_a_duplicate() {
         let mut ledger = PartitionOffsetLedger::new(1);
         ledger.charge([charge(0), charge(1)]).unwrap();
+        let held = ledger.held();
+
+        let charged = ledger.charge([charge(1)]).expect("the window places it");
+
+        assert_eq!(charged.duplicates, vec![Offset(1)]);
+        assert_eq!(charged.charge, Charge::ZERO, "a repeat adds no charge");
+        assert_eq!(ledger.held(), held, "the window is untouched");
+
+        // The offset the window already holds still completes once.
+        ledger.complete([Offset(0), Offset(1)]).unwrap();
+        assert_eq!(ledger.frontier(), Some(Offset(2)));
+    }
+
+    #[test]
+    fn a_repeat_of_a_completed_offset_is_a_duplicate() {
+        let mut ledger = PartitionOffsetLedger::new(1);
+        ledger.charge([charge(0), charge(1)]).unwrap();
+        // Offset 0 is complete but the window still holds it: offset 1 keeps
+        // the frontier from draining.
+        ledger.complete([Offset(0)]).unwrap();
+        let held = ledger.held();
+
+        let charged = ledger.charge([charge(0)]).expect("the window places it");
+
+        assert_eq!(charged.duplicates, vec![Offset(0)]);
+        assert_eq!(ledger.held(), held, "the window is untouched");
+        assert_eq!(ledger.frontier(), Some(Offset(1)), "and still completed");
+    }
+
+    #[test]
+    fn one_slice_repeating_an_offset_reports_the_second_copy() {
+        let mut ledger = PartitionOffsetLedger::new(1);
+
+        let charged = ledger
+            .charge([charge(0), charge(1), charge(1), charge(2)])
+            .expect("the window places the repeat");
+
+        assert_eq!(charged.duplicates, vec![Offset(1)]);
+        assert_eq!(
+            ledger.held(),
+            Held {
+                offsets: 3,
+                charge: Charge {
+                    events: 3,
+                    bytes: 30
+                }
+            },
+            "one slot per distinct offset"
+        );
+    }
+
+    #[test]
+    fn a_repeat_landing_on_gap_filler_is_rejected() {
+        let mut ledger = PartitionOffsetLedger::new(1);
+        // Offset 1 was never delivered, so its slot is filler and the ledger
+        // cannot tell a repeat from a first delivery.
+        ledger.charge([charge(0), charge(2)]).unwrap();
+
+        assert_eq!(
+            ledger.charge([charge(1)]),
+            Err(LedgerError::OffsetNotAboveWindow {
+                offset: Offset(1),
+                next: Offset(3),
+            })
+        );
+    }
+
+    #[test]
+    fn a_charge_below_the_window_after_a_take_is_rejected() {
+        let mut ledger = PartitionOffsetLedger::new(1);
+        ledger.charge([charge(0), charge(1)]).unwrap();
+        ledger.complete([Offset(0)]).unwrap();
+        ledger.take_frontier().unwrap();
+
+        assert_eq!(
+            ledger.charge([charge(0)]),
+            Err(LedgerError::OffsetNotAboveWindow {
+                offset: Offset(0),
+                next: Offset(2),
+            })
+        );
+    }
+
+    #[test]
+    fn a_charge_below_a_drained_window_is_rejected() {
+        let mut ledger = PartitionOffsetLedger::new(1);
+        ledger.charge([charge(0), charge(1)]).unwrap();
+        ledger.complete([Offset(0), Offset(1)]).unwrap();
+        ledger.take_frontier().unwrap();
+        assert_eq!(ledger.held().offsets, 0);
+
         assert_eq!(
             ledger.charge([charge(1)]),
             Err(LedgerError::OffsetNotAboveWindow {

--- a/rust/common/kafka-consumer/src/topic_offset_ledger.rs
+++ b/rust/common/kafka-consumer/src/topic_offset_ledger.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use metrics::{counter, gauge};
+use tracing::info;
 
 use crate::charge::Charge;
 use crate::partition_offset_ledger::{Held, LedgerError, PartitionOffsetLedger};
@@ -14,6 +15,9 @@ const UNCOMMITTED_OFFSETS: &str = "kafka_consumer_ledger_uncommitted_offsets";
 const UNCOMMITTED_EVENTS: &str = "kafka_consumer_ledger_uncommitted_events";
 /// Bytes those offsets carry.
 const UNCOMMITTED_BYTES: &str = "kafka_consumer_ledger_uncommitted_bytes";
+/// Redelivered offsets the window already held, which the ledger recognised
+/// and did not charge again.
+const DEDUPLICATED: &str = "kafka_consumer_ledger_deduplicated_total";
 /// Charges and settlements dropped because their partition was reassigned
 /// while they were in flight.
 const STALE_SLICES: &str = "kafka_consumer_ledger_stale_slices_total";
@@ -54,6 +58,17 @@ pub enum Rejection {
         generation: u64,
         held: Held,
     },
+}
+
+/// What one charge did to a partition's window.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ChargeOutcome {
+    /// What the window holds after the charge.
+    pub held: Held,
+    /// Offsets of the slice the window already held. The ledger charged
+    /// nothing for them, so the caller must drop those messages: the window's
+    /// charge states what the owner holds.
+    pub duplicates: Vec<Offset>,
 }
 
 /// One [`PartitionOffsetLedger`] per partition, each founded under a
@@ -103,14 +118,19 @@ impl TopicOffsetLedger {
 
     /// Record one slice of delivered offsets on the partition's ledger,
     /// founding the ledger when the slice is the partition's first delivery.
-    /// Returns what the partition's window holds after the charge, or why
-    /// the slice was rejected. Publishes the outcome either way.
+    /// Returns what the partition's window holds after the charge and the
+    /// offsets of the slice it already held, or why the slice was rejected.
+    /// Publishes the outcome either way.
+    ///
+    /// A returned duplicate is a message the caller must drop before it
+    /// reaches any consumer of the slice. The ledger holds one slot and one
+    /// charge for that offset, and the charge states what the owner holds.
     pub fn charge(
         &self,
         topic_partition: &TopicPartition,
         stamp: u64,
         offset_charges: impl IntoIterator<Item = (Offset, Charge)>,
-    ) -> Result<Held, Rejection> {
+    ) -> Result<ChargeOutcome, Rejection> {
         let result = {
             let mut partitions = self.partitions.lock().unwrap();
             let ledger = partitions
@@ -121,7 +141,10 @@ impl TopicOffsetLedger {
                 Err(Rejection::Stale { stamp, generation })
             } else {
                 match ledger.charge(offset_charges) {
-                    Ok(_) => Ok(ledger.held()),
+                    Ok(charged) => Ok(ChargeOutcome {
+                        held: ledger.held(),
+                        duplicates: charged.duplicates,
+                    }),
                     Err(error) => {
                         let held = ledger.held();
                         *ledger = PartitionOffsetLedger::new(generation + 1);
@@ -137,9 +160,14 @@ impl TopicOffsetLedger {
             }
         };
         // Outside the lock, and on every path, so no caller has to remember.
-        match result {
-            Ok(held) => publish_held(topic_partition, held),
-            Err(rejection) => count_rejection("charge", rejection),
+        match &result {
+            Ok(outcome) => {
+                publish_held(topic_partition, outcome.held);
+                if !outcome.duplicates.is_empty() {
+                    count_duplicates(topic_partition, &outcome.duplicates);
+                }
+            }
+            Err(rejection) => count_rejection("charge", *rejection),
         }
         result
     }
@@ -283,6 +311,23 @@ fn count_gap_offsets(topic_partition: &TopicPartition, gap_offset_count: usize) 
         .increment(gap_offset_count as u64);
 }
 
+/// Count and log one partition's redeliveries, one line per charge. Reached
+/// only when a charge recognised at least one, so a poll that delivers each
+/// offset once pays nothing.
+fn count_duplicates(topic_partition: &TopicPartition, duplicates: &[Offset]) {
+    let (topic, partition) = labels(topic_partition);
+    counter!(DEDUPLICATED, "topic" => topic, "partition" => partition)
+        .increment(duplicates.len() as u64);
+    info!(
+        topic = %topic_partition.topic,
+        partition = topic_partition.partition,
+        first = %duplicates[0],
+        last = %duplicates[duplicates.len() - 1],
+        count = duplicates.len(),
+        "Offset ledger recognised redelivered offsets its window already holds"
+    );
+}
+
 /// Count one charge or settlement the ledger rejected. A stale slice is
 /// expected around a rebalance; a violation is a bug in the accounting. The
 /// rejection is returned to the caller, which alone still holds the slice
@@ -308,10 +353,28 @@ fn labels(topic_partition: &TopicPartition) -> (Arc<str>, Arc<str>) {
 
 #[cfg(test)]
 mod tests {
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
+
     use super::*;
 
     fn tp(topic: &str, partition: i32) -> TopicPartition {
         TopicPartition::new(topic, partition)
+    }
+
+    /// One counter's total across its label sets; `None` when nothing
+    /// incremented it. The recorder is thread-local, so each test reads only
+    /// what its own body emitted.
+    fn counter_value(snapshotter: &Snapshotter, name: &str) -> Option<u64> {
+        let mut total = None;
+        for (key, _, _, value) in snapshotter.snapshot().into_vec() {
+            if key.key().name() != name {
+                continue;
+            }
+            if let DebugValue::Counter(count) = value {
+                total = Some(total.unwrap_or(0) + count);
+            }
+        }
+        total
     }
 
     fn charge(ledger: &TopicOffsetLedger, tp: &TopicPartition, stamp: u64, offsets: &[i64]) {
@@ -373,7 +436,7 @@ mod tests {
         assert_eq!(
             ledger
                 .charge(&p0, 1, [(Offset(10), Charge::ZERO)])
-                .map(|held| held.offsets),
+                .map(|outcome| outcome.held.offsets),
             Ok(1)
         );
     }
@@ -623,53 +686,99 @@ mod tests {
         assert_eq!(
             ledger
                 .charge(&p0, 2, [(Offset(10), Charge::ZERO)])
-                .map(|held| held.offsets),
+                .map(|outcome| outcome.held.offsets),
             Ok(1)
         );
     }
 
     #[test]
-    fn a_violating_charge_resets_the_partition_to_a_new_generation() {
+    fn a_redelivered_offset_inside_the_window_is_returned_and_counted() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
         let ledger = TopicOffsetLedger::new();
         let p0 = tp("events", 0);
-        charge(&ledger, &p0, 0, &[10, 11]);
 
-        // A duplicate delivery under the same generation is a contract
-        // violation, not a rebalance: the ledger cannot trust its window.
-        assert_eq!(
-            ledger.charge(&p0, 0, [(Offset(11), Charge::ZERO)]),
-            Err(Rejection::Violation {
-                error: LedgerError::OffsetNotAboveWindow {
-                    offset: Offset(11),
-                    next: Offset(12),
-                },
-                stamp: 0,
-                generation: 0,
-                held: Held {
-                    offsets: 2,
-                    charge: Charge::ZERO
-                },
-            })
-        );
+        metrics::with_local_recorder(&recorder, || {
+            charge(&ledger, &p0, 0, &[10, 11]);
+            let outcome = ledger
+                .charge(&p0, 0, [(Offset(11), Charge::ZERO)])
+                .expect("a redelivery inside the window is not a violation");
+            assert_eq!(outcome.duplicates, vec![Offset(11)]);
+            assert_eq!(outcome.held.offsets, 2, "no slot is added for it");
+        });
+
+        assert_eq!(ledger.generation(&p0), 0, "the partition is not reset");
+        assert_eq!(counter_value(&snapshotter, DEDUPLICATED), Some(1));
+        assert_eq!(counter_value(&snapshotter, ERRORS), None);
+
+        // The partition settles and commits as if the repeat never arrived.
+        let frontier = ledger
+            .settle(&p0, 0, [Offset(10), Offset(11)])
+            .expect("live ledger settles");
+        assert_eq!(frontier, Some(Offset(12)));
+        assert_eq!(ledger.take_frontier(&p0), Some(Offset(12)));
+    }
+
+    #[test]
+    fn a_violating_charge_resets_the_partition_to_a_new_generation() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let ledger = TopicOffsetLedger::new();
+        let p0 = tp("events", 0);
+
+        metrics::with_local_recorder(&recorder, || {
+            charge(&ledger, &p0, 0, &[10, 11]);
+            ledger
+                .settle(&p0, 0, [Offset(10)])
+                .expect("live ledger settles");
+            ledger.take_frontier(&p0);
+
+            // Offset 10 is below the base the take left behind, so the ledger
+            // cannot tell a repeat from a message it never saw.
+            assert_eq!(
+                ledger.charge(&p0, 0, [(Offset(10), Charge::ZERO)]),
+                Err(Rejection::Violation {
+                    error: LedgerError::OffsetNotAboveWindow {
+                        offset: Offset(10),
+                        next: Offset(12),
+                    },
+                    stamp: 0,
+                    generation: 0,
+                    held: Held {
+                        offsets: 1,
+                        charge: Charge::ZERO
+                    },
+                })
+            );
+        });
+
         assert_eq!(ledger.held(&p0).offsets, 0, "the window is discarded");
         assert_eq!(ledger.generation(&p0), 1);
         assert_eq!(ledger.generations_version(), 1);
+        assert_eq!(counter_value(&snapshotter, ERRORS), Some(1));
 
-        // In-flight work from before the reset drops as stale; the next
-        // delivery under the new generation founds a fresh ledger.
+        // In-flight work from before the reset drops as stale.
         assert_eq!(
-            ledger.settle(&p0, 0, [Offset(10)]),
+            ledger.settle(&p0, 0, [Offset(11)]),
             Err(Rejection::Stale {
                 stamp: 0,
                 generation: 1
             })
         );
+
+        // The next delivery under the new generation founds a fresh ledger,
+        // and the partition commits again from there.
         assert_eq!(
             ledger
                 .charge(&p0, 1, [(Offset(12), Charge::ZERO)])
-                .map(|held| held.offsets),
+                .map(|outcome| outcome.held.offsets),
             Ok(1)
         );
+        let frontier = ledger
+            .settle(&p0, 1, [Offset(12)])
+            .expect("the new generation settles");
+        assert_eq!(frontier, Some(Offset(13)));
+        assert_eq!(ledger.take_frontier(&p0), Some(Offset(13)));
     }
 
     #[test]

--- a/rust/ingestion-consumer/README.md
+++ b/rust/ingestion-consumer/README.md
@@ -33,8 +33,10 @@ The consumer holds the per-partition offset ledger from `common/kafka-consumer`,
 Every delivered message is charged to its partition's ledger during collection, and a committed batch completes its offsets there; the commit is then each partition's frontier, one past its longest completed prefix.
 A partition that settles without a frontier is not committed and stays on its last commit.
 A batch with no frontier on any partition is not committed at all; `ingestion_consumer_commits_skipped_total{reason}` counts those, where `rejected` means the ledger dropped every slice (expected around a rebalance) and `no_frontier` means an earlier batch is still incomplete at the front of every window the batch settled.
+When Kafka redelivers an offset the partition's window still holds, the ledger recognises it, charges nothing for it, and the consumer drops that copy from the batch, so no worker ever sees it.
 The ledger emits its own metrics, so any consumer built on the crate reports the same series.
 `kafka_consumer_ledger_uncommitted_offsets{topic,partition}` gauges each partition's window depth; `kafka_consumer_ledger_uncommitted_events` and `kafka_consumer_ledger_uncommitted_bytes` gauge the charge those offsets carry, where bytes is the payload plus key plus headers of each message.
+`kafka_consumer_ledger_deduplicated_total{topic,partition}` counts the redelivered offsets it recognised.
 `kafka_consumer_ledger_stale_slices_total{stage}` counts charges and settlements dropped because their partition was reassigned while they were in flight; a few around a rebalance are expected.
 `kafka_consumer_ledger_errors_total{stage,kind}` counts contract violations in the ledger's accounting; it must stay 0. A violation resets that partition's ledger and the consumer keeps running; the consumer logs the rejected slice with the batch and ledger generations and the window depth before the reset.
 

--- a/rust/ingestion-consumer/src/consumer.rs
+++ b/rust/ingestion-consumer/src/consumer.rs
@@ -676,22 +676,31 @@ impl IngestionConsumer {
 
         // One ledger call per partition keeps the lock and the gauge labels
         // off the per-message path.
+        let mut redelivered: Vec<(TopicPartition, Vec<Offset>)> = Vec::new();
         for (topic_partition, partition) in &partitions {
-            // The ledger counts both outcomes and publishes what the window
-            // holds; a rejection is logged here, where the slice is still
-            // known.
-            if let Err(rejection) = self.topic_offset_ledger.charge(
+            // The ledger counts every outcome and publishes what the window
+            // holds. A rejection is logged here, where the slice is still
+            // known, and the offsets the window already held need follow-up.
+            match self.topic_offset_ledger.charge(
                 topic_partition,
                 partition.generation,
                 partition.charges.iter().copied(),
             ) {
-                warn_rejection(
+                Ok(outcome) => {
+                    if !outcome.duplicates.is_empty() {
+                        redelivered.push((topic_partition.clone(), outcome.duplicates));
+                    }
+                }
+                Err(rejection) => warn_rejection(
                     "charge",
                     topic_partition,
                     rejection,
                     RejectedSlice::charged(&partition.charges),
-                );
+                ),
             }
+        }
+        if !redelivered.is_empty() {
+            drop_redelivered(&mut accumulator, &mut partitions, redelivered);
         }
 
         Ok(CollectedBatch {
@@ -811,6 +820,52 @@ impl IngestionConsumer {
         counter!("ingestion_consumer_offset_commits_total").increment(1);
 
         Ok(())
+    }
+}
+
+/// Drop the message copies the ledger recognised as offsets it already
+/// holds. The ledger keeps one slot and one charge per offset, so a further
+/// copy must reach no worker: processing it would be work the consumer can
+/// prove is duplicate, and the poll's charge would stop stating what the
+/// workers hold. Exactly the recognised copies go, so a poll that delivered
+/// an offset twice keeps the copy that founded the slot and still completes
+/// it. The span follows what the partition still holds, so completions keep
+/// landing on this poll, and a partition left with nothing leaves the batch.
+/// Reached only when a charge recognised a redelivery.
+fn drop_redelivered(
+    accumulator: &mut Accumulator,
+    partitions: &mut HashMap<TopicPartition, PartitionDeliveries>,
+    redelivered: Vec<(TopicPartition, Vec<Offset>)>,
+) {
+    for (topic_partition, duplicates) in redelivered {
+        let mut copies: HashMap<Offset, usize> = HashMap::new();
+        for offset in duplicates {
+            *copies.entry(offset).or_default() += 1;
+        }
+        let kept = accumulator.remove_offsets(Partition(topic_partition.partition), &copies);
+        let Some((first, last)) = kept else {
+            partitions.remove(&topic_partition);
+            continue;
+        };
+        let Some(partition) = partitions.get_mut(&topic_partition) else {
+            continue;
+        };
+        partition.span = OffsetSpan {
+            first: first.0,
+            last: last.0,
+        };
+        // The settlement completes the charges, so every dropped copy leaves
+        // them; the copy the ledger charged stays and completes its slot.
+        let mut left = copies;
+        partition
+            .charges
+            .retain(|(offset, _)| match left.get_mut(offset) {
+                Some(remaining) if *remaining > 0 => {
+                    *remaining -= 1;
+                    false
+                }
+                _ => true,
+            });
     }
 }
 
@@ -1098,6 +1153,125 @@ mod tests {
 
         assert_eq!(in_flight[0].covered, 0);
         assert_eq!(in_flight[0].accepted, 0);
+    }
+
+    /// One collected poll: `deliveries` are `(partition, offset)` pairs in
+    /// delivery order, each one message keyed by its partition.
+    fn collected(
+        deliveries: &[(i32, i64)],
+    ) -> (Accumulator, HashMap<TopicPartition, PartitionDeliveries>) {
+        let mut accumulator = Accumulator::default();
+        let mut partitions: HashMap<TopicPartition, PartitionDeliveries> = HashMap::new();
+        for &(partition, offset) in deliveries {
+            let delivery = Delivery {
+                offset,
+                charge: Charge {
+                    events: 1,
+                    bytes: 10,
+                },
+                kafka_ts: 0,
+                lag_ms: None,
+            };
+            let key = TopicPartition::new("test", partition);
+            match partitions.get_mut(&key) {
+                Some(entry) => entry.record(0, || 0, &delivery),
+                None => {
+                    partitions.insert(key, PartitionDeliveries::new(0, 0, &delivery));
+                }
+            }
+            accumulator.push(
+                Partition(partition),
+                SerializedKafkaMessage {
+                    topic: "test".to_string(),
+                    partition,
+                    offset,
+                    timestamp: 0,
+                    key: Some(format!("key-{partition}")),
+                    value: None,
+                    headers: HashMap::new(),
+                }
+                .into(),
+            );
+        }
+        (accumulator, partitions)
+    }
+
+    fn charged_offsets(
+        partitions: &HashMap<TopicPartition, PartitionDeliveries>,
+        partition: i32,
+    ) -> Vec<i64> {
+        partitions[&TopicPartition::new("test", partition)]
+            .charges
+            .iter()
+            .map(|(offset, _)| offset.0)
+            .collect()
+    }
+
+    #[test]
+    fn dropping_redelivered_offsets_shrinks_the_batch_to_what_is_dispatched() {
+        let (mut accumulator, mut partitions) =
+            collected(&[(0, 10), (0, 11), (0, 12), (1, 40), (1, 41)]);
+
+        drop_redelivered(
+            &mut accumulator,
+            &mut partitions,
+            vec![(TopicPartition::new("test", 0), vec![Offset(10), Offset(12)])],
+        );
+
+        assert_eq!(accumulator.message_count(), 3);
+        assert_eq!(charged_offsets(&partitions, 0), vec![11]);
+        assert_eq!(
+            partitions[&TopicPartition::new("test", 0)].span,
+            OffsetSpan {
+                first: 11,
+                last: 11
+            },
+            "the span covers only what the poll still holds"
+        );
+        assert_eq!(
+            charged_offsets(&partitions, 1),
+            vec![40, 41],
+            "another partition is untouched"
+        );
+    }
+
+    #[test]
+    fn a_partition_emptied_by_redelivery_leaves_the_batch() {
+        let (mut accumulator, mut partitions) = collected(&[(0, 10), (1, 40)]);
+
+        drop_redelivered(
+            &mut accumulator,
+            &mut partitions,
+            vec![(TopicPartition::new("test", 0), vec![Offset(10)])],
+        );
+
+        assert_eq!(accumulator.message_count(), 1);
+        assert!(!partitions.contains_key(&TopicPartition::new("test", 0)));
+        assert_eq!(charged_offsets(&partitions, 1), vec![40]);
+    }
+
+    #[test]
+    fn a_poll_delivering_one_offset_twice_keeps_the_copy_it_charged() {
+        // The ledger founded the slot on the first copy of offset 11 and
+        // reported the second, so exactly one copy may be dispatched and
+        // exactly one charge may complete it.
+        let (mut accumulator, mut partitions) = collected(&[(0, 10), (0, 11), (0, 11)]);
+
+        drop_redelivered(
+            &mut accumulator,
+            &mut partitions,
+            vec![(TopicPartition::new("test", 0), vec![Offset(11)])],
+        );
+
+        assert_eq!(accumulator.message_count(), 2);
+        assert_eq!(charged_offsets(&partitions, 0), vec![10, 11]);
+        assert_eq!(
+            partitions[&TopicPartition::new("test", 0)].span,
+            OffsetSpan {
+                first: 10,
+                last: 11
+            }
+        );
     }
 
     #[test]

--- a/rust/ingestion-consumer/tests/e2e_integration_test.rs
+++ b/rust/ingestion-consumer/tests/e2e_integration_test.rs
@@ -24,7 +24,7 @@ use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
-use common_kafka_consumer::{TopicOffsetLedger, TopicPartition};
+use common_kafka_consumer::{Charge, Offset, TopicOffsetLedger, TopicPartition};
 use ingestion_consumer::consumer::{IngestionConsumer, IngestionConsumerOptions};
 use ingestion_consumer::discovery::reconcile_membership;
 use ingestion_consumer::dispatcher::Dispatcher;
@@ -2035,6 +2035,216 @@ async fn the_committed_offset_is_the_ledger_frontier() {
     assert_eq!(
         total, 15,
         "a committed frontier behind the accepted work would redeliver here"
+    );
+
+    harness.stop().await;
+}
+
+/// Kafka can hand the same offset to a consumer twice on a partition it holds
+/// continuously. An offset the ledger's window still holds is one the ledger
+/// already accounts for, so the consumer drops that copy and no worker ever
+/// sees it, while the partition keeps committing.
+///
+/// A broker will not repeat an offset on demand, so the test charges the
+/// offsets to the ledger before the consumer polls them, which is the state a
+/// repeat leaves behind. A worker held under a full in-flight bound keeps the
+/// consumer out of the poll loop while that happens.
+#[tokio::test]
+async fn a_redelivered_offset_never_reaches_a_worker() {
+    let topic = format!("e2e-ledger-dedup-{}", Uuid::new_v4());
+    let harness = Harness::start(
+        &topic,
+        1,
+        1,
+        1,
+        Duration::from_secs(60),
+        fast_registry_config(),
+    )
+    .await;
+    let producer = make_producer();
+    let partition = TopicPartition::new(topic.clone(), 0);
+
+    // Offsets 0..5 run through the consumer normally, so the window is empty
+    // and its base is the committed offset.
+    for seq in 0..5usize {
+        produce(&producer, &topic, 0, "tok", "user-1", seq).await;
+    }
+    harness.wait_for(5, Duration::from_secs(15)).await;
+    wait_until(Duration::from_secs(10), "the first batch to commit", || {
+        harness.committed_offset(0) == Some(5)
+    })
+    .await;
+
+    // Offset 5 is held at the worker, so the consumer sits at its in-flight
+    // bound and polls nothing while the test sets the window up.
+    let guard = harness.workers[0].block().await;
+    produce(&producer, &topic, 0, "tok", "user-1", 500).await;
+    wait_until(
+        Duration::from_secs(10),
+        "the held batch to be charged",
+        || harness.ledger.held(&partition).offsets == 1,
+    )
+    .await;
+
+    // Offsets 6..11 reach the broker and the ledger, but not the consumer.
+    // Its next poll finds them already in the window.
+    for seq in 5..10usize {
+        produce(&producer, &topic, 0, "tok", "user-1", seq).await;
+    }
+    let generation = harness.ledger.generation(&partition);
+    harness
+        .ledger
+        .charge(
+            &partition,
+            generation,
+            (6..11).map(|offset| {
+                (
+                    Offset(offset),
+                    Charge {
+                        events: 1,
+                        bytes: 1,
+                    },
+                )
+            }),
+        )
+        .expect("the window takes the offsets");
+
+    // Offset 11 follows them, so its delivery proves the consumer polled the
+    // whole redelivered range.
+    produce(&producer, &topic, 0, "tok", "user-1", 100).await;
+    drop(guard);
+
+    wait_until(
+        Duration::from_secs(30),
+        "the consumer to poll past the redelivered range",
+        || {
+            !harness.workers[0].seqs_for("user-1").is_empty() && {
+                let delivered: HashSet<usize> =
+                    harness.workers[0].seqs_for("user-1").into_iter().collect();
+                delivered.contains(&100)
+            }
+        },
+    )
+    .await;
+
+    let delivered: HashSet<usize> = harness.workers[0].seqs_for("user-1").into_iter().collect();
+    for seq in 5..10usize {
+        assert!(
+            !delivered.contains(&seq),
+            "seq {seq} was redelivered and must never reach a worker"
+        );
+    }
+    assert_eq!(
+        harness.ledger.held(&partition).offsets,
+        6,
+        "the repeats added no slot: offsets 6..11 plus the one that followed"
+    );
+
+    // The redelivered offsets were charged outside the consumer, so the test
+    // completes them; the frontier then moves over the whole range.
+    harness
+        .ledger
+        .settle(&partition, generation, (6..11).map(Offset))
+        .expect("the window completes them");
+    produce(&producer, &topic, 0, "tok", "user-1", 200).await;
+    wait_until(
+        Duration::from_secs(30),
+        "the commit to reach one past the last produced offset",
+        || harness.committed_offset(0) == Some(13),
+    )
+    .await;
+
+    harness.stop().await;
+}
+
+/// An offset below the window is one the ledger cannot place, so it resets the
+/// partition: the window goes, the generation moves, and every batch in flight
+/// settles as stale. The consumer must survive that and resume committing on
+/// the next assignment's offsets, without redelivering or losing anything the
+/// workers already took.
+#[tokio::test]
+async fn an_offset_below_the_window_resets_the_partition_and_recovers() {
+    let topic = format!("e2e-ledger-reset-{}", Uuid::new_v4());
+    let harness = Harness::start(
+        &topic,
+        1,
+        2,
+        128,
+        Duration::from_secs(60),
+        fast_registry_config(),
+    )
+    .await;
+    let producer = make_producer();
+    let partition = TopicPartition::new(topic.clone(), 0);
+
+    // Offsets 0..5 commit normally, so the window's base is above zero.
+    for seq in 0..5usize {
+        produce(&producer, &topic, 0, "tok", "user-1", seq).await;
+    }
+    harness.wait_for(5, Duration::from_secs(15)).await;
+    wait_until(Duration::from_secs(10), "the first batch to commit", || {
+        harness.committed_offset(0) == Some(5)
+    })
+    .await;
+
+    // Offsets 5..10 are in flight at the held workers when the violation
+    // lands, so their settlement arrives after the reset.
+    let mut guards: Vec<Option<tokio::sync::OwnedMutexGuard<()>>> = Vec::new();
+    for worker in &harness.workers {
+        guards.push(Some(worker.block().await));
+    }
+    for seq in 5..10usize {
+        produce(&producer, &topic, 0, "tok", "user-1", seq).await;
+    }
+    wait_until(Duration::from_secs(15), "the batch to be charged", || {
+        harness.ledger.held(&partition).offsets == 5
+    })
+    .await;
+
+    let generation = harness.ledger.generation(&partition);
+    assert!(
+        harness
+            .ledger
+            .charge(&partition, generation, [(Offset(4), Charge::default())])
+            .is_err(),
+        "an offset below the base is a violation"
+    );
+    assert_eq!(
+        harness.ledger.generation(&partition),
+        generation + 1,
+        "the partition starts a new generation"
+    );
+    guards.clear();
+
+    // The reset costs the in-flight batch its commit, not its delivery. The
+    // next offsets found a fresh window and commit from there.
+    for seq in 10..15usize {
+        produce(&producer, &topic, 0, "tok", "user-1", seq).await;
+    }
+    wait_until(
+        Duration::from_secs(30),
+        "the commit to reach one past the last produced offset",
+        || harness.committed_offset(0) == Some(15),
+    )
+    .await;
+    assert!(
+        !harness.shutdown.is_cancelled(),
+        "the consumer must survive the reset"
+    );
+
+    let delivered: Vec<usize> = harness
+        .delivery_log
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|(_, seq)| *seq)
+        .collect();
+    let mut sorted = delivered.clone();
+    sorted.sort_unstable();
+    assert_eq!(
+        sorted,
+        (0..15).collect::<Vec<usize>>(),
+        "every message reached a worker exactly once"
     );
 
     harness.stop().await;


### PR DESCRIPTION
## Problem

A consumer pod stops committing a partition for the rest of its in-flight work when Kafka hands it the same offset twice, even though nothing is wrong with the data.
That happened in production: librdkafka delivered one offset twice in consecutive polls, on a partition the pod held continuously, shortly after an incremental assignment during a rolling deploy.

The ledger read the second copy as `OffsetNotAboveWindow`, which resets the partition: the window goes, the generation moves, every batch in flight settles as stale, and the partition commits nothing until a batch charged under the new generation completes.
The reset is safe, but the ledger can prove this case is harmless, because it still holds a slot for that exact offset.

Stacked on #94950, which makes the ledger the owner of every commit.

## Changes

- A repeat of an offset the window still holds costs nothing: no worker sees the second copy, the partition keeps committing, and the deploy leaves no gap in commits.
- The ledger recognises the repeat, keeps the one slot and charge it has, and hands the offset back to the caller. A slot that is complete but not yet drained counts the same.
- The consumer drops exactly the recognised copies from the batch before dispatch, shrinks the partition's offset span to what it still holds, and drops a partition the removal empties. The poll's expected message count comes from the accumulator, so it covers only what is dispatched.
- Dropping the copy beats processing it. The held charge feeds the in-flight budget and the memory control, so it has to equal what the workers hold, and processing a copy the ledger can prove is a copy is duplication the consumer already paid to avoid.
- Two cases stay violations, with the reset behavior unchanged: an offset below the window base, and an offset landing on the filler that spans an offset gap. The ledger recorded no delivery in either place, so it cannot tell a repeat from a message it never saw.
- New: `kafka_consumer_ledger_deduplicated_total{topic,partition}` counts the recognised repeats, with one log line per partition per charge. It must stay near zero.
- Mechanical: `Accumulator::remove_offsets` is the removal API the drop step needs. Removal counts copies, because one poll can hold the same offset twice and the copy that founded the slot has to stay.

## How did you test this code?

New tests, and the regression each one catches:

- `common-kafka-consumer`, partition level: a repeat of an uncompleted slot, a repeat of a completed slot, and a repeat inside one slice are duplicates that add no slot and no charge. Without them a later change could count the repeat twice.
- `common-kafka-consumer`, partition level: a repeat on gap filler, a charge below the base after a take, and a charge below a drained window stay `OffsetNotAboveWindow`. These fence the rule so it cannot widen into cases the ledger cannot prove.
- `common-kafka-consumer`, topic level: the charge returns the duplicates, counts them, and leaves the generation alone. The reset test now runs the whole recovery: stale settlement, fresh generation, frontier, and one error counted.
- `ingestion-consumer`, unit: the drop step removes the right copies, shrinks the span, drops an emptied partition, and keeps the copy that founded the slot when one poll delivered an offset twice.
- `ingestion-consumer`, e2e: `a_redelivered_offset_never_reaches_a_worker` puts offsets in a partition's window before the consumer polls them, which is the state a repeat leaves behind, then checks no worker sees them and the commit still reaches one past the last produced offset. A broker will not repeat an offset on demand, so a held worker keeps the consumer out of the poll loop while the test sets the window up.
- `ingestion-consumer`, e2e: `an_offset_below_the_window_resets_the_partition_and_recovers` forces the real violation path while batches are in flight, then checks the consumer survives, commits again on the next generation's offsets, and delivered every message exactly once.

Run locally inside flox against a local Kafka: `cargo test -p common-kafka-consumer -p ingestion-consumer`, `cargo clippy -p common-kafka-consumer -p ingestion-consumer --all-targets -- -D warnings`, and `cargo fmt`.
The whole `e2e_integration_test` file passes on its own, including the three named scenarios `the_committed_offset_is_the_ledger_frontier`, `partition_lost_and_regained_keeps_the_consumer_alive` and `consumer_crash_before_commit_redelivers_without_loss`.
One run of every target at once had `fenced_static_member_exits_on_fatal_error` fail; it passes alone, and #94950 reports the same pre-existing load flake of the local broker.

Not run: the full Rust workspace, and anything outside these two crates. Nothing was tested by hand.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- `rust/common/kafka-consumer/README.md`: the new counter joins the metrics table.
- `rust/ingestion-consumer/README.md`: the ledger section states the drop rule and the counter.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session: https://claude.ai/code/session_014LXyWuRuD4L4p2wTHidWZt. The rule and the two rejected alternatives were settled with the owner before any code was written; the agent implemented the agreed design.
- Skills invoked: `/writing-pr-descriptions`.
- Decided during the session: removal counts copies rather than matching every message at an offset. Matching by offset alone would drop the copy that founded the ledger slot too, and the partition's frontier would then never move past it.
- The production event above is described without offsets, partitions, or timestamps. No customer data, log content, or internal thread reaches this PR.
