### PR TITLE
fix(warehouse): drop the xmin cursor when a reset wipes the table

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -1532,6 +1532,7 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
 
         # CDC snapshot schemas fall through to run initial full_refresh via postgres_source()
         require_ssl = source_requires_ssl(schema.source, config)
+        table_rebuild_pending = inputs.reset_pipeline or schema.delta_revive_required is not None
 
         # Prefer the per-row `schema_metadata.source_schema` so multi-schema warehouse sources work
         # without needing to encode the schema in `config.schema`. Falls back to `config.schema` for
@@ -1558,13 +1559,14 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 row_filters=inputs.row_filters,
                 # xmin state is read straight off the schema here (the generic `SourceInputs` stays
                 # Postgres-agnostic). xmin rides the normal full per-schema path — no CDC dispatch.
-                # A reset deletes the Delta table before this read, so the cursor has to go with it:
-                # kept, the read covers only the window since the last run, and the overwrite
-                # collapses the table to that slice. The activity drops the incremental cursor on a
-                # reset for the same reason; the xmin cursor is dropped here because it is read here.
+                # A reset, and a pending corrupt-delta revive, both delete the Delta table before
+                # this read, so the cursor has to go with it: kept, the read covers only the window
+                # since the last run, and the overwrite collapses the table to that slice. The
+                # activity drops the incremental cursor for both cases for the same reason; the xmin
+                # cursor is dropped here because it is read here.
                 is_xmin=schema.is_xmin,
-                xmin_last_value=None if inputs.reset_pipeline else schema.xmin_last_value,
-                xmin_num_wraparound=None if inputs.reset_pipeline else schema.xmin_num_wraparound,
+                xmin_last_value=None if table_rebuild_pending else schema.xmin_last_value,
+                xmin_num_wraparound=None if table_rebuild_pending else schema.xmin_num_wraparound,
                 byte_bounded_extraction=inputs.byte_bounded_extraction,
                 activity_attempt=inputs.activity_attempt,
             )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -1558,9 +1558,13 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 row_filters=inputs.row_filters,
                 # xmin state is read straight off the schema here (the generic `SourceInputs` stays
                 # Postgres-agnostic). xmin rides the normal full per-schema path — no CDC dispatch.
+                # A reset deletes the Delta table before this read, so the cursor has to go with it:
+                # kept, the read covers only the window since the last run, and the overwrite
+                # collapses the table to that slice. The activity drops the incremental cursor on a
+                # reset for the same reason; the xmin cursor is dropped here because it is read here.
                 is_xmin=schema.is_xmin,
-                xmin_last_value=schema.xmin_last_value,
-                xmin_num_wraparound=schema.xmin_num_wraparound,
+                xmin_last_value=None if inputs.reset_pipeline else schema.xmin_last_value,
+                xmin_num_wraparound=None if inputs.reset_pipeline else schema.xmin_num_wraparound,
                 byte_bounded_extraction=inputs.byte_bounded_extraction,
                 activity_attempt=inputs.activity_attempt,
             )

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_import_data.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_import_data.py
@@ -77,19 +77,28 @@ def _setup(
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_reset_drops_the_xmin_cursor(activity_environment, team, **kwargs):
-    # A reset deletes the Delta table before the read. Keeping the cursor makes that read the
+@pytest.mark.parametrize(
+    "rebuild_trigger",
+    [
+        {"reset_pipeline": True},
+        {
+            "delta_revive_required": {
+                "reason": "hollow",
+                "missing_path": "p",
+                "detected_at": "2026-01-01T00:00:00+00:00",
+            }
+        },
+    ],
+    ids=["reset", "corrupt_delta_revive"],
+)
+async def test_table_rebuild_drops_the_xmin_cursor(activity_environment, team, rebuild_trigger, **kwargs):
+    # Both triggers delete the Delta table before the read. Keeping the cursor makes that read the
     # window since the last run, and the overwrite collapses the table to that slice.
     activity_inputs = await _setup(
         team,
         {"host": "host.com", "port": 5432, "user": "u", "password": "p", "database": "db", "schema": "public"},
         sync_type=ExternalDataSchema.SyncType.XMIN,
-        sync_type_config={
-            "reset_pipeline": True,
-            "xmin_last_value": 100,
-            "xmin_ceiling": 100,
-            "xmin_num_wraparound": 0,
-        },
+        sync_type_config={**rebuild_trigger, "xmin_last_value": 100, "xmin_ceiling": 100, "xmin_num_wraparound": 0},
     )
 
     with (

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_import_data.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_import_data.py
@@ -26,7 +26,12 @@ from products.warehouse_sources.backend.temporal.data_imports.workflow_activitie
 
 
 @sync_to_async
-def _setup(team: Team, job_inputs: dict[Any, Any]) -> ImportDataActivityInputs:
+def _setup(
+    team: Team,
+    job_inputs: dict[Any, Any],
+    sync_type: str | None = None,
+    sync_type_config: dict[str, Any] | None = None,
+) -> ImportDataActivityInputs:
     source = ExternalDataSource.objects.create(
         team=team,
         source_id="source_id",
@@ -54,6 +59,8 @@ def _setup(team: Team, job_inputs: dict[Any, Any]) -> ImportDataActivityInputs:
         should_sync=True,
         status=ExternalDataSchema.Status.COMPLETED,
         last_synced_at="2024-01-01",
+        sync_type=sync_type,
+        sync_type_config=sync_type_config or {},
     )
     job = ExternalDataJob.objects.create(
         team=team,
@@ -66,6 +73,43 @@ def _setup(team: Team, job_inputs: dict[Any, Any]) -> ImportDataActivityInputs:
     )
 
     return ImportDataActivityInputs(team_id=team.pk, schema_id=schema.pk, source_id=source.pk, run_id=str(job.pk))
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_reset_drops_the_xmin_cursor(activity_environment, team, **kwargs):
+    # A reset deletes the Delta table before the read. Keeping the cursor makes that read the
+    # window since the last run, and the overwrite collapses the table to that slice.
+    activity_inputs = await _setup(
+        team,
+        {"host": "host.com", "port": 5432, "user": "u", "password": "p", "database": "db", "schema": "public"},
+        sync_type=ExternalDataSchema.SyncType.XMIN,
+        sync_type_config={
+            "reset_pipeline": True,
+            "xmin_last_value": 100,
+            "xmin_ceiling": 100,
+            "xmin_num_wraparound": 0,
+        },
+    )
+
+    with (
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source.postgres_source"
+        ) as mock_postgres_source,
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.workflow_activities.import_data_sync._run"
+        ),
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins._is_host_safe",
+            return_value=(True, None),
+        ),
+    ):
+        await activity_environment.run(import_data_activity_sync, activity_inputs)
+
+    called_with = mock_postgres_source.call_args.kwargs
+    assert called_with["is_xmin"] is True
+    assert called_with["xmin_last_value"] is None
+    assert called_with["xmin_num_wraparound"] is None
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
## Problem

