### PR TITLE
feat(replay-vision): say why a recording was skipped instead of "not scanned"

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -8377,9 +8377,9 @@ snapshots:
     scenes-app-replay-vision--scanner-observations--light:
         hash: v1.k794b7964.f0551bd49f4f37ff94a346960a244b02dbdbe6798826c7c53c4d5541ebe99e74.7zBopcC7VvU8XUZehEBxzdUHTxfM1m64uoZcBXkMlXo
     scenes-app-replay-vision--scanner-on-demand--dark:
-        hash: v1.k794b7964.2a0ea0198da6166d9fb3daf278d4de9b3ec80a0e8b9234cf8a831c12424fb7d0.awEhTQe1f-gzSwOsUJz_uv7FaRwajBLmO-pgng3Gs9U
+        hash: v1.k794b7964.e3c55f635fcc957d786bf810c6be7f7ba8da1287a4390314893282062f43e108._oT0AUvPgnwHst_b6VX6Op2av3k5NsOyjnquUcgTB4c
     scenes-app-replay-vision--scanner-on-demand--light:
-        hash: v1.k794b7964.d6b1a876ab50b940e9bcbe27164922f5c564a01c25c56bbc8955255a2d47173f.DOdeCbLwHWJmW1H1uAYkxdvHS2rpSR6froY4FXuOW7s
+        hash: v1.k794b7964.ee354fdd1202a3489ea67393713b268bbfe711e771102c975aeab4921a61f9f7.MP0HrALcb5hmcbxbIRroM0f93rHw-v6_egWPGV-CL9Y
     scenes-app-replay-vision--scanner-scan-drought--dark:
         hash: v1.k794b7964.47963d3ee2fc2934b80cfd51b0db411baf326710d528c8995ed7eecbae4d6faa.zV2CxUwodEqwEiQT5_Tr3XAFLhkhAGTY3z8LUm97USo
     scenes-app-replay-vision--scanner-scan-drought--light:

--- a/products/replay_vision/frontend/components/ObservationsDock.tsx
+++ b/products/replay_vision/frontend/components/ObservationsDock.tsx
@@ -19,6 +19,7 @@ import { visionQuotaLogic } from '../logics/visionQuotaLogic'
 import { getReplayVisionEditDisabledReason } from '../utils/accessControl'
 import { BUILT_IN_SUMMARY_LABEL, dockObservations, isUnsuccessfulScan } from '../utils/observation'
 import { quotaUx } from '../utils/quotaProjection'
+import { ScanBlock, recordingScanBlock } from '../utils/scanEligibility'
 import { VisionDocsLink, visionDocsUrl } from './DocsLink'
 import { ObservationDockCard } from './ObservationCard'
 
@@ -37,7 +38,7 @@ export function ObservationsDock(): JSX.Element | null {
 }
 
 /** Runs whichever summarizer `resolveSummarizer` settles on, and lets the user pick another. */
