### PR TITLE
fix(skills): say which spec rule blocks a skill download or import

### DIFF
--- a/products/skills/backend/api/skills.py
+++ b/products/skills/backend/api/skills.py
@@ -323,7 +323,7 @@ class ZipRenderer(BaseRenderer):
 
 def _spec_problems_detail(lead: str, problems: list[str], next_step: str) -> str:
     # Clients such as the app toast show only `detail`, so the specific problems must live there too.
-    sentences = ". ".join(problem[:1].upper() + problem[1:] for problem in problems)
+    sentences = ". ".join((problem[:1].upper() + problem[1:]).removesuffix(".") for problem in problems)
     return f"{lead} {sentences}. {next_step}"
 
 

--- a/products/skills/backend/api/skills.py
+++ b/products/skills/backend/api/skills.py
@@ -321,6 +321,12 @@ class ZipRenderer(BaseRenderer):
         return SafeJSONRenderer().render(data, "application/json", renderer_context)
 
 
+def _spec_problems_detail(lead: str, problems: list[str], next_step: str) -> str:
+    # Clients such as the app toast show only `detail`, so the specific problems must live there too.
+    sentences = ". ".join(problem[:1].upper() + problem[1:] for problem in problems)
+    return f"{lead} {sentences}. {next_step}"
+
+
 _ZIP_ACTIONS = ("bundle", "export")
 # With two renderers on an action, drf-spectacular advertises DRF's ``?format=`` override as a query
 # parameter. Clients select the zip with ``Accept``; keep the generated types free of it.
@@ -809,7 +815,14 @@ class LLMSkillViewSet(
         problems = validate_for_export(export)
         if problems:
             return Response(
-                {"detail": "Skill is not export-ready under the Agent Skills spec.", "problems": problems},
+                {
+                    "detail": _spec_problems_detail(
+                        "Couldn't download this skill because it doesn't meet the Agent Skills spec.",
+                        problems,
+                        "Edit the skill to fix this, then try again.",
+                    ),
+                    "problems": problems,
+                },
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -905,7 +918,14 @@ class LLMSkillViewSet(
         problems = self._import_problems(skill_export)
         if problems:
             return Response(
-                {"detail": "Zip is not a valid, spec-compliant skill.", "problems": problems},
+                {
+                    "detail": _spec_problems_detail(
+                        "Couldn't import this zip because it doesn't meet the Agent Skills spec.",
+                        problems,
+                        "Fix the skill files, then try again.",
+                    ),
+                    "problems": problems,
+                },
                 status=status.HTTP_400_BAD_REQUEST,
             )
 

--- a/products/skills/backend/api/test/test_marketplace_endpoints.py
+++ b/products/skills/backend/api/test/test_marketplace_endpoints.py
@@ -166,7 +166,9 @@ class TestSkillZipExport(APIBaseTest):
         )
         response = self.client.get(self._url("too-long"))
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json()["problems"]
+        body = response.json()
+        assert body["problems"]
+        assert "Description is 1025 characters; the spec maximum is 1024" in body["detail"]
 
 
 SANDBOX_FLAG = "posthog.permissions.posthoganalytics.feature_enabled"


### PR DESCRIPTION
## Problem

- A person who clicks "Download" on a skill in the skill store can get the toast "Skill is not export-ready under the Agent Skills spec." with no hint of what to change.
- The most common cause is a description longer than the spec limit of 1024 characters on a skill last saved before that limit was enforced on save.
- The export endpoint already computes the exact problem, but it returns it in a separate `problems` list that the app toast never shows. Only `detail` reaches the person.
- The import endpoint has the same shape, so a rejected zip upload is equally opaque.

## Changes

- The download toast now reads, for example: "Couldn't download this skill because it doesn't meet the Agent Skills spec. Description is 1386 characters; the spec maximum is 1024. Edit the skill to fix this, then try again."
- A rejected zip import now names each problem in the same way, followed by "Fix the skill files, then try again."
- Both endpoints fold the problems into the `detail` string and keep the `problems` list unchanged, so every client benefits without a frontend change.
- No visual change beyond the toast text.

## How did you test this code?

- Extended `test_export_rejects_spec_invalid_description` to assert the detail string names the description length and the limit. This catches a regression where `detail` goes back to the generic sentence.
- Ran the export and import tests in `products/skills/backend/api/test/test_marketplace_endpoints.py` locally.
- Not run: repo-wide mypy. The change adds one typed helper and touches no serializer or schema annotation, so no OpenAPI regen is needed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code from a support report. The problem statement above is paraphrased; nothing from the report is quoted.
- Skills invoked: /writing-user-facing-copy, /writing-tests, /improving-drf-endpoints, /writing-pr-descriptions.
- The frontend alternative was to read `problems` in the download helper. Fixing `detail` on the backend covers MCP and API clients too, so that won.
- No open PR already fixes this.

https://claude.ai/code/session_01BteV7VFWUTMccG3MBtZUNB
