### PR TITLE
feat(conversations): expose internal_note_key on ticket messages

### DIFF
--- a/posthog/api/comments.py
+++ b/posthog/api/comments.py
@@ -88,11 +88,19 @@ def _require_ticket_editor_access(
 # A reservation with no posted root older than this is a crashed send — safe to retry.
 STALE_SLACK_RESERVATION_GRACE = timedelta(minutes=2)
 
-# item_context keys the Slack mirror sync stamps server-side. Stripped from client input so a
-# caller can't forge sync state (suppress mirroring of a reply, block ingestion of a real Slack
-# message by squatting on its ts, or spoof a Slack author identity in the discussion UI).
+# item_context keys the server stamps itself. Stripped from client input so a caller can't forge
+# them: Slack mirror sync state (suppress mirroring of a reply, block ingestion of a real Slack
+# message by squatting on its ts, or spoof a Slack author identity in the discussion UI), and
+# internal_note_key, which clients read to tell an automation's ticket note from an AI draft.
 RESERVED_ITEM_CONTEXT_KEYS = frozenset(
-    {"from_slack", "slack_synced_ts", "slack_message_ts", "slack_author_name", "slack_author_avatar"}
+    {
+        "from_slack",
+        "slack_synced_ts",
+        "slack_message_ts",
+        "slack_author_name",
+        "slack_author_avatar",
+        "internal_note_key",
+    }
 )
 
 

--- a/posthog/api/test/test_comments.py
+++ b/posthog/api/test/test_comments.py
@@ -742,6 +742,28 @@ class TestComments(APIBaseTest, QueryMatchingTest):
         else:
             assert "threadState" not in item_context
 
+    @parameterized.expand(
+        [
+            ("slack_author_name", "Someone else"),
+            ("internal_note_key", "signals_report:forged"),
+        ]
+    )
+    def test_reserved_item_context_keys_are_stripped_from_client_input(self, key: str, value: str) -> None:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/comments",
+            {
+                "content": "Comment",
+                "scope": "Insight",
+                "item_id": "insight-1",
+                "item_context": {"anchor": {"kind": "document"}, key: value},
+            },
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        item_context = response.json()["item_context"]
+        assert key not in item_context
+        assert item_context["anchor"] == {"kind": "document"}
+
     @mock.patch("posthog.api.comments.send_mention_notifications")
     def test_personal_channel_comments_ignore_mentions(self, send_notifications: mock.Mock) -> None:
         task = self._task_artifact_target()

--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -2293,15 +2293,29 @@ class TestTicketMessagesAPI(APIBaseTest):
             content="Suggested reply the pipeline did not send",
             item_context={"author_type": "AI", "is_private": True},
         )
+        forged_note = Comment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            scope="conversations_ticket",
+            item_id=str(self.ticket.id),
+            content="Note a person wrote before the comments API reserved the key",
+            item_context={
+                "author_type": "AI",
+                "is_private": True,
+                "internal_note_key": "signals_report:forged",
+            },
+        )
         # Stamp explicit, strictly-increasing created_at so ordering can't tie on fast DBs.
         Comment.objects.filter(id=automation_note.id).update(created_at=base)
         Comment.objects.filter(id=draft_note.id).update(created_at=base + timedelta(seconds=1))
+        Comment.objects.filter(id=forged_note.id).update(created_at=base + timedelta(seconds=2))
 
         response = self.client.get(self.url)
         assert response.status_code == status.HTTP_200_OK
-        automation, draft = response.json()["results"]
+        automation, draft, forged = response.json()["results"]
         assert automation["internal_note_key"] == "signals_report:report-id"
         assert draft["internal_note_key"] is None
+        assert forged["internal_note_key"] is None
 
     def test_messages_lookup_by_ticket_number(self, mock_on_commit):
         Comment.objects.create(

--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -2268,9 +2268,38 @@ class TestTicketMessagesAPI(APIBaseTest):
             "author_email",
             "is_private",
             "has_full_email_content",
+            "internal_note_key",
             "created_at",
             "version",
         }
