### PR TITLE
fix(tasks): stop offering upload_artifact on slack runs

### DIFF
--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -5205,6 +5205,28 @@ describe("AgentServer HTTP Mode", () => {
       );
     });
 
+    // `upload_artifact` writes a run artifact behind a PostHog login, so offering it beside
+    // the Slack route makes the agent choose, and it picks the one that never reaches the
+    // thread. A run that cannot deliver into Slack keeps the offer as its only way out.
+    it.each([
+      { delivery: "canvas_file" as const, offered: false },
+      { delivery: "message" as const, offered: false },
+      { delivery: "none" as const, offered: true },
+      { delivery: null, offered: true },
+    ])(
+      "offers upload_artifact only when Slack cannot take the file: $delivery",
+      ({ delivery, offered }) => {
+        const s = createServer() as unknown as TestableServer;
+        s.slackArtifactDelivery = delivery;
+
+        const prompt = s.buildCloudSystemPrompt();
+
+        expect(
+          prompt.includes("## Delivering non-code files (artifacts)"),
+        ).toBe(offered);
+      },
+    );
+
     // Charts need only the rollout flag, while canvas/file also needs Slack scopes still in
     // review, so the chart offer has to be independent of the delivery mode in both
     // directions: present on a message-only workspace, absent on a canvas_file one whose

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -4437,7 +4437,16 @@ Optimize for the fewest shell round trips.
 - Read multiple files at once.
 - Never rerun a command solely to reproduce output you already have.`;
 
-    const artifactInstructions = `
+    // Withheld when the run can deliver into Slack, because `upload_artifact` writes a run
+    // artifact that only a signed-in PostHog user can reach. Offering both paths makes the
+    // agent choose, and it picks this one, so the Slack reader gets a link they cannot open
+    // instead of the file. The "none" mode keeps it: that run has no Slack delivery at all,
+    // and a run artifact is still the best a person gets.
+    const artifactInstructions =
+      this.slackArtifactDelivery !== null &&
+      this.slackArtifactDelivery !== "none"
+        ? ""
+        : `
 ## Delivering non-code files (artifacts)
 When you create a non-code file the user should be able to download (such as a report, chart, image, archive, or data file), call the \`upload_artifact\` tool with its path before your final reply. In your final reply, link to the download URL returned by the tool—never link to the file's local workspace path. Files left in the workspace don't reach the user. Don't upload source code or repository changes—those belong in a commit or PR.`;
 


### PR DESCRIPTION
## Problem

A person in a Slack thread asks a task for a report and gets a link they cannot open, instead of the file.

- The cloud system prompt names two file-delivery paths on a Slack-triggered run.
- `## Delivering non-code files (artifacts)` names `upload_artifact`. `## Delivering to Slack` names the living-artifact endpoint.
- The two sections sit next to each other and state no precedence, so the agent chooses.
- The agent takes `upload_artifact`, which writes a run artifact behind a PostHog login. The Slack relay never attaches it.
- The agent then calls the report attached, because it expects the relay to carry the file.

## Changes

- A Slack-capable run now gets one file-delivery path, so the report arrives in the thread as a file.
- `buildCloudSystemPrompt` withholds the `upload_artifact` section when the backend resolved `slack_artifact_delivery` to `message` or `canvas_file`.
- A run with mode `none` or an unresolved mode keeps the section. That run has no Slack delivery, so a run artifact is still the best result.
- The `upload_artifact` tool stays registered, and the Slack delivery section is unchanged. Only the prompt text moves.

> [!NOTE]
> A workflow whose own prompt asks for a "downloadable task asset" still steers the agent back to `upload_artifact`. That wording lives in workflow config, not in this repo.

## How did you test this code?

Four parameterized cases added to the existing `buildCloudSystemPrompt` block, one per delivery mode.

They catch one regression: making `artifactInstructions` unconditional again, which restores the two-path prompt. Reverting the source change fails the `canvas_file` and `message` cases and passes `none` and `null`.

Not run: the wider desktop suite, and no live Slack task run. This change was not exercised end to end against a real workspace.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus 5 in Claude Code, working from a task run whose report never reached its Slack thread. Reading the run's session logs showed the agent calling `upload_artifact` seven times and the living-artifact endpoint never, which located the conflict in the prompt rather than in delivery or permissions.

Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

The first reading blamed a blocked Slack MCP tool, since the run also hit a `blocked by team policy` error on `slack_reply_in_thread`. That block is correct and stays: the harness already relays the final message, and the living-artifact path already carries files. The prompt conflict is the defect.

No customer data, ticket, or conversation informed this change.
