### PR TITLE
fix(experiments): receiving fewer metrics on latest now starts a recalcualtion

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -318,6 +318,37 @@ describe('experimentLogic', () => {
                 ])
                 .toFinishAllListeners()
         })
+
+        it('addSharedMetricsToExperiment reuses the window (metric_config_change)', async () => {
+            // A keyed logic with a real experiment id so loadExperiment returns the launched experiment
+            // (the default unkeyed logic resolves experimentId to "new" and loads a draft). Mock every
+            // endpoint the follow-up refresh touches so its async work settles before unmount.
+            useMocks({
+                get: { '/api/projects/:team/experiments/:id': experiment },
+                post: {
+                    '/api/environments/:team/query': () => [
+                        200,
+                        { cache_key: 'cache_key', query_status: experimentMetricResultsSuccessJson.query_status },
+                    ],
+                },
+            })
+            jest.spyOn(api, 'update').mockResolvedValue(experiment)
+            const keyed = experimentLogic({ experimentId: experiment.id })
+            keyed.mount()
+            keyed.actions.setExperiment(experiment)
+
+            await expectLogic(keyed, () => {
+                keyed.actions.addSharedMetricsToExperiment([1], { type: 'primary' })
+            })
+                .toDispatchActions([
+                    (action) =>
+                        action.type === keyed.actionTypes.refreshExperimentResults &&
+                        action.payload.triggeredBy === 'metric_config_change',
+                ])
+                .toFinishAllListeners()
+
+            keyed.unmount()
+        })
     })
 
     describe('currentRefresh tracking', () => {

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
@@ -381,6 +381,37 @@ describe('experimentMetricsLogic', () => {
             expect(capturedBody).toEqual({ trigger: 'cold_run' })
         })
 
+        it('heals a completed run that is missing a metric added after it finished', async () => {
+            // A metric added after the last run finished is absent from that run's results. The run's own
+            // counts look complete, so only a uuid comparison catches the gap; without the heal the new metric
+            // stays stuck loading on every page load.
+            const experimentWithExtraMetric = {
+                ...EXPERIMENT,
+                metrics: [...(EXPERIMENT.metrics ?? []), { uuid: 'added-after-run-uuid' }],
+            } as unknown as Experiment
+            let capturedBody: any
+            useMocks({
+                get: {
+                    // Completed run that covers only the two original metrics, not the newly added one.
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': () => [
+                        200,
+                        completedRecalculation,
+                    ],
+                },
+                post: {
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/': async ({ request }) => {
+                        capturedBody = await request.json()
+                        return [201, completedRecalculation2]
+                    },
+                },
+            })
+            logic = experimentMetricsLogic({ experiment: experimentWithExtraMetric })
+            logic.mount()
+
+            await expectLogic(logic).toDispatchActions(['triggerRecalculation']).toFinishAllListeners()
+            expect(capturedBody).toEqual({ trigger: 'experiment_config_change' })
+        })
+
         it('applies terminal results and resumes polling the active run (reload while recalculating)', async () => {
             const createMock = jest.fn(() => [201, pendingRecalculation])
             useMocks({
@@ -622,6 +653,40 @@ describe('experimentMetricsLogic', () => {
 
                 expect(logic.values.queuedRerun).toBe('metric_config_change')
                 expect(createMock).not.toHaveBeenCalled()
+            })
+
+            it('posts instead of queuing when only a latest-load is in flight (no running run)', async () => {
+                // Adding a shared metric reloads the experiment, which re-fires loadLatestRecalculation. That
+                // fetch flips recalculationLoading true but never polls, so it can't drain a queue. A config
+                // change here must create a run, not queue against the transient load and strand forever.
+                const createMock = jest.fn(() => [201, pendingRecalculation])
+                useMocks({
+                    get: {
+                        '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': () => [
+                            200,
+                            completedRecalculation,
+                        ],
+                    },
+                    post: { '/api/projects/:team_id/experiments/:id/metrics_recalculation/': createMock },
+                })
+                mountLogic()
+                await expectLogic(logic).toDispatchActions(['setCurrentRecalculation']).toFinishAllListeners()
+
+                // Reproduce the transient state a latest-load leaves: loading true, only a completed run
+                // resolved. This is busy under isRecalculating, but no run is pending or in_progress.
+                logic.actions.setRecalculationLoading(true)
+                expect(logic.values.isRecalculating).toBe(true)
+                expect(logic.values.currentRecalculation?.status).toBe('completed')
+
+                await expectLogic(logic, () => {
+                    logic.actions.triggerRecalculation('metric_config_change')
+                })
+                    .toDispatchActions(['triggerRecalculation'])
+                    .toNotHaveDispatchedActions(['setQueuedRerun'])
+                    .toFinishAllListeners()
+
+                expect(logic.values.queuedRerun).toBeNull()
+                expect(createMock).toHaveBeenCalled()
             })
 
             it('does not queue a cold_run (cold_run always starts fresh)', async () => {

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
@@ -691,6 +691,64 @@ describe('experimentMetricsLogic', () => {
                 expect(createMock).toHaveBeenCalled()
             })
 
+            it('queues a config change that arrives while a create POST is still in flight', async () => {
+                // Between the create POST firing and its response landing, currentRecalculation still holds the
+                // previous terminal status. A second config change here must queue, not post a duplicate the
+                // backend would dedupe to the active run and silently drop. cache.createInFlight closes it.
+                let resolveFirstCreate: (value: unknown) => void = () => {}
+                const createMock = jest.fn(async () => {
+                    if (createMock.mock.calls.length === 1) {
+                        // Hold the first create in flight until the test releases it.
+                        await new Promise((resolve) => {
+                            resolveFirstCreate = resolve
+                        })
+                    }
+                    // Terminal-on-create so no poll arms; the drain must fire the queued rerun.
+                    return [201, completedRecalculation2]
+                })
+                useMocks({
+                    get: {
+                        // Completed latest so mount does not auto-trigger; the run is at rest.
+                        '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': () => [
+                            200,
+                            completedRecalculation,
+                        ],
+                    },
+                    post: { '/api/projects/:team_id/experiments/:id/metrics_recalculation/': createMock },
+                })
+                mountLogic()
+                await expectLogic(logic).toDispatchActions(['setCurrentRecalculation']).toFinishAllListeners()
+
+                // First config change: its create POST is now in flight (held by the mock).
+                logic.actions.triggerRecalculation('metric_config_change')
+                while (createMock.mock.calls.length === 0) {
+                    await new Promise((resolve) => setTimeout(resolve, 0))
+                }
+                expect(createMock).toHaveBeenCalledTimes(1)
+
+                // Second config change arrives during the in-flight create: it must queue, not post again.
+                // No toFinishAllListeners here: the first create is deliberately held, so its listener is open.
+                await expectLogic(logic, () => {
+                    logic.actions.triggerRecalculation('experiment_config_change')
+                }).toDispatchActions(['setQueuedRerun'])
+                expect(logic.values.queuedRerun).toBe('experiment_config_change')
+                expect(createMock).toHaveBeenCalledTimes(1)
+
+                // The first create settles terminal; the drain fires the queued rerun, which now creates.
+                await expectLogic(logic, () => {
+                    resolveFirstCreate([201, completedRecalculation2])
+                }).toDispatchActions([
+                    (a) =>
+                        a.type === logic.actionTypes.triggerRecalculation &&
+                        a.payload.trigger === 'experiment_config_change',
+                ])
+                while (createMock.mock.calls.length < 2) {
+                    await new Promise((resolve) => setTimeout(resolve, 0))
+                }
+                expect(logic.values.queuedRerun).toBeNull()
+                expect(createMock).toHaveBeenCalledTimes(2)
+            })
+
             it('does not queue a cold_run (cold_run always starts fresh)', async () => {
                 const createMock = jest.fn(() => [201, pendingRecalculation])
                 useMocks({

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
@@ -385,10 +385,12 @@ describe('experimentMetricsLogic', () => {
             // A metric added after the last run finished is absent from that run's results. The run's own
             // counts look complete, so only a uuid comparison catches the gap; without the heal the new metric
             // stays stuck loading on every page load.
-            const experimentWithExtraMetric = {
+            // Derive the extra metric from a real fixture metric so it stays fully typed; only the uuid differs.
+            const addedMetric = { ...EXPERIMENT.metrics[0], uuid: 'added-after-run-uuid' }
+            const experimentWithExtraMetric: Experiment = {
                 ...EXPERIMENT,
-                metrics: [...(EXPERIMENT.metrics ?? []), { uuid: 'added-after-run-uuid' }],
-            } as unknown as Experiment
+                metrics: [...EXPERIMENT.metrics, addedMetric],
+            }
             let capturedBody: any
             useMocks({
                 get: {

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.ts
@@ -739,15 +739,23 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                     return
                 }
                 /**
-                 * A config change while a real run is polling queues a rerun; the poll's terminal branch
-                 * drains it. Guard on the run status, not isRecalculating: a transient loadLatestRecalculation
-                 * fetch also flips isRecalculating, and queueing against it strands the rerun forever, because
-                 * that fetch never polls and so never drains the queue.
+                 * A config change while a run is active queues a rerun; the terminal branch (poll, or a
+                 * terminal-on-create) drains it. Guard on the run status, not isRecalculating: a transient
+                 * loadLatestRecalculation fetch also flips isRecalculating, and queueing against it strands the
+                 * rerun forever, because that fetch never polls and so never drains the queue.
+                 *
+                 * `cache.createInFlight` closes the window between the create POST firing and
+                 * setCurrentRecalculation landing the pending run: during that round-trip currentRecalculation
+                 * still holds the previous terminal status, so without this a second config change would post
+                 * again, and the backend would dedupe it to the active run and drop its trigger.
                  */
                 const runStatus = values.currentRecalculation?.status
                 const runInFlight =
                     runStatus === RECALCULATION_STATUSES.pending || runStatus === RECALCULATION_STATUSES.in_progress
-                if ((trigger === 'experiment_config_change' || trigger === 'metric_config_change') && runInFlight) {
+                if (
+                    (trigger === 'experiment_config_change' || trigger === 'metric_config_change') &&
+                    (runInFlight || cache.createInFlight)
+                ) {
                     actions.setQueuedRerun(trigger)
                     return
                 }
@@ -781,6 +789,9 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                  * Cleared by setCurrentRecalculation on success, or in the catch below on failure.
                  */
                 actions.setRecalculationLoading(true)
+                // Mark the create in flight synchronously so a second config change during the POST round-trip
+                // queues instead of posting a duplicate the backend would dedupe and drop. Cleared in finally.
+                cache.createInFlight = true
                 try {
                     const { projectId, experimentId } = resolvedIds
 
@@ -823,6 +834,16 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                          */
                         applyResults(recalculation)
                         emitTerminalEvent(recalculation)
+                        // Terminal-on-create arms no poll, so drain any rerun queued during this create here,
+                        // the way the poll's terminal branch does. Otherwise a config change made mid-create
+                        // would strand. Clear createInFlight first so the drained rerun creates instead of
+                        // re-queuing against this finished create.
+                        cache.createInFlight = false
+                        const queued = values.queuedRerun
+                        if (queued) {
+                            actions.setQueuedRerun(null)
+                            actions.triggerRecalculation(queued)
+                        }
                     } else {
                         if (trigger === 'manual' && !recalculation.is_existing) {
                             lemonToast.info(
@@ -837,6 +858,8 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                      */
                     actions.setRecalculationLoading(false)
                     lemonToast.error(error?.detail || 'Failed to trigger metrics recalculation')
+                } finally {
+                    cache.createInFlight = false
                 }
             },
             /**

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.ts
@@ -92,6 +92,22 @@ const metricsInOrder = (experiment: Experiment, type: 'primary' | 'secondary'): 
     return [...(inline as ExperimentMetric[]), ...sharedMetrics]
 }
 
+/**
+ * Every metric uuid on the experiment now, across primary and secondary (inline + shared). Metrics without
+ * a uuid are skipped: they can't be matched against a run's per-uuid results, so they never signal a gap.
+ */
+const currentMetricUuids = (experiment: Experiment): string[] =>
+    [
+        ...metricsInOrder(experiment, 'primary').map((metric) => metric.uuid),
+        ...metricsInOrder(experiment, 'secondary').map((metric) => metric.uuid),
+    ].filter((uuid): uuid is string => !!uuid)
+
+/** Metric uuids a run resolved: a computed result or a recorded failure. */
+const coveredMetricUuids = (recalculation: ExperimentMetricsRecalculationApi): string[] => [
+    ...(recalculation.results ?? []).map(({ metric_uuid }) => metric_uuid),
+    ...Object.keys((recalculation.metric_errors as Record<string, unknown> | null) ?? {}),
+]
+
 type MetricErrorState = { detail: string } | null
 type ResolveByUuid<T> = (uuid: string) => T
 
@@ -672,14 +688,23 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                     }
 
                     /**
-                     * We have no per-metric staleness signal, so a results + failures count short of the total
-                     * means the run diverged: re-run to heal it. This recovery is generic (it also fires after a
-                     * reset and relaunch), so advance the window with experiment_config_change rather than reuse a
-                     * cutoff that may predate the new start_date.
+                     * Heal a completed run that does not cover every current metric. Two cases:
+                     * 1. The run diverged: its own resolved count fell short of its total (also fires after a
+                     *    reset and relaunch).
+                     * 2. A metric was added after this run finished, so a current metric uuid is absent from the
+                     *    run's results. The run's own counts look complete, so only a uuid comparison catches it.
+                     * Otherwise the new metric shows a perpetual loading state, since nothing else re-runs on
+                     * page load. Advance the window with experiment_config_change rather than reuse a cutoff that
+                     * may predate the new start_date.
                      */
+                    const coveredUuids = new Set(coveredMetricUuids(recalculation))
+                    const missingCurrentMetric = currentMetricUuids(props.experiment).some(
+                        (uuid) => !coveredUuids.has(uuid)
+                    )
                     if (
                         recalculation.status === RECALCULATION_STATUSES.completed &&
-                        recalculation.completed_metrics + recalculation.failed_metrics < recalculation.total_metrics
+                        (recalculation.completed_metrics + recalculation.failed_metrics < recalculation.total_metrics ||
+                            missingCurrentMetric)
                     ) {
                         actions.triggerRecalculation('experiment_config_change')
                         return
@@ -714,13 +739,15 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                     return
                 }
                 /**
-                 * If we have a recalculation in flight, and the user has changed the experiment or the metrics configuration,
-                 * we schedule a new recalculation with the corresponding trigger.
+                 * A config change while a real run is polling queues a rerun; the poll's terminal branch
+                 * drains it. Guard on the run status, not isRecalculating: a transient loadLatestRecalculation
+                 * fetch also flips isRecalculating, and queueing against it strands the rerun forever, because
+                 * that fetch never polls and so never drains the queue.
                  */
-                if (
-                    (trigger === 'experiment_config_change' || trigger === 'metric_config_change') &&
-                    values.isRecalculating
-                ) {
+                const runStatus = values.currentRecalculation?.status
+                const runInFlight =
+                    runStatus === RECALCULATION_STATUSES.pending || runStatus === RECALCULATION_STATUSES.in_progress
+                if ((trigger === 'experiment_config_change' || trigger === 'metric_config_change') && runInFlight) {
                     actions.setQueuedRerun(trigger)
                     return
                 }


### PR DESCRIPTION
## Problem

A metric on a running experiment could stay stuck in a loading state forever. Adding a shared metric, or just reloading the page, left the new metric spinning; the network tab showed a `/latest` fetch but no `metrics_recalculation/` POST. Only a manual recalculation cleared it.

Root cause, in two layers:

- On page load, `loadLatestRecalculation` self-heals a completed run whose own counts fall short: `completed_metrics + failed_metrics < total_metrics`. That compares the run against itself. A metric added after the run finished is absent from the run entirely, so the run's counts still look complete and the heal never fires.
- The self-heal calls `triggerRecalculation` while `recalculationLoading` is still true. The queue guard read `isRecalculating`, which includes that transient load, so it queued the rerun instead of creating it. The queue drains only in the poll's terminal branch, and a `loadLatestRecalculation` never polls, so the queued rerun stranded.

This is a stopgap. The reload-and-heal design is the underlying issue; metric operations will move to atomic RESTful endpoints so an add no longer PATCHes the whole experiment and forces a reload.

## Changes

Both fixes live in `experimentMetricsLogic` and are needed together: the first fires the heal, the second lets it through.

### Heal a run that is missing a current metric

`loadLatestRecalculation` now heals a completed run when any current experiment metric UUID is absent from the run's covered UUIDs, not only when the run's own counts fall short. Two new helpers, `currentMetricUuids` (every metric UUID on the experiment now) and `coveredMetricUuids` (UUIDs the run resolved, result or failure), drive the comparison. A metric added after the last run now triggers `experiment_config_change` on the next load, so it computes instead of spinning. Metrics without a UUID are skipped, since they cannot be matched by UUID.

- `frontend/src/scenes/experiments/experimentMetricsLogic.ts`

### Queue only against a real running run

The `triggerRecalculation` queue guard now checks the run status (`pending` or `in_progress`) instead of `isRecalculating`. A transient `loadLatestRecalculation` fetch flips `isRecalculating` true but never polls, so queueing against it stranded the rerun forever. Guarding on status lets a config change during a plain latest-load create a run.

- `frontend/src/scenes/experiments/experimentMetricsLogic.ts`

## How did you test this code?

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

```bash
pnpm --filter=@posthog/frontend jest experimentMetricsLogic.test.ts experimentLogic.test.ts
```

```bash
pnpm --filter=@posthog/frontend typescript:check
```

New tests, each verified to fail without its matching fix:

- `heals a completed run that is missing a metric added after it finished`: the missing-UUID heal.
- `posts instead of queuing when only a latest-load is in flight`: the status-based queue guard.
- `addSharedMetricsToExperiment reuses the window`: routing coverage that a shared-metric add reaches `refreshExperimentResults` with `metric_config_change` (no prior coverage).

![cat-type-small](https://github.com/user-attachments/assets/f449f6a5-f9cd-4902-bbb9-5e644c3b0a92)

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8

Manually refactored: **no**

Skills used:

- /systematic-debugging (superpowers)
- /writing-tests (local)
- /writing-pull-requests (local)

Relevant decisions:

- Heal by comparing metric UUIDs, not counts. A count check misses the add-after-run case (and an equal-count remove-then-add), because the run's stored `total_metrics` describes only the metrics it knew about.
- Guard the queue on run status rather than `isRecalculating`. The two layers interlock: the self-heal fires `triggerRecalculation` mid latest-load, so a status-based guard is required or the heal itself would strand.
- Scoped as a stopgap. Metric operations will move to atomic RESTful endpoints; the missing-metric heal is removed once an add triggers its own recalculation without the `loadExperiment` reload.