### PR TITLE
chore(proxy): remove managed root redirect feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -386,7 +386,6 @@ export const FEATURE_FLAGS = {
     LOGS_TRANSFORMATIONS: 'logs-transformations', // owner: #team-logs
     MANAGED_MIGRATIONS_IAM_ROLE_AUTH: 'managed-migrations-iam-role-auth', // owner: #team-ingestion, gates IAM role auth for S3 batch imports
     MANAGED_MIGRATIONS_TRIAL_RUNS: 'managed-migrations-trial-runs', // owner: #team-ingestion, gates trial runs for managed migrations
-    MANAGED_REVERSE_PROXY_ROOT_REDIRECT: 'managed-reverse-proxy-root-redirect', // owner: @reecejones #team-platform-features
     MANAGED_VIEWSETS: 'managed-viewsets', // owner: @rafaeelaudibert #team-revenue-analytics
     MARKETING_ANALYTICS_AI: 'marketing-analytics-ai', // owner: @jabahamondes #team-web-analytics
     MARKETING_ANALYTICS_ATTRIBUTION: 'marketing-analytics-attribution', // owner: @jabahamondes #team-web-analytics — gates the Attribution tab

--- a/frontend/src/scenes/settings/environment/ManagedReverseProxy.tsx
+++ b/frontend/src/scenes/settings/environment/ManagedReverseProxy.tsx
@@ -22,7 +22,6 @@ import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { DomainConnectBanner } from 'lib/components/DomainConnect'
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { OrganizationMembershipLevel } from 'lib/constants'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { Link } from 'lib/lemon-ui/Link'
@@ -48,7 +47,6 @@ const statusText = {
 }
 
 export function ManagedReverseProxy(): JSX.Element {
-    const rootRedirectEnabled = useFeatureFlag('MANAGED_REVERSE_PROXY_ROOT_REDIRECT')
     const {
         shouldShowCloudflareOptIn,
         formState,
@@ -225,9 +223,7 @@ export function ManagedReverseProxy(): JSX.Element {
                 columns={columns}
                 dataSource={proxyRecords}
                 expandable={{
-                    expandedRowRender: (record) => (
-                        <ExpandedRow record={record} rootRedirectEnabled={rootRedirectEnabled} />
-                    ),
+                    expandedRowRender: (record) => <ExpandedRow record={record} />,
                     isRowExpanded: (record) => (expandedRecordIds.includes(record.id) ? true : -1),
                     onRowExpand: (record) => setRecordExpanded(record.id, true),
                     onRowCollapse: (record) => setRecordExpanded(record.id, false),
@@ -350,13 +346,7 @@ function CloudflareOptInBanner({
     )
 }
 
-const ExpandedRow = ({
-    record,
-    rootRedirectEnabled,
-}: {
-    record: ProxyRecord
-    rootRedirectEnabled: boolean
-}): JSX.Element => {
+const ExpandedRow = ({ record }: { record: ProxyRecord }): JSX.Element => {
     const { diagnosticReports, recordActiveTabs, rootRedirectDrafts, proxyRecordsLoading } = useValues(proxyLogic)
     const { setRecordActiveTab, setRootRedirectDraft, updateRootRedirect } = useActions(proxyLogic)
 
@@ -374,7 +364,7 @@ const ExpandedRow = ({
                 </CodeSnippet>
             ),
         },
-        ...(canConfigureRootRedirect(record, rootRedirectEnabled)
+        ...(canConfigureRootRedirect(record)
             ? [
                   {
                       label: 'Root redirect',

--- a/frontend/src/scenes/settings/environment/proxyLogic.test.ts
+++ b/frontend/src/scenes/settings/environment/proxyLogic.test.ts
@@ -142,14 +142,13 @@ describe('proxyLogic — shouldShowCloudflareOptIn', () => {
 })
 
 describe('proxyLogic — root redirect', () => {
-    it.each<[string, boolean, ProxyRecord, boolean]>([
-        ['supported valid proxy', true, mockProxyRecord(), true],
-        ['supported warning proxy', true, mockProxyRecord({ status: 'warning' }), true],
-        ['legacy proxy', true, mockProxyRecord({ root_redirect_supported: false }), false],
-        ['disabled feature', false, mockProxyRecord(), false],
-        ['proxy that is not ready', true, mockProxyRecord({ status: 'waiting' }), false],
-    ])('allows configuration for a %s when expected', (_name, featureEnabled, record, expected) => {
-        expect(canConfigureRootRedirect(record, featureEnabled)).toBe(expected)
+    it.each<[string, ProxyRecord, boolean]>([
+        ['supported valid proxy', mockProxyRecord(), true],
+        ['supported warning proxy', mockProxyRecord({ status: 'warning' }), true],
+        ['legacy proxy', mockProxyRecord({ root_redirect_supported: false }), false],
+        ['proxy that is not ready', mockProxyRecord({ status: 'waiting' }), false],
+    ])('allows configuration for a %s when expected', (_name, record, expected) => {
+        expect(canConfigureRootRedirect(record)).toBe(expected)
     })
 
     it('updates the record from the PATCH response', async () => {

--- a/frontend/src/scenes/settings/environment/proxyLogic.ts
+++ b/frontend/src/scenes/settings/environment/proxyLogic.ts
@@ -47,12 +47,8 @@ export type DiagnosticRemediation = DiagnosticRemediationApi
 export type DiagnosticCheckResult = DiagnosticCheckResultApi
 export type DiagnosticReport = DiagnosticReportApi
 
-export function canConfigureRootRedirect(proxyRecord: ProxyRecord, featureEnabled: boolean): boolean {
-    return (
-        featureEnabled &&
-        proxyRecord.root_redirect_supported &&
-        (proxyRecord.status === 'valid' || proxyRecord.status === 'warning')
-    )
+export function canConfigureRootRedirect(proxyRecord: ProxyRecord): boolean {
+    return proxyRecord.root_redirect_supported && (proxyRecord.status === 'valid' || proxyRecord.status === 'warning')
 }
 
 export function domainFor(proxyRecord: ProxyRecord | undefined): string {


### PR DESCRIPTION
## Problem

Users with an eligible managed proxy cannot configure root redirects when the rollout flag is disabled.

## Changes

- Eligible Cloudflare-managed proxies now show the existing root redirect settings without a client-side feature flag gate.
- Legacy and not-ready proxies keep the existing eligibility checks.
- The unused frontend flag definition is removed. The server-side flag remains for manual deletion after merge.
- The backend redirect API remains unchanged.
- The existing layout and controls do not change, so no screenshot is included.

## How did you test this code?

- `pnpm --filter=@posthog/frontend exec jest src/scenes/settings/environment/proxyLogic.test.ts --runInBand`
- `pnpm --filter=@posthog/frontend fix`
- Targeted Oxlint and Oxfmt checks passed.
- Full TypeScript check remains blocked by unrelated existing missing `@posthog/hogvm` declarations.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- Not needed. This change removes a rollout gate from existing functionality.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The change used the Explore subagent, PostHog MCP flag lookup, repository file tools, and GitHub CLI. The invoked skills were `/writing-ui-components`, `/writing-tests`, and `/writing-pr-descriptions`. The PR search found no matching open PR. The server-side feature flag was not deleted.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
