### PR TITLE
feat(signals): fail research reports stranded in progress

### DIFF
--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -300,6 +300,21 @@ SIGNALS_INBOX_PR_NOTIFICATION_POLL_SECONDS: int = get_from_env(
     "SIGNALS_INBOX_PR_NOTIFICATION_POLL_SECONDS", 30, type_cast=int
 )
 
+# Signals stranded-report reconciler (products/signals/backend/temporal/stranded_reports.py). A
+# report whose research workflow closed without running its own failure path (execution timeout,
+# termination, a history that no longer replays) stays `in_progress` forever, because no promotion
+# rule reads that status. The reconciler marks such reports failed. On by default: it only stamps
+# a failure on a report whose workflow is verifiably gone, which is what the workflow's own error
+# handler would have done. The switch is the kill switch; pausing the Temporal schedule is the other.
+SIGNAL_STRANDED_REPORT_RECONCILER_ENABLED: bool = get_from_env(
+    "SIGNAL_STRANDED_REPORT_RECONCILER_ENABLED", True, type_cast=str_to_bool
+)
+# A report must have been `in_progress` at least this long before its workflow is checked, so a
+# pass that just started (workflow registered, first activity still scheduling) is never judged.
+SIGNAL_STRANDED_REPORT_MIN_AGE_MINUTES: int = get_from_env("SIGNAL_STRANDED_REPORT_MIN_AGE_MINUTES", 20, type_cast=int)
+# Upper bound on reports examined per tick; the oldest go first, so a backlog drains across ticks.
+SIGNAL_STRANDED_REPORT_MAX_PER_TICK: int = get_from_env("SIGNAL_STRANDED_REPORT_MAX_PER_TICK", 200, type_cast=int)
+
 # Incoming webhook for experiment precompute canary divergence alerts. Unset: Slack alerting is skipped.
 EXPERIMENT_CANARY_SLACK_WEBHOOK_URL: str = os.getenv("EXPERIMENT_CANARY_SLACK_WEBHOOK_URL", "")
 

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -121,6 +121,9 @@ from products.signals.backend.temporal.agentic.schedule import (
     create_scout_suggestions_coordinator_schedule,
     create_signals_scout_coordinator_schedule,
 )
+from products.signals.backend.temporal.stranded_reports_schedule import (
+    create_signals_stranded_report_reconciler_schedule,
+)
 from products.web_analytics.backend.temporal.digest_notification.types import WADigestNotificationInput
 from products.web_analytics.backend.temporal.weekly_digest.types import WAWeeklyDigestInput
 
@@ -928,6 +931,7 @@ schedules = [
     create_cleanup_alert_checks_schedule,
     create_signals_scout_coordinator_schedule,
     create_scout_suggestions_coordinator_schedule,
+    create_signals_stranded_report_reconciler_schedule,
     create_support_reply_coordinator_schedule,
     create_channel_summary_coordinator_schedule,
     create_account_track_rule_coordinator_schedule,

--- a/posthog/temporal/tests/ai/test_module_integrity.py
+++ b/posthog/temporal/tests/ai/test_module_integrity.py
@@ -105,6 +105,7 @@ class TestSignalsProductModuleIntegrity:
             "ScoutSuggestionsCoordinatorWorkflow",
             "CustomSignalAgentWorkflow",
             "SignalReportInboxNotificationWorkflow",
+            "StrandedReportReconcilerWorkflow",
         ]
         actual_workflow_names = [w.__name__ for w in SIGNALS_PRODUCT_WORKFLOWS]
         assert len(actual_workflow_names) == len(expected_workflows), (
@@ -172,6 +173,8 @@ class TestSignalsProductModuleIntegrity:
             "run_scout_suggestions_activity",
             "stamp_requested_scout_suggestions_activity",
             "run_custom_signal_agent_activity",
+            "find_stranded_reports_activity",
+            "fail_stranded_report_activity",
         ]
         actual_activity_names = [a.__name__ for a in SIGNALS_PRODUCT_ACTIVITIES]
         assert len(actual_activity_names) == len(expected_activities), (

--- a/products/signals/backend/management/AGENTS.md
+++ b/products/signals/backend/management/AGENTS.md
@@ -39,6 +39,7 @@ python manage.py list_signal_reports --team-id 1 --signals --json
    - `failed` — failed safety review (possible prompt injection)
    - `potential` (reset, weight zeroed) — deemed not actionable
 7. On reaching `ready`, the summary workflow starts `signal-report-inbox-notification` to post the Slack inbox notification. If the report auto-started an implementation task, that workflow waits for the PR to open (bounded by `SIGNALS_INBOX_PR_NOTIFICATION_TIMEOUT_SECONDS`) so the card can show a "Review PR" button; if that task never opens a PR (fails, is cancelled, or the wait times out) no notification is sent. Reports with no auto-start task notify immediately.
+   If a summary workflow closes without running its own failure path (execution timeout, termination, a history that no longer replays), the report stays `in_progress`. `signal_pipeline_status` lists such reports as stranded and does not wait on them; the scheduled stranded report reconciler (`../temporal/stranded_reports.py`) marks them `failed` on its next tick.
 8. `ready` reports accumulate new signals silently. After enough new signals (`signal_count >= signals_at_run`), the report is re-promoted and the summary workflow runs again — reusing the previous repo selection and lightly validating previous findings instead of re-researching from scratch.
 
 Reports that aren't `ready` still appear in the output with their `error` field explaining why they were filtered, plus `artefacts` containing the full judge reasoning.

--- a/products/signals/backend/management/commands/signal_pipeline_status.py
+++ b/products/signals/backend/management/commands/signal_pipeline_status.py
@@ -97,7 +97,10 @@ class Command(BaseCommand):
 
     def _is_settled(self, status, expected_signals, ch_count, prev_ch_count, stable_polls):
         pg = status["postgres"]
-        transient = pg.get("candidate", 0) + pg.get("in_progress", 0)
+        # A stranded report is in_progress with no workflow behind it, so nothing will move it;
+        # waiting on it would never end.
+        stranded = len(status["temporal"].get("stranded_report_ids", []))
+        transient = pg.get("candidate", 0) + pg.get("in_progress", 0) - stranded
         if transient > 0:
             return False
 
@@ -113,6 +116,9 @@ class Command(BaseCommand):
     def _status_summary(self, status):
         pg = status["postgres"]
         parts = [f"{count} {s}" for s, count in pg.items() if s != "total" and count > 0]
+        stranded = len(status["temporal"].get("stranded_report_ids", []))
+        if stranded:
+            parts.append(f"{stranded} stranded")
         return ", ".join(parts) if parts else "no reports"
 
     def _collect_status(self, team, report_id=None):
@@ -143,13 +149,16 @@ class Command(BaseCommand):
         result["grouping_v2_workflow"] = self._describe_workflow(client, grouping_v2_wf_id)
 
         if report_id:
-            reports = list(SignalReport.objects.filter(team=team, id=report_id).only("id", "run_count"))
+            reports = list(SignalReport.objects.filter(team=team, id=report_id).only("id", "run_count", "status"))
         else:
             reports = list(
-                SignalReport.objects.filter(team=team, status__in=["candidate", "in_progress"]).only("id", "run_count")
+                SignalReport.objects.filter(team=team, status__in=["candidate", "in_progress"]).only(
+                    "id", "run_count", "status"
+                )
             )
 
         summary_workflows = {}
+        stranded_report_ids = []
         for report in reports:
             base_wf_id = SignalReportSummaryWorkflow.workflow_id_for(team.id, str(report.id))
             candidate_ids = [base_wf_id]
@@ -166,7 +175,10 @@ class Command(BaseCommand):
                 if wf["status"] != "NOT_FOUND" and chosen is None:
                     chosen = wf
 
-            summary_workflows[str(report.id)] = chosen or {"workflow_id": candidate_ids[0], "status": "NOT_FOUND"}
+            chosen = chosen or {"workflow_id": candidate_ids[0], "status": "NOT_FOUND"}
+            summary_workflows[str(report.id)] = chosen
+            if report.status == SignalReport.Status.IN_PROGRESS and chosen["status"] != "RUNNING":
+                stranded_report_ids.append(str(report.id))
 
         paused_until = None
         gv2_running = result["grouping_v2_workflow"]["status"] == "RUNNING"
@@ -179,6 +191,7 @@ class Command(BaseCommand):
         result["grouping_v2_paused_until"] = paused_until.isoformat() if paused_until else None
 
         result["summary_workflows"] = summary_workflows
+        result["stranded_report_ids"] = stranded_report_ids
         return result
 
     def _describe_workflow(self, client, workflow_id):
@@ -308,6 +321,18 @@ class Command(BaseCommand):
                     self.stdout.write(f"    {rid}: {style(wf['status'])}")
             else:
                 self.stdout.write("  Summary workflows: none in transient state")
+
+            stranded = temporal.get("stranded_report_ids", [])
+            if stranded:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  Stranded in_progress reports (summary workflow not running): {', '.join(stranded)}"
+                    )
+                )
+                self.stdout.write(
+                    "    The stranded report reconciler fails these on its next tick. To run it now: "
+                    "temporal schedule trigger --schedule-id signals-stranded-report-reconciler-schedule"
+                )
 
         self.stdout.write(self.style.MIGRATE_HEADING("\nClickHouse (document_embeddings):"))
         ch = status["clickhouse"]

