### PR TITLE
feat(desktop): close tabs with middle click

### DIFF
--- a/products/desktop/packages/ui/src/features/browser-tabs/AGENTS.md
+++ b/products/desktop/packages/ui/src/features/browser-tabs/AGENTS.md
@@ -111,6 +111,7 @@ differ. Desktop ships first.
 
 ### Closing
 - Closing the active tab focuses its neighbour.
+- Middle-clicking any tab closes it, including a pinned tab.
 - Closing the last tab of a **secondary** window closes the window. Closing the
   last tab of the **primary** window replaces it with a fresh `/activity` tab.
 

--- a/products/desktop/packages/ui/src/features/browser-tabs/TabStrip.test.tsx
+++ b/products/desktop/packages/ui/src/features/browser-tabs/TabStrip.test.tsx
@@ -66,6 +66,19 @@ describe("TabStrip", () => {
     expect(props.onSelect).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["an unpinned", false],
+    ["a pinned", true],
+  ])("closes %s tab without selecting it on middle-click", (_label, pinned) => {
+    const props = setup({ tabs: [{ ...tabs[0], pinned }, tabs[1]] });
+    const tab = pinned
+      ? screen.getByLabelText("Overview (pinned)")
+      : screen.getByText("Overview");
+    fireEvent(tab, new MouseEvent("auxclick", { bubbles: true, button: 1 }));
+    expect(props.onClose).toHaveBeenCalledWith("t1");
+    expect(props.onSelect).not.toHaveBeenCalled();
+  });
+
   it("calls onNewTab when the new-tab button is clicked", async () => {
     const props = setup();
     await userEvent.click(screen.getByLabelText("New tab"));

--- a/products/desktop/packages/ui/src/features/browser-tabs/TabStrip.tsx
+++ b/products/desktop/packages/ui/src/features/browser-tabs/TabStrip.tsx
@@ -177,6 +177,12 @@ function SortableTabPill({
   const pill = (
     <div
       ref={ref}
+      onAuxClick={(event) => {
+        if (event.button !== 1) return;
+        event.preventDefault();
+        event.stopPropagation();
+        onClose(tab.id);
+      }}
       className={
         tab.pinned
           ? "no-drag flex shrink-0 items-center"


### PR DESCRIPTION
## Problem

PostHog Desktop users cannot close browser tabs with the middle mouse button.

## Changes

- PostHog Desktop now closes any tab on middle-click, including pinned tabs.
- The handler accepts only mouse button 1, so right-click continues to open the tab menu.
- No screenshots: this changes pointer behavior without changing the interface.

## How did you test this code?

- Ran `pnpm lint`, `pnpm typecheck`, and `pnpm --filter @posthog/ui test`.
- The new test catches middle-click selecting instead of closing, for pinned and unpinned tabs.
- Ran `hogli ci:preflight --fix`. Manual Electron testing was not run.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the browser-tabs feature guide.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The PostHog Slack app used repository tools and the `/posthog-desktop`, `/writing-ui-components`, `/writing-tests`, and `/writing-pr-descriptions` skills.

No matching open issue or PR was found. The public diff uses no private session data.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1788541007301869?thread_ts=1788541007.301869&cid=C09G8Q32R6F)*