### PR TITLE
fix(workflows): default step error handling to continue

### DIFF
--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -1611,6 +1611,35 @@ describe('Hogflow Executor', () => {
                         )
                     })
 
+                    // Steps saved before error handling was configurable, and steps the author never
+                    // touched, carry no on_error. They get the documented default: continue.
+                    it('continues to next action when on_error is not set', async () => {
+                        const action = hogFlow.actions.find((a) => a.id === 'function_id_1')!
+                        delete action.on_error
+
+                        const functionHandler = executor['actionHandlers']['function']
+                        jest.spyOn(functionHandler, 'execute').mockResolvedValueOnce({
+                            error: new Error('Mocked handler error'),
+                        })
+
+                        const invocation = createExampleHogFlowInvocation(hogFlow, {
+                            event: {
+                                ...createHogExecutionGlobals().event,
+                                properties: { name: 'Test User' },
+                            },
+                        })
+                        invocation.state.currentAction = {
+                            id: 'function_id_1',
+                            startedAtTimestamp: DateTime.now().toMillis(),
+                        }
+
+                        const result = await executor.executeCurrentAction(invocation)
+
+                        expect(result.error).toBe('Mocked handler error')
+                        expect(result.finished).toBe(false)
+                        expect(result.invocation.state.currentAction?.id).toBe('middle_action')
+                    })
+
                     it('does NOT continue to next action when on_error is abort', async () => {
                         const action = hogFlow.actions.find((a) => a.id === 'function_id_1')!
                         action.on_error = 'abort'

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -769,7 +769,8 @@ export class HogFlowExecutorService {
     }
 
     /**
-     * If the action has on_error set to 'continue' then we continue to the next action instead of failing the flow
+     * Unless the action has on_error set to 'abort' we continue to the next action instead of failing the flow.
+     * An action without on_error gets the default, which is to continue.
      */
     private maybeContinueToNextActionOnError(
         result: CyclotronJobInvocationResult<CyclotronJobInvocationHogFlow>
@@ -783,9 +784,10 @@ export class HogFlowExecutorService {
             if (invocation.state.currentAction?.delayUntilUnresolved) {
                 return
             }
-            // If current action's on_error is set to 'continue', we move to the next action instead of failing the flow
+            // Unless the current action's on_error is set to 'abort', we move to the next action instead of
+            // failing the flow. 'continue' is the default, so an action that never had on_error set gets it too.
             const currentAction = ensureCurrentAction(invocation)
-            if (currentAction?.on_error === 'continue') {
+            if (currentAction?.on_error !== 'abort') {
                 const nextAction = findContinueAction(invocation)
                 if (nextAction) {
                     this.logAction(

--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuildDetail.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuildDetail.tsx
@@ -442,7 +442,7 @@ export function HogFlowEditorPanelBuildDetail(): JSX.Element | null {
                                                     { value: 'continue', label: 'Continue to next step' },
                                                     { value: 'abort', label: 'Exit the workflow' },
                                                 ]}
-                                                value={action.on_error || 'abort'}
+                                                value={action.on_error || 'continue'}
                                                 onChange={(value) =>
                                                     setWorkflowAction(action.id, {
                                                         ...action,


### PR DESCRIPTION
## Problem

A workflow author who never opens a step's "Error handling" panel gets the opposite of what the product tells them. The panel says "By default, the user will continue to the next step", but a step with no `on_error` set ends the run when it fails — one failed send drops the person out of the whole workflow. The select box made this worse by showing "Exit the workflow" as the selected value while the text above it promised the opposite.

Raised in #team-messaging.

## Changes

- A step that fails with no `on_error` set now continues to the next step. The executor continued only on an explicit `on_error: 'continue'`; it now continues unless the step is explicitly set to `abort`. Steps saved before error handling was configurable, and steps nobody touched, all get the documented default.
- The "Error handling" select now shows "Continue to next step" for a step with nothing set, matching both the copy above it and the new runtime behaviour.
- The one exception is unchanged: a delay that cannot work out the date to wait for still ends the run, because continuing would run the next step immediately and defeat the wait.

Nothing changes for a step explicitly set to `abort`.

## How did you test this code?

Added an executor unit test covering the case no existing test did: `on_error` absent (not `'continue'`, not `'abort'`) must move the run to the next action. The two neighbouring tests already pin the explicit values.

The tests were not run in this session — `hogflow-executor.service.test.ts` builds a real hub and needs Postgres/Kafka, which this environment does not have. CI is the check here. No manual UI testing was done either, so the select change is unverified beyond reading the diff.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Any docs stating that a failed step exits the workflow by default should be updated.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a Slack thread reporting the mismatch between the panel copy and the select default. No repo skills were invoked.

The first read suggested a frontend-only fix — just flip the select's fallback. Tracing `on_error` into `nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts` showed the runtime shares the bug: `maybeContinueToNextActionOnError` matched on `=== 'continue'`, so an unset value behaved as abort. Changing only the select would have made the UI misreport the runtime in the other direction, so both sides moved. `shouldEndHogFlowExecution` already matched on `=== 'abort'` and needed no change.

A search for an open PR fixing this found nothing.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C06GG249PR6/p1788527469367299?thread_ts=1788527469.367299&cid=C06GG249PR6)*
