### PR TITLE
chore(csp): allow WebAssembly compilation

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -1212,7 +1212,13 @@ class CSPMiddleware:
             csp_parts = [
                 "default-src 'self'",
                 f"style-src 'self' 'unsafe-inline' {resource_url} https://fonts.googleapis.com",
-                f"script-src 'self' 'nonce-{nonce}' {resource_url} https://*.i.posthog.com",
+                # 'wasm-unsafe-eval' permits WebAssembly compilation and nothing else. It is not
+                # 'unsafe-eval': it does not permit eval() or the Function constructor. Compiling a
+                # module still requires calling WebAssembly.instantiate from JavaScript, so it grants
+                # nothing to an attacker who cannot already run script, and nothing further to one who
+                # can. Session replay decompresses snapshots with snappy-wasm and the HogQL editor
+                # parses with a WebAssembly build, so both break without it.
+                f"script-src 'self' 'nonce-{nonce}' 'wasm-unsafe-eval' {resource_url} https://*.i.posthog.com",
                 f"font-src 'self' {resource_url} https://app-static.eu.posthog.com https://app-static-prod.posthog.com https://fonts.gstatic.com https://cdn.jsdelivr.net",
                 "worker-src 'self'",
                 "child-src 'none'",


### PR DESCRIPTION
## Problem

Two features compile a WebAssembly module at runtime, and `script-src` blocks both:

- **Session replay** decompresses snapshots with `snappy-wasm`.
- **The HogQL editor** parses with a WebAssembly build of the parser.

Together they report about **38,000 violations a week** across both cloud regions. One chunk — holding `snappy-wasm` and the replay `DecompressionWorkerManager` — accounts for 36,220 of them, confirmed from the chunk's sourcemap. The rest is `hogql_parser_wasm_browser`, `image-blob-reduce`, and browser extensions.

Nothing breaks today because the policy is report-only. Enforce `script-src` without this and the replay player stops loading recordings.

## Changes

- Nothing changes for a user. The policy is report-only, so no module is blocked before or after this PR.
- Add `'wasm-unsafe-eval'` to `script-src`.

> [!IMPORTANT]
> `'wasm-unsafe-eval'` is not `'unsafe-eval'`. It permits WebAssembly compilation and nothing else — no `eval()`, no `Function` constructor.
>
> It is safe for a mechanical reason: compiling a module requires calling `WebAssembly.instantiate` from JavaScript. An attacker who can do that already has script execution, and therefore already has everything. So the keyword grants nothing to an attacker who cannot run script, and nothing further to one who can. WebAssembly also has no direct DOM access; it reaches the page only through JavaScript the page itself provides.
>
> The keyword exists precisely so a site can allow WebAssembly without allowing eval. Before it, sites were forced to enable `'unsafe-eval'` for WASM — which is the concession we are separately working to remove, since `eval` is 49% of all violations the app reports.

## How did you test this code?

No new tests, and none run locally.

The change adds one source expression to one policy string. No test in `TestCSPMiddleware` asserts `script-src` contents, so running that suite would only re-confirm header assembly, which CI does anyway. It needs Postgres, which is not running here, and standing one up would have proved nothing about this change.

Not checked: that WebAssembly actually compiles under the new policy. Nothing is enforced, so there is no runtime behaviour to observe — the only observable effect is that `wasm-eval` reports stop arriving. Confirm that after deploy by querying `$csp_violation` where `$csp_blocked_url = 'wasm-eval'`; it should fall to the browser-extension floor of roughly 400 a week.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this PR. Skills invoked: `/writing-pr-descriptions`, `superpowers:using-git-worktrees`.

The source was identified by fetching the live chunk's sourcemap rather than inferring from `package.json`: `chunk-GLDCRAC3.js` has exactly two sources, `DecompressionWorkerManager.ts` and `snappy-wasm/es/snappy.js`.

This is part of a wider effort to enforce a real `script-src`. The other half is zod's JIT parser compiler, which needs true `'unsafe-eval'` and is being measured behind a flag in #94413. Keeping the two apart matters: this one is a narrow allowance worth taking, that one is a concession that would cancel the directive.
