### PR TITLE
chore(ci): stop npm's audit stalling every pnpm setup

### DIFF
--- a/.depot/actions/pnpm-install/action.yml
+++ b/.depot/actions/pnpm-install/action.yml
@@ -39,6 +39,11 @@ runs:
     steps:
         - name: Install pnpm
           uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+          env:
+              # Kept in sync with .github/actions/pnpm-install: npm's audit blocks the pnpm
+              # bootstrap and gates nothing.
+              NPM_CONFIG_AUDIT: 'false'
+              NPM_CONFIG_FUND: 'false'
 
         - name: Fix node-gyp permissions
           shell: bash

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -1997,7 +1997,7 @@ jobs:
               shell: bash
               run: |
                   if [[ -f products/canvas/packages/canvas_builder/package.json ]]; then
-                      npm ci --ignore-scripts --omit=dev --prefix products/canvas/packages/canvas_builder
+                      npm ci --ignore-scripts --omit=dev --no-audit --no-fund --prefix products/canvas/packages/canvas_builder
                   fi
             - name: Install the working version of hogql-parser
               if: ${{ needs.changes.outputs.backend == 'true' && steps.hogql-parser-diff.outputs.changed == 'true' }}

--- a/.github/actions/pnpm-install/action.yml
+++ b/.github/actions/pnpm-install/action.yml
@@ -41,6 +41,13 @@ runs:
     steps:
         - name: Install pnpm
           uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+          env:
+              # The action bootstraps pnpm with `npm ci`, which audits by default. That audit
+              # covers two packages and gates nothing, but it blocks until npm answers, so a
+              # degraded audit endpoint stalls the step until npm's 300s fetch timeout. That
+              # alone exhausts a 5 minute job budget before any test runs.
+              NPM_CONFIG_AUDIT: 'false'
+              NPM_CONFIG_FUND: 'false'
 
         - name: Fix node-gyp permissions
           shell: bash

--- a/.github/workflows/build-hogql-parser-npm.yml
+++ b/.github/workflows/build-hogql-parser-npm.yml
@@ -14,6 +14,11 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
     cancel-in-progress: true
 
+env:
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
+
 jobs:
     check-package-version:
         name: Check npm package version

--- a/.github/workflows/ci-agent-proxy.yml
+++ b/.github/workflows/ci-agent-proxy.yml
@@ -14,6 +14,11 @@ permissions:
     contents: read
     pull-requests: read
 
+env:
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
+
 jobs:
     changes:
         runs-on: ubuntu-latest

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -2955,7 +2955,7 @@ jobs:
               shell: bash
               run: |
                   if [[ -f products/canvas/packages/canvas_builder/package.json ]]; then
