### PR TITLE
fix(revenuecat): name the scope missing when webhook registration is denied

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/revenuecat/revenuecat.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/revenuecat/revenuecat.py
@@ -470,7 +470,18 @@ def create_webhook(
         response.raise_for_status()
     except requests.HTTPError as e:
         logger.warning("Failed to register RevenueCat webhook integration", error=str(e))
-        return WebhookCreationResult(success=False, error=_format_http_error(e))
+        return WebhookCreationResult(
+            success=False,
+            error=_format_http_error(
+                e,
+                # The read-only hint the validate path passes doesn't fit here: registering the
+                # integration needs write scope, and the failure screen offers manual setup.
+                forbidden_hint=(
+                    "The v2 secret API key is missing write access. Give it write permission for "
+                    "integrations, or follow the manual setup below."
+                ),
+            ),
+        )
     except requests.RequestException as e:
         logger.warning("Could not reach RevenueCat to register webhook", error=str(e))
         return WebhookCreationResult(success=False, error=f"Could not reach RevenueCat: {e}")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/revenuecat/tests/test_revenuecat.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/revenuecat/tests/test_revenuecat.py
@@ -500,6 +500,10 @@ class TestCreateWebhook:
         # Webhook creation needs write scope, so this shared 403 message must not tell the user to
         # grant read access (unlike the credential-check path).
         assert "read" not in result.error.lower()
+        # Naming the scope is the point: a scope-neutral 403 sends people round re-checking a key
+        # that was never missing the permission they looked at.
+        assert "write permission for integrations" in result.error
+        assert "manual setup" in result.error
 
 
 class TestDeleteWebhook:


### PR DESCRIPTION
## Problem

Someone setting up RevenueCat whose API key lacks write scope is told the key "has the permissions this request needs", without which permission. Session scans of the new-source flow show people re-reading their key scopes and re-entering the key, then leaving the webhook unconfigured.

- Registering the webhook posts to the integrations endpoint, which needs write scope.
- `create_webhook` calls the shared 403 formatter with no hint, so it falls back to the scope-neutral default written for read and write callers.
- The credential check already passes a read-specific hint, so only this path is vague.

## Changes

- The denial now names the permission: write access for integrations.
- It also points at the manual setup, which the same screen renders directly under the error banner.
- One call site changes. Nothing else about webhook registration moves.

Only the text of an existing error banner changes, so there is no screenshot.

## How did you test this code?

Extended `test_translates_403_into_permission_error`, which asserted the message avoided the read hint but not that it named any scope, so the vague default passed it.

- The added assertions catch a revert to a scope-neutral hint, and catch losing the pointer to manual setup.

Ran the RevenueCat source tests locally. Not run: anything against a live RevenueCat project, so the 403 is a mocked response as in the surrounding tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The key scopes the docs list are unchanged.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code while reviewing friction themes in the data-warehouse new-source flow. Skills invoked: `/writing-user-facing-copy` and `/writing-pr-descriptions`.

An earlier draft told people to grant the permission "then reconnect", matching the read hint. Reading `WebhookSetupForm` showed the failure renders the manual setup card, so the message offers that as the second option instead.

The delete and status paths share the same formatter and the same default. They are left alone: neither blocks setup, and widening the change would put unrelated surfaces in this diff.

No duplicate: `gh pr list --state open --search "revenuecat"` and a search for webhook permission scopes found nothing on this path.

Public artifact: no customer material is in the diff. The scope names come from this repo's own field captions.
