### PR TITLE
fix(cohorts): stop rescanning every team cohort on each cohort write

### DIFF
--- a/posthog/settings/cohorts.py
+++ b/posthog/settings/cohorts.py
@@ -87,3 +87,10 @@ BEHAVIORAL_BACKFILL_PERSON_READINESS_ENABLED: bool = get_from_env(
 BEHAVIORAL_BACKFILL_FINALIZER_MAX_RUNS_PER_PASS: int = get_from_env(
     "BEHAVIORAL_BACKFILL_FINALIZER_MAX_RUNS_PER_PASS", 500, type_cast=int
 )
+# Kill switch for incremental cohort dependency cache maintenance. Off, every cohort create, delete,
+# and dependency change rescans the whole team, which is the cost the incremental path removes. The
+# fallback exists because a wrong incremental update only shows up as a shorter recalculation chain,
+# which no dashboard surfaces, so a config flip has to be faster than a revert.
+COHORT_DEPENDENCY_INCREMENTAL_MAINTENANCE: bool = get_from_env(
+    "COHORT_DEPENDENCY_INCREMENTAL_MAINTENANCE", True, type_cast=str_to_bool
+)

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -686,6 +686,14 @@ CACHES["organization_access"] = {
     "LOCATION": REDIS_URL,
 }
 
+# Cohort dependency reads must see the writes made earlier in the same request: the create path
+# writes the new cohort's keys and then reads them back before responding, and a replica-lag miss
+# there rescans every cohort of the team inside the request.
+CACHES["cohort_dependencies"] = {
+    **CACHES["default"],
+    "LOCATION": REDIS_URL,
+}
+
 # Dedicated cache for the feature flags service (if configured)
 # Django only writes to this cache (never reads), so no reader URL needed
 if FLAGS_REDIS_URL:
@@ -749,6 +757,7 @@ if TEST:
     CACHES["default"] = {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}
     CACHES["query_cache"] = CACHES["default"]
     CACHES["organization_access"] = CACHES["default"]
+    CACHES["cohort_dependencies"] = CACHES["default"]
 
 # Cache timeout for materialized columns metadata (in seconds)
 MATERIALIZED_COLUMNS_CACHE_TIMEOUT: int = get_from_env("MATERIALIZED_COLUMNS_CACHE_TIMEOUT", 900, type_cast=int)

--- a/products/cohorts/backend/models/dependencies.py
+++ b/products/cohorts/backend/models/dependencies.py
@@ -253,25 +253,15 @@ def get_cohort_dependencies(cohort: Cohort) -> list[int]:
     """
     cache_key = _cohort_dependencies_key(cohort.id)
 
-    # Check if value exists in cache first
-    cache_hit = dependency_cache.has_key(cache_key)
-
-    def compute_dependencies():
-        COHORT_DEPENDENCY_CACHE_COUNTER.labels(cache_type="dependencies", result="miss").inc()
-        return list(extract_cohort_dependencies(cohort))
-
-    if cache_hit:
+    dependencies = dependency_cache.get(cache_key)
+    if dependencies is not None:
         COHORT_DEPENDENCY_CACHE_COUNTER.labels(cache_type="dependencies", result="hit").inc()
+        return dependencies
 
-    result = dependency_cache.get_or_set(
-        cache_key,
-        compute_dependencies,
-        timeout=DEPENDENCY_CACHE_TIMEOUT,
-    )
-
-    if result is None:
-        logger.error("Cohort dependencies cache returned None", cohort_id=cohort.id)
-    return result or []
+    COHORT_DEPENDENCY_CACHE_COUNTER.labels(cache_type="dependencies", result="miss").inc()
+    dependencies = list(extract_cohort_dependencies(cohort))
+    dependency_cache.set(cache_key, dependencies, timeout=DEPENDENCY_CACHE_TIMEOUT)
+    return dependencies
 
 
 def get_cohort_dependents(cohort: Cohort | int) -> list[int]:
@@ -283,35 +273,36 @@ def get_cohort_dependents(cohort: Cohort | int) -> list[int]:
     cohort_id = cohort.id if isinstance(cohort, Cohort) else cohort
     cache_key = _cohort_dependents_key(cohort_id)
 
-    # Check if value exists in cache first
-    cache_hit = dependency_cache.has_key(cache_key)
-
-    def compute_or_fallback() -> list[int]:
-        COHORT_DEPENDENCY_CACHE_COUNTER.labels(cache_type="dependents", result="miss").inc()
-        # If we only have an ID, query the database for team_id. A soft-deleted cohort can still
-        # have live dependents, so the lookup must not filter on deleted.
-        if isinstance(cohort, int):
-            try:
-                team_id = Cohort.objects.filter(pk=cohort_id).values_list("team_id", flat=True).first()
-                if team_id is None:
-                    logger.warning("Cohort not found when computing dependents", cohort_id=cohort_id)
-                    return []
-            except Exception as e:
-                logger.exception("Failed to fetch team_id for cohort", cohort_id=cohort_id, error=str(e))
-                return []
-        else:
-            team_id = cohort.team_id
-
-        warm_team_cohort_dependency_cache(team_id)
-        return dependency_cache.get(cache_key, [])
-
-    if cache_hit:
+    dependents = dependency_cache.get(cache_key)
+    if dependents is not None:
         COHORT_DEPENDENCY_CACHE_COUNTER.labels(cache_type="dependents", result="hit").inc()
+        return dependents
+    COHORT_DEPENDENCY_CACHE_COUNTER.labels(cache_type="dependents", result="miss").inc()
 
-    result = dependency_cache.get_or_set(cache_key, compute_or_fallback, timeout=DEPENDENCY_CACHE_TIMEOUT)
-    if result is None:
-        logger.error("Cohort dependents cache returned None", cohort_id=cohort_id)
-    return result or []
+    # If we only have an ID, query the database for team_id. A soft-deleted cohort can still
+    # have live dependents, so the lookup must not filter on deleted.
+    if isinstance(cohort, int):
+        try:
+            team_id = Cohort.objects.filter(pk=cohort_id).values_list("team_id", flat=True).first()
+        except Exception as e:
+            logger.exception("Failed to fetch team_id for cohort", cohort_id=cohort_id, error=str(e))
+            return []
+    else:
+        team_id = cohort.team_id
+
+    if team_id is None:
+        logger.warning("Cohort not found when computing dependents", cohort_id=cohort_id)
+    else:
+        warm_team_cohort_dependency_cache(team_id)
+
+    dependents = dependency_cache.get(cache_key)
+    if dependents is None:
+        # The warm writes keys only for live cohorts and the cohorts they reference. Caching the
+        # empty list for anything else keeps a stale id in a reverse list from rescanning the team
+        # on every read.
+        dependents = []
+        dependency_cache.set(cache_key, dependents, timeout=DEPENDENCY_CACHE_TIMEOUT)
+    return dependents
 
 
 def warm_team_cohort_dependency_cache(team_id: int, batch_size: int = 1000) -> int:
@@ -392,7 +383,8 @@ def _on_cohort_changed(
     else:
         operation = "update"
         # An expired key reads as "no previous edges", which leaves this cohort in a former
-        # dependency's reverse list until the next warm. Consumers filter such extra ids out.
+        # dependency's reverse list until the next warm. The cost is one unneeded recalculation
+        # of this cohort when that former dependency recalculates, never a missed one.
         old_dependencies = set(dependency_cache.get(_cohort_dependencies_key(cohort.id)) or [])
     new_dependencies = set() if removed else extract_cohort_dependencies(cohort)
 

--- a/products/cohorts/backend/models/dependencies.py
+++ b/products/cohorts/backend/models/dependencies.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from typing import Any
+from uuid import uuid4
 
 from django.conf import settings
 from django.core.cache import cache, caches
@@ -22,6 +23,8 @@ from products.cohorts.backend.realtime_teams import is_cohort_backfill_trigger_t
 
 logger = get_logger(__name__)
 DEPENDENCY_CACHE_TIMEOUT = 7 * 24 * 60 * 60  # 1 week
+# Bounds the rescans one warm does while edges keep changing under it.
+DEPENDENCY_WARM_MAX_ATTEMPTS = 3
 
 # The dependency key families are read back in the request that writes them: on create,
 # `_on_cohort_changed` runs before `enqueue_calculation` reads `dependents` for the new cohort
@@ -79,6 +82,10 @@ def _cohort_dependencies_key(cohort_id: int) -> str:
 
 def _cohort_dependents_key(cohort_id: int) -> str:
     return f"cohort:dependents:{cohort_id}"
+
+
+def _team_dependency_generation_key(team_id: int) -> str:
+    return f"cohort:dependency_generation:{team_id}"
 
 
 # Set of behavioral (flag-incompatible) cohort ids per team, hidden from the feature-flag
@@ -310,6 +317,28 @@ def warm_team_cohort_dependency_cache(team_id: int, batch_size: int = 1000) -> i
     Rebuilds both key families for every live cohort of a team from Postgres. Returns the number of
     cohorts scanned.
 
+    An edge change that commits during the scan bumps the team generation before it deletes any
+    reverse key. A scan that ends on a different generation than it started on may have published a
+    reverse list from pre-edit rows, so it runs again and overwrites its own output. Writers never
+    wait on a warm. The attempt bound caps the scans that continuous edge edits in one team can
+    force on a single read miss.
+    """
+    generation_key = _team_dependency_generation_key(team_id)
+    scanned = 0
+    for _ in range(DEPENDENCY_WARM_MAX_ATTEMPTS):
+        generation = dependency_cache.get(generation_key)
+        scanned = _publish_team_cohort_dependencies(team_id, batch_size)
+        if dependency_cache.get(generation_key) == generation:
+            return scanned
+    logger.warning("cohort_dependency_warm_unsettled", team_id=team_id, attempts=DEPENDENCY_WARM_MAX_ATTEMPTS)
+    return scanned
+
+
+def _publish_team_cohort_dependencies(team_id: int, batch_size: int) -> int:
+    """
+    One scan of a team's live cohorts that writes both key families. Returns the number of cohorts
+    scanned.
+
     Uses keyset pagination on id instead of .iterator(), which opens a named
     server-side cursor that can be invalidated by connection recycling between
     batches (e.g. behind a pooler) and raises InvalidCursorName mid-scan.
@@ -360,7 +389,8 @@ def _on_cohort_changed(
 
     Only the changed cohort's own keys are written. The reverse lists of the cohorts it started or
     stopped referencing are deleted rather than edited: DEL is idempotent, so two concurrent writers
-    cannot lose each other's update, and the next reader rebuilds the list from Postgres.
+    cannot lose each other's update, and the next reader rebuilds the list from Postgres. A warm that
+    overlaps those deletes is fenced by the team generation, see warm_team_cohort_dependency_cache.
     """
     if not settings.COHORT_DEPENDENCY_INCREMENTAL_MAINTENANCE:
         _on_cohort_changed_full_warm(cohort, always_invalidate=hard_deleted)
@@ -406,6 +436,12 @@ def _on_cohort_changed(
 
     changed_dependencies = old_dependencies ^ new_dependencies
     if changed_dependencies:
+        # The bump precedes the deletes. A warm checks the generation after it publishes, so a bump
+        # that lands before that check forces a rescan. If the bump lands after the check, the
+        # deletes land after the publish too and remove the stale keys themselves.
+        dependency_cache.set(
+            _team_dependency_generation_key(cohort.team_id), uuid4().hex, timeout=DEPENDENCY_CACHE_TIMEOUT
+        )
         dependency_cache.delete_many([_cohort_dependents_key(dep_id) for dep_id in changed_dependencies])
 
     path = "edges" if old_dependencies or new_dependencies else "no_edges"

--- a/products/cohorts/backend/models/dependencies.py
+++ b/products/cohorts/backend/models/dependencies.py
@@ -1,14 +1,15 @@
 from collections import defaultdict
 from typing import Any
 
-from django.core.cache import cache
+from django.conf import settings
+from django.core.cache import cache, caches
 from django.db import transaction
 from django.db.models import Q, TextField
 from django.db.models.functions import Cast
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
-from prometheus_client import Counter
+from prometheus_client import Counter, Histogram
 from rest_framework.exceptions import ValidationError
 from structlog import get_logger
 
@@ -21,6 +22,17 @@ from products.cohorts.backend.realtime_teams import is_cohort_backfill_trigger_t
 
 logger = get_logger(__name__)
 DEPENDENCY_CACHE_TIMEOUT = 7 * 24 * 60 * 60  # 1 week
+
+# The dependency key families are read back in the request that writes them: on create,
+# `_on_cohort_changed` runs before `enqueue_calculation` reads `dependents` for the new cohort
+# (on_commit callbacks run FIFO). The default cache serves reads from a replica, and a replica-lag
+# miss on `dependents` rebuilds the whole team on the request path, which is the cost this module
+# exists to avoid. The behavioral-ids keys stay on the default cache: only the list endpoint reads
+# them.
+dependency_cache = caches["cohort_dependencies"]
+
+# A save that persists none of these fields cannot change a dependency edge.
+DEPENDENCY_FIELDS = frozenset({"filters", "groups", "deleted"})
 COHORT_BACKFILL_DEBOUNCE_SECONDS = 300  # 5 minutes
 # The lock expiring exactly as the task fires is what closes the lost-dispatch window: a TTL longer
 # than the countdown would swallow a save that lands after the task already read its state.
@@ -31,6 +43,18 @@ COHORT_DEPENDENCY_CACHE_COUNTER = Counter(
     "posthog_cohort_dependency_cache_requests_total",
     "Total number of cohort dependency cache requests",
     labelnames=["cache_type", "result"],
+)
+
+COHORT_DEPENDENCY_MAINTENANCE_COUNTER = Counter(
+    "posthog_cohort_dependency_maintenance_total",
+    "Cohort dependency cache maintenance operations, by change kind and whether any edge was involved",
+    labelnames=["operation", "path"],
+)
+
+COHORT_DEPENDENCY_WARM_COHORTS_SCANNED = Histogram(
+    "posthog_cohort_dependency_warm_cohorts_scanned",
+    "Cohorts scanned per team dependency cache warm",
+    buckets=(1, 10, 100, 1_000, 10_000, 100_000),
 )
 
 COHORT_REALTIME_STATE_ORPHANED_COUNTER = Counter(
@@ -204,12 +228,15 @@ def _invalidate_team_behavioral_cohort_cache(team_id: int) -> None:
 invalidate_team_behavioral_cohort_cache = _invalidate_team_behavioral_cohort_cache
 
 
-def extract_cohort_dependencies(cohort: Cohort) -> set[int]:
+def extract_cohort_dependencies(cohort: Cohort, *, ignore_deleted: bool = False) -> set[int]:
     """
     Extract cohort dependencies from the given cohort.
+
+    A deleted cohort has no dependencies unless `ignore_deleted` is set, which the delete path uses
+    to find the edges it tears down.
     """
     dependencies = set()
-    if not cohort.deleted:
+    if ignore_deleted or not cohort.deleted:
         try:
             for prop in cohort.properties.flat:
                 if prop.type == "cohort" and isinstance(prop.value, int) and prop.value != cohort.id:
@@ -220,24 +247,23 @@ def extract_cohort_dependencies(cohort: Cohort) -> set[int]:
     return dependencies
 
 
-def get_cohort_dependencies(cohort: Cohort, _warming: bool = False) -> list[int]:
+def get_cohort_dependencies(cohort: Cohort) -> list[int]:
     """
     Get the list of cohort IDs that the given cohort depends on.
     """
     cache_key = _cohort_dependencies_key(cohort.id)
 
     # Check if value exists in cache first
-    cache_hit = cache.has_key(cache_key)
+    cache_hit = dependency_cache.has_key(cache_key)
 
     def compute_dependencies():
-        if not _warming:
-            COHORT_DEPENDENCY_CACHE_COUNTER.labels(cache_type="dependencies", result="miss").inc()
+        COHORT_DEPENDENCY_CACHE_COUNTER.labels(cache_type="dependencies", result="miss").inc()
         return list(extract_cohort_dependencies(cohort))
 
-    if cache_hit and not _warming:
+    if cache_hit:
         COHORT_DEPENDENCY_CACHE_COUNTER.labels(cache_type="dependencies", result="hit").inc()
 
-    result = cache.get_or_set(
+    result = dependency_cache.get_or_set(
         cache_key,
         compute_dependencies,
         timeout=DEPENDENCY_CACHE_TIMEOUT,
@@ -258,14 +284,15 @@ def get_cohort_dependents(cohort: Cohort | int) -> list[int]:
     cache_key = _cohort_dependents_key(cohort_id)
 
     # Check if value exists in cache first
-    cache_hit = cache.has_key(cache_key)
+    cache_hit = dependency_cache.has_key(cache_key)
 
     def compute_or_fallback() -> list[int]:
         COHORT_DEPENDENCY_CACHE_COUNTER.labels(cache_type="dependents", result="miss").inc()
-        # If we only have an ID, query the database for team_id
+        # If we only have an ID, query the database for team_id. A soft-deleted cohort can still
+        # have live dependents, so the lookup must not filter on deleted.
         if isinstance(cohort, int):
             try:
-                team_id = Cohort.objects.filter(pk=cohort_id, deleted=False).values_list("team_id", flat=True).first()
+                team_id = Cohort.objects.filter(pk=cohort_id).values_list("team_id", flat=True).first()
                 if team_id is None:
                     logger.warning("Cohort not found when computing dependents", cohort_id=cohort_id)
                     return []
@@ -276,59 +303,142 @@ def get_cohort_dependents(cohort: Cohort | int) -> list[int]:
             team_id = cohort.team_id
 
         warm_team_cohort_dependency_cache(team_id)
-        return cache.get(cache_key, [])
+        return dependency_cache.get(cache_key, [])
 
     if cache_hit:
         COHORT_DEPENDENCY_CACHE_COUNTER.labels(cache_type="dependents", result="hit").inc()
 
-    result = cache.get_or_set(cache_key, compute_or_fallback, timeout=DEPENDENCY_CACHE_TIMEOUT)
+    result = dependency_cache.get_or_set(cache_key, compute_or_fallback, timeout=DEPENDENCY_CACHE_TIMEOUT)
     if result is None:
         logger.error("Cohort dependents cache returned None", cohort_id=cohort_id)
     return result or []
 
 
-def warm_team_cohort_dependency_cache(team_id: int, batch_size: int = 1000):
+def warm_team_cohort_dependency_cache(team_id: int, batch_size: int = 1000) -> int:
     """
-    Preloads the cohort dependencies and dependents cache for a given team.
+    Rebuilds both key families for every live cohort of a team from Postgres. Returns the number of
+    cohorts scanned.
 
     Uses keyset pagination on id instead of .iterator(), which opens a named
     server-side cursor that can be invalidated by connection recycling between
     batches (e.g. behind a pooler) and raises InvalidCursorName mid-scan.
+
+    Forward keys are written per batch. The reverse map is written once at the end, because a
+    dependency's dependents can span batches and a per-batch write would overwrite the earlier
+    part of the list.
     """
     dependents_map: dict[str, list[int]] = {}
+    scanned = 0
     last_id = 0
     while True:
-        batch = list(Cohort.objects.filter(team_id=team_id, deleted=False, id__gt=last_id).order_by("id")[:batch_size])
+        batch = list(
+            Cohort.objects.filter(team_id=team_id, deleted=False, id__gt=last_id)
+            .order_by("id")
+            .only("id", "team_id", "deleted", "filters", "groups")[:batch_size]
+        )
         if not batch:
             break
+        dependencies_map: dict[str, list[int]] = {}
         for cohort in batch:
-            # Any invalidated dependencies cache is rebuilt here
+            dependencies = extract_cohort_dependencies(cohort)
+            dependencies_map[_cohort_dependencies_key(cohort.id)] = list(dependencies)
             dependents_map.setdefault(_cohort_dependents_key(cohort.id), [])
-            dependencies = get_cohort_dependencies(cohort, _warming=True)
-            # Dependency keys aren't fully invalidated; make sure they don't expire.
-            cache.touch(_cohort_dependencies_key(cohort.id), timeout=DEPENDENCY_CACHE_TIMEOUT)
-            # Build reverse map
             for dep_id in dependencies:
                 dependents_map.setdefault(_cohort_dependents_key(dep_id), []).append(cohort.id)
+        dependency_cache.set_many(dependencies_map, timeout=DEPENDENCY_CACHE_TIMEOUT)
+        scanned += len(batch)
         last_id = batch[-1].id
-    cache.set_many(dependents_map, timeout=DEPENDENCY_CACHE_TIMEOUT)
+
+    dependents_items = list(dependents_map.items())
+    for start in range(0, len(dependents_items), batch_size):
+        dependency_cache.set_many(dict(dependents_items[start : start + batch_size]), timeout=DEPENDENCY_CACHE_TIMEOUT)
+
+    COHORT_DEPENDENCY_WARM_COHORTS_SCANNED.observe(scanned)
+    return scanned
 
 
-def _on_cohort_changed(cohort: Cohort, always_invalidate: bool = False):
+def _on_cohort_changed(
+    cohort: Cohort,
+    *,
+    created: bool = False,
+    hard_deleted: bool = False,
+    update_fields: frozenset[str] | None = None,
+) -> None:
+    """
+    Keeps the dependency key families consistent with one cohort's save or delete.
+
+    Only the changed cohort's own keys are written. The reverse lists of the cohorts it started or
+    stopped referencing are deleted rather than edited: DEL is idempotent, so two concurrent writers
+    cannot lose each other's update, and the next reader rebuilds the list from Postgres.
+    """
+    if not settings.COHORT_DEPENDENCY_INCREMENTAL_MAINTENANCE:
+        _on_cohort_changed_full_warm(cohort, always_invalidate=hard_deleted)
+        return
+
+    if update_fields is not None and DEPENDENCY_FIELDS.isdisjoint(update_fields):
+        COHORT_DEPENDENCY_MAINTENANCE_COUNTER.labels(operation="skipped", path="no_edges").inc()
+        return
+
+    removed = hard_deleted or cohort.deleted
+    if created:
+        operation = "create"
+        # Nothing can reference an id that did not exist before this save.
+        old_dependencies: set[int] = set()
+    elif removed:
+        operation = "hard_delete" if hard_deleted else "soft_delete"
+        # The cached value may have expired, but the instance still carries the filters that
+        # describe the edges being torn down.
+        old_dependencies = extract_cohort_dependencies(cohort, ignore_deleted=True)
+    else:
+        operation = "update"
+        # An expired key reads as "no previous edges", which leaves this cohort in a former
+        # dependency's reverse list until the next warm. Consumers filter such extra ids out.
+        old_dependencies = set(dependency_cache.get(_cohort_dependencies_key(cohort.id)) or [])
+    new_dependencies = set() if removed else extract_cohort_dependencies(cohort)
+
+    dependencies_key = _cohort_dependencies_key(cohort.id)
+    if removed:
+        # A soft-deleted cohort keeps its own reverse list: live cohorts may still reference it,
+        # and the scheduler follows those edges.
+        own_keys = [dependencies_key]
+        if hard_deleted:
+            own_keys.append(_cohort_dependents_key(cohort.id))
+        dependency_cache.delete_many(own_keys)
+    elif created:
+        dependency_cache.set_many(
+            {dependencies_key: list(new_dependencies), _cohort_dependents_key(cohort.id): []},
+            timeout=DEPENDENCY_CACHE_TIMEOUT,
+        )
+    else:
+        dependency_cache.set(dependencies_key, list(new_dependencies), timeout=DEPENDENCY_CACHE_TIMEOUT)
+
+    changed_dependencies = old_dependencies ^ new_dependencies
+    if changed_dependencies:
+        dependency_cache.delete_many([_cohort_dependents_key(dep_id) for dep_id in changed_dependencies])
+
+    path = "edges" if old_dependencies or new_dependencies else "no_edges"
+    COHORT_DEPENDENCY_MAINTENANCE_COUNTER.labels(operation=operation, path=path).inc()
+
+
+def _on_cohort_changed_full_warm(cohort: Cohort, always_invalidate: bool = False) -> None:
+    """
+    Fallback behind the COHORT_DEPENDENCY_INCREMENTAL_MAINTENANCE kill switch: invalidates the
+    changed cohort's keys and rescans the whole team.
+    """
     new_dependencies = extract_cohort_dependencies(cohort)
-    existing_dependencies = cache.get(_cohort_dependencies_key(cohort.id))
+    existing_dependencies = dependency_cache.get(_cohort_dependencies_key(cohort.id))
     dependencies_changed = existing_dependencies is None or set(existing_dependencies) != new_dependencies
 
     # If the dependencies haven't changed, no need to refresh the cache
     if not always_invalidate and not cohort.deleted and not dependencies_changed:
         return
 
-    cache.delete(_cohort_dependencies_key(cohort.id))
-    cache.delete(_cohort_dependents_key(cohort.id))
+    dependency_cache.delete(_cohort_dependencies_key(cohort.id))
+    dependency_cache.delete(_cohort_dependents_key(cohort.id))
 
     if existing_dependencies:
         for dep_id in existing_dependencies:
-            cache.delete(_cohort_dependents_key(dep_id))
+            dependency_cache.delete(_cohort_dependents_key(dep_id))
 
     warm_team_cohort_dependency_cache(cohort.team_id)
 
@@ -442,7 +552,9 @@ def cohort_changed(sender, instance, **kwargs):
     if is_cohort_recalculation_only_save(kwargs):
         return
 
-    transaction.on_commit(lambda: _on_cohort_changed(instance))
+    created = kwargs.get("created", False)
+    update_fields = kwargs.get("update_fields")
+    transaction.on_commit(lambda: _on_cohort_changed(instance, created=created, update_fields=update_fields))
     transaction.on_commit(lambda: _invalidate_team_behavioral_cohort_cache(instance.team_id))
 
 
@@ -560,7 +672,7 @@ def cohort_deleted(sender, instance, **kwargs):
     """
     Clear and rebuild dependency caches when cohort is deleted.
     """
-    transaction.on_commit(lambda: _on_cohort_changed(instance, always_invalidate=True))
+    transaction.on_commit(lambda: _on_cohort_changed(instance, hard_deleted=True))
     transaction.on_commit(lambda: _invalidate_team_behavioral_cohort_cache(instance.team_id))
 
 
@@ -573,8 +685,8 @@ def clear_team_cohort_dependency_cache(sender, instance: Team, **kwargs):
     def clear_cache():
         team_cohorts = Cohort.objects.filter(team_id=instance.pk, deleted=False).values_list("id", flat=True)
         for cohort_id in team_cohorts:
-            cache.delete(_cohort_dependencies_key(cohort_id))
-            cache.delete(_cohort_dependents_key(cohort_id))
+            dependency_cache.delete(_cohort_dependencies_key(cohort_id))
+            dependency_cache.delete(_cohort_dependents_key(cohort_id))
         _invalidate_team_behavioral_cohort_cache(instance.pk)
 
     transaction.on_commit(clear_cache)

--- a/products/cohorts/backend/models/test/test_dependencies.py
+++ b/products/cohorts/backend/models/test/test_dependencies.py
@@ -1,9 +1,11 @@
+from typing import Any
+
 from posthog.test.base import BaseTest
 from pytest import fixture
 from unittest import mock
 
 from django.core.cache import cache
-from django.db import connection
+from django.db import OperationalError, connection
 from django.test import override_settings
 from django.test.utils import CaptureQueriesContext
 
@@ -291,6 +293,27 @@ class TestCohortDependencies(BaseTest):
 
         self.assertCountEqual(cache.get(f"cohort:dependents:{base.id}"), [cohort.id for cohort in dependents])
 
+    def test_warm_rescans_when_an_edge_changes_during_the_scan(self) -> None:
+        cohort_a = self._create_cohort(name="Test Cohort A")
+        cohort_b = self._create_cohort(name="Test Cohort B")
+        cache.clear()
+        real_set_many = dependency_cache.set_many
+        edited = False
+
+        def add_edge_during_first_publish(data: dict[str, list[int]], **kwargs: Any) -> list[str]:
+            nonlocal edited
+            if not edited:
+                edited = True
+                cohort_b.groups = [{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.id}]}]
+                cohort_b.save()
+            return real_set_many(data, **kwargs)
+
+        with mock.patch.object(dependency_cache, "set_many", side_effect=add_edge_during_first_publish):
+            warm_team_cohort_dependency_cache(self.team.id)
+
+        self.assertEqual(cache.get(f"cohort:dependents:{cohort_a.id}"), [cohort_b.id])
+        self.assertEqual(cache.get(f"cohort:dependencies:{cohort_b.id}"), [cohort_a.id])
+
     def test_create_does_not_scan_team_cohorts(self) -> None:
         for i in range(25):
             self._create_cohort(name=f"Existing Cohort {i}")
@@ -419,6 +442,15 @@ class TestCohortDependencies(BaseTest):
 
         self.assertEqual(get_cohort_dependents(cohort_a.id), [cohort_b.id])
         self._assert_depends_on(cohort_b, cohort_a)
+
+    def test_dependents_lookup_failure_is_not_cached(self) -> None:
+        cohort_a = self._create_cohort(name="Test Cohort A")
+        cache.clear()
+
+        with mock.patch.object(Cohort.objects, "filter", side_effect=OperationalError("connection reset")):
+            self.assertEqual(get_cohort_dependents(cohort_a.id), [])
+
+        self.assertIsNone(cache.get(f"cohort:dependents:{cohort_a.id}"))
 
     @parameterized.expand(
         [

--- a/products/cohorts/backend/models/test/test_dependencies.py
+++ b/products/cohorts/backend/models/test/test_dependencies.py
@@ -3,6 +3,9 @@ from pytest import fixture
 from unittest import mock
 
 from django.core.cache import cache
+from django.db import connection
+from django.test import override_settings
+from django.test.utils import CaptureQueriesContext
 
 from parameterized import parameterized
 from rest_framework.exceptions import ValidationError
@@ -12,6 +15,7 @@ from products.cohorts.backend.models.dependencies import (
     COHORT_DEPENDENCY_CACHE_COUNTER,
     DEPENDENCY_CACHE_TIMEOUT,
     _behavioral_cohort_ids_key,
+    dependency_cache,
     extract_cohort_dependencies,
     get_cohort_dependencies,
     get_cohort_dependents,
@@ -26,9 +30,10 @@ class TestCohortDependencies(BaseTest):
 
     def _assert_depends_on(self, dependent_cohort: Cohort, dependency_cohort: Cohort) -> None:
         self.assertEqual(cache.get(f"cohort:dependencies:{dependent_cohort.id}"), [dependency_cohort.id])
-        self.assertEqual(cache.get(f"cohort:dependents:{dependency_cohort.id}"), [dependent_cohort.id])
         self.assertEqual(list(get_cohort_dependencies(dependent_cohort)), [dependency_cohort.id])
         self.assertEqual(list(get_cohort_dependents(dependency_cohort)), [dependent_cohort.id])
+        # Writes invalidate reverse lists and reads rebuild them, so the raw key is checked after the read.
+        self.assertEqual(cache.get(f"cohort:dependents:{dependency_cohort.id}"), [dependent_cohort.id])
 
     def _assert_cohorts_have_no_relationships(self, *cohorts: Cohort) -> None:
         for cohort in cohorts:
@@ -230,33 +235,149 @@ class TestCohortDependencies(BaseTest):
                 self.assertEqual(cache.get(f"cohort:dependencies:{cohort.id}"), [cohorts[i - 1].id])
                 self.assertEqual(cache.get(f"cohort:dependents:{cohort.id}"), [cohorts[i + 1].id])
 
-    def test_warm_team_cohort_dependency_cache_refreshes_ttl(self) -> None:
+    def test_warm_team_cohort_dependency_cache_sets_ttl_for_both_families(self) -> None:
         cohort_a = self._create_cohort(name="Test Cohort A")
         cohort_b = self._create_cohort(
             name="Test Cohort B", groups=[{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.id}]}]
         )
 
-        # Warm the cache initially
-        warm_team_cohort_dependency_cache(self.team.id)
-
-        # Mock cache.touch and cache.set_many to verify TTL refresh
-        with mock.patch.object(cache, "touch") as mock_touch, mock.patch.object(cache, "set_many") as mock_set_many:
-            # Call warm again - should refresh TTL
+        with mock.patch.object(dependency_cache, "set_many", wraps=dependency_cache.set_many) as mock_set_many:
             warm_team_cohort_dependency_cache(self.team.id)
 
-            # Verify touch was called for dependency keys
-            expected_dependency_keys = [
-                f"cohort:dependencies:{cohort_a.id}",
-                f"cohort:dependencies:{cohort_b.id}",
-            ]
+        written: dict[str, list[int]] = {}
+        for call in mock_set_many.call_args_list:
+            self.assertEqual(call.kwargs.get("timeout"), DEPENDENCY_CACHE_TIMEOUT)
+            written.update(call.args[0])
+        self.assertEqual(written[f"cohort:dependencies:{cohort_b.id}"], [cohort_a.id])
+        self.assertEqual(written[f"cohort:dependents:{cohort_a.id}"], [cohort_b.id])
 
-            for key in expected_dependency_keys:
-                mock_touch.assert_any_call(key, timeout=DEPENDENCY_CACHE_TIMEOUT)
+    def test_warm_uses_batched_writes_only(self) -> None:
+        cohort_a = self._create_cohort(name="Test Cohort A")
+        cohort_b = self._create_cohort(
+            name="Test Cohort B", groups=[{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.id}]}]
+        )
+        cohort_c = self._create_cohort(
+            name="Test Cohort C", groups=[{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.id}]}]
+        )
+        cache.clear()
 