A reset resync of an xmin schema replaces the whole warehouse table with only the rows written since the last run. A 42M-row table came back as 2M rows, with the job reporting `Completed`.

- A reset deletes the Delta table before the read and overwrites it from the first batch.
- The activity drops the incremental cursor for a reset run so the read covers the whole table again: [import_data_sync.py:428](https://github.com/PostHog/posthog/blob/d61da5f73cd/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py#L428).
- The xmin cursor is not on `SourceInputs`. `PostgresSource` reads it straight off the schema and passes it through regardless of the reset.
- With a cursor present the read takes the bounded `xmin >= last AND xmin < ceiling` window instead of the full scan, and the overwrite collapses the table to that window.
- The run then advances the ceiling, so nothing about the schema shows it happened.

The comment on the incremental branch in the activity describes this exact failure. It was never wired for xmin.

## Changes

Nothing user-visible changes shape. A reset resync of an xmin schema now rebuilds the whole table.

- `PostgresSource` passes `xmin_last_value=None` and `xmin_num_wraparound=None` to the read when the run rebuilds the table: a reset, or a pending corrupt-delta revive. With no cursor the read takes the full scan, which is what a rebuild means.
- A normal xmin run is unchanged.

The check lives in the Postgres source rather than the activity because that is where the cursor is read. `SourceInputs` stays Postgres-agnostic, as the existing comment at that call site says.

The revive is included on review. The activity already drops the incremental cursor for both triggers, and the rebuild runs inside the pipeline after the read, so the collapse is identical.

Repairing a table this already collapsed needs the cursor cleared and a reset staged. `reset_wrapped_xmin_cursors --schema-id <id> --live-run` clears it; a `--reset` resync then rebuilds.

## How did you test this code?

Automated only. Not exercised against a live source.

- `test_table_rebuild_drops_the_xmin_cursor` in `tests/e2e/test_import_data.py`, parametrized over a staged reset and a pending revive, catches a rebuild run that passes the stored xmin cursor through to the read. It asserts only the three cursor kwargs, so it does not pin the rest of the call. Both cases fail with `assert 100 is None` before the fix; the revive case fails the same way against a reset-only gate.

Not checked: the rest of `test_postgres.py` that needs a live Postgres, which errors on the shared test database from a concurrent session.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The [Postgres sync methods](https://posthog.com/docs/data-warehouse/sources/postgres#sync-methods) docs describe a reset as a full re-read, which is what this restores.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

**No duplicate:** searched open PRs for `xmin cursor`, `reset_pipeline xmin`, and `clear_xmin_state`. Nothing addresses the reset path. #93392 and #95274 touch the xmin read but not its cursor.

Written by Claude Code, directed by @danielcarletti. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Found while checking why a reset resync completed with a fraction of the expected rows. The run's own log showed `reset_pipeline = True` and a windowed `WHERE xmin >= ...` predicate in the same run, which is the whole diagnosis.

**Public artifact:** this work started from a customer support ticket. No customer material reached the diff, the tests, the comments, the commit messages, or this description. The test reuses the fixtures already in `test_import_data.py` with invented cursor values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

