### PR TITLE
fix(data-modeling): fail first builds that exceed query limit

### DIFF
--- a/posthog/temporal/data_modeling/activities/fail_materialization.py
+++ b/posthog/temporal/data_modeling/activities/fail_materialization.py
@@ -1,6 +1,5 @@
 import datetime as dt
 import dataclasses
-from uuid import UUID
 
 from django.db import transaction
 
@@ -18,40 +17,23 @@ from products.data_modeling.backend.facade.models import (
     DataWarehouseSavedQuery,
     Node,
 )
-from products.data_warehouse.backend.facade.api import pause_saved_query_schedule
 
 from ..metrics import get_node_suspended_metric
 from .notify_materialization_failure import maybe_notify_materialization_failure
 from .utils import (
     CONSECUTIVE_FAILURES_TO_SUSPEND,
     bind_data_modeling_log_context,
-    get_previous_jobs,
+    has_newer_job,
+    has_newer_terminal_job,
+    mark_node_suspended,
     maybe_suspend_node_for_engine,
+    query_fingerprint,
     strip_hostname_from_error,
     update_node_system_properties,
+    update_saved_query_latest_error,
 )
 
 LOGGER = get_logger(__name__)
-
-CONSECUTIVE_TIMEOUTS_TO_PAUSE = 5
-
-
-def should_pause_schedule_for_timeout(saved_query_id: UUID, current_job: DataModelingJob) -> tuple[bool, int]:
-    """Check if the schedule should be paused based on consecutive timeout failures.
-
-    Returns True only if all of the previous CONSECUTIVE_TIMEOUTS_TO_PAUSE jobs
-    failed due to query timeouts. This prevents pausing schedules for transient
-    timeouts that can occur due to temporary ClickHouse load.
-    """
-    previous_jobs = list(get_previous_jobs(saved_query_id, current_job, CONSECUTIVE_TIMEOUTS_TO_PAUSE))
-    count = 0
-    for job in previous_jobs:
-        if job.status != DataModelingJobStatus.FAILED:
-            break
-        if not job.error or ("Timeout exceeded" not in job.error and "exceeded timeout" not in job.error.lower()):
-            break
-        count += 1
-    return count == CONSECUTIVE_TIMEOUTS_TO_PAUSE, count
 
 
 @dataclasses.dataclass
@@ -63,39 +45,78 @@ class FailMaterializationInputs:
     error: str
     cancelled: bool = False
     update_node: bool = True
+    suspend_immediately: bool = False
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True, slots=True)
+class FailNodeAndJobOutcome:
+    job: DataModelingJob
+    is_latest_terminal: bool
+    suspended_immediately: bool
 
 
 @database_sync_to_async_pool
-def _fail_node_and_data_modeling_job(inputs: FailMaterializationInputs):
-    # strip hostnames from error for user-facing storage while preserving original for logging
+def _fail_node_and_data_modeling_job(inputs: FailMaterializationInputs) -> FailNodeAndJobOutcome:
     sanitized_error = strip_hostname_from_error(inputs.error)
 
