### PR TITLE
perf(data-warehouse): use source existence probe for setup

### DIFF
--- a/products/data_warehouse/frontend/emptyState/dataWarehouseSetupLogic.test.ts
+++ b/products/data_warehouse/frontend/emptyState/dataWarehouseSetupLogic.test.ts
@@ -1,0 +1,29 @@
+import { expectLogic } from 'kea-test-utils'
+
+import api from 'lib/api'
+import { productSetupStatusLogic } from 'lib/components/ProductEmptyState/productSetupStatusLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+
+import * as warehouseSourcesApi from 'products/warehouse_sources/frontend/generated/api'
+
+import { dataWarehouseSetupLogic } from './dataWarehouseSetupLogic'
+
+describe('dataWarehouseSetupLogic', () => {
+    it('requests one source row for setup detection', async () => {
+        initKeaTests()
+        const sourcesSpy = jest.spyOn(warehouseSourcesApi, 'externalDataSourcesList').mockResolvedValue({
+            count: 1,
+            results: [],
+        })
+        jest.spyOn(api.dataWarehouseTables, 'list').mockResolvedValue({ results: [] })
+
+        const logic = dataWarehouseSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(sourcesSpy).toHaveBeenCalledWith(expect.any(String), { limit: 1 })
+        expect(productSetupStatusLogic({ productKey: ProductKey.DATA_WAREHOUSE }).values.status).toBe('has-data')
+    })
+})