--- a/products/signals/backend/temporal/__init__.py
+++ b/products/signals/backend/temporal/__init__.py
@@ -68,6 +68,11 @@ from products.signals.backend.temporal.signal_queries import (
     run_signal_semantic_search_activity,
     wait_for_signal_in_clickhouse_activity,
 )
+from products.signals.backend.temporal.stranded_reports import (
+    StrandedReportReconcilerWorkflow,
+    fail_stranded_report_activity,
+    find_stranded_reports_activity,
+)
 from products.signals.backend.temporal.summary import (
     SignalReportSummaryWorkflow,
     check_report_quota_gate_activity,
@@ -102,6 +107,7 @@ WORKFLOWS = [
     RunScoutSuggestionsWorkflow,
     ScoutSuggestionsCoordinatorWorkflow,
     SignalReportInboxNotificationWorkflow,
+    StrandedReportReconcilerWorkflow,
 ]
 
 ACTIVITIES = [
@@ -158,4 +164,6 @@ ACTIVITIES = [
     soft_delete_report_signals_activity,
     verify_match_specificity_activity,
     wait_for_signal_in_clickhouse_activity,
+    find_stranded_reports_activity,
+    fail_stranded_report_activity,
 ]

--- a/products/signals/backend/temporal/metrics.py
+++ b/products/signals/backend/temporal/metrics.py
@@ -170,6 +170,21 @@ def increment_report_run_deferred(reason: str) -> None:
     ).add(1)
 
 
+STRANDED_OUTCOME_FAILED = "failed"
+STRANDED_OUTCOME_SKIPPED_RUNNING = "skipped_running"
+STRANDED_OUTCOME_SKIPPED_CHANGED = "skipped_changed"
+
+
+def increment_stranded_report_reconciled(outcome: str) -> None:
+    """Count an `in_progress` report the stranded-report reconciler examined, by what it did with it."""
+    if not _in_temporal_context():
+        return
+    get_metric_meter({"outcome": outcome}).create_counter(
+        "signals_stranded_reports_reconciled_total",
+        "In-progress signal reports examined by the stranded-report reconciler, by outcome",
+    ).add(1)
+
+
 def increment_scout_run(status: str) -> None:
     """Count a scout run by terminal status."""
     if not _in_temporal_context():

--- a/products/signals/backend/temporal/stranded_reports.py
+++ b/products/signals/backend/temporal/stranded_reports.py
@@ -1,0 +1,304 @@
+"""Scheduled reconciler for signal reports stranded in `in_progress`.
+
+`SignalReportSummaryWorkflow` moves a report to `in_progress` at the start of a research pass and
+back out through its own activities at the end. When Temporal closes the workflow without running
+that code (execution timeout, termination, a history that no longer replays after a deploy), the
+report keeps `in_progress`. No promotion rule in grouping reads that status, so nothing ever moves
+it again. This workflow finds such reports and fails them, which is what the summary workflow's own
+error handler would have done.
+
+A report counts as stranded only when its summary workflow is verifiably not running: a long pass
+is `RUNNING` and is left alone, and a describe that errors for any reason other than NOT_FOUND
+proves nothing and is left alone too.
+"""
+
+from __future__ import annotations
+
+from dataclasses import field
+from datetime import datetime, timedelta
+
+from django.conf import settings
+from django.utils import timezone
+
+import structlog
+import temporalio
+from temporalio import workflow
+from temporalio.client import WorkflowExecutionStatus
+from temporalio.common import RetryPolicy
+from temporalio.service import RPCError, RPCStatusCode
+
+from posthog.dataclasses import frozen
+from posthog.models import Team
+from posthog.sync import database_sync_to_async
+from posthog.temporal.common.client import async_connect
+from posthog.temporal.common.heartbeat import Heartbeater
+from posthog.temporal.common.scoped import scoped_temporal
+from posthog.temporal.common.utils import close_db_connections
+
+from products.signals.backend.models import SignalReport
+from products.signals.backend.signal_metadata import fetch_source_products_for_reports
+from products.signals.backend.temporal import metrics
+from products.signals.backend.temporal.summary import (
+    FAIL_REPORT_FAILED,
+    MarkReportFailedInput,
+    SignalReportSummaryWorkflow,
+    fail_report,
+)
+
+logger = structlog.get_logger(__name__)
+
+WORKFLOW_NAME = "signals-stranded-report-reconciler"
+SCHEDULE_ID = "signals-stranded-report-reconciler-schedule"
+SCHEDULE_INTERVAL = timedelta(minutes=30)
+# `failure_reason` on the `signal_report_completed` event, so stranded passes can be told apart from
+# passes the summary workflow failed itself.
+STRANDED_FAILURE_REASON = "research_run_stranded"
+
+# A workflow in either of these states is still doing its pass.
+_LIVE_WORKFLOW_STATUSES = frozenset({WorkflowExecutionStatus.RUNNING, WorkflowExecutionStatus.CONTINUED_AS_NEW})
+
+
+@frozen
+class StrandedReportReconcilerInput:
+    pass
+
+
+@frozen
+class StrandedReport:
+    team_id: int
+    report_id: str
+    run_count: int
+    signal_count: int
+    # ISO 8601. The value the report carried when it was judged stranded; the failing activity
+    # refuses to act if the row has moved on since.
+    last_run_at: str
+    # The summary workflow's status name, or NOT_FOUND when Temporal no longer has it.
+    workflow_status: str
+
+
+@frozen
+class FindStrandedReportsInput:
+    older_than_minutes: int | None = None
+    limit: int | None = None
+
+
+@frozen
+class FindStrandedReportsOutput:
+    stranded: list[StrandedReport] = field(default_factory=list)
+    scanned: int = 0
+    running: int = 0
+    truncated: bool = False
+
+
+@frozen
+class FailStrandedReportInput:
+    team_id: int
+    report_id: str
+    expected_last_run_at: str
+    workflow_status: str
+    run_count: int
+    signal_count: int
+
+
+@frozen
+class FailStrandedReportOutput:
+    outcome: str
+
+
+@frozen
+class _InProgressReport:
+    team_id: int
+    report_id: str
+    run_count: int
+    signal_count: int
+    last_run_at: datetime
+
+
+def _fetch_old_in_progress_reports(older_than: timedelta, limit: int) -> list[_InProgressReport]:
+    cutoff = timezone.now() - older_than
+    rows = (
+        SignalReport.objects.filter(status=SignalReport.Status.IN_PROGRESS, last_run_at__lt=cutoff)
+        .order_by("last_run_at", "id")
+        .values_list("team_id", "id", "run_count", "signal_count", "last_run_at")[:limit]
+    )
+    return [
+        _InProgressReport(
+            team_id=team_id,
+            report_id=str(report_id),
+            run_count=run_count,
+            signal_count=signal_count,
+            last_run_at=last_run_at,
+        )
+        for team_id, report_id, run_count, signal_count, last_run_at in rows
+        # The `__lt` filter already excludes a null clock; this narrows the type.
+        if last_run_at is not None
+    ]
+
+
+@temporalio.activity.defn
+@scoped_temporal()
+@close_db_connections
+async def find_stranded_reports_activity(input: FindStrandedReportsInput) -> FindStrandedReportsOutput:
+    if not settings.SIGNAL_STRANDED_REPORT_RECONCILER_ENABLED:
+        logger.info("signals stranded report reconciler: disabled, skipping scan")
+        return FindStrandedReportsOutput()
+
+    older_than_minutes = (
+        input.older_than_minutes
+        if input.older_than_minutes is not None
+        else settings.SIGNAL_STRANDED_REPORT_MIN_AGE_MINUTES
+    )
+    limit = input.limit if input.limit is not None else settings.SIGNAL_STRANDED_REPORT_MAX_PER_TICK
+
+    candidates = await database_sync_to_async(_fetch_old_in_progress_reports, thread_sensitive=False)(
+        timedelta(minutes=older_than_minutes), limit
+    )
+
+    stranded: list[StrandedReport] = []
+    running = 0
+    client = await async_connect()
+    async with Heartbeater():
+        for candidate in candidates:
+            workflow_id = SignalReportSummaryWorkflow.workflow_id_for(candidate.team_id, candidate.report_id)
+            try:
+                description = await client.get_workflow_handle(workflow_id).describe()
+            except RPCError as error:
+                if error.status != RPCStatusCode.NOT_FOUND:
+                    logger.warning(
+                        "signals stranded report reconciler: describe failed, leaving report alone",
+                        report_id=candidate.report_id,
+                        team_id=candidate.team_id,
+                        workflow_id=workflow_id,
+                        error=str(error),
+                    )
+                    continue
+                workflow_status = "NOT_FOUND"
+            else:
+                if description.status in _LIVE_WORKFLOW_STATUSES:
+                    running += 1
+                    metrics.increment_stranded_report_reconciled(metrics.STRANDED_OUTCOME_SKIPPED_RUNNING)
+                    continue
+                workflow_status = description.status.name if description.status else "UNKNOWN"
+            stranded.append(
+                StrandedReport(
+                    team_id=candidate.team_id,
+                    report_id=candidate.report_id,
+                    run_count=candidate.run_count,
+                    signal_count=candidate.signal_count,
+                    last_run_at=candidate.last_run_at.isoformat(),
+                    workflow_status=workflow_status,
+                )
+            )
+
+    output = FindStrandedReportsOutput(
+        stranded=stranded,
+        scanned=len(candidates),
+        running=running,
+        truncated=len(candidates) >= limit,
+    )
+    logger.info(
+        "signals stranded report reconciler: scan",
+        scanned=output.scanned,
+        running=output.running,
+        stranded=len(output.stranded),
+        truncated=output.truncated,
+    )
+    return output
+
+
+def _source_products_for(team: Team, report_id: str) -> list[str]:
+    meta = fetch_source_products_for_reports(team, [report_id]).get(report_id)
+    return meta.source_products if meta else []
+
+
+@temporalio.activity.defn
+@scoped_temporal()
+@close_db_connections
+async def fail_stranded_report_activity(input: FailStrandedReportInput) -> FailStrandedReportOutput:
+    expected_last_run_at = datetime.fromisoformat(input.expected_last_run_at)
+
+    def still_stranded(report: SignalReport) -> bool:
+        # A new pass rewrites `last_run_at` on CANDIDATE -> IN_PROGRESS, and any other move changes
+        # the status, so the two together prove the row is the one the scan judged.
+        return report.status == SignalReport.Status.IN_PROGRESS and report.last_run_at == expected_last_run_at
+
+    team = await Team.objects.aget(pk=input.team_id)
+    try:
+        source_products = await database_sync_to_async(_source_products_for, thread_sensitive=False)(
+            team, input.report_id
+        )
+    except Exception:
+        logger.warning(
+            "signals stranded report reconciler: could not read source products",
+            report_id=input.report_id,
+            team_id=input.team_id,
+            exc_info=True,
+        )
+        source_products = []
+
+    result = await fail_report(
+        MarkReportFailedInput(
+            team_id=input.team_id,
+            report_id=input.report_id,
+            error=f"Research run did not complete (summary workflow {input.workflow_status})",
+            failure_reason=STRANDED_FAILURE_REASON,
+            signal_count=input.signal_count,
+            source_products=source_products,
+        ),
+        guard=still_stranded,
+    )
+    outcome = (
+        metrics.STRANDED_OUTCOME_FAILED if result == FAIL_REPORT_FAILED else metrics.STRANDED_OUTCOME_SKIPPED_CHANGED
+    )
+    metrics.increment_stranded_report_reconciled(outcome)
+    logger.info(
+        "signals stranded report reconciler: reconciled report",
+        report_id=input.report_id,
+        team_id=input.team_id,
+        outcome=outcome,
+        workflow_status=input.workflow_status,
+        run_count=input.run_count,
+    )
+    return FailStrandedReportOutput(outcome=outcome)
+
+
+@temporalio.workflow.defn(name=WORKFLOW_NAME)
+class StrandedReportReconcilerWorkflow:
+    """One tick: scan for stranded reports, then fail each one in its own activity."""
+
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> StrandedReportReconcilerInput:
+        return StrandedReportReconcilerInput()
+
+    @temporalio.workflow.run
+    async def run(self, _input: StrandedReportReconcilerInput) -> None:
+        found = await workflow.execute_activity(
+            find_stranded_reports_activity,
+            FindStrandedReportsInput(),
+            start_to_close_timeout=timedelta(minutes=10),
+            heartbeat_timeout=timedelta(minutes=2),
+            retry_policy=RetryPolicy(maximum_attempts=2),
+        )
+        for report in found.stranded:
+            # One activity per report, contained, so a row that keeps erroring costs this tick that
+            # report and nothing else. Sequential on purpose: a deploy strands tens of reports, not
+            # thousands, and the per-report work is two small queries.
+            try:
+                await workflow.execute_activity(
+                    fail_stranded_report_activity,
+                    FailStrandedReportInput(
+                        team_id=report.team_id,
+                        report_id=report.report_id,
+                        expected_last_run_at=report.last_run_at,
+                        workflow_status=report.workflow_status,
+                        run_count=report.run_count,
+                        signal_count=report.signal_count,
+                    ),
+                    start_to_close_timeout=timedelta(minutes=2),
+                    retry_policy=RetryPolicy(maximum_attempts=3),
+                )
+            except Exception:
+                workflow.logger.exception(
+                    "signals stranded report reconciler: failing report raised",
+                    extra={"team_id": report.team_id, "report_id": report.report_id},
+                )

--- a/products/signals/backend/temporal/stranded_reports_schedule.py
+++ b/products/signals/backend/temporal/stranded_reports_schedule.py
@@ -1,0 +1,51 @@
+"""Schedule registration for the stranded signal report reconciler."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+
+from django.conf import settings
+
+from temporalio.client import (
+    Client,
+    Schedule,
+    ScheduleActionStartWorkflow,
+    ScheduleIntervalSpec,
+    ScheduleOverlapPolicy,
+    SchedulePolicy,
+    ScheduleSpec,
+)
+
+from posthog.temporal.common.schedule import a_create_schedule, a_schedule_exists, a_update_schedule
+
+from products.signals.backend.temporal.stranded_reports import (
+    SCHEDULE_ID,
+    SCHEDULE_INTERVAL,
+    WORKFLOW_NAME,
+    StrandedReportReconcilerInput,
+)
+
+
+async def create_signals_stranded_report_reconciler_schedule(client: Client) -> None:
+    """Create or update the schedule that fails signal reports stranded in `in_progress`.
+
+    Same task queue and overlap posture as the scout coordinator. One tick is bounded by the per-tick
+    report cap, and `execution_timeout` caps it at one interval so a tick that hangs on Temporal
+    describes cannot starve the next one under `SKIP`.
+    """
+    schedule = Schedule(
+        action=ScheduleActionStartWorkflow(
+            WORKFLOW_NAME,
+            asdict(StrandedReportReconcilerInput()),
+            id=SCHEDULE_ID,
+            task_queue=settings.VIDEO_EXPORT_TASK_QUEUE,
+            execution_timeout=SCHEDULE_INTERVAL,
+        ),
+        spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=SCHEDULE_INTERVAL)]),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP, catchup_window=SCHEDULE_INTERVAL),
+    )
+
+    if await a_schedule_exists(client, SCHEDULE_ID):
+        await a_update_schedule(client, SCHEDULE_ID, schedule)
+    else:
+        await a_create_schedule(client, SCHEDULE_ID, schedule, trigger_immediately=False)

--- a/products/signals/backend/temporal/summary.py
+++ b/products/signals/backend/temporal/summary.py
@@ -2,6 +2,7 @@
 
 import json
 import asyncio
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Any
@@ -933,36 +934,35 @@ class MarkReportFailedInput:
     source_products: list[str] = field(default_factory=list)
 
 
-@temporalio.activity.defn
-@scoped_temporal()
-@close_db_connections
-async def mark_report_failed_activity(input: MarkReportFailedInput) -> None:
-    """Mark a report as failed and store the error message."""
-    try:
+FAIL_REPORT_FAILED = "failed"
+FAIL_REPORT_ALREADY_FAILED = "already_failed"
+FAIL_REPORT_SKIPPED = "skipped"
 
-        @transaction.atomic
-        def do_update() -> tuple[int, bool]:
-            report = SignalReport.objects.select_for_update().get(id=input.report_id, team_id=input.team_id)
-            if report.status == SignalReport.Status.FAILED:
-                return report.run_count, True
-            updated_fields = report.transition_to(SignalReport.Status.FAILED, error=input.error)
-            report.save(update_fields=updated_fields)
-            return report.run_count, False
 
-        run_count, was_already_failed = await database_sync_to_async(do_update, thread_sensitive=False)()
-    except Exception as e:
-        logger.exception(
-            f"Failed to mark report {input.report_id} as failed: {e}",
-            report_id=input.report_id,
-        )
-        raise
+async def fail_report(input: MarkReportFailedInput, *, guard: Callable[[SignalReport], bool] | None = None) -> str:
+    """Move a report to FAILED and report the pass as completed with `result="failed"`.
 
-    if was_already_failed:
-        logger.info(
-            f"Report {input.report_id} already in failed status, skipping duplicate transition",
-            report_id=input.report_id,
-        )
-        return
+    The transition, the analytics event and the `signals_reports_total{result=failed}` metric belong
+    together: a caller that does only the transition leaves a started pass that never completes in
+    the analytics, which is the same signature as a stranded report. `guard` runs on the locked row
+    and may veto the write, for callers whose evidence that the report should fail is external and
+    can go stale between reading it and taking the lock. Returns one of the FAIL_REPORT_* outcomes.
+    """
+
+    @transaction.atomic
+    def do_update() -> tuple[int, str]:
+        report = SignalReport.objects.select_for_update().get(id=input.report_id, team_id=input.team_id)
+        if report.status == SignalReport.Status.FAILED:
+            return report.run_count, FAIL_REPORT_ALREADY_FAILED
+        if guard is not None and not guard(report):
+            return report.run_count, FAIL_REPORT_SKIPPED
+        updated_fields = report.transition_to(SignalReport.Status.FAILED, error=input.error)
+        report.save(update_fields=updated_fields)
+        return report.run_count, FAIL_REPORT_FAILED
+
+    run_count, outcome = await database_sync_to_async(do_update, thread_sensitive=False)()
+    if outcome != FAIL_REPORT_FAILED:
+        return outcome
 
     team = await Team.objects.select_related("organization").aget(pk=input.team_id)
     _capture_report_event(
@@ -976,6 +976,30 @@ async def mark_report_failed_activity(input: MarkReportFailedInput) -> None:
         result="failed",
         failure_reason=input.failure_reason,
     )
+    return outcome
+
+
+@temporalio.activity.defn
+@scoped_temporal()
+@close_db_connections
+async def mark_report_failed_activity(input: MarkReportFailedInput) -> None:
+    """Mark a report as failed and store the error message."""
+    try:
+        outcome = await fail_report(input)
+    except Exception as e:
+        logger.exception(
+            f"Failed to mark report {input.report_id} as failed: {e}",
+            report_id=input.report_id,
+        )
+        raise
+
+    if outcome == FAIL_REPORT_ALREADY_FAILED:
+        logger.info(
+            f"Report {input.report_id} already in failed status, skipping duplicate transition",
+            report_id=input.report_id,
+        )
+        return
+
     logger.debug(
         f"Marked report {input.report_id} as failed",
         report_id=input.report_id,

--- a/products/signals/backend/test/test_stranded_reports.py
+++ b/products/signals/backend/test/test_stranded_reports.py
@@ -1,0 +1,369 @@
+import uuid
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from django.conf import settings
+from django.test import override_settings
+from django.utils import timezone
+
+from temporalio import activity
+from temporalio.client import (
+    ScheduleActionStartWorkflow,
+    ScheduleIntervalSpec,
+    ScheduleOverlapPolicy,
+    WorkflowExecutionStatus,
+)
+from temporalio.exceptions import ApplicationError
+from temporalio.service import RPCError, RPCStatusCode
+from temporalio.testing import ActivityEnvironment, WorkflowEnvironment
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
+from posthog.sync import database_sync_to_async
+
+from products.signals.backend.management.commands.signal_pipeline_status import Command as PipelineStatusCommand
+from products.signals.backend.models import SignalReport
+from products.signals.backend.signal_metadata import ReportSignalMeta
+from products.signals.backend.temporal import metrics
+from products.signals.backend.temporal.stranded_reports import (
+    SCHEDULE_ID,
+    SCHEDULE_INTERVAL,
+    STRANDED_FAILURE_REASON,
+    WORKFLOW_NAME,
+    FailStrandedReportInput,
+    FailStrandedReportOutput,
+    FindStrandedReportsInput,
+    FindStrandedReportsOutput,
+    StrandedReport,
+    StrandedReportReconcilerInput,
+    StrandedReportReconcilerWorkflow,
+    fail_stranded_report_activity,
+    find_stranded_reports_activity,
+)
+from products.signals.backend.temporal.stranded_reports_schedule import (
+    create_signals_stranded_report_reconciler_schedule,
+)
+from products.signals.backend.temporal.summary import SignalReportSummaryWorkflow
+
+MODULE = "products.signals.backend.temporal.stranded_reports"
+SCHEDULE_MODULE = "products.signals.backend.temporal.stranded_reports_schedule"
+SUMMARY_MODULE = "products.signals.backend.temporal.summary"
+TASK_QUEUE = "test-stranded-reports-queue"
+
+
+async def _report(team, *, status=SignalReport.Status.IN_PROGRESS, last_run_minutes_ago=30) -> SignalReport:
+    report = await database_sync_to_async(SignalReport.objects.create)(
+        team=team, status=status, signal_count=2, total_weight=1.0, run_count=1
+    )
+    await database_sync_to_async(SignalReport.objects.filter(id=report.id).update)(
+        last_run_at=timezone.now() - timedelta(minutes=last_run_minutes_ago)
+    )
+    await database_sync_to_async(report.refresh_from_db)()
+    return report
+
+
+def _temporal_client(outcomes: dict[str, WorkflowExecutionStatus | Exception]) -> MagicMock:
+    client = MagicMock()
+
+    def get_workflow_handle(workflow_id: str) -> MagicMock:
+        handle = MagicMock()
+
+        async def describe():
+            outcome = outcomes.get(workflow_id, RPCError("not found", RPCStatusCode.NOT_FOUND, b""))
+            if isinstance(outcome, Exception):
+                raise outcome
+            return SimpleNamespace(status=outcome)
+
+        handle.describe = describe
+        return handle
+
+    client.get_workflow_handle.side_effect = get_workflow_handle
+    return client
+
+
+def _patched_connect(client: MagicMock):
+    return patch(f"{MODULE}.async_connect", new=AsyncMock(return_value=client))
+
+
+async def _find(client: MagicMock, **kwargs) -> FindStrandedReportsOutput:
+    with _patched_connect(client):
+        return await ActivityEnvironment().run(find_stranded_reports_activity, FindStrandedReportsInput(**kwargs))
+
+
+async def _refreshed(report: SignalReport) -> SignalReport:
+    return await database_sync_to_async(SignalReport.objects.get)(id=report.id)
+
+
+def _last_run_at(report: SignalReport) -> datetime:
+    assert report.last_run_at is not None
+    return report.last_run_at
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "workflow_outcome,expected_status",
+    [
+        (WorkflowExecutionStatus.TIMED_OUT, "TIMED_OUT"),
+        (WorkflowExecutionStatus.TERMINATED, "TERMINATED"),
+        (WorkflowExecutionStatus.COMPLETED, "COMPLETED"),
+        (RPCError("not found", RPCStatusCode.NOT_FOUND, b""), "NOT_FOUND"),
+    ],
+)
+async def test_find_returns_in_progress_reports_whose_workflow_is_gone(ateam, workflow_outcome, expected_status):
+    report = await _report(ateam)
+    workflow_id = SignalReportSummaryWorkflow.workflow_id_for(ateam.id, str(report.id))
+
+    output = await _find(_temporal_client({workflow_id: workflow_outcome}))
+
+    assert [s.report_id for s in output.stranded] == [str(report.id)]
+    stranded = output.stranded[0]
+    assert stranded.workflow_status == expected_status
+    assert stranded.team_id == ateam.id
+    assert stranded.last_run_at == _last_run_at(report).isoformat()
+    assert output.scanned == 1
+    assert output.running == 0
+    assert output.truncated is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "workflow_outcome",
+    [
+        WorkflowExecutionStatus.RUNNING,
+        WorkflowExecutionStatus.CONTINUED_AS_NEW,
+        RPCError("unavailable", RPCStatusCode.UNAVAILABLE, b""),
+    ],
+)
+async def test_find_leaves_live_and_unknown_workflows_alone(ateam, workflow_outcome):
+    report = await _report(ateam)
+    workflow_id = SignalReportSummaryWorkflow.workflow_id_for(ateam.id, str(report.id))
+
+    output = await _find(_temporal_client({workflow_id: workflow_outcome}))
+
+    assert output.stranded == []
+    assert output.scanned == 1
+    assert output.running == (0 if isinstance(workflow_outcome, RPCError) else 1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_find_skips_young_reports_and_non_in_progress_statuses(ateam):
+    await _report(ateam, last_run_minutes_ago=5)
+    await _report(ateam, status=SignalReport.Status.CANDIDATE)
+    await _report(ateam, status=SignalReport.Status.READY)
+
+    output = await _find(_temporal_client({}))
+
+    assert output.scanned == 0
+    assert output.stranded == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_find_takes_the_oldest_first_and_reports_truncation(ateam):
+    newest = await _report(ateam, last_run_minutes_ago=40)
+    oldest = await _report(ateam, last_run_minutes_ago=120)
+    middle = await _report(ateam, last_run_minutes_ago=80)
+
+    output = await _find(_temporal_client({}), limit=2)
+
+    assert [s.report_id for s in output.stranded] == [str(oldest.id), str(middle.id)]
+    assert output.truncated is True
+    assert str(newest.id) not in [s.report_id for s in output.stranded]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_find_is_a_noop_when_disabled(ateam):
+    await _report(ateam)
+    client = _temporal_client({})
+
+    with override_settings(SIGNAL_STRANDED_REPORT_RECONCILER_ENABLED=False):
+        output = await _find(client)
+
+    assert output == FindStrandedReportsOutput()
+    client.get_workflow_handle.assert_not_called()
+
+
+def _fail_input(report: SignalReport, *, expected_last_run_at: str | None = None) -> FailStrandedReportInput:
+    return FailStrandedReportInput(
+        team_id=report.team_id,
+        report_id=str(report.id),
+        expected_last_run_at=expected_last_run_at or _last_run_at(report).isoformat(),
+        workflow_status="TIMED_OUT",
+        run_count=report.run_count,
+        signal_count=report.signal_count,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_fail_marks_the_report_failed_and_completes_the_pass(ateam):
+    report = await _report(ateam)
+    meta = {str(report.id): ReportSignalMeta(source_products=["zendesk"], scout_name=None)}
+
+    with (
+        patch(f"{MODULE}.fetch_source_products_for_reports", return_value=meta),
+        patch(f"{SUMMARY_MODULE}.posthoganalytics.capture") as capture,
+    ):
+        output = await ActivityEnvironment().run(fail_stranded_report_activity, _fail_input(report))
+
+    assert output == FailStrandedReportOutput(outcome=metrics.STRANDED_OUTCOME_FAILED)
+    refreshed = await _refreshed(report)
+    assert refreshed.status == SignalReport.Status.FAILED
+    assert "TIMED_OUT" in (refreshed.error or "")
+    completed = [c for c in capture.call_args_list if c.kwargs["event"] == "signal_report_completed"]
+    assert len(completed) == 1
+    properties = completed[0].kwargs["properties"]
+    assert properties["result"] == "failed"
+    assert properties["failure_reason"] == STRANDED_FAILURE_REASON
+    assert properties["source_products"] == ["zendesk"]
+    assert properties["run_count"] == report.run_count
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_fail_still_fails_the_report_when_source_products_cannot_be_read(ateam):
+    report = await _report(ateam)
+
+    with (
+        patch(f"{MODULE}.fetch_source_products_for_reports", side_effect=RuntimeError("clickhouse down")),
+        patch(f"{SUMMARY_MODULE}.posthoganalytics.capture") as capture,
+    ):
+        output = await ActivityEnvironment().run(fail_stranded_report_activity, _fail_input(report))
+
+    assert output.outcome == metrics.STRANDED_OUTCOME_FAILED
+    assert (await _refreshed(report)).status == SignalReport.Status.FAILED
+    assert capture.call_args.kwargs["properties"]["source_products"] == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+@pytest.mark.parametrize("status", [SignalReport.Status.IN_PROGRESS, SignalReport.Status.READY])
+async def test_fail_leaves_a_report_that_moved_since_the_scan_alone(ateam, status):
+    report = await _report(ateam, status=status)
+    # A newer pass rewrites last_run_at; a later status keeps it. Both must veto the write.
+    stale_last_run_at = (_last_run_at(report) - timedelta(minutes=10)).isoformat()
+    expected = stale_last_run_at if status == SignalReport.Status.IN_PROGRESS else None
+
+    with (
+        patch(f"{MODULE}.fetch_source_products_for_reports", return_value={}),
+        patch(f"{SUMMARY_MODULE}.posthoganalytics.capture") as capture,
+    ):
+        output = await ActivityEnvironment().run(
+            fail_stranded_report_activity, _fail_input(report, expected_last_run_at=expected)
+        )
+
+    assert output.outcome == metrics.STRANDED_OUTCOME_SKIPPED_CHANGED
+    refreshed = await _refreshed(report)
+    assert refreshed.status == status
+    assert refreshed.error is None
+    capture.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_workflow_fails_every_stranded_report_even_when_one_raises():
+    stranded = [
+        StrandedReport(
+            team_id=1,
+            report_id=str(uuid.uuid4()),
+            run_count=1,
+            signal_count=1,
+            last_run_at=timezone.now().isoformat(),
+            workflow_status="TIMED_OUT",
+        )
+        for _ in range(2)
+    ]
+    attempted: list[str] = []
+
+    @activity.defn(name="find_stranded_reports_activity")
+    async def fake_find(_input: FindStrandedReportsInput) -> FindStrandedReportsOutput:
+        return FindStrandedReportsOutput(stranded=stranded, scanned=2)
+
+    @activity.defn(name="fail_stranded_report_activity")
+    async def fake_fail(input: FailStrandedReportInput) -> FailStrandedReportOutput:
+        attempted.append(input.report_id)
+        if input.report_id == stranded[0].report_id:
+            raise ApplicationError("boom", non_retryable=True)
+        return FailStrandedReportOutput(outcome=metrics.STRANDED_OUTCOME_FAILED)
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=TASK_QUEUE,
+            workflows=[StrandedReportReconcilerWorkflow],
+            activities=[fake_find, fake_fail],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            await env.client.execute_workflow(
+                StrandedReportReconcilerWorkflow.run,
+                StrandedReportReconcilerInput(),
+                id=f"stranded-{uuid.uuid4()}",
+                task_queue=TASK_QUEUE,
+            )
+
+    assert attempted == [s.report_id for s in stranded]
+
+
+@pytest.fixture
+def schedule_helpers():
+    with (
+        patch(f"{SCHEDULE_MODULE}.a_create_schedule", new_callable=AsyncMock) as create,
+        patch(f"{SCHEDULE_MODULE}.a_update_schedule", new_callable=AsyncMock) as update,
+        patch(f"{SCHEDULE_MODULE}.a_schedule_exists", new_callable=AsyncMock) as exists,
+    ):
+        yield {"create": create, "update": update, "exists": exists}
+
+
+def _assert_reconciler_schedule(schedule) -> None:
+    assert isinstance(schedule.action, ScheduleActionStartWorkflow)
+    assert schedule.action.workflow == WORKFLOW_NAME
+    assert schedule.action.id == SCHEDULE_ID
+    assert schedule.action.task_queue == settings.VIDEO_EXPORT_TASK_QUEUE
+    assert schedule.policy.overlap == ScheduleOverlapPolicy.SKIP
+    assert schedule.policy.catchup_window == SCHEDULE_INTERVAL
+    assert schedule.spec.intervals == [ScheduleIntervalSpec(every=SCHEDULE_INTERVAL)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exists", [False, True])
+async def test_schedule_is_created_when_missing_and_updated_when_present(schedule_helpers, exists):
+    schedule_helpers["exists"].return_value = exists
+    client = MagicMock()
+
+    await create_signals_stranded_report_reconciler_schedule(client)
+
+    called = schedule_helpers["update"] if exists else schedule_helpers["create"]
+    skipped = schedule_helpers["create"] if exists else schedule_helpers["update"]
+    called.assert_awaited_once()
+    skipped.assert_not_called()
+    passed_client, schedule_id, schedule = called.call_args.args
+    assert passed_client is client
+    assert schedule_id == SCHEDULE_ID
+    _assert_reconciler_schedule(schedule)
+    if not exists:
+        assert called.call_args.kwargs["trigger_immediately"] is False
+
+
+@pytest.mark.parametrize(
+    "stranded_ids,settled",
+    [
+        (["report-a"], True),
+        ([], False),
+    ],
+)
+def test_pipeline_status_does_not_wait_on_stranded_reports(stranded_ids, settled):
+    status = {
+        "postgres": {"in_progress": 1, "total": 1},
+        "temporal": {"stranded_report_ids": stranded_ids},
+    }
+
+    result = PipelineStatusCommand()._is_settled(
+        status, expected_signals=1, ch_count=1, prev_ch_count=1, stable_polls=1
+    )
+
+    assert result is settled

--- a/products/signals/backend/test/test_temporal_metrics.py
+++ b/products/signals/backend/test/test_temporal_metrics.py
@@ -49,8 +49,20 @@ class TestCounterHelpers:
             metrics.increment_llm_call("match", metrics.LLM_STATUS_OK)
             metrics.increment_ch_wait_timeout()
             metrics.increment_scout_run("completed")
+            metrics.increment_stranded_report_reconciled(metrics.STRANDED_OUTCOME_FAILED)
 
         get_meter.assert_not_called()
+
+    def test_stranded_report_reconciled_labels_outcome(self):
+        meter = _mock_meter()
+        with (
+            patch.object(metrics, "_in_temporal_context", return_value=True),
+            patch.object(metrics, "get_metric_meter", return_value=meter) as get_meter,
+        ):
+            metrics.increment_stranded_report_reconciled(metrics.STRANDED_OUTCOME_SKIPPED_RUNNING)
+
+        assert get_meter.call_args[0][0] == {"outcome": "skipped_running"}
+        meter.create_counter.return_value.add.assert_called_once_with(1)
 
     def test_zero_count_is_a_noop(self):
         with (

--- a/products/signals/skills/debugging-signals-pipeline/SKILL.md
+++ b/products/signals/skills/debugging-signals-pipeline/SKILL.md
@@ -194,6 +194,28 @@ The `signal-emitter` completed but `buffer-signals` never got the `submit_signal
 This happens when the emitter sent the signal to a previous buffer run that then continued-as-new,
 and the new run started fresh without the pending signal. Re-emit the signal.
 
+### Report stuck in `in_progress` (stranded)
+
+The report shows `in_progress` in Postgres, but its summary workflow `signals-report:<team_id>:<report_id>` is `TIMED_OUT`, `TERMINATED`, or not found in Temporal.
+The workflow closed without running its own failure path, so the report never left `in_progress`, and no promotion rule picks that status up.
+Typical causes: the summary workflow hit its execution timeout mid-research, a worker deploy left an in-flight history that no longer replays, or a worker outage outlasted the timeout.
+Locally, a laptop that sleeps during a research pass does the same.
+
+`signal_pipeline_status --team-id N` lists these reports as stranded and stops waiting on them.
+
+The stranded report reconciler (`products/signals/backend/temporal/stranded_reports.py`) runs every 30 minutes.
+It marks each stranded report `failed` with an error naming the workflow status, and emits `signal_report_completed` with `result=failed` and `failure_reason=research_run_stranded`.
+The report does not research again on its own; a later matching signal starts a fresh report.
+
+To run the reconciler now:
+
+```bash
+docker exec posthog-temporal-admin-tools-1 temporal schedule trigger --address temporal:7233 --schedule-id signals-stranded-report-reconciler-schedule
+```
+
+Counter: `signals_stranded_reports_reconciled_total{outcome}` (`failed`, `skipped_running`, `skipped_changed`).
+Settings: `SIGNAL_STRANDED_REPORT_RECONCILER_ENABLED` (kill switch), `SIGNAL_STRANDED_REPORT_MIN_AGE_MINUTES`, `SIGNAL_STRANDED_REPORT_MAX_PER_TICK`.
+
 ### ClickHouse embedding tables "not found" during cleanup
 
 The tables exist in the `posthog` database but `sync_execute` queries the `default` database.
@@ -223,6 +245,7 @@ grep CLICKHOUSE_DATABASE .env
 - Buffer workflow: `products/signals/backend/temporal/buffer.py`
 - Grouping workflow: `products/signals/backend/temporal/grouping_v2.py`
 - Report summary workflow: `products/signals/backend/temporal/summary.py`
+- Stranded report reconciler: `products/signals/backend/temporal/stranded_reports.py`
 - Docker sandbox implementation: `products/tasks/backend/logic/services/docker_sandbox.py`
 - Sandbox Dockerfiles: `products/tasks/backend/sandbox/images/`
 - Agent log polling: `products/tasks/backend/logic/services/custom_prompt_internals.py`


### PR DESCRIPTION
## Problem

- A signal report whose research pass dies with the worker stays "in progress" in the inbox forever, and no later signal moves it.
- Temporal closes the summary workflow without running its code on an execution timeout, a termination, or a history that no longer replays after a deploy, so the workflow's own failure activity never runs.
- Grouping's promotion rules never promote `in_progress`, the stale sweep reaches it only after two idle weeks for opted-in teams, and `signal_pipeline_status` counts it as transient and waits on it.
- Production analytics (`signal_report_started` with no matching `signal_report_completed`) show the pattern in bursts right after signals worker deploys. A laptop sleep during a research pass reproduces it locally.

## Changes

- A stranded report now ends up `failed` within about 30 minutes of its workflow closing, with an error naming the workflow status.
- A new scheduled workflow, `signals-stranded-report-reconciler`, finds `in_progress` reports older than 20 minutes and asks Temporal whether each report's summary workflow is still running. Only a closed or missing workflow counts; a running one is a legitimate long pass.
- The pass completes in analytics: `signal_report_completed` with `result=failed` and `failure_reason=research_run_stranded`, through the same helper `mark_report_failed_activity` uses. A row lock plus an unchanged `last_run_at` guard the write, so a pass that restarted since the scan is left alone.
- `signal_pipeline_status` lists stranded reports with a trigger hint and no longer waits on them.
- Stranded reports are not re-researched: a later matching signal starts a fresh report. Relaunching research was rejected because it needs a recovery cap and a model field to carry it.
- Three settings gate the reconciler: `SIGNAL_STRANDED_REPORT_RECONCILER_ENABLED` (kill switch, on by default), `SIGNAL_STRANDED_REPORT_MIN_AGE_MINUTES`, and `SIGNAL_STRANDED_REPORT_MAX_PER_TICK`. The counter `signals_stranded_reports_reconciled_total{outcome}` records what each tick did.
- Mechanical: worker and schedule registration, the worker-integrity test list, and the debugging skill and management guide.
- Not changed: the summary workflow's 75-minute execution timeout in grouping.

Before:

```mermaid
flowchart LR
    C[candidate] --> P[in_progress]
    P -->|workflow completes| R[ready / pending_input / failed]
    P -->|workflow times out or is terminated| S[in_progress forever]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class C phYellow;
    class P,R phBlue;
    class S phRed;
```

After:

```mermaid
flowchart LR
    C[candidate] --> P[in_progress]
    P -->|workflow completes| R[ready / pending_input / failed]
    P -->|workflow times out or is terminated| S[in_progress, no workflow]
    S -->|reconciler, every 30 min| F[failed]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class C phYellow;
    class P,R,F phBlue;
    class S phRed;
```

## How did you test this code?

- New `test_stranded_reports.py`, activity level: which workflow statuses count as stranded, a running workflow and an undecidable describe error are skipped, the minimum age and per-tick cap with oldest-first ordering, and the kill switch. These catch a scan that fails a live pass or an unreachable one.
- Fail activity: the report ends `failed` with the completion event, a source-products lookup failure still fails the report, and a moved `last_run_at` or status vetoes the write. These catch a reconciler racing a restarted pass.
- Workflow level with fake activities: one failing report does not stop the tick.
- Schedule factory create and update, the metric label, and `_is_settled` ignoring stranded reports.
- The existing report telemetry tests cover the refactored failure helper unchanged.
- Manual, on a local Temporal server with one worker: a seeded `in_progress` report with no workflow was listed as stranded by `signal_pipeline_status`, a triggered schedule failed it with the expected error and event, and a second trigger was an empty tick.
- Not checked end to end: a real research pass timing out, which needs the full sandbox stack.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The debugging skill (`products/signals/skills/debugging-signals-pipeline/SKILL.md`) and the management guide gained a section on the stranded signature and the reconciler.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Claude Fable 5.1), session: https://claude.ai/code/session_01DdASu2sWC2Ln5a2ri2E6V8
- Skills invoked: `/writing-dataclasses`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, and `posthog:querying-posthog-data` for the production analysis.
- Origin: found while testing the PR supersede flow locally, where a laptop sleep during a research pass left the report stuck. The production analysis used only the signals pipeline's own lifecycle events.
- Decisions across the session: the first design restarted research with a capped retry count and a new model field. The reviewer chose fail-only recovery with no schema change, and to leave the summary workflow's execution timeout as is.
- No duplicate: `gh pr list --state open --search "stranded in_progress signal report"` found nothing.
- Public artifact: no material from the session beyond the repository's own code and its analytics event names. No customer data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdASu2sWC2Ln5a2ri2E6V8