+
+    def test_messages_expose_internal_note_key_of_agent_notes(self, mock_on_commit):
+        """A client reading the thread has to tell an agent's note from an unsent AI draft:
+        both are private and both are authored by "AI", and only the key says which."""
+        Comment.objects.create(
+            team=self.team,
+            scope="conversations_ticket",
+            item_id=str(self.ticket.id),
+            content="Report: https://us.posthog.com/project/1/inbox/report-id",
+            item_context={
+                "author_type": "AI",
+                "is_private": True,
+                "internal_note_key": "signals_report:report-id",
+            },
+        )
+        Comment.objects.create(
+            team=self.team,
+            scope="conversations_ticket",
+            item_id=str(self.ticket.id),
+            content="Suggested reply the pipeline did not send",
+            item_context={"author_type": "AI", "is_private": True},
+        )
+
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        agent_note, draft = response.json()["results"]
+        assert agent_note["internal_note_key"] == "signals_report:report-id"
+        assert draft["internal_note_key"] is None
 
     def test_messages_lookup_by_ticket_number(self, mock_on_commit):
         Comment.objects.create(

--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -2273,10 +2273,9 @@ class TestTicketMessagesAPI(APIBaseTest):
             "version",
         }
 
-    def test_messages_expose_internal_note_key_of_agent_notes(self, mock_on_commit):
-        """A client reading the thread has to tell an agent's note from an unsent AI draft:
-        both are private and both are authored by "AI", and only the key says which."""
-        Comment.objects.create(
+    def test_messages_expose_internal_note_key_of_automation_notes(self, mock_on_commit):
+        base = timezone.now()
+        automation_note = Comment.objects.create(
             team=self.team,
             scope="conversations_ticket",
             item_id=str(self.ticket.id),
@@ -2287,18 +2286,21 @@ class TestTicketMessagesAPI(APIBaseTest):
                 "internal_note_key": "signals_report:report-id",
             },
         )