-            # Verify set_many was called with timeout for dependents
-            self.assertTrue(mock_set_many.called)
-            args, kwargs = mock_set_many.call_args
-            self.assertEqual(kwargs.get("timeout"), DEPENDENCY_CACHE_TIMEOUT)
+        with (
+            mock.patch.object(dependency_cache, "has_key") as mock_has_key,
+            mock.patch.object(dependency_cache, "touch") as mock_touch,
+            mock.patch.object(dependency_cache, "get_or_set") as mock_get_or_set,
+            mock.patch.object(dependency_cache, "set_many", wraps=dependency_cache.set_many) as mock_set_many,
+        ):
+            scanned = warm_team_cohort_dependency_cache(self.team.id)
+
+        self.assertEqual(scanned, 3)
+        mock_has_key.assert_not_called()
+        mock_touch.assert_not_called()
+        mock_get_or_set.assert_not_called()
+        self.assertEqual(mock_set_many.call_count, 2)
+        self.assertCountEqual(cache.get(f"cohort:dependents:{cohort_a.id}"), [cohort_b.id, cohort_c.id])
+
+    def test_warm_reverse_map_spans_batches(self) -> None:
+        base = self._create_cohort(name="Base Cohort")
+        dependents = [
+            self._create_cohort(
+                name=f"Dependent Cohort {i}",
+                groups=[{"properties": [{"key": "id", "type": "cohort", "value": base.id}]}],
+            )
+            for i in range(4)
+        ]
+        cache.clear()
+
+        warm_team_cohort_dependency_cache(self.team.id, batch_size=2)
+
+        self.assertCountEqual(cache.get(f"cohort:dependents:{base.id}"), [cohort.id for cohort in dependents])
+
+    def test_create_does_not_scan_team_cohorts(self) -> None:
+        for i in range(25):
+            self._create_cohort(name=f"Existing Cohort {i}")
+
+        with (
+            mock.patch("products.cohorts.backend.models.dependencies.warm_team_cohort_dependency_cache") as mock_warm,
+            CaptureQueriesContext(connection) as queries,
+        ):
+            self._create_cohort(name="New Cohort")
+
+        mock_warm.assert_not_called()
+        cohort_reads = [query["sql"] for query in queries.captured_queries if 'FROM "posthog_cohort"' in query["sql"]]
+        self.assertEqual(cohort_reads, [])
+
+    def test_create_with_no_dependencies_writes_only_own_keys(self) -> None:
+        cohort_a = self._create_cohort(name="Test Cohort A")
+        cache.set(f"cohort:dependents:{cohort_a.id}", [999])
+
+        with mock.patch.object(dependency_cache, "delete_many", wraps=dependency_cache.delete_many) as mock_delete:
+            cohort_b = self._create_cohort(name="Test Cohort B")
+
+        mock_delete.assert_not_called()
+        self.assertEqual(cache.get(f"cohort:dependencies:{cohort_b.id}"), [])
+        self.assertEqual(cache.get(f"cohort:dependents:{cohort_b.id}"), [])
+        self.assertEqual(cache.get(f"cohort:dependents:{cohort_a.id}"), [999])
+
+    def test_create_with_dependency_invalidates_target_dependents(self) -> None:
+        cohort_a = self._create_cohort(name="Test Cohort A")
+        cache.set(f"cohort:dependents:{cohort_a.id}", [999])
+
+        cohort_c = self._create_cohort(
+            name="Test Cohort C", groups=[{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.id}]}]
+        )
+
+        self.assertIsNone(cache.get(f"cohort:dependents:{cohort_a.id}"))
+        self.assertEqual(cache.get(f"cohort:dependencies:{cohort_c.id}"), [cohort_a.id])
+        self.assertEqual(get_cohort_dependents(cohort_a), [cohort_c.id])
+
+    def test_hard_delete_with_dependencies_key_absent(self) -> None:
+        cohort_a = self._create_cohort(name="Test Cohort A")
+        cohort_b = self._create_cohort(
+            name="Test Cohort B", groups=[{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.id}]}]
+        )
+        self._assert_depends_on(cohort_b, cohort_a)
+        cache.delete(f"cohort:dependencies:{cohort_b.id}")
+
+        cohort_b.delete()
+
+        self.assertIsNone(cache.get(f"cohort:dependents:{cohort_a.id}"))
+        self.assertEqual(get_cohort_dependents(cohort_a), [])
+
+    def test_soft_delete_then_restore_readds_reverse_edge(self) -> None:
+        cohort_a = self._create_cohort(name="Test Cohort A")
+        cohort_c = self._create_cohort(
+            name="Test Cohort C", groups=[{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.id}]}]
+        )
+        self._assert_depends_on(cohort_c, cohort_a)
+
+        cohort_c.deleted = True
+        cohort_c.save()
+        self.assertEqual(get_cohort_dependents(cohort_a), [])
+
+        cohort_c.deleted = False
+        cohort_c.save()
+        self.assertEqual(get_cohort_dependents(cohort_a), [cohort_c.id])
+
+    def test_save_without_definition_fields_skips_maintenance(self) -> None:
+        cohort_a = self._create_cohort(name="Test Cohort A")
+        cohort_b = self._create_cohort(
+            name="Test Cohort B", groups=[{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.id}]}]
+        )
+        self._assert_depends_on(cohort_b, cohort_a)
+
+        with mock.patch("products.cohorts.backend.models.dependencies.warm_team_cohort_dependency_cache") as mock_warm:
+            cohort_b.name = "Renamed Cohort B"
+            cohort_b.save(update_fields=["name"])
+
+        mock_warm.assert_not_called()
+        self.assertEqual(cache.get(f"cohort:dependents:{cohort_a.id}"), [cohort_b.id])
+        self.assertEqual(cache.get(f"cohort:dependencies:{cohort_b.id}"), [cohort_a.id])
+
+    @override_settings(COHORT_DEPENDENCY_INCREMENTAL_MAINTENANCE=False)
+    def test_kill_switch_restores_full_warm(self) -> None:
+        with mock.patch("products.cohorts.backend.models.dependencies.warm_team_cohort_dependency_cache") as mock_warm:
+            cohort = self._create_cohort(name="Test Cohort A")
+
+        mock_warm.assert_called_once_with(cohort.team_id)
 
     def test_cache_miss_get_cohort_dependencies(self) -> None:
         cohort_a = self._create_cohort(name="Test Cohort A")


