### PR TITLE
feat(metrics): count OTel metrics ingestion in usage reports and activate on data

### DIFF
--- a/posthog/models/product_intent/product_intent.py
+++ b/posthog/models/product_intent/product_intent.py
@@ -229,10 +229,17 @@ class ProductIntent(UUIDTModel, RootTeamMixin):
         return contexts.get("mcp_analytics_viewed", 0) >= 1
 
     def has_activated_metrics(self) -> bool:
-        # The user has charted or queried metrics. Charting/querying is only possible
-        # once metrics have reached the team (a metric name has to exist to pick), so an
-        # engagement signal is itself proof of ingestion — and ingestion on its own is a
-        # connected pipeline, not an activated product.
+        # Two independent paths activate metrics:
+        #
+        # 1. Engagement: the user has charted or queried metrics. Charting/querying is only
+        #    possible once metrics have reached the team (a metric name has to exist to pick),
+        #    so an engagement signal is itself proof of ingestion.
+        #
+        # 2. Ingestion: the team has metric data flowing. While the viewer sat behind a
+        #    private-alpha allowlist, engagement-only activation was circular — only
+        #    allowlisted teams could ever fire the UI events — so a team sending data with
+        #    no UI access could never activate. Data flowing is the outcome the product
+        #    intent describes, whether or not anyone has opened the viewer yet.
         #
         # We deliberately do NOT gate on `metrics_first_ingested`: that context fires only
         # when the frontend observes a no-metrics -> has-metrics flip in-session, so a team
@@ -247,7 +254,14 @@ class ProductIntent(UUIDTModel, RootTeamMixin):
             return False
 
         contexts = intent.contexts or {}
-        return contexts.get("metrics_viewer_query_run", 0) >= 1 or contexts.get("metrics_sql_query_run", 0) >= 1
+        if contexts.get("metrics_viewer_query_run", 0) >= 1 or contexts.get("metrics_sql_query_run", 0) >= 1:
+            return True
+
+        # Local import: this module loads during django.setup() (via posthog.models), and the
+        # metrics query runner pulls in HogQL execution (circular).
+        from products.metrics.backend.has_metrics_query_runner import team_has_metrics  # noqa: PLC0415
+
+        return team_has_metrics(self.team)
 
     def has_activated_workflows(self) -> bool:
         # At least one workflow needs to be active (not just drafted)

--- a/posthog/models/product_intent/product_intent.py
+++ b/posthog/models/product_intent/product_intent.py
@@ -235,11 +235,8 @@ class ProductIntent(UUIDTModel, RootTeamMixin):
         #    possible once metrics have reached the team (a metric name has to exist to pick),
         #    so an engagement signal is itself proof of ingestion.
         #
-        # 2. Ingestion: the team has metric data flowing. While the viewer sat behind a
-        #    private-alpha allowlist, engagement-only activation was circular — only
-        #    allowlisted teams could ever fire the UI events — so a team sending data with
-        #    no UI access could never activate. Data flowing is the outcome the product
-        #    intent describes, whether or not anyone has opened the viewer yet.
+        # 2. Ingestion: the team has metric data flowing. Sending data does not require the
+        #    viewer, so a team can reach the product outcome without ever firing a UI event.
         #
         # We deliberately do NOT gate on `metrics_first_ingested`: that context fires only
         # when the frontend observes a no-metrics -> has-metrics flip in-session, so a team
@@ -258,10 +255,17 @@ class ProductIntent(UUIDTModel, RootTeamMixin):
             return True
 
         # Local import: this module loads during django.setup() (via posthog.models), and the
-        # metrics query runner pulls in HogQL execution (circular).
-        from products.metrics.backend.has_metrics_query_runner import team_has_metrics  # noqa: PLC0415
+        # metrics facade pulls in HogQL execution (circular).
+        from products.metrics.backend.facade.api import team_has_metrics  # noqa: PLC0415
 
-        return team_has_metrics(self.team)
+        # Activation checks run on the request path (intent registration), so a ClickHouse
+        # failure must not fail the caller — treat it as "no data yet" and let the periodic
+        # recheck pick the team up later.
+        try:
+            return team_has_metrics(self.team)
+        except Exception:
+            logger.exception("has_activated_metrics: data lookup failed", team_id=self.team_id)
+            return False
 
     def has_activated_workflows(self) -> bool:
         # At least one workflow needs to be active (not just drafted)

--- a/posthog/models/test/test_product_intent.py
+++ b/posthog/models/test/test_product_intent.py
@@ -813,9 +813,8 @@ class TestProductIntent(BaseTest):
             # Pre-existing-metrics teams never record the transition-only first-ingested
             # context, so engagement alone must still activate them.
             ("charted without first-ingested intent", {"metrics_viewer_query_run": 3}, False, True),
-            # Data flowing activates without any engagement: during the gated alpha only
-            # allowlisted teams could fire the UI events, so a sending team with no viewer
-            # access would otherwise never activate.
+            # Data flowing activates without any engagement: sending does not require the
+            # viewer, so ingestion alone is the product outcome.
             ("ingesting but never looked at", {"metrics_first_ingested": 1}, True, True),
             ("ingesting with no contexts at all", {}, True, True),
             # No engagement and no data is not activation.
@@ -827,7 +826,7 @@ class TestProductIntent(BaseTest):
         intent = self._make_metrics_intent(contexts)
 
         with patch(
-            "products.metrics.backend.has_metrics_query_runner.team_has_metrics",
+            "products.metrics.backend.facade.api.team_has_metrics",
             return_value=has_data,
         ):
             assert intent.has_activated_metrics() is expected

