### PR TITLE
chore(agents): keep screenshots when rewriting a PR description

### DIFF
--- a/.agents/skills/writing-pr-descriptions/SKILL.md
+++ b/.agents/skills/writing-pr-descriptions/SKILL.md
@@ -19,15 +19,12 @@ Order decides whether they understand the change at all.
 Form and length only decide how fast.
 So get the order right first, and never buy shape at the cost of it.
 
-Work in five passes: lead, route, cut, shape, check. Run all five.
-
-When a body already exists, start from what is there. Pass 0 says how.
+Work in five passes: lead, route, cut, shape, check. Run all five. When a body already exists, pass 0 comes first.
 
 ## Pass 0: keep what the body already holds
 
 `gh pr edit --body` replaces the whole body, so every part of your draft that has no home is gone the moment you push it.
 An existing body holds work you cannot recreate: screenshots and recordings a person uploaded, links they collected, a checkbox they ticked, a note to a named reviewer.
-Losing one of those costs the author more than a rewrite gains them.
 
 Read the current body and edit it, rather than writing a fresh one over the top:
 
@@ -37,9 +34,8 @@ gh pr view <number> --json body --jq .body > pr-body.md
 gh pr edit <number> --body-file pr-body.md
 ```
 
-Carry every image, video, link and ticked box into the new body, under the heading it belongs to.
+Carry every image, video, link and ticked box into the new body, under the heading it belongs to, and add the heading when your draft has none.
 Replace one only when the change made it wrong, and say in the body that you replaced it.
-Keep a screenshot even when your draft has no section for it, and add the section.
 
 ## Pass 1: lead with the effect
 

--- a/.agents/skills/writing-pr-descriptions/SKILL.md
+++ b/.agents/skills/writing-pr-descriptions/SKILL.md
@@ -21,6 +21,26 @@ So get the order right first, and never buy shape at the cost of it.
 
 Work in five passes: lead, route, cut, shape, check. Run all five.
 
+When a body already exists, start from what is there. Pass 0 says how.
+
+## Pass 0: keep what the body already holds
+
+`gh pr edit --body` replaces the whole body, so every part of your draft that has no home is gone the moment you push it.
+An existing body holds work you cannot recreate: screenshots and recordings a person uploaded, links they collected, a checkbox they ticked, a note to a named reviewer.
+Losing one of those costs the author more than a rewrite gains them.
+
+Read the current body and edit it, rather than writing a fresh one over the top:
+
+```sh
+gh pr view <number> --json body --jq .body > pr-body.md
+# edit pr-body.md
+gh pr edit <number> --body-file pr-body.md
+```
+
+Carry every image, video, link and ticked box into the new body, under the heading it belongs to.
+Replace one only when the change made it wrong, and say in the body that you replaced it.
+Keep a screenshot even when your draft has no section for it, and add the section.
+
 ## Pass 1: lead with the effect
 
 The first line is the one line you can count on being read.
@@ -234,13 +254,14 @@ A "no" anywhere means the body is ordered for the writer, not the reader. Go bac
 9. Rewrite every passive sentence in active voice, unless the actor is genuinely unknown. Break every noun string longer than three words with a preposition.
 10. Does any sentence take its author as the subject? Rewrite it around the change. "I", "me" and "my" appear nowhere.
 11. Does the PR change anything a person sees? Include before-and-after screenshots, or say why nothing looks different.
-12. Does the PR change a flow or topology? Include branded before-and-after diagrams.
-13. Does prose compare several values across the same dimensions? Replace it with a table.
-14. Does every claim about what you ran, measured or saw link its evidence, or say it went unchecked? Descriptions of behavior need no link.
-15. Did a `<!-- -->` template comment survive anywhere? That section is unfilled. Fill it or delete it.
-16. Is the `## 🤖 Agent context` section filled, listing the skills invoked?
-17. Does the body claim manual testing that did not happen? Delete it.
-18. Does the body name an internal customer, incident, Slack quote, or operational metric? This repo is public. Delete it.
+12. Did you rewrite an existing body? Every image, video, link and ticked box a person put there still appears.
+13. Does the PR change a flow or topology? Include branded before-and-after diagrams.
+14. Does prose compare several values across the same dimensions? Replace it with a table.
+15. Does every claim about what you ran, measured or saw link its evidence, or say it went unchecked? Descriptions of behavior need no link.
+16. Did a `<!-- -->` template comment survive anywhere? That section is unfilled. Fill it or delete it.
+17. Is the `## 🤖 Agent context` section filled, listing the skills invoked?
+18. Does the body claim manual testing that did not happen? Delete it.
+19. Does the body name an internal customer, incident, Slack quote, or operational metric? This repo is public. Delete it.
 
 ## Background
 


### PR DESCRIPTION
## Problem

- An author who uploads screenshots to a PR loses them when an agent rewrites the description.
- `gh pr edit --body` replaces the whole body, so anything absent from the agent's draft is gone.
- The `/writing-pr-descriptions` skill only covered writing a body from scratch, so nothing told the agent to look at what was already there.
- Reported in [Slack](https://posthog.slack.com/archives/C09G8QA6740/p1788541646378139).

## Changes

- The skill now opens with pass 0: read the current body with `gh pr view --json body` and edit that, rather than writing a new body over the top.
- Pass 0 lists what to carry over: images, videos, links, ticked boxes, notes to a reviewer.
- A screenshot the change made wrong gets replaced and called out, never dropped in silence.
- The pass 5 line check gains one item, so the agent verifies nothing a person added went missing.

## How did you test this code?

- No tests. The file is agent instructions, not code, and no check runs it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5) made the change. Skills invoked: `/writing-skills`, `/writing-pr-descriptions`.
- No GitHub Actions workflow in this repo edits a PR body, so the skill is the only place the behavior lives.
- The skill is the right layer under AGENTS.md "Agent automation": a linter cannot read a PR body.
- Nothing from the session reached the diff.

https://claude.ai/code/session_019qpQhTa3UJVxJv1bAFaU12
