### PR TITLE
perf(ci): cache the pnpm install so jobs skip the npm registry

### DIFF
--- a/.github/actions/pnpm-install/action.yml
+++ b/.github/actions/pnpm-install/action.yml
@@ -8,7 +8,9 @@ description: |
     instead of fragmenting across runner-arch casings or per-workflow keys.
 
     Also pre-seeds the Node tool cache (`node-toolcache-<os>-<arch>-<version>`,
-    master-gated save) so setup-node makes no GitHub API calls on a hit.
+    master-gated save) so setup-node makes no GitHub API calls on a hit, and the
+    pnpm install itself (`setup-pnpm-<os>-<arch>-<version>-<action-hash>`) so a
+    job does not download pnpm from the npm registry.
 
     Deliberately does NOT use setup-node's `cache: pnpm`: that auto-saves on
     every run (PRs included, and the post-save can't be gated) and keys on
@@ -39,12 +41,60 @@ inputs:
 runs:
     using: composite
     steps:
+        # pnpm/action-setup wipes ~/setup-pnpm and runs `npm ci` there on every
+        # job, so each job downloads pnpm from registry.npmjs.org. A registry
+        # stall therefore hits every Node job at once and can outlast a job's
+        # timeout-minutes. The install is identical for a given pnpm version, so
+        # cache the result and skip the action when it is already on disk.
+        - name: Resolve pnpm version
+          id: pnpm-version
+          shell: bash
+          # An empty version disables the cache steps, so the action installs as
+          # before. The key must pin the exact version, because the restored
+          # directory holds that version and nothing revalidates it.
+          run: |
+              version=$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"pnpm@\([^"+]*\)".*/\1/p' package.json | head -1)
+              [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]] || version=""
+              echo "version=$version" >> "$GITHUB_OUTPUT"
+
+        # The action's own pinned SHA decides which bootstrap pnpm `npm ci`
+        # installs, so hash this file to invalidate the cache when the pin moves.
+        - name: Restore pnpm setup
+          id: setup-pnpm
+          if: steps.pnpm-version.outputs.version != ''
+          uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+          with:
+              path: ~/setup-pnpm
+              key: setup-pnpm-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm-version.outputs.version }}-${{ hashFiles('.github/actions/pnpm-install/action.yml') }}
+
         - name: Install pnpm
+          if: steps.setup-pnpm.outputs.cache-hit != 'true'
           uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
         - name: Fix node-gyp permissions
           shell: bash
           run: find ~/setup-pnpm -name gyp_main.py -exec chmod +x {} +
+
+        # Reproduce what the action exports on a hit. PNPM_HOME/bin holds the
+        # self-updated target version and PNPM_HOME holds the bootstrap symlinks,
+        # so bin must win on PATH. GITHUB_PATH prepends each line in turn, which
+        # means the last line written ends up first.
+        - name: Use cached pnpm
+          if: steps.setup-pnpm.outputs.cache-hit == 'true'
+          shell: bash
+          run: |
+              pnpm_home="$HOME/setup-pnpm/node_modules/.bin"
+              echo "PNPM_HOME=$pnpm_home" >> "$GITHUB_ENV"
+              echo "$pnpm_home" >> "$GITHUB_PATH"
+              echo "$pnpm_home/bin" >> "$GITHUB_PATH"
+
+        # Save only on the default branch, for the same reasons as the pnpm store save below.
+        - name: Save pnpm setup
+          if: github.ref == 'refs/heads/master' && steps.pnpm-version.outputs.version != '' && steps.setup-pnpm.outputs.cache-hit != 'true'
+          uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+          with:
+              path: ~/setup-pnpm
+              key: setup-pnpm-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm-version.outputs.version }}-${{ hashFiles('.github/actions/pnpm-install/action.yml') }}
 
         - name: Resolve Node version
           id: node-version


### PR DESCRIPTION
## Problem

- Every Node CI job downloads pnpm from registry.npmjs.org before it runs any work, so a slow registry delays all of them at the same time.
- On 4 September 2026 that download took 7 minutes per job. MCP CI unit tests allow 10 minutes, so the job timed out before the tests started ([example run](https://github.com/PostHog/posthog/actions/runs/33860782515/job/100984542582)).
- `pnpm/action-setup` deletes `~/setup-pnpm` and runs `npm ci` there on every job, so nothing caches that download today. The pnpm store cache restores later in the same step and does not cover it.

## Changes

- A Node job now restores the pnpm install from a cache and makes no npm registry request. A healthy install takes about 10 seconds, so the saving on a normal run is small; the point is that a registry stall stops costing whole jobs.
- The cache key is `setup-pnpm-<os>-<arch>-<pnpm version>-<hash of this action file>`. The version comes from `packageManager` in package.json. The file hash moves the key when the pinned `pnpm/action-setup` SHA changes, because that SHA decides which pnpm `npm ci` installs.
- On a cache hit the action is skipped, and a shell step exports `PNPM_HOME` and PATH the way the action does. `PNPM_HOME/bin` holds the self-updated target version, so it has to win on PATH.
- Saves run only on master, matching the pnpm store and Node tool caches in the same action.
- A cache miss runs the action exactly as before, so an unrebased PR is unaffected.
- Nothing a person sees changes. The whole diff is CI wiring in one composite action.

[#95098](https://github.com/PostHog/posthog/pull/95098) is the other candidate fix for the same failure: it bounds npm's fetch timeout instead of removing the fetch. The two are independent and compose, because this PR still runs the action on a miss.

## How did you test this code?

- `bin/hogli lint:workflows` passes.
- This PR's own CI exercises the miss path only. Cache saves are gated to master, so the first master run writes the entry and every run after that is the first real test of the hit path.
- Not checked: behavior on a runner whose `HOME` is not `/home/runner`, which would restore the cache to a path the exported `PNPM_HOME` does not match.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app after a thread about merge queue timeouts. The investigation read the failing job log, then sampled the `Install pnpm dependencies` step duration across recent runs of Backend CI, Frontend CI, Node.js CI, Storybook and MCP CI to separate a standing cost from a one-off stall. It also read the `pnpm/action-setup` source to confirm the action deletes and reinstalls `~/setup-pnpm` on every job, which rules out caching without skipping the action.

Skills invoked: `/authoring-ci-workflows`, `/writing-code-comments`, `/writing-pr-descriptions`.

No duplicate: `gh pr list --state open --search "pnpm install cache in:title"` and the same search for `action-setup` returned nothing.

Public artifact: the diff and this description contain only CI configuration and links to public workflow runs.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8QA6740/p1788517946881889?thread_ts=1788517946.881889&cid=C09G8QA6740)*