--- a/products/data_warehouse/frontend/emptyState/dataWarehouseSetupLogic.test.ts
+++ b/products/data_warehouse/frontend/emptyState/dataWarehouseSetupLogic.test.ts
@@ -11,19 +11,18 @@ import * as warehouseSourcesApi from 'products/warehouse_sources/frontend/genera
 import { dataWarehouseSetupLogic } from './dataWarehouseSetupLogic'
 
 describe('dataWarehouseSetupLogic', () => {
-    it('requests one source row for setup detection', async () => {
+    it('checks source existence without loading source rows', async () => {
         initKeaTests()
-        const sourcesSpy = jest.spyOn(warehouseSourcesApi, 'externalDataSourcesList').mockResolvedValue({
-            count: 1,
-            results: [],
-        })
+        const sourcesSpy = jest
+            .spyOn(warehouseSourcesApi, 'externalDataSourcesExistsRetrieve')
+            .mockResolvedValue({ exists: true })
         jest.spyOn(api.dataWarehouseTables, 'list').mockResolvedValue({ results: [] })
 
         const logic = dataWarehouseSetupLogic()
         logic.mount()
         await expectLogic(logic).toFinishAllListeners()
 
-        expect(sourcesSpy).toHaveBeenCalledWith(expect.any(String), { limit: 1 })
+        expect(sourcesSpy).toHaveBeenCalledWith(expect.any(String))
         expect(productSetupStatusLogic({ productKey: ProductKey.DATA_WAREHOUSE }).values.status).toBe('has-data')
     })
 })

--- a/products/data_warehouse/frontend/emptyState/dataWarehouseSetupLogic.ts
+++ b/products/data_warehouse/frontend/emptyState/dataWarehouseSetupLogic.ts
@@ -1,7 +1,10 @@
 import api from 'lib/api'
 import { createSetupDetectionLogic } from 'lib/components/ProductEmptyState/setupDetectionLogic'
+import { projectLogic } from 'scenes/projectLogic'
 
 import { ProductKey } from '~/queries/schema/schema-general'
+
+import { externalDataSourcesList } from 'products/warehouse_sources/frontend/generated/api'
 
 /**
  * Setup detection for the data warehouse empty state. A managed source counts
@@ -12,10 +15,11 @@ export const dataWarehouseSetupLogic = createSetupDetectionLogic({
     productKey: ProductKey.DATA_WAREHOUSE,
     path: ['products', 'data_warehouse', 'frontend', 'emptyState', 'dataWarehouseSetupLogic'],
     detect: async () => {
+        const projectId = String(projectLogic.findMounted()?.values.currentProjectId)
         const [sources, tables] = await Promise.all([
-            api.externalDataSources.list(),
+            externalDataSourcesList(projectId, { limit: 1 }),
             api.dataWarehouseTables.list({ limit: 1 }),
         ])
-        return sources.results.length > 0 || tables.results.length > 0 ? 'has-data' : 'needs-setup'
+        return sources.count > 0 || tables.results.length > 0 ? 'has-data' : 'needs-setup'
     },
 })

--- a/products/data_warehouse/frontend/emptyState/dataWarehouseSetupLogic.ts
+++ b/products/data_warehouse/frontend/emptyState/dataWarehouseSetupLogic.ts
@@ -4,7 +4,7 @@ import { projectLogic } from 'scenes/projectLogic'
 
 import { ProductKey } from '~/queries/schema/schema-general'
 
-import { externalDataSourcesList } from 'products/warehouse_sources/frontend/generated/api'
+import { externalDataSourcesExistsRetrieve } from 'products/warehouse_sources/frontend/generated/api'
 
 /**
  * Setup detection for the data warehouse empty state. A managed source counts
@@ -17,9 +17,9 @@ export const dataWarehouseSetupLogic = createSetupDetectionLogic({
     detect: async () => {
         const projectId = String(projectLogic.findMounted()?.values.currentProjectId)
         const [sources, tables] = await Promise.all([
-            externalDataSourcesList(projectId, { limit: 1 }),
+            externalDataSourcesExistsRetrieve(projectId),
             api.dataWarehouseTables.list({ limit: 1 }),
         ])
-        return sources.count > 0 || tables.results.length > 0 ? 'has-data' : 'needs-setup'
+        return sources.exists || tables.results.length > 0 ? 'has-data' : 'needs-setup'
     },
 })

--- a/products/warehouse_sources/backend/presentation/views/external_data_source.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_source.py
@@ -1728,6 +1728,10 @@ class ExternalDataSourceCreateResponseSerializer(serializers.Serializer):
     id = serializers.UUIDField(help_text="ID of the created external data source.")
 
 
+class ExternalDataSourceExistsResponseSerializer(serializers.Serializer):
+    exists = serializers.BooleanField(help_text="Whether the project has at least one visible external data source.")
+
+
 class ExternalDataSourceErrorResponseSerializer(serializers.Serializer):
     message = serializers.CharField(help_text="Human-readable explanation of why the source could not be created.")
 
@@ -2037,6 +2041,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
     ]
     scope_object_read_actions = [
         "list",
+        "exists",
         "retrieve",
         "jobs",
         "wizard",
@@ -2185,6 +2190,17 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
             )
             .order_by(self.ordering)
         )
+
+    @extend_schema(
+        responses=ExternalDataSourceExistsResponseSerializer,
+        description="Check whether the project has at least one visible external data source.",
+    )
+    @action(methods=["GET"], detail=False, pagination_class=None, filter_backends=[])
+    def exists(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        queryset = self.get_queryset()
+        if not is_service_auth(request):
+            queryset = self.user_access_control.filter_queryset_by_access_level(queryset)
+        return Response(ExternalDataSourceExistsResponseSerializer({"exists": queryset.exists()}).data)
 
     def _resolve_stored_credential(self, source_type: str, payload: dict) -> ResolvedStoredCredential:
         """Merge a connect-link stored credential into `payload` when it carries a `credential_id`.

--- a/products/warehouse_sources/backend/tests/api/test_external_data_source.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_source.py
@@ -236,6 +236,18 @@ class TestExternalDataSource(APIBaseTest):
         self.assertEqual(result["status"], ExternalDataSchema.Status.FAILED)
         self.assertEqual(result["latest_error"], "boom")
 
+    def test_exists_reports_active_sources(self):
+        url = f"/api/environments/{self.team.pk}/external_data_sources/exists/"
+        self.assertEqual(self.client.get(url).json(), {"exists": False})
+
+        source = self._make_source("exists")
+        self._make_schema_with_table(source, "Customers")
+        self.assertEqual(self.client.get(url).json(), {"exists": True})
+
+        source.deleted = True
+        source.save(update_fields=["deleted"])
+        self.assertEqual(self.client.get(url).json(), {"exists": False})
+
     def test_list_query_count_does_not_scale_with_source_count(self):
         # Guards the prefetch design: adding sources (each with schemas + tables) must not add queries.
         # A regression to per-source credential/source lookups or the duplicate schema prefetch shows up

--- a/products/warehouse_sources/backend/tests/api/test_external_data_source_access_control.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_source_access_control.py
@@ -316,6 +316,20 @@ class TestExternalDataSourceAccessControl(APIBaseTest):
         self.assertEqual(response.json()["count"], 1)
         self.assertEqual(response.json()["results"][0]["id"], str(self.source.id))
 
+    def test_exists_ignores_inaccessible_sources(self):
+        self._create_access_control(self.viewer_user, access_level="viewer")
+        self._create_access_control(
+            self.viewer_user,
+            resource_id=str(self.source.id),
+            access_level="none",
+        )
+
+        self.client.force_login(self.viewer_user)
+        response = self.client.get(f"/api/environments/{self.team.pk}/external_data_sources/exists/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"exists": False})
+
     def test_connections_includes_only_ready_managed_warehouse_regardless_of_source_access(self):
         external_source = ExternalDataSource.objects.create(
             team=self.team,
@@ -626,6 +640,25 @@ class TestExternalDataSourceAccessControl(APIBaseTest):
 
         response = self.client.get(
             f"/api/environments/{self.team.pk}/external_data_sources/connections/",
+            headers={"authorization": f"Bearer {api_key}"},
+        )
+
+        self.assertEqual(response.status_code, expected_status)
+
+    @parameterized.expand(
+        [
+            ("external_data_source_read", "external_data_source:read", status.HTTP_200_OK),
+            ("query_read", "query:read", status.HTTP_403_FORBIDDEN),
+        ]
+    )
+    def test_exists_preserves_external_data_source_api_scope(
+        self, _name: str, scope: str, expected_status: int
+    ) -> None:
+        api_key = self.create_personal_api_key_with_scopes([scope])
+        self.client.force_authenticate(None)
+
+        response = self.client.get(
+            f"/api/environments/{self.team.pk}/external_data_sources/exists/",
             headers={"authorization": f"Bearer {api_key}"},
         )
 

--- a/products/warehouse_sources/frontend/generated/api.schemas.ts
+++ b/products/warehouse_sources/frontend/generated/api.schemas.ts
@@ -9028,6 +9028,11 @@ export interface DraftCustomManifestResponseApi {
     error: string | null
 }
 
+export interface ExternalDataSourceExistsResponseApi {
+    /** Whether the project has at least one visible external data source. */
+    exists: boolean
+}
+
 /**
  * A selectable account/resource exposed by an OAuth integration, in the shared shape every ad
  * platform produces (see ``IntegrationAccount`` in the data-imports common module). One serializer

--- a/products/warehouse_sources/frontend/generated/api.ts
+++ b/products/warehouse_sources/frontend/generated/api.ts
@@ -22,6 +22,7 @@ import type {
     ExternalDataSourceConnectionOptionApi,
     ExternalDataSourceCreateApi,
     ExternalDataSourceCreateResponseApi,
+    ExternalDataSourceExistsResponseApi,
     ExternalDataSourceSerializersApi,
     ExternalDataSourcesBulkUpdateSchemasPartialUpdateParams,
     ExternalDataSourcesCheckCdcPrerequisitesCreate200,
@@ -1174,6 +1175,23 @@ export const externalDataSourcesDraftCustomManifestCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(draftCustomManifestRequestApi),
+    })
+}
+
+export const getExternalDataSourcesExistsRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/external_data_sources/exists/`
+}
+
+/**
+ * Check whether the project has at least one visible external data source.
+ */
+export const externalDataSourcesExistsRetrieve = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<ExternalDataSourceExistsResponseApi> => {
+    return apiMutator<ExternalDataSourceExistsResponseApi>(getExternalDataSourcesExistsRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
     })
 }
 