--- a/posthog/models/test/test_product_intent.py
+++ b/posthog/models/test/test_product_intent.py
@@ -802,25 +802,35 @@ class TestProductIntent(BaseTest):
         [
             # Charting or querying is only possible once metrics have reached the team,
             # so any engagement signal is itself proof of ingestion + activation.
-            ("charted", {"metrics_viewer_query_run": 1}, True),
-            ("queried in sql", {"metrics_sql_query_run": 2}, True),
+            ("charted", {"metrics_viewer_query_run": 1}, False, True),
+            ("queried in sql", {"metrics_sql_query_run": 2}, False, True),
             (
                 "first-ingested recorded then charted",
                 {"metrics_first_ingested": 1, "metrics_viewer_query_run": 1},
+                False,
                 True,
             ),
             # Pre-existing-metrics teams never record the transition-only first-ingested
             # context, so engagement alone must still activate them.
-            ("charted without first-ingested intent", {"metrics_viewer_query_run": 3}, True),
-            # Ingestion alone (no engagement) is a connected pipeline, not activation.
-            ("first-ingested but never looked at", {"metrics_first_ingested": 1}, False),
-            ("no engagement at all", {}, False),
+            ("charted without first-ingested intent", {"metrics_viewer_query_run": 3}, False, True),
+            # Data flowing activates without any engagement: during the gated alpha only
+            # allowlisted teams could fire the UI events, so a sending team with no viewer
+            # access would otherwise never activate.
+            ("ingesting but never looked at", {"metrics_first_ingested": 1}, True, True),
+            ("ingesting with no contexts at all", {}, True, True),
+            # No engagement and no data is not activation.
+            ("first-ingested context but no data found", {"metrics_first_ingested": 1}, False, False),
+            ("no engagement at all", {}, False, False),
         ]
     )
-    def test_has_activated_metrics(self, _name: str, contexts: dict, expected: bool) -> None:
+    def test_has_activated_metrics(self, _name: str, contexts: dict, has_data: bool, expected: bool) -> None:
         intent = self._make_metrics_intent(contexts)
 
-        assert intent.has_activated_metrics() is expected
+        with patch(
+            "products.metrics.backend.has_metrics_query_runner.team_has_metrics",
+            return_value=has_data,
+        ):
+            assert intent.has_activated_metrics() is expected
 
     def test_check_and_update_activation_activates_metrics(self) -> None:
         # Guards the registration, not the criterion: an unregistered check never runs.

