### PR TITLE
feat(tasks): offer the vendor-served models in the web task composer

### DIFF
--- a/products/tasks/backend/logic/services/model_catalogue.py
+++ b/products/tasks/backend/logic/services/model_catalogue.py
@@ -178,7 +178,11 @@ def available_model_choices(product: Product) -> tuple[ModelChoice, ...]:
     by_provider = _runtime_adapter_by_provider()
     choices = []
     for model in list_gateway_models(product):
-        runtime_adapter = by_provider.get(model.owned_by)
+        # The catalog names the harness that drives a model; `owned_by` names whoever
+        # serves it, which for the vendor-served models is `cloudflare`/`baseten`/the
+        # vendor org and says nothing about the harness. Falling back to the provider
+        # keeps an unlisted `gpt-*` working and still drops a provider we cannot route.
+        runtime_adapter = runtime_adapter_for(model.id) or by_provider.get(model.owned_by)
         if runtime_adapter is None:
             continue
         choices.append(

--- a/products/tasks/backend/tests/test_model_catalog.py
+++ b/products/tasks/backend/tests/test_model_catalog.py
@@ -152,3 +152,21 @@ class TestAvailableModelChoices:
             return_value=gateway,
         ):
             assert [c.model for c in available_model_choices("posthog_code")] == ["claude-fable-5"]
+
+    def test_keeps_vendor_served_models_the_catalog_routes(self) -> None:
+        # The gateway owns these under the party serving them, not the harness that drives
+        # them, so routing on the owner alone dropped every one from the web picker.
+        gateway = (
+            GatewayModel(id="deepseek-ai/deepseek-v4-flash-0731", owned_by="baseten", context_window=128000),
+            GatewayModel(id="zai-org/glm-5.3-flash", owned_by="cloudflare", context_window=128000),
+            GatewayModel(id="moonshotai/kimi-k3", owned_by="moonshotai", context_window=128000),
+        )
+        with patch(
+            "products.tasks.backend.logic.services.model_catalogue.list_gateway_models",
+            return_value=gateway,
+        ):
+            choices = available_model_choices("posthog_code")
+
+        assert [c.model for c in choices] == [m.id for m in gateway]
+        assert {c.runtime_adapter for c in choices} == {"claude"}
+        assert [c.label for c in choices] == ["DeepSeek V4 Flash", "GLM-5.3 Flash", "Kimi K3"]


### PR DESCRIPTION
## Problem

The vendor-served models — GLM, Kimi, DeepSeek — were missing from the web task composer while the desktop app offered them.

The composer routes a gateway model by its `owned_by`, which names whoever serves it rather than the harness that drives it. These come back owned by `cloudflare`, `baseten`, or the vendor org, none of which maps to a runtime adapter, so every one was dropped.

Stacked on #93153, which makes the catalog the one definition of which adapter drives a model.

## Changes

- The vendor-served models appear in the web composer's model picker.
- The catalog answers first, and `owned_by` stays the fallback. That keeps an unlisted `gpt-*` working and still drops a provider we have no runtime for.

One line of routing, one test.

## How did you test this code?

`test_keeps_vendor_served_models_the_catalog_routes` feeds the gateway list three vendor-owned ids and asserts all three survive with the `claude` adapter. Reverting the routing line makes it fail, which I checked.

Not checked: no run reached a live gateway.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). Skills: `/stacking-prs`, `/writing-tests`, `/writing-pr-descriptions`.

This layer was larger before. The label mechanism and the DeepSeek catalog row moved down into #93153, because that PR removes the desktop's private display-name map and so needs the catalog to name every model the desktop knows. What stays here is the routing change alone, which is the part that actually puts these models in the picker.