-    node = None
-    if inputs.update_node:
-        with transaction.atomic():
-            node = Node.objects.select_for_update().get(id=inputs.node_id, team_id=inputs.team_id, dag_id=inputs.dag_id)
-            status = DataModelingJobStatus.CANCELLED if inputs.cancelled else DataModelingJobStatus.FAILED
-            update_node_system_properties(
-                node,
-                status=status,
-                job_id=inputs.job_id,
-                error=sanitized_error,
+    with transaction.atomic():
+        job = DataModelingJob.objects.select_for_update().get(id=inputs.job_id)
+        if job.status in (
+            DataModelingJobStatus.FAILED,
+            DataModelingJobStatus.CANCELLED,
+            DataModelingJobStatus.COMPLETED,
+        ):
+            return FailNodeAndJobOutcome(
+                job=job,
+                is_latest_terminal=not has_newer_terminal_job(job),
+                suspended_immediately=False,
             )
-            node.save()
 
-    job = DataModelingJob.objects.get(id=inputs.job_id)
+        node = None
+        suspended_immediately = False
+        is_latest_terminal = not has_newer_terminal_job(job)
+        if inputs.update_node:
+            locked_node = Node.objects.select_for_update().get(
+                id=inputs.node_id, team_id=inputs.team_id, dag_id=inputs.dag_id
+            )
+            is_latest_terminal = not has_newer_terminal_job(job)
+            if is_latest_terminal:
+                node = locked_node
+                update_node_system_properties(
+                    node,
+                    status=DataModelingJobStatus.CANCELLED if inputs.cancelled else DataModelingJobStatus.FAILED,
+                    job_id=inputs.job_id,
+                    error=sanitized_error,
+                )
+            if node is not None and inputs.suspend_immediately and node.saved_query_id is not None:
+                fingerprint = query_fingerprint(
+                    DataWarehouseSavedQuery.objects.filter(id=node.saved_query_id)
+                    .values_list("query", flat=True)
+                    .first()
+                )
+                mark_node_suspended(
+                    node,
+                    engine=DataModelingJobEngine.CLICKHOUSE,
+                    reason=sanitized_error,
+                    job_id=inputs.job_id,
+                    fingerprint=fingerprint,
+                    enforce_without_flag=True,
+                )
+                suspended_immediately = True
+            if node is not None:
+                node.save()
 
-    # if the job is already in a terminal state, don't overwrite it — preserves the first error
-    if job.status in (DataModelingJobStatus.FAILED, DataModelingJobStatus.CANCELLED, DataModelingJobStatus.COMPLETED):
-        return node, job
+        job.status = DataModelingJobStatus.CANCELLED if inputs.cancelled else DataModelingJobStatus.FAILED
+        job.rows_materialized = 0
+        job.error = sanitized_error
+        job.last_run_at = dt.datetime.now(dt.UTC)
+        job.save()
 
-    job.status = DataModelingJobStatus.CANCELLED if inputs.cancelled else DataModelingJobStatus.FAILED
-    job.rows_materialized = 0
-    job.error = sanitized_error
-    job.last_run_at = dt.datetime.now(dt.UTC)
-    job.save()
-
-    return node, job
+    return FailNodeAndJobOutcome(
+        job=job,
+        is_latest_terminal=is_latest_terminal,
+        suspended_immediately=suspended_immediately,
+    )
 
 
 @database_sync_to_async_pool
@@ -106,32 +127,16 @@ def _get_saved_query_for_job(job: DataModelingJob) -> DataWarehouseSavedQuery | 
 
 
 @database_sync_to_async_pool
-def _maybe_pause_schedule_on_timeout(job: DataModelingJob, saved_query: DataWarehouseSavedQuery) -> bool:
-    """Pause the schedule only if the previous N jobs all failed due to timeouts.
-
-    Returns True if the schedule was paused, False otherwise. This prevents pausing
-    schedules for transient timeouts that can occur due to temporary ClickHouse load.
-    """
-    should_pause, _ = should_pause_schedule_for_timeout(saved_query.id, job)
-    if not should_pause:
+def _revert_materialization_on_unknown_table(job: DataModelingJob, saved_query: DataWarehouseSavedQuery) -> bool:
+    if has_newer_job(job):
         return False
-
-    saved_query.sync_frequency_interval = None
-    saved_query.save(update_fields=["sync_frequency_interval"])
-    pause_saved_query_schedule(saved_query)
-    job.error = f"This materialized view sync schedule has been paused until you modify the query and reset the sync schedule. Error: {job.error}"
-    job.save(update_fields=["error"])
-    return True
-
-
-@database_sync_to_async_pool
-def _revert_materialization_on_unknown_table(job: DataModelingJob, saved_query: DataWarehouseSavedQuery) -> None:
     saved_query.revert_materialization()
     # we can use this specific language in the error to add these jobs to the daily email digest later
     job.error = (
         f"This materialized view has been reverted to a view because it referenced an unknown table. Error: {job.error}"
     )
     job.save(update_fields=["error"])
+    return True
 
 
 @activity.defn
@@ -139,7 +144,8 @@ async def fail_materialization_activity(inputs: FailMaterializationInputs) -> No
     """Mark materialization as failed and update node properties."""
     bind_contextvars(team_id=inputs.team_id)
     logger = LOGGER.bind()
-    _, job = await _fail_node_and_data_modeling_job(inputs)
+    outcome = await _fail_node_and_data_modeling_job(inputs)
+    job = outcome.job
     if job.saved_query_id is not None:
         bind_data_modeling_log_context(inputs.team_id, job.saved_query_id)
     job_context = (
@@ -150,56 +156,45 @@ async def fail_materialization_activity(inputs: FailMaterializationInputs) -> No
     # error the job row does. The raw one stays write-only, where only internal logging sees it.
     await logger.aerror(f"Failed materialization job: {job_context} error={strip_hostname_from_error(inputs.error)}")
     await logger.aerror(f"Failed materialization job: {job_context} error={inputs.error}", write_only=True)
-    # error-specific recovery: pause schedule on timeout, revert on unknown table, else suspend after repeated failures
-    if not inputs.update_node:
-        return
     error = inputs.error
-    saved_query = None
-    try:
-        saved_query = await _get_saved_query_for_job(job)
-        if saved_query is None:
-            return
-
-        if "Timeout exceeded" in error:
-            paused = await _maybe_pause_schedule_on_timeout(job, saved_query)
-            if paused:
-                await logger.ainfo(
-                    f"Pausing schedule for node {inputs.node_id} due to {CONSECUTIVE_TIMEOUTS_TO_PAUSE} consecutive timeout failures",
-                )
-            else:
-                await logger.ainfo(
-                    f"Timeout for node {inputs.node_id} - not pausing schedule (fewer than {CONSECUTIVE_TIMEOUTS_TO_PAUSE} consecutive timeouts)",
-                )
-        elif "Unknown table" in error:
-            await logger.ainfo(
-                f"Reverting materialization for node {inputs.node_id} due to unknown table reference",
-            )
-            await _revert_materialization_on_unknown_table(job, saved_query)
-        else:
-            suspended = await maybe_suspend_node_for_engine(
-                node_id=inputs.node_id,
-                team_id=inputs.team_id,
-                dag_id=inputs.dag_id,
-                saved_query_id=saved_query.id,
-                engine=DataModelingJobEngine.CLICKHOUSE,
-                reason=strip_hostname_from_error(error),
-                job_id=inputs.job_id,
-            )
-            if suspended:
+    saved_query = await _get_saved_query_for_job(job) if inputs.update_node else None
+    if saved_query is not None and outcome.is_latest_terminal:
+        try:
+            if outcome.suspended_immediately:
                 get_node_suspended_metric(DataModelingJobEngine.CLICKHOUSE.value).add(1)
-                await logger.ainfo(
-                    f"Suspended node {inputs.node_id} (clickhouse) after {CONSECUTIVE_FAILURES_TO_SUSPEND} consecutive failures",
+                await logger.ainfo(f"Suspended node {inputs.node_id} (clickhouse) immediately")
+            elif "Unknown table" in error:
+                if await _revert_materialization_on_unknown_table(job, saved_query):
+                    await logger.ainfo(
+                        f"Reverted materialization for node {inputs.node_id} due to unknown table reference",
+                    )
+            else:
+                suspended = await maybe_suspend_node_for_engine(
+                    node_id=inputs.node_id,
+                    team_id=inputs.team_id,
+                    dag_id=inputs.dag_id,
+                    saved_query_id=saved_query.id,
+                    engine=DataModelingJobEngine.CLICKHOUSE,
+                    reason=strip_hostname_from_error(error),
+                    job_id=inputs.job_id,
                 )
+                if suspended:
+                    get_node_suspended_metric(DataModelingJobEngine.CLICKHOUSE.value).add(1)
+                    await logger.ainfo(
+                        f"Suspended node {inputs.node_id} (clickhouse) after "
+                        f"{CONSECUTIVE_FAILURES_TO_SUSPEND} consecutive failures",
+                    )
 
-    except Exception as e:
-        capture_exception(e)
-        await logger.aexception(
-            f"Failed to run error-specific recovery for node {inputs.node_id}: {strip_hostname_from_error(str(e))}"
-        )
+        except Exception as e:
+            capture_exception(e)
+            await logger.aexception(
+                f"Failed to run error-specific recovery for node {inputs.node_id}: {strip_hostname_from_error(str(e))}"
+            )
 
-    # Kept out of the recovery block above: a failing pause or revert is exactly when someone most
-    # needs telling, so it must not take the notification down with it.
-    if saved_query is not None and not inputs.cancelled:
+    await update_saved_query_latest_error(job.id)
+
+    # Keep notification outside recovery so a failed revert or suspension does not suppress it.
+    if saved_query is not None and outcome.is_latest_terminal and not inputs.cancelled:
         try:
             notified = await maybe_notify_materialization_failure(job, saved_query, inputs.team_id)
             if notified:

--- a/posthog/temporal/data_modeling/activities/get_dag_structure.py
+++ b/posthog/temporal/data_modeling/activities/get_dag_structure.py
@@ -7,7 +7,7 @@ from posthog.temporal.common.logger import get_logger
 
 from products.data_modeling.backend.facade.models import DataModelingJobEngine, Edge, Node, NodeType
 
-from .utils import is_node_suspended, is_suspension_enforced
+from .utils import is_node_suspended, is_node_suspension_always_enforced, is_suspension_enforced
 
 LOGGER = get_logger(__name__)
 
@@ -55,13 +55,16 @@ def _get_dag_structure_async(team_id: int, dag_id: str) -> DAG:
         .filter(team_id=team_id, dag_id=dag_id)
         .exclude(source__type=NodeType.TABLE)
     )
-    if is_suspension_enforced(team_id):
-        suspended_nodes = {
-            engine.value: [str(n.id) for n in executable_nodes if is_node_suspended(n, engine)]
-            for engine in DataModelingJobEngine
-        }
-    else:
-        suspended_nodes = {engine.value: [] for engine in DataModelingJobEngine}
+    suspension_enforced = is_suspension_enforced(team_id)
+    suspended_nodes = {
+        engine.value: [
+            str(node.id)
+            for node in executable_nodes
+            if is_node_suspended(node, engine)
+            and (suspension_enforced or is_node_suspension_always_enforced(node, engine))
+        ]
+        for engine in DataModelingJobEngine
+    }
     # ids are uuid objects by default. primitives are probably better
     return DAG(
         nodes=[str(n.id) for n in nodes],

--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -12,6 +12,7 @@ import pyarrow.parquet as pq
 from structlog.contextvars import bind_contextvars
 from structlog.types import FilteringBoundLogger
 from temporalio import activity
+from temporalio.exceptions import ApplicationError
 
 from posthog.hogql import ast
 from posthog.hogql.constants import HogQLGlobalSettings
@@ -30,8 +31,14 @@ from posthog.ph_client import feature_enabled_or_false
 from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME
 from posthog.settings.base_variables import TEST
 from posthog.sync import database_sync_to_async_pool
+from posthog.temporal.common.asyncpa import InvalidMessageFormat
 from posthog.temporal.common.clickhouse import (
+    ClickHouseCheckQueryStatusError,
+    ClickHouseClient,
     ClickHouseError,
+    ClickHouseQueryNotFound,
+    ClickHouseQueryStatus,
+    ClickHouseQueryTimeoutError,
     get_client as get_clickhouse_client,
 )
 from posthog.temporal.common.heartbeat import Heartbeater
@@ -46,7 +53,11 @@ from posthog.temporal.data_modeling.activities.incremental_write import (
     upsert_batch,
     upsert_stats_fields,
 )
-from posthog.temporal.data_modeling.activities.utils import bind_data_modeling_log_context
+from posthog.temporal.data_modeling.activities.utils import bind_data_modeling_log_context, strip_hostname_from_error
+from posthog.temporal.data_modeling.errors import (
+    INITIAL_FULL_REFRESH_TIMEOUT_ERROR_TYPE,
+    INITIAL_FULL_REFRESH_TIMEOUT_MESSAGE,
+)
 
 from products.data_modeling.backend.facade.api import (
     IncrementalConfig,
@@ -73,6 +84,9 @@ from products.warehouse_sources.backend.facade.temporal import AccountPropertyRo
 LOGGER = get_logger(__name__)
 
 MB_100_IN_BYTES = 100 * 1000 * 1000
+ARROW_FAILURE_DIAGNOSTIC_ATTEMPTS = 10
+ARROW_FAILURE_DIAGNOSTIC_DELAY_SECONDS = 1
+ARROW_FAILURE_DIAGNOSTIC_TIMEOUT_SECONDS = 3
 
 # ClickHouse builds every GLOBAL IN subquery as a temporary table while it plans a query, and
 # DESCRIBE plans the query too, so the schema probe scans the source tables just to return column
@@ -110,6 +124,20 @@ def _print_untouched(
     prepared_query: ast.SelectQuery | ast.SelectSetQuery, context: HogQLContext, settings: HogQLGlobalSettings
 ) -> str:
     return print_prepared_ast(prepared_query, context=context, dialect="clickhouse", settings=settings, stack=[])
+
+
+async def _diagnose_arrow_failure(client: ClickHouseClient, query_id: str) -> None:
+    for attempt in range(ARROW_FAILURE_DIAGNOSTIC_ATTEMPTS):
+        try:
+            status = await asyncio.wait_for(
+                client.acheck_query(query_id), timeout=ARROW_FAILURE_DIAGNOSTIC_TIMEOUT_SECONDS
+            )
+        except (ClickHouseQueryNotFound, TimeoutError):
+            status = None
+        if status not in (None, ClickHouseQueryStatus.RUNNING):
+            return
+        if attempt < ARROW_FAILURE_DIAGNOSTIC_ATTEMPTS - 1:
+            await asyncio.sleep(ARROW_FAILURE_DIAGNOSTIC_DELAY_SECONDS)
 
 
 async def _describe_columns(
@@ -193,17 +221,35 @@ class WritePlan:
 @database_sync_to_async_pool
 def _resolve_write_plan(saved_query: DataWarehouseSavedQuery, team_id: int) -> WritePlan:
     config = get_incremental_config(saved_query)
+    incremental_enabled = config is not None and _incremental_enabled(team_id)
+    has_completed_materialization = DataModelingJob.objects.filter(
+        saved_query_id=saved_query.id,
+        engine=DataModelingJob.Engine.CLICKHOUSE,
+        status=DataModelingJob.Status.COMPLETED,
+    ).exists()
+
+    if not has_completed_materialization:
+        fingerprint = (
+            definition_fingerprint(typing.cast(dict, saved_query.query), config) if incremental_enabled else None
+        )
+        return WritePlan(
+            incremental=False,
+            reason="first run",
+            fingerprint=fingerprint,
+            config=config if incremental_enabled else None,
+        )
+
     if config is None:
         return WritePlan(incremental=False, reason="not configured for incremental materialization")
 
-    if not _incremental_enabled(team_id):
+    if not incremental_enabled:
         return WritePlan(incremental=False, reason="incremental materialization is not enabled")
 
     fingerprint = definition_fingerprint(typing.cast(dict, saved_query.query), config)
     state = get_incremental_state(saved_query)
 
     if state.watermark is None:
-        return WritePlan(incremental=False, reason="first run", fingerprint=fingerprint, config=config)
+        return WritePlan(incremental=False, reason="no usable watermark", fingerprint=fingerprint, config=config)
 
     if fingerprint is None or fingerprint != state.definition_fingerprint:
         # The query or its config changed, so existing rows were computed by a definition that no
@@ -674,20 +720,33 @@ async def hogql_table(
             nonlocal arrow_schema
             arrow_schema = schema
 
-        async for batch in client.astream_query_as_arrow(
-            arrow_printed,
-            query_parameters=context.values,
-            on_schema=capture_arrow_schema,
-        ):
-            batches_size = batches_size + batch.nbytes
-            batches.append(batch)
+        query_id = str(uuid.uuid4())
+        try:
+            async for batch in client.astream_query_as_arrow(
+                arrow_printed,
+                query_parameters=context.values,
+                query_id=query_id,
+                on_schema=capture_arrow_schema,
+            ):
+                batches_size = batches_size + batch.nbytes
+                batches.append(batch)
 
-            if batches_size >= MB_100_IN_BYTES:
-                await logger.adebug(f"Yielding {len(batches)} batches for total size of {batches_size / 1000 / 1000}MB")
-                yield (_combine_batches(batches), ch_typings_pairs)
-                yielded_results = True
-                batches_size = 0
-                batches = []
+                if batches_size >= MB_100_IN_BYTES:
+                    await logger.adebug(
+                        f"Yielding {len(batches)} batches for total size of {batches_size / 1000 / 1000}MB"
+                    )
+                    yield (_combine_batches(batches), ch_typings_pairs)
+                    yielded_results = True
+                    batches_size = 0
+                    batches = []
+        except InvalidMessageFormat as arrow_error:
+            try:
+                await _diagnose_arrow_failure(client, query_id)
+            except ClickHouseCheckQueryStatusError:
+                raise arrow_error
+            except ClickHouseError as query_error:
+                raise query_error from arrow_error
+            raise
 
         if len(batches) > 0:
             await logger.adebug(f"Yielding {len(batches)} batches for total size of {batches_size / 1000 / 1000}MB")
@@ -1157,10 +1216,22 @@ async def materialize_view_activity(inputs: MaterializeViewInputs) -> Materializ
                         cdp_sink,
                         person_property_sink,
                     )
-            except (Exception, asyncio.CancelledError):
+            except asyncio.CancelledError:
+                await cdp_sink.discard()
+                raise
+            except Exception as error:
                 # A retry stages from scratch and a terminal failure produces nothing, so whatever
                 # this attempt wrote is only ever waste.
                 await cdp_sink.discard()
+                sanitized_error = strip_hostname_from_error(str(error))
+                await logger.aerror(f"Materialization attempt failed: {sanitized_error}")
+                await logger.aerror(f"Materialization attempt failed: {error}", write_only=True)
+                if plan.reason == "first run" and isinstance(error, ClickHouseQueryTimeoutError):
+                    raise ApplicationError(
+                        INITIAL_FULL_REFRESH_TIMEOUT_MESSAGE,
+                        type=INITIAL_FULL_REFRESH_TIMEOUT_ERROR_TYPE,
+                        non_retryable=True,
+                    ) from error
                 raise
 
             await logger.ainfo(f"Materialized node {objects.node.name} with {row_count} rows")

--- a/posthog/temporal/data_modeling/activities/succeed_materialization.py
+++ b/posthog/temporal/data_modeling/activities/succeed_materialization.py
@@ -17,7 +17,13 @@ from products.data_modeling.backend.facade.models import (
     Node,
 )
 
-from .utils import bind_data_modeling_log_context, clear_node_suspension, update_node_system_properties
+from .utils import (
+    bind_data_modeling_log_context,
+    clear_node_suspension,
+    has_newer_terminal_job,
+    update_node_system_properties,
+    update_saved_query_latest_error,
+)
 
 LOGGER = get_logger(__name__)
 
@@ -84,44 +90,48 @@ def _succeed_node_and_data_modeling_job(
     inputs: SucceedMaterializationInputs,
 ) -> SucceedNodeAndJobOutcome:
     node: Node | None = None
-    if inputs.update_node:
-        with transaction.atomic():
-            # of=("self",) + select_related: skip the extra node.saved_query query without locking the joined row.
-            node = (
-                Node.objects.select_for_update(of=("self",))
-                .select_related("saved_query")
-                .get(id=inputs.node_id, team_id=inputs.team_id, dag_id=inputs.dag_id)
+    replayed_completed_job = False
+    with transaction.atomic():
+        job = DataModelingJob.objects.select_for_update().get(id=inputs.job_id)
+        if job.status in (
+            DataModelingJobStatus.FAILED,
+            DataModelingJobStatus.CANCELLED,
+            DataModelingJobStatus.COMPLETED,
+        ):
+            replayed_completed_job = (
+                inputs.update_node and job.status == DataModelingJobStatus.COMPLETED and not has_newer_terminal_job(job)
             )
-            status = DataModelingJobStatus.COMPLETED
-            update_node_system_properties(
-                node,
-                status=status,
-                job_id=inputs.job_id,
-                rows=inputs.row_count,
-                duration_seconds=inputs.duration_seconds,
-            )
-            clear_node_suspension(node, engine=DataModelingJobEngine.CLICKHOUSE)
-            node.save()
+        else:
+            if inputs.update_node:
+                # of=("self",) + select_related: skip the extra node.saved_query query without locking the joined row.
+                locked_node = (
+                    Node.objects.select_for_update(of=("self",))
+                    .select_related("saved_query")
+                    .get(id=inputs.node_id, team_id=inputs.team_id, dag_id=inputs.dag_id)
+                )
+                if not has_newer_terminal_job(job):
+                    node = locked_node
+                    update_node_system_properties(
+                        node,
+                        status=DataModelingJobStatus.COMPLETED,
+                        job_id=inputs.job_id,
+                        rows=inputs.row_count,
+                        duration_seconds=inputs.duration_seconds,
+                    )
+                    clear_node_suspension(node, engine=DataModelingJobEngine.CLICKHOUSE)
+                    node.save()
 
-    enrichment_needed, enrichment_saved_query_id = _view_enrichment_needed(node)
+            job.status = DataModelingJobStatus.COMPLETED
+            job.rows_materialized = inputs.row_count
+            job.last_run_at = dt.datetime.now(dt.UTC)
+            job.error = None
+            job.save()
 
-    job = DataModelingJob.objects.get(id=inputs.job_id)
-
-    # if the job is already in a terminal state, don't overwrite it
-    if job.status in (DataModelingJobStatus.FAILED, DataModelingJobStatus.CANCELLED, DataModelingJobStatus.COMPLETED):
-        return SucceedNodeAndJobOutcome(
-            node=node,
-            job=job,
-            enrichment_needed=enrichment_needed,
-            enrichment_saved_query_id=enrichment_saved_query_id,
+    if replayed_completed_job:
+        node = Node.objects.select_related("saved_query").get(
+            id=inputs.node_id, team_id=inputs.team_id, dag_id=inputs.dag_id
         )
-
-    job.status = DataModelingJobStatus.COMPLETED
-    job.rows_materialized = inputs.row_count
-    job.last_run_at = dt.datetime.now(dt.UTC)
-    job.error = None
-    job.save()
-
+    enrichment_needed, enrichment_saved_query_id = _view_enrichment_needed(node)
     return SucceedNodeAndJobOutcome(
         node=node,
         job=job,
@@ -136,6 +146,7 @@ async def succeed_materialization_activity(inputs: SucceedMaterializationInputs)
     logger = LOGGER.bind()
 
     outcome = await _succeed_node_and_data_modeling_job(inputs)
+    await update_saved_query_latest_error(outcome.job.id)
 
     if outcome.job.saved_query_id is not None:
         bind_data_modeling_log_context(inputs.team_id, outcome.job.saved_query_id)

--- a/posthog/temporal/data_modeling/activities/utils.py
+++ b/posthog/temporal/data_modeling/activities/utils.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 from django.db import transaction
+from django.db.models import Exists, Q
 
 from structlog.contextvars import bind_contextvars
 
@@ -16,6 +17,7 @@ from posthog.temporal.data_modeling.activities.preempt_dag_run import ABANDONED_
 from products.data_modeling.backend.facade.api import (
     clear_node_suspension,
     is_node_suspended,
+    is_node_suspension_always_enforced,
     mark_node_suspended,
     query_fingerprint,
     suspension_reset_at,
@@ -37,14 +39,18 @@ __all__ = [
     "clear_node_suspension_for_engine",
     "count_leading_failures",
     "get_previous_jobs",
+    "has_newer_job",
+    "has_newer_terminal_job",
     "is_externally_aborted",
     "is_node_suspended",
+    "is_node_suspension_always_enforced",
     "is_suspension_enforced",
     "mark_node_suspended",
     "maybe_suspend_node_for_engine",
     "starts_a_failure_streak",
     "strip_hostname_from_error",
     "update_node_system_properties",
+    "update_saved_query_latest_error",
 ]
 
 if TYPE_CHECKING:
@@ -76,16 +82,41 @@ def get_previous_jobs(
             engine=DataModelingJobEngine.CLICKHOUSE,
             created_at__lt=current_job.created_at,
         )
-        # a skipped run never executed, so it is evidence of neither health nor failure. Leaving it
-        # in lets one upstream outage clear a timeout streak that is about to pause the schedule.
+        # A skipped run never executed, so it is evidence of neither health nor failure.
         .exclude(status=DataModelingJobStatus.SKIPPED)
     )
     if ignore_inconclusive:
         # Neither status says whether the query recovered: a cancel is our doing (preemption, a
         # deploy), and a run still marked running either is one, or was abandoned by a dead worker.
-        # The timeout counter keeps treating both as a break, deliberately.
+        # The failure counter keeps treating both as a break, deliberately.
         jobs = jobs.exclude(status__in=(DataModelingJobStatus.CANCELLED, DataModelingJobStatus.RUNNING))
     return jobs.order_by("-created_at")[:count]
+
+
+def _newer_jobs(job: DataModelingJob) -> "QuerySet[DataModelingJob]":
+    if job.saved_query_id is None:
+        return DataModelingJob.objects.none()
+    return DataModelingJob.objects.filter(saved_query_id=job.saved_query_id, engine=job.engine).filter(
+        Q(created_at__gt=job.created_at) | Q(created_at=job.created_at, id__gt=job.id)
+    )
+
+
+def has_newer_job(job: DataModelingJob) -> bool:
+    return _newer_jobs(job).exists()
+
+
+def has_newer_terminal_job(job: DataModelingJob) -> bool:
+    return (
+        _newer_jobs(job)
+        .filter(
+            status__in=(
+                DataModelingJobStatus.CANCELLED,
+                DataModelingJobStatus.COMPLETED,
+                DataModelingJobStatus.FAILED,
+            )
+        )
+        .exists()
+    )
 
 
 def starts_a_failure_streak(saved_query_id: UUID, current_job: DataModelingJob) -> bool:
@@ -189,6 +220,32 @@ def update_node_system_properties(
     node.properties = properties
 
 
+@database_sync_to_async_pool
+def update_saved_query_latest_error(job_id: UUID | str) -> bool:
+    visible_statuses = (DataModelingJobStatus.COMPLETED, DataModelingJobStatus.FAILED)
+    job = DataModelingJob.objects.filter(
+        id=job_id,
+        engine=DataModelingJobEngine.CLICKHOUSE,
+        status__in=visible_statuses,
+    ).first()
+    if job is None or job.saved_query_id is None:
+        return False
+
+    newer_visible_jobs = DataModelingJob.objects.filter(
+        saved_query_id=job.saved_query_id,
+        engine=DataModelingJobEngine.CLICKHOUSE,
+        status__in=visible_statuses,
+    ).filter(Q(created_at__gt=job.created_at) | Q(created_at=job.created_at, id__gt=job.id))
+
+    latest_error = strip_hostname_from_error(job.error or "") if job.status == DataModelingJobStatus.FAILED else None
+    return bool(
+        DataWarehouseSavedQuery.objects.exclude(deleted=True)
+        .filter(id=job.saved_query_id)
+        .filter(~Exists(newer_visible_jobs))
+        .update(latest_error=latest_error)
+    )
+
+
 def count_leading_failures(saved_query_id: UUID, engine: str, *, since: str | None = None) -> int:
     jobs = DataModelingJob.objects.filter(saved_query_id=saved_query_id, engine=str(engine)).exclude(
         # a skipped node never ran, so it is evidence of neither health nor failure. Counting it
@@ -230,10 +287,14 @@ def maybe_suspend_node_for_engine(
         fingerprint = query_fingerprint(
             DataWarehouseSavedQuery.objects.filter(id=saved_query_id).values_list("query", flat=True).first()
         )
-        mark_node_suspended(node, engine=engine, reason=reason, job_id=job_id, fingerprint=fingerprint)
+        mark_node_suspended(
+            node,
+            engine=engine,
+            reason=reason,
+            job_id=job_id,
+            fingerprint=fingerprint,
+        )
         node.save()
-    # Without enforcement the node keeps materializing every tick, so telling the customer it stopped
-    # would be false.
     if str(engine) == DataModelingJobEngine.CLICKHOUSE.value and is_suspension_enforced(team_id):
         job = DataModelingJob.objects.get(id=job_id)
         job.error = (

--- a/posthog/temporal/data_modeling/errors.py
+++ b/posthog/temporal/data_modeling/errors.py
@@ -1,0 +1,5 @@
+INITIAL_FULL_REFRESH_TIMEOUT_ERROR_TYPE = "InitialFullRefreshQueryTimeout"
+INITIAL_FULL_REFRESH_TIMEOUT_MESSAGE = (
+    "The initial full build reached the query time limit. Reduce the initial data range or simplify the query, "
+    "then run it again."
+)

--- a/posthog/temporal/data_modeling/workflows/materialize_view.py
+++ b/posthog/temporal/data_modeling/workflows/materialize_view.py
@@ -43,6 +43,10 @@ from posthog.temporal.data_modeling.activities import (
     succeed_materialization_activity,
 )
 from posthog.temporal.data_modeling.activities.enrich_view_semantics import EnrichViewSemanticsInputs
+from posthog.temporal.data_modeling.errors import (
+    INITIAL_FULL_REFRESH_TIMEOUT_ERROR_TYPE,
+    INITIAL_FULL_REFRESH_TIMEOUT_MESSAGE,
+)
 from posthog.temporal.data_modeling.metrics import (
     get_clickhouse_materialization_duration_metric,
     get_duckgres_shadow_duration_metric,
@@ -448,12 +452,17 @@ class MaterializeViewWorkflow(PostHogWorkflow):
                     quality_audited=quality_audited,
                 )
             except Exception as e:
-                # handle failure
                 cancelled = _is_cancellation(e)
+                error_type: str | None = None
                 if cancelled:
                     error_message = "Workflow was cancelled"
                 elif isinstance(e, temporalio.exceptions.ActivityError):
-                    error_message = str(e.cause) if e.cause else str(e)
+                    cause = e.cause
+                    if isinstance(cause, temporalio.exceptions.ApplicationError):
+                        error_message = cause.message
+                        error_type = cause.type
+                    else:
+                        error_message = str(cause) if cause else str(e)
                 else:
                     capture_exception(e)
                     error_message = str(e)
@@ -475,6 +484,7 @@ class MaterializeViewWorkflow(PostHogWorkflow):
                             job_id=job_id,
                             error=error_message,
                             cancelled=cancelled,
+                            suspend_immediately=error_type == INITIAL_FULL_REFRESH_TIMEOUT_ERROR_TYPE,
                         ),
                         start_to_close_timeout=dt.timedelta(minutes=5),
                         retry_policy=temporalio.common.RetryPolicy(
@@ -487,6 +497,12 @@ class MaterializeViewWorkflow(PostHogWorkflow):
                         extra=inputs.properties_to_log,
                     )
                 get_node_finished_metric("cancelled" if cancelled else "failed").add(1)
+                if error_type == INITIAL_FULL_REFRESH_TIMEOUT_ERROR_TYPE:
+                    raise temporalio.exceptions.ApplicationError(
+                        INITIAL_FULL_REFRESH_TIMEOUT_MESSAGE,
+                        type=INITIAL_FULL_REFRESH_TIMEOUT_ERROR_TYPE,
+                        non_retryable=True,
+                    ) from e
                 raise
 
         # await the duckgres shadow activity so the parent workflow's concurrency

--- a/posthog/temporal/tests/data_modeling/test_execute_dag_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_execute_dag_workflow.py
@@ -185,6 +185,28 @@ class TestGetDagStructureActivity:
         assert dag.suspended_nodes["clickhouse"] == ([str(suspended_node.id)] if enforced else [])
         assert dag.suspended_nodes["duckgres"] == []
 
+    async def test_reports_forced_suspension_without_enforcement(self, activity_environment, ateam, dag_nodes, adag):
+        from posthog.temporal.data_modeling.activities import get_dag_structure as gds
+        from posthog.temporal.data_modeling.activities.utils import mark_node_suspended
+
+        suspended_node = dag_nodes[1]
+        mark_node_suspended(
+            suspended_node,
+            engine=DataModelingJobEngine.CLICKHOUSE,
+            reason="Initial full build timed out",
+            job_id="j",
+            enforce_without_flag=True,
+        )
+        await database_sync_to_async(suspended_node.save)()
+
+        with unittest.mock.patch.object(gds, "is_suspension_enforced", return_value=False):
+            dag = await activity_environment.run(
+                get_dag_structure_activity,
+                GetDAGStructureInputs(team_id=ateam.pk, dag_id=str(adag.id)),
+            )
+
+        assert dag.suspended_nodes["clickhouse"] == [str(suspended_node.id)]
+
     @pytest.mark.usefixtures("dag_edges")  # avoids type checking unused arg
     async def test_excludes_source_table_edges(self, activity_environment, ateam, adag):
         inputs = GetDAGStructureInputs(team_id=ateam.pk, dag_id=str(adag.id))

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -15,12 +15,14 @@ from django.test import override_settings
 import pyarrow as pa
 import deltalake
 import pyarrow.parquet as pq
+from temporalio.exceptions import ApplicationError
 
 from posthog.hogql.resolver import ResolverFactory
 
 from posthog.models import Team, User
 from posthog.sync import database_sync_to_async
-from posthog.temporal.common.clickhouse import ClickHouseError
+from posthog.temporal.common.asyncpa import InvalidMessageFormat
+from posthog.temporal.common.clickhouse import ClickHouseError, ClickHouseQueryNotFound, ClickHouseQueryTimeoutError
 from posthog.temporal.data_modeling.activities import (
     CreateDataModelingJobInputs,
     FailMaterializationInputs,
@@ -44,6 +46,10 @@ from posthog.temporal.data_modeling.activities.materialize_view import (
     hogql_table,
 )
 from posthog.temporal.data_modeling.activities.notify_materialization_failure import _SavedQueryViewers
+from posthog.temporal.data_modeling.errors import (
+    INITIAL_FULL_REFRESH_TIMEOUT_ERROR_TYPE,
+    INITIAL_FULL_REFRESH_TIMEOUT_MESSAGE,
+)
 
 from products.customer_analytics.backend.facade.temporal import stage_warehouse_account_property_files_activity
 from products.customer_analytics.backend.facade.temporal_contracts import StageAccountPropertySyncInput
@@ -114,8 +120,10 @@ class TestFailMaterializationActivity:
         [(False, DataModelingJob.Status.FAILED), (True, DataModelingJob.Status.CANCELLED)],
     )
     async def test_marks_job_as_terminal(
-        self, activity_environment, ateam, anode, ajob, adag, cancelled, expected_status
+        self, activity_environment, ateam, anode, asaved_query, ajob, adag, cancelled, expected_status
     ):
+        asaved_query.latest_error = "Previous error"
+        await database_sync_to_async(asaved_query.save)(update_fields=["latest_error"])
         inputs = FailMaterializationInputs(
             team_id=ateam.pk,
             node_id=str(anode.id),
@@ -129,9 +137,87 @@ class TestFailMaterializationActivity:
         assert ajob.status == expected_status
         assert ajob.rows_materialized == 0
         assert ajob.error == "Test error message"
+        await database_sync_to_async(asaved_query.refresh_from_db)()
+        assert asaved_query.latest_error == ("Previous error" if cancelled else "Test error message")
         # The UI derives run duration and the log-search window from last_run_at, so a
         # terminal transition must stamp it (the model default is the job's start time).
         assert ajob.last_run_at > ajob.created_at
+
+    @pytest.mark.parametrize("succeeds", [False, True])
+    async def test_duckgres_terminal_job_does_not_update_latest_error(
+        self, activity_environment, ateam, anode, asaved_query, adag, succeeds
+    ):
+        asaved_query.latest_error = "ClickHouse failure"
+        await database_sync_to_async(asaved_query.save)(update_fields=["latest_error"])
+        job = await _make_job(
+            ateam,
+            asaved_query,
+            DataModelingJob.Status.RUNNING,
+            engine=DataModelingJobEngine.DUCKGRES,
+        )
+        if succeeds:
+            await activity_environment.run(
+                succeed_materialization_activity,
+                SucceedMaterializationInputs(
+                    team_id=ateam.pk,
+                    node_id=str(anode.id),
+                    dag_id=str(adag.id),
+                    job_id=str(job.id),
+                    row_count=1,
+                    duration_seconds=1,
+                    update_node=False,
+                ),
+            )
+        else:
+            await activity_environment.run(
+                fail_materialization_activity,
+                FailMaterializationInputs(
+                    team_id=ateam.pk,
+                    node_id=str(anode.id),
+                    dag_id=str(adag.id),
+                    job_id=str(job.id),
+                    error="Duckgres failure",
+                    update_node=False,
+                ),
+            )
+
+        await database_sync_to_async(asaved_query.refresh_from_db)()
+        assert asaved_query.latest_error == "ClickHouse failure"
+        await database_sync_to_async(job.delete)()
+
+    async def test_stale_failure_does_not_replace_a_newer_success(
+        self, activity_environment, ateam, anode, asaved_query, adag
+    ):
+        older_job = await _make_job(ateam, asaved_query, DataModelingJob.Status.RUNNING)
+        newer_job = await _make_job(ateam, asaved_query, DataModelingJob.Status.RUNNING)
+        await activity_environment.run(
+            succeed_materialization_activity,
+            SucceedMaterializationInputs(
+                team_id=ateam.pk,
+                node_id=str(anode.id),
+                dag_id=str(adag.id),
+                job_id=str(newer_job.id),
+                row_count=1,
+                duration_seconds=1,
+            ),
+        )
+        await activity_environment.run(
+            fail_materialization_activity,
+            FailMaterializationInputs(
+                team_id=ateam.pk,
+                node_id=str(anode.id),
+                dag_id=str(adag.id),
+                job_id=str(older_job.id),
+                error="Older failure",
+            ),
+        )
+
+        await database_sync_to_async(asaved_query.refresh_from_db)()
+        await database_sync_to_async(anode.refresh_from_db)()
+        assert asaved_query.latest_error is None
+        assert anode.properties["system"]["last_run_status"] == DataModelingJobStatus.COMPLETED
+        await database_sync_to_async(older_job.delete)()
+        await database_sync_to_async(newer_job.delete)()
 
     async def test_does_not_overwrite_already_terminal_job(self, activity_environment, ateam, anode, ajob, adag):
         ajob.status = DataModelingJob.Status.COMPLETED
@@ -168,8 +254,12 @@ class TestFailMaterializationActivity:
         assert system_props["last_run_error"] == "Query failed: timeout"
         assert "last_run_at" in system_props
 
+    @pytest.mark.parametrize(
+        "error",
+        ["Some non-timeout error", "Code: 159. DB::Exception: Query exceeded timeout (TIMEOUT_EXCEEDED)"],
+    )
     async def test_suspends_node_after_consecutive_failures(
-        self, activity_environment, ateam, anode, asaved_query, adag
+        self, activity_environment, ateam, anode, asaved_query, adag, error
     ):
         from posthog.temporal.data_modeling.activities.utils import is_node_suspended
 
@@ -182,12 +272,48 @@ class TestFailMaterializationActivity:
             node_id=str(anode.id),
             dag_id=str(adag.id),
             job_id=str(current_job.id),
-            error="Some non-timeout error",
+            error=error,
         )
         await activity_environment.run(fail_materialization_activity, inputs)
 
         await database_sync_to_async(anode.refresh_from_db)()
         assert is_node_suspended(anode, DataModelingJobEngine.CLICKHOUSE) is True
+
+    async def test_forces_immediate_suspension_for_initial_full_refresh_timeout(
+        self, activity_environment, ateam, anode, asaved_query, adag
+    ):
+        from posthog.temporal.data_modeling.activities.utils import (
+            clear_node_suspension_for_engine,
+            is_node_suspended,
+            is_node_suspension_always_enforced,
+        )
+
+        current_job = await _make_job(ateam, asaved_query, DataModelingJob.Status.RUNNING)
+        inputs = FailMaterializationInputs(
+            team_id=ateam.pk,
+            node_id=str(anode.id),
+            dag_id=str(adag.id),
+            job_id=str(current_job.id),
+            error=INITIAL_FULL_REFRESH_TIMEOUT_MESSAGE,
+            suspend_immediately=True,
+        )
+        await activity_environment.run(fail_materialization_activity, inputs)
+
+        await database_sync_to_async(anode.refresh_from_db)()
+        assert is_node_suspended(anode, DataModelingJobEngine.CLICKHOUSE) is True
+        assert is_node_suspension_always_enforced(anode, DataModelingJobEngine.CLICKHOUSE) is True
+
+        await clear_node_suspension_for_engine(
+            node_id=str(anode.id),
+            team_id=ateam.pk,
+            dag_id=str(adag.id),
+            engine=DataModelingJobEngine.CLICKHOUSE,
+        )
+        await activity_environment.run(fail_materialization_activity, inputs)
+
+        await database_sync_to_async(anode.refresh_from_db)()
+        assert is_node_suspended(anode, DataModelingJobEngine.CLICKHOUSE) is False
+        await database_sync_to_async(current_job.delete)()
 
     @pytest.mark.parametrize(
         "previous_status,expect_notification",
@@ -366,174 +492,6 @@ class TestFailMaterializationActivity:
         resolver = mock_create.call_args.args[0].resolver
         assert isinstance(resolver, _SavedQueryViewers)
 
-    async def test_timeout_does_not_pause_schedule_with_fewer_than_5_previous_jobs(
-        self, activity_environment, ateam, anode, asaved_query, adag
-    ):
-        # Create only 3 previous failed timeout jobs - not enough to pause
-        previous_jobs = []
-        for i in range(3):
-            job = await database_sync_to_async(DataModelingJob.objects.create)(
-                team=ateam,
-                saved_query=asaved_query,
-                status=DataModelingJob.Status.FAILED,
-                error="Timeout exceeded",
-                workflow_id=f"prev-workflow-{i}",
-            )
-            previous_jobs.append(job)
-
-        # Create current job
-        current_job = await database_sync_to_async(DataModelingJob.objects.create)(
-            team=ateam,
-            saved_query=asaved_query,
-            status=DataModelingJob.Status.RUNNING,
-            workflow_id="current-workflow",
-        )
-
-        inputs = FailMaterializationInputs(
-            team_id=ateam.pk,
-            node_id=str(anode.id),
-            dag_id=str(adag.id),
-            job_id=str(current_job.id),
-            error="Timeout exceeded in query",
-        )
-        with unittest.mock.patch(
-            "posthog.temporal.data_modeling.activities.fail_materialization.pause_saved_query_schedule"
-        ) as mock_pause:
-            await activity_environment.run(fail_materialization_activity, inputs)
-            mock_pause.assert_not_called()
-
-        # Cleanup
-        await database_sync_to_async(current_job.delete)()
-        for job in previous_jobs:
-            await database_sync_to_async(job.delete)()
-
-    async def test_timeout_does_not_pause_schedule_when_previous_jobs_not_all_failures(
-        self, activity_environment, ateam, anode, asaved_query, adag
-    ):
-        # Create 5 previous jobs but one succeeded
-        previous_jobs = []
-        for i in range(5):
-            status = DataModelingJob.Status.COMPLETED if i == 2 else DataModelingJob.Status.FAILED
-            error = None if i == 2 else "Timeout exceeded"
-            job = await database_sync_to_async(DataModelingJob.objects.create)(
-                team=ateam,
-                saved_query=asaved_query,
-                status=status,
-                error=error,
-                workflow_id=f"prev-workflow-{i}",
-            )
-            previous_jobs.append(job)
-
-        current_job = await database_sync_to_async(DataModelingJob.objects.create)(
-            team=ateam,
-            saved_query=asaved_query,
-            status=DataModelingJob.Status.RUNNING,
-            workflow_id="current-workflow",
-        )
-
-        inputs = FailMaterializationInputs(
-            team_id=ateam.pk,
-            node_id=str(anode.id),
-            dag_id=str(adag.id),
-            job_id=str(current_job.id),
-            error="Timeout exceeded in query",
-        )
-        with unittest.mock.patch(
-            "posthog.temporal.data_modeling.activities.fail_materialization.pause_saved_query_schedule"
-        ) as mock_pause:
-            await activity_environment.run(fail_materialization_activity, inputs)
-            mock_pause.assert_not_called()
-
-        await database_sync_to_async(current_job.delete)()
-        for job in previous_jobs:
-            await database_sync_to_async(job.delete)()
-
-    async def test_timeout_does_not_pause_schedule_when_previous_failures_not_all_timeouts(
-        self, activity_environment, ateam, anode, asaved_query, adag
-    ):
-        # Create 5 previous failed jobs but with different errors
-        previous_jobs = []
-        for i in range(5):
-            error = "Memory limit exceeded" if i == 3 else "Timeout exceeded"
-            job = await database_sync_to_async(DataModelingJob.objects.create)(
-                team=ateam,
-                saved_query=asaved_query,
-                status=DataModelingJob.Status.FAILED,
-                error=error,
-                workflow_id=f"prev-workflow-{i}",
-            )
-            previous_jobs.append(job)
-
-        current_job = await database_sync_to_async(DataModelingJob.objects.create)(
-            team=ateam,
-            saved_query=asaved_query,
-            status=DataModelingJob.Status.RUNNING,
-            workflow_id="current-workflow",
-        )
-
-        inputs = FailMaterializationInputs(
-            team_id=ateam.pk,
-            node_id=str(anode.id),
-            dag_id=str(adag.id),
-            job_id=str(current_job.id),
-            error="Timeout exceeded in query",
-        )
-        with unittest.mock.patch(
-            "posthog.temporal.data_modeling.activities.fail_materialization.pause_saved_query_schedule"
-        ) as mock_pause:
-            await activity_environment.run(fail_materialization_activity, inputs)
-            mock_pause.assert_not_called()
-
-        await database_sync_to_async(current_job.delete)()
-        for job in previous_jobs:
-            await database_sync_to_async(job.delete)()
-
-    async def test_timeout_pauses_schedule_after_5_consecutive_timeout_failures(
-        self, activity_environment, ateam, anode, asaved_query, adag
-    ):
-        # Create 5 previous timeout failed jobs
-        previous_jobs = []
-        for i in range(5):
-            job = await database_sync_to_async(DataModelingJob.objects.create)(
-                team=ateam,
-                saved_query=asaved_query,
-                status=DataModelingJob.Status.FAILED,
-                error="Timeout exceeded",
-                workflow_id=f"prev-workflow-{i}",
-            )
-            previous_jobs.append(job)
-
-        current_job = await database_sync_to_async(DataModelingJob.objects.create)(
-            team=ateam,
-            saved_query=asaved_query,
-            status=DataModelingJob.Status.RUNNING,
-            workflow_id="current-workflow",
-        )
-
-        inputs = FailMaterializationInputs(
-            team_id=ateam.pk,
-            node_id=str(anode.id),
-            dag_id=str(adag.id),
-            job_id=str(current_job.id),
-            error="Timeout exceeded in query",
-        )
-        with unittest.mock.patch(
-            "posthog.temporal.data_modeling.activities.fail_materialization.pause_saved_query_schedule"
-        ) as mock_pause:
-            await activity_environment.run(fail_materialization_activity, inputs)
-            mock_pause.assert_called_once_with(asaved_query)
-
-        await database_sync_to_async(current_job.refresh_from_db)()
-        assert current_job.error is not None
-        assert "schedule has been paused" in current_job.error
-
-        await database_sync_to_async(asaved_query.refresh_from_db)()
-        assert asaved_query.sync_frequency_interval is None
-
-        await database_sync_to_async(current_job.delete)()
-        for job in previous_jobs:
-            await database_sync_to_async(job.delete)()
-
 
 class TestQualityBlockMaterializationActivity:
     async def test_a_blocked_publish_fails_the_node_and_job_but_starts_no_recovery(
@@ -560,136 +518,6 @@ class TestQualityBlockMaterializationActivity:
         assert "suspended" not in system_props
 
         await database_sync_to_async(job.delete)()
-
-
-class TestShouldPauseScheduleForTimeout:
-    async def test_returns_false_when_fewer_than_5_previous_jobs(self, ateam, asaved_query):
-        from posthog.temporal.data_modeling.activities.fail_materialization import should_pause_schedule_for_timeout
-
-        previous_jobs = []
-        for i in range(3):
-            job = await database_sync_to_async(DataModelingJob.objects.create)(
-                team=ateam,
-                saved_query=asaved_query,
-                status=DataModelingJob.Status.FAILED,
-                error="Timeout exceeded",
-                workflow_id=f"prev-workflow-{i}",
-            )
-            previous_jobs.append(job)
-
-        current_job = await database_sync_to_async(DataModelingJob.objects.create)(
-            team=ateam,
-            saved_query=asaved_query,
-            status=DataModelingJob.Status.RUNNING,
-            workflow_id="current-workflow",
-        )
-
-        should_pause, count = await database_sync_to_async(should_pause_schedule_for_timeout)(
-            asaved_query.id, current_job
-        )
-        assert should_pause is False
-        assert count == 3
-
-        await database_sync_to_async(current_job.delete)()
-        for job in previous_jobs:
-            await database_sync_to_async(job.delete)()
-
-    async def test_returns_true_when_5_consecutive_timeout_failures(self, ateam, asaved_query):
-        from posthog.temporal.data_modeling.activities.fail_materialization import should_pause_schedule_for_timeout
-
-        previous_jobs = []
-        for i in range(5):
-            job = await database_sync_to_async(DataModelingJob.objects.create)(
-                team=ateam,
-                saved_query=asaved_query,
-                status=DataModelingJob.Status.FAILED,
-                error="Timeout exceeded",
-                workflow_id=f"prev-workflow-{i}",
-            )
-            previous_jobs.append(job)
-
-        current_job = await database_sync_to_async(DataModelingJob.objects.create)(
-            team=ateam,
-            saved_query=asaved_query,
-            status=DataModelingJob.Status.RUNNING,
-            workflow_id="current-workflow",
-        )
-
-        should_pause, count = await database_sync_to_async(should_pause_schedule_for_timeout)(
-            asaved_query.id, current_job
-        )
-        assert should_pause is True
-        assert count == 5
-
-        await database_sync_to_async(current_job.delete)()
-        for job in previous_jobs:
-            await database_sync_to_async(job.delete)()
-
-    async def test_streak_survives_a_run_skipped_for_an_upstream_failure(self, ateam, asaved_query):
-        from posthog.temporal.data_modeling.activities.fail_materialization import should_pause_schedule_for_timeout
-
-        previous_jobs = []
-        for i in range(5):
-            job = await database_sync_to_async(DataModelingJob.objects.create)(
-                team=ateam,
-                saved_query=asaved_query,
-                status=DataModelingJob.Status.FAILED,
-                error="Timeout exceeded",
-                workflow_id=f"prev-workflow-{i}",
-            )
-            previous_jobs.append(job)
-
-        skipped = await database_sync_to_async(DataModelingJob.objects.create)(
-            team=ateam,
-            saved_query=asaved_query,
-            status=DataModelingJob.Status.SKIPPED,
-            error="Skipped because upstream view orders_daily is failing.",
-            workflow_id="skipped-workflow",
-        )
-        previous_jobs.append(skipped)
-
-        current_job = await database_sync_to_async(DataModelingJob.objects.create)(
-            team=ateam,
-            saved_query=asaved_query,
-            status=DataModelingJob.Status.RUNNING,
-            workflow_id="current-workflow",
-        )
-
-        should_pause, count = await database_sync_to_async(should_pause_schedule_for_timeout)(
-            asaved_query.id, current_job
-        )
-        assert should_pause is True
-        assert count == 5
-
-        await database_sync_to_async(current_job.delete)()
-        for job in previous_jobs:
-            await database_sync_to_async(job.delete)()
-
-    async def test_streak_ignores_jobs_from_other_engines(self, ateam, asaved_query):
-        from posthog.temporal.data_modeling.activities.fail_materialization import should_pause_schedule_for_timeout
-
-        jobs = [
-            await _make_job(ateam, asaved_query, DataModelingJob.Status.FAILED, error="Timeout exceeded")
-            for _ in range(5)
-        ]
-        # a more recent duckgres failure must not break the clickhouse timeout streak
-        jobs.append(
-            await _make_job(
-                ateam, asaved_query, DataModelingJob.Status.FAILED, engine=DataModelingJobEngine.DUCKGRES, error="boom"
-            )
-        )
-        current_job = await _make_job(ateam, asaved_query, DataModelingJob.Status.RUNNING)
-        jobs.append(current_job)
-
-        should_pause, count = await database_sync_to_async(should_pause_schedule_for_timeout)(
-            asaved_query.id, current_job
-        )
-        assert should_pause is True
-        assert count == 5
-
-        # DataModelingJob.team is SET_NULL, so it survives the ateam fixture's team teardown.
-        for job in jobs:
-            await database_sync_to_async(job.delete)()
 
 
 class TestNodeSuspension:
@@ -1070,7 +898,9 @@ class TestNodeSuspension:
 
 
 class TestSucceedMaterializationActivity:
-    async def test_marks_job_as_completed(self, activity_environment, ateam, anode, ajob, adag):
+    async def test_marks_job_as_completed(self, activity_environment, ateam, anode, asaved_query, ajob, adag):
+        asaved_query.latest_error = "Previous error"
+        await database_sync_to_async(asaved_query.save)(update_fields=["latest_error"])
         inputs = SucceedMaterializationInputs(
             team_id=ateam.pk,
             node_id=str(anode.id),
@@ -1084,6 +914,46 @@ class TestSucceedMaterializationActivity:
         assert ajob.status == DataModelingJob.Status.COMPLETED
         assert ajob.error is None
         assert ajob.last_run_at is not None
+        await database_sync_to_async(asaved_query.refresh_from_db)()
+        assert asaved_query.latest_error is None
+
+    async def test_stale_success_does_not_clear_a_newer_failure(
+        self, activity_environment, ateam, anode, asaved_query, adag
+    ):
+        older_job = await _make_job(ateam, asaved_query, DataModelingJob.Status.RUNNING)
+        newer_job = await _make_job(ateam, asaved_query, DataModelingJob.Status.RUNNING)
+        await activity_environment.run(
+            fail_materialization_activity,
+            FailMaterializationInputs(
+                team_id=ateam.pk,
+                node_id=str(anode.id),
+                dag_id=str(adag.id),
+                job_id=str(newer_job.id),
+                error="Newer failure",
+                suspend_immediately=True,
+            ),
+        )
+        await activity_environment.run(
+            succeed_materialization_activity,
+            SucceedMaterializationInputs(
+                team_id=ateam.pk,
+                node_id=str(anode.id),
+                dag_id=str(adag.id),
+                job_id=str(older_job.id),
+                row_count=1,
+                duration_seconds=1,
+            ),
+        )
+
+        from posthog.temporal.data_modeling.activities.utils import is_node_suspended
+
+        await database_sync_to_async(asaved_query.refresh_from_db)()
+        await database_sync_to_async(anode.refresh_from_db)()
+        assert asaved_query.latest_error == "Newer failure"
+        assert anode.properties["system"]["last_run_status"] == DataModelingJobStatus.FAILED
+        assert is_node_suspended(anode, DataModelingJobEngine.CLICKHOUSE) is True
+        await database_sync_to_async(older_job.delete)()
+        await database_sync_to_async(newer_job.delete)()
 
     async def test_updates_node_system_properties(self, activity_environment, ateam, anode, ajob, adag):
         inputs = SucceedMaterializationInputs(
@@ -1345,6 +1215,71 @@ class TestMaterializeViewActivity:
         with pytest.raises(InvalidNodeTypeException, match="Cannot materialize a TABLE node"):
             await activity_environment.run(materialize_view_activity, inputs)
         await database_sync_to_async(table_node.delete)()
+
+    @pytest.mark.parametrize(
+        "case",
+        ["incremental_first_run", "previously_completed", "not_incremental", "incremental_disabled"],
+    )
+    async def test_only_first_run_timeout_is_a_dedicated_non_retryable_error(
+        self, activity_environment, ateam, anode, asaved_query, ajob, adag, case
+    ):
+        if case != "not_incremental":
+            asaved_query.incremental_config = {"enabled": True, "incremental_key": "id", "unique_key": ["id"]}
+            await database_sync_to_async(asaved_query.save)(update_fields=["incremental_config"])
+        completed_job = None
+        if case == "previously_completed":
+            completed_job = await _make_job(ateam, asaved_query, DataModelingJob.Status.COMPLETED)
+        timeout = ClickHouseQueryTimeoutError("Code: 159. DB::Exception: Query timed out (TIMEOUT_EXCEEDED)")
+        logger = unittest.mock.MagicMock()
+        logger.ainfo = unittest.mock.AsyncMock()
+        logger.adebug = unittest.mock.AsyncMock()
+        logger.aerror = unittest.mock.AsyncMock()
+
+        with (
+            unittest.mock.patch.object(LOGGER, "bind", return_value=logger),
+            unittest.mock.patch(
+                "posthog.temporal.data_modeling.activities.materialize_view._incremental_enabled",
+                return_value=case != "incremental_disabled",
+            ),
+            unittest.mock.patch(
+                "posthog.temporal.data_modeling.activities.materialize_view._build_person_property_sink",
+                new=unittest.mock.AsyncMock(return_value=None),
+            ),
+            unittest.mock.patch(
+                "posthog.temporal.data_modeling.activities.materialize_view._materialize_fully",
+                new=unittest.mock.AsyncMock(side_effect=timeout),
+            ),
+            unittest.mock.patch(
+                "posthog.temporal.data_modeling.activities.materialize_view._CDPRowSink.prepare",
+                new=unittest.mock.AsyncMock(),
+            ),
+            unittest.mock.patch(
+                "posthog.temporal.data_modeling.activities.materialize_view._CDPRowSink.discard",
+                new=unittest.mock.AsyncMock(),
+            ),
+        ):
+            expected_error = ClickHouseQueryTimeoutError if case == "previously_completed" else ApplicationError
+            with pytest.raises(expected_error) as error:
+                await activity_environment.run(
+                    materialize_view_activity,
+                    MaterializeViewInputs(
+                        team_id=ateam.pk,
+                        dag_id=str(adag.id),
+                        node_id=str(anode.id),
+                        job_id=str(ajob.id),
+                    ),
+                )
+
+        if case != "previously_completed":
+            assert isinstance(error.value, ApplicationError)
+            assert error.value.type == INITIAL_FULL_REFRESH_TIMEOUT_ERROR_TYPE
+            assert error.value.non_retryable is True
+            assert INITIAL_FULL_REFRESH_TIMEOUT_MESSAGE in str(error.value)
+        visible_attempt_logs = [call for call in logger.aerror.await_args_list if not call.kwargs.get("write_only")]
+        assert len(visible_attempt_logs) == 1
+        assert "TIMEOUT_EXCEEDED" in visible_attempt_logs[0].args[0]
+        if completed_job is not None:
+            await database_sync_to_async(completed_job.delete)()
 
     async def test_materializes_view_to_delta_table(
         self, activity_environment, ateam, anode, asaved_query, ajob, bucket_name, adag
@@ -1646,6 +1581,7 @@ class _EmptyArrowClient:
         self.describe_calls: list[tuple[str, dict[str, str] | None]] = []
         self.reject_describe_with_settings = False
         self.arrow_query: str | None = None
+        self.arrow_query_id: str | None = None
 
     async def astream_query_as_arrow(
         self,
@@ -1657,6 +1593,7 @@ class _EmptyArrowClient:
     ) -> AsyncIterator[pa.RecordBatch]:
         self.arrow_query_calls += 1
         self.arrow_query = query
+        self.arrow_query_id = query_id
         if on_schema is not None:
             on_schema(self.schema)
         return
@@ -1763,7 +1700,56 @@ class TestHogqlTableModifiers:
         assert client.arrow_query is not None
 
 
+class _MaskedArrowFailureClient(_EmptyArrowClient):
+    def __init__(self, schema: pa.Schema):
+        super().__init__(schema)
+        self.diagnostic_query_ids: list[str] = []
+
+    async def astream_query_as_arrow(
+        self,
+        query: str,
+        *data: Any,
+        query_parameters: dict[str, Any] | None = None,
+        query_id: str | None = None,
+        on_schema: Callable[[pa.Schema], None] | None = None,
+    ) -> AsyncIterator[pa.RecordBatch]:
+        self.arrow_query = query
+        self.arrow_query_id = query_id
+        raise InvalidMessageFormat("Arrow stream contained a ClickHouse error")
+        yield pa.RecordBatch.from_arrays([], names=[])
+
+    async def acheck_query(self, query_id: str) -> None:
+        self.diagnostic_query_ids.append(query_id)
+        if len(self.diagnostic_query_ids) == 1:
+            raise ClickHouseQueryNotFound(query_id)
+        raise ClickHouseQueryTimeoutError("Code: 159. DB::Exception: TIMEOUT_EXCEEDED", query_id=query_id)
+
+
 class TestHogqlTableEmptyResults:
+    async def test_recovers_typed_failure_from_masked_arrow_error(self, ateam):
+        client = _MaskedArrowFailureClient(pa.schema([pa.field("id", pa.int64())]))
+
+        @contextlib.asynccontextmanager
+        async def fake_get_client(**kwargs):
+            yield client
+
+        with (
+            unittest.mock.patch(
+                "posthog.temporal.data_modeling.activities.materialize_view.get_clickhouse_client",
+                fake_get_client,
+            ),
+            unittest.mock.patch(
+                "posthog.temporal.data_modeling.activities.materialize_view.asyncio.sleep",
+                new=unittest.mock.AsyncMock(),
+            ) as sleep,
+        ):
+            with pytest.raises(ClickHouseQueryTimeoutError):
+                _ = [batch async for batch in hogql_table("SELECT 1", ateam, LOGGER.bind())]
+
+        assert client.arrow_query_id is not None
+        assert client.diagnostic_query_ids == [client.arrow_query_id, client.arrow_query_id]
+        sleep.assert_awaited_once()
+
     async def test_zero_row_query_uses_the_initial_stream_schema(self, ateam):
         client = _EmptyArrowClient(pa.schema([pa.field("id", pa.int64())]))
 

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_workflow.py
@@ -7,7 +7,13 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import temporalio.workflow
-from temporalio.exceptions import CancelledError, ChildWorkflowError, WorkflowAlreadyStartedError
+from temporalio.exceptions import (
+    ActivityError,
+    ApplicationError,
+    CancelledError,
+    ChildWorkflowError,
+    WorkflowAlreadyStartedError,
+)
 
 from posthog.temporal.data_modeling.activities import (
     DuckgresShadowEligibilityInputs,
@@ -19,6 +25,10 @@ from posthog.temporal.data_modeling.activities import (
     fail_materialization_activity,
 )
 from posthog.temporal.data_modeling.activities.enrich_view_semantics import EnrichViewSemanticsInputs
+from posthog.temporal.data_modeling.errors import (
+    INITIAL_FULL_REFRESH_TIMEOUT_ERROR_TYPE,
+    INITIAL_FULL_REFRESH_TIMEOUT_MESSAGE,
+)
 from posthog.temporal.data_modeling.workflows.materialize_view import (
     ACCOUNT_PROPERTY_S3_SYNC_PATCH,
     ACCOUNT_PROPERTY_STAGING_WORKFLOW_PATCH,
@@ -87,6 +97,7 @@ class TestQualityGateBranching:
             stack.enter_context(patch(f"{WORKFLOW_MODULE}.capture_exception"))
             if shadow_handle is not None:
                 stack.enter_context(patch.object(temporalio.workflow, "start_activity", return_value=shadow_handle))
+            self._last_execute_activity = execute_activity
             for metric in (
                 "get_node_finished_metric",
                 "get_node_duration_metric",
@@ -104,6 +115,37 @@ class TestQualityGateBranching:
                 stack.enter_context(patch(f"{WORKFLOW_MODULE}.{metric}"))
             result = await MaterializeViewWorkflow().run(_inputs())
         return result, execute_activity
+
+    async def test_dedicated_timeout_forces_suspension_during_finalization(self):
+        activity_error = ActivityError(
+            "materialize failed",
+            scheduled_event_id=1,
+            started_event_id=2,
+            identity="worker",
+            activity_type="materialize_view_activity",
+            activity_id="activity-1",
+            retry_state=None,
+        )
+        activity_error.__cause__ = ApplicationError(
+            INITIAL_FULL_REFRESH_TIMEOUT_MESSAGE,
+            type=INITIAL_FULL_REFRESH_TIMEOUT_ERROR_TYPE,
+            non_retryable=True,
+        )
+
+        with pytest.raises(ApplicationError) as error:
+            await self._run([False, "job-1", activity_error, None], {})
+
+        assert error.value.type == INITIAL_FULL_REFRESH_TIMEOUT_ERROR_TYPE
+        assert error.value.non_retryable is True
+        fail_call = next(
+            call
+            for call in self._last_execute_activity.await_args_list
+            if call.args[0] is fail_materialization_activity
+        )
+        payload = fail_call.args[1]
+        assert isinstance(payload, FailMaterializationInputs)
+        assert payload.error == INITIAL_FULL_REFRESH_TIMEOUT_MESSAGE
+        assert payload.suspend_immediately is True
 
     async def test_blocking_failures_stop_the_publish(self):
         activity_results = [

--- a/products/data_modeling/backend/facade/api.py
+++ b/products/data_modeling/backend/facade/api.py
@@ -47,6 +47,7 @@ _LAZY = {
     "saved_query_target_bounds": "logic.node_frequency",
     "clear_node_suspension": "logic.node_suspension",
     "is_node_suspended": "logic.node_suspension",
+    "is_node_suspension_always_enforced": "logic.node_suspension",
     "mark_node_suspended": "logic.node_suspension",
     "query_fingerprint": "logic.node_suspension",
     "resume_nodes": "logic.node_suspension",

--- a/products/data_modeling/backend/logic/node_suspension.py
+++ b/products/data_modeling/backend/logic/node_suspension.py
@@ -45,21 +45,36 @@ def is_node_suspended(node: Node, engine: str) -> bool:
     return bool(suspension_state(node).get(str(engine)))
 
 
+def is_node_suspension_always_enforced(node: Node, engine: str) -> bool:
+    return suspension_state(node).get(str(engine), {}).get("enforce_without_flag") is True
+
+
 def suspension_reset_at(node: Node, engine: str) -> str | None:
     """Failures before this point no longer count toward suspension."""
     return ((_system(node).get(RESET_KEY) or {}).get(str(engine)) or {}).get("at")
 
 
-def mark_node_suspended(node: Node, *, engine: str, reason: str, job_id: str, fingerprint: str | None = None) -> None:
+def mark_node_suspended(
+    node: Node,
+    *,
+    engine: str,
+    reason: str,
+    job_id: str,
+    fingerprint: str | None = None,
+    enforce_without_flag: bool = False,
+) -> None:
     properties: dict = node.properties or {}
     system = properties.setdefault("system", {})
     suspended = system.setdefault(SUSPENDED_KEY, {})
-    suspended[str(engine)] = {
+    state: dict[str, object] = {
         "at": _now(),
         "reason": reason,
         "job_id": job_id,
         "query_fingerprint": fingerprint,
     }
+    if enforce_without_flag:
+        state["enforce_without_flag"] = True
+    suspended[str(engine)] = state
     # A fresh suspension supersedes the resume that preceded it.
     (system.get(RESET_KEY) or {}).pop(str(engine), None)
     node.properties = properties

--- a/products/data_modeling/backend/management/commands/clear_unearned_node_suspensions.py
+++ b/products/data_modeling/backend/management/commands/clear_unearned_node_suspensions.py
@@ -27,7 +27,12 @@ from posthog.temporal.data_modeling.activities.utils import (
     is_externally_aborted,
 )
 
-from products.data_modeling.backend.logic.node_suspension import resume_nodes, suspension_reset_at, suspension_state
+from products.data_modeling.backend.logic.node_suspension import (
+    is_node_suspension_always_enforced,
+    resume_nodes,
+    suspension_reset_at,
+    suspension_state,
+)
 from products.data_modeling.backend.models.node import Node
 
 RESUMED_BY = "suspension_recheck"
@@ -40,10 +45,11 @@ class Marker:
     engine: str
     reason: str
     failures: int
+    always_enforced: bool
 
     @property
     def earned(self) -> bool:
-        return self.failures >= CONSECUTIVE_FAILURES_TO_SUSPEND
+        return self.always_enforced or self.failures >= CONSECUTIVE_FAILURES_TO_SUSPEND
 
     @property
     def blamed_on_an_abort(self) -> bool:
@@ -52,7 +58,7 @@ class Marker:
     def still_unearned(self, node: Node) -> bool:
         """The sweep counts every marker before it clears any, and a model keeps failing while that
         runs, so the verdict is re-taken against the row we are about to write."""
-        return (
+        return not is_node_suspension_always_enforced(node, self.engine) and (
             count_leading_failures(self.saved_query_id, self.engine, since=suspension_reset_at(node, self.engine))
             < CONSECUTIVE_FAILURES_TO_SUSPEND
         )
@@ -113,4 +119,5 @@ class Command(BaseCommand):
                     engine=engine,
                     reason=entry.get("reason") or "",
                     failures=count_leading_failures(saved_query_id, engine, since=suspension_reset_at(node, engine)),
+                    always_enforced=is_node_suspension_always_enforced(node, engine),
                 )

--- a/products/data_modeling/backend/test/test_clear_unearned_node_suspensions.py
+++ b/products/data_modeling/backend/test/test_clear_unearned_node_suspensions.py
@@ -28,7 +28,13 @@ ABORT_ERROR = "Preempted: a new DAG run started before this job completed"
 
 @pytest.mark.django_db
 class TestClearUnearnedNodeSuspensions(BaseTest):
-    def _suspended_node(self, *, errors: list[str], engine: str = DataModelingJobEngine.CLICKHOUSE) -> Node:
+    def _suspended_node(
+        self,
+        *,
+        errors: list[str],
+        engine: str = DataModelingJobEngine.CLICKHOUSE,
+        enforce_without_flag: bool = False,
+    ) -> Node:
         saved_query = DataWarehouseSavedQuery.objects.create(
             name=f"model_{uuid4().hex[:8]}",
             team=self.team,
@@ -37,7 +43,13 @@ class TestClearUnearnedNodeSuspensions(BaseTest):
         node = sync_saved_query_to_dag(saved_query)
         assert node is not None
         self._record_failures(saved_query, errors, engine=engine)
-        mark_node_suspended(node, engine=engine, reason=errors[-1], job_id=str(uuid4()))
+        mark_node_suspended(
+            node,
+            engine=engine,
+            reason=errors[-1],
+            job_id=str(uuid4()),
+            enforce_without_flag=enforce_without_flag,
+        )
         node.save()
         return node
 
@@ -73,6 +85,14 @@ class TestClearUnearnedNodeSuspensions(BaseTest):
 
     def test_keeps_a_marker_five_genuine_failures_still_earn(self):
         node = self._suspended_node(errors=[CUSTOMER_ERROR] * 5)
+
+        call_command("clear_unearned_node_suspensions", "--apply", stdout=StringIO())
+
+        node.refresh_from_db()
+        assert is_node_suspended(node, DataModelingJobEngine.CLICKHOUSE)
+
+    def test_keeps_an_always_enforced_marker_without_five_failures(self):
+        node = self._suspended_node(errors=[CUSTOMER_ERROR], enforce_without_flag=True)
 
         call_command("clear_unearned_node_suspensions", "--apply", stdout=StringIO())
 


### PR DESCRIPTION
## Problem

People who start a materialization that cannot finish within the query limit see repeated runs instead of a terminal error.

Closes #92125

## Changes

- First builds that hit the query limit now fail once with guidance.
- The model stops scheduled retries until a manual run or query edit resumes it.
- Each failed query attempt now adds a sanitized line to the model's run log.
- `latest_error` now follows the newest terminal ClickHouse job and clears after recovery.
- Late Arrow failures now recover the typed ClickHouse error through the query log.
- Later materializations keep the existing five-failure suspension threshold.

### Before

```mermaid
flowchart LR
    A[First full build] --> B[Query timeout]
    B --> C[Activity retry]
    C --> D[Workflow or scheduled retry]
    D --> A
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phBlue;
    class B phRed;
    class C,D phYellow;
```

### After

```mermaid
flowchart LR
    A[First full build] --> B[Query timeout]
    B --> C[Visible terminal error]
    C --> D[Suspended model]
    D --> E[Manual run or query edit]
    E --> A
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,E phBlue;
    class B phRed;
    class C phYellow;
    class D phGray;
```

## How did you test this code?

- Ran the focused data-modeling activity, workflow, DAG, and suspension-cleanup suites.
- Added cases for timeout classification, attempt logs, forced suspension, stale finalizers, and error recovery.
- Ran Ruff checks and `hogli ci:preflight --fix` with no failures.
- Repo-wide mypy did not complete within the sandbox time limit.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The error on the affected model provides the recovery guidance.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: PostHog Desktop with Explore, Plan, and General subagents.
- Skills: `/subagent-orchestration`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-dataclasses`, `/writing-code-comments`, `/announcing-behavior-changes`, and `/writing-pr-descriptions`.
- No open PR matched #92125 or the first-build timeout terms.
- The fix uses the existing node suspension model instead of retired per-query schedules.
- The diff contains no session-only data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