-        Comment.objects.create(
+        draft_note = Comment.objects.create(
             team=self.team,
             scope="conversations_ticket",
             item_id=str(self.ticket.id),
             content="Suggested reply the pipeline did not send",
             item_context={"author_type": "AI", "is_private": True},
         )
+        # Stamp explicit, strictly-increasing created_at so ordering can't tie on fast DBs.
+        Comment.objects.filter(id=automation_note.id).update(created_at=base)
+        Comment.objects.filter(id=draft_note.id).update(created_at=base + timedelta(seconds=1))
 
         response = self.client.get(self.url)
         assert response.status_code == status.HTTP_200_OK
-        agent_note, draft = response.json()["results"]
-        assert agent_note["internal_note_key"] == "signals_report:report-id"
+        automation, draft = response.json()["results"]
+        assert automation["internal_note_key"] == "signals_report:report-id"
         assert draft["internal_note_key"] is None
 
     def test_messages_lookup_by_ticket_number(self, mock_on_commit):

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -1402,6 +1402,10 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
         else:
             author_name = "Support"
 
+        # Only the server writes this key, and it leaves the author empty. A key on an authored
+        # comment is client input, which the comments API accepted before it reserved the field.
+        internal_note_key = item_context.get("internal_note_key") if comment.created_by_id is None else None
+
         return {
             "id": comment.id,
             "content": comment.content,
@@ -1411,7 +1415,7 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
             "author_email": comment.created_by.email if comment.created_by else None,
             "is_private": item_context.get("is_private") is True,
             "has_full_email_content": item_context.get("has_full_email_content") is True,
-            "internal_note_key": item_context.get("internal_note_key") or None,
+            "internal_note_key": internal_note_key or None,
             "version": comment.version,
             "created_at": comment.created_at,
         }

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -133,6 +133,16 @@ class TicketMessageSerializer(serializers.Serializer):
     has_full_email_content = serializers.BooleanField(
         read_only=True, help_text="True when the complete inbound email body can be retrieved."
     )
+    internal_note_key = serializers.CharField(
+        read_only=True,
+        allow_null=True,
+        help_text=(
+            "Identifies the automation that left this internal note, e.g. "
+            "`signals_report:<report id>` for a Self-driving report pointer. Null for every "
+            "message a person wrote and for the AI reply pipeline's own suggested replies, so a "
+            "client can tell an agent's note from an unsent draft."
+        ),
+    )
     version = serializers.IntegerField(read_only=True, help_text="Edit count. 0 means never edited.")
     created_at = serializers.DateTimeField(read_only=True)
 
@@ -1401,6 +1411,7 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
             "author_email": comment.created_by.email if comment.created_by else None,
             "is_private": item_context.get("is_private") is True,
             "has_full_email_content": item_context.get("has_full_email_content") is True,
+            "internal_note_key": item_context.get("internal_note_key") or None,
             "version": comment.version,
             "created_at": comment.created_at,
         }

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -404,6 +404,11 @@ export interface TicketMessageApi {
     readonly is_private: boolean
     /** True when the complete inbound email body can be retrieved. */
     readonly has_full_email_content: boolean
+    /**
+     * Identifies the automation that left this internal note, e.g. `signals_report:<report id>` for a Self-driving report pointer. Null for every message a person wrote and for the AI reply pipeline's own suggested replies, so a client can tell an agent's note from an unsent draft.
+     * @nullable
+     */
+    readonly internal_note_key: string | null
     /** Edit count. 0 means never edited. */
     readonly version: number
     readonly created_at: string

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -59066,6 +59066,11 @@ export namespace Schemas {
       readonly is_private: boolean;
       /** True when the complete inbound email body can be retrieved. */
       readonly has_full_email_content: boolean;
+      /**
+         * Identifies the automation that left this internal note, e.g. `signals_report:<report id>` for a Self-driving report pointer. Null for every message a person wrote and for the AI reply pipeline's own suggested replies, so a client can tell an agent's note from an unsent draft.
+         * @nullable
+         */
+      readonly internal_note_key: string | null;
       /** Edit count. 0 means never edited. */
       readonly version: number;
       readonly created_at: string;


### PR DESCRIPTION
## Problem

A support agent reading a ticket outside the PostHog app cannot tell an automation's note from an unsent AI draft. Over `GET /conversations/tickets/:id/messages/` both look identical: `author_type: "AI"`, `is_private: true`.

A client that hides unapproved drafts therefore hides the Self-driving report link too. The PostHog app does this today in `supportTicketSceneLogic`, and hogdesk is adopting it.

The server already knows the difference. `post_ticket_internal_note` stamps every automation note with `item_context.internal_note_key`, set to `signals_report:<report id>` for Self-driving. The messages action never passed it on.

## Changes

- Ticket messages now carry `internal_note_key`, so a client can show Self-driving report notes and still hide unsent drafts.
- The value names the automation that wrote the note. It is null for messages people wrote and for the AI reply pipeline's own replies.
- The comments API now strips `internal_note_key` from client input. Without that, any team member can post a note carrying a forged key, and the field names an automation that never wrote it.
- Existing consumers see no change. The field is additive and read-only.
- Mechanical: the generated OpenAPI types for the frontend and the MCP service.

## How did you test this code?

- `test_messages_expose_internal_note_key_of_automation_notes` posts one AI note with a key and one without, then asserts the endpoint separates them. No existing test covered an AI note's provenance.
- `test_reserved_item_context_keys_are_stripped_from_client_input` covers a Slack key and the new one. Nothing asserted the stripping, so dropping a key from `RESERVED_ITEM_CONTEXT_KEYS` was a silent regression.

The forged-key path was reproduced against a local database before the fix, and confirmed blocked after it. The affected backend suites were run locally.

Not checked: the frontend, which has no consumer of the field yet.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, and the repo's `qa-team` multi-agent review.

That review changed three things: the reserved-key fix above, which two reviewers found independently; stamping `created_at` in the messages test, which had relied on insertion order; and dropping a test docstring under the repo's no-doc-comments rule.

Alternatives considered: exposing the whole `item_context` bag, which leaks unrelated internals such as citations and email routing; and matching the report URL in the note body client-side, which breaks when the note copy changes.

No customer content, ticket text, or internal metrics appear in this diff.
