### PR TITLE
fix(batch-exports): handle expected staging failures

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/file_download_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/file_download_batch_export.py
@@ -386,11 +386,16 @@ class FileDownloadBatchExportWorkflow(PostHogWorkflow):
             file_format=inputs.file_format,
             max_file_size_mb=inputs.max_file_size_mb,
         )
-        result: S3BatchExportResult = await execute_batch_export_using_internal_stage(
+        result = await execute_batch_export_using_internal_stage(
             export_to_file_download_bucket_with_temporary_credentials,
             export_inputs,  # type: ignore
             interval=f"every {int(interval_delta.total_seconds())} seconds",
         )
+
+        # A run that failed for a reason the user has to resolve comes back as a plain
+        # `BatchExportResult`, so it uploaded no files and there is nothing to generate downloads for.
+        if not isinstance(result, S3BatchExportResult):
+            return FileDownloadBatchExportResult(records_completed=0, bytes_exported=0, error=result.error)
 
         file_downloads = await workflow.execute_activity(
             generate_file_downloads,

--- a/products/batch_exports/backend/temporal/destinations/file_download_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/file_download_batch_export.py
@@ -394,7 +394,7 @@ class FileDownloadBatchExportWorkflow(PostHogWorkflow):
 
         # A failed run gets no download links, even where some files did reach the bucket. The
         # `isinstance` arm is unreachable in practice, since every failure comes back as a plain
-        # `BatchExportResult`; it narrows the type for `files_uploaded` below.
+        # `BatchExportResult`; it's needed to narrow the type for `files_uploaded` below.
         if result.error is not None or not isinstance(result, S3BatchExportResult):
             return FileDownloadBatchExportResult(records_completed=0, bytes_exported=0, error=result.error)
 

--- a/products/batch_exports/backend/temporal/destinations/file_download_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/file_download_batch_export.py
@@ -392,9 +392,10 @@ class FileDownloadBatchExportWorkflow(PostHogWorkflow):
             interval=f"every {int(interval_delta.total_seconds())} seconds",
         )
 
-        # A run that failed for a reason the user has to resolve comes back as a plain
-        # `BatchExportResult`, so it uploaded no files and there is nothing to generate downloads for.
-        if not isinstance(result, S3BatchExportResult):
+        # A failed run gets no download links, even where some files did reach the bucket. The
+        # `isinstance` arm is unreachable in practice, since every failure comes back as a plain
+        # `BatchExportResult`; it narrows the type for `files_uploaded` below.
+        if result.error is not None or not isinstance(result, S3BatchExportResult):
             return FileDownloadBatchExportResult(records_completed=0, bytes_exported=0, error=result.error)
 
         file_downloads = await workflow.execute_activity(

--- a/products/batch_exports/backend/temporal/pipeline/entrypoint.py
+++ b/products/batch_exports/backend/temporal/pipeline/entrypoint.py
@@ -21,6 +21,7 @@ from products.batch_exports.backend.service import (
 from products.batch_exports.backend.temporal.batch_exports import FinishBatchExportRunInputs, finish_batch_export_run
 from products.batch_exports.backend.temporal.metrics import get_export_finished_metric, get_export_started_metric
 from products.batch_exports.backend.temporal.pipeline.internal_stage import (
+    EXPECTED_STAGE_ERRORS,
     BatchExportInsertIntoInternalStageInputs,
     InternalStageResult,
     insert_into_internal_stage_activity,
@@ -70,11 +71,10 @@ INITIAL_RETRY_INTERVAL_SECONDS = 1
 DEFAULT_MAX_RETRY_INTERVAL_SECONDS = 3600
 DEFAULT_MAX_STAGE_RETRY_INTERVAL_SECONDS = 600
 
-STAGE_NON_RETRYABLE_ERROR_TYPES = (
-    "InvalidFilterError",
-    "DataIntervalEndInFutureError",
-    "HogQLQueryResourceLimitExceededError",
-)
+# The staging activity returns these as an `InternalStageResult.error` rather than raising, so
+# Temporal normally never sees them. They stay listed here to stop an endless retry loop if one is
+# ever raised from a path the activity's own handling does not cover.
+STAGE_NON_RETRYABLE_ERROR_TYPES = tuple(error.__name__ for error in EXPECTED_STAGE_ERRORS)
 
 
 @frozen
@@ -147,14 +147,16 @@ def _get_status_for_activity_error(error: exceptions.ActivityError) -> BatchExpo
     if isinstance(error.cause, exceptions.CancelledError):
         return BatchExportRun.Status.CANCELLED
 
+    # Both activities report their expected errors through their result rather than by raising, so
+    # this covers only an expected error escaping from a path that handling does not reach.
     if isinstance(error.cause, exceptions.ApplicationError) and error.cause.type in STAGE_NON_RETRYABLE_ERROR_TYPES:
         return BatchExportRun.Status.FAILED
 
     # Reaching this outside tests means one of two assumptions broke, so `finish_batch_export_run`
     # logs it. Callers pass `maximum_attempts=0` with no schedule-to-close or run timeout, so a
     # retryable error (or activity timeout) retries forever and never surfaces here; and a terminal
-    # error from the destination activity comes back as a `BatchExportResult` with `error_repr`
-    # rather than raising. That leaves `TEST`, which forces `maximum_attempts=1`.
+    # error from either activity comes back as a result with an error rather than raising. That
+    # leaves `TEST`, which forces `maximum_attempts=1`.
     return BatchExportRun.Status.FAILED_RETRYABLE
 
 
@@ -235,7 +237,7 @@ async def execute_batch_export_using_internal_stage(
     maximum_stage_retry_interval_seconds: int = DEFAULT_MAX_STAGE_RETRY_INTERVAL_SECONDS,
     override_start_to_close_timeout_seconds: int | None = None,
     is_workflows: bool = False,
-) -> BatchExportResultType:
+) -> BatchExportResultType | BatchExportResult:
     """Run one batch export: stage its data, write it to the destination, record how it went.
 
     All batch exports boil down to inserting some data somewhere, and they all follow the same error
@@ -263,7 +265,8 @@ async def execute_batch_export_using_internal_stage(
             query.
 
     Returns:
-        The destination activity's result.
+        The destination activity's result, or a plain `BatchExportResult` carrying the staging
+        error when staging failed for a reason the user has to resolve.
     """
     if hasattr(inputs, "batch_export"):
         batch_export_inputs: _BatchExportInputsProtocol = inputs.batch_export  # ty: ignore[invalid-assignment]
@@ -320,6 +323,11 @@ async def execute_batch_export_using_internal_stage(
                 non_retryable_error_types=list(STAGE_NON_RETRYABLE_ERROR_TYPES),
             ),
         )
+
+        if stage_result.error is not None:
+            finish_inputs.status = BatchExportRun.Status.FAILED
+            finish_inputs.latest_error = stage_result.error.message
+            return BatchExportResult(error=stage_result.error)
 
         batch_export_inputs.stage_folder = stage_result.stage_folder
         batch_export_inputs.records_total = stage_result.records_total

--- a/products/batch_exports/backend/temporal/pipeline/entrypoint.py
+++ b/products/batch_exports/backend/temporal/pipeline/entrypoint.py
@@ -21,7 +21,7 @@ from products.batch_exports.backend.service import (
 from products.batch_exports.backend.temporal.batch_exports import FinishBatchExportRunInputs, finish_batch_export_run
 from products.batch_exports.backend.temporal.metrics import get_export_finished_metric, get_export_started_metric
 from products.batch_exports.backend.temporal.pipeline.internal_stage import (
-    EXPECTED_STAGE_ERRORS,
+    NON_RETRYABLE_ERRORS,
     BatchExportInsertIntoInternalStageInputs,
     InternalStageResult,
     insert_into_internal_stage_activity,
@@ -74,7 +74,7 @@ DEFAULT_MAX_STAGE_RETRY_INTERVAL_SECONDS = 600
 # The staging activity returns these as an `InternalStageResult.error` rather than raising, so
 # Temporal normally never sees them. They stay listed here to stop an endless retry loop if one is
 # ever raised from a path the activity's own handling does not cover.
-STAGE_NON_RETRYABLE_ERROR_TYPES = tuple(error.__name__ for error in EXPECTED_STAGE_ERRORS)
+STAGE_NON_RETRYABLE_ERROR_TYPES = tuple(error.__name__ for error in NON_RETRYABLE_ERRORS)
 
 
 @frozen
@@ -147,8 +147,8 @@ def _get_status_for_activity_error(error: exceptions.ActivityError) -> BatchExpo
     if isinstance(error.cause, exceptions.CancelledError):
         return BatchExportRun.Status.CANCELLED
 
-    # Both activities report their expected errors through their result rather than by raising, so
-    # this covers only an expected error escaping from a path that handling does not reach.
+    # Both activities report their non-retryable errors through their result rather than by raising,
+    # so this covers only one escaping from a path that handling does not reach.
     if isinstance(error.cause, exceptions.ApplicationError) and error.cause.type in STAGE_NON_RETRYABLE_ERROR_TYPES:
         return BatchExportRun.Status.FAILED
 

--- a/products/batch_exports/backend/temporal/pipeline/entrypoint.py
+++ b/products/batch_exports/backend/temporal/pipeline/entrypoint.py
@@ -237,7 +237,7 @@ async def execute_batch_export_using_internal_stage(
     maximum_stage_retry_interval_seconds: int = DEFAULT_MAX_STAGE_RETRY_INTERVAL_SECONDS,
     override_start_to_close_timeout_seconds: int | None = None,
     is_workflows: bool = False,
-) -> BatchExportResultType | BatchExportResult:
+) -> BatchExportResult:
     """Run one batch export: stage its data, write it to the destination, record how it went.
 
     All batch exports boil down to inserting some data somewhere, and they all follow the same error

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -52,13 +52,14 @@ from products.batch_exports.backend.service import (
     afetch_last_run_records_completed,
 )
 from products.batch_exports.backend.temporal.batch_exports import default_fields
-from products.batch_exports.backend.temporal.filters import compose_filters_clause
+from products.batch_exports.backend.temporal.filters import InvalidFilterError, compose_filters_clause
 from products.batch_exports.backend.temporal.metrics import log_query_duration
 from products.batch_exports.backend.temporal.pipeline.query_ranges import (
     is_5_min_batch_export,
     use_distributed_events_recent_table,
     wait_for_delta_past_data_interval_end,
 )
+from products.batch_exports.backend.temporal.pipeline.types import BatchExportError
 from products.batch_exports.backend.temporal.record_batch_model import RecordBatchModel, resolve_batch_exports_model
 from products.batch_exports.backend.temporal.sql.common import get_s3_function_call
 from products.batch_exports.backend.temporal.sql.events import (
@@ -89,12 +90,25 @@ class DataIntervalEndInFutureError(Exception):
 class HogQLQueryResourceLimitExceededError(Exception):
     """A user's HogQL batch export query exceeded a per-query ClickHouse resource limit.
 
-    Raised in place of the ClickHouse error so the workflow treats it as non-retryable (see the
-    stage activity's `non_retryable_error_types`): re-running the query unchanged would fail again.
+    Raised in place of the ClickHouse error so the staging activity treats it as expected (see
+    `EXPECTED_STAGE_ERRORS`): re-running the query unchanged would fail again.
 
     Only raised for the `hogql` model. The fixed models keep their ClickHouse errors and stay
     retryable, since their queries are ours and any failures are our responsibility to address.
     """
+
+
+EXPECTED_STAGE_ERRORS: tuple[type[Exception], ...] = (
+    DataIntervalEndInFutureError,
+    HogQLQueryResourceLimitExceededError,
+    InvalidFilterError,
+)
+"""Staging failures the user has to resolve, so retrying them ourselves would achieve nothing.
+
+The activity returns these as an `InternalStageResult.error` instead of raising, which fails the
+run without failing the activity. This mirrors how the destination activities treat their own
+expected errors (see `handle_non_retryable_errors`), and keeps a user's mistake from paging us.
+"""
 
 
 def _raise_on_hogql_resource_limit_error(exc: ClickHouseError, model_name: str) -> None:
@@ -257,6 +271,8 @@ class InternalStageResult:
     stage_folder: str
     # Total rows written to the stage (from ClickHouse's query summary), or None if unknown.
     records_total: int | None = None
+    # Set when staging failed with one of `EXPECTED_STAGE_ERRORS`, in which case nothing was staged.
+    error: BatchExportError | None = None
 
 
 @dataclass
@@ -303,6 +319,8 @@ async def insert_into_internal_stage_activity(
 
     Returns:
         The S3 staging folder where the data was written to, and the total number of rows staged.
+        If staging failed with one of `EXPECTED_STAGE_ERRORS`, the result carries that error
+        instead and the activity still succeeds.
     """
     bind_contextvars(
         team_id=inputs.team_id,
@@ -346,47 +364,83 @@ async def insert_into_internal_stage_activity(
         )
         logger.info("Computed staging partitions", num_partitions=num_partitions)
 
-        if record_batch_model is not None:
-            query_or_model = record_batch_model
-            query_parameters = {}
-        else:
-            query, query_parameters = await _get_query(
+        try:
+            records_total = await _stage_query_results(
+                inputs,
+                record_batch_model=record_batch_model,
                 model_name=model_name,
-                backfill_details=inputs.backfill_details,
-                team_id=inputs.team_id,
-                batch_export_id=inputs.batch_export_id,
-                s3_staging_folder_url=s3_staging_folder.url,
-                full_range=full_range,
-                data_interval_start=inputs.data_interval_start,
-                data_interval_end=inputs.data_interval_end,
                 fields=fields,
                 filters=filters,
-                destination_default_fields=inputs.destination_default_fields,
-                exclude_events=inputs.exclude_events,
-                include_events=inputs.include_events,
                 extra_query_parameters=extra_query_parameters,
-                num_partitions=num_partitions,
-                is_workflows=inputs.is_workflows,
-            )
-            query_or_model = query
-
-        try:
-            records_total = await _write_batch_export_record_batches_to_internal_stage(
-                query_or_model=query_or_model,
                 full_range=full_range,
-                query_parameters=query_parameters,
-                team_id=inputs.team_id,
-                batch_export_id=inputs.batch_export_id,
-                data_interval_start=inputs.data_interval_start,
-                data_interval_end=inputs.data_interval_end,
-                s3_staging_folder_url=s3_staging_folder.url,
+                s3_staging_folder=s3_staging_folder,
                 num_partitions=num_partitions,
             )
-        except ClickHouseError as e:
-            _raise_on_hogql_resource_limit_error(e, model_name)
-            raise
+        except EXPECTED_STAGE_ERRORS as e:
+            logger.warning("Staging data failed with an expected error", error=str(e))
+            return InternalStageResult(
+                stage_folder=s3_staging_folder.folder,
+                error=BatchExportError(type=type(e).__name__, message=str(e)),
+            )
+
     logger.info("Staging data completed successfully", records_total=records_total)
     return InternalStageResult(stage_folder=s3_staging_folder.folder, records_total=records_total)
+
+
+async def _stage_query_results(
+    inputs: BatchExportInsertIntoInternalStageInputs,
+    *,
+    record_batch_model: RecordBatchModel | None,
+    model_name: str,
+    fields: list[BatchExportField] | None,
+    filters: list[dict[str, str | list[str] | None]] | None,
+    extra_query_parameters: dict[str, typing.Any] | None,
+    full_range: tuple[dt.datetime | None, dt.datetime],
+    s3_staging_folder: S3StagingFolder,
+    num_partitions: int,
+) -> int | None:
+    """Build this run's query and write its results into the internal S3 staging area.
+
+    Returns the number of rows staged, or None if the count couldn't be determined.
+    """
+    if record_batch_model is not None:
+        query_or_model: str | RecordBatchModel = record_batch_model
+        query_parameters: dict[str, typing.Any] = {}
+    else:
+        query_or_model, query_parameters = await _get_query(
+            model_name=model_name,
+            backfill_details=inputs.backfill_details,
+            team_id=inputs.team_id,
+            batch_export_id=inputs.batch_export_id,
+            s3_staging_folder_url=s3_staging_folder.url,
+            full_range=full_range,
+            data_interval_start=inputs.data_interval_start,
+            data_interval_end=inputs.data_interval_end,
+            fields=fields,
+            filters=filters,
+            destination_default_fields=inputs.destination_default_fields,
+            exclude_events=inputs.exclude_events,
+            include_events=inputs.include_events,
+            extra_query_parameters=extra_query_parameters,
+            num_partitions=num_partitions,
+            is_workflows=inputs.is_workflows,
+        )
+
+    try:
+        return await _write_batch_export_record_batches_to_internal_stage(
+            query_or_model=query_or_model,
+            full_range=full_range,
+            query_parameters=query_parameters,
+            team_id=inputs.team_id,
+            batch_export_id=inputs.batch_export_id,
+            data_interval_start=inputs.data_interval_start,
+            data_interval_end=inputs.data_interval_end,
+            s3_staging_folder_url=s3_staging_folder.url,
+            num_partitions=num_partitions,
+        )
+    except ClickHouseError as e:
+        _raise_on_hogql_resource_limit_error(e, model_name)
+        raise
 
 
 async def compute_num_partitions(

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -19,6 +19,7 @@ from temporalio import activity
 from posthog.clickhouse import query_tagging
 from posthog.clickhouse.query_tagging import Product
 from posthog.credentials import AWSKeyPair
+from posthog.dataclasses import frozen
 
 from products.batch_exports.backend.temporal.utils import make_retryable_with_exponential_backoff
 
@@ -262,7 +263,7 @@ class S3StagingFolder:
     url: str
 
 
-@dataclass
+@frozen
 class InternalStageResult:
     """Result of staging a batch export run's data in the internal S3 area."""
 

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -90,25 +90,23 @@ class DataIntervalEndInFutureError(Exception):
 class HogQLQueryResourceLimitExceededError(Exception):
     """A user's HogQL batch export query exceeded a per-query ClickHouse resource limit.
 
-    Raised in place of the ClickHouse error so the staging activity treats it as expected (see
-    `EXPECTED_STAGE_ERRORS`): re-running the query unchanged would fail again.
+    Raised in place of the ClickHouse error so the staging activity treats it as non-retryable
+    (see `NON_RETRYABLE_ERRORS`): re-running the query unchanged would fail again.
 
     Only raised for the `hogql` model. The fixed models keep their ClickHouse errors and stay
     retryable, since their queries are ours and any failures are our responsibility to address.
     """
 
 
-EXPECTED_STAGE_ERRORS: tuple[type[Exception], ...] = (
+# Staging failures the user has to resolve; retrying them ourselves would achieve nothing.
+# The activity returns these as an `InternalStageResult.error` instead of raising, which fails the
+# run without failing the activity. This mirrors how the destination activities treat their own
+# non-retryable errors (see `handle_non_retryable_errors`), and prevents us being alerted on user errors.
+NON_RETRYABLE_ERRORS: tuple[type[Exception], ...] = (
     DataIntervalEndInFutureError,
     HogQLQueryResourceLimitExceededError,
     InvalidFilterError,
 )
-"""Staging failures the user has to resolve, so retrying them ourselves would achieve nothing.
-
-The activity returns these as an `InternalStageResult.error` instead of raising, which fails the
-run without failing the activity. This mirrors how the destination activities treat their own
-expected errors (see `handle_non_retryable_errors`), and keeps a user's mistake from paging us.
-"""
 
 
 def _raise_on_hogql_resource_limit_error(exc: ClickHouseError, model_name: str) -> None:
@@ -271,7 +269,7 @@ class InternalStageResult:
     stage_folder: str
     # Total rows written to the stage (from ClickHouse's query summary), or None if unknown.
     records_total: int | None = None
-    # Set when staging failed with one of `EXPECTED_STAGE_ERRORS`, in which case nothing was staged.
+    # Set when staging failed with one of `NON_RETRYABLE_ERRORS`, in which case nothing was staged.
     error: BatchExportError | None = None
 
 
@@ -315,13 +313,7 @@ class BatchExportInsertIntoInternalStageInputs:
 async def insert_into_internal_stage_activity(
     inputs: BatchExportInsertIntoInternalStageInputs,
 ) -> InternalStageResult:
-    """Write record batches to our own internal S3 staging area.
-
-    Returns:
-        The S3 staging folder where the data was written to, and the total number of rows staged.
-        If staging failed with one of `EXPECTED_STAGE_ERRORS`, the result carries that error
-        instead and the activity still succeeds.
-    """
+    """Write record batches to our own internal S3 staging area."""
     bind_contextvars(
         team_id=inputs.team_id,
         batch_export_id=inputs.batch_export_id,
@@ -376,8 +368,8 @@ async def insert_into_internal_stage_activity(
                 s3_staging_folder=s3_staging_folder,
                 num_partitions=num_partitions,
             )
-        except EXPECTED_STAGE_ERRORS as e:
-            logger.warning("Staging data failed with an expected error", error=str(e))
+        except NON_RETRYABLE_ERRORS as e:
+            logger.warning("Staging data failed with a non-retryable error", error=str(e))
             return InternalStageResult(
                 stage_folder=s3_staging_folder.folder,
                 error=BatchExportError(type=type(e).__name__, message=str(e)),

--- a/products/batch_exports/backend/tests/temporal/destinations/file_download/test_file_download_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/file_download/test_file_download_workflow.py
@@ -210,7 +210,8 @@ async def test_file_download_workflow_generates_no_downloads_for_a_failed_run(
     """A run that fails while staging must not leave download records behind.
 
     An invalid filter fails the staging activity before it reaches S3, so this needs no AWS
-    credentials. The workflow has to complete, because a user's invalid filter is not our error.
+    credentials. The workflow should complete successfully, because this is user error, not our
+    fault.
     """
     batch_export_id = str(file_download_batch_export.id)
 
@@ -257,6 +258,6 @@ async def test_file_download_workflow_generates_no_downloads_for_a_failed_run(
     assert len(runs) == 1
     assert runs[0].status == "Failed"
     assert runs[0].latest_error is not None
-    assert "One or more provided filters are invalid" in runs[0].latest_error
+    assert runs[0].latest_error.startswith("One or more provided filters are invalid")
 
     assert not await BatchExportFileDownload.objects.filter(team_id=ateam.pk, batch_export_run_id=runs[0].id).aexists()

--- a/products/batch_exports/backend/tests/temporal/destinations/file_download/test_file_download_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/file_download/test_file_download_workflow.py
@@ -28,14 +28,14 @@ from products.batch_exports.backend.tests.temporal.destinations.s3.utils import 
 )
 from products.batch_exports.backend.tests.temporal.utils.workflow import fail_on_application_error
 
-pytestmark = [
-    pytest.mark.asyncio,
-    pytest.mark.django_db,
-    pytest.mark.skipif(
-        not has_valid_credentials(),
-        reason="AWS credentials not set in environment",
-    ),
-]
+pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
+
+# Only the tests that reach S3 need credentials. A run that fails before the export activity never
+# gets there, so gating the whole module would skip that coverage in CI, which sets no credentials.
+requires_aws_credentials = pytest.mark.skipif(
+    not has_valid_credentials(),
+    reason="AWS credentials not set in environment",
+)
 
 
 @pytest_asyncio.fixture
@@ -73,6 +73,7 @@ async def file_download_batch_export(
     await adelete_batch_export(batch_export, temporal_client)
 
 
+@requires_aws_credentials
 @pytest.mark.parametrize("interval", ["hour"], indirect=True)
 @pytest.mark.parametrize("model", [BatchExportModel(name="events", schema=None)])
 @pytest.mark.parametrize("exclude_events", [None], indirect=True)
@@ -194,3 +195,70 @@ async def test_file_download_workflow_exports_data(
     for fd in file_downloads:
         response = await s3_client.head_object(Bucket=s3_bucket, Key=fd.key)
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+
+@pytest.mark.parametrize("interval", ["hour"], indirect=True)
+@pytest.mark.parametrize("exclude_events", [None], indirect=True)
+async def test_file_download_workflow_generates_no_downloads_for_a_failed_run(
+    ateam,
+    file_download_batch_export,
+    interval,
+    compression,
+    exclude_events,
+    file_format,
+    data_interval_start,
+    data_interval_end,
+):
+    """A run that fails while staging must not leave download records behind.
+
+    An invalid filter fails the staging activity before it reaches S3, so this needs no AWS
+    credentials. The workflow has to complete, because a user's invalid filter is not our error.
+    """
+    batch_export_id = str(file_download_batch_export.id)
+
+    inputs = FileDownloadBatchExportInputs(
+        team_id=ateam.pk,
+        batch_export_id=batch_export_id,
+        data_interval_end=data_interval_end.isoformat(),
+        data_interval_start=data_interval_start.isoformat(),
+        interval=interval,
+        batch_export_model=BatchExportModel(
+            name="events",
+            schema=None,
+            filters=[{"key": "event =", "type": "hogql", "value": None}],
+        ),
+        file_format=file_format,
+        compression=compression,
+    )
+
+    async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+        async with Worker(
+            activity_environment.client,
+            task_queue=settings.BATCH_EXPORTS_TASK_QUEUE,
+            workflows=[FileDownloadBatchExportWorkflow],
+            activities=[
+                start_batch_export_run,
+                finish_batch_export_run,
+                insert_into_internal_stage_activity,
+                export_to_file_download_bucket_with_temporary_credentials,
+                generate_file_downloads,
+            ],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            with fail_on_application_error():
+                await activity_environment.client.execute_workflow(
+                    FileDownloadBatchExportWorkflow.run,
+                    inputs,
+                    id=str(uuid.uuid4()),
+                    task_queue=settings.BATCH_EXPORTS_TASK_QUEUE,
+                    retry_policy=RetryPolicy(maximum_attempts=1),
+                    execution_timeout=dt.timedelta(seconds=30),
+                )
+
+    runs = await afetch_batch_export_runs(batch_export_id=batch_export_id)
+    assert len(runs) == 1
+    assert runs[0].status == "Failed"
+    assert runs[0].latest_error is not None
+    assert "One or more provided filters are invalid" in runs[0].latest_error
+
+    assert not await BatchExportFileDownload.objects.filter(team_id=ateam.pk, batch_export_run_id=runs[0].id).aexists()

--- a/products/batch_exports/backend/tests/temporal/destinations/file_download/test_file_download_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/file_download/test_file_download_workflow.py
@@ -30,8 +30,6 @@ from products.batch_exports.backend.tests.temporal.utils.workflow import fail_on
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
 
-# Only the tests that reach S3 need credentials. A run that fails before the export activity never
-# gets there, so gating the whole module would skip that coverage in CI, which sets no credentials.
 requires_aws_credentials = pytest.mark.skipif(
     not has_valid_credentials(),
     reason="AWS credentials not set in environment",

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_entrypoint.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_entrypoint.py
@@ -274,8 +274,9 @@ class TestErrorHandling:
     )
 
     async def test_hogql_queries_fail_terminally_if_per_query_resource_limit_reached(self, batch_export):
-        """A user-supplied HogQL query that hits a per-query ClickHouse resource limit should be
-        fail as a non-retryable error (re-running it would not produce a different result).
+        """A user-supplied HogQL query that hits a per-query ClickHouse resource limit is a user
+        error, so it should fail the run but not the Temporal activity or the workflow. Re-running
+        the query would not produce a different result, and it is the user who has to change it.
         """
         inputs = DummyExportInputs(
             team_id=batch_export.team_id,
@@ -290,11 +291,33 @@ class TestErrorHandling:
             "products.batch_exports.backend.temporal.pipeline.internal_stage._write_batch_export_record_batches_to_internal_stage",
             new=AsyncMock(side_effect=self._QUERY_MEMORY_ERROR),
         ):
-            run = await self._run_workflow(inputs, expect_workflow_failure=True)
+            run = await self._run_workflow(inputs, expect_workflow_failure=False)
 
         assert run.status == "Failed"
         assert run.latest_error is not None
         assert "The batch export query needed too much memory to run" in run.latest_error
+
+    async def test_invalid_filters_fail_the_run_but_not_the_workflow(self, batch_export):
+        """An invalid filter is a user error too, but it is raised while building the staging
+        query rather than while running it, so it exercises a different path to the resource
+        limit case above.
+        """
+        inputs = DummyExportInputs(
+            team_id=batch_export.team_id,
+            batch_export_id=str(batch_export.id),
+            interval="hour",
+            data_interval_end=dt.datetime(2025, 7, 21, 13, 0, 0, tzinfo=dt.UTC).isoformat(),
+            batch_export_model=BatchExportModel(
+                name="events",
+                schema=None,
+                filters=[{"key": "event =", "type": "hogql", "value": None}],
+            ),
+        )
+        run = await self._run_workflow(inputs, expect_workflow_failure=False)
+
+        assert run.status == "Failed"
+        assert run.latest_error is not None
+        assert "One or more provided filters are invalid" in run.latest_error
 
     async def test_per_query_resource_limit_only_applies_to_hogql(self, batch_export):
         """The identical ClickHouse error under a fixed model stays retryable, unchanged."""

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_entrypoint.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_entrypoint.py
@@ -275,8 +275,7 @@ class TestErrorHandling:
 
     async def test_hogql_queries_fail_terminally_if_per_query_resource_limit_reached(self, batch_export):
         """A user-supplied HogQL query that hits a per-query ClickHouse resource limit is a user
-        error, so it should fail the run but not the Temporal activity or the workflow. Re-running
-        the query would not produce a different result, and it is the user who has to change it.
+        error, so it should fail the run but not the Temporal activity or the workflow.
         """
         inputs = DummyExportInputs(
             team_id=batch_export.team_id,
@@ -296,28 +295,6 @@ class TestErrorHandling:
         assert run.status == "Failed"
         assert run.latest_error is not None
         assert "The batch export query needed too much memory to run" in run.latest_error
-
-    async def test_invalid_filters_fail_the_run_but_not_the_workflow(self, batch_export):
-        """An invalid filter is a user error too, but it is raised while building the staging
-        query rather than while running it, so it exercises a different path to the resource
-        limit case above.
-        """
-        inputs = DummyExportInputs(
-            team_id=batch_export.team_id,
-            batch_export_id=str(batch_export.id),
-            interval="hour",
-            data_interval_end=dt.datetime(2025, 7, 21, 13, 0, 0, tzinfo=dt.UTC).isoformat(),
-            batch_export_model=BatchExportModel(
-                name="events",
-                schema=None,
-                filters=[{"key": "event =", "type": "hogql", "value": None}],
-            ),
-        )
-        run = await self._run_workflow(inputs, expect_workflow_failure=False)
-
-        assert run.status == "Failed"
-        assert run.latest_error is not None
-        assert "One or more provided filters are invalid" in run.latest_error
 
     async def test_per_query_resource_limit_only_applies_to_hogql(self, batch_export):
         """The identical ClickHouse error under a fixed model stays retryable, unchanged."""


### PR DESCRIPTION
## Problem

Previously we didn't expect the staging activity to fail. Now, with user-provided HogQL queries, the staging activity can fail for a number of reasons (such as an invalid query or breaching resource limits). When one of these occurs, we mark the Temporal activity as failed and we get notified of the error. For 'expected' user errors, we don't want this to happen; we only want to know when unexpected, or internal, errors happen.

The destination activity already splits its failures in two: a user error (bad credentials, missing table) returns a `BatchExportResult` carrying the error, so the run fails but Temporal sees a successful activity, while an internal error raises and retries.

## Changes

- Nothing a user sees changes. The run still reads `Failed`, carries the same message, still emails the user, and still counts toward the threshold that auto-pauses a failing export.
- The staging activity returns `DataIntervalEndInFutureError`, `HogQLQueryResourceLimitExceededError`, and `InvalidFilterError` as an `InternalStageResult.error` instead of raising. The workflow marks the run failed and skips the destination activity.
- Mechanical: the query build and the ClickHouse write move into `_stage_query_results` so one `try` covers both. Their bodies do not change.


## How did you test this code?

One case in `test_entrypoint.py`:

- `test_hogql_queries_fail_terminally_if_per_query_resource_limit_reached` flips to expect a completed workflow. It catches the change reverting: a resource limit failing the workflow again.

One case in `test_file_download_workflow.py`, for the only caller that reads the result:

- `test_file_download_workflow_generates_no_downloads_for_a_failed_run` asserts a failed run leaves no `BatchExportFileDownload` rows. Removing the guard fails it with a `WorkflowFailureError`, which is the `AttributeError` this PR also fixes.

Ran locally: `test_entrypoint.py`, `test_internal_stage.py` (against a real ClickHouse), `s3/test_workflow_error_handling.py`, the `file_download` suite, and repo-wide mypy. Not run: the other destination suites, and nothing was exercised against a real Temporal deployment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 5) from a description of the asymmetry between the two activities. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

No duplicate: `gh pr list --state open --search "batch export staging expected error"` found nothing related.

Public artifact: nothing here draws on material outside this repository.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*



