### PR TITLE
fix(desktop): open report artifacts in Inbox

### DIFF
--- a/products/desktop/docs/CLOUD-TASK-ARTIFACTS.md
+++ b/products/desktop/docs/CLOUD-TASK-ARTIFACTS.md
@@ -16,7 +16,7 @@ Reference artifacts do not upload a file and do not have a storage path, size, o
 
 Registration failure does not block the completed turn or replace the current artifact list. Desktop retries when it hydrates the completed turn again, so the client and backend can deploy in either order.
 
-The Artifacts pane shows file and reference artifacts in one list. The Timeline announces a new reference as an added artifact. Both surfaces open the same artifact tab, which resolves the current object data from the active PostHog project.
+The Artifacts pane shows file and reference artifacts in one list. The Timeline announces a new reference as an added artifact. Inbox report references open in the native Inbox report view. Other references open an artifact tab that resolves current object data from the active PostHog project.
 
 The desktop app runs scripts embedded in HTML artifacts inside an isolated preview process. The preview cannot access Node.js, Electron, PostHog credentials, remote resources, downloads, or device permissions. Use **Stop preview** if a script becomes unresponsive, then use **Restart preview** to load it in a fresh process.
 

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskArtifactsList.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskArtifactsList.test.tsx
@@ -13,6 +13,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   runs: [] as TaskRun[],
   openArtifactTab: vi.fn(),
+  openInboxReport: vi.fn(),
   openExternalUrl: vi.fn(),
   getCloudAttachmentPreviewUrl: vi.fn(),
   commentsError: false,
@@ -53,6 +54,9 @@ vi.mock("@posthog/ui/features/sessions/sessionStore", () => ({
 }));
 vi.mock("@posthog/ui/features/panels/panelLayoutStore", () => ({
   usePanelLayoutStore: () => mocks.openArtifactTab,
+}));
+vi.mock("@posthog/ui/features/inbox/hooks/useOpenInboxReport", () => ({
+  useOpenInboxReport: () => mocks.openInboxReport,
 }));
 vi.mock("@posthog/ui/features/git-interaction/usePrArtifact", () => ({
   usePrArtifact: (url: string) => ({
@@ -141,6 +145,7 @@ describe("TaskArtifactsList", () => {
     mocks.taskRunsRefreshKeys = [];
     mocks.runs = [run("run-1", { prNumber: 1 }), run("run-2", { prNumber: 2 })];
     mocks.openArtifactTab.mockReset();
+    mocks.openInboxReport.mockReset();
     mocks.openExternalUrl.mockReset();
     mocks.getCloudAttachmentPreviewUrl.mockReset();
     useReviewNavigationStore.setState({
@@ -280,6 +285,35 @@ describe("TaskArtifactsList", () => {
     expect(
       screen.queryByRole("button", { name: "Download Checkout funnel" }),
     ).toBeNull();
+  });
+
+  it("opens an Inbox report reference in the native report view", () => {
+    mocks.runs = [
+      run("run-1", {
+        artifacts: [
+          {
+            id: "phref-report-1",
+            name: "Checkout errors increased",
+            type: "reference",
+            source: "posthog_object",
+            uploaded_at: "2026-08-19T00:00:00Z",
+            metadata: {
+              reference_type: "posthog_object",
+              object_kind: "report",
+              object_id: "report-1",
+              source_message_ids: ["turn-1"],
+              occurrence_count: 1,
+            },
+          },
+        ],
+      }),
+    ];
+
+    render(<TaskArtifactsList task={task} timeline={[]} />);
+
+    fireEvent.click(screen.getByText("Checkout errors increased"));
+    expect(mocks.openInboxReport).toHaveBeenCalledWith("report-1");
+    expect(mocks.openArtifactTab).not.toHaveBeenCalled();
   });
 
   it("keeps artifacts visible when comment counts fail", () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskArtifactsList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskArtifactsList.tsx
@@ -42,6 +42,7 @@ import { useTaskRuns } from "@posthog/ui/features/canvas/hooks/useTaskRuns";
 import { canvasArtifactOpenHandler } from "@posthog/ui/features/canvas/utils/canvasArtifactNavigation";
 import { openPrInReview } from "@posthog/ui/features/code-review/openPrInReview";
 import { usePrArtifact } from "@posthog/ui/features/git-interaction/usePrArtifact";
+import { useOpenInboxReport } from "@posthog/ui/features/inbox/hooks/useOpenInboxReport";
 import { usePanelLayoutStore } from "@posthog/ui/features/panels/panelLayoutStore";
 import { usePrComments } from "@posthog/ui/features/pr-review/usePrComments";
 import { usePrReviewThreads } from "@posthog/ui/features/pr-review/usePrReviewThreads";
@@ -346,6 +347,7 @@ function PostHogObjectRow({
   runId,
   name,
   objectKind,
+  objectId,
   occurrenceCount,
   uploadedAt,
   commentCount,
@@ -355,11 +357,13 @@ function PostHogObjectRow({
   runId: string;
   name: string;
   objectKind: string;
+  objectId: string;
   occurrenceCount: number;
   uploadedAt: string | undefined;
   commentCount: number;
 }) {
   const openArtifactTab = usePanelLayoutStore((state) => state.openArtifactTab);
+  const openInboxReport = useOpenInboxReport();
   const object = getObjectKind(objectKind);
   const ObjectIcon = object.icon;
   const meta = [
@@ -375,9 +379,13 @@ function PostHogObjectRow({
       icon={<ObjectIcon size={16} color={POSTHOG_OBJECT_ICON_COLOR} />}
       title={name}
       meta={meta}
-      onOpen={() =>
-        openArtifactTab(taskId, { runId, artifactId, name, objectKind })
-      }
+      onOpen={() => {
+        if (objectKind === "report") {
+          void openInboxReport(objectId);
+          return;
+        }
+        openArtifactTab(taskId, { runId, artifactId, name, objectKind });
+      }}
       actions={<CommentCountBadge count={commentCount} />}
     />
   );
@@ -484,6 +492,7 @@ export function TaskArtifactsList({
             runId={row.runId}
             name={row.name}
             objectKind={row.metadata.object_kind}
+            objectId={row.metadata.object_id}
             occurrenceCount={row.metadata.occurrence_count}
             uploadedAt={row.uploadedAt}
             commentCount={openCountByItem.get(row.artifactId) ?? 0}


### PR DESCRIPTION
## Problem

People who open an Inbox report reference from a task see a generic artifact preview instead of the native report view.

The preview omits Inbox actions and can miss the current report tab or channel.

## Changes

- Inbox report references now use the shared status-aware Inbox opener.
- Other PostHog object references still open the generic artifact preview.
- No pixels changed, so screenshots do not apply.

## How did you test this code?

- `pnpm --filter @posthog/ui test -- TaskArtifactsList.test.tsx`
- `pnpm lint`
- `pnpm typecheck`
- Not run: `hogli ci:preflight --fix`; `hogli` and `flox` are unavailable in this cloud image.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the cloud task artifact guide with the native Inbox routing rule.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The PostHog Slack app made this change with `/posthog-desktop`, `/writing-ui-components`, `/writing-tests`, and `/writing-pr-descriptions`.

The duplicate search found no open PR for this behavior. The committed fixture is invented and contains no private session material.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1788532208983559?thread_ts=1788532208.983559&cid=C09G8Q32R6F)*