--- a/products/warehouse_sources/mcp/tools.yaml
+++ b/products/warehouse_sources/mcp/tools.yaml
@@ -441,6 +441,9 @@ tools:
     external-data-sources-enable-cdc-create:
         operation: external_data_sources_enable_cdc_create
         enabled: false
+    external-data-sources-exists-retrieve:
+        operation: external_data_sources_exists_retrieve
+        enabled: false
     external-data-sources-jobs:
         operation: external_data_sources_jobs_retrieve
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -39102,6 +39102,11 @@ export namespace Schemas {
       latest_error: string | null;
     }
 
+    export interface ExternalDataSourceExistsResponse {
+      /** Whether the project has at least one visible external data source. */
+      exists: boolean;
+    }
+
     export interface ExternalDataSourceRevenueAnalyticsConfig {
       enabled?: boolean;
       include_invoiceless_charges?: boolean;


### PR DESCRIPTION
## Problem

The data warehouse setup gate only needs to know whether a visible managed source exists. Using `external_data_sources/?limit=1` still ran the normal list serializer and loaded every schema belonging to the first source, duplicating expensive source work before the sources table loaded.

## Why

A collection-level existence action is the smallest contract for this decision and follows the existing Error Tracking `exists` action pattern. It avoids coupling onboarding to either the full source representation or the new summary representation.

## Changes

- Add `GET /external_data_sources/exists/`, returning `{ "exists": boolean }`.
- Apply source visibility filtering and the `external_data_source:read` scope before the database `EXISTS` query.
- Use the generated client in the data warehouse setup gate.

## How did you test this code?

- Backend coverage for active/deleted sources, object access, and API token scopes.
- Frontend empty-state coverage.
- OpenAPI/MCP generation and repository preflight.
- Synthetic local benchmark with one source and 5,000 schemas: warm each route once, then measure five interleaved requests and report the median.
  - `?limit=1`: 609.0 ms, 12 queries, 1,337,400-byte response.
  - `/exists/`: 16.9 ms, 9 queries, 15-byte response.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
