### PR TITLE
fix(taxonomic-filter): rank pageview URL values below property names

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2777,9 +2777,9 @@ snapshots:
     filters-taxonomic-filter--numerical-properties--light:
         hash: v1.k794b7964.eeb595aa423f9104a03146d58f306ebd252f3bdda868b8655a5761018ab7427c.j2JfKgLjpJ7o0RyENwpHLY4OngOa0-6sLl1L0PsLM1Y
     filters-taxonomic-filter--promoted-groups-are-reordered--dark:
-        hash: v1.k794b7964.39744906c8145c68fe6ad70dfa8ced56e7f6d045229ff4d3fbd4c894171bc257.Vaqlw4UTz8B-BwS403uV5Np0khWqWlYnl1No8x-uFlA
+        hash: v1.k794b7964.5e98351034d834994dd973f36bbffb6fa45fbf1be6e8903ff023705344359f2b.9BlE8GF53LlCv-5gpABv88NPbpFzZAscLQNXZF9hlBs
     filters-taxonomic-filter--promoted-groups-are-reordered--light:
-        hash: v1.k794b7964.0c8b187fcf7c964ff6aa5e75ee8b031e1a9dd0c082d24b1f18cec53027bae49b.jXdNveI8wV9kdPURWyCTHuBo78KfszKmauXXOIo17Ck
+        hash: v1.k794b7964.ff3ab8df5c8c537290d3ac06c44fd393ac3a611e33020e8084f32fe0882921e8.gFcwvyfCUg9DAMqy3z4geuiLLGsvJn4FtX7lXBddQkI
     filters-taxonomic-filter--properties--dark:
         hash: v1.k794b7964.aa34b04cf14ce8e95422fcf1c2dd76ac83b04eac3e6c6d5326dbce7eee4d0f11.XXsKHQ9DntH3SiWm0zeEz4W6r0Uj9VxqAtxK1LRC4Uo
     filters-taxonomic-filter--properties--light:

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
@@ -5,6 +5,7 @@ import { expectLogic } from 'kea-test-utils'
 import posthog from 'posthog-js'
 
 import {
+    demoteValueShortcutGroups,
     isSkeletonItem,
     propertyTaxonomicGroupProps,
     redistributeTopMatches,
@@ -1674,6 +1675,61 @@ describe('redistributeTopMatches', () => {
         },
     ])('$description', ({ items, activeGroupCount, expected, groupTypeOrder }) => {
         expect(redistributeTopMatches(items, activeGroupCount, groupTypeOrder)).toEqual(expected)
+    })
+})
+
+describe('demoteValueShortcutGroups', () => {
+    it('moves value shortcut groups below the name matching groups', () => {
+        expect(
+            demoteValueShortcutGroups([
+                TaxonomicFilterGroupType.PageviewUrls,
+                TaxonomicFilterGroupType.EmailAddresses,
+                TaxonomicFilterGroupType.Events,
+                TaxonomicFilterGroupType.EventProperties,
+                TaxonomicFilterGroupType.PersonProperties,
+            ])
+        ).toEqual([
+            TaxonomicFilterGroupType.Events,
+            TaxonomicFilterGroupType.EventProperties,
+            TaxonomicFilterGroupType.PersonProperties,
+            TaxonomicFilterGroupType.PageviewUrls,
+            TaxonomicFilterGroupType.EmailAddresses,
+        ])
+    })
+
+    it('keeps the relative order inside each set', () => {
+        expect(
+            demoteValueShortcutGroups([
+                TaxonomicFilterGroupType.EmailAddresses,
+                TaxonomicFilterGroupType.PageviewUrls,
+                TaxonomicFilterGroupType.EventProperties,
+                TaxonomicFilterGroupType.Events,
+            ])
+        ).toEqual([
+            TaxonomicFilterGroupType.EventProperties,
+            TaxonomicFilterGroupType.Events,
+            TaxonomicFilterGroupType.EmailAddresses,
+            TaxonomicFilterGroupType.PageviewUrls,
+        ])
+    })
+
+    it('ranks pageview URL rows below property name rows in the cross-category list', () => {
+        const makeItem = (name: string, group: TaxonomicFilterGroupType): any => ({ name, group })
+        const groupTypes = [TaxonomicFilterGroupType.PageviewUrls, TaxonomicFilterGroupType.EventProperties]
+
+        expect(
+            redistributeTopMatches(
+                [
+                    makeItem('https://posthog.com/a/very/long/url', TaxonomicFilterGroupType.PageviewUrls),
+                    makeItem('$host', TaxonomicFilterGroupType.EventProperties),
+                ],
+                groupTypes.length,
+                demoteValueShortcutGroups(groupTypes)
+            )
+        ).toEqual([
+            expect.objectContaining({ name: '$host' }),
+            expect.objectContaining({ name: 'https://posthog.com/a/very/long/url' }),
+        ])
     })
 })
 

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
@@ -1714,38 +1714,41 @@ describe('redistributeTopMatches', () => {
 })
 
 describe('demoteValueShortcutGroups', () => {
-    it('moves value shortcut groups below the name matching groups', () => {
-        expect(
-            demoteValueShortcutGroups([
+    it.each([
+        {
+            description: 'moves value shortcut groups below the name matching groups',
+            groupTypes: [
                 TaxonomicFilterGroupType.PageviewUrls,
                 TaxonomicFilterGroupType.EmailAddresses,
                 TaxonomicFilterGroupType.Events,
                 TaxonomicFilterGroupType.EventProperties,
                 TaxonomicFilterGroupType.PersonProperties,
-            ])
-        ).toEqual([
-            TaxonomicFilterGroupType.Events,
-            TaxonomicFilterGroupType.EventProperties,
-            TaxonomicFilterGroupType.PersonProperties,
-            TaxonomicFilterGroupType.PageviewUrls,
-            TaxonomicFilterGroupType.EmailAddresses,
-        ])
-    })
-
-    it('keeps the relative order inside each set', () => {
-        expect(
-            demoteValueShortcutGroups([
+            ],
+            expected: [
+                TaxonomicFilterGroupType.Events,
+                TaxonomicFilterGroupType.EventProperties,
+                TaxonomicFilterGroupType.PersonProperties,
+                TaxonomicFilterGroupType.PageviewUrls,
+                TaxonomicFilterGroupType.EmailAddresses,
+            ],
+        },
+        {
+            description: 'keeps the relative order inside each set',
+            groupTypes: [
                 TaxonomicFilterGroupType.EmailAddresses,
                 TaxonomicFilterGroupType.PageviewUrls,
                 TaxonomicFilterGroupType.EventProperties,
                 TaxonomicFilterGroupType.Events,
-            ])
-        ).toEqual([
-            TaxonomicFilterGroupType.EventProperties,
-            TaxonomicFilterGroupType.Events,
-            TaxonomicFilterGroupType.EmailAddresses,
-            TaxonomicFilterGroupType.PageviewUrls,
-        ])
+            ],
+            expected: [
+                TaxonomicFilterGroupType.EventProperties,
+                TaxonomicFilterGroupType.Events,
+                TaxonomicFilterGroupType.EmailAddresses,
+                TaxonomicFilterGroupType.PageviewUrls,
+            ],
+        },
+    ])('$description', ({ groupTypes, expected }) => {
+        expect(demoteValueShortcutGroups(groupTypes)).toEqual(expected)
     })
 })
 

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
@@ -532,6 +532,41 @@ describe('taxonomicFilterLogic', () => {
             expect(quickLogic.values.revealBarrierOpen).toBe(true)
         })
 
+        it('renders pageview URL rows below property name rows once the reveal barrier opens', async () => {
+            const logicProps: TaxonomicFilterLogicProps = {
+                taxonomicFilterLogicKey: 'testDemotedShortcuts',
+                taxonomicGroupTypes: [
+                    TaxonomicFilterGroupType.SuggestedFilters,
+                    TaxonomicFilterGroupType.PageviewUrls,
+                    TaxonomicFilterGroupType.EventProperties,
+                ],
+            }
+            const demotedLogic = taxonomicFilterLogic(logicProps)
+            demotedLogic.mount()
+
+            await expectLogic(demotedLogic, () => {
+                demotedLogic.actions.setSearchQuery('host')
+                demotedLogic.actions.appendTopMatches([
+                    {
+                        name: 'https://posthog.com/a/very/long/url',
+                        group: TaxonomicFilterGroupType.PageviewUrls,
+                    } as any,
+                    { name: '$host', group: TaxonomicFilterGroupType.EventProperties } as any,
+                ])
+                demotedLogic.actions.openRevealBarrier()
+            }).toMatchValues({
+                topMatchItemsWithSkeletons: [
+                    expect.objectContaining({ name: '$host', group: TaxonomicFilterGroupType.EventProperties }),
+                    expect.objectContaining({
+                        name: 'https://posthog.com/a/very/long/url',
+                        group: TaxonomicFilterGroupType.PageviewUrls,
+                    }),
+                ],
+            })
+
+            demotedLogic.unmount()
+        })
+
         it('does not insert skeletons when search query is empty', async () => {
             const eventsListLogic = infiniteListLogic({
                 ...quickLogic.props,
@@ -1710,25 +1745,6 @@ describe('demoteValueShortcutGroups', () => {
             TaxonomicFilterGroupType.Events,
             TaxonomicFilterGroupType.EmailAddresses,
             TaxonomicFilterGroupType.PageviewUrls,
-        ])
-    })
-
-    it('ranks pageview URL rows below property name rows in the cross-category list', () => {
-        const makeItem = (name: string, group: TaxonomicFilterGroupType): any => ({ name, group })
-        const groupTypes = [TaxonomicFilterGroupType.PageviewUrls, TaxonomicFilterGroupType.EventProperties]
-
-        expect(
-            redistributeTopMatches(
-                [
-                    makeItem('https://posthog.com/a/very/long/url', TaxonomicFilterGroupType.PageviewUrls),
-                    makeItem('$host', TaxonomicFilterGroupType.EventProperties),
-                ],
-                groupTypes.length,
-                demoteValueShortcutGroups(groupTypes)
-            )
-        ).toEqual([
-            expect.objectContaining({ name: '$host' }),
-            expect.objectContaining({ name: 'https://posthog.com/a/very/long/url' }),
         ])
     })
 })

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -247,6 +247,17 @@ export function redistributeTopMatches(
     return result
 }
 
+// The shortcut groups match on the *value* someone typed, so their rows are whole URLs,
+// screen names or email addresses. In the cross-category list that put long URLs above the
+// property names people usually search for, so they rank last there. The tab order keeps them
+// up front.
+export function demoteValueShortcutGroups(groupTypes: TaxonomicFilterGroupType[]): TaxonomicFilterGroupType[] {
+    return [
+        ...groupTypes.filter((groupType) => !SHORTCUT_TO_PROPERTY_FILTER_GROUP_TYPES.has(groupType)),
+        ...groupTypes.filter((groupType) => SHORTCUT_TO_PROPERTY_FILTER_GROUP_TYPES.has(groupType)),
+    ]
+}
+
 export const eventTaxonomicGroupProps: Pick<TaxonomicFilterGroup, 'getPopoverHeader' | 'getIcon'> = {
     getPopoverHeader: (eventDefinition: EventDefinition): string => {
         if (CORE_FILTER_DEFINITIONS_BY_GROUP.events[eventDefinition.name]) {
@@ -2332,7 +2343,11 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 metaGroupTypes: Set<string>
             ): TopMatchItem[] => {
                 const nonMetaGroups = taxonomicGroupTypes.filter((t) => !metaGroupTypes.has(t))
-                return redistributeTopMatches(topMatchItems, nonMetaGroups.length, nonMetaGroups)
+                return redistributeTopMatches(
+                    topMatchItems,
+                    nonMetaGroups.length,
+                    demoteValueShortcutGroups(nonMetaGroups)
+                )
             },
         ],
         topMatchItemsWithSkeletons: [

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -639,11 +639,11 @@ export interface taxonomicFilterLogicMeta {
             topMatchItems: (TaxonomicDefinitionTypes & {
                 group: TaxonomicFilterGroupType
             })[],
-            suggestedFilterGroupOrder: any
+            suggestedFilterGroupOrder: TaxonomicFilterGroupType[]
         ) => TopMatchItem[]
         topMatchItemsWithSkeletons: (
             redistributedTopMatchItems: TopMatchItem[],
-            suggestedFilterGroupOrder: any,
+            suggestedFilterGroupOrder: TaxonomicFilterGroupType[],
             loadingGroupTypes: TaxonomicFilterGroupType[],
             taxonomicGroups: TaxonomicFilterGroup[],
             searchQuery: string,
@@ -2338,9 +2338,9 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                     .join('')
             },
         ],
-        // The order the cross-category "All" list renders its groups in. Every consumer of that
-        // list must read this, so the skeleton rows and the revealed rows land in the same place.
         suggestedFilterGroupOrder: [
+            // The order the cross-category "All" list renders its groups in. Every consumer of that
+            // list must read this, so the skeleton rows and the revealed rows land in the same place.
             (s) => [s.taxonomicGroupTypes, s.metaGroupTypes],
             (
                 taxonomicGroupTypes: TaxonomicFilterGroupType[],
@@ -2364,7 +2364,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
             ],
             (
                 redistributed: TopMatchItem[],
-                nonMetaGroups: TaxonomicFilterGroupType[],
+                groupOrder: TaxonomicFilterGroupType[],
                 loadingGroupTypes: TaxonomicFilterGroupType[],
                 taxonomicGroups: TaxonomicFilterGroup[],
                 searchQuery: string,
@@ -2389,14 +2389,14 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 // when a slower group finishes.
                 if (!revealBarrierOpen) {
                     const result: SkeletonItem[] = []
-                    for (const groupType of nonMetaGroups) {
+                    for (const groupType of groupOrder) {
                         result.push(...buildSkeletons(groupType))
                     }
                     return result
                 }
 
                 const result: (TopMatchItem | SkeletonItem)[] = []
-                for (const groupType of nonMetaGroups) {
+                for (const groupType of groupOrder) {
                     const groupItems = redistributed.filter((item) => item.group === groupType)
                     if (groupItems.length > 0) {
                         result.push(...groupItems)

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -2335,45 +2335,41 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                     .join('')
             },
         ],
-        redistributedTopMatchItems: [
-            (s) => [s.topMatchItems, s.taxonomicGroupTypes, s.metaGroupTypes],
+        // The order the cross-category "All" list renders its groups in. Every consumer of that
+        // list must read this, so the skeleton rows and the revealed rows land in the same place.
+        suggestedFilterGroupOrder: [
+            (s) => [s.taxonomicGroupTypes, s.metaGroupTypes],
             (
-                topMatchItems: TopMatchItem[],
                 taxonomicGroupTypes: TaxonomicFilterGroupType[],
                 metaGroupTypes: Set<string>
-            ): TopMatchItem[] => {
-                const nonMetaGroups = taxonomicGroupTypes.filter((t) => !metaGroupTypes.has(t))
-                return redistributeTopMatches(
-                    topMatchItems,
-                    nonMetaGroups.length,
-                    demoteValueShortcutGroups(nonMetaGroups)
-                )
-            },
+            ): TaxonomicFilterGroupType[] =>
+                demoteValueShortcutGroups(taxonomicGroupTypes.filter((t) => !metaGroupTypes.has(t))),
+        ],
+        redistributedTopMatchItems: [
+            (s) => [s.topMatchItems, s.suggestedFilterGroupOrder],
+            (topMatchItems: TopMatchItem[], groupOrder: TaxonomicFilterGroupType[]): TopMatchItem[] =>
+                redistributeTopMatches(topMatchItems, groupOrder.length, groupOrder),
         ],
         topMatchItemsWithSkeletons: [
             (s) => [
                 s.redistributedTopMatchItems,
-                s.taxonomicGroupTypes,
+                s.suggestedFilterGroupOrder,
                 s.loadingGroupTypes,
                 s.taxonomicGroups,
                 s.searchQuery,
-                s.metaGroupTypes,
                 s.revealBarrierOpen,
             ],
             (
                 redistributed: TopMatchItem[],
-                taxonomicGroupTypes: TaxonomicFilterGroupType[],
+                nonMetaGroups: TaxonomicFilterGroupType[],
                 loadingGroupTypes: TaxonomicFilterGroupType[],
                 taxonomicGroups: TaxonomicFilterGroup[],
                 searchQuery: string,
-                metaGroupTypes: Set<string>,
                 revealBarrierOpen: boolean
             ): (TopMatchItem | SkeletonItem)[] => {
                 if (!searchQuery) {
                     return redistributed
                 }
-
-                const nonMetaGroups = taxonomicGroupTypes.filter((t) => !metaGroupTypes.has(t))
 
                 const buildSkeletons = (groupType: TaxonomicFilterGroupType): SkeletonItem[] => {
                     const groupDef = taxonomicGroups.find((g) => g.type === groupType)

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -419,6 +419,7 @@ export interface taxonomicFilterLogicValues {
     selectedItemMeta: any
     selectedProperties: TaxonomicFilterGroupValueMap
     showNumericalPropsOnly: any
+    suggestedFilterGroupOrder: TaxonomicFilterGroupType[]
     suggestedFiltersLabel: any
     taxonomicFilterLogicKey: string
     taxonomicGroupTypes: TaxonomicFilterGroupType[]
@@ -594,12 +595,12 @@ export interface taxonomicFilterLogicMeta {
         groupAnalyticsTaxonomicGroupNames: (
             groupTypes: Map<GroupTypeIndex, GroupType>,
             currentTeamId: number | null,
-            aggregationLabel: (groupTypeIndex: number | null | undefined, deferToUserWording?: boolean) => Noun
+            aggregationLabel: (groupTypeIndex: number | null | undefined, deferToUserWording?: boolean) => Noun // groupsModel
         ) => TaxonomicFilterGroup[]
         groupAnalyticsTaxonomicGroups: (
             groupTypes: Map<GroupTypeIndex, GroupType>,
             currentProjectId: number | null,
-            aggregationLabel: (groupTypeIndex: number | null | undefined, deferToUserWording?: boolean) => Noun
+            aggregationLabel: (groupTypeIndex: number | null | undefined, deferToUserWording?: boolean) => Noun // groupsModel
         ) => TaxonomicFilterGroup[]
         infiniteListLogics: (
             taxonomicGroupTypes: TaxonomicFilterGroupType[],
@@ -630,20 +631,22 @@ export interface taxonomicFilterLogicMeta {
             taxonomicGroups: TaxonomicFilterGroup[],
             taxonomicGroupTypes: TaxonomicFilterGroupType[]
         ) => string
+        suggestedFilterGroupOrder: (
+            taxonomicGroupTypes: TaxonomicFilterGroupType[],
+            metaGroupTypes: Set<string>
+        ) => TaxonomicFilterGroupType[]
         redistributedTopMatchItems: (
             topMatchItems: (TaxonomicDefinitionTypes & {
                 group: TaxonomicFilterGroupType
             })[],
-            taxonomicGroupTypes: TaxonomicFilterGroupType[],
-            metaGroupTypes: Set<string>
+            suggestedFilterGroupOrder: any
         ) => TopMatchItem[]
         topMatchItemsWithSkeletons: (
             redistributedTopMatchItems: TopMatchItem[],
-            taxonomicGroupTypes: TaxonomicFilterGroupType[],
+            suggestedFilterGroupOrder: any,
             loadingGroupTypes: TaxonomicFilterGroupType[],
             taxonomicGroups: TaxonomicFilterGroup[],
             searchQuery: string,
-            metaGroupTypes: Set<string>,
             revealBarrierOpen: boolean
         ) => (SkeletonItem | TopMatchItem)[]
     }


### PR DESCRIPTION
## Problem

Someone filtering session replays types a property name such as `hostname` into the taxonomic filter and gets a list of full page URLs instead of the property they asked for. The only way through is to click one of those URLs and then edit the resulting filter by hand.

The cross-category "All" list (`redistributedTopMatchItems`) reuses the tab order for its display order. That order deliberately promotes the value shortcut groups — pageview URLs, screens, email addresses — to the front, so their rows outrank every property name match.

Pageview URL values are still worth keeping: most picks are used exactly as chosen, and only a minority get edited afterwards. The rank is the problem, not the option.

## Changes

- Property name matches now come first in the "All" list. Pageview URL, screen and email address values still appear, below them.
- The tab order is unchanged, so the shortcut categories keep their front position in the category row.
- The skeleton placeholder rows and the revealed rows follow the same order, so the list does not reorder when results arrive. Both selectors read one shared `suggestedFilterGroupOrder` selector instead of rebuilding the group order from the tab order.
- `demoteValueShortcutGroups` is exported so the ordering is testable on its own, and it reuses the existing `SHORTCUT_TO_PROPERTY_FILTER_GROUP_TYPES` set rather than a second list.

## Variant coverage

Per `.claude/skills/modifying-taxonomic-filter`, ordering changes have to be judged against all three live surfaces:

- `legacy-control` and `legacy-pill` share the `taxonomicFilterLogic` → `infiniteListLogic` → `InfiniteList` path, so both get the fix. The "All" tab is auto-injected only for the pill arm, so on control the new order applies wherever a call site opts that tab in.
- `rebuild-menu` is **not** covered. It builds its own "All" ordering in `menu/Combobox.tsx`, fed by `resolveTaxonomicGroupTypes` in `hooks/useTaxonomicFilter.ts`, which promotes its own narrower `SHORTCUT_GROUPS_BASE` (no `PageviewEvents`, `ScreenEvents` or `AutocaptureEvents`). It therefore still ranks URL values above property names for any query outside the `url` / `path` / `email` promotions. Mirroring is a separate ordering decision rather than a copy of this diff, so it is flagged here rather than bundled in.

## How did you test this code?

Automated only — no manual or visual check was done in this environment.

- Added two unit tests for `demoteValueShortcutGroups`: the two set orders, and the stability of the order inside each set.
- Added one logic test that asserts the rendered `topMatchItemsWithSkeletons` list puts a `$host` row above a URL row once the reveal barrier opens. It fails against the first commit, where the rendered list still walked the tab order. No existing test covered the display order of value groups against name groups.
- Ran the `TaxonomicFilter` jest suite locally; it passes.
- Not run after the second commit: `typescript:check`. The new selector needs kea typegen, which CI runs. CI should be treated as the authority.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from replay filter feedback that searching for a property name returned page URLs. Product analytics on taxonomic filter selections was used to size the group before choosing a fix: pageview URL values are a meaningful share of replay selections and are mostly kept as picked, which argued for re-ranking rather than removing the category. Two insights were saved in the PostHog project to watch the share of selections by source group after this ships, so the "remove it" option stays measurable.

An alternative of dropping the `PageviewUrls` shortcut group entirely was considered and rejected on that evidence.

Note for reviewers: `frontend/src/lib/components/TaxonomicFilter/utils/redistributeTopMatches.ts` is an unused duplicate of the function that lives in `taxonomicFilterLogic.tsx`. It was left alone here, but it is a trap for the next person changing this ranking.

The second commit came from review triage: the Codex review found that the rendered list rebuilt the top matches in tab order, so the demotion never reached the screen. The fix and its logic test were pushed and the thread resolved.

Tools: PostHog Slack app (Claude Code agent) for the first commit, Claude Code review triage for the second. Skills invoked: review-triage, modifying-taxonomic-filter, writing-tests, writing-pr-descriptions, qa-swarm.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08499A7REU/p1788537398057519?thread_ts=1788537398.057519&cid=C08499A7REU)*


