### PR TITLE
fix(signals): grey out the inbox PR pill for draft pull requests

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -7545,7 +7545,7 @@ snapshots:
     scenes-app-inbox-sourcesteeringmodal--rules-set--light:
         hash: v1.k794b7964.d1279fa1214369e191ab56aeef694231fcd401abf93e1854000fdfdcf97399bc.BKbf7ywpJGW7XqCNbou14Du1jqORsoYt5No4mJCVU3Q
     scenes-app-inbox-tabs--pull-requests-legacy--dark:
-        hash: v1.k794b7964.7a8a1ac4681274dd7f60472421a6f6362d11d3aad177531004cf98c756e505ef.acR7Y_EmrnKN4GzYlFAScr8a4_ZKjmxeCYKzgiwBHro
+        hash: v1.k794b7964.9021fe78606b9d4fe9969dd2093af3296148c7cb1e827453b47cf8bf2db6ef9e.ppLZXULxZZHR7EBFNweGPXZ5Yz1peNL4gCTeeDEOdk4
     scenes-app-inbox-tabs--pull-requests-legacy--light:
         hash: v1.k794b7964.d66d0f73814191c857a64891ddd73dbbca609b40f71b80b5a97b95b1d0ed5d0d.coTm8czKJGGrvOoP28HGqgyV0I1HTpvp14uWHt7b4dQ
     scenes-app-inbox-tabs--reports--dark:

