### PR TITLE
fix(tasks): identify sandbox startup errors

### DIFF
--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -2818,7 +2818,13 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
         if not connection.sandbox_url:
             return Response(
-                TaskRunErrorResponseSerializer({"error": "No active sandbox for this task run"}).data,
+                TaskRunErrorResponseSerializer(
+                    {
+                        "type": "runtime_unavailable",
+                        "code": "sandbox_not_ready",
+                        "error": "No active sandbox for this task run",
+                    }
+                ).data,
                 status=status.HTTP_400_BAD_REQUEST,
             )
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -11451,7 +11451,14 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("No active sandbox", response.json()["error"])
+        self.assertEqual(
+            response.json(),
+            {
+                "type": "runtime_unavailable",
+                "code": "sandbox_not_ready",
+                "error": "No active sandbox for this task run",
+            },
+        )
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

- A task client cannot distinguish a sandbox that is starting from other command failures.

## Changes

- The task-run command API now identifies a missing sandbox connection as `sandbox_not_ready`.
- The response keeps the existing status and human-readable error for existing clients.
- No visual changes. This PR adds a machine-readable API response field.

## How did you test this code?

- Extended the task-run command API test to assert the complete structured error response.
- Ran the targeted Django task-run command test.
- Regenerated OpenAPI clients and MCP types.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- Added the `skip-inkeep-docs` label. The generated API clients are up to date.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Created with Pi and an Explore subagent. Skills invoked: `improving-drf-endpoints`, `writing-tests`, `run-posthog`, `running-ci-preflight`, and `writing-pr-descriptions`.
- A duplicate-PR search found no open fix for this sandbox startup race.
- This public PR contains no customer data, secrets, or other private session material.