### PR TITLE
fix(snowflake): explain an MFA-blocked login instead of the raw driver error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
@@ -61,6 +61,16 @@ _UNENCRYPTED_KEY_WITH_PASSPHRASE_MESSAGE = (
     "Remove the passphrase, or paste your encrypted private key, then {action}"
 )
 
+# Snowflake rejects the login (250001 / 08001) when the account enforces multi-factor auth for the
+# connecting user. The server phrases this several ways, and the bare "MFA authentication is
+# required" variant carries the account host and vendor codes, so it must not reach the customer
+# raw. Same `{action}` placeholder convention as `_MALFORMED_PEM_MESSAGE`.
+_MFA_ENFORCED_MESSAGE = (
+    "Snowflake rejected the login because multi-factor authentication is enforced for this user. "
+    "Automated syncs can't answer an MFA prompt, so connect with a service user that uses key-pair "
+    "authentication or is exempt from MFA, then {action}"
+)
+
 SnowflakeErrors = {
     "No active warehouse selected in the current session": "No active warehouse is available for this connection. Check that the configured warehouse exists, is running, and that the connecting role has USAGE on it, then try again.",
     "or attempt to login with another role": "Role specified doesn't exist or is not authorized",
@@ -73,6 +83,11 @@ SnowflakeErrors = {
     # connector raises HttpError rather than the "Verify the account name is correct" OperationalError,
     # so it needs its own entry. The host and port in the message are volatile, so we match "404 Not Found".
     "404 Not Found": "Can't find a Snowflake account with the specified account ID. Please check your account identifier and try again.",
+    # Snowflake error 250001 (08001): the account enforces MFA for this user, either as a denied Duo
+    # push or as a bare requirement. Without these entries the wizard falls back to the generic
+    # "check all connection details" message, so people re-enter correct credentials repeatedly.
+    "Duo Security authentication is denied": _MFA_ENFORCED_MESSAGE.format(action="try again."),
+    "MFA authentication is required": _MFA_ENFORCED_MESSAGE.format(action="try again."),
 }
 
 
@@ -241,7 +256,7 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
             # Snowflake error 250001 (08001): the user's password has expired. Snowflake requires it
             # to be changed via the web console before any login can succeed, so retrying never works.
             "Specified password has expired": "Your Snowflake password has expired. Please change it in the Snowflake web console (or switch to key-pair authentication), then resync.",
-            "MFA authentication is required": None,
+            "MFA authentication is required": _MFA_ENFORCED_MESSAGE.format(action="resync."),
             # The account enforces Duo Security multi-factor auth for this user, so the
             # connector's login is rejected (250001 / 08001). An unattended sync can't answer a
             # Duo push, so retrying never succeeds — surface an actionable message instead.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -728,6 +728,18 @@ class TestSnowflakeSourceNonRetryableErrors:
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert is_non_retryable, f"MFA-enrollment error should be non-retryable: {error_msg}"
 
+    def test_mfa_required_maps_to_a_message_instead_of_the_raw_snowflake_text(self, source):
+        # The raw text carries the account host and vendor codes, so the entry must supply its own
+        # message rather than letting the failure surface unchanged.
+        error_msg = (
+            "250001 (08001): None: Failed to connect to DB: acme-xy123.snowflakecomputing.com:443. "
+            "MFA authentication is required."
+        )
+        non_retryable = source.get_non_retryable_errors()
+        messages = [message for pattern, message in non_retryable.items() if pattern in error_msg]
+        assert messages, f"MFA-required error should be non-retryable: {error_msg}"
+        assert all(message is not None and "multi-factor authentication" in message for message in messages)
+
     @pytest.mark.parametrize(
         "error_msg",
         [
@@ -1046,6 +1058,32 @@ class TestSnowflakeValidateCredentials:
 
         assert ok is False
         assert message is not None and "multi-factor authentication" in message
+        mock_capture.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "raw_message",
+        [
+            "250001 (08001): None: Failed to connect to DB: acme-xy123.snowflakecomputing.com:443. "
+            "Duo Security authentication is denied.",
+            "250001 (08001): None: Failed to connect to DB: acme-xy123.snowflakecomputing.com:443. "
+            "MFA authentication is required.",
+        ],
+    )
+    def test_mfa_enforced_login_returns_friendly_message_without_capture(self, source, raw_message):
+        # Without a mapping these fall back to the generic "check all connection details" message,
+        # which sends people round re-entering credentials that were correct all along.
+        error = DatabaseError(msg=raw_message, errno=250001, sqlstate="08001")
+        with (
+            patch.object(source, "get_schemas", side_effect=error),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.snowflake.source.capture_exception"
+            ) as mock_capture,
+        ):
+            ok, message = source.validate_credentials(_make_config("password"), team_id=1)
+
+        assert ok is False
+        assert message is not None and "multi-factor authentication" in message
+        assert "snowflakecomputing.com" not in message
         mock_capture.assert_not_called()
 
     def test_unexpected_value_error_is_still_captured(self, source):


### PR DESCRIPTION
## Problem

Someone connecting Snowflake whose account enforces multi-factor authentication is told to "check all connection details are valid", so they re-enter credentials that were already correct and never learn why the connection fails. Session scans of the new-source flow show this loop repeating until the person abandons the setup.

- Automated syncs cannot answer an MFA prompt, so no credential edit in the wizard can ever succeed.
- `validate_credentials` maps neither the Duo denial nor the bare "MFA authentication is required" reply, so both fall through to the generic message and get captured as unexpected failures.
- On the sync path the bare MFA entry mapped to `None`, which surfaces the driver text unchanged, including the account host and the vendor error codes.

## Changes

- The wizard now says multi-factor authentication is enforced and to connect with a service user that uses key-pair authentication or is exempt from MFA.
- A failed sync shows the same explanation instead of the raw driver string, so the account host and error codes stay out of the visible message.
- The three call sites share one `_MFA_ENFORCED_MESSAGE` constant, following the `{action}` placeholder convention the private-key messages in this file already use.
- The two existing MFA messages are untouched. The enrollment wording and the Duo sync wording already read well, and rewriting them would widen the diff for no reader.

Nothing in the UI layout changes, so there is no screenshot: only the text of an existing error.

## How did you test this code?

Extended `test_snowflake.py`, which had no coverage for either new case:

- `test_mfa_required_maps_to_a_message_instead_of_the_raw_snowflake_text` catches the entry regressing to `None` and leaking the host and codes again.
- `test_mfa_enforced_login_returns_friendly_message_without_capture` catches the wizard falling back to the generic message, and asserts the account host is absent.

Ran the Snowflake source tests locally. Not run: anything needing a live Snowflake account, so the trigger strings are matched against the message shapes the existing tests already record.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code while reviewing friction themes in the data-warehouse new-source flow. Skills invoked: `/writing-user-facing-copy` and `/writing-pr-descriptions`.

The first draft only fixed the sync-path `None`. Reading `validate_credentials` showed the wizard was the surface people actually hit, and that it had no mapping at all, so the change covers both.

No duplicate: `gh pr list --state open --search "snowflake"` and a search for MFA found nothing addressing this. The related open Snowflake work covers retries and the batch-export destination.

Public artifact: the trigger strings and the test fixtures are invented from the message shapes already committed in this repo. No customer material is in the diff.
