### PR TITLE
fix(eng-analytics): serve workflow tiles from the window

### DIFF
--- a/products/engineering_analytics/backend/facade/api.py
+++ b/products/engineering_analytics/backend/facade/api.py
@@ -341,6 +341,7 @@ def list_workflow_health(
     date_to: str | None = None,
     branch: str | None = None,
     run_scope: str | None = None,
+    workflow_name: str | None = None,
     source_id: str | None = None,
     repo: str | None = None,
     user_access_control: "UserAccessControl | None" = None,
@@ -351,6 +352,7 @@ def list_workflow_health(
         date_to=date_to,
         branch=branch,
         run_scope=run_scope,
+        workflow_name=workflow_name,
     )
 
 

--- a/products/engineering_analytics/backend/logic/queries/_workflow_filters.py
+++ b/products/engineering_analytics/backend/logic/queries/_workflow_filters.py
@@ -159,6 +159,18 @@ def branch_filter_clause(
     return f"AND {column} = {{branch}}"
 
 
+def workflow_name_filter_clause(
+    workflow_name: str | None, placeholders: dict[str, ast.Expr], *, column: str = "r.workflow_name"
+) -> str:
+    """Exact workflow-name filter; registers its ``{workflow_name}`` placeholder. Empty means no
+    filter, so a blank query param ranks every workflow rather than matching a workflow named ''."""
+    value = workflow_name.strip() if workflow_name else ""
+    if not value:
+        return ""
+    placeholders["workflow_name"] = ast.Constant(value=value)
+    return f"AND {column} = {{workflow_name}}"
+
+
 def date_to_filter_clause(
     date_to: datetime | None, placeholders: dict[str, ast.Expr], *, column: str = "r.run_started_at"
 ) -> str:

--- a/products/engineering_analytics/backend/logic/queries/workflow_health.py
+++ b/products/engineering_analytics/backend/logic/queries/workflow_health.py
@@ -53,6 +53,7 @@ from products.engineering_analytics.backend.logic.queries._workflow_filters impo
     run_started_floor_constant,
     success_rate_expr,
     window_pair_predicates,
+    workflow_name_filter_clause,
 )
 from products.engineering_analytics.backend.logic.queries.pr_cost import query_workflow_window_costs
 
@@ -80,7 +81,7 @@ _SELECT = f"""
         argMaxIf(run_attempt, (run_started_at, id), status = 'completed') AS latest_run_attempt,
         countIf(run_attempt > 1) AS rerun_cycles
     FROM __RUNS_SOURCE__ AS r
-    WHERE run_started_at >= {{date_from}} __DATE_TO__ __BRANCH__ __RUN_SCOPE__
+    WHERE run_started_at >= {{date_from}} __DATE_TO__ __BRANCH__ __RUN_SCOPE__ __WORKFLOW__
     GROUP BY repo_owner, repo_name, workflow_name
     ORDER BY run_count DESC
     LIMIT {_LIMIT}
@@ -99,7 +100,7 @@ _PREV_SELECT = f"""
         workflow_name,
         {success_rate_expr()} AS success_rate
     FROM __RUNS_SOURCE__ AS r
-    WHERE run_started_at >= {{prev_from}} AND run_started_at < {{date_from}} __BRANCH__ __RUN_SCOPE__
+    WHERE run_started_at >= {{prev_from}} AND run_started_at < {{date_from}} __BRANCH__ __RUN_SCOPE__ __WORKFLOW__
     GROUP BY repo_owner, repo_name, workflow_name
     LIMIT {UNPAGED_SCAN_LIMIT}
 """
@@ -115,7 +116,7 @@ _BUCKET_SELECT = f"""
         countIf({SUCCESSFUL_RUN_CONDITION}) AS successes,
         countIf(status = 'completed' AND conclusion IN ({DECISIVE_FAILURE_CONCLUSIONS_SQL})) AS failures
     FROM __RUNS_SOURCE__ AS r
-    WHERE run_started_at >= {{date_from}} __DATE_TO__ __BRANCH__ __RUN_SCOPE__
+    WHERE run_started_at >= {{date_from}} __DATE_TO__ __BRANCH__ __RUN_SCOPE__ __WORKFLOW__
     GROUP BY repo_owner, repo_name, workflow_name, bucket_start
     LIMIT {_BUCKET_LIMIT}
 """
@@ -271,6 +272,7 @@ def query_workflow_health(
     date_to: datetime | None,
     branch: str | None,
     run_scope: WorkflowHealthRunScope,
+    workflow_name: str | None = None,
     workload: Workload = Workload.DEFAULT,
 ) -> list[WorkflowHealthItem]:
     granularity = pick_granularity(date_from, date_to)
@@ -281,6 +283,7 @@ def query_workflow_health(
     date_to_clause = date_to_filter_clause(date_to, placeholders)
     branch_clause = branch_filter_clause(branch, placeholders)
     run_scope_clause = run_scope_filter_clause(run_scope)
+    workflow_clause = workflow_name_filter_clause(workflow_name, placeholders)
 
     runs_source = curated.run_source(started_floor=True)
 
@@ -290,6 +293,7 @@ def query_workflow_health(
             .replace("__DATE_TO__", date_to_clause)
             .replace("__BRANCH__", branch_clause)
             .replace("__RUN_SCOPE__", run_scope_clause)
+            .replace("__WORKFLOW__", workflow_clause)
             .replace("__BUCKET_FN__", bucket_expr(granularity))
         )
 

--- a/products/engineering_analytics/backend/logic/workflows.py
+++ b/products/engineering_analytics/backend/logic/workflows.py
@@ -121,6 +121,7 @@ def build_workflow_health(
     date_to: str | None = None,
     branch: str | None = None,
     run_scope: str | None = None,
+    workflow_name: str | None = None,
 ) -> list[WorkflowHealthItem]:
     parsed_from, parsed_to = _parse_window(curated.team, date_from, date_to, default=_DEFAULT_WORKFLOW_WINDOW)
     return query_workflow_health(
@@ -129,6 +130,7 @@ def build_workflow_health(
         date_to=parsed_to,
         branch=branch,
         run_scope=_parse_run_scope(run_scope),
+        workflow_name=workflow_name,
     )
 
 

--- a/products/engineering_analytics/backend/presentation/views/_base.py
+++ b/products/engineering_analytics/backend/presentation/views/_base.py
@@ -70,6 +70,15 @@ _RUN_SCOPE = OpenApiParameter(
     "(a GitHub limitation), so 'pull_request' covers same-repo PRs only. Any other value is a 400.",
 )
 
+_WORKFLOW_NAME = OpenApiParameter(
+    name="workflow_name",
+    type=OpenApiTypes.STR,
+    location=OpenApiParameter.QUERY,
+    required=False,
+    description="Optional exact workflow name to scope results to, e.g. 'Backend CI'. Omit to rank every "
+    "workflow. Pass it when you want one workflow's figures over the whole window rather than the top slice.",
+)
+
 _SOURCE_ID = OpenApiParameter(
     name="source_id",
     type=OpenApiTypes.UUID,

--- a/products/engineering_analytics/backend/presentation/views/workflows.py
+++ b/products/engineering_analytics/backend/presentation/views/workflows.py
@@ -28,6 +28,7 @@ from products.engineering_analytics.backend.presentation.views._base import (
     _RUN_SCOPE,
     _SOURCE_ID,
     _WORKFLOW_DATE_FROM,
+    _WORKFLOW_NAME,
     EngineeringAnalyticsViewSetBase,
     _bad_request,
     _bool_param,
@@ -54,7 +55,7 @@ class WorkflowActionsMixin(EngineeringAnalyticsViewSetBase):
 
     @extend_schema(
         operation_id="engineering_analytics_workflow_health",
-        parameters=[_WORKFLOW_DATE_FROM, _DATE_TO, _BRANCH, _RUN_SCOPE, _SOURCE_ID, _REPO],
+        parameters=[_WORKFLOW_DATE_FROM, _DATE_TO, _BRANCH, _RUN_SCOPE, _WORKFLOW_NAME, _SOURCE_ID, _REPO],
         responses={
             200: WorkflowHealthItemSerializer(many=True),
             400: OpenApiResponse(
@@ -67,7 +68,7 @@ class WorkflowActionsMixin(EngineeringAnalyticsViewSetBase):
             "by hour/day/week to fit the window. Success rate covers runs that succeeded or ended in a decisive "
             "failure. Skipped, cancelled, neutral, and action-required runs are excluded. p50/p95 are over "
             "successful runs only, so cancelled (superseded) and failed runs never bias the duration trend. "
-            "Optionally scope to a single git branch via `branch`, "
+            "Optionally scope to a single git branch via `branch`, to one workflow via `workflow_name`, "
             "or to attributed pull-request runs via `run_scope=pull_request`. Use this for 'is CI getting slower' "
             "and 'which workflow is the long pole'; compare two windows to get a trend."
         ),
@@ -81,6 +82,7 @@ class WorkflowActionsMixin(EngineeringAnalyticsViewSetBase):
                 date_to=request.query_params.get("date_to") or None,
                 branch=request.query_params.get("branch") or None,
                 run_scope=request.query_params.get("run_scope") or None,
+                workflow_name=request.query_params.get("workflow_name") or None,
                 source_id=request.query_params.get("source_id") or None,
                 repo=request.query_params.get("repo") or None,
                 user_access_control=self.user_access_control,

--- a/products/engineering_analytics/frontend/generated/api.schemas.ts
+++ b/products/engineering_analytics/frontend/generated/api.schemas.ts
@@ -2128,6 +2128,10 @@ export type EngineeringAnalyticsWorkflowHealthParams = {
      * Connected GitHub data warehouse source to read from. Defaults to the oldest connected GitHub source when the team has more than one.
      */
     source_id?: string
+    /**
+     * Optional exact workflow name to scope results to, e.g. 'Backend CI'. Omit to rank every workflow. Pass it when you want one workflow's figures over the whole window rather than the top slice.
+     */
+    workflow_name?: string
 }
 
 export type EngineeringAnalyticsWorkflowHealthRunScope =

--- a/products/engineering_analytics/frontend/generated/api.ts
+++ b/products/engineering_analytics/frontend/generated/api.ts
@@ -889,7 +889,7 @@ export const getEngineeringAnalyticsWorkflowHealthUrl = (
 }
 
 /**
- * Per-workflow CI health over a window (default last 24 hours, maximum 366 days): run count, success rate, p50/p95 duration, last failure time, latest-run status, and a zero-filled run history bucketed by hour/day/week to fit the window. Success rate covers runs that succeeded or ended in a decisive failure. Skipped, cancelled, neutral, and action-required runs are excluded. p50/p95 are over successful runs only, so cancelled (superseded) and failed runs never bias the duration trend. Optionally scope to a single git branch via `branch`, or to attributed pull-request runs via `run_scope=pull_request`. Use this for 'is CI getting slower' and 'which workflow is the long pole'; compare two windows to get a trend.
+ * Per-workflow CI health over a window (default last 24 hours, maximum 366 days): run count, success rate, p50/p95 duration, last failure time, latest-run status, and a zero-filled run history bucketed by hour/day/week to fit the window. Success rate covers runs that succeeded or ended in a decisive failure. Skipped, cancelled, neutral, and action-required runs are excluded. p50/p95 are over successful runs only, so cancelled (superseded) and failed runs never bias the duration trend. Optionally scope to a single git branch via `branch`, to one workflow via `workflow_name`, or to attributed pull-request runs via `run_scope=pull_request`. Use this for 'is CI getting slower' and 'which workflow is the long pole'; compare two windows to get a trend.
  */
 export const engineeringAnalyticsWorkflowHealth = async (
     projectId: string,

--- a/products/engineering_analytics/frontend/lib/runHealth.test.ts
+++ b/products/engineering_analytics/frontend/lib/runHealth.test.ts
@@ -50,7 +50,6 @@ describe('runHealth', () => {
             { conclusion: 'neutral', durationSeconds: 600, startedAt: at(13) },
             { conclusion: 'future_outcome', durationSeconds: 600, startedAt: at(14) },
         ])
-        expect(summary.completedRuns).toBe(6)
         expect(summary.conclusiveRuns).toBe(1)
         expect(summary.passedRuns).toBe(1)
         expect(summary.passRate).toBe(1)
@@ -75,8 +74,6 @@ describe('runHealth', () => {
             { conclusion: 'failure', durationSeconds: 240, startedAt: at(10), runAttempt: 2 },
             { conclusion: null, durationSeconds: null, startedAt: at(11), runAttempt: 1 },
         ])
-        expect(summary.completedRuns).toBe(2)
-        expect(summary.running).toBe(1)
         expect(summary.passRate).toBe(0.5)
         expect(summary.failures).toBe(1)
         expect(summary.reruns).toBe(1)
@@ -109,7 +106,6 @@ describe('runHealth', () => {
         expect(summary.medianSeconds).toBe(600)
         expect(summary.p95Seconds).toBe(900)
         expect(summary.totalRuns).toBe(5)
-        expect(summary.completedRuns).toBe(5)
         expect(summary.passRate).toBe(1)
     })
 

--- a/products/engineering_analytics/frontend/lib/runHealth.ts
+++ b/products/engineering_analytics/frontend/lib/runHealth.ts
@@ -29,14 +29,14 @@ export interface CostableJob {
 
 export type WorkflowState = 'healthy' | 'degraded' | 'failing' | 'unknown'
 
+/** What the workflow tiles read, from either the server's window-wide figures or a fold over a page
+ *  of runs. Every field is answerable from both, so neither source has to invent one. */
 export interface HealthSummary {
     state: WorkflowState
     totalRuns: number
-    completedRuns: number
     conclusiveRuns: number
     passedRuns: number
     failures: number
-    running: number
     /** Runs that were a 2nd+ attempt. */
     reruns: number
     /** Passes divided by conclusive runs (null when no run reached a verdict). */
@@ -146,7 +146,7 @@ function workflowState(counts: {
  * The tiles read this rather than folding the run table, which only holds the newest page: on a busy
  * workflow that page is a few hours of a 30-day window, so a client-side pass rate answered a
  * different question than the Workflows table's, and cost-per-run divided a window-wide total by the
- * page size. `running` and `completedRuns` are not in the contract and are not on any tile.
+ * page size.
  */
 export function workflowHealthSummary(item: {
     run_count: number
@@ -168,11 +168,9 @@ export function workflowHealthSummary(item: {
             failures,
         }),
         totalRuns: item.run_count,
-        completedRuns: item.conclusive_run_count,
         conclusiveRuns: item.conclusive_run_count,
         passedRuns: item.successful_run_count,
         failures,
-        running: 0,
         reruns: item.rerun_cycles ?? 0,
         passRate: item.success_rate,
         medianSeconds: item.p50_seconds,
@@ -185,7 +183,6 @@ export function workflowHealthSummary(item: {
 export function computeHealthSummary(runs: HealthRun[]): HealthSummary {
     const completed = runs.filter((run) => run.conclusion !== null)
     const successful = completed.filter((run) => run.conclusion === 'success')
-    const running = runs.length - completed.length
     const passed = successful.length
     const failures = completed.filter((run) => isDecisiveFailure(run.conclusion)).length
     const conclusiveRuns = passed + failures
@@ -222,11 +219,9 @@ export function computeHealthSummary(runs: HealthRun[]): HealthSummary {
     return {
         state,
         totalRuns: runs.length,
-        completedRuns: completed.length,
         conclusiveRuns,
         passedRuns: passed,
         failures,
-        running,
         reruns,
         passRate,
         medianSeconds: percentileSorted(durations, 0.5),

--- a/products/engineering_analytics/frontend/lib/runHealth.ts
+++ b/products/engineering_analytics/frontend/lib/runHealth.ts
@@ -121,6 +121,67 @@ export function percentileSorted(sortedAsc: number[], q: number): number | null 
  * Verdict + headline stats for one workflow's runs. Durations use successful runs. Rates use
  * conclusive runs, so an unsettled or non-verdict run is never counted as a failure.
  */
+/** The workflow verdict, from counts either side can supply, so the client-side summary over a page
+ *  of runs and the server's window-wide figures can never disagree on the badge. */
+function workflowState(counts: {
+    hasCompleted: boolean
+    latestConclusion: string | null
+    conclusiveRuns: number
+    failures: number
+}): WorkflowState {
+    if (!counts.hasCompleted) {
+        return 'unknown'
+    }
+    if (isDecisiveFailure(counts.latestConclusion)) {
+        return 'failing'
+    }
+    if (counts.conclusiveRuns > 0 && counts.failures / counts.conclusiveRuns >= DEGRADED_FAILURE_RATE) {
+        return 'degraded'
+    }
+    return 'healthy'
+}
+
+/** The window-wide figures for one workflow, as the server computed them.
+ *
+ * The tiles read this rather than folding the run table, which only holds the newest page: on a busy
+ * workflow that page is a few hours of a 30-day window, so a client-side pass rate answered a
+ * different question than the Workflows table's, and cost-per-run divided a window-wide total by the
+ * page size. `running` and `completedRuns` are not in the contract and are not on any tile.
+ */
+export function workflowHealthSummary(item: {
+    run_count: number
+    successful_run_count: number
+    conclusive_run_count: number
+    success_rate: number | null
+    p50_seconds: number | null
+    p95_seconds: number | null
+    last_failure_at: string | null
+    latest_run_conclusion?: string | null
+    rerun_cycles?: number
+}): HealthSummary {
+    const failures = item.conclusive_run_count - item.successful_run_count
+    return {
+        state: workflowState({
+            hasCompleted: item.latest_run_conclusion != null,
+            latestConclusion: item.latest_run_conclusion ?? null,
+            conclusiveRuns: item.conclusive_run_count,
+            failures,
+        }),
+        totalRuns: item.run_count,
+        completedRuns: item.conclusive_run_count,
+        conclusiveRuns: item.conclusive_run_count,
+        passedRuns: item.successful_run_count,
+        failures,
+        running: 0,
+        reruns: item.rerun_cycles ?? 0,
+        passRate: item.success_rate,
+        medianSeconds: item.p50_seconds,
+        p95Seconds: item.p95_seconds,
+        lastFailureAt: item.last_failure_at,
+        latestConclusion: item.latest_run_conclusion ?? null,
+    }
+}
+
 export function computeHealthSummary(runs: HealthRun[]): HealthSummary {
     const completed = runs.filter((run) => run.conclusion !== null)
     const successful = completed.filter((run) => run.conclusion === 'success')
@@ -151,16 +212,12 @@ export function computeHealthSummary(runs: HealthRun[]): HealthSummary {
             .sort()
             .at(-1) ?? null
 
-    let state: WorkflowState
-    if (completed.length === 0) {
-        state = 'unknown'
-    } else if (isDecisiveFailure(latestConclusion)) {
-        state = 'failing'
-    } else if (conclusiveRuns > 0 && failures / conclusiveRuns >= DEGRADED_FAILURE_RATE) {
-        state = 'degraded'
-    } else {
-        state = 'healthy'
-    }
+    const state = workflowState({
+        hasCompleted: completed.length > 0,
+        latestConclusion,
+        conclusiveRuns,
+        failures,
+    })
 
     return {
         state,

--- a/products/engineering_analytics/frontend/scenes/WorkflowRunsScene.tsx
+++ b/products/engineering_analytics/frontend/scenes/WorkflowRunsScene.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
 import { IconExternal, IconGear } from '@posthog/icons'
-import { LemonButton, LemonTable, LemonTableColumns, LemonTag, Link } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonTable, LemonTableColumns, LemonTag, Link } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { LemonCard } from 'lib/lemon-ui/LemonCard'
@@ -98,6 +98,7 @@ export function WorkflowRunsScene(): JSX.Element {
         workflowName,
         healthSummary,
         workflowHealthLoading,
+        workflowHealthFailed,
         costSummary,
         runsTruncated,
         activityRuns,
@@ -312,6 +313,12 @@ export function WorkflowRunsScene(): JSX.Element {
                 slug={`${repoOwner}/${repoName}`}
                 right={verdictPill}
             />
+            {workflowHealthFailed && (
+                <LemonBanner type="warning">
+                    These figures could not load, so they cover only the runs in the table below rather than the whole
+                    window. Refresh to try again.
+                </LemonBanner>
+            )}
             <div className="flex flex-wrap gap-2.5">
                 <MetricTile
                     label="Pass rate"

--- a/products/engineering_analytics/frontend/scenes/WorkflowRunsScene.tsx
+++ b/products/engineering_analytics/frontend/scenes/WorkflowRunsScene.tsx
@@ -97,6 +97,7 @@ export function WorkflowRunsScene(): JSX.Element {
         repoName,
         workflowName,
         healthSummary,
+        workflowHealthLoading,
         costSummary,
         runsTruncated,
         activityRuns,
@@ -318,7 +319,7 @@ export function WorkflowRunsScene(): JSX.Element {
                         healthSummary.conclusiveRuns
                     )} runs with a pass-or-fail result passed.`}
                     value={percent(healthSummary.passRate)}
-                    loading={runsLoading}
+                    loading={workflowHealthLoading}
                 />
                 <MetricTile
                     label="Runs"
@@ -328,12 +329,12 @@ export function WorkflowRunsScene(): JSX.Element {
                             : undefined
                     }
                     value={compactCount(healthSummary.totalRuns)}
-                    sub={runsTruncated ? `stats cover the most recent ${runRows.length}` : undefined}
-                    loading={runsLoading}
+                    sub={runsTruncated ? `table shows the most recent ${runRows.length}` : undefined}
+                    loading={workflowHealthLoading}
                 />
                 <MetricTile
                     label="Duration p50"
-                    tooltip="Wall-clock, over successful runs."
+                    tooltip="Median wall-clock duration over successful runs, excluding runs that settled in under 10 seconds without doing work."
                     value={
                         healthSummary.medianSeconds != null ? humanFriendlyDuration(healthSummary.medianSeconds) : '—'
                     }
@@ -342,7 +343,7 @@ export function WorkflowRunsScene(): JSX.Element {
                             ? `→ ${humanFriendlyDuration(healthSummary.p95Seconds)} p95`
                             : undefined
                     }
-                    loading={runsLoading}
+                    loading={workflowHealthLoading}
                 />
                 <MetricTile
                     label="Queue time p50"

--- a/products/engineering_analytics/frontend/scenes/workflowRunsLogic.test.ts
+++ b/products/engineering_analytics/frontend/scenes/workflowRunsLogic.test.ts
@@ -6,6 +6,7 @@ import { initKeaTests } from '~/test/init'
 
 import {
     engineeringAnalyticsJobAggregates,
+    engineeringAnalyticsWorkflowHealth,
     engineeringAnalyticsWorkflowJobs,
     engineeringAnalyticsWorkflowRunActivity,
     engineeringAnalyticsWorkflowRunnerCosts,
@@ -16,6 +17,7 @@ import { workflowRunsLogic } from './workflowRunsLogic'
 
 jest.mock('../generated/api', () => ({
     engineeringAnalyticsJobAggregates: jest.fn(),
+    engineeringAnalyticsWorkflowHealth: jest.fn(),
     engineeringAnalyticsWorkflowJobs: jest.fn(),
     engineeringAnalyticsWorkflowRunActivity: jest.fn(),
     engineeringAnalyticsWorkflowRunnerCosts: jest.fn(),
@@ -33,6 +35,9 @@ const mockJobs = engineeringAnalyticsWorkflowJobs as jest.MockedFunction<typeof 
 const mockJobAggregates = engineeringAnalyticsJobAggregates as jest.MockedFunction<
     typeof engineeringAnalyticsJobAggregates
 >
+const mockWorkflowHealth = engineeringAnalyticsWorkflowHealth as jest.MockedFunction<
+    typeof engineeringAnalyticsWorkflowHealth
+>
 
 describe('workflowRunsLogic', () => {
     let logic: ReturnType<typeof workflowRunsLogic.build>
@@ -46,6 +51,7 @@ describe('workflowRunsLogic', () => {
         mockRunnerCosts.mockResolvedValue([])
         mockJobs.mockResolvedValue([])
         mockJobAggregates.mockResolvedValue([])
+        mockWorkflowHealth.mockResolvedValue([])
     })
 
     let unmountFilters: (() => void) | undefined
@@ -63,6 +69,7 @@ describe('workflowRunsLogic', () => {
         unmountFilters = filters.mount()
         await expectLogic(logic).toDispatchActions([
             'loadRunsSuccess',
+            'loadWorkflowHealthSuccess',
             'loadRunActivitySuccess',
             'loadRunnerCostsSuccess',
         ])
@@ -72,6 +79,9 @@ describe('workflowRunsLogic', () => {
         expect(mockRuns).toHaveBeenLastCalledWith('1', expect.objectContaining(runsArgs))
         expect(mockRunActivity).toHaveBeenLastCalledWith('1', expect.objectContaining(runsArgs))
         expect(mockRunnerCosts).toHaveBeenLastCalledWith('1', expect.objectContaining(runsArgs))
+        // The tiles read this endpoint rather than folding the capped run table, so it carries the
+        // same workflow, window and branch as the rest of the page.
+        expect(mockWorkflowHealth).toHaveBeenLastCalledWith('1', expect.objectContaining(runsArgs))
 
         // Applying a branch on the shared filters logic reloads all three reads scoped to it — so the detail
         // page's numbers (and the chart's runs) match the branch-scoped Workflows tab instead of widening
@@ -80,14 +90,49 @@ describe('workflowRunsLogic', () => {
         filters.actions.applyBranchFilter()
         await expectLogic(logic).toDispatchActions([
             'loadRuns',
+            'loadWorkflowHealth',
             'loadRunActivity',
             'loadRunnerCosts',
             'loadRunsSuccess',
+            'loadWorkflowHealthSuccess',
             'loadRunActivitySuccess',
             'loadRunnerCostsSuccess',
         ])
         expect(mockRuns).toHaveBeenLastCalledWith('1', expect.objectContaining({ branch: 'master' }))
         expect(mockRunActivity).toHaveBeenLastCalledWith('1', expect.objectContaining({ branch: 'master' }))
         expect(mockRunnerCosts).toHaveBeenLastCalledWith('1', expect.objectContaining({ branch: 'master' }))
+        expect(mockWorkflowHealth).toHaveBeenLastCalledWith('1', expect.objectContaining({ branch: 'master' }))
+    })
+
+    it('reads the tiles from the window-wide figures, not the capped run table', async () => {
+        // 3800 of 3900 conclusive runs passed across the window; the run table only ever holds a page
+        // of that, so folding the tiles off the table answered a narrower question than the Workflows
+        // table did for the same workflow and window.
+        mockWorkflowHealth.mockResolvedValue([
+            {
+                repo: { provider: 'github', owner: 'PostHog', name: 'posthog' },
+                workflow_name: 'CI',
+                run_count: 4000,
+                successful_run_count: 3800,
+                conclusive_run_count: 3900,
+                success_rate: 0.974,
+                p50_seconds: 120,
+                p95_seconds: 600,
+                last_failure_at: null,
+                latest_run_failed: false,
+                latest_run_conclusion: 'success',
+                latest_run_id: 1,
+                latest_run_attempt: 1,
+                granularity: 'day',
+                buckets: [],
+            },
+        ])
+        logic = workflowRunsLogic({ repoOwner: 'PostHog', repoName: 'posthog', workflowName: 'CI', sourceId: null })
+        logic.mount()
+        await expectLogic(logic).toDispatchActions(['loadWorkflowHealthSuccess'])
+
+        expect(logic.values.healthSummary.totalRuns).toBe(4000)
+        expect(logic.values.healthSummary.passRate).toBe(0.974)
+        expect(logic.values.healthSummary.state).toBe('healthy')
     })
 })

--- a/products/engineering_analytics/frontend/scenes/workflowRunsLogic.ts
+++ b/products/engineering_analytics/frontend/scenes/workflowRunsLogic.ts
@@ -87,6 +87,7 @@ export interface workflowRunsLogicValues {
     runsTruncated: boolean
     sourceId: string | null
     workflowHealth: WorkflowHealthItemApi | null
+    workflowHealthFailed: boolean
     workflowHealthLoading: boolean
     workflowName: string
 }
@@ -363,6 +364,16 @@ export const workflowRunsLogic = kea<workflowRunsLogicType>([
                 loadRuns: () => false,
                 loadRunsSuccess: () => false,
                 loadRunsFailure: () => true,
+            },
+        ],
+        // Without this, a failed health fetch is indistinguishable from a quiet window: the tiles fall
+        // back to the capped run table and present a narrower answer as if it were the window's.
+        workflowHealthFailed: [
+            false,
+            {
+                loadWorkflowHealth: () => false,
+                loadWorkflowHealthSuccess: () => false,
+                loadWorkflowHealthFailure: () => true,
             },
         ],
         expandedRunKeys: [

--- a/products/engineering_analytics/frontend/scenes/workflowRunsLogic.ts
+++ b/products/engineering_analytics/frontend/scenes/workflowRunsLogic.ts
@@ -11,11 +11,13 @@ import { runPrNumber } from '../components/runTables'
 import {
     engineeringAnalyticsJobAggregates,
     engineeringAnalyticsWorkflowJobs,
+    engineeringAnalyticsWorkflowHealth,
     engineeringAnalyticsWorkflowRunActivity,
     engineeringAnalyticsWorkflowRunnerCosts,
     engineeringAnalyticsWorkflowRuns,
 } from '../generated/api'
 import type {
+    WorkflowHealthItemApi,
     WorkflowJobAggregateApi,
     WorkflowJobApi,
     WorkflowRunActivityApi,
@@ -23,7 +25,7 @@ import type {
     WorkflowRunnerCostApi,
 } from '../generated/api.schemas'
 import { jobCacheKey } from '../lib/jobs'
-import { type CostSummary, type HealthSummary, computeHealthSummary } from '../lib/runHealth'
+import { type CostSummary, type HealthSummary, computeHealthSummary, workflowHealthSummary } from '../lib/runHealth'
 import { engineeringAnalyticsFiltersLogic } from './engineeringAnalyticsFiltersLogic'
 
 const projectId = (): string => String(ApiConfig.getCurrentProjectId())
@@ -84,6 +86,8 @@ export interface workflowRunsLogicValues {
     runsLoading: boolean
     runsTruncated: boolean
     sourceId: string | null
+    workflowHealth: WorkflowHealthItemApi | null
+    workflowHealthLoading: boolean
     workflowName: string
 }
 
@@ -173,6 +177,21 @@ export interface workflowRunsLogicActions {
         runs: WorkflowRunDetailApi[]
         payload?: any
     }
+    loadWorkflowHealth: () => any
+    loadWorkflowHealthFailure: (
+        error: string,
+        errorObject?: any
+    ) => {
+        error: string
+        errorObject?: any
+    }
+    loadWorkflowHealthSuccess: (
+        workflowHealth: WorkflowHealthItemApi | null,
+        payload?: any
+    ) => {
+        workflowHealth: WorkflowHealthItemApi | null
+        payload?: any
+    }
     setRunExpanded: (
         rowKey: string,
         expanded: boolean,
@@ -197,7 +216,7 @@ export interface workflowRunsLogicMeta {
         runRows: (runs: WorkflowRunDetailApi[]) => WorkflowRunRow[]
         activityRuns: (runActivity: WorkflowRunActivityApi) => ActivityRun[]
         activityTruncated: (runActivity: WorkflowRunActivityApi) => boolean
-        healthSummary: (runRows: WorkflowRunRow[]) => HealthSummary
+        healthSummary: (workflowHealth: WorkflowHealthItemApi | null, runRows: WorkflowRunRow[]) => HealthSummary
         masterConclusion: (runRows: WorkflowRunRow[]) => string | null
         queueP50Seconds: (jobAggregates: WorkflowJobAggregateApi[]) => number | null
         runsTruncated: (runRows: WorkflowRunRow[]) => boolean
@@ -263,6 +282,25 @@ export const workflowRunsLogic = kea<workflowRunsLogicType>([
                         branch: values.appliedBranch || undefined,
                         source_id: props.sourceId ?? undefined,
                     }),
+            },
+        ],
+        // This workflow's window-wide figures, computed server-side. The run table below is capped at
+        // RUN_LIST_LIMIT, so the tiles cannot be folded from it without answering a narrower question
+        // than the Workflows table does for the same workflow and window.
+        workflowHealth: [
+            null as WorkflowHealthItemApi | null,
+            {
+                loadWorkflowHealth: async (): Promise<WorkflowHealthItemApi | null> => {
+                    const items = await engineeringAnalyticsWorkflowHealth(projectId(), {
+                        workflow_name: props.workflowName,
+                        repo: `${props.repoOwner}/${props.repoName}`,
+                        date_from: values.dateFrom ?? undefined,
+                        date_to: values.dateTo ?? undefined,
+                        branch: values.appliedBranch || undefined,
+                        source_id: props.sourceId ?? undefined,
+                    })
+                    return items[0] ?? null
+                },
             },
         ],
         // Cost split by runner tier; [] when the job-level source isn't synced.
@@ -382,9 +420,12 @@ export const workflowRunsLogic = kea<workflowRunsLogicType>([
             (s) => [s.runActivity],
             (runActivity: WorkflowRunActivityApi): boolean => runActivity.truncated,
         ],
+        // Server figures when they have arrived; the capped run table only stands in while they load
+        // or when the workflow has no rows in the window.
         healthSummary: [
-            (s) => [s.runRows],
-            (runRows: WorkflowRunRow[]): HealthSummary => computeHealthSummary(runRows),
+            (s) => [s.workflowHealth, s.runRows],
+            (workflowHealth: WorkflowHealthItemApi | null, runRows: WorkflowRunRow[]): HealthSummary =>
+                workflowHealth ? workflowHealthSummary(workflowHealth) : computeHealthSummary(runRows),
         ],
         // Latest completed master/main run's conclusion; null when the window has none (PR-only workflow).
         masterConclusion: [
@@ -475,12 +516,14 @@ export const workflowRunsLogic = kea<workflowRunsLogicType>([
         },
         [engineeringAnalyticsFiltersLogic.actionTypes.setDateRange]: () => {
             actions.loadRuns()
+            actions.loadWorkflowHealth()
             actions.loadRunActivity()
             actions.loadRunnerCosts()
             actions.loadJobAggregates()
         },
         [engineeringAnalyticsFiltersLogic.actionTypes.setAppliedBranch]: () => {
             actions.loadRuns()
+            actions.loadWorkflowHealth()
             actions.loadRunActivity()
             actions.loadRunnerCosts()
             actions.loadJobAggregates()
@@ -489,6 +532,7 @@ export const workflowRunsLogic = kea<workflowRunsLogicType>([
 
     afterMount(({ actions }) => {
         actions.loadRuns()
+        actions.loadWorkflowHealth()
         actions.loadRunActivity()
         actions.loadRunnerCosts()
         actions.loadJobAggregates()

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -94107,6 +94107,10 @@ export namespace Schemas {
      * Connected GitHub data warehouse source to read from. Defaults to the oldest connected GitHub source when the team has more than one.
      */
     source_id?: string;
+    /**
+     * Optional exact workflow name to scope results to, e.g. 'Backend CI'. Omit to rank every workflow. Pass it when you want one workflow's figures over the whole window rather than the top slice.
+     */
+    workflow_name?: string;
     };
 
     export type EngineeringAnalyticsWorkflowHealthRunScope = typeof EngineeringAnalyticsWorkflowHealthRunScope[keyof typeof EngineeringAnalyticsWorkflowHealthRunScope];

--- a/services/mcp/src/generated/engineering_analytics/api.ts
+++ b/services/mcp/src/generated/engineering_analytics/api.ts
@@ -248,7 +248,7 @@ export const EngineeringAnalyticsTeamCiHealthQueryParams = () => zod.object({
 })
 
 /**
- * Per-workflow CI health over a window (default last 24 hours, maximum 366 days): run count, success rate, p50/p95 duration, last failure time, latest-run status, and a zero-filled run history bucketed by hour/day/week to fit the window. Success rate covers runs that succeeded or ended in a decisive failure. Skipped, cancelled, neutral, and action-required runs are excluded. p50/p95 are over successful runs only, so cancelled (superseded) and failed runs never bias the duration trend. Optionally scope to a single git branch via `branch`, or to attributed pull-request runs via `run_scope=pull_request`. Use this for 'is CI getting slower' and 'which workflow is the long pole'; compare two windows to get a trend.
+ * Per-workflow CI health over a window (default last 24 hours, maximum 366 days): run count, success rate, p50/p95 duration, last failure time, latest-run status, and a zero-filled run history bucketed by hour/day/week to fit the window. Success rate covers runs that succeeded or ended in a decisive failure. Skipped, cancelled, neutral, and action-required runs are excluded. p50/p95 are over successful runs only, so cancelled (superseded) and failed runs never bias the duration trend. Optionally scope to a single git branch via `branch`, to one workflow via `workflow_name`, or to attributed pull-request runs via `run_scope=pull_request`. Use this for 'is CI getting slower' and 'which workflow is the long pole'; compare two windows to get a trend.
  */
 export const EngineeringAnalyticsWorkflowHealthParams = () => zod.object({
     project_id: zod
@@ -284,6 +284,12 @@ export const EngineeringAnalyticsWorkflowHealthQueryParams = () => zod.object({
         .optional()
         .describe(
             'Connected GitHub data warehouse source to read from. Defaults to the oldest connected GitHub source when the team has more than one.'
+        ),
+    workflow_name: zod
+        .string()
+        .optional()
+        .describe(
+            "Optional exact workflow name to scope results to, e.g. 'Backend CI'. Omit to rank every workflow. Pass it when you want one workflow's figures over the whole window rather than the top slice."
         ),
 })
 

--- a/services/mcp/src/tools/generated/engineering_analytics.ts
+++ b/services/mcp/src/tools/generated/engineering_analytics.ts
@@ -330,6 +330,7 @@ const workflowHealth = (): ToolBase<
                 repo: params.repo,
                 run_scope: params.run_scope,
                 source_id: params.source_id,
+                workflow_name: params.workflow_name,
             },
         })
         return await withPostHogUrl(context, result, '/engineering-analytics/workflows')


### PR DESCRIPTION
## Problem

- Opening a workflow from the Workflows table shows different numbers than the table for the same window.
- The detail page folds its tiles from the run table, capped at 200 rows. Cost per run divides a window-wide total by that cap.

## Changes

- The Pass rate, Runs, Duration and Cost tiles read the same window-wide figures the Workflows table does.
- The Runs sub-line says the table shows the most recent 200, rather than implying the stats do.
- The duration tooltip states the sub-10-second exclusion the backend applies.
- A banner appears if the server figures fail to load and the tiles fall back to the run table. A failed reload no longer keeps the previous window's figures.
- `workflow_health` gains a `workflow_name` filter, so one workflow costs one scoped query instead of fetching all workflows past the 100 cap.

Backend CI, last 7 days, seeded data. The Workflows table row reads 727 runs, 84.73%, 18m and 40m 45s, $245.67:

![tiles-after](https://raw.githubusercontent.com/PostHog/pr-assets/2f11553ed1d0f58b1a3f6db0b361ca9338bc821c/2026/09/5b164d4d-4183-4cb0-ad6d-24586b04edd3.png)

## How did you test this code?

- A case pins the tiles to the server figures over a mocked 4,000-run window, and asserts a failed reload drops them.
- Backend: the health query honors `workflow_name` end to end.
- Rendered against the seeded stack after merging master: the tiles match the table row.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1). Skills: /improving-drf-endpoints, /writing-tests, /writing-code-comments, /writing-pr-descriptions, /stacking-prs, /simplify. Master merged 2026-09-14: master replaced the branch filter with run scope, so the health loader sends run-scope params. Screenshot replaces the pre-merge one. CodeRabbit CLI not run.

https://claude.ai/code/session_013tN9YVgxdH4ZF78XhbHPGi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added exact workflow-name filtering for workflow health results.
  - Workflow health metrics now use complete workflow statistics, with fallback data when needed.
  - Added loading and error states, including a warning when health metrics cannot be loaded.
  - Updated metric tooltips and coverage messaging for clarity.

- **Bug Fixes**
  - Failed health-data reloads now clear stale results and reset displayed health values appropriately.
  - Health summaries now apply consistent workflow health-status calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->