### PR TITLE
fix(flags): clarify disabled flag response

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsReadonly.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsReadonly.tsx
@@ -140,7 +140,7 @@ export function FeatureFlagReleaseConditionsReadonly({
                 <LemonLabel>Release conditions</LemonLabel>
                 {isDisabled && (
                     <LemonTag type="muted" size="small">
-                        Flag disabled – returns false regardless of conditions
+                        Flag disabled: SDKs receive no value
                     </LemonTag>
                 )}
             </div>


### PR DESCRIPTION
## Problem

People viewing a disabled feature flag see that it returns false, but disabled flags are omitted from SDK responses.

## Changes

- The disabled status now says SDKs receive no value for the flag.
- Screenshot not included because the local app was not running.

Related SDK documentation update: PostHog/posthog-js#4785.

## How did you test this code?

- Oxfmt and Oxlint passed for the changed file.
- The frontend type check was blocked by unrelated missing Quill workspace exports.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation update. This PR corrects existing UI copy.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi using `/pr`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, and `/autoreview`. The duplicate PR search found no open PR for this copy change. No private session material appears in the branch.

