### PR TITLE
fix(flags): retry usage records the connection dropped

### DIFF
--- a/rust/feature-flags/src/billing/usage_reporter.rs
+++ b/rust/feature-flags/src/billing/usage_reporter.rs
@@ -458,16 +458,18 @@ mod tests {
         assert_eq!(service.client_names(), vec![Some(PRODUCER_ID.to_string())]);
     }
 
-    // `internal` and `cancelled` are how a connection that went away underneath the call
-    // reaches us, not something the service decided. Dropping them loses usage the service
-    // never saw.
+    // The last three are how a connection that went away underneath the call reaches us,
+    // not something the service decided. Dropping them loses usage the service never saw.
+    // Each case fails twice, so the whole budget runs rather than one attempt of it.
     #[rstest]
     #[case::draining_pod(Code::Unavailable)]
     #[case::goaway_at_max_connection_age(Code::Internal)]
     #[case::reset_stream(Code::Cancelled)]
+    #[case::unrecognised_transport_error(Code::Unknown)]
     #[tokio::test]
     async fn retries_a_transient_failure_with_the_same_record_id(#[case] code: Code) {
         let service = RecordingIngestion::default();
+        service.fail_next(code);
         service.fail_next(code);
         let reporter = reporter_for(serve(service.clone()).await).await;
 
@@ -475,10 +477,10 @@ mod tests {
         reporter.shutdown(std::time::Duration::from_secs(5)).await;
 
         let requests = service.requests();
-        assert_eq!(requests.len(), 2);
+        assert_eq!(requests.len(), SEND_ATTEMPTS as usize);
         // Reusing the ID is what makes the retry safe: the service deduplicates on it, so a
         // batch Kafka took only part of does not bill twice.
-        assert_eq!(requests[0][0].record_id, requests[1][0].record_id);
+        assert_eq!(requests[0][0].record_id, requests[2][0].record_id);
     }
 
     /// Counter totals by name, captured while the reporter ran. The recorder is
@@ -548,6 +550,34 @@ mod tests {
         });
 
         assert_eq!(totals, vec![(FLAGS_USAGE_RECORDS_SENT.to_string(), 2)]);
+    }
+
+    // A chunk the budget could not save is lost, so it has to read as one drop on the failed
+    // counter and not once per attempt.
+    #[test]
+    fn a_chunk_that_exhausts_its_attempts_counts_as_failed_once() {
+        let totals = counted(|runtime| {
+            runtime.block_on(async {
+                let service = RecordingIngestion::default();
+                for _ in 0..SEND_ATTEMPTS {
+                    service.fail_next(Code::Internal);
+                }
+                let reporter = reporter_for(serve(service.clone()).await).await;
+
+                reporter.report(&[(key(7, None), 1)], 1_700_000_000_000);
+                reporter.shutdown(std::time::Duration::from_secs(5)).await;
+
+                assert_eq!(service.requests().len(), SEND_ATTEMPTS as usize);
+            });
+        });
+
+        assert_eq!(
+            totals,
+            vec![
+                (FLAGS_USAGE_RECORDS_FAILED.to_string(), 1),
+                (FLAGS_USAGE_RETRIES.to_string(), 2),
+            ]
+        );
     }
 
     #[tokio::test]

--- a/rust/feature-flags/src/billing/usage_reporter.rs
+++ b/rust/feature-flags/src/billing/usage_reporter.rs
@@ -22,7 +22,9 @@ use uuid::Uuid;
 
 use crate::config::TeamIdCollection;
 use crate::flags::flag_request::FlagRequestType;
-use crate::metrics::consts::{FLAGS_USAGE_RECORDS_FAILED, FLAGS_USAGE_RECORDS_SENT};
+use crate::metrics::consts::{
+    FLAGS_USAGE_RECORDS_FAILED, FLAGS_USAGE_RECORDS_SENT, FLAGS_USAGE_RETRIES,
+};
 
 use super::AggregationKey;
 
