### PR TITLE
fix(notebooks): stabilize widget insertion flow

### DIFF
--- a/frontend/src/lib/components/MarkdownNotebook/InsertMenu.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/InsertMenu.tsx
@@ -182,11 +182,11 @@ export function renderHighlightedInsertCommandLabel(label: string, query: string
 
 export function getFilteredInsertCommands(commands: InsertCommand[], query: string): InsertCommand[] {
     const normalizedQuery = query.trim().toLowerCase()
-    if (!normalizedQuery) {
-        return commands
-    }
+    const filteredCommands = normalizedQuery
+        ? commands.filter((command) => getInsertCommandSearchText(command).includes(normalizedQuery))
+        : commands
 
-    return commands.filter((command) => getInsertCommandSearchText(command).includes(normalizedQuery))
+    return Object.values(groupInsertCommandsByCategory(filteredCommands)).flat()
 }
 
 export function getInsertCommandSearchText(command: InsertCommand): string {

--- a/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.test.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.test.ts
@@ -3481,7 +3481,23 @@ ${queryMarkdown}`)
 
     it('moves slash menu selection with arrow keys', () => {
         const onChange = jest.fn()
-        const { container } = render(createElement(MarkdownNotebook, { value: withNotebookTitle(' '), onChange }))
+        const registry = createMarkdownNotebookRegistry([
+            {
+                tagName: 'Widget',
+                label: 'Widget',
+                category: 'Code',
+                insertCommand: { category: 'Common' },
+                ViewComponent: () => createElement('div'),
+            },
+        ])
+        const { container } = render(
+            createElement(MarkdownNotebook, {
+                value: withNotebookTitle(' '),
+                registry,
+                onAskAI: jest.fn(),
+                onChange,
+            })
+        )
         const row = getBodyTextBlock(container).closest('.MarkdownNotebook__row')
 
         expect(row).toBeInstanceOf(HTMLElement)
@@ -3492,9 +3508,9 @@ ${queryMarkdown}`)
         const getSelectedLabel = (): string | null =>
             container.querySelector('.MarkdownNotebook__insert-item[aria-selected="true"]')?.textContent ?? null
 
-        expect(getSelectedLabel()).toEqual('Text')
+        expect(getSelectedLabel()).toEqual('Ask AI')
 
-        for (const label of ['SQL', 'Trend', 'Funnel']) {
+        for (const label of ['Text', 'SQL', 'Widget', 'Trend', 'Funnel']) {
             fireEvent.keyDown(textBlock, { key: 'ArrowDown' })
             expect(getSelectedLabel()).toEqual(label)
         }

--- a/products/notebooks/frontend/NotebookNodeGeneratedWidget/notebookNodeGeneratedWidgetLogic.test.ts
+++ b/products/notebooks/frontend/NotebookNodeGeneratedWidget/notebookNodeGeneratedWidgetLogic.test.ts
@@ -105,6 +105,25 @@ describe('notebookNodeGeneratedWidgetLogic', () => {
         expect(notebooksWidgetGenerate).not.toHaveBeenCalled()
     })
 
+    it('persists a newly inserted widget before retrying its initial status', async () => {
+        jest.mocked(notebooksWidgetStatus)
+            .mockRejectedValueOnce(
+                new ApiError('Not found', 404, undefined, {
+                    code: 'node_not_found',
+                    detail: 'This generated widget is no longer in the notebook.',
+                })
+            )
+            .mockResolvedValueOnce(status())
+        logic = notebookNodeGeneratedWidgetLogic(props)
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(props.persistNotebook).toHaveBeenCalledTimes(1)
+        expect(notebooksWidgetStatus).toHaveBeenCalledTimes(2)
+        expect(logic.values.status?.lifecycle_status).toBe('awaiting_generation')
+        expect(logic.values.statusLoadError).toBeNull()
+    })
+
     it('times out a status request instead of leaving the widget loading forever', async () => {
         jest.useFakeTimers()
         jest.mocked(notebooksWidgetStatus).mockImplementation(

--- a/products/notebooks/frontend/NotebookNodeGeneratedWidget/notebookNodeGeneratedWidgetLogic.ts
+++ b/products/notebooks/frontend/NotebookNodeGeneratedWidget/notebookNodeGeneratedWidgetLogic.ts
@@ -1088,11 +1088,22 @@ export const notebookNodeGeneratedWidgetLogic: LogicWrapper<notebookNodeGenerate
                     const requestId = nextStatusRequestId()
                     actions.statusRequestStarted()
                     try {
-                        const loadedStatus = await requestWithTimeout((signal) =>
-                            notebooksWidgetStatus(String(props.projectId), props.notebookShortId, props.nodeId, {
-                                signal,
-                            })
-                        )
+                        const requestStatus = async (): Promise<WidgetStatusApi> =>
+                            await requestWithTimeout((signal) =>
+                                notebooksWidgetStatus(String(props.projectId), props.notebookShortId, props.nodeId, {
+                                    signal,
+                                })
+                            )
+                        let loadedStatus: WidgetStatusApi
+                        try {
+                            loadedStatus = await requestStatus()
+                        } catch (error) {
+                            if (!props.isEditable || !isMissingNodeError(error)) {
+                                throw error
+                            }
+                            await props.persistNotebook()
+                            loadedStatus = await requestStatus()
+                        }
                         if (isCurrentStatusRequest(requestId)) {
                             actions.statusReceived(loadedStatus)
                         }


### PR DESCRIPTION
## Problem

Notebook users can skip visible slash-menu items with Arrow Down, and new widgets initially show a status error.

The menu grouped items visually without applying that order to keyboard selection. Widget status could also race the notebook autosave.

## Changes

- Arrow-key selection now follows the rendered category order, including Widget before Trend.
- New widgets now save and retry their status lookup when the first request races notebook autosave.
- No screenshot: the menu and widget appearance stay unchanged.

Before:

~~~mermaid
flowchart LR
    A[Insert widget] --> B[Load status]
    B --> C[Node missing]
    C --> D[Show Retry]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,D phYellow;
    class B phBlue;
    class C phRed;
~~~

After:

~~~mermaid
flowchart LR
    A[Insert widget] --> B[Load status]
    B -->|Node missing| C[Save notebook]
    C --> D[Retry status]
    D --> E[Show widget controls]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,E phYellow;
    class B,C,D phBlue;
~~~

## How did you test this code?

- Extended the notebook component test with the exact Ask AI, Text, SQL, Widget, Trend, Funnel key sequence.
- Added a widget logic case covering a missing node, notebook persistence, and automatic status retry.
- Ran the focused Jest suites, frontend lint and formatting, the full frontend TypeScript check, and CI preflight.
- Not run in a browser: another worktree held the local stack ports, so starting this checkout would disrupt active work.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This restores the expected notebook interaction and loading behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used terminal tooling. Skills: /writing-ui-components, /writing-user-facing-copy, /writing-tests, /writing-kea-logics, /run-posthog, browser control, /running-ci-preflight, and /writing-pr-descriptions. Session link is unavailable in this client.

Duplicate searches for notebook widget and notebook slash-menu fixes found no overlapping PR. Regression tests cover both changed behaviors. No private or external material appears in the patch.