-function SummarizeButton({ sessionId }: { sessionId: string }): JSX.Element {
+function SummarizeButton({ sessionId, scanBlock }: { sessionId: string; scanBlock: ScanBlock | null }): JSX.Element {
     const logic = observationsDockLogic({ sessionId })
     const { summarizing, defaultSummarizer, summarizerScanners } = useValues(logic)
     const { summarize, summarizeWith } = useActions(logic)
@@ -50,11 +51,15 @@ function SummarizeButton({ sessionId }: { sessionId: string }): JSX.Element {
     const inFlightDisabledReason = summarizing ? 'A summary is already running' : null
     // Both paths are scanner writes: an inline scan mints a scanner, and `observe` is a write action on
     // the scanner it runs. Each also exposes recording contents, so both need recording read as well.
-    const builtInDisabledReason = inFlightDisabledReason ?? getReplayVisionEditDisabledReason() ?? quotaDisabledReason
+    // A recording the scan-time gate would refuse is refused for every summarizer, so it blocks the
+    // button and each menu row rather than spending a scan that comes back ineligible.
+    const builtInDisabledReason =
+        inFlightDisabledReason ?? getReplayVisionEditDisabledReason() ?? scanBlock?.reason ?? quotaDisabledReason
     // Object-level, so a scanner this user cannot edit is disabled rather than answering with a 403.
     const scannerDisabledReason = (scanner: ReplayScannerApi): string | null | undefined =>
         inFlightDisabledReason ??
         getReplayVisionEditDisabledReason(scanner.user_access_level as AccessControlLevel | null) ??
+        scanBlock?.reason ??
         quotaDisabledReason
     // Nobody could tell which summarizer the button used, so it says so.
     const label = defaultSummarizer ? `Summarize with ${defaultSummarizer.name}` : 'Summarize this recording'
@@ -178,10 +183,11 @@ function ObservationsDockContent({ sessionId }: { sessionId: string }): JSX.Elem
     const { setDockOpen, retryObservation } = useActions(logic)
     // sessionRecordingPlayerLogic is keyed by playerKey+sessionRecordingId; seek the exact mounted
     // player by its bound props rather than a propless default instance.
-    const { logicProps } = useValues(sessionRecordingPlayerLogic)
+    const { logicProps, sessionPlayerMetaData } = useValues(sessionRecordingPlayerLogic)
     const seekToTime = (ms: number): void => {
         sessionRecordingPlayerLogic.findMounted(logicProps)?.actions.seekToTime(ms)
     }
+    const scanBlock = recordingScanBlock(sessionPlayerMetaData)
 
     const dockRef = useRef<HTMLDivElement>(null)
     const resizerProps: ResizerLogicProps = {
@@ -212,8 +218,18 @@ function ObservationsDockContent({ sessionId }: { sessionId: string }): JSX.Elem
         >
             {dockOpen && <Resizer {...resizerProps} />}
             <div className="flex items-center gap-2 lg:gap-3 h-11 px-3 shrink-0">
-                <SummarizeButton sessionId={sessionId} />
+                <SummarizeButton sessionId={sessionId} scanBlock={scanBlock} />
                 <SummarizeExplainer />
+                {scanBlock &&
+                    !hasContent && (
+                        // Collapsed with nothing to expand, the disabled button's tooltip is the only place
+                        // the skip is explained, so the bar says it outright.
+                        <Tooltip title={scanBlock.reason}>
+                            <span className="ml-auto text-muted text-xs truncate" data-attr="vision-dock-skipped">
+                                Skipped: {scanBlock.label.toLowerCase()}
+                            </span>
+                        </Tooltip>
+                    )}
                 {hasContent && (
                     <div className="ml-auto flex items-center gap-2 min-w-0">
                         {!dockOpen && unsuccessfulCount > 0 && (
@@ -240,6 +256,13 @@ function ObservationsDockContent({ sessionId }: { sessionId: string }): JSX.Elem
                     {observationsLoading && shown.length === 0 ? (
                         <div className="flex items-center gap-2 text-muted py-4">
                             <Spinner /> Loading summaries…
+                        </div>
+                    ) : shown.length === 0 && scanBlock ? (
+                        <div className="text-muted text-sm py-4">
+                            Replay vision skipped this recording, so it has no summary. {scanBlock.reason}{' '}
+                            <VisionDocsLink page="observations" dataAttr="vision-skipped-docs-link-dock">
+                                Learn how observations work
+                            </VisionDocsLink>
                         </div>
                     ) : shown.length === 0 ? (
                         <div className="text-muted text-sm py-4">

--- a/products/replay_vision/frontend/components/PlayerSidebarObservationsTab.tsx
+++ b/products/replay_vision/frontend/components/PlayerSidebarObservationsTab.tsx
@@ -11,6 +11,7 @@ import type { ReplayScannerApi } from '../generated/api.schemas'
 import { observationsDockLogic } from '../logics/observationsDockLogic'
 import { visionQuotaLogic } from '../logics/visionQuotaLogic'
 import { quotaUx } from '../utils/quotaProjection'
+import { ScanBlock, recordingScanBlock } from '../utils/scanEligibility'
 import { visionSurfaceShown } from '../utils/visionSurface'
 import { ObservationDockCard } from './ObservationCard'
 import { ScannerTypeBadge } from './ScannerTypeBadge'
@@ -27,10 +28,12 @@ export function PlayerSidebarObservationsTab(): JSX.Element | null {
 
 function ScannerPicker({
     sessionId,
+    scanBlock,
     type = 'primary',
     placement = 'bottom-start',
 }: {
     sessionId: string
+    scanBlock: ScanBlock | null
     type?: 'primary' | 'secondary'
     placement?: 'bottom-start' | 'top-start'
 }): JSX.Element {
@@ -100,7 +103,7 @@ function ScannerPicker({
                 icon={<IconEye />}
                 sideIcon={<IconChevronDown />}
                 loading={observing}
-                disabledReason={quotaDisabledReason}
+                disabledReason={scanBlock?.reason ?? quotaDisabledReason}
                 tooltip={quotaTooltip}
                 data-attr="vision-scan-recording"
             >
@@ -115,10 +118,11 @@ function ObservationsTabContent({ sessionId }: { sessionId: string }): JSX.Eleme
     const { observations, observationsLoading, retryingObservationIds } = useValues(logic)
     const { retryObservation } = useActions(logic)
     // The player logic is keyed; seek the exact mounted instance, not a propless default
-    const { logicProps } = useValues(sessionRecordingPlayerLogic)
+    const { logicProps, sessionPlayerMetaData } = useValues(sessionRecordingPlayerLogic)
     const seekToTime = (ms: number): void => {
         sessionRecordingPlayerLogic.findMounted(logicProps)?.actions.seekToTime(ms)
     }
+    const scanBlock = recordingScanBlock(sessionPlayerMetaData)
 
     return (
         <div className="flex flex-col flex-1 min-h-0" data-attr="vision-observations-tab">
@@ -128,10 +132,23 @@ function ObservationsTabContent({ sessionId }: { sessionId: string }): JSX.Eleme
                 </div>
             ) : observations.length === 0 ? (
                 <div className="flex flex-col flex-1 items-center justify-center gap-2 p-4 text-center">
-                    <p className="text-muted text-sm mb-0">
-                        No observations yet. Pick a scanner to run on this recording.
-                    </p>
-                    <ScannerPicker sessionId={sessionId} />
+                    {scanBlock ? (
+                        // No scanner can clear the gate for this recording, so offering the picker would
+                        // only lead to an ineligible result.
+                        <>
+                            <p className="text-muted text-sm mb-0" data-attr="vision-observations-tab-skipped">
+                                Replay vision skipped this recording, so it has no summary.
+                            </p>
+                            <p className="text-muted text-xs mb-0">{scanBlock.reason}</p>
+                        </>
+                    ) : (
+                        <>
+                            <p className="text-muted text-sm mb-0">
+                                No observations yet. Pick a scanner to run on this recording.
+                            </p>
+                            <ScannerPicker sessionId={sessionId} scanBlock={scanBlock} />
+                        </>
+                    )}
                 </div>
             ) : (
                 <div className="flex-1 overflow-y-auto p-2 space-y-2">
@@ -145,7 +162,12 @@ function ObservationsTabContent({ sessionId }: { sessionId: string }): JSX.Eleme
                         />
                     ))}
                     <div className="flex justify-center">
-                        <ScannerPicker sessionId={sessionId} type="secondary" placement="top-start" />
+                        <ScannerPicker
+                            sessionId={sessionId}
+                            scanBlock={scanBlock}
+                            type="secondary"
+                            placement="top-start"
+                        />
                     </div>
                 </div>
             )}

--- a/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.stories.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.stories.tsx
@@ -398,6 +398,58 @@ const observationsTrend = {
     ],
 }
 
+// Recordings for the on-demand picker, one per status the list can show: a session the scanner
+// already observed, one it has not reached, and two the eligibility gate refuses.
+const recording = (overrides: Record<string, any>): Record<string, any> => ({
+    distinct_id: 'user_8f3k2j',
+    viewed: false,
+    viewers: [],
+    recording_duration: 240,
+    active_seconds: 95,
+    inactive_seconds: 145,
+    start_time: '2026-05-11T09:00:00Z',
+    end_time: '2026-05-11T09:04:00Z',
+    click_count: 18,
+    keypress_count: 9,
+    mouse_activity_count: 64,
+    console_log_count: 0,
+    console_warn_count: 0,
+    console_error_count: 0,
+    start_url: 'https://app.example.com/checkout',
+    person: {
+        id: 1001,
+        name: 'alice@example.com',
+        distinct_ids: ['user_8f3k2j'],
+        properties: { email: 'alice@example.com' },
+        created_at: '2026-05-01T00:00:00Z',
+        uuid: '00000000-0000-0000-0000-0000000000f1',
+    },
+    snapshot_source: 'web',
+    ongoing: false,
+    ...overrides,
+})
+
+const onDemandRecordings = [
+    // Already observed: shares a session id with the succeeded observation above.
+    recording({ id: '01966b3f-70a1-7c52-a4d5-3f9b2e8c1d07' }),
+    recording({ id: '01966b3f-70a1-7c52-a4d5-3f9b2e8c1e01' }),
+    // Over the active-time ceiling, so the scan-time gate would refuse it.
+    recording({
+        id: '01966b3f-70a1-7c52-a4d5-3f9b2e8c1e02',
+        recording_duration: 10_800,
+        active_seconds: 4_320,
+        inactive_seconds: 6_480,
+        end_time: '2026-05-11T12:00:00Z',
+    }),
+    recording({
+        id: '01966b3f-70a1-7c52-a4d5-3f9b2e8c1e03',
+        recording_duration: 9,
+        active_seconds: 6,
+        inactive_seconds: 3,
+        end_time: '2026-05-11T09:00:09Z',
+    }),
+]
+
 const paginated = (names: string[]): Record<string, any> => ({
     count: names.length,
     next: null,
@@ -440,6 +492,8 @@ const meta: Meta = {
                     evaluation_session_cap: 25,
                 },
                 '/api/projects/:team_id/vision/observations/:id/': observationDetail,
+                '/api/environments/:team_id/session_recordings/': { results: onDemandRecordings, has_next: false },
+                '/api/environments/:team_id/session_recordings/matching_events': { results: [] },
                 '/api/projects/:team_id/signals/scout/configs/': [],
                 '/api/projects/:team_id/signals/scout/runs/recent-per-scout/': [],
                 '/api/projects/:team_id/signals/scout/runs/findings/summary/': [],

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerRunTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerRunTab.tsx
@@ -2,7 +2,7 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { useEffect, useRef, useState } from 'react'
 
 import { IconEye, IconPlay } from '@posthog/icons'
-import { LemonButton, LemonInput, LemonTable, Link, Spinner } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonTable, LemonTag, Link, Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { LemonTableColumns } from 'lib/lemon-ui/LemonTable'
@@ -22,6 +22,7 @@ import { SessionRecordingType } from '~/types'
 
 import { ObservationStatusTag } from '../../components/ObservationCard'
 import { getReplayVisionEditDisabledReason } from '../../utils/accessControl'
+import { recordingScanBlock } from '../../utils/scanEligibility'
 import { replayScannerLogic } from '../replayScannerLogic'
 import { IN_PROGRESS_STATUSES, scannerRunTabLogic } from '../scannerRunTabLogic'
 
@@ -143,7 +144,28 @@ function RecordingsList({ scannerId }: { scannerId: string }): JSX.Element {
                 if (pendingId === recording.id) {
                     return <ObservationStatusTag status="running" errorReason={null} />
                 }
-                return <span className="text-muted italic">Not scanned</span>
+                // Skipped, not merely unscanned: this recording can't clear the scan-time gate, so the
+                // scheduled run passed it over and an on-demand scan would land on the same answer.
+                const scanBlock = recordingScanBlock(recording)
+                if (scanBlock) {
+                    return (
+                        <Tooltip
+                            title={
+                                <div className="flex flex-col gap-1">
+                                    <div>{scanBlock.label}</div>
+                                    <div className="text-xs opacity-80">{scanBlock.reason}</div>
+                                </div>
+                            }
+                        >
+                            <LemonTag type="muted">Skipped</LemonTag>
+                        </Tooltip>
+                    )
+                }
+                return (
+                    <Tooltip title="This scanner hasn't run on this recording yet. Scheduled runs only cover recordings that match the scanner's triggers and sampling, so scan it here to get a result now.">
+                        <span className="text-muted italic">Not scanned</span>
+                    </Tooltip>
+                )
             },
         },
         {
@@ -174,6 +196,9 @@ function RecordingsList({ scannerId }: { scannerId: string }): JSX.Element {
                         </LemonButton>
                     )
                 } else {
+                    // The gate would refuse this recording, so the button says why rather than spending
+                    // a scan that comes back ineligible.
+                    const scanBlock = recordingScanBlock(recording)
                     content = (
                         <LemonButton
                             fullWidth
@@ -183,6 +208,7 @@ function RecordingsList({ scannerId }: { scannerId: string }): JSX.Element {
                             icon={<IconPlay />}
                             disabledReason={
                                 editDisabledReason ??
+                                scanBlock?.reason ??
                                 (scanning
                                     ? 'Scan in progress…'
                                     : pendingId && pendingId !== recording.id
@@ -223,11 +249,15 @@ function RecordingsList({ scannerId }: { scannerId: string }): JSX.Element {
                 bulkSelection={{
                     noun: ['recording', 'recordings'],
                     // Only not-yet-scanned rows are selectable — a scanned or in-flight session has nothing
-                    // to (re)scan, matching the per-row button that swaps to "View observation".
-                    isRowSelectable: (recording) =>
-                        observationBySession[recording.id] || pendingId === recording.id
-                            ? { disabledReason: 'Already scanned' }
-                            : true,
+                    // to (re)scan, matching the per-row button that swaps to "View observation". Rows the
+                    // gate would refuse are out too, so a bulk run can't spend scans on them.
+                    isRowSelectable: (recording) => {
+                        if (observationBySession[recording.id] || pendingId === recording.id) {
+                            return { disabledReason: 'Already scanned' }
+                        }
+                        const scanBlock = recordingScanBlock(recording)
+                        return scanBlock ? { disabledReason: scanBlock.reason } : true
+                    },
                     renderActions: ({ selectedKeys, selectedCount, clearSelection }) => (
                         <LemonButton
                             type="primary"

--- a/products/replay_vision/frontend/replay_scanners/types.ts
+++ b/products/replay_vision/frontend/replay_scanners/types.ts
@@ -229,6 +229,10 @@ export function ineligibleKindDescription(kind: IneligibleKind): string {
     return INELIGIBLE_KINDS[kind].description
 }
 
+export function ineligibleKindLabel(kind: IneligibleKind): string {
+    return INELIGIBLE_KINDS[kind].label
+}
+
 export const DEFAULT_PROVIDER = 'google'
 export const DEFAULT_MODEL: ScannerModelEnumApi = ScannerModelEnumApi.Gemini3FlashPreview
 

--- a/products/replay_vision/frontend/utils/scanEligibility.test.ts
+++ b/products/replay_vision/frontend/utils/scanEligibility.test.ts
@@ -1,0 +1,33 @@
+import { SessionRecordingType } from '~/types'
+
+import { recordingScanBlock } from './scanEligibility'
+
+describe('recordingScanBlock', () => {
+    const recording = (partial: Partial<SessionRecordingType>): SessionRecordingType =>
+        ({ id: 'session-1', recording_duration: 300, active_seconds: 120, ...partial }) as SessionRecordingType
+
+    it('clears a recording the gate accepts', () => {
+        expect(recordingScanBlock(recording({}))).toBeNull()
+    })
+
+    it('has nothing to say without metadata', () => {
+        expect(recordingScanBlock(null)).toBeNull()
+        expect(recordingScanBlock(recording({ recording_duration: undefined, active_seconds: undefined }))).toBeNull()
+    })
+
+    it.each([
+        ['too_long', { recording_duration: 10800, active_seconds: 4200 }],
+        ['too_short', { recording_duration: 8, active_seconds: 8 }],
+        ['too_inactive', { recording_duration: 600, active_seconds: 4 }],
+    ])('blocks %s recordings with the numbers behind it', (kind, metadata) => {
+        const block = recordingScanBlock(recording(metadata))
+        expect(block?.kind).toEqual(kind)
+        expect(block?.reason).toContain('Replay vision')
+    })
+
+    it('holds off on the minimums while a recording is still going', () => {
+        expect(recordingScanBlock(recording({ recording_duration: 8, active_seconds: 4, ongoing: true }))).toBeNull()
+        // Active time only grows, so the maximum still applies.
+        expect(recordingScanBlock(recording({ active_seconds: 4200, ongoing: true }))?.kind).toEqual('too_long')
+    })
+})

--- a/products/replay_vision/frontend/utils/scanEligibility.ts
+++ b/products/replay_vision/frontend/utils/scanEligibility.ts
@@ -1,0 +1,60 @@
+import { humanFriendlyDuration } from 'lib/utils/durations'
+
+import { SessionRecordingType } from '~/types'
+
+import { IneligibleKind, ineligibleKindLabel } from '../replay_scanners/types'
+
+// Mirror: keep in sync with products/replay_vision/backend/session_limits.py, which the scan-time gate reads.
+const MIN_SESSION_DURATION_S = 15
+const MIN_ACTIVE_SECONDS_S = 10
+const MAX_ACTIVE_SECONDS_S = 3600
+
+export interface ScanBlock {
+    kind: IneligibleKind
+    /** Short label for a status cell. */
+    label: string
+    /** Why this recording cannot be scanned, in terms of its own numbers. Stands alone as a tooltip. */
+    reason: string
+}
+
+type ScannableRecording = Pick<SessionRecordingType, 'recording_duration' | 'active_seconds' | 'ongoing'>
+
+function block(kind: IneligibleKind, reason: string): ScanBlock {
+    return { kind, label: ineligibleKindLabel(kind), reason }
+}
+
+/**
+ * Whether the scan-time eligibility gate will refuse this recording, decided from the metadata the
+ * recordings list and the player already hold. Null means we cannot tell from here, so the scan stays
+ * on offer and the backend remains the authority. A recording that is still going can still grow past
+ * the minimums, so only the maximum applies to it.
+ */
+export function recordingScanBlock(recording: ScannableRecording | null | undefined): ScanBlock | null {
+    if (!recording) {
+        return null
+    }
+    const activeSeconds = recording.active_seconds
+    const duration = recording.recording_duration
+    if (typeof activeSeconds === 'number' && activeSeconds > MAX_ACTIVE_SECONDS_S) {
+        return block(
+            'too_long',
+            `This recording has ${humanFriendlyDuration(activeSeconds)} of active time, and Replay vision can scan up to ${humanFriendlyDuration(MAX_ACTIVE_SECONDS_S)}.`
+        )
+    }
+    if (recording.ongoing) {
+        return null
+    }
+    if (typeof duration === 'number' && duration < MIN_SESSION_DURATION_S) {
+        return block(
+            'too_short',
+            `This recording is ${humanFriendlyDuration(duration)} long, and Replay vision needs at least ${humanFriendlyDuration(MIN_SESSION_DURATION_S)}.`
+        )
+    }
+    if (typeof activeSeconds === 'number' && activeSeconds < MIN_ACTIVE_SECONDS_S) {
+        return block(
+            'too_inactive',
+            `This recording has ${humanFriendlyDuration(activeSeconds)} of active time, and Replay vision needs at least ${humanFriendlyDuration(MIN_ACTIVE_SECONDS_S)}.`
+        )
+    }
+    return null
+}


### PR DESCRIPTION
## Problem

Someone browsing a scanner's **On-demand** tab sees a recording sitting at "Not scanned" with an enabled "Scan recording" button, and no way to tell what that means: is a scan running, was the recording passed over, or do they have to start it themselves? Some recordings can never be scanned — the eligibility gate refuses anything too short, too idle, or with more active time than Replay vision can analyze — and those recordings never get an observation at all, so the row falls through to the same "Not scanned" text as one nobody has gotten to yet. Clicking scan on one of those spends a scan and comes back ineligible.

The same recording also shows no summary on the session replay page, with nothing saying why.

Raised as Replay vision product feedback.

## Changes

- The on-demand list now shows a **Skipped** status for a recording the gate would refuse, with the reason and the recording's own numbers on hover ("This recording has 1h 12m of active time, and Replay vision can scan up to 1h").
- "Scan recording" and bulk selection are disabled for those rows, carrying the same reason, so nobody spends a scan that cannot succeed.
- "Not scanned" now has a tooltip of its own: the scanner has not reached this recording yet, scheduled runs only cover what matches its triggers and sampling, and scanning here gets a result now.
- On the session replay page, the summary dock and the observations tab say the recording was skipped and why, instead of offering a summarize button that would fail. The summarize button and every summarizer menu row are disabled with the reason.
- Mechanical: a new `recordingScanBlock` helper mirrors the three deterministic gates from `session_limits.py`, and `ineligibleKindLabel` exposes labels the ineligible vocabulary already carried.

The gate stays authoritative on the backend. The helper only speaks up when the metadata it has proves the answer, and stays quiet when a value is missing, so an unknown recording is still offered rather than wrongly blocked. A recording that is still going is only blocked on the maximum, since it can still grow past the minimums.

### Screenshots

The **Skipped** status, with the reason and the recording's own numbers on hover:

![On-demand list showing a Skipped status with a "Too long" tooltip](https://raw.githubusercontent.com/PostHog/pr-assets/e70a5daf67dd14ca015bfaf351e6af2c7453e8f7/2026/09/a14f920b-65ff-4c07-9b72-3641cae975b0.png)

"Scan recording" disabled on that row, carrying the same reason:

![Disabled scan button with the too-long reason as its tooltip](https://raw.githubusercontent.com/PostHog/pr-assets/e70a5daf67dd14ca015bfaf351e6af2c7453e8f7/2026/09/9bf7aafe-6a4e-4a71-ae65-388ba0fc8e81.png)

And "Not scanned" now explains itself too:

![Not scanned tooltip explaining scheduled runs and sampling](https://raw.githubusercontent.com/PostHog/pr-assets/e70a5daf67dd14ca015bfaf351e6af2c7453e8f7/2026/09/3eaebd5f-8fa0-4f85-9719-a85348d42915.png)

## How did you test this code?

Automated: new unit tests for `recordingScanBlock` cover each blocked kind, the clear case, missing metadata, and the ongoing-recording carve-out — the regression being a client-side gate that blocks a scannable recording (or misses a skipped one) as the limits drift. Ran the replay vision Jest suites and a full frontend typecheck locally.

Rendered the on-demand tab in Storybook via headless Chromium and confirmed each status by eye: the observed row links to its observation, the ordinary row stays scannable, and both refused rows show **Skipped** with the right reason while their scan button reports disabled. The screenshots above are those renders. The `ScannerOnDemand` story previously mocked no recordings and rendered an empty table, so this PR seeds it and visual regression now covers these states.

Not done: I did not render the session replay player surfaces (the summary dock and the observations tab), which need replay snapshot data Storybook does not mock here. Those changes are the same helper feeding a `disabledReason` and an empty-state string.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code in PostHog Desktop, from product feedback about the On-demand tab's Status column. Skills invoked: `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

Two decisions worth a reviewer's attention. First, the limits are mirrored in TypeScript with a "keep in sync" comment rather than served from the API — the alternative was a serializer field plus OpenAPI regeneration for three integers that have not changed, and the repo already has this mirroring pattern. Second, "Skipped" is a distinct status from the existing "Ineligible" tag on purpose: "Ineligible" means a scan ran and the gate refused it, "Skipped" means no scan was ever attempted and none can succeed.

Searched open PRs first. [#88807](https://github.com/PostHog/posthog/pull/88807) adds a backend preflight for recordings with no replay data; it does not change what the on-demand list tells a person, so this is not a duplicate.

Nothing in this diff or description carries non-public material: the feedback is described in product terms and the test data is invented.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