### PR DESCRIPTION
## Problem

Creating, deleting, or editing one cohort costs time proportional to how many cohorts the project already holds, and that work runs inside the web request.

- Each such write runs `warm_team_cohort_dependency_cache` inline, through `transaction.on_commit` with no `ATOMIC_REQUESTS`.
- The warm loads every live cohort of the team from Postgres with full `filters` and does three to four Redis round trips per cohort.
- A create always takes that path: the new cohort's cache key does not exist yet, so it reads as "dependencies changed".
- The cost is independent of the request itself, so a project with many cohorts pays for all of them on every write.

## Changes

- A cohort write now costs one or two Redis round trips and no extra Postgres reads. Nothing user-visible changes.
- `_on_cohort_changed` writes only the changed cohort's own keys and deletes the reverse lists of the cohorts it started or stopped referencing. DEL is idempotent, so concurrent writers cannot lose an update, and the next reader rebuilds the list.
- Delete paths take the old dependency set from the instance's own filters, so an expired cache key no longer leaves a dangling reverse entry.
- A read miss on `dependents` still warms the team, but the warm loads only `filters` and `groups`, writes with `set_many`, and never runs from a write path.
- The two key families move to a writer-only cache alias, `cohort_dependencies`, mirroring `organization_access`. The create path reads its own keys back in the same request, and a replica-lag miss would rescan the team.
- `COHORT_DEPENDENCY_INCREMENTAL_MAINTENANCE` (default on) falls back to the full warm. A wrong incremental update shows only as a shorter recalculation chain, which no dashboard surfaces, so a config flip has to beat a revert.
- `get_cohort_dependents` no longer filters the team lookup on `deleted`, so a soft-deleted cohort with live dependents stops caching an empty list for a week.
- New metrics: `posthog_cohort_dependency_maintenance_total{operation,path}` and the histogram `posthog_cohort_dependency_warm_cohorts_scanned`.
- Supersedes #94251, which batched the warm's Redis calls but kept the warm on every save.

> [!NOTE]
> Residual staleness: an update whose cached `dependencies` key expired leaves the cohort in a former dependency's reverse list until the next warm. Consumers filter extra ids out. Missing ids, the case consumers do not tolerate, are never produced by this path.

## How did you test this code?

- Existing `test_dependencies.py` cases pass with one helper reordered (the raw reverse-key assertion moves after the read that rebuilds it) and the TTL test rewritten for `set_many`.
- New tests, each named for the regression it catches: a create on a team with existing cohorts issues no cohort table read and no warm; a create with no references writes only its own keys; a create with a reference invalidates the target's reverse list; a hard delete with the `dependencies` key absent still invalidates; soft delete then restore re-adds the reverse edge; a save without definition fields skips maintenance; the warm uses batched writes only; the reverse map spans batches; the kill switch restores the full warm.
- Also run locally: `test_cohort_update_recalculated_after_caching`, the dependency-chain tests in `test_calculate_cohort.py`, the dependency tests in `test_util.py`, `hogli lint:tach`, repo-wide mypy, and `hogli ci:preflight`.
- Not run: the full `test_cohort.py` and `test_calculate_cohort.py` suites.

## Docs update

No.