### PR TITLE
chore(tests): stop the keystore TTL test racing the wall clock

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/shared/keystore/cache/memory-cache.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/shared/keystore/cache/memory-cache.test.ts
@@ -223,23 +223,40 @@ describe('MemoryCachedKeyStore', () => {
         })
 
         it('should expire cached items after ttlMs', async () => {
-            const ttlMs = 50 // Short TTL for testing
-            const customCachedKeyStore = new MemoryCachedKeyStore(mockDelegate, { ttlMs })
+            const ttlMs = 50
+            // lru-cache reads the clock through the performance object it captured at import, so
+            // Jest's fake timers cannot reach it: they replace that global object instead of
+            // patching it. A spy on the method does reach it. Drive the clock by hand, because on
+            // a loaded runner the wall clock can pass ttlMs between the two reads below.
+            let now = performance.now()
+            const nowSpy = jest.spyOn(performance, 'now').mockImplementation(() => now)
 
-            // First call populates cache
-            await customCachedKeyStore.getKey('session-123', 1)
-            mockDelegate.getKey.mockClear()
+            try {
+                const customCachedKeyStore = new MemoryCachedKeyStore(mockDelegate, { ttlMs })
 
-            // Immediate second call should use cache
-            await customCachedKeyStore.getKey('session-123', 1)
-            expect(mockDelegate.getKey).not.toHaveBeenCalled()
+                // First call populates cache
+                await customCachedKeyStore.getKey('session-123', 1)
+                mockDelegate.getKey.mockClear()
 
-            // Wait for TTL to expire
-            await new Promise((resolve) => setTimeout(resolve, ttlMs + 10))
+                // Baseline: still cached while the clock has not moved
+                await customCachedKeyStore.getKey('session-123', 1)
+                expect(mockDelegate.getKey).not.toHaveBeenCalled()
 
-            // After TTL - should call delegate
-            await customCachedKeyStore.getKey('session-123', 1)
-            expect(mockDelegate.getKey).toHaveBeenCalledWith('session-123', 1)
+                // Move past the TTL
+                now += ttlMs + 10
+
+                // The read above made lru-cache keep its staleness reading for ttlResolution, which
+                // is 1 ms by default, and only a timer clears it. Wait for a timer that expires
+                // after that one, so the next staleness check reads the clock above. Elapsed time
+                // is all this wait needs, so a slow runner cannot break it.
+                await new Promise((resolve) => setTimeout(resolve, 5))
+
+                // After TTL - should call delegate
+                await customCachedKeyStore.getKey('session-123', 1)
+                expect(mockDelegate.getKey).toHaveBeenCalledWith('session-123', 1)
+            } finally {
+                nowSpy.mockRestore()
+            }
         })
     })
 


### PR DESCRIPTION
## Problem

`MemoryCachedKeyStore › should expire cached items after ttlMs` fails intermittently and takes the whole Node.js suite with it, which kicks whatever PR is in the merge queue at the time.

- The test builds a cache with a 50 ms TTL, then asserts an *immediate* second read still hits it.
- On a loaded runner (`--maxWorkers=4` across 583 suites) the worker is descheduled for longer than that between the two lines, the entry has already expired, and the delegate is called.
- It hit #94481 in the queue on 4 Sep. Trunk lists both variants as HEALTHY, so it is not quarantined and blocks a batch whenever it lands.

## Changes

- The test no longer depends on how fast the runner is between two adjacent lines. It drives the cache's clock by hand.
- `lru-cache` reads its TTL from `performance.now()`. Jest's fake timers cannot reach it: they replace the global `performance` object, while lru-cache keeps the one it captured at import. A spy on the method reaches the object it already holds.
- The remaining 5 ms wait only clears lru-cache's staleness cache, which it holds for `ttlResolution` and drops from a timer. That wait needs time to pass rather than to stand still, so a slow runner makes it safer, not flakier.
- The spy is restored in a `finally`. `nodejs/jest.config.shared.js` sets `clearMocks` but not `restoreMocks`, so without that the mocked clock leaks into every later test in the file.

`session-filter.test.ts` already uses this pattern for the same library in the same tree, so this brings the two into line.

Nothing user-visible changes. One test file.

## How did you test this code?

The regression this guards is the one above: a >50 ms deschedule between two reads. Verified by inducing it rather than waiting for CI to be unlucky.

<details>
<summary>Evidence</summary>

- With an 80 ms busy-wait inserted between the two reads, the old shape fails every time and the new shape passes. That is the exact failure mode from the queue.
- 40/40 consecutive passes at `--maxWorkers=4`.
- 173 tests in `sessionreplay/shared` pass, so the restored spy does not leak.
- Root cause confirmed at the library level: a 55 ms stall expires a 50 ms `lru-cache` entry, a 40 ms stall does not.

</details>

`eslint`, `prettier` and `tsc` are clean for this file. `hogli ci:preflight --strict` passes.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 5) at @webjunkie's direction, from a merge queue investigation that found this test failing a queued PR.

Skills invoked: `/writing-tests`, `/fixing-flaky-tests`, `/writing-code-comments`, `/simplify`.

Two approaches were tried and rejected before this one. `jest.useFakeTimers()` does not work here, for the reason in Changes. `standalone: true` on the pnpm side is unrelated. A clock injected through `MemoryCachedKeyStore` was also rejected: the pinned `lru-cache` 11.0.2 has no `perf` option to forward it to, so it would have been a test-only seam in production code with nowhere to go.

A zero-wait variant using `jest.useFakeTimers({ doNotFake: ['performance'] })` does work, but it fakes `Date` for the whole test body, which is a wide blast radius for clearing one 1 ms timer. The 5 ms wait is the more predictable trade.
