### PR TITLE
fix(experiments): make interval bar delta marker clickable

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/ChartCell.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ChartCell.tsx
@@ -213,6 +213,12 @@ export function ChartCell({
                                 stroke={colors.BAR_MIDDLE_POINT}
                                 strokeWidth={2}
                                 shapeRendering="crispEdges"
+                                style={{
+                                    cursor: isClickable ? 'pointer' : 'default',
+                                }}
+                                onClick={onTimeseriesClick}
+                                onMouseEnter={isClickable ? () => setIsHovered(true) : undefined}
+                                onMouseLeave={isClickable ? () => setIsHovered(false) : undefined}
                             />
                         </>
                     )}


### PR DESCRIPTION
## Problem

Clicking the credible interval bar in experiment results opens the timeseries modal, but clicking the black delta marker line in the middle does nothing. The line sits on top of the bar and swallows the click and the pointer cursor. Same for the frequentist confidence interval bar.

## Changes

- The delta marker line now shows the pointer cursor, triggers the hover highlight, and opens the timeseries modal on click, same as the rest of the bar.
- One `<line>` element renders the marker for both Bayesian and frequentist bars, so one change covers both.
- Nothing looks different at rest, only hover and click behavior on the line changes.

## How did you test this code?

Not run: frontend typecheck and jest, because the change was made in a light worktree without node_modules. The added props copy the ones already on the sibling bar elements two lines up; CI covers the typecheck.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code in a light worktree. Skills invoked: /wt, /writing-pr-descriptions. Single-file change to `ChartCell.tsx`, no design decisions beyond reusing the existing bar handlers.
