### PR TITLE
perf(clickhouse): add a bloom filter on the bare $session_id column

### DIFF
--- a/posthog/clickhouse/hcl/golden/local-multi/data.hcl
+++ b/posthog/clickhouse/hcl/golden/local-multi/data.hcl
@@ -5500,6 +5500,11 @@ database "posthog" {
       type        = "bloom_filter"
       granularity = 1
     }
+    index "bloom_filter_$session_id_column" {
+      expr        = "`$session_id`"
+      type        = "bloom_filter(0.01)"
+      granularity = 1
+    }
     index "minmax_$group_0" {
       expr        = "`$group_0`"
       type        = "minmax"

--- a/posthog/clickhouse/hcl/golden/local-single/all.hcl
+++ b/posthog/clickhouse/hcl/golden/local-single/all.hcl
@@ -9887,6 +9887,11 @@ SQL
       type        = "bloom_filter"
       granularity = 1
     }
+    index "bloom_filter_$session_id_column" {
+      expr        = "`$session_id`"
+      type        = "bloom_filter(0.01)"
+      granularity = 1
+    }
     index "minmax_$group_0" {
       expr        = "`$group_0`"
       type        = "minmax"

--- a/posthog/clickhouse/hcl/roles/data/shared/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/data/shared/tables.hcl
@@ -215,6 +215,11 @@ database "posthog" {
       type        = "bloom_filter"
       granularity = 1
     }
+    index "bloom_filter_$session_id_column" {
+      expr        = "`$session_id`"
+      type        = "bloom_filter(0.01)"
+      granularity = 1
+    }
     engine "replicated_replacing_merge_tree" {
       zoo_path       = "/clickhouse/tables/{shard}/posthog.events"
       replica_name   = "{replica}"

--- a/posthog/clickhouse/hcl/sql/local-multi/data.sql
+++ b/posthog/clickhouse/hcl/sql/local-multi/data.sql
@@ -1028,6 +1028,7 @@ CREATE TABLE posthog.sharded_events (
   INDEX minmax_$ai_experiment_id `mat_$ai_experiment_id` TYPE minmax GRANULARITY 1,
   INDEX minmax_$session_id_uuid `$session_id_uuid` TYPE minmax GRANULARITY 1,
   INDEX bloom_filter_$session_id nullIf(nullIf(`$session_id`, ''), 'null') TYPE bloom_filter GRANULARITY 1,
+  INDEX bloom_filter_$session_id_column `$session_id` TYPE bloom_filter(0.01) GRANULARITY 1,
   INDEX minmax_$group_0 `$group_0` TYPE minmax GRANULARITY 1,
   INDEX minmax_$group_1 `$group_1` TYPE minmax GRANULARITY 1,
   INDEX minmax_$group_2 `$group_2` TYPE minmax GRANULARITY 1,

--- a/posthog/clickhouse/hcl/sql/local-single/all.sql
+++ b/posthog/clickhouse/hcl/sql/local-single/all.sql
@@ -1775,6 +1775,7 @@ CREATE TABLE posthog.sharded_events (
   INDEX minmax_$ai_experiment_id `mat_$ai_experiment_id` TYPE minmax GRANULARITY 1,
   INDEX minmax_$session_id_uuid `$session_id_uuid` TYPE minmax GRANULARITY 1,
   INDEX bloom_filter_$session_id nullIf(nullIf(`$session_id`, ''), 'null') TYPE bloom_filter GRANULARITY 1,
+  INDEX bloom_filter_$session_id_column `$session_id` TYPE bloom_filter(0.01) GRANULARITY 1,
   INDEX minmax_$group_0 `$group_0` TYPE minmax GRANULARITY 1,
   INDEX minmax_$group_1 `$group_1` TYPE minmax GRANULARITY 1,
   INDEX minmax_$group_2 `$group_2` TYPE minmax GRANULARITY 1,

--- a/posthog/clickhouse/migrations/0314_add_bare_session_id_bloom_filter.py
+++ b/posthog/clickhouse/migrations/0314_add_bare_session_id_bloom_filter.py
@@ -1,0 +1,16 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+ADD_BARE_COLUMN_BLOOM_FILTER_INDEX = """
+ALTER TABLE sharded_events
+ADD INDEX IF NOT EXISTS `bloom_filter_$session_id_column` `$session_id`
+TYPE bloom_filter(0.01)
+GRANULARITY 1
+"""
+
+operations = [
+    run_sql_with_exceptions(
+        ADD_BARE_COLUMN_BLOOM_FILTER_INDEX,
+        sharded=True,
+        is_alter_on_replicated_table=True,
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0313_logs_pattern_buckets
+0314_add_bare_session_id_bloom_filter

--- a/posthog/clickhouse/test/test_0314.py
+++ b/posthog/clickhouse/test/test_0314.py
@@ -1,0 +1,55 @@
+import importlib
+
+from posthog.test.base import ClickhouseDestroyTablesMixin, _create_event, flush_persons_and_events
+
+from parameterized import parameterized
+
+from posthog.hogql.test.test_property_skip_indexes import _run_explain_and_get_skip_indexes
+
+from posthog.clickhouse.client import sync_execute
+
+module = importlib.import_module("posthog.clickhouse.migrations.0314_add_bare_session_id_bloom_filter")
+
+EXPRESSION_INDEX_FROM_0293 = """
+ALTER TABLE sharded_events
+ADD INDEX IF NOT EXISTS `bloom_filter_$session_id` nullIf(nullIf(`$session_id`, ''), 'null')
+TYPE bloom_filter GRANULARITY 1
+"""
+SESSION_ID = "019f9a50-0000-7000-8000-000000000001"
+
+
+def _session_id_bloom_filter_indexes() -> dict[str, str]:
+    return dict(
+        sync_execute(
+            "SELECT name, expr FROM system.data_skipping_indices "
+            "WHERE database = currentDatabase() AND table = 'sharded_events' AND type = 'bloom_filter' "
+            "AND position(expr, '$session_id') > 0"
+        )
+    )
+
+
+class Test0314(ClickhouseDestroyTablesMixin):
+    def test_adds_a_bare_column_index_next_to_the_expression_index_and_can_be_reapplied(self):
+        sync_execute(EXPRESSION_INDEX_FROM_0293)
+        sync_execute(module.ADD_BARE_COLUMN_BLOOM_FILTER_INDEX)
+        sync_execute(module.ADD_BARE_COLUMN_BLOOM_FILTER_INDEX)
+
+        indexes = _session_id_bloom_filter_indexes()
+        assert set(indexes) == {"bloom_filter_$session_id", "bloom_filter_$session_id_column"}
+        assert indexes["bloom_filter_$session_id_column"] == "`$session_id`"
+
+    @parameterized.expand(
+        [
+            ("has", "has(%(session_ids)s, `$session_id`)"),
+            ("equals", "equals(`$session_id`, %(session_id)s)"),
+        ]
+    )
+    def test_bare_column_index_engages_under_default_hogql_settings(self, _name: str, predicate: str):
+        sync_execute(module.ADD_BARE_COLUMN_BLOOM_FILTER_INDEX)
+        _create_event(team=self.team, distinct_id="d", event="$pageview", properties={"$session_id": SESSION_ID})
+        flush_persons_and_events()
+        values = {"team_id": self.team.pk, "session_ids": [SESSION_ID], "session_id": SESSION_ID}
+        skip_indexes = _run_explain_and_get_skip_indexes(
+            f"SELECT count() FROM events WHERE team_id = %(team_id)s AND {predicate}", values
+        )
+        assert "bloom_filter_$session_id_column" in skip_indexes


### PR DESCRIPTION
## Problem

Filtering events by session id (replay matching events, the recordings list filtered to specific sessions, the ReplayVision scans) reads every event the team has in the date range. The `$session_id` bloom filter from PR 74973 (https://github.com/PostHog/posthog/pull/74973) never engages.

It indexes the null-scrubbed expression `nullIf(nullIf($session_id, ''), 'null')`, picked to match what HogQL prints for `properties.$session_id`. An `IN` on that expression never uses a bloom filter under `transform_null_in=1` (HogQL's default), and the shapes ClickHouse does index (`=` and `has([..], col)`) are on the bare column, which an expression index can't match.

PR 94535 (https://github.com/PostHog/posthog/pull/94535) replaced it in place. Its `DROP INDEX` is a mutation, dev rejected it while deletions were in flight, and it was reverted in PR 94903 (https://github.com/PostHog/posthog/pull/94903).

## Changes

- Adds `bloom_filter_$session_id_column` on the bare `$session_id` column (`bloom_filter(0.01)`, granularity 1) with `ADD INDEX` only. No `MATERIALIZE INDEX`, existing parts pick it up as they merge, and no `DROP`: the old expression index stays until the ClickHouse team removes it.
- Mechanical: HCL layer, golden and generated SQL, `max_migration.txt`.

## How did you test this code?

`hogli test posthog/clickhouse/test/test_0314.py posthog/clickhouse/test/test_migrations.py`

- `test_adds_a_bare_column_index_next_to_the_expression_index_and_can_be_reapplied`: adds the 0293 index first, applies the migration twice, asserts both indexes exist and the new one is on the bare column. Fails if the migration drops anything, indexes an expression, or loses its `IF NOT EXISTS`.
- `test_bare_column_index_engages_under_default_hogql_settings`: `EXPLAIN indexes=1` with the HogQL default settings for `equals(..)` and `has([..], $session_id)`, so it fails if the new index stops serving those shapes.

`bash posthog/clickhouse/hcl/check.sh` passes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1). Skills invoked: /clickhouse-migrations, /writing-tests, /writing-pr-descriptions, plus the superpowers TDD and worktree skills. Add-only re-land of the reverted 0314 after the incident. The index name is a placeholder pending the ClickHouse team's preference; the materialized-column registry detects bloom filters by `bloom_filter_<column>`, which the old expression index already occupies, and that flag gates nothing today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013A8zoSs3ZyCFjVQi1YvEmF