@@ -95,7 +97,11 @@ impl UsageReporter {
             None => false,
         };
         if !queued {
-            inc(FLAGS_USAGE_RECORDS_FAILED, &[], record_count);
+            inc(
+                FLAGS_USAGE_RECORDS_FAILED,
+                &error_code("queue_full"),
+                record_count,
+            );
             tracing::warn!(
                 records = record_count,
                 "usage-ingestion send queue is full or closed; dropped usage records"
@@ -129,11 +135,51 @@ impl UsageReporter {
 /// A code the service returns for a condition that clears on its own: an unreachable
 /// or draining pod, a timeout, a full queue. The rest, `invalid_argument` above all,
 /// describe the records themselves and would fail the same way forever.
+///
+/// The last three are how a connection that went away underneath the call reaches us
+/// rather than anything the service decided. The service ends every connection with
+/// GOAWAY at max_connection_age, and tonic maps that h2 NO_ERROR to `internal`, an
+/// RST_STREAM CANCEL to `cancelled`, and a transport error it does not recognise to
+/// `unknown`. Retrying is safe because the service deduplicates on `record_id`.
 fn is_retryable(code: Code) -> bool {
     matches!(
         code,
-        Code::Unavailable | Code::DeadlineExceeded | Code::ResourceExhausted | Code::Aborted
+        Code::Unavailable
+            | Code::DeadlineExceeded
+            | Code::ResourceExhausted
+            | Code::Aborted
+            | Code::Internal
+            | Code::Cancelled
+            | Code::Unknown
     )
+}
+
+/// A stable label value for `code`. `Display` gives a human sentence, which makes a
+/// useless metric label.
+fn code_label(code: Code) -> &'static str {
+    match code {
+        Code::Cancelled => "cancelled",
+        Code::Unknown => "unknown",
+        Code::InvalidArgument => "invalid_argument",
+        Code::DeadlineExceeded => "deadline_exceeded",
+        Code::NotFound => "not_found",
+        Code::AlreadyExists => "already_exists",
+        Code::PermissionDenied => "permission_denied",
+        Code::ResourceExhausted => "resource_exhausted",
+        Code::FailedPrecondition => "failed_precondition",
+        Code::Aborted => "aborted",
+        Code::OutOfRange => "out_of_range",
+        Code::Unimplemented => "unimplemented",
+        Code::Internal => "internal",
+        Code::Unavailable => "unavailable",
+        Code::DataLoss => "data_loss",
+        Code::Unauthenticated => "unauthenticated",
+        Code::Ok => "ok",
+    }
+}
+
+fn error_code(value: &'static str) -> [(String, String); 1] {
+    [("error_code".to_string(), value.to_string())]
 }
 
 async fn run_sender(
@@ -167,7 +213,7 @@ async fn send_chunk(client: &UsageIngestionClient<Channel>, chunk: &[BillingUsag
                 if accepted.len() < chunk.len() {
                     inc(
                         FLAGS_USAGE_RECORDS_FAILED,
-                        &[],
+                        &error_code("rejected"),
                         count - accepted.len() as u64,
                     );
                     tracing::warn!(
@@ -179,9 +225,10 @@ async fn send_chunk(client: &UsageIngestionClient<Channel>, chunk: &[BillingUsag
                 return;
             }
             Err(status) => {
+                let label = code_label(status.code());
                 let retryable = is_retryable(status.code());
                 if !retryable || attempt == SEND_ATTEMPTS {
-                    inc(FLAGS_USAGE_RECORDS_FAILED, &[], count);
+                    inc(FLAGS_USAGE_RECORDS_FAILED, &error_code(label), count);
                     tracing::warn!(
                         records = count,
                         attempts = attempt,
@@ -191,6 +238,8 @@ async fn send_chunk(client: &UsageIngestionClient<Channel>, chunk: &[BillingUsag
                     );
                     return;
                 }
+                // A retry that lands drops nothing, so it reads on its own counter.
+                inc(FLAGS_USAGE_RETRIES, &error_code(label), 1);
                 tokio::time::sleep(RETRY_BACKOFF * attempt).await;
             }
         }
@@ -266,6 +315,7 @@ mod tests {
     use super::*;
     use crate::billing::usage_test_support::{serve, RecordingIngestion};
     use crate::handler::types::Library;
+    use rstest::rstest;
 
     fn key(team_id: i32, library: Option<Library>) -> AggregationKey {
         AggregationKey {
@@ -408,10 +458,17 @@ mod tests {
         assert_eq!(service.client_names(), vec![Some(PRODUCER_ID.to_string())]);
     }
 
+    // `internal` and `cancelled` are how a connection that went away underneath the call
+    // reaches us, not something the service decided. Dropping them loses usage the service
+    // never saw.
+    #[rstest]
+    #[case::draining_pod(Code::Unavailable)]
+    #[case::goaway_at_max_connection_age(Code::Internal)]
+    #[case::reset_stream(Code::Cancelled)]
     #[tokio::test]
-    async fn retries_a_transient_failure_with_the_same_record_id() {
+    async fn retries_a_transient_failure_with_the_same_record_id(#[case] code: Code) {
         let service = RecordingIngestion::default();
-        service.fail_next(Code::Unavailable);
+        service.fail_next(code);
         let reporter = reporter_for(serve(service.clone()).await).await;
 
         reporter.report(&[(key(7, None), 1)], 1_700_000_000_000);

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -230,8 +230,13 @@ pub const FLAGS_BILLING_FLUSH_DURATION_MS: &str = "flags_billing_flush_duration_
 // Counters: records the usage-ingestion mirror accepted / gave up on. A gap
 // between them and `flags_billing_entries_flushed_total` is expected while the
 // mirror is rolled out to a subset of teams.
+// `flags_usage_records_failed_total` carries an `error_code` label naming why the
+// records went nowhere: a gRPC code, `rejected` for what the service declined, or
+// `queue_full`. Retries that later succeeded read on `flags_usage_retries_total`
+// instead, so a drop here means the records really were lost.
 pub const FLAGS_USAGE_RECORDS_SENT: &str = "flags_usage_records_sent_total";
 pub const FLAGS_USAGE_RECORDS_FAILED: &str = "flags_usage_records_failed_total";
+pub const FLAGS_USAGE_RETRIES: &str = "flags_usage_retries_total";
 
 // Histogram of per-call `record()` latency in microseconds, with no labels
 // to keep the hot-path emission allocation-free. The expected uncontended


### PR DESCRIPTION
## Problem

Feature flag usage records go missing when the usage-ingestion service recycles a connection, so a team's flag requests are undercounted for billing.

- The service ends every connection with GOAWAY at `max_connection_age`.
- tonic maps that teardown to `internal`, `cancelled`, or `unknown`, depending on how the connection died.
- `is_retryable` covered none of those three, so the reporter wrote the whole chunk off after one attempt.
- The service never saw the request, so nothing downstream can recover the records.

The same gap exists in the Node client, fixed separately in #95018.

## Changes

- The reporter retries a send that failed because the connection went away, instead of dropping it. The service deduplicates on `record_id`, so a resend cannot bill twice.
- `flags_usage_records_failed_total` gains an `error_code` label. A drop now names its reason: a gRPC code, `rejected` for what the service declined, or `queue_full`.
- `flags_usage_retries_total` counts attempts that failed and were retried. A retry that lands drops nothing, so the failed counter stays clean.

Retrying `unknown` is the one judgment call. tonic collapses unrecognised transport errors onto it, and the reporter passes no cancellation of its own, so `unknown` and `cancelled` can only mean the transport here.

Nothing user-visible changes. The two counters are the only observable difference, and both are already on the realtime billing usage-ingestion dashboard.

## How did you test this code?

`cargo test -p feature-flags --lib billing::usage_reporter` passes. The existing retry test now runs as three cases: `unavailable` (the old one), `internal`, and `cancelled`. The two new cases fail against the old `is_retryable`, which is the regression this PR fixes.

Not checked: no manual run against a live usage-ingestion service, and no reproduction of a real GOAWAY. The connection-teardown to gRPC-code mapping comes from reading tonic's `Status::from_h2_error`, not from an observed failure.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this after investigating dropped records on the sibling Node client. The Node investigation traced the drops to connection teardown codes missing from that client's retry set; this PR applies the same root-cause fix to the Rust reporter, which shares the service and the failure mode.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The `error_code` label was not in the original scope. It went in because the unlabeled counter is what made the Node-side drops slow to diagnose, and the Rust counter had the same blind spot.