### PR TITLE
feat(metrics): open the metrics alpha to self-serve enrollment

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1977,13 +1977,13 @@ snapshots:
     components-sample-data-state--wizard-installing--light:
         hash: v1.k794b7964.2052c49beff2e0a5c5c533ae05c73bacc2619a04053b4529acf93574160c3a66.sTXp62J02o4EVCFfSt9_QV7YwS6UN87FpVxkPGrmZ3o
     components-search--default--dark:
-        hash: v1.k794b7964.fac5f5d37c971bd086b80c74912c404fa94efd54d3f06cd9977f30dc77d3b95b.M4DujdDqdcqaMc_a55BBUsP9ba7B0GYwLzVvv9RDF30
+        hash: v1.k794b7964.4d547ac55501863b11034e51dfa0e6da46277ddb82d93dfff89bceb95ca3c457.xmcEpMR2kLjRqYgG8WhE7NMfZ4aq18g8E0y3UZTt_ek
     components-search--default--light:
-        hash: v1.k794b7964.b25ae3aeaa1f64b557faf9333a23abd452a839c362ee24206b4fa2065f669b77.gTlqMJc7-zkyELSvT2A2J3BefIk1ZN9Z26ylJRiYCmA
+        hash: v1.k794b7964.4b12fa9beacbe7bd53eceed4c9506c4b72d3f965ef420371c90fc9ff2869d0e0.kwiTpTyd5He77Bw8P62p8IH4KgzmWQ0Ny1v7MsMtLpo
     components-search--product-recents-and-starred--dark:
-        hash: v1.k794b7964.2c51029339a90ded8e9418dc7fca38b56c4933839cd2a71d9bdde2a17d874115.62fXgMoCTwdyiE8RHF1kO3XZhDQ8KJbaP6Zv2rN8St0
+        hash: v1.k794b7964.d4f3237e829a99a011fa463d061944dd2af82e010292656dde0c1052d893a2dc.dy_2uM10B_3hbRAPCMmt3tJlGObSqT5M27Tdk8BEaUw
     components-search--product-recents-and-starred--light:
-        hash: v1.k794b7964.f2c75682469c037327f94f22550286ed866d4883e03ef7c66a3f234a31b1017b.1gKkr-42m5_F8qJMq6ahElSjOFRERpPTay3A0__UOo0
+        hash: v1.k794b7964.419cabcff30a22d68b283cf59562b74ca2d4910552fc4240e95b856303622508.0xCO-YA2i8xkqSjPXRWXjmLuVEiiP11XfIC6v9y77yU
     components-search--searching--dark:
         hash: v1.k794b7964.3ce8ecf4192605f50f2ab332c2f6f370e79080ef1dd9628746b59ec59043e1b0.8RSulgjoFeYFhPE9GqdfAZ5eNfm4qVUy88-C8XemASA
     components-search--searching--light:

