### PR TITLE
fix(replay-vision): keep goal drafts from truncating, and name the failure

### DIFF
--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -58,6 +58,7 @@ const ERROR_FILTER_ALLOW_LIST = [
     'loadMonitoringSeries', // The managed warehouse Monitoring tab renders its own partial/error state
     'loadInstrumentationChecklist', // AI observability hides its checklist entirely rather than accusing a project on data it could not read
     'loadFullEmail', // Its failure listener shows a retry toast and closes the modal
+    'draftScannerFromGoal', // replayScannerLogic's failure listener toasts and routes back to the goal questions
 ]
 
 /*

--- a/products/replay_vision/backend/api/scanners.py
+++ b/products/replay_vision/backend/api/scanners.py
@@ -2254,12 +2254,19 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, vi
                     user_access_control=self.user_access_control,
                     include_business_context=include_business_context,
                 )
-        except DraftError:
+        except DraftError as e:
+            # The 503 below is deliberately uniform, so the reason only survives here.
+            logger.warning(
+                "replay_vision.scanner_draft.failed",
+                team_id=self.team_id,
+                reason=e.reason,
+                goal_flow=goal_flow,
+            )
             # Report failures too, so model errors don't read as user abandonment.
             report_user_action(
                 cast(User, request.user),
                 "replay_vision_scanner_drafted",
-                {**draft_properties, "success": False},
+                {**draft_properties, "success": False, "failure_reason": e.reason},
                 team=self.team,
                 request=request,
             )

--- a/products/replay_vision/backend/scanner_draft.py
+++ b/products/replay_vision/backend/scanner_draft.py
@@ -20,7 +20,7 @@ from django.db.models import Q
 
 import structlog
 import posthoganalytics
-from google.genai.types import GenerateContentConfig, GenerateContentResponse
+from google.genai.types import FinishReason, GenerateContentConfig, GenerateContentResponse
 from posthoganalytics.ai.gemini import genai
 from pydantic import BaseModel, Field
 
@@ -73,8 +73,10 @@ _SCALE_MAX_ALLOWED = 100
 _SCALE_SPAN_ALLOWED = 100
 # CoreMemory.text is model-capped at 10k chars; cap lower to keep the one-shot draft prompt lean.
 _MAX_BUSINESS_CONTEXT_CHARS = 5_000
-# Well above the largest plausible draft (a full config is a few hundred tokens); only caps runaway output.
-_MAX_OUTPUT_TOKENS = 4096
+# Thinking tokens are drawn from this same budget, and a vague goal ("help") makes the model
+# deliberate far longer than it writes: at 4096 the JSON was being cut off mid-object after only
+# ~150 tokens of answer. The draft itself is a few hundred tokens, so this only caps runaway output.
+_MAX_OUTPUT_TOKENS = 16384
 # Bounds on assembled context so a scanner-heavy team can't blow up the prompt.
 _MAX_EXISTING_SCANNERS = 15
 _SCANNER_GIST_CHARS = 200
@@ -525,6 +527,14 @@ def draft_scanner_from_goal(
     return _finalize(parsed, allowed_screens=taxonomy.screens, allowed_events=taxonomy.events, team_id=team.id)
 
 
+def _hit_output_cap(response: GenerateContentResponse) -> bool:
+    """Whether the model stopped because it ran out of output budget, leaving the JSON unfinished."""
+    for candidate in response.candidates or []:
+        if candidate.finish_reason == FinishReason.MAX_TOKENS:
+            return True
+    return False
+
+
 def _generate(
     *,
     user_content: str,
@@ -582,6 +592,11 @@ def _generate(
             logger.exception("replay_vision.scanner_draft.generate_failed", team_id=team_id)
             raise DraftError("model_call_failed") from e
 
+    if _hit_output_cap(response):
+        # Truncated JSON parses as invalid, but the cause is our budget rather than the model
+        # writing nonsense — keep the two apart so a recurrence is recognizable.
+        logger.warning("replay_vision.scanner_draft.output_truncated", team_id=team_id, feature=feature)
+        raise DraftError("output_truncated")
     if not response.text:
         raise DraftError("empty_response")
     try:

--- a/products/replay_vision/backend/scanner_draft.py
+++ b/products/replay_vision/backend/scanner_draft.py
@@ -819,6 +819,10 @@ recordings of the user's product and produces one observation per recording. The
 - summarizer: writes a free-text summary of the session. Best when the goal is broad ("what are users
   doing?", "give me an overview") and doesn't fit one question, dimension, or vocabulary.
 
+A short or vague goal ("help", "what's going on") is not a puzzle to work out. Draft a summarizer over
+the whole product with no filters and move on. The user reviews the draft in the wizard and narrows it
+there, so a broad draft is the right answer, not a guess at what they meant.
+
 Pick the single type that best fits the goal, then draft the scanner:
 - name: short and specific, under 8 words.
 - description: one sentence saying what the scanner looks for.

--- a/products/replay_vision/backend/scanner_draft.py
+++ b/products/replay_vision/backend/scanner_draft.py
@@ -819,7 +819,7 @@ recordings of the user's product and produces one observation per recording. The
 - summarizer: writes a free-text summary of the session. Best when the goal is broad ("what are users
   doing?", "give me an overview") and doesn't fit one question, dimension, or vocabulary.
 
-A short or vague goal ("help", "what's going on") is not a puzzle to work out. Draft a summarizer over
+A short or vague goal ("test", "help", "what's going on") is not a puzzle to work out. Draft a summarizer over
 the whole product with no filters and move on. The user reviews the draft in the wizard and narrows it
 there, so a broad draft is the right answer, not a guess at what they meant.
 

--- a/products/replay_vision/backend/scanner_draft.py
+++ b/products/replay_vision/backend/scanner_draft.py
@@ -206,7 +206,16 @@ _GOAL_STOPWORDS = frozenset(
 
 
 class DraftError(Exception):
-    """Raised when the model call fails or returns nothing usable."""
+    """Raised when the model call fails or returns nothing usable.
+
+    `reason` is a stable slug carried into telemetry. The user-facing 503 is deliberately generic,
+    so it is the only thing that tells a provider outage apart from a draft the model got wrong.
+    """
+
+    def __init__(self, reason: str = "unknown", detail: str = "") -> None:
+        super().__init__(f"{reason}: {detail}" if detail else reason)
+        self.reason = reason
+        self.detail = detail
 
 
 class _LlmDraft(BaseModel):
@@ -536,7 +545,7 @@ def _generate(
     except Exception as e:
         # A missing or malformed API key raises at construction. Wrap it so the API returns
         # the friendly 503 instead of a 500.
-        raise DraftError("model client unavailable") from e
+        raise DraftError("model_client_unavailable") from e
     config = GenerateContentConfig(
         system_instruction=system_prompt,
         response_mime_type="application/json",
@@ -571,14 +580,14 @@ def _generate(
             response = call_model()
         except Exception as e:
             logger.exception("replay_vision.scanner_draft.generate_failed", team_id=team_id)
-            raise DraftError("model call failed") from e
+            raise DraftError("model_call_failed") from e
 
     if not response.text:
-        raise DraftError("empty response")
+        raise DraftError("empty_response")
     try:
         return response_model.model_validate_json(response.text)
     except Exception as e:
-        raise DraftError("invalid response") from e
+        raise DraftError("invalid_response") from e
 
 
 def _grounded(proposed: list[str], allowed: Sequence[str], cap: int) -> list[str]:
@@ -642,7 +651,7 @@ def _normalized_config(parsed: _LlmDraft) -> dict[str, Any]:
     # (e.g. a classifier whose tags all slugified away).
     error = scanner_config_error(ScannerType(parsed.scanner_type), scanner_config)
     if error:
-        raise DraftError(f"draft config invalid: {error}")
+        raise DraftError("config_invalid", str(error))
     return scanner_config
 
 
@@ -656,7 +665,7 @@ def _finalize(
     """Normalize the model output into a draft the wizard form (and later the create endpoint) will accept."""
     name = parsed.name.strip()[:_MAX_NAME_LENGTH]
     if not name or not parsed.prompt.strip():
-        raise DraftError("draft missing name or prompt")
+        raise DraftError("missing_name_or_prompt")
     scanner_config = _normalized_config(parsed)
 
     screens = _grounded(
@@ -1344,7 +1353,7 @@ def _finalize_v2(
     """Normalize the v2 model output; costing is applied by the caller."""
     name = parsed.name.strip()[:_MAX_NAME_LENGTH]
     if not name or not parsed.prompt.strip():
-        raise DraftError("draft missing name or prompt")
+        raise DraftError("missing_name_or_prompt")
     scanner_config = _normalized_config(parsed)  # type: ignore[arg-type]
 
     # The briefing shows each page as "/billing (10)" for ranking, but the prompt tells the model to

--- a/products/replay_vision/backend/scanner_draft.py
+++ b/products/replay_vision/backend/scanner_draft.py
@@ -73,10 +73,11 @@ _SCALE_MAX_ALLOWED = 100
 _SCALE_SPAN_ALLOWED = 100
 # CoreMemory.text is model-capped at 10k chars; cap lower to keep the one-shot draft prompt lean.
 _MAX_BUSINESS_CONTEXT_CHARS = 5_000
-# Thinking tokens are drawn from this same budget, and a vague goal ("help") makes the model
-# deliberate far longer than it writes: at 4096 the JSON was being cut off mid-object after only
-# ~150 tokens of answer. The draft itself is a few hundred tokens, so this only caps runaway output.
-_MAX_OUTPUT_TOKENS = 16384
+# Thinking tokens are drawn from this same budget, and a vague goal makes the model deliberate far
+# longer than it writes: at 4096 the JSON was being cut off mid-object after only ~150 tokens of
+# answer. Doubling it clears that while staying well inside `_MODEL_CALL_TIMEOUT_MS` — a budget the
+# model cannot exhaust before the request times out just trades a quick failure for a slow one.
+_MAX_OUTPUT_TOKENS = 8192
 # Bounds on assembled context so a scanner-heavy team can't blow up the prompt.
 _MAX_EXISTING_SCANNERS = 15
 _SCANNER_GIST_CHARS = 200

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -1062,12 +1062,18 @@ class TestScannerLifecycleTelemetry(_VisionAPITestCase):
 
     @parameterized.expand(
         [
-            ("drafted", None, 200, True),
-            ("model_failed", DraftError(), 503, False),
+            ("drafted", None, 200, True, None),
+            ("model_failed", DraftError("model_call_failed"), 503, False, "model_call_failed"),
+            ("bad_draft", DraftError("config_invalid", "tags are required"), 503, False, "config_invalid"),
         ]
     )
     def test_draft_reports_outcome(
-        self, _name: str, error: Exception | None, expected_status: int, expected_success: bool
+        self,
+        _name: str,
+        error: Exception | None,
+        expected_status: int,
+        expected_success: bool,
+        expected_reason: str | None,
     ) -> None:
         # A draft that reports nothing would read as user abandonment instead of a model failure.
         self.organization.is_ai_data_processing_approved = True
@@ -1097,6 +1103,8 @@ class TestScannerLifecycleTelemetry(_VisionAPITestCase):
         properties = drafted_events[0].args[2]
         self.assertEqual(properties["success"], expected_success)
         self.assertEqual(properties["goal_length"], len(goal))
+        # A uniform 503 can't be triaged, so the failure mode has to reach telemetry.
+        self.assertEqual(properties.get("failure_reason"), expected_reason)
         # The goal is customer text; only its length may ride along.
         self.assertNotIn("goal", properties)
 

--- a/products/replay_vision/backend/tests/test_scanner_draft.py
+++ b/products/replay_vision/backend/tests/test_scanner_draft.py
@@ -422,7 +422,7 @@ class TestGenerate:
 
         _generate(user_content="goal", team_id=1, distinct_id="u")
 
-        assert generate.call_args.kwargs["config"].max_output_tokens == 16384
+        assert generate.call_args.kwargs["config"].max_output_tokens == 8192
 
     @patch("products.replay_vision.backend.scanner_draft.genai.Client")
     def test_output_cut_off_by_the_token_budget_is_its_own_failure(self, mock_client_cls):

--- a/products/replay_vision/backend/tests/test_scanner_draft.py
+++ b/products/replay_vision/backend/tests/test_scanner_draft.py
@@ -3,9 +3,8 @@ from unittest.mock import MagicMock, patch
 
 from django.utils import timezone
 
-from rest_framework import status
-
 from google.genai.types import FinishReason
+from rest_framework import status
 
 from posthog.schema import RecordingsQuery
 

--- a/products/replay_vision/backend/tests/test_scanner_draft.py
+++ b/products/replay_vision/backend/tests/test_scanner_draft.py
@@ -5,6 +5,8 @@ from django.utils import timezone
 
 from rest_framework import status
 
+from google.genai.types import FinishReason
+
 from posthog.schema import RecordingsQuery
 
 from posthog.models import EventDefinition, PersonalAPIKey
@@ -420,7 +422,22 @@ class TestGenerate:
 
         _generate(user_content="goal", team_id=1, distinct_id="u")
 
-        assert generate.call_args.kwargs["config"].max_output_tokens == 4096
+        assert generate.call_args.kwargs["config"].max_output_tokens == 16384
+
+    @patch("products.replay_vision.backend.scanner_draft.genai.Client")
+    def test_output_cut_off_by_the_token_budget_is_its_own_failure(self, mock_client_cls):
+        # Thinking shares the output budget, so a truncated draft is our cap's fault, not a bad
+        # model response — the two used to be indistinguishable as "invalid_response".
+        truncated = MagicMock(
+            text='{"scanner_type": "classifier", "name": "Chec',
+            candidates=[MagicMock(finish_reason=FinishReason.MAX_TOKENS)],
+        )
+        self._mock_client(mock_client_cls, [truncated])
+
+        with pytest.raises(DraftError) as caught:
+            _generate(user_content="goal", team_id=1, distinct_id="u")
+
+        assert caught.value.reason == "output_truncated"
 
 
 class TestDraftScannerEndpoint(_VisionAPITestCase):


### PR DESCRIPTION
## Problem

Drafting a Replay Vision scanner from a goal fails intermittently: the wizard shows "Couldn't draft a scanner right now. Try again in a moment." Retrying the same goal keeps failing, while other goals in the same project succeed, which made it look project-specific or flaky.

It isn't. Gemini draws thinking tokens from the same `max_output_tokens` budget as the answer. A short or vague goal gives the model nothing to decide the page, event, and cohort filters from, so it deliberates instead of answering, blows through the 4096-token cap, and stops mid-JSON after only ~150 tokens of actual draft. The truncated body then fails schema validation and becomes a generic 503. Every failed draft in the telemetry pairs with a *successful* model call that finished on `MAX_TOKENS`; every successful draft finished on `STOP`.

Two things hid this. The `DraftError` for a truncated response was indistinguishable from every other one, so the drafted-outcome event could say a draft failed but not why. And the failure raised two stacked toasts for one error — `replayScannerLogic` toasts it, then `initKea`'s generic kea-loaders handler toasts the same 503 again.

## Changes

- Vague goals get a draft instead of an error. The drafting prompt now says that a short goal ("test", "help") is not a puzzle to work out: draft a broad summarizer over the whole product, because the user narrows it in the wizard anyway. That removes the deliberation that exhausted the budget.
- The output budget doubles to 8192 as the backstop for when the model still thinks its way past the answer. It is sized against the request timeout, not just against the draft: truncated runs burned their whole 4096 budget in roughly 17-21 seconds, so a much larger budget would take longer to exhaust than the 90 second provider timeout allows, turning a quick failure into a slow one.
- A failed draft now shows one toast instead of two. `draftScannerFromGoal` joins `ERROR_FILTER_ALLOW_LIST`, the existing opt-out for loaders whose own failure listener already handles the error.
- `DraftError` carries a stable `reason` slug, logged and attached to the `replay_vision_scanner_drafted` failure event as `failure_reason`. A truncated response gets its own reason rather than being folded into `invalid_response`, so a recurrence is recognizable instead of looking like flakiness. The user-facing 503 body is unchanged.

## How did you test this code?

Automated only. This environment has no Django/ClickHouse test runner, so nothing was executed locally and no manual UI check was done — relying on CI.

Two tests were added or extended, each for a regression nothing else caught. `test_output_cut_off_by_the_token_budget_is_its_own_failure` covers a `MAX_TOKENS` response, which previously fell through to `invalid_response` and was indistinguishable from a malformed one. `test_draft_reports_outcome` now asserts the reported `failure_reason` and covers a second failure mode; before, any `DraftError` passed as long as `success` was `False`.

The prompt rule and the budget are only verifiable against the real provider, and neither is covered beyond the existing assertion on the configured value. No eval suite covers drafting, so the prompt change is unguarded — worth a manual pass with a deliberately vague goal before this leaves draft.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Started from a screenshot of two stacked toasts and traced both strings to their sources, then to the 503 and the `DraftError` raise sites. The double toast looked like the whole story until the drafted-outcome events showed failures clustered on the goal-based flow. Correlating those with AI observability generations settled it: no errored model calls at all, and every failure lined up with a successful generation whose `$ai_stop_reason` was `MAX_TOKENS`.

Two revisions came out of review. The first version only raised the budget, which was the wrong emphasis — the model should answer a vague goal broadly rather than deliberate, so the prompt rule is now the fix and the budget is the backstop. The budget itself was then cut from 16384 to 8192 once the truncated runs' own throughput showed the larger value could not be exhausted inside the request timeout. Bounding thinking with an explicit `ThinkingConfig` budget was considered and rejected: provider support for a thinking budget on these models could not be verified here, and getting it wrong fails every draft rather than some.

Two neighbouring failure modes turned up in the same telemetry and are deliberately out of scope: the legacy flow truncates in a different way (a rambling answer rather than long deliberation), and a small number of calls on both flows time out at the 90s provider timeout with zero output tokens.

No repo skills were invoked. `gh pr list --state open --search` found no existing PR for this. No customer data, session material, or operational figures appear in this diff or description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
