### PR TITLE
chore(insights): remove query_from_filters read-path fallbacks

### DIFF
--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -927,7 +927,6 @@
     'last_refresh',
     'objects',
     'objects_including_soft_deleted',
-    'query_from_filters',
     'refresh_attempt',
     'refreshing',
     'save',

--- a/posthog/tasks/alerts/test/test_alert_evaluation.py
+++ b/posthog/tasks/alerts/test/test_alert_evaluation.py
@@ -11,7 +11,6 @@ from posthog.models.instance_setting import set_instance_setting
 from posthog.tasks.alerts.test.alert_check_helpers import run_alert_check
 
 from products.alerts.backend.models import AlertCheck, AlertConfiguration
-from products.product_analytics.backend.facade.models import Insight
 
 
 @freeze_time("2024-06-02T08:55:00.000Z")
@@ -86,25 +85,6 @@ class TestAlertEvaluation(APIBaseTest, ClickhouseDestroyTablesMixin):
         self.set_thresholds(lower=2)
 
         assert AlertConfiguration.objects.get(pk=self.alert["id"]).state == AlertState.NOT_FIRING
-
-    def test_alert_with_insight_with_filter(
-        self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
-    ) -> None:
-        # An alert still runs on an insight stored as filters, and only the ORM writes one now.
-        insight = Insight.objects.create(
-            team=self.team,
-            name="insight",
-            filters={"events": [{"id": "$pageview"}], "display": "BoldNumber"},
-        )
-
-        self.client.patch(f"/api/projects/{self.team.id}/alerts/{self.alert['id']}", data={"insight": insight.id})
-        self.set_thresholds(lower=1)
-
-        run_alert_check(self.alert["id"])
-
-        assert mock_send_notifications_for_breaches.call_count == 1
-        anomalies = self.get_breach_description(mock_send_notifications_for_breaches, call_index=0)
-        assert "The insight value ($pageview) for current interval (0) is less than lower threshold (1)" in anomalies
 
     def test_alert_triggered_for_single_formula(
         self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock

--- a/products/data_catalog/backend/logic/drift.py
+++ b/products/data_catalog/backend/logic/drift.py
@@ -25,8 +25,8 @@ def canonical_query_hash(query: dict) -> str:
 
 
 def effective_insight_query(insight: Insight) -> Optional[dict]:
-    """The insight's query, converting legacy ``filters``-only insights via query_from_filters."""
-    return insight.query or insight.query_from_filters
+    """The insight's query."""
+    return insight.query
 
 
 def fetch_insight(team_id: int, short_id: str, *, include_deleted: bool = False) -> Optional[Insight]:

--- a/products/exports/backend/temporal/subscriptions/insight_snapshot.py
+++ b/products/exports/backend/temporal/subscriptions/insight_snapshot.py
@@ -129,8 +129,6 @@ def _resolve_effective_query_json(insight: Insight, dashboard: Dashboard | None)
     query_json = insight.get_effective_query(dashboard=dashboard)
     if query_json is None:
         query_json = insight.query
-    if query_json is None:
-        query_json = insight.query_from_filters
     return query_json
 
 

--- a/products/product_analytics/backend/models/insight.py
+++ b/products/product_analytics/backend/models/insight.py
@@ -1,4 +1,3 @@
-from functools import cached_property
 from typing import TYPE_CHECKING, Any, Optional
 
 from django.contrib.postgres.fields import ArrayField
@@ -277,19 +276,6 @@ class Insight(RootTeamMixin, FileSystemSyncMixin, models.Model):
         # uses .all and not .first so that prefetching can be used
         sharing_configurations = self.sharingconfiguration_set.all()
         return sharing_configurations[0].enabled if sharing_configurations and sharing_configurations[0] else False
-
-    @cached_property
-    def query_from_filters(self):
-        from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
-
-        try:
-            return {
-                "kind": "InsightVizNode",
-                "source": filter_to_query(self.filters).model_dump(exclude_none=True),
-                "full": True,
-            }
-        except Exception as e:
-            capture_exception(e)
 
     def dashboard_filters(
         self, dashboard: Optional["Dashboard"] = None, dashboard_filters_override: Optional[dict] = None

--- a/products/product_analytics/backend/presentation/insight.py
+++ b/products/product_analytics/backend/presentation/insight.py
@@ -482,9 +482,9 @@ class InsightBasicSerializer(
         else:
             representation.pop("dashboards", None)
 
-        if instance.query is not None or instance.query_from_filters is not None:
+        if instance.query is not None:
             representation["filters"] = {}
-            representation["query"] = instance.query or instance.query_from_filters
+            representation["query"] = instance.query
         else:
             filters = instance.dashboard_filters()
             representation["filters"] = filters
@@ -1237,10 +1237,10 @@ class InsightSerializer(InsightBasicSerializer):
             tile_filters_override_requested_by_client(request, dashboard_tile, is_shared=is_shared) if request else {}
         )
 
-        if instance.query is not None or instance.query_from_filters is not None:
+        if instance.query is not None:
             # Upgrade before applying dashboard filters: the stored query may predate the current
             # schema, and apply_dashboard_filters_to_dict validates against the latest one
-            query = upgrade(instance.query or instance.query_from_filters)
+            query = upgrade(instance.query)
             if (
                 dashboard is not None
                 or dashboard_filters_override is not None


### PR DESCRIPTION
## Problem

Every insight carries a `query` now, but four read paths still pay for a legacy fallback: they convert `filters` to a query on every read when `query` is null. That fallback hides the cleanup's end state and keeps `filter_to_query` on hot paths it should never reach. Stacked on #94944, which removed the same conversion from `upgrade_query`.

## Changes

Nothing changes for users: no insight is filters-only, so the removed branches never executed.

- API reads return the stored `query` directly. The serializer no longer derives one from `filters`.
- Metric drift detection and subscription snapshots read `insight.query` only.
- Deletes `Insight.query_from_filters` and `test_alert_with_insight_with_filter`, which only exercised the removed path.

The `filters` column itself stays; write-side conversion in `insight_write_validation.py` is untouched.

## How did you test this code?

- `posthog/tasks/alerts/test/test_alert_evaluation.py`: 5 passed locally.
- `products/data_catalog/backend/tests/test_logic.py` (drift): 64 passed.
- `products/exports/backend/temporal/subscriptions`: 543 passed.
- Not run: the full product_analytics API suite (CI covers it).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

skip-inkeep-docs

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (PostHog Desktop) authored the change. Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`, `/writing-tests` (test deletion reviewed against the retention gate). This is the second layer of the stack under #94922: #94944 removed the conversion from `upgrade_query`, this PR removes the remaining read-path fallbacks.