-                      npm ci --ignore-scripts --omit=dev --prefix products/canvas/packages/canvas_builder
+                      npm ci --ignore-scripts --omit=dev --no-audit --no-fund --prefix products/canvas/packages/canvas_builder
                   fi
 
             - name: Install the working version of hogql-parser

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -978,7 +978,7 @@ jobs:
 
             - name: Install VR CLI
               if: always() && (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push')
-              run: cd products/visual_review/cli && npm ci && npm run build && npm link
+              run: cd products/visual_review/cli && npm ci --no-audit --no-fund && npm run build && npm link
 
             - name: Create VR run
               id: vr-create
@@ -1274,7 +1274,7 @@ jobs:
                   restore-keys: npm-vr-cli-${{ runner.os }}-
 
             - name: Install VR CLI
-              run: cd products/visual_review/cli && npm ci && npm run build && npm link
+              run: cd products/visual_review/cli && npm ci --no-audit --no-fund && npm run build && npm link
 
             - name: Complete Visual Review run
               # On master pushes the run was created with --purpose observe (tracking-only), but

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -65,6 +65,9 @@ env:
     # matches the Node plugins container's non-prod default, so Django<->Node internal calls authenticate.
     INTERNAL_API_SECRET: posthog123
     RUNS_ON_INTERNAL_PR: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -40,6 +40,9 @@ permissions:
 
 env:
     RUNS_ON_INTERNAL_PR: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
 
 jobs:
     # Job to decide if we should run frontend ci

--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -16,6 +16,11 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
+
 jobs:
     # Job to decide if we should run backend ci
     # See .github/actions/paths-filter/README.md for filter semantics

--- a/.github/workflows/ci-integration-service.yml
+++ b/.github/workflows/ci-integration-service.yml
@@ -25,6 +25,11 @@ concurrency:
 permissions:
     contents: read
 
+env:
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
+
 jobs:
     integration-service:
         name: Integration Service checks

--- a/.github/workflows/ci-paths-filter.yml
+++ b/.github/workflows/ci-paths-filter.yml
@@ -27,7 +27,7 @@ jobs:
               with:
                   node-version-file: .nvmrc
                   token: ${{ github.token }}
-            - run: npm ci
+            - run: npm ci --no-audit --no-fund
             - run: npx tsc --noEmit
             - run: npx jest
             # The action runs the committed dist/index.js. Rebuild from src and fail if it

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -27,6 +27,9 @@ permissions:
 
 env:
     RUNS_ON_INTERNAL_PR: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
 
 jobs:
     # Job to decide if we should run storybook ci

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -380,7 +380,7 @@ jobs:
                   restore-keys: npm-vr-cli-${{ runner.os }}-
 
             - name: Install VR CLI
-              run: cd vr-cli/products/visual_review/cli && npm ci && npm run build
+              run: cd vr-cli/products/visual_review/cli && npm ci --no-audit --no-fund && npm run build
 
             - name: Save VR CLI npm cache
               # The only writer for every VR CLI install, here and in
@@ -616,7 +616,7 @@ jobs:
 
             - name: Install VR CLI
               if: always() && needs.vr-setup.outputs.run_id != ''
-              run: cd vr-cli/products/visual_review/cli && npm ci && npm run build
+              run: cd vr-cli/products/visual_review/cli && npm ci --no-audit --no-fund && npm run build
 
             - name: Upload snapshots to Visual Review
               if: always() && needs.vr-setup.outputs.run_id != ''
@@ -874,7 +874,7 @@ jobs:
                   restore-keys: npm-vr-cli-${{ runner.os }}-
 
             - name: Install VR CLI
-              run: cd vr-cli/products/visual_review/cli && npm ci && npm run build
+              run: cd vr-cli/products/visual_review/cli && npm ci --no-audit --no-fund && npm run build
 
             - name: Complete Visual Review run
               # Pass the same --purpose vr-setup created the run with. The backend reports zero

--- a/.github/workflows/desktop-agent-release-verify.yml
+++ b/.github/workflows/desktop-agent-release-verify.yml
@@ -19,6 +19,11 @@ on:
             - 'products/desktop/pnpm-lock.yaml'
             - 'products/desktop/pnpm-workspace.yaml'
 
+env:
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
+
 jobs:
     verify:
         name: Verify agent release build

--- a/.github/workflows/desktop-agent-release.yml
+++ b/.github/workflows/desktop-agent-release.yml
@@ -9,6 +9,11 @@ concurrency:
     group: desktop-agent-release
     cancel-in-progress: false
 
+env:
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
+
 jobs:
     release:
         name: Publish agent to npm

--- a/.github/workflows/desktop-build-test.yml
+++ b/.github/workflows/desktop-build-test.yml
@@ -24,6 +24,11 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
+
 jobs:
     build-macos:
         # Fork PRs never receive the signing/AWS secrets, so only same-repo PRs

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -17,6 +17,11 @@ concurrency:
     group: desktop-build-${{ github.head_ref || github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
+
 jobs:
     changes:
         runs-on: depot-ubuntu-24.04

--- a/.github/workflows/desktop-mobile-build.yml
+++ b/.github/workflows/desktop-mobile-build.yml
@@ -28,6 +28,11 @@ concurrency:
     group: desktop-mobile-build-${{ github.ref }}-${{ inputs.profile }}
     cancel-in-progress: false
 
+env:
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
+
 jobs:
     build:
         name: Build (${{ matrix.platform }})

--- a/.github/workflows/desktop-mobile-promote.yml
+++ b/.github/workflows/desktop-mobile-promote.yml
@@ -48,6 +48,11 @@ concurrency:
     group: desktop-mobile-promote-${{ github.ref }}
     cancel-in-progress: false
 
+env:
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
+
 jobs:
     submit:
         name: Submit (${{ matrix.platform }})

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -9,6 +9,11 @@ concurrency:
     group: desktop-release
     cancel-in-progress: false
 
+env:
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
+
 jobs:
     prepare-release:
         runs-on: depot-ubuntu-24.04

--- a/.github/workflows/desktop-test.yml
+++ b/.github/workflows/desktop-test.yml
@@ -21,6 +21,11 @@ concurrency:
     group: desktop-test-${{ github.head_ref || github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
+
 jobs:
     changes:
         runs-on: depot-ubuntu-24.04

--- a/.github/workflows/desktop-typecheck.yml
+++ b/.github/workflows/desktop-typecheck.yml
@@ -17,6 +17,11 @@ concurrency:
     group: desktop-typecheck-${{ github.head_ref || github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
+
 jobs:
     changes:
         runs-on: depot-ubuntu-24.04

--- a/.github/workflows/desktop-update-e2e.yml
+++ b/.github/workflows/desktop-update-e2e.yml
@@ -25,6 +25,11 @@ concurrency:
     group: desktop-update-e2e-${{ github.ref }}
     cancel-in-progress: true
 
+env:
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
+
 jobs:
     update-e2e-macos:
         runs-on: depot-macos-26

--- a/.github/workflows/desktop-warm-caches.yml
+++ b/.github/workflows/desktop-warm-caches.yml
@@ -23,6 +23,11 @@ concurrency:
     # the older run's, so cancelling that run loses nothing.
     cancel-in-progress: true
 
+env:
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
+
 jobs:
     linux:
         runs-on: depot-ubuntu-24.04-4

--- a/.github/workflows/publish-quill-npm.yml
+++ b/.github/workflows/publish-quill-npm.yml
@@ -23,6 +23,11 @@ concurrency:
     group: ${{ github.workflow }}
     cancel-in-progress: false
 
+env:
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
+
 jobs:
     publish:
         name: Build and publish

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -13,6 +13,9 @@ env:
     SAMPO_VERSION: 0.17.4
     CARGO_DIST_VERSION: 0.32.0
     CARGO_DIST_INSTALLER_SHA256: b657cf8c04a8b7bc28f39d220f7e6dd11bbd2bdb072c552262bd9ccf597261b5
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
 
 concurrency:
     group: release-cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ permissions:
 env:
     CARGO_DIST_VERSION: 0.32.0
     CARGO_DIST_INSTALLER_SHA256: b657cf8c04a8b7bc28f39d220f7e6dd11bbd2bdb072c552262bd9ccf597261b5
+    # npm's audit blocks the pnpm bootstrap. See .github/actions/pnpm-install for why.
+    NPM_CONFIG_AUDIT: 'false'
+    NPM_CONFIG_FUND: 'false'
 
 # Publishing is handled by the Release CLI workflow after Release environment approval.
 # Reusable workflow, called by pr-housekeeping.yml on every PR push.

--- a/Dockerfile
+++ b/Dockerfile
@@ -150,7 +150,7 @@ RUN --mount=type=cache,id=pnpm,target=/tmp/pnpm-store-v24 \
 
 COPY products/canvas/packages/canvas_builder/ products/canvas/packages/canvas_builder/
 RUN --mount=type=cache,id=npm,target=/root/.npm \
-    npm ci --ignore-scripts --omit=dev --prefix products/canvas/packages/canvas_builder
+    npm ci --ignore-scripts --omit=dev --no-audit --no-fund --prefix products/canvas/packages/canvas_builder
 
 # The transpiler bundle externalizes @babel/standalone (its only external runtime require — a
 # self-contained 24MB package with no deps). Materialize it as real files inside the transpiler's


### PR DESCRIPTION
## Problem

Node jobs across CI died in setup today without running a single test, and the failures looked like merge-queue teardown rather than a bug.

- `pnpm/action-setup` bootstraps pnpm by running `npm ci`, which audits by default.
- npm's audit endpoint was degraded on 4 Sep ([npm status](https://status.npmjs.org/)), so that call blocked until npm's 300s fetch timeout.
- A job with `timeout-minutes: 5` is over budget on the bootstrap alone. The repo has 140 such jobs and 71 more at 10 minutes.
- A job timeout marks its steps `cancelled`, not `failure`, so these kills were indistinguishable from Trunk tearing an attempt down.

The audit was never wanted here. It covers two packages, pnpm and its bootstrap, and gates nothing. Our real dependency tree is installed by pnpm, which does not audit.

## Changes

- CI jobs no longer wait on npm's audit endpoint during the pnpm bootstrap. `NPM_CONFIG_AUDIT` and `NPM_CONFIG_FUND` go in the environment, because the action exposes no way to pass flags.
- The shared composite covers most workflows. The 16 that call `pnpm/action-setup` directly get their own top-level `env:`, since the composite never runs for them.
- Raw `npm ci` call sites take the equivalent flags: `ci-storybook`, `ci-e2e-playwright`, `ci-backend`, `ci-paths-filter`, and the root `Dockerfile`.
- The `.depot` shadow workflow and its composite are mirrored, so Depot CI stays apples-to-apples.

This matches what the repo already does elsewhere, in `products/tasks/backend/logic/services/modal_sandbox.py` and `products/desktop/packages/core/src/settings/imagePreset.ts`.

Nothing user-visible changes. Every edit is CI configuration.

> [!NOTE]
> Two open drafts target the same stall from other angles: #95095 caches `~/setup-pnpm` so a job skips the registry, and #95098 bounds the fetch with `npm_config_fetch_timeout`. Both touch only `.github/actions/pnpm-install`, so neither reaches the 16 direct callers or the raw `npm ci` sites. They compose with this one: caching avoids the call, bounding shortens it, and this removes the part of it that stalled.

## How did you test this code?

Measured locally against a real `npm ci`, since the stall is in npm rather than in our code:

<details>
<summary>Audit on vs off</summary>

```
baseline                 added 2 packages, and audited 3 packages in 388ms
NPM_CONFIG_AUDIT=false   added 2 packages in 130ms
npm_config_audit=false   added 2 packages in 127ms
```

`NPM_CONFIG_FUND` made no measurable difference; it is set for quieter logs.
</details>

The "no audit clause" output above is the same signature seen in the stalled CI logs, where a 7 minute step printed `added 1 package in 7m` with the audit line absent.

`bin/hogli lint:workflows` passes. `actionlint` reports the same finding count on this branch as on master. `hogli ci:preflight --strict` passes, after it correctly caught the missing `.depot` mirror.

Verified on this branch's own runners, which is what the first push got wrong:

- `Build Storybook` logged `added 1 package, and audited 2 packages in 570ms` before the second commit, and `added 1 package in 390ms` after it. The step now takes 1s.
- `Vendored paths-filter action` logged `added 576 packages in 3s`, with no audit clause, which covers the raw-flag path.

The first push set the env only on workflows that never touch the composite. A workflow can use the composite in one job and call `pnpm/action-setup` directly in another, so `ci-frontend`, `ci-storybook`, `ci-e2e-playwright`, `ci-hog` and `release-cli` were still auditing. The criterion is a direct call, not the absence of the composite.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 5) at @webjunkie's direction, in a session that started from a merge-queue investigation and narrowed to this root cause.

Skills invoked: `/authoring-ci-workflows`, `/writing-code-comments`, `/writing-pr-descriptions`, and earlier `/triaging-merge-queue-failures`, `/writing-tests`, `/fixing-flaky-tests`.

The diagnosis moved twice. It started as "the npm registry is slow", which the CI data contradicted: a Sep 2 baseline ran the identical bootstrap in 3 seconds, and the slow jobs were bimodal, clustering at 300s rather than spreading. That 300s is npm's default `fetch-timeout`, which pointed at a blocked request rather than slow bandwidth. Comparing log lines then isolated the audit, because a fast run prints `and audited 2 packages` and a stalled one omits it.

`standalone: true` was considered and rejected: the action runs `npm ci` either way and only swaps the package name, so it would not have helped.

No customer data, tickets, or internal systems informed this change. It came from public GitHub Actions API data and the npm status page.