--- a/frontend/src/lib/signals/SignalReportFixOrStatus.tsx
+++ b/frontend/src/lib/signals/SignalReportFixOrStatus.tsx
@@ -14,6 +14,7 @@ import { PrBadge } from './SignalReportPrBadge'
 /** The inbox's own labels are written to stand alone in a badge, so this surface phrases the same
  * states as a sentence a teammate can act on. The state derivation stays shared. */
 const FIX_LABEL: Record<PrBadgeState, string> = {
+    draft: 'Fix drafted',
     open: 'Fix proposed',
     merged: 'Fix merged',
     closed: 'Fix closed',
@@ -32,7 +33,7 @@ export function SignalReportFixOrStatus({ report }: { report: SignalReportApi })
     const prUrl = safeHttpUrl(report.implementation_pr_url)
     const prNumber = prUrl ? parsePrUrlParts(prUrl)?.number : undefined
     if (prUrl && prNumber) {
-        const state = derivePrState(report.status, report.implementation_pr_merged)
+        const state = derivePrState(report.status, report.implementation_pr_merged, report.implementation_pr_state)
         return (
             <div className="flex items-center gap-1.5">
                 <span className="text-xs font-semibold">{FIX_LABEL[state]}</span>

--- a/frontend/src/lib/signals/SignalReportPrBadge.tsx
+++ b/frontend/src/lib/signals/SignalReportPrBadge.tsx
@@ -41,6 +41,14 @@ function PrCiGlyph({ status }: { status: PrCiGlyphStatus | null }): JSX.Element 
     return <IconCheckCircle className={className} />
 }
 
+function IconGitPullRequestDraft(props: IconProps): JSX.Element {
+    return (
+        <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false" {...props}>
+            <path d="M3.25 1A2.25 2.25 0 0 1 4 5.372v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.251 2.251 0 0 1 3.25 1Zm9.5 14a2.25 2.25 0 1 1 0-4.5 2.25 2.25 0 0 1 0 4.5ZM2.5 3.25a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0ZM3.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm9.5 0a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0-5.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm0-3a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z" />
+        </svg>
+    )
+}
+
 export function PrBadge({
     prNumber,
     prUrl,
@@ -54,8 +62,15 @@ export function PrBadge({
     ciStatus?: PullRequestCiStatusEnumApi | null
 }): JSX.Element {
     const { label, className, hoverClassName } = PR_BADGE_STATE[state]
+    // Each state carries its own shape, so the pill still reads when its colour does not.
     const StateIcon =
-        state === 'merged' ? IconGitMerge : state === 'closed' ? IconGitPullRequestClosed : IconPullRequest
+        state === 'merged'
+            ? IconGitMerge
+            : state === 'closed'
+              ? IconGitPullRequestClosed
+              : state === 'draft'
+                ? IconGitPullRequestDraft
+                : IconPullRequest
     const glyphStatus = prCiGlyphStatus(state, ciStatus)
     const description = glyphStatus ? `${label}, ${PR_CI_GLYPH[glyphStatus].label}` : label
     const badge = (

--- a/frontend/src/lib/signals/prState.test.ts
+++ b/frontend/src/lib/signals/prState.test.ts
@@ -1,8 +1,30 @@
+import type { SignalReportAssignmentPrStateEnumApi } from 'products/signals/frontend/generated/api.schemas'
 import { SignalReportStatus } from 'products/signals/frontend/inbox/types'
 
-import { derivePrState, prCiGlyphStatus } from './prState'
+import { derivePrState, prCiGlyphStatus, type PrBadgeState } from './prState'
 
 describe('prState', () => {
+    describe('derivePrState', () => {
+        const cases: [
+            string,
+            SignalReportStatus,
+            boolean,
+            SignalReportAssignmentPrStateEnumApi | null | undefined,
+            PrBadgeState,
+        ][] = [
+            ['merged wins over every other state', SignalReportStatus.READY, true, 'draft', 'merged'],
+            ['a terminal report has no open PR', SignalReportStatus.SUPPRESSED, false, 'open', 'closed'],
+            ['a terminal report outranks a stale draft flag', SignalReportStatus.SUPPRESSED, false, 'draft', 'closed'],
+            ['a draft PR is not up for review', SignalReportStatus.READY, false, 'draft', 'draft'],
+            ['an open PR is up for review', SignalReportStatus.READY, false, 'open', 'open'],
+            ['an unreported PR state reads as open', SignalReportStatus.READY, false, undefined, 'open'],
+        ]
+
+        test.each(cases)('%s', (_name, status, prMerged, prState, expected) => {
+            expect(derivePrState(status, prMerged, prState)).toBe(expected)
+        })
+    })
+
     describe('prCiGlyphStatus', () => {
         // A glyph is a claim about work a reader can still act on. Claiming it for a landed pull
         // request, or claiming green when nothing answered, is worse than saying nothing.
@@ -10,6 +32,7 @@ describe('prState', () => {
             ['a failing open pull request', 'open', 'failing', 'failing'],
             ['a passing open pull request', 'open', 'passing', 'passing'],
             ['an open pull request mid-build', 'open', 'pending', 'pending'],
+            ['a failing draft pull request', 'draft', 'failing', 'failing'],
             ['a head commit with no checks', 'open', 'none', null],
             ['a status nothing has answered with', 'open', undefined, null],
             ['a merged pull request', 'merged', 'failing', null],

--- a/frontend/src/lib/signals/prState.ts
+++ b/frontend/src/lib/signals/prState.ts
@@ -1,7 +1,15 @@
-import type { PullRequestCiStatusEnumApi } from 'products/signals/frontend/generated/api.schemas'
+import type {
+    PullRequestCiStatusEnumApi,
+    SignalReportAssignmentPrStateEnumApi,
+} from 'products/signals/frontend/generated/api.schemas'
 import { SignalReportStatus } from 'products/signals/frontend/inbox/types'
 
 export const PR_BADGE_STATE = {
+    draft: {
+        label: 'Draft',
+        className: 'border-primary bg-surface-secondary text-secondary',
+        hoverClassName: 'hover:text-primary',
+    },
     open: {
         label: 'Open',
         className: 'border-success bg-success-highlight text-success',
@@ -25,7 +33,11 @@ export const PR_BADGE_STATE = {
 
 export type PrBadgeState = keyof typeof PR_BADGE_STATE
 
-export function derivePrState(status: SignalReportStatus | string, prMerged: boolean): PrBadgeState {
+export function derivePrState(
+    status: SignalReportStatus | string,
+    prMerged: boolean,
+    prState?: SignalReportAssignmentPrStateEnumApi | null
+): PrBadgeState {
     if (prMerged) {
         return 'merged'
     }
@@ -38,6 +50,11 @@ export function derivePrState(status: SignalReportStatus | string, prMerged: boo
         status === SignalReportStatus.RESOLVED
     ) {
         return 'closed'
+    }
+    // GitHub keeps a draft pull request in the `open` state, so the draft flag is the only thing
+    // that separates work in review from work still being written.
+    if (prState === 'draft') {
+        return 'draft'
     }
     return 'open'
 }
@@ -60,8 +77,9 @@ export function prCiGlyphStatus(
     state: PrBadgeState,
     ciStatus?: PullRequestCiStatusEnumApi | null
 ): PrCiGlyphStatus | null {
-    // Only an open pull request has CI a reader can act on; on a merged or closed one it is history.
-    if (state !== 'open' || !ciStatus || !(ciStatus in PR_CI_GLYPH)) {
+    // Only a pull request still in flight has CI a reader can act on; on a merged or closed one it is
+    // history. A draft still builds, so it keeps its glyph.
+    if ((state !== 'open' && state !== 'draft') || !ciStatus || !(ciStatus in PR_CI_GLYPH)) {
         return null
     }
     return ciStatus as PrCiGlyphStatus

--- a/products/desktop/packages/shared/src/domain-types.ts
+++ b/products/desktop/packages/shared/src/domain-types.ts
@@ -677,6 +677,14 @@ export type { SignalReportStatus };
 /** Actionability priority from the researched report (actionability judgment artefact). */
 export type SignalReportPriority = "P0" | "P1" | "P2" | "P3" | "P4";
 
+/** Latest known state of a report's implementation PR. */
+export type SignalReportPrState =
+  | "unknown"
+  | "draft"
+  | "open"
+  | "closed"
+  | "merged";
+
 /** Actionability choice from the researched report. */
 export type SignalReportActionability =
   | "immediately_actionable"
@@ -742,6 +750,8 @@ export interface SignalReport {
    * its old PR must not read as reviewable or continuable.
    */
   implementation_pr_merged?: boolean;
+  /** Latest known state of that PR, per the GitHub webhook. */
+  implementation_pr_state?: SignalReportPrState | null;
   /** Charts the report shows, placed by `[label](chart:<chart_id>)` links in the summary. */
   charts?: SignalReportChart[];
   /** The report's PR refund, when one exists (one refund per report, ever). */

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxReportRowView.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxReportRowView.test.tsx
@@ -23,7 +23,7 @@ function fakeReport(overrides: Partial<SignalReport> = {}): SignalReport {
   };
 }
 
-describe("InboxReportRowView resolved badge", () => {
+describe("InboxReportRowView", () => {
   afterEach(cleanup);
 
   it("labels a resolved report Shipped only when its PR merged", () => {
@@ -53,6 +53,42 @@ describe("InboxReportRowView resolved badge", () => {
 
     expect(screen.getByText("Resolved")).toBeTruthy();
     expect(screen.queryByText("Shipped")).toBeNull();
+  });
+
+  it("marks a draft pull request as draft", () => {
+    render(
+      <InboxReportRowView
+        report={fakeReport({
+          status: "ready",
+          implementation_pr_url: "https://github.com/PostHog/posthog/pull/1",
+          implementation_pr_state: "draft",
+        })}
+        onOpen={vi.fn()}
+        onOpenPr={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByTitle("Open the draft pull request on GitHub").textContent,
+    ).toContain("draft");
+  });
+
+  it("does not mark a resolved report's stale draft PR as draft", () => {
+    render(
+      <InboxReportRowView
+        report={fakeReport({
+          status: "resolved",
+          implementation_pr_url: "https://github.com/PostHog/posthog/pull/1",
+          implementation_pr_state: "draft",
+        })}
+        onOpen={vi.fn()}
+        onOpenPr={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByTitle("Open the draft pull request on GitHub"),
+    ).toBeNull();
   });
 
   it("labels a reasonless suppressed report Archived", () => {

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxReportRowView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxReportRowView.tsx
@@ -43,6 +43,13 @@ export function InboxReportRowView({
   const pr = prUrl ? parsePrUrl(prUrl) : null;
   const isTerminal =
     report.status === "resolved" || report.status === "suppressed";
+  // GitHub keeps a draft pull request in the `open` state, so the draft flag is the only thing
+  // that separates a PR ready for review from one the agent is still writing. A terminal report has
+  // no work left either way, and its PR close can lag or fail, so its stale draft flag says nothing.
+  const isDraftPr =
+    !isTerminal &&
+    report.implementation_pr_state === "draft" &&
+    report.implementation_pr_merged !== true;
   const isShipped =
     report.status === "resolved" &&
     (report.implementation_pr_merged === true ||
@@ -160,10 +167,12 @@ export function InboxReportRowView({
               title={
                 report.implementation_pr_merged
                   ? "This report's earlier PR merged, but evidence kept arriving"
-                  : "Open the pull request on GitHub"
+                  : isDraftPr
+                    ? "Open the draft pull request on GitHub"
+                    : "Open the pull request on GitHub"
               }
               className={
-                report.implementation_pr_merged
+                report.implementation_pr_merged || isDraftPr
                   ? "flex items-center gap-1 rounded border border-(--gray-6) px-1.5 py-0.5 font-mono text-[12px] text-gray-11 hover:bg-(--gray-3) hover:text-gray-12"
                   : "flex items-center gap-1 rounded border border-(--accent-7) bg-(--accent-2) px-1.5 py-0.5 font-mono text-(--accent-11) text-[12px] hover:bg-(--accent-3)"
               }
@@ -174,7 +183,11 @@ export function InboxReportRowView({
                 <GitPullRequestIcon size={11} />
               )}
               #{pr.number}
-              {report.implementation_pr_merged ? " merged" : ""}
+              {report.implementation_pr_merged
+                ? " merged"
+                : isDraftPr
+                  ? " draft"
+                  : ""}
             </button>
           )}
           {restoreAction}

--- a/products/signals/frontend/inbox/__mocks__/inboxMocks.ts
+++ b/products/signals/frontend/inbox/__mocks__/inboxMocks.ts
@@ -128,6 +128,7 @@ export const pullRequestReports: SignalReport[] = [
         signal_count: 12,
         source_products: ['error_tracking'],
         implementation_pr_url: 'https://github.com/PostHog/posthog/pull/12001',
+        implementation_pr_state: 'draft',
         is_suggested_reviewer: true,
     }),
     makeReport({
@@ -140,6 +141,7 @@ export const pullRequestReports: SignalReport[] = [
         signal_count: 31,
         source_products: ['error_tracking'],
         implementation_pr_url: 'https://github.com/PostHog/posthog/pull/12002',
+        implementation_pr_state: 'open',
     }),
     makeReport({
         title: 'perf(dashboards): paginate cohort filter resolution',
@@ -218,6 +220,7 @@ const finishedRuns: SignalReport[] = [
         signal_count: 12,
         source_products: ['error_tracking'],
         implementation_pr_url: 'https://github.com/PostHog/posthog/pull/12001',
+        implementation_pr_state: 'draft',
     }),
     makeReport({
         title: 'Investigate webhook delivery failures',

--- a/products/signals/frontend/inbox/components/cards/ReportCard.tsx
+++ b/products/signals/frontend/inbox/components/cards/ReportCard.tsx
@@ -166,7 +166,11 @@ export function ReportCard({
     // Painted from the shared map the report lists fill; absent until (or unless) GitHub answers.
     const { ciStatusByReportId } = useValues(prCiStatusLogic)
     const ciStatus = preview ? null : ciStatusByReportId[report.id]
-    const prState = derivePrState(report.status, report.implementation_pr_merged === true)
+    const prState = derivePrState(
+        report.status,
+        report.implementation_pr_merged === true,
+        report.implementation_pr_state
+    )
     const glyphStatus = prCiGlyphStatus(prState, ciStatus)
 
     const isRefunded = !!report.refund

--- a/products/signals/frontend/inbox/logics/reportListLogic.test.ts
+++ b/products/signals/frontend/inbox/logics/reportListLogic.test.ts
@@ -185,7 +185,7 @@ describe('reportListLogic', () => {
 
     // Which rows get a CI glyph, and which pull requests the batch endpoint is asked about. A landed
     // or dropped pull request has no CI worth reading, and asking about it spends a GitHub call.
-    describe('open pull requests on the page', () => {
+    describe('pull requests still in flight on the page', () => {
         let logic: ReturnType<typeof reportListLogic.build>
 
         const withPr = (id: string, overrides: Partial<SignalReport>): SignalReport => ({
@@ -202,13 +202,14 @@ describe('reportListLogic', () => {
                     [REPORTS_URL]: () => [
                         200,
                         {
-                            count: 4,
+                            count: 5,
                             next: null,
                             previous: null,
                             results: [
                                 withPr('1', {}),
                                 withPr('2', { implementation_pr_merged: true }),
                                 withPr('3', { status: SignalReportStatus.SUPPRESSED }),
+                                withPr('5', { implementation_pr_state: 'draft' }),
                                 makeReport('4'),
                             ],
                         },
@@ -227,8 +228,8 @@ describe('reportListLogic', () => {
 
         afterEach(() => logic.unmount())
 
-        it('counts only the rows whose pull request is still open', () => {
-            expect(logic.values.openPrReportIds).toEqual(['1'])
+        it('counts the rows whose pull request is still in flight, drafts included', () => {
+            expect(logic.values.livePrReportIds).toEqual(['1', '5'])
         })
     })
 })

--- a/products/signals/frontend/inbox/logics/reportListLogic.ts
+++ b/products/signals/frontend/inbox/logics/reportListLogic.ts
@@ -157,7 +157,7 @@ export interface reportListLogicValues {
         scope: InboxScope
     } | null
     loadedQueryKey: string | null
-    openPrReportIds: string[]
+    livePrReportIds: string[]
     pageLoadFailed: boolean
     primarySectionKey: InboxReportSectionKey
     reports: SignalReport[]
@@ -311,7 +311,7 @@ export interface reportListLogicMeta {
         reports: (reportsResponse: ReportListResponse | null) => SignalReport[]
         hasMore: (reportsResponse: ReportListResponse | null) => boolean
         isLoaded: (reportsResponse: ReportListResponse | null) => boolean
-        openPrReportIds: (reports: SignalReport[]) => string[]
+        livePrReportIds: (reports: SignalReport[]) => string[]
         totalCount: (reportsResponse: ReportListResponse | null) => number | null
         loadedQueryKey: (reportsResponse: ReportListResponse | null) => string | null
         loadedContext: (reportsResponse: ReportListResponse | null) => {
@@ -545,17 +545,24 @@ export const reportListLogic = kea<reportListLogicType>([
             (s) => [s.reportsResponse],
             (reportsResponse: ReportListResponse | null): boolean => reportsResponse !== null,
         ],
-        // The loaded rows whose pull request is still open, so the pill can say whether CI is red.
-        // A merged or closed pull request is left out: its checks are history, not something to act on.
-        openPrReportIds: [
+        // The loaded rows whose pull request is still in flight, so the pill can say whether CI is
+        // red. A draft counts: it still builds. A merged or closed pull request is left out — its
+        // checks are history, not something to act on.
+        livePrReportIds: [
             (s) => [s.reports],
             (reports: SignalReport[]): string[] =>
                 reports
-                    .filter(
-                        (report) =>
-                            !!report.implementation_pr_url &&
-                            derivePrState(report.status, report.implementation_pr_merged === true) === 'open'
-                    )
+                    .filter((report) => {
+                        if (!report.implementation_pr_url) {
+                            return false
+                        }
+                        const prState = derivePrState(
+                            report.status,
+                            report.implementation_pr_merged === true,
+                            report.implementation_pr_state
+                        )
+                        return prState === 'open' || prState === 'draft'
+                    })
                     .map((report) => report.id),
         ],
         // Total matching the *loaded* results — from the same response, so it can never be stale
@@ -586,8 +593,8 @@ export const reportListLogic = kea<reportListLogicType>([
         // Announce this section's open pull requests so their CI state is resolved in one batch. Both
         // loaders report: the first page and each appended page bring rows that need painting. An
         // empty announcement matters too, because it retires the rows a narrowed filter dropped.
-        loadReportsSuccess: () => actions.trackReports(props.sectionKey, values.openPrReportIds),
-        loadMoreReportsSuccess: () => actions.trackReports(props.sectionKey, values.openPrReportIds),
+        loadReportsSuccess: () => actions.trackReports(props.sectionKey, values.livePrReportIds),
+        loadMoreReportsSuccess: () => actions.trackReports(props.sectionKey, values.livePrReportIds),
         // First For-you count for the primary section: if the user has no reports suggested to
         // them, default to Entire project so they don't land on an empty inbox. Only when they haven't
         // picked a scope themselves, and only once the user's uuid has resolved (so the count is

--- a/products/signals/frontend/inbox/logics/reportListLogic.ts
+++ b/products/signals/frontend/inbox/logics/reportListLogic.ts
@@ -152,12 +152,12 @@ export interface reportListLogicValues {
     hasMore: boolean
     isLoaded: boolean
     listApiParams: any
+    livePrReportIds: string[]
     loadedContext: {
         hasActiveFilters: boolean
         scope: InboxScope
     } | null
     loadedQueryKey: string | null
-    livePrReportIds: string[]
     pageLoadFailed: boolean
     primarySectionKey: InboxReportSectionKey
     reports: SignalReport[]

--- a/products/signals/frontend/inbox/types.ts
+++ b/products/signals/frontend/inbox/types.ts
@@ -2,6 +2,7 @@ import type { UserBasicType } from '~/types'
 
 import {
     type ReportChartApi,
+    type SignalReportAssignmentPrStateEnumApi,
     type SignalReportRefundApi,
     type SignalReportStateRequestApi,
     type SignalScoutRunSummaryApi,
@@ -95,6 +96,8 @@ export interface SignalReport {
     /** Whether that implementation PR is merged, per the GitHub webhook. Status doesn't imply it: a
      * resolved report may have been resolved directly, without a merged PR. */
     implementation_pr_merged?: boolean
+    /** Latest known state of that PR: unknown, draft, open, closed, or merged. */
+    implementation_pr_state?: SignalReportAssignmentPrStateEnumApi | null
     /** Reason code from the latest dismissal artefact (when archived). See dismissalReasons. */
     dismissal_reason?: string | null
     /** Free-form note from the latest dismissal artefact (when archived). */


### PR DESCRIPTION
## Problem

Anyone scanning the self-driving inbox sees the same green pill on a draft pull request as on one that is ready to review, so the list gives no way to tell which fixes still need work from the agent.

Most inbox PRs open as drafts, which leaves the color saying almost nothing.

A draft PR keeps GitHub's `open` state, and the pill only read report status and the merged flag. The serializer already returns `implementation_pr_state`, which carries `draft`.

## Changes

- A draft PR now shows a grey pill with GitHub's draft icon, so it reads as a draft without color. An open PR keeps the green one.
- The desktop inbox row greys the same pill and appends `draft` next to the PR number, matching how it already appends `merged`.
- A resolved or suppressed report never reads as a draft. Its PR close runs after the status commits and can fail, which leaves a stale `draft` flag behind.
- A draft keeps the CI glyph that [#93921](https://github.com/PostHog/posthog/pull/93921) added to the pill, because a draft still builds.
- `derivePrState` takes the PR state and returns a new `draft` badge state.
- Mechanical: `implementation_pr_state` added to the web and desktop report types, and to two Storybook mock reports.

Below, `#12001` is a draft and the other two are open. The draft pill is what every PR looked like in green before this change.

![pr-cards-light](https://raw.githubusercontent.com/PostHog/pr-assets/dbb12ce797d9ff525e0f91ca38c1d96f9fc369e8/2026/09/cdec46e9-21b5-4897-843d-4bc6447716c0.png)

> [!NOTE]
> A report that still resolves its PR through a task run, rather than a report assignment, serializes `unknown` for every unmerged PR. Those rows keep the green pill until the backend carries the run's `pr_state` through that fallback.

## How did you test this code?

- New `frontend/src/lib/signals/prState.test.ts` covers the draft case and the precedence around it. It catches a change that lets a draft PR read as open again, and it locks in that merged and terminal reports still win over the draft flag.
- Two cases added to the desktop `InboxReportRowView` test: the grey draft pill on a row, and a resolved report whose stale draft flag must not paint one. No existing case covered the pill.
- One case added to the `reportListLogic` test, for the draft rows that must still fetch a CI status.
- Rendered the `Scenes-App/Inbox/Cards` Storybook story in light and dark through headless Chromium to confirm the grey and the draft icon read against both card backgrounds. The screenshot above is that render.
- Not run: the wider Jest and Playwright suites, and the backend, which this PR does not touch.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a Slack request to make draft PRs obvious in the inbox list. Skills invoked: `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The web inbox and the desktop inbox each own their PR pill, so both got the same rule rather than a shared component. Merging them is a larger refactor than this fix.

A later session rebased the branch onto [#93921](https://github.com/PostHog/posthog/pull/93921), which had landed the CI glyph on the same pill, and answered the automated review: the terminal-report gate, the generated `SignalReportAssignmentPrStateEnumApi` type in place of a bare `string`, and the draft icon as a cue that does not rely on color.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1788522853190859)*