--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -624,6 +624,22 @@
   '''
   
   SELECT team_id,
+         metric_name,
+         SUM(count) as count
+  FROM app_metrics2
+  WHERE app_source='metrics'
+    AND metric_name IN ('bytes_ingested',
+                        'records_ingested')
+    AND timestamp >= '2022-01-10 00:00:00'
+    AND timestamp < '2022-01-10 23:59:59'
+  GROUP BY team_id,
+           metric_name
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.32
+  '''
+  
+  SELECT team_id,
          multiIf(replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'web', 'web', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'js', 'web_lite', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-node', 'node', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-edge', 'node', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-android', 'android', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-flutter', 'flutter', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-ios', 'ios', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-go', 'go', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-java', 'java', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-server', 'java', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-react-native', 'react_native', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-ruby', 'ruby', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-python', 'python', 'unknown') AS library,
          count(1) as total
   FROM events
@@ -634,7 +650,7 @@
            library
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.32
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.33
   '''
   
   SELECT team_id,
@@ -646,7 +662,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.33
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.34
   '''
   
   SELECT team_id,
@@ -658,7 +674,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.34
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.35
   '''
   
   SELECT team_id,
@@ -670,7 +686,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.35
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.36
   '''
   
   SELECT team_id,
@@ -682,7 +698,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.36
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.37
   '''
   
   SELECT team_id,
@@ -694,7 +710,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.37
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.38
   '''
   
   SELECT team_id,
@@ -706,7 +722,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.38
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.39
   '''
   
   SELECT team_id,
@@ -714,18 +730,6 @@
   FROM events
   WHERE timestamp >= '2022-01-10 12:00:00'
     AND timestamp < '2022-01-10 14:00:00'
-    AND event NOT IN ['$feature_flag_called', '$experiment_exposure', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$llm_prompt_fetched', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_tag', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters', '$conversations_loaded', '$conversations_widget_loaded', '$conversations_message_sent', '$conversations_user_identified', '$conversations_restore_link_requested', '$conversations_widget_state_changed', '$conversations_back_to_tickets']
-  GROUP BY team_id
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.39
-  '''
-  
-  SELECT team_id,
-         count(distinct toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)) as count
-  FROM events
-  WHERE timestamp >= '2022-01-10 14:00:00'
-    AND timestamp < '2022-01-10 16:00:00'
     AND event NOT IN ['$feature_flag_called', '$experiment_exposure', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$llm_prompt_fetched', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_tag', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters', '$conversations_loaded', '$conversations_widget_loaded', '$conversations_message_sent', '$conversations_user_identified', '$conversations_restore_link_requested', '$conversations_widget_state_changed', '$conversations_back_to_tickets']
   GROUP BY team_id
   '''
@@ -776,13 +780,25 @@
   SELECT team_id,
          count(distinct toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)) as count
   FROM events
+  WHERE timestamp >= '2022-01-10 14:00:00'
+    AND timestamp < '2022-01-10 16:00:00'
+    AND event NOT IN ['$feature_flag_called', '$experiment_exposure', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$llm_prompt_fetched', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_tag', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters', '$conversations_loaded', '$conversations_widget_loaded', '$conversations_message_sent', '$conversations_user_identified', '$conversations_restore_link_requested', '$conversations_widget_state_changed', '$conversations_back_to_tickets']
+  GROUP BY team_id
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.41
+  '''
+  
+  SELECT team_id,
+         count(distinct toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)) as count
+  FROM events
   WHERE timestamp >= '2022-01-10 16:00:00'
     AND timestamp < '2022-01-10 18:00:00'
     AND event NOT IN ['$feature_flag_called', '$experiment_exposure', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$llm_prompt_fetched', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_tag', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters', '$conversations_loaded', '$conversations_widget_loaded', '$conversations_message_sent', '$conversations_user_identified', '$conversations_restore_link_requested', '$conversations_widget_state_changed', '$conversations_back_to_tickets']
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.41
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.42
   '''
   
   SELECT team_id,
@@ -794,7 +810,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.42
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.43
   '''
   
   SELECT team_id,
@@ -806,7 +822,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.43
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.44
   '''
   
   SELECT team_id,
@@ -818,7 +834,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.44
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.45
   '''
   
   SELECT team_id,
@@ -832,7 +848,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.45
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.46
   '''
   
   SELECT team_id,
@@ -846,7 +862,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.46
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.47
   '''
   
   SELECT team_id,
@@ -860,7 +876,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.47
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.48
   '''
   
   SELECT team_id,
@@ -874,7 +890,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.48
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.49
   '''
   
   SELECT team_id,
@@ -882,20 +898,6 @@
   FROM events
   WHERE timestamp >= '2022-01-10 08:00:00'
     AND timestamp < '2022-01-10 10:00:00'
-    AND event NOT IN ['$feature_flag_called', '$experiment_exposure', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$llm_prompt_fetched', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_tag', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters', '$conversations_loaded', '$conversations_widget_loaded', '$conversations_message_sent', '$conversations_user_identified', '$conversations_restore_link_requested', '$conversations_widget_state_changed', '$conversations_back_to_tickets']
-    AND person_mode IN ('full',
-                        'force_upgrade')
-  GROUP BY team_id
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.49
-  '''
-  
-  SELECT team_id,
-         count(distinct toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)) as count
-  FROM events
-  WHERE timestamp >= '2022-01-10 10:00:00'
-    AND timestamp < '2022-01-10 12:00:00'
     AND event NOT IN ['$feature_flag_called', '$experiment_exposure', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$llm_prompt_fetched', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_tag', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters', '$conversations_loaded', '$conversations_widget_loaded', '$conversations_message_sent', '$conversations_user_identified', '$conversations_restore_link_requested', '$conversations_widget_state_changed', '$conversations_back_to_tickets']
     AND person_mode IN ('full',
                         'force_upgrade')
@@ -948,6 +950,20 @@
   SELECT team_id,
          count(distinct toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)) as count
   FROM events
+  WHERE timestamp >= '2022-01-10 10:00:00'
+    AND timestamp < '2022-01-10 12:00:00'
+    AND event NOT IN ['$feature_flag_called', '$experiment_exposure', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$llm_prompt_fetched', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_tag', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters', '$conversations_loaded', '$conversations_widget_loaded', '$conversations_message_sent', '$conversations_user_identified', '$conversations_restore_link_requested', '$conversations_widget_state_changed', '$conversations_back_to_tickets']
+    AND person_mode IN ('full',
+                        'force_upgrade')
+  GROUP BY team_id
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.51
+  '''
+  
+  SELECT team_id,
+         count(distinct toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)) as count
+  FROM events
   WHERE timestamp >= '2022-01-10 12:00:00'
     AND timestamp < '2022-01-10 14:00:00'
     AND event NOT IN ['$feature_flag_called', '$experiment_exposure', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$llm_prompt_fetched', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_tag', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters', '$conversations_loaded', '$conversations_widget_loaded', '$conversations_message_sent', '$conversations_user_identified', '$conversations_restore_link_requested', '$conversations_widget_state_changed', '$conversations_back_to_tickets']
@@ -956,7 +972,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.51
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.52
   '''
   
   SELECT team_id,
@@ -970,7 +986,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.52
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.53
   '''
   
   SELECT team_id,
@@ -984,7 +1000,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.53
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.54
   '''
   
   SELECT team_id,
@@ -998,7 +1014,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.54
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.55
   '''
   
   SELECT team_id,
@@ -1012,7 +1028,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.55
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.56
   '''
   
   SELECT team_id,
@@ -1026,7 +1042,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.56
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.57
   '''
   
   SELECT team_id,
@@ -1042,7 +1058,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.57
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.58
   '''
   
   SELECT team_id,
@@ -1050,29 +1066,6 @@
   FROM heatmaps
   WHERE timestamp >= '2022-01-10 00:00:00'
     AND timestamp < '2022-01-10 23:59:59'
-  GROUP BY team_id
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.58
-  '''
-  
-  SELECT team_id,
-         count(distinct session_id) as count
-  FROM
-    (SELECT any(team_id) as team_id,
-            session_id
-     FROM session_replay_events
-     WHERE min_first_timestamp >= '2022-01-10 00:00:00'
-       AND min_first_timestamp < '2022-01-10 23:59:59'
-     GROUP BY session_id
-     HAVING (ifNull(argMinMerge(snapshot_source), 'web') == 'mobile') == 0
-     AND max(is_deleted) = 0)
-  WHERE session_id NOT IN
-      (SELECT DISTINCT session_id
-       FROM session_replay_events
-       WHERE min_first_timestamp >= '2022-01-09 00:00:00'
-         AND min_first_timestamp < '2022-01-10 00:00:00'
-       GROUP BY session_id)
   GROUP BY team_id
   '''
 # ---
@@ -1088,7 +1081,7 @@
      WHERE min_first_timestamp >= '2022-01-10 00:00:00'
        AND min_first_timestamp < '2022-01-10 23:59:59'
      GROUP BY session_id
-     HAVING dateDiff('milliseconds', min(min_first_timestamp), max(max_last_timestamp)) = 0
+     HAVING (ifNull(argMinMerge(snapshot_source), 'web') == 'mobile') == 0
      AND max(is_deleted) = 0)
   WHERE session_id NOT IN
       (SELECT DISTINCT session_id
@@ -1143,6 +1136,29 @@
   '''
   
   SELECT team_id,
+         count(distinct session_id) as count
+  FROM
+    (SELECT any(team_id) as team_id,
+            session_id
+     FROM session_replay_events
+     WHERE min_first_timestamp >= '2022-01-10 00:00:00'
+       AND min_first_timestamp < '2022-01-10 23:59:59'
+     GROUP BY session_id
+     HAVING dateDiff('milliseconds', min(min_first_timestamp), max(max_last_timestamp)) = 0
+     AND max(is_deleted) = 0)
+  WHERE session_id NOT IN
+      (SELECT DISTINCT session_id
+       FROM session_replay_events
+       WHERE min_first_timestamp >= '2022-01-09 00:00:00'
+         AND min_first_timestamp < '2022-01-10 00:00:00'
+       GROUP BY session_id)
+  GROUP BY team_id
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.61
+  '''
+  
+  SELECT team_id,
          sum(total_size) as bytes
   FROM
     (SELECT any(team_id) as team_id,
@@ -1163,7 +1179,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.61
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.62
   '''
   
   SELECT team_id,
@@ -1186,7 +1202,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.62
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.63
   '''
   
   SELECT team_id,
@@ -1210,7 +1226,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.63
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.64
   '''
   
   SELECT team_id,
@@ -1233,7 +1249,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.64
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.65
   '''
   
   SELECT distinct_id as team,
@@ -1247,7 +1263,7 @@
   GROUP BY team
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.65
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.66
   '''
   
   SELECT distinct_id as team,
@@ -1261,32 +1277,13 @@
   GROUP BY team
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.66
-  '''
-  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
-       JSONExtractString(log_comment, 'query_type') as query_type,
-       JSONExtractString(log_comment, 'access_method') as access_method
-  SELECT team_id,
-         sum(read_bytes) as count
-  FROM clusterAllReplicas(posthog, system.query_log)
-  WHERE (type = 'QueryFinish'
-         OR type = 'ExceptionWhileProcessing')
-    AND is_initial_query = 1
-    AND event_time >= 'today 00:00:00'
-    AND event_time < '2022-01-11 05:59:59'
-    AND query_start_time >= '2022-01-10 00:00:00'
-    AND query_start_time < '2022-01-10 23:59:59'
-    AND access_method = ''
-  GROUP BY team_id
-  '''
-# ---
 # name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.67
   '''
   WITH JSONExtractInt(log_comment, 'team_id') as team_id,
        JSONExtractString(log_comment, 'query_type') as query_type,
        JSONExtractString(log_comment, 'access_method') as access_method
   SELECT team_id,
-         sum(read_rows) as count
+         sum(read_bytes) as count
   FROM clusterAllReplicas(posthog, system.query_log)
   WHERE (type = 'QueryFinish'
          OR type = 'ExceptionWhileProcessing')
@@ -1305,7 +1302,7 @@
        JSONExtractString(log_comment, 'query_type') as query_type,
        JSONExtractString(log_comment, 'access_method') as access_method
   SELECT team_id,
-         sum(query_duration_ms) as count
+         sum(read_rows) as count
   FROM clusterAllReplicas(posthog, system.query_log)
   WHERE (type = 'QueryFinish'
          OR type = 'ExceptionWhileProcessing')
@@ -1324,7 +1321,7 @@
        JSONExtractString(log_comment, 'query_type') as query_type,
        JSONExtractString(log_comment, 'access_method') as access_method
   SELECT team_id,
-         sum(read_bytes) as count
+         sum(query_duration_ms) as count
   FROM clusterAllReplicas(posthog, system.query_log)
   WHERE (type = 'QueryFinish'
          OR type = 'ExceptionWhileProcessing')
@@ -1333,7 +1330,7 @@
     AND event_time < '2022-01-11 05:59:59'
     AND query_start_time >= '2022-01-10 00:00:00'
     AND query_start_time < '2022-01-10 23:59:59'
-    AND access_method = 'personal_api_key'
+    AND access_method = ''
   GROUP BY team_id
   '''
 # ---
@@ -1383,7 +1380,7 @@
        JSONExtractString(log_comment, 'query_type') as query_type,
        JSONExtractString(log_comment, 'access_method') as access_method
   SELECT team_id,
-         sum(read_rows) as count
+         sum(read_bytes) as count
   FROM clusterAllReplicas(posthog, system.query_log)
   WHERE (type = 'QueryFinish'
          OR type = 'ExceptionWhileProcessing')
@@ -1402,7 +1399,7 @@
        JSONExtractString(log_comment, 'query_type') as query_type,
        JSONExtractString(log_comment, 'access_method') as access_method
   SELECT team_id,
-         sum(query_duration_ms) as count
+         sum(read_rows) as count
   FROM clusterAllReplicas(posthog, system.query_log)
   WHERE (type = 'QueryFinish'
          OR type = 'ExceptionWhileProcessing')
@@ -1421,17 +1418,16 @@
        JSONExtractString(log_comment, 'query_type') as query_type,
        JSONExtractString(log_comment, 'access_method') as access_method
   SELECT team_id,
-         sum(read_bytes) as count
+         sum(query_duration_ms) as count
   FROM clusterAllReplicas(posthog, system.query_log)
   WHERE (type = 'QueryFinish'
          OR type = 'ExceptionWhileProcessing')
     AND is_initial_query = 1
-    AND query_type IN (['EventsQuery'])
     AND event_time >= 'today 00:00:00'
     AND event_time < '2022-01-11 05:59:59'
     AND query_start_time >= '2022-01-10 00:00:00'
     AND query_start_time < '2022-01-10 23:59:59'
-    AND access_method = ''
+    AND access_method = 'personal_api_key'
   GROUP BY team_id
   '''
 # ---
@@ -1441,7 +1437,7 @@
        JSONExtractString(log_comment, 'query_type') as query_type,
        JSONExtractString(log_comment, 'access_method') as access_method
   SELECT team_id,
-         sum(read_rows) as count
+         sum(read_bytes) as count
   FROM clusterAllReplicas(posthog, system.query_log)
   WHERE (type = 'QueryFinish'
          OR type = 'ExceptionWhileProcessing')
@@ -1461,7 +1457,7 @@
        JSONExtractString(log_comment, 'query_type') as query_type,
        JSONExtractString(log_comment, 'access_method') as access_method
   SELECT team_id,
-         sum(query_duration_ms) as count
+         sum(read_rows) as count
   FROM clusterAllReplicas(posthog, system.query_log)
   WHERE (type = 'QueryFinish'
          OR type = 'ExceptionWhileProcessing')
@@ -1481,7 +1477,7 @@
        JSONExtractString(log_comment, 'query_type') as query_type,
        JSONExtractString(log_comment, 'access_method') as access_method
   SELECT team_id,
-         sum(read_bytes) as count
+         sum(query_duration_ms) as count
   FROM clusterAllReplicas(posthog, system.query_log)
   WHERE (type = 'QueryFinish'
          OR type = 'ExceptionWhileProcessing')
@@ -1491,7 +1487,7 @@
     AND event_time < '2022-01-11 05:59:59'
     AND query_start_time >= '2022-01-10 00:00:00'
     AND query_start_time < '2022-01-10 23:59:59'
-    AND access_method = 'personal_api_key'
+    AND access_method = ''
   GROUP BY team_id
   '''
 # ---
@@ -1501,7 +1497,7 @@
        JSONExtractString(log_comment, 'query_type') as query_type,
        JSONExtractString(log_comment, 'access_method') as access_method
   SELECT team_id,
-         sum(read_rows) as count
+         sum(read_bytes) as count
   FROM clusterAllReplicas(posthog, system.query_log)
   WHERE (type = 'QueryFinish'
          OR type = 'ExceptionWhileProcessing')
@@ -1521,7 +1517,7 @@
        JSONExtractString(log_comment, 'query_type') as query_type,
        JSONExtractString(log_comment, 'access_method') as access_method
   SELECT team_id,
-         sum(query_duration_ms) as count
+         sum(read_rows) as count
   FROM clusterAllReplicas(posthog, system.query_log)
   WHERE (type = 'QueryFinish'
          OR type = 'ExceptionWhileProcessing')
@@ -1536,6 +1532,26 @@
   '''
 # ---
 # name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.78
+  '''
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(query_duration_ms) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['EventsQuery'])
+    AND event_time >= 'today 00:00:00'
+    AND event_time < '2022-01-11 05:59:59'
+    AND query_start_time >= '2022-01-10 00:00:00'
+    AND query_start_time < '2022-01-10 23:59:59'
+    AND access_method = 'personal_api_key'
+  GROUP BY team_id
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.79
   '''
   
   SELECT team_id,
@@ -1557,21 +1573,6 @@
                     ELSE replaceRegexpAll(JSONExtractRaw(properties, '$survey_submission_id'), '^"|"$', '')
                 END)
   GROUP BY team_id
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.79
-  '''
-  
-  SELECT team_id,
-         SUM(count) as count
-  FROM app_metrics2
-  WHERE app_source='hog_function'
-    AND metric_name IN ('succeeded',
-                        'failed')
-    AND timestamp >= '2022-01-10 00:00:00'
-    AND timestamp < '2022-01-10 23:59:59'
-  GROUP BY team_id,
-           metric_name
   '''
 # ---
 # name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.8
@@ -1621,7 +1622,8 @@
          SUM(count) as count
   FROM app_metrics2
   WHERE app_source='hog_function'
-    AND metric_name IN ('fetch')
+    AND metric_name IN ('succeeded',
+                        'failed')
     AND timestamp >= '2022-01-10 00:00:00'
     AND timestamp < '2022-01-10 23:59:59'
   GROUP BY team_id,
@@ -1635,13 +1637,27 @@
          SUM(count) as count
   FROM app_metrics2
   WHERE app_source='hog_function'
+    AND metric_name IN ('fetch')
+    AND timestamp >= '2022-01-10 00:00:00'
+    AND timestamp < '2022-01-10 23:59:59'
+  GROUP BY team_id,
+           metric_name
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.82
+  '''
+  
+  SELECT team_id,
+         SUM(count) as count
+  FROM app_metrics2
+  WHERE app_source='hog_function'
     AND metric_name IN ('billable_invocation')
     AND timestamp >= '2022-01-10 00:00:00'
     AND timestamp < '2022-01-10 23:59:59'
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.82
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.83
   '''
   
   SELECT team_id,
@@ -1663,7 +1679,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.83
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.84
   '''
   
   SELECT team_id,
@@ -1677,7 +1693,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.84
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.85
   '''
   
   SELECT team_id,
@@ -1691,7 +1707,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.85
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.86
   '''
   
   SELECT team_id,
@@ -1705,7 +1721,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.86
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.87
   '''
   
   SELECT team_id,
@@ -1719,7 +1735,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.87
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.88
   '''
   
   SELECT team_id,

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -3655,6 +3655,48 @@ class TestHogFunctionUsageReports(ClickhouseDestroyTablesMixin, TestCase, Clickh
             assert org_1_report[field] == value, field
             assert team_1_report[field] == value, field
 
+    @patch("posthog.tasks.usage_report.get_ph_client")
+    @patch("posthog.tasks.usage_report.send_report_to_billing_service")
+    def test_metrics_usage_metrics(
+        self,
+        billing_task_mock: MagicMock,
+        posthog_capture_mock: MagicMock,
+    ) -> None:
+        self._setup_teams()
+
+        for metric_name, count in {"bytes_ingested": 3_500_000, "records_ingested": 120}.items():
+            create_app_metric2(
+                team_id=self.org_1_team_1.id,
+                app_source="metrics",
+                metric_name=metric_name,
+                count=count,
+            )
+        # Same metric names under the logs app_source must not leak into the metrics counters.
+        create_app_metric2(
+            team_id=self.org_1_team_1.id,
+            app_source="logs",
+            metric_name="records_ingested",
+            count=999,
+        )
+
+        period = get_previous_day(at=now() + relativedelta(days=1))
+        all_reports = _get_all_org_reports(period=period)
+
+        org_1_report = _get_full_org_usage_report_as_dict(
+            _get_full_org_usage_report(all_reports[str(self.org_1.id)], get_instance_metadata(period))
+        )
+
+        expected = {
+            "metrics_bytes_in_period": 3_500_000,
+            "metrics_records_in_period": 120,
+            "metrics_mb_in_period": 3,
+        }
+        # Only org_1_team_1 has metrics usage, so the org-level rollup equals that team's values.
+        team_1_report = org_1_report["teams"][str(self.org_1_team_1.id)]
+        for field, value in expected.items():
+            assert org_1_report[field] == value, field
+            assert team_1_report[field] == value, field
+
 
 @freeze_time("2022-01-10T10:00:00Z")
 class TestErrorTrackingUsageReport(ClickhouseDestroyTablesMixin, TestCase, ClickhouseTestMixin):

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -3687,7 +3687,6 @@ class TestHogFunctionUsageReports(ClickhouseDestroyTablesMixin, TestCase, Clickh
         )
 
         expected = {
-            "metrics_bytes_in_period": 3_500_000,
             "metrics_records_in_period": 120,
             "metrics_mb_in_period": 3,
         }

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -391,7 +391,6 @@ class UsageReportCounters:
 
     # Metrics (OTel). Report-only while the product is in alpha — makes per-team ingestion
     # visible fleet-wide, the same signal logs_records_in_period provides for logs.
-    metrics_bytes_in_period: int
     metrics_records_in_period: int
     metrics_mb_in_period: int
 
@@ -2871,7 +2870,7 @@ def has_non_zero_usage(report: UsageReportCounters) -> bool:
         or report.task_sandbox_seconds_in_period > 0
         or report.logs_bytes_in_period > 0
         or report.apm_tracing_bytes_in_period > 0
-        or report.metrics_bytes_in_period > 0
+        or report.metrics_records_in_period > 0
         or report.workflow_emails_sent_in_period > 0
         or report.workflow_push_sent_in_period > 0
         or report.workflow_sms_sent_in_period > 0
@@ -3237,7 +3236,6 @@ def _get_team_report(all_data: dict[str, Any], team: Team) -> UsageReportCounter
     )
     logs_bytes_in_period = all_data["teams_with_logs_bytes_in_period"].get(team.id, 0)
     apm_tracing_bytes_in_period = all_data["teams_with_apm_tracing_bytes_in_period"].get(team.id, 0)
-    metrics_bytes_in_period = all_data["teams_with_metrics_bytes_in_period"].get(team.id, 0)
     return UsageReportCounters(
         event_count_in_period=all_data["teams_with_event_count_in_period"].get(team.id, 0),
         enhanced_persons_event_count_in_period=all_data["teams_with_enhanced_persons_event_count_in_period"].get(
@@ -3457,9 +3455,8 @@ def _get_team_report(all_data: dict[str, Any], team: Team) -> UsageReportCounter
         apm_tracing_bytes_in_period=apm_tracing_bytes_in_period,
         apm_tracing_spans_in_period=all_data["teams_with_apm_tracing_spans_in_period"].get(team.id, 0),
         apm_tracing_mb_in_period=int(apm_tracing_bytes_in_period // 1_000_000),
-        metrics_bytes_in_period=metrics_bytes_in_period,
         metrics_records_in_period=all_data["teams_with_metrics_records_in_period"].get(team.id, 0),
-        metrics_mb_in_period=int(metrics_bytes_in_period // 1_000_000),
+        metrics_mb_in_period=int(all_data["teams_with_metrics_bytes_in_period"].get(team.id, 0) // 1_000_000),
     )
 
 

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -2719,6 +2719,7 @@ def get_teams_with_apm_tracing_usage_in_period(
 def get_teams_with_metrics_usage_in_period(
     begin: datetime,
     end: datetime,
+    # nosemgrep: tuple-return-prefer-dataclass -- (team_id, count) rows are the shared usage-report contract consumed by convert_team_usage_rows_to_dict, like the logs and traces functions above.
 ) -> dict[str, list[tuple[int, int]]]:
     """
     Returns Metrics (OTel) ingested bytes and record counts per team for the period,

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -389,6 +389,12 @@ class UsageReportCounters:
     apm_tracing_spans_in_period: int
     apm_tracing_mb_in_period: int
 
+    # Metrics (OTel). Report-only while the product is in alpha — makes per-team ingestion
+    # visible fleet-wide, the same signal logs_records_in_period provides for logs.
+    metrics_bytes_in_period: int
+    metrics_records_in_period: int
+    metrics_mb_in_period: int
+
 
 # Instance metadata to be included in overall report
 @dataclasses.dataclass
@@ -2708,6 +2714,43 @@ def get_teams_with_apm_tracing_usage_in_period(
     return usage
 
 
+@timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
+def get_teams_with_metrics_usage_in_period(
+    begin: datetime,
+    end: datetime,
+) -> dict[str, list[tuple[int, int]]]:
+    """
+    Returns Metrics (OTel) ingested bytes and record counts per team for the period,
+    keyed by `bytes` / `records`; each value is a list of `(team_id, count)` tuples ready
+    for `convert_team_usage_rows_to_dict`.
+
+    The metrics ingestion consumer emits the same pre-aggregated `app_metrics2` counters
+    as logs and traces, under `app_source='metrics'`.
+    """
+    with tags_context(product=Product.METRICS, feature=Feature.USAGE_REPORT):
+        rows = sync_execute(
+            """
+            SELECT team_id, metric_name, SUM(count) as count
+            FROM app_metrics2
+            WHERE app_source='metrics'
+              AND metric_name IN ('bytes_ingested', 'records_ingested')
+              AND timestamp >= %(begin)s AND timestamp < %(end)s
+            GROUP BY team_id, metric_name
+            """,
+            {"begin": begin, "end": end},
+            workload=Workload.OFFLINE,
+            settings=CH_BILLING_SETTINGS,
+            ch_user=ClickHouseUser.BILLING,
+        )
+
+    key_by_metric = {"bytes_ingested": "bytes", "records_ingested": "records"}
+    usage: dict[str, list[tuple[int, int]]] = {"bytes": [], "records": []}
+    for team_id, metric_name, count in rows:
+        usage[key_by_metric[metric_name]].append((team_id, count))
+    return usage
+
+
 def _trim_oversize_usage_report_payload(full_report_dict: dict[str, Any]) -> dict[str, Any]:
     """Drop the per-team breakdown when the serialized report would exceed Kafka's
     message size limit, so the org-level roll-up still makes it through ingestion.
@@ -2827,6 +2870,7 @@ def has_non_zero_usage(report: UsageReportCounters) -> bool:
         or report.task_sandbox_seconds_in_period > 0
         or report.logs_bytes_in_period > 0
         or report.apm_tracing_bytes_in_period > 0
+        or report.metrics_bytes_in_period > 0
         or report.workflow_emails_sent_in_period > 0
         or report.workflow_push_sent_in_period > 0
         or report.workflow_sms_sent_in_period > 0
@@ -2865,6 +2909,7 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
     logs_retention_by_tier = get_teams_with_logs_retention_bytes_in_period(period_start, period_end)
     logs_retention_byte_days_rows = get_teams_with_logs_retention_byte_days_in_period(period_start, period_end)
     apm_tracing_usage = get_teams_with_apm_tracing_usage_in_period(period_start, period_end)
+    metrics_usage = get_teams_with_metrics_usage_in_period(period_start, period_end)
     exception_metrics_by_library, exception_metrics = get_teams_with_exceptions_captured_in_period(
         period_start, period_end
     )
@@ -3153,6 +3198,8 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
         "teams_with_ruby_logs_records_in_period": sdk_logs_by_suffix["ruby"],
         "teams_with_apm_tracing_bytes_in_period": apm_tracing_usage["bytes"],
         "teams_with_apm_tracing_spans_in_period": apm_tracing_usage["spans"],
+        "teams_with_metrics_bytes_in_period": metrics_usage["bytes"],
+        "teams_with_metrics_records_in_period": metrics_usage["records"],
     }
 
 
@@ -3189,6 +3236,7 @@ def _get_team_report(all_data: dict[str, Any], team: Team) -> UsageReportCounter
     )
     logs_bytes_in_period = all_data["teams_with_logs_bytes_in_period"].get(team.id, 0)
     apm_tracing_bytes_in_period = all_data["teams_with_apm_tracing_bytes_in_period"].get(team.id, 0)
+    metrics_bytes_in_period = all_data["teams_with_metrics_bytes_in_period"].get(team.id, 0)
     return UsageReportCounters(
         event_count_in_period=all_data["teams_with_event_count_in_period"].get(team.id, 0),
         enhanced_persons_event_count_in_period=all_data["teams_with_enhanced_persons_event_count_in_period"].get(
@@ -3408,6 +3456,9 @@ def _get_team_report(all_data: dict[str, Any], team: Team) -> UsageReportCounter
         apm_tracing_bytes_in_period=apm_tracing_bytes_in_period,
         apm_tracing_spans_in_period=all_data["teams_with_apm_tracing_spans_in_period"].get(team.id, 0),
         apm_tracing_mb_in_period=int(apm_tracing_bytes_in_period // 1_000_000),
+        metrics_bytes_in_period=metrics_bytes_in_period,
+        metrics_records_in_period=all_data["teams_with_metrics_records_in_period"].get(team.id, 0),
+        metrics_mb_in_period=int(metrics_bytes_in_period // 1_000_000),
     )
 
 

--- a/posthog/temporal/usage_report/queries.py
+++ b/posthog/temporal/usage_report/queries.py
@@ -75,6 +75,7 @@ from posthog.tasks.usage_report import (
     get_teams_with_logs_records_in_period,
     get_teams_with_logs_retention_byte_days_in_period,
     get_teams_with_logs_retention_bytes_in_period,
+    get_teams_with_metrics_usage_in_period,
     get_teams_with_mobile_billable_recording_count_in_period,
     get_teams_with_posthog_code_credits_used_in_period,
     get_teams_with_query_metric,
@@ -583,6 +584,16 @@ QUERIES: list[QuerySpec] = [
         multi_keys_mapping={
             "bytes": "teams_with_apm_tracing_bytes_in_period",
             "spans": "teams_with_apm_tracing_spans_in_period",
+        },
+    ),
+    # ---- ClickHouse: Metrics (OTel) -------------------------------------------
+    QuerySpec(
+        name="metrics_usage",
+        fn=get_teams_with_metrics_usage_in_period,
+        output="multi",
+        multi_keys_mapping={
+            "bytes": "teams_with_metrics_bytes_in_period",
+            "records": "teams_with_metrics_records_in_period",
         },
     ),
     # ---- Snapshot queries (kind="snapshot") ---------------------------------

--- a/products/metrics/backend/has_metrics_query_runner.py
+++ b/products/metrics/backend/has_metrics_query_runner.py
@@ -12,6 +12,15 @@ from posthog.models import Team
 
 HAS_METRICS_CACHE_TTL = int(dt.timedelta(days=7).total_seconds())
 
+# Negative results are cached too, but only briefly. The activation check
+# (posthog/models/product_intent) reaches this from the un-throttled
+# add_product_intent request path, so an uncached False is a fresh ClickHouse
+# query per request — a resource-exhaustion path. The TTL stays well under the
+# setup prompt's 5s poll interval (metricsSetupLogic.pollIntervalMs), so a team
+# that just wired up OTel sees the no-metrics -> has-metrics flip within one
+# extra poll cycle instead of being pinned to a stale empty state.
+HAS_METRICS_NEGATIVE_CACHE_TTL = int(dt.timedelta(seconds=4).total_seconds())
+
 
 class HasMetricsQueryRunner:
     def __init__(self, team: Team) -> None:
@@ -41,10 +50,10 @@ class HasMetricsQueryRunner:
 
 def team_has_metrics(team: Team) -> bool:
     cache_key = f"team:{team.id}:has_metrics"
-    if cache.get(cache_key) is True:
-        return True
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
 
     has_metrics = HasMetricsQueryRunner(team).run()
-    if has_metrics:
-        cache.set(cache_key, True, HAS_METRICS_CACHE_TTL)
+    cache.set(cache_key, has_metrics, HAS_METRICS_CACHE_TTL if has_metrics else HAS_METRICS_NEGATIVE_CACHE_TTL)
     return has_metrics

--- a/products/metrics/backend/tests/test_has_metrics_query_runner.py
+++ b/products/metrics/backend/tests/test_has_metrics_query_runner.py
@@ -123,7 +123,12 @@ class TestHasMetricsAPI(ClickhouseTestMixin, APIBaseTest):
 
             assert mock_report.call_count == 2
 
-    def test_has_metrics_api_does_not_cache_negative_results(self):
+    def test_has_metrics_api_caches_negative_results_briefly(self):
+        # Negatives are cached with a short TTL: the activation check reaches
+        # this through the un-throttled add_product_intent request path, so an
+        # uncached False is a per-request ClickHouse query. The TTL stays under
+        # the setup prompt's 5s poll interval, so a team that just wired up
+        # OTel still sees the flip within one extra poll cycle.
         cache.clear()
 
         with patch("products.metrics.backend.has_metrics_query_runner.HasMetricsQueryRunner") as mock_runner:
@@ -134,7 +139,25 @@ class TestHasMetricsAPI(ClickhouseTestMixin, APIBaseTest):
             self.assertEqual(response.json(), {"hasMetrics": False})
             self.assertEqual(mock_runner.return_value.run.call_count, 1)
 
+            # Second call within the TTL hits the cache, not ClickHouse
             response = self.client.get(f"/api/projects/{self.team.id}/metrics/has_metrics")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.json(), {"hasMetrics": False})
+            self.assertEqual(mock_runner.return_value.run.call_count, 1)
+
+    def test_has_metrics_negative_cache_expires(self):
+        cache.clear()
+
+        with (
+            patch("products.metrics.backend.has_metrics_query_runner.HasMetricsQueryRunner") as mock_runner,
+            patch("products.metrics.backend.has_metrics_query_runner.HAS_METRICS_NEGATIVE_CACHE_TTL", 0),
+        ):
+            mock_runner.return_value.run.return_value = False
+
+            response = self.client.get(f"/api/projects/{self.team.id}/metrics/has_metrics")
+            self.assertEqual(response.json(), {"hasMetrics": False})
+
+            # TTL of 0 means the negative is not held: the next call re-queries
+            response = self.client.get(f"/api/projects/{self.team.id}/metrics/has_metrics")
             self.assertEqual(response.json(), {"hasMetrics": False})
             self.assertEqual(mock_runner.return_value.run.call_count, 2)


### PR DESCRIPTION
## Problem

A team sending OTel metrics is invisible fleet-wide: usage reports carry logs and traces ingestion counters but none for metrics, so nobody can answer "which teams are sending metrics" from analytics.

The metrics product intent also could not activate for such a team. Activation requires viewer or SQL engagement events, and those fire only inside the flag-gated viewer, so a team sending data without viewer access could never count as activated. This matters now: metrics is moving from a private-alpha allowlist to an open alpha, and the funnel from setup to data flowing needs to be measurable from day one.

## Changes

- Usage reports gain `metrics_bytes_in_period`, `metrics_records_in_period`, and `metrics_mb_in_period` per team and org, so metrics ingestion becomes visible in the `organization usage report` events. Read from the `app_metrics2` counters the metrics ingestion consumer already emits under `app_source='metrics'`, mirroring `get_teams_with_apm_tracing_usage_in_period`. Report-only: no billing or quota behavior changes.
- A team with metric data flowing now activates the metrics product intent even if nobody has opened the viewer. Engagement events still activate as before; the new path asks `team_has_metrics` (cached ClickHouse existence check) only when engagement is absent.
- `has_non_zero_usage` now counts metrics bytes, so an org whose only usage is metrics still gets a usage report.

## How did you test this code?

- `pytest posthog/models/test/test_product_intent.py -k metrics` — extends the existing parameterized activation test with an ingestion dimension; catches a regression where a data-sending team without viewer engagement fails to activate, and where no data plus no engagement wrongly activates.
- `pytest posthog/tasks/test/test_usage_report.py -k 'test_metrics_usage_metrics or test_apm_tracing_usage_metrics'` — new test mirrors the APM one; catches the `app_source` filter leaking logs counters into metrics fields.
- Not checked: a live usage-report run against production ClickHouse.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal reporting fields.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Agent-authored (Claude Code in PostHog Desktop) directed by the assignee, as part of moving Metrics from private to open alpha. Skills invoked: /writing-tests, /writing-pr-descriptions. The usage-report function copies the APM tracing pattern rather than the logs one because metrics, like traces, needs bytes and records from one query. Duplicate search: `gh pr list --search 'metrics usage report'` found nothing covering this.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*