### PR TITLE
fix(dags): retry the duckgres idle-session reap in the events backfill

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -165,6 +165,18 @@ DUCKGRES_WORKER_PROFILE_ENABLED = os.environ.get("DUCKGRES_WORKER_PROFILE_ENABLE
 DUCKGRES_BACKFILL_COLOCATE_CPU = "4"
 DUCKGRES_BACKFILL_COLOCATE_MEMORY = "16Gi"
 
+# Optional client-requested idle timeout. The backfill holds its duckgres connection
+# open and untouched across the ClickHouse->S3 export; when that gap outruns the
+# server's duckgres.idle_timeout the session is reaped and the next statement pays a
+# reconnect-and-replay (see 57P05 in _CONNECTION_DROPPED_SQLSTATES). Raising the
+# timeout avoids that churn, but duckgres REJECTS a value above its configured
+# DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX with a FATAL at connect — and that ceiling is unset
+# (client overrides disabled) by default — so this is opt-in per deployment and empty
+# here. Correctness does not depend on it: the 57P05 retry handles the reap either way.
+# Each deployment sets its own ceiling, so check the target environment's configured
+# maximum before setting a value — an over-ceiling request fails the connection outright.
+DUCKGRES_BACKFILL_IDLE_TIMEOUT = os.environ.get("DUCKGRES_BACKFILL_IDLE_TIMEOUT", "").strip()
+
 
 def _duckgres_backfill_options() -> str:
     """libpq startup `options` for a backfill connection.
@@ -173,19 +185,23 @@ def _duckgres_backfill_options() -> str:
     colocated worker shape. Returns a single space-joined `-c key=value` string —
     psycopg forwards it as the startup `options` parameter, which duckgres parses
     to size/schedule the worker. No statement_timeout is set (see
-    DUCKGRES_CONNECT_TIMEOUT note above). Returns "" when the profile is disabled,
-    so the connection falls back to the default exclusive worker with no extra
-    startup options.
+    DUCKGRES_CONNECT_TIMEOUT note above). With the profile disabled and no idle
+    timeout requested this is "", so the connection falls back to the default
+    exclusive worker with no extra startup options.
     """
-    if not DUCKGRES_WORKER_PROFILE_ENABLED:
-        return ""
-    return " ".join(
-        [
+    opts: list[str] = []
+    # Emitted independently of the worker profile: the idle reap is a property of the
+    # connection, not of the worker shape, so disabling the profile must not silently
+    # drop it.
+    if DUCKGRES_BACKFILL_IDLE_TIMEOUT:
+        opts.append(f"-c duckgres.idle_timeout={DUCKGRES_BACKFILL_IDLE_TIMEOUT}")
+    if DUCKGRES_WORKER_PROFILE_ENABLED:
+        opts += [
             "-c duckgres.colocate=true",
             f"-c duckgres.worker_cpu={DUCKGRES_BACKFILL_COLOCATE_CPU}",
             f"-c duckgres.worker_memory={DUCKGRES_BACKFILL_COLOCATE_MEMORY}",
         ]
-    )
+    return " ".join(opts)
 
 
 @retry(
@@ -423,6 +439,14 @@ _CONNECTION_DROPPED_SQLSTATES = {
     "57P01",  # admin_shutdown
     "57P02",  # crash_shutdown
     "57P03",  # cannot_connect_now
+    # idle_session_timeout: duckgres reaped an idle client session (the backfill
+    # holds its connection open across the ClickHouse->S3 export, which can outrun
+    # the server's duckgres.idle_timeout). Older duckgres just closed the socket,
+    # so this arrived as a transport error matching _CONNECTION_DROPPED_MARKERS;
+    # it now sends a proper FATAL first, which is a cleaner signal but a different
+    # shape. Safest possible replay: the session was idle, so no statement was
+    # in flight and a retry cannot double-apply.
+    "57P05",
 }
 
 # Transport/connection-loss phrases ONLY. Deliberately NOT "flight execute":
@@ -448,6 +472,7 @@ _CONNECTION_DROPPED_MARKERS = (
     "error reading from server",
     "server closed the connection",
     "terminating connection due to administrator command",
+    "terminating connection due to idle timeout",
     "transport:",
 )
 

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -165,18 +165,6 @@ DUCKGRES_WORKER_PROFILE_ENABLED = os.environ.get("DUCKGRES_WORKER_PROFILE_ENABLE
 DUCKGRES_BACKFILL_COLOCATE_CPU = "4"
 DUCKGRES_BACKFILL_COLOCATE_MEMORY = "16Gi"
 
-# Optional client-requested idle timeout. The backfill holds its duckgres connection
-# open and untouched across the ClickHouse->S3 export; when that gap outruns the
-# server's duckgres.idle_timeout the session is reaped and the next statement pays a
-# reconnect-and-replay (see 57P05 in _CONNECTION_DROPPED_SQLSTATES). Raising the
-# timeout avoids that churn, but duckgres REJECTS a value above its configured
-# DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX with a FATAL at connect — and that ceiling is unset
-# (client overrides disabled) by default — so this is opt-in per deployment and empty
-# here. Correctness does not depend on it: the 57P05 retry handles the reap either way.
-# Each deployment sets its own ceiling, so check the target environment's configured
-# maximum before setting a value — an over-ceiling request fails the connection outright.
-DUCKGRES_BACKFILL_IDLE_TIMEOUT = os.environ.get("DUCKGRES_BACKFILL_IDLE_TIMEOUT", "").strip()
-
 
 def _duckgres_backfill_options() -> str:
     """libpq startup `options` for a backfill connection.
@@ -185,23 +173,19 @@ def _duckgres_backfill_options() -> str:
     colocated worker shape. Returns a single space-joined `-c key=value` string —
     psycopg forwards it as the startup `options` parameter, which duckgres parses
     to size/schedule the worker. No statement_timeout is set (see
-    DUCKGRES_CONNECT_TIMEOUT note above). With the profile disabled and no idle
-    timeout requested this is "", so the connection falls back to the default
-    exclusive worker with no extra startup options.
+    DUCKGRES_CONNECT_TIMEOUT note above). Returns "" when the profile is disabled,
+    so the connection falls back to the default exclusive worker with no extra
+    startup options.
     """
-    opts: list[str] = []
-    # Emitted independently of the worker profile: the idle reap is a property of the
-    # connection, not of the worker shape, so disabling the profile must not silently
-    # drop it.
-    if DUCKGRES_BACKFILL_IDLE_TIMEOUT:
-        opts.append(f"-c duckgres.idle_timeout={DUCKGRES_BACKFILL_IDLE_TIMEOUT}")
-    if DUCKGRES_WORKER_PROFILE_ENABLED:
-        opts += [
+    if not DUCKGRES_WORKER_PROFILE_ENABLED:
+        return ""
+    return " ".join(
+        [
             "-c duckgres.colocate=true",
             f"-c duckgres.worker_cpu={DUCKGRES_BACKFILL_COLOCATE_CPU}",
             f"-c duckgres.worker_memory={DUCKGRES_BACKFILL_COLOCATE_MEMORY}",
         ]
-    return " ".join(opts)
+    )
 
 
 @retry(

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -1364,6 +1364,30 @@ class TestConnectionDropped:
 
     @parameterized.expand(
         [
+            # duckgres reaps a client session that idled past duckgres.idle_timeout
+            # (the backfill holds its connection across the ClickHouse->S3 export).
+            # It sends a FATAL 57P05 before closing; older builds just dropped the
+            # socket, which landed in the transport-marker branch instead. Both the
+            # sqlstate and the message are pinned so either shape keeps retrying.
+            (
+                "idle_session_timeout",
+                psycopg.errors.IdleSessionTimeout(
+                    "terminating connection due to idle timeout (duckgres.idle_timeout is 5m0s)"
+                ),
+            ),
+            (
+                "idle_timeout_message_without_sqlstate",
+                psycopg.OperationalError("terminating connection due to idle timeout (duckgres.idle_timeout is 5m0s)"),
+            ),
+        ]
+    )
+    def test_idle_session_reap_is_dropped(self, _label, exc):
+        # Safest possible replay: the session was idle, so no statement was in
+        # flight and a retry cannot double-apply.
+        assert _connection_dropped(exc) is True
+
+    @parameterized.expand(
+        [
             ("disk_full", psycopg.errors.DiskFull()),
             ("undefined_table", psycopg.errors.UndefinedTable()),
             ("value_error", ValueError("nope")),
@@ -1704,7 +1728,10 @@ class TestDuckgresBackfillOptions:
     """
 
     def test_enabled_requests_small_colocated_worker(self):
-        with patch("posthog.dags.events_backfill_to_duckling.DUCKGRES_WORKER_PROFILE_ENABLED", True):
+        with (
+            patch("posthog.dags.events_backfill_to_duckling.DUCKGRES_WORKER_PROFILE_ENABLED", True),
+            patch("posthog.dags.events_backfill_to_duckling.DUCKGRES_BACKFILL_IDLE_TIMEOUT", ""),
+        ):
             assert (
                 _duckgres_backfill_options()
                 == "-c duckgres.colocate=true -c duckgres.worker_cpu=4 -c duckgres.worker_memory=16Gi"
@@ -1712,8 +1739,30 @@ class TestDuckgresBackfillOptions:
 
     def test_disabled_returns_empty_string(self):
         # Disabled → no startup options → falls back to the default exclusive worker.
-        with patch("posthog.dags.events_backfill_to_duckling.DUCKGRES_WORKER_PROFILE_ENABLED", False):
+        with (
+            patch("posthog.dags.events_backfill_to_duckling.DUCKGRES_WORKER_PROFILE_ENABLED", False),
+            patch("posthog.dags.events_backfill_to_duckling.DUCKGRES_BACKFILL_IDLE_TIMEOUT", ""),
+        ):
             assert _duckgres_backfill_options() == ""
+
+    def test_idle_timeout_requested_when_configured(self):
+        with (
+            patch("posthog.dags.events_backfill_to_duckling.DUCKGRES_WORKER_PROFILE_ENABLED", True),
+            patch("posthog.dags.events_backfill_to_duckling.DUCKGRES_BACKFILL_IDLE_TIMEOUT", "30m"),
+        ):
+            assert _duckgres_backfill_options() == (
+                "-c duckgres.idle_timeout=30m -c duckgres.colocate=true "
+                "-c duckgres.worker_cpu=4 -c duckgres.worker_memory=16Gi"
+            )
+
+    def test_idle_timeout_survives_disabled_worker_profile(self):
+        # The idle reap is a property of the connection, not the worker shape —
+        # turning the profile off must not silently drop the requested timeout.
+        with (
+            patch("posthog.dags.events_backfill_to_duckling.DUCKGRES_WORKER_PROFILE_ENABLED", False),
+            patch("posthog.dags.events_backfill_to_duckling.DUCKGRES_BACKFILL_IDLE_TIMEOUT", "30m"),
+        ):
+            assert _duckgres_backfill_options() == "-c duckgres.idle_timeout=30m"
 
     @parameterized.expand([("enabled", True), ("disabled", False)])
     def test_never_sets_statement_timeout(self, _label, enabled):

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -1728,10 +1728,7 @@ class TestDuckgresBackfillOptions:
     """
 
     def test_enabled_requests_small_colocated_worker(self):
-        with (
-            patch("posthog.dags.events_backfill_to_duckling.DUCKGRES_WORKER_PROFILE_ENABLED", True),
-            patch("posthog.dags.events_backfill_to_duckling.DUCKGRES_BACKFILL_IDLE_TIMEOUT", ""),
-        ):
+        with patch("posthog.dags.events_backfill_to_duckling.DUCKGRES_WORKER_PROFILE_ENABLED", True):
             assert (
                 _duckgres_backfill_options()
                 == "-c duckgres.colocate=true -c duckgres.worker_cpu=4 -c duckgres.worker_memory=16Gi"
@@ -1739,30 +1736,8 @@ class TestDuckgresBackfillOptions:
 
     def test_disabled_returns_empty_string(self):
         # Disabled → no startup options → falls back to the default exclusive worker.
-        with (
-            patch("posthog.dags.events_backfill_to_duckling.DUCKGRES_WORKER_PROFILE_ENABLED", False),
-            patch("posthog.dags.events_backfill_to_duckling.DUCKGRES_BACKFILL_IDLE_TIMEOUT", ""),
-        ):
+        with patch("posthog.dags.events_backfill_to_duckling.DUCKGRES_WORKER_PROFILE_ENABLED", False):
             assert _duckgres_backfill_options() == ""
-
-    def test_idle_timeout_requested_when_configured(self):
-        with (
-            patch("posthog.dags.events_backfill_to_duckling.DUCKGRES_WORKER_PROFILE_ENABLED", True),
-            patch("posthog.dags.events_backfill_to_duckling.DUCKGRES_BACKFILL_IDLE_TIMEOUT", "30m"),
-        ):
-            assert _duckgres_backfill_options() == (
-                "-c duckgres.idle_timeout=30m -c duckgres.colocate=true "
-                "-c duckgres.worker_cpu=4 -c duckgres.worker_memory=16Gi"
-            )
-
-    def test_idle_timeout_survives_disabled_worker_profile(self):
-        # The idle reap is a property of the connection, not the worker shape —
-        # turning the profile off must not silently drop the requested timeout.
-        with (
-            patch("posthog.dags.events_backfill_to_duckling.DUCKGRES_WORKER_PROFILE_ENABLED", False),
-            patch("posthog.dags.events_backfill_to_duckling.DUCKGRES_BACKFILL_IDLE_TIMEOUT", "30m"),
-        ):
-            assert _duckgres_backfill_options() == "-c duckgres.idle_timeout=30m"
 
     @parameterized.expand([("enabled", True), ("disabled", False)])
     def test_never_sets_statement_timeout(self, _label, enabled):

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -1367,17 +1367,30 @@ class TestConnectionDropped:
             # duckgres reaps a client session that idled past duckgres.idle_timeout
             # (the backfill holds its connection across the ClickHouse->S3 export).
             # It sends a FATAL 57P05 before closing; older builds just dropped the
-            # socket, which landed in the transport-marker branch instead. Both the
-            # sqlstate and the message are pinned so either shape keeps retrying.
+            # socket, which landed in the transport-marker branch instead. The two
+            # halves of that classification are guarded independently below, so
+            # neither can regress while the other keeps these cases green.
+            #
+            # The real observed shape: sqlstate AND message both present.
             (
                 "idle_session_timeout",
                 psycopg.errors.IdleSessionTimeout(
                     "terminating connection due to idle timeout (duckgres.idle_timeout is 5m0s)"
                 ),
             ),
+            # Message alone, no sqlstate — psycopg surfacing the text without a
+            # parsed ErrorResponse. Guards the _CONNECTION_DROPPED_MARKERS entry.
             (
                 "idle_timeout_message_without_sqlstate",
                 psycopg.OperationalError("terminating connection due to idle timeout (duckgres.idle_timeout is 5m0s)"),
+            ),
+            # Sqlstate alone. PostgreSQL's own idle_session_timeout wording is
+            # hyphenated ("idle-session timeout") and so does NOT match the
+            # duckgres-shaped marker — which is exactly why this guards the
+            # _CONNECTION_DROPPED_SQLSTATES entry on its own.
+            (
+                "idle_session_timeout_sqlstate_without_marker",
+                psycopg.errors.IdleSessionTimeout("terminating connection due to idle-session timeout"),
             ),
         ]
     )


### PR DESCRIPTION
## Problem

The events backfill holds its duckgres connection open and untouched across the ClickHouse→S3 export. When that gap outruns the server's `duckgres.idle_timeout`, the session is reaped and the next statement — the partition `DELETE` inside the register step — fails the op:

```
psycopg.errors.IdleSessionTimeout: terminating connection due to idle timeout
  ...
  File "posthog/dags/events_backfill_to_duckling.py", line 2641, in register_events_files
    delete_events_partition_data(context, target, team_id, date, conn=conn)
```

## Why it started failing now

The reap was already happening — it just used to recover silently.

duckgres previously closed the socket without warning, so psycopg raised an `OperationalError` carrying a transport phrase already listed in `_CONNECTION_DROPPED_MARKERS`; `DucklingSession.run` reconnected to a fresh worker and replayed. duckgres now sends a proper `FATAL 57P05` (`IdleSessionTimeout`) before closing — a strictly better signal, but a shape `_connection_dropped` did not recognise:

| check | result |
|---|---|
| `isinstance(exc, ConnectionException)` | ✗ — `IdleSessionTimeout` subclasses `OperationalError` |
| sqlstate `08*` or in `_CONNECTION_DROPPED_SQLSTATES` | ✗ — `57P05` was absent |
| marker match on the message | ✗ — `"...due to idle timeout"` ≠ `"...due to administrator command"` |

So it returned `False` and the error propagated. The better error message cost us the existing auto-recovery.

## Change

Purely additive: add `57P05` to `_CONNECTION_DROPPED_SQLSTATES`, and the idle-timeout phrase to `_CONNECTION_DROPPED_MARKERS`, so a FATAL-sending *and* a socket-dropping server both keep retrying.

Replay is the safest case in this path: the session was idle, so no statement was in flight and a retry cannot double-apply — and `register_events_files` is already documented as an idempotent replay unit.

## Testing

- New cases pin both shapes: `IdleSessionTimeout` carrying its sqlstate, and a bare `OperationalError` carrying only the message (so a server that drops the sqlstate still retries).
- Existing guards still hold — notably `QueryCanceled` (`57014`, also class 57) is still *not* treated as a drop, since the sqlstate set is exact-match.
- `236 passed` on `posthog/dags/test_events_backfill_to_duckling.py`; `ruff format --check` and `ruff check` clean.

## Not included

An earlier revision added an opt-in env var to request a longer `duckgres.idle_timeout`, avoiding the reap (and the reconnect churn) entirely. It has been dropped so this change does one thing. Correctness never depended on it — the `57P05` retry handles the reap on its own — and the always-on alternative would be riskier, since duckgres rejects an over-ceiling `idle_timeout` with a `FATAL` at connect.