--- a/frontend/src/layout/scenes/components/FeaturePreviewSceneGate.test.tsx
+++ b/frontend/src/layout/scenes/components/FeaturePreviewSceneGate.test.tsx
@@ -29,6 +29,8 @@ jest.mock('scenes/sceneLogic', () => ({
 jest.mock('scenes/scenes', () => ({
     sceneConfigurations: {
         CustomerAnalytics: { name: 'Customer analytics', description: 'Analytics for customers', iconType: 'default' },
+        Error404: { name: 'Not found', iconType: 'default' },
+        Metrics: { name: 'Metrics', description: 'Application metrics', iconType: 'default' },
     },
 }))
 
@@ -250,6 +252,19 @@ describe('FeaturePreviewSceneGate', () => {
             render(<FeaturePreviewSceneGate config={BASE_CONFIG}>{CHILDREN}</FeaturePreviewSceneGate>)
 
             expect(screen.getByTestId('scene-title-section')).toHaveTextContent('Customer analytics')
+        })
+
+        test('config sceneId overrides the active scene for the title, so a flag-hidden route is not titled "Not found"', () => {
+            setupMocks({ activeSceneId: 'Error404' })
+
+            render(
+                <FeaturePreviewSceneGate config={{ ...BASE_CONFIG, sceneId: 'Metrics' }}>
+                    {CHILDREN}
+                </FeaturePreviewSceneGate>
+            )
+
+            expect(screen.getByTestId('scene-title-section')).toHaveTextContent('Metrics')
+            expect(screen.queryByText('Not found')).not.toBeInTheDocument()
         })
 
         test('does not show toggle for a different feature flag key', () => {

--- a/frontend/src/layout/scenes/components/FeaturePreviewSceneGate.tsx
+++ b/frontend/src/layout/scenes/components/FeaturePreviewSceneGate.tsx
@@ -48,7 +48,8 @@ function FeaturePreviewGateContent({ config }: { config: FeaturePreviewGateConfi
     }, [loadEarlyAccessFeatures])
 
     const feature = earlyAccessFeatures.find((f) => f.flagKey === config.flag)
-    const sceneConfig = activeSceneId ? sceneConfigurations[activeSceneId] : undefined
+    const sceneIdForHeader = config.sceneId ?? activeSceneId
+    const sceneConfig = sceneIdForHeader ? sceneConfigurations[sceneIdForHeader] : undefined
     const flagsHonored = areClientFeatureFlagsHonored(preflight)
 
     return (

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -2379,7 +2379,6 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         iconType: 'metrics',
         iconColor: ['var(--color-product-metrics-light)', 'var(--color-product-metrics-dark)'] as FileSystemIconColor,
         href: urls.metrics(),
-        flag: FEATURE_FLAGS.METRICS,
         tags: ['alpha'],
         sceneKey: 'Metrics',
         sceneKeys: ['Metrics'],

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7840,6 +7840,12 @@ export interface FeaturePreviewGateConfig {
     description: string
     docsURL?: string
     /**
+     * Scene whose name and icon the gated state renders as its header. Without it the gate
+     * falls back to the router's active scene, which can resolve to Error404 ("Not found")
+     * and mislabel the page.
+     */
+    sceneId?: string
+    /**
      * Offer a "Request access" support CTA. Set this for betas that aren't self-serve early-access
      * features, so the gated state offers a way to request access instead of dead-ending on the
      * feature previews page.

--- a/products/metrics/frontend/components/ViewServiceMetricsButton.test.tsx
+++ b/products/metrics/frontend/components/ViewServiceMetricsButton.test.tsx
@@ -38,8 +38,8 @@ describe('ViewServiceMetricsButton', () => {
         )
     }
 
-    // Metrics is in private alpha behind a flag. A link rendered without it lands on the waitlist
-    // screen, not a chart — a dead end reached from a GA product.
+    // Metrics is in alpha behind a flag. A link rendered without it lands on the feature
+    // preview gate, not a chart — a dead end reached from a GA product.
     it.each([
         ['the metrics flag is off', { serviceName: 'checkout', flagOn: false }, AccessControlLevel.Viewer],
         ['the user cannot view metrics', { serviceName: 'checkout' }, undefined],

--- a/products/metrics/frontend/components/ViewServiceMetricsButton.tsx
+++ b/products/metrics/frontend/components/ViewServiceMetricsButton.tsx
@@ -31,9 +31,9 @@ export function useCanViewServiceMetrics(): boolean {
 /**
  * "Show me this service's metrics", for Logs and Tracing to drop into a service row or a span.
  *
- * Metrics owns this gate rather than each caller, because the product is in private alpha behind a
- * flag: a link rendered without it lands on the waitlist screen instead of a chart, and callers
- * would each have to remember that.
+ * Metrics owns this gate rather than each caller, because the product is in alpha behind a
+ * flag: a link rendered without it lands on the feature preview gate instead of a chart, and
+ * callers would each have to remember that.
  */
 export function ViewServiceMetricsButton({
     serviceName,

--- a/products/metrics/frontend/featurePreviewGate.ts
+++ b/products/metrics/frontend/featurePreviewGate.ts
@@ -4,8 +4,9 @@ import { FeaturePreviewGateConfig } from '~/types'
 
 export const metricsFeaturePreviewGate: FeaturePreviewGateConfig = {
     flag: FEATURE_FLAGS.METRICS,
-    title: 'Metrics is in private alpha',
+    title: 'Metrics is in alpha',
     description:
-        "Metrics is available to select teams while we polish it. You can already send metrics with any OpenTelemetry client. Join the waitlist and we'll turn on the viewer for your team.",
+        'Metrics is in open alpha: things may change while we polish it. Send metrics with any OpenTelemetry client, then turn on the feature preview to open the viewer.',
     docsURL: 'https://posthog.com/docs/metrics',
+    sceneId: 'Metrics',
 }

--- a/products/metrics/manifest.tsx
+++ b/products/metrics/manifest.tsx
@@ -1,4 +1,3 @@
-import { FEATURE_FLAGS } from 'lib/constants'
 import { urls } from 'scenes/urls'
 
 import { ProductItemCategory, ProductKey } from '~/queries/schema/schema-general'
@@ -38,7 +37,8 @@ export const manifest: ProductManifest = {
                 'var(--color-product-metrics-dark)',
             ] as FileSystemIconColor,
             href: urls.metrics(),
-            flag: FEATURE_FLAGS.METRICS,
+            // Open alpha: the nav item is visible to everyone; the scene gate offers the
+            // feature preview toggle to visitors who have not enrolled yet.
             tags: ['alpha'],
             sceneKey: 'Metrics',
         },


### PR DESCRIPTION
## Problem

Metrics is moving from a private-alpha allowlist to an open alpha, where anyone can enroll through the feature preview toggle. Three things in the gated experience contradict that:

- The nav hides Metrics entirely for anyone off the flag, so nobody discovers the product to enroll in it.
- The gate copy promises a waitlist ("join the waitlist and we'll turn on the viewer"), which required manual allowlisting. In open alpha the toggle takes effect immediately.
- The gate page title renders "Not found" when the router resolves Error404 for the flag-hidden route, mislabeling a working page.

## Changes

- The Metrics nav item is visible to everyone; visitors who have not enrolled land on the scene gate with the preview toggle instead of finding nothing in the nav. Mechanical part: `flag` removed from the product manifest and `products.tsx` regenerated.
- Gate copy now reads as open alpha: turn on the feature preview to open the viewer now.
- `FeaturePreviewGateConfig` gains an optional `sceneId` so a gate names its own scene header. The metrics gate sets it, so the page is titled "Metrics" instead of "Not found".

> [!NOTE]
> Enrollment only works once the `metrics` feature flag has a super group on `$feature_enrollment/metrics`, the same shape the `logs` flag uses. The flag edit happens in the PostHog UI, not in this repo; until it lands, the toggle records enrollment without unlocking the viewer, matching today's behavior.

## How did you test this code?

- `jest --testPathPattern='(FeaturePreviewSceneGate|ViewServiceMetricsButton)'` — 29 tests pass, covering the gate render paths and the flag-off button behavior.
- Not checked: full `typescript:check` (tsgo was OOM-killed in the sandbox; CI runs it), and a visual pass over the gated scene.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Docs describe sending metrics and reference the preview toggle; the waitlist wording only existed in-app. No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Agent-authored (Claude Code in PostHog Desktop) directed by the assignee, as part of the metrics open-alpha rollout, together with [#95278](https://github.com/PostHog/posthog/pull/95278) (usage report + activation). Skills invoked: /writing-user-facing-copy, /writing-pr-descriptions, /writing-tests. The nav-visible-plus-gate shape copies how Logs opened up. Duplicate search: `gh pr list --search 'metrics open alpha'` found nothing covering this.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*