### PR TITLE
fix(replay-vision): render non-string pinned property values

### DIFF
--- a/products/replay_vision/frontend/observations/observationSessionPropertiesLogic.test.ts
+++ b/products/replay_vision/frontend/observations/observationSessionPropertiesLogic.test.ts
@@ -1,0 +1,60 @@
+import { expectLogic } from 'kea-test-utils'
+
+import api from '~/lib/api'
+import { initKeaTests } from '~/test/init'
+
+import { observationPinnedPropertiesLogic } from './observationPinnedPropertiesLogic'
+import { observationSessionPropertiesLogic, toDisplayValue } from './observationSessionPropertiesLogic'
+
+jest.mock('~/lib/api')
+
+const SESSION_ID = '01994a1e-4a3f-7000-8000-000000000000'
+
+describe('observationSessionPropertiesLogic', () => {
+    let logic: ReturnType<typeof observationSessionPropertiesLogic.build>
+
+    const mockApi = api as jest.Mocked<typeof api>
+
+    beforeEach(() => {
+        initKeaTests()
+        jest.resetAllMocks()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    // A property keeps its own type through HogQL, so the strip used to call startsWith on the
+    // number $browser_version reads back as.
+    it.each([
+        [143, '143'],
+        [0, '0'],
+        [false, 'false'],
+        ['Chrome', 'Chrome'],
+        [['a', 'b'], '["a","b"]'],
+        [null, null],
+        [undefined, null],
+        ['', null],
+    ])('reads %p as %p', (value, expected) => {
+        expect(toDisplayValue(value)).toBe(expected)
+    })
+
+    it('renders non-string property values as text', async () => {
+        observationPinnedPropertiesLogic.mount()
+        observationPinnedPropertiesLogic.actions.setPinnedProperties([
+            { key: '$browser_version', type: 'event' },
+            { key: '$browser', type: 'event' },
+        ])
+        mockApi.queryHogQL.mockResolvedValue({ results: [[143, 'Chrome']] } as any)
+
+        logic = observationSessionPropertiesLogic({ sessionId: SESSION_ID })
+        logic.mount()
+
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(logic.values.sessionProperties).toEqual({
+            'event:$browser_version': '143',
+            'event:$browser': 'Chrome',
+        })
+    })
+})

--- a/products/replay_vision/frontend/observations/observationSessionPropertiesLogic.ts
+++ b/products/replay_vision/frontend/observations/observationSessionPropertiesLogic.ts
@@ -21,6 +21,23 @@ export function pinnedPropertyId(property: PinnedProperty): string {
     return `${property.type}:${property.key}`
 }
 
+/**
+ * A property keeps its own type through HogQL, so a pin like $browser_version comes back as a
+ * number and a flag as a boolean. The strip renders text, so everything is stringified here.
+ */
+export function toDisplayValue(value: unknown): string | null {
+    if (value === null || value === undefined || value === '') {
+        return null
+    }
+    if (typeof value === 'string') {
+        return value
+    }
+    if (typeof value === 'number' || typeof value === 'boolean') {
+        return String(value)
+    }
+    return JSON.stringify(value)
+}
+
 function selectExpression(property: PinnedProperty): string {
     const identifier = escapePropertyAsHogQLIdentifier(property.key)
     if (property.type === 'session') {
@@ -132,7 +149,7 @@ export const observationSessionPropertiesLogic = kea<observationSessionPropertie
                     }
                     return Object.fromEntries(
                         // An event carrying the key with an empty value reads the same as never carrying it.
-                        properties.map((property, index) => [pinnedPropertyId(property), row[index] || null])
+                        properties.map((property, index) => [pinnedPropertyId(property), toDisplayValue(row[index])])
                     )
                 },
             },

--- a/products/replay_vision/frontend/observations/observationSessionPropertiesLogic.ts
+++ b/products/replay_vision/frontend/observations/observationSessionPropertiesLogic.ts
@@ -85,12 +85,12 @@ export interface observationSessionPropertiesLogicActions {
     }
     loadSessionPropertiesSuccess: (
         sessionProperties: {
-            [k: string]: any
+            [k: string]: string | null
         } | null,
         payload?: any
     ) => {
         sessionProperties: {
-            [k: string]: any
+            [k: string]: string | null
         } | null
         payload?: any
     }


### PR DESCRIPTION
## Problem

Pinning a property whose value is not text crashes the Replay Vision observation page for the person who pinned it. Browser version is the easy one to hit: the page goes to an error screen with `TypeError: n.startsWith is not a function`, and the only way out is to unpin the property.

A property keeps its own type through HogQL, so `$browser_version` comes back as a number and a flag comes back as a boolean. The pinned strip typed every value as `string | null` and called `startsWith` on it to decide whether to render a link.

## Changes

- Pinning a numeric, boolean, or list-valued property now shows its value as text instead of breaking the page.
- An empty value still reads as "—", but a value of `0` or `false` now reads as the value rather than as no value.
- Mechanical: the query result is stringified in one place in `observationSessionPropertiesLogic`, so the `string | null` the component already expected is now true.

## How did you test this code?

Automated only — I did not run the app. Added `observationSessionPropertiesLogic.test.ts`, which covers the value types a pin can return and asserts that a numeric property loads as text end to end through the loader. No existing test covered the loader.

`jest --testPathPattern='replay_vision/frontend/observations'` passes locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

Written by an agent from a bug report about pinned properties on the observation page, including the browser stack trace. The agent read the reporter's exception details, reproduced the cause by reading the code path, and did not run the app.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
