### PR TITLE
fix(pgcollector): add RDS CA bundle to Docker image for TLS verification

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3866,21 +3866,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
- "der_derive",
- "flagset",
  "pem-rfc7468",
  "zeroize",
-]
-
-[[package]]
-name = "der_derive"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -4680,12 +4667,6 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
 ]
-
-[[package]]
-name = "flagset"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flatbuffers"
@@ -8981,24 +8962,23 @@ dependencies = [
  "futures-util",
  "humantime",
  "jsonwebtoken",
+ "native-tls",
  "once_cell",
+ "postgres-native-tls",
  "prometheus",
  "regex",
  "reqwest 0.12.28",
  "rmcp",
  "rust_decimal",
  "rustls 0.23.37",
- "rustls-native-certs 0.8.3",
  "schemars 1.2.1",
  "serde",
  "serde_json",
  "tokio",
  "tokio-postgres",
- "tokio-postgres-rustls",
  "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
- "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -9018,23 +8998,22 @@ dependencies = [
  "glob",
  "humantime-serde",
  "include_dir",
+ "native-tls",
  "once_cell",
+ "postgres-native-tls",
  "prometheus",
  "regex",
  "rust_decimal",
  "rustls 0.23.37",
- "rustls-native-certs 0.8.3",
  "serde",
  "serde_json",
  "serde_yaml",
  "shellexpand",
  "tokio",
  "tokio-postgres",
- "tokio-postgres-rustls",
  "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
- "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -9266,6 +9245,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postgres-native-tls"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef4de47bb81477e0c3deaf153a1b10ae176484713ff1640969f4cb96b653ebc"
+dependencies = [
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-postgres",
 ]
 
 [[package]]
@@ -13043,27 +13034,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tls_codec"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
-dependencies = [
- "tls_codec_derive",
- "zeroize",
-]
-
-[[package]]
-name = "tls_codec_derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13135,21 +13105,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "whoami 2.1.3",
-]
-
-[[package]]
-name = "tokio-postgres-rustls"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d684bad428a0f2481f42241f821db42c54e2dc81d8c00db8536c506b0a0144"
-dependencies = [
- "const-oid 0.9.6",
- "ring 0.17.14",
- "rustls 0.23.37",
- "tokio",
- "tokio-postgres",
- "tokio-rustls 0.26.4",
- "x509-cert",
 ]
 
 [[package]]
@@ -14704,18 +14659,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "x509-cert"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
-dependencies = [
- "const-oid 0.9.6",
- "der",
- "spki",
- "tls_codec",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3866,8 +3866,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4667,6 +4680,12 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
 ]
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flatbuffers"
@@ -8962,20 +8981,20 @@ dependencies = [
  "futures-util",
  "humantime",
  "jsonwebtoken",
- "native-tls",
  "once_cell",
- "postgres-native-tls",
  "prometheus",
  "regex",
  "reqwest 0.12.28",
  "rmcp",
  "rust_decimal",
  "rustls 0.23.37",
+ "rustls-native-certs 0.8.3",
  "schemars 1.2.1",
  "serde",
  "serde_json",
  "tokio",
  "tokio-postgres",
+ "tokio-postgres-rustls",
  "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
@@ -8998,19 +9017,19 @@ dependencies = [
  "glob",
  "humantime-serde",
  "include_dir",
- "native-tls",
  "once_cell",
- "postgres-native-tls",
  "prometheus",
  "regex",
  "rust_decimal",
  "rustls 0.23.37",
+ "rustls-native-certs 0.8.3",
  "serde",
  "serde_json",
  "serde_yaml",
  "shellexpand",
  "tokio",
  "tokio-postgres",
+ "tokio-postgres-rustls",
  "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
@@ -9245,18 +9264,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
 dependencies = [
  "portable-atomic",
-]
-
-[[package]]
-name = "postgres-native-tls"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef4de47bb81477e0c3deaf153a1b10ae176484713ff1640969f4cb96b653ebc"
-dependencies = [
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tokio-postgres",
 ]
 
 [[package]]
@@ -13034,6 +13041,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13105,6 +13133,21 @@ dependencies = [
  "tokio",
  "tokio-util",
  "whoami 2.1.3",
+]
+
+[[package]]
+name = "tokio-postgres-rustls"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d684bad428a0f2481f42241f821db42c54e2dc81d8c00db8536c506b0a0144"
+dependencies = [
+ "const-oid 0.9.6",
+ "ring 0.17.14",
+ "rustls 0.23.37",
+ "tokio",
+ "tokio-postgres",
+ "tokio-rustls 0.26.4",
+ "x509-cert",
 ]
 
 [[package]]
@@ -14659,6 +14702,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid 0.9.6",
+ "der",
+ "spki",
+ "tls_codec",
 ]
 
 [[package]]

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -111,6 +111,11 @@ RUN --mount=type=secret,id=posthog_upload_symbols_cli_api_key \
 
 FROM debian:bookworm-slim AS runtime
 
+# AWS RDS global CA bundle — all root and intermediate CAs for TLS verification.
+# To update: download the bundle, recompute the hash with sha256sum, and replace both values.
+#   curl -fsS "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" | sha256sum
+ARG RDS_CA_BUNDLE_SHA256=e5bb2084ccf45087bda1c9bffdea0eb15ee67f0b91646106e466714f9de3c7e3
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     libssl-dev "ca-certificates" \
@@ -126,7 +131,7 @@ RUN apt-get update && \
     rm -rf ./share && \
     curl -fsS -o /tmp/rds-combined-ca-bundle.crt \
         "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" && \
-    echo "e5bb2084ccf45087bda1c9bffdea0eb15ee67f0b91646106e466714f9de3c7e3  /tmp/rds-combined-ca-bundle.crt" | sha256sum -c - && \
+    echo "${RDS_CA_BUNDLE_SHA256}  /tmp/rds-combined-ca-bundle.crt" | sha256sum -c - && \
     mv /tmp/rds-combined-ca-bundle.crt /usr/local/share/ca-certificates/rds-combined-ca-bundle.crt && \
     update-ca-certificates
 

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -124,10 +124,8 @@ RUN apt-get update && \
     mkdir -p /app/share && \
     mv ./share/GeoLite2-City.mmdb /app/share/ && \
     rm -rf ./share && \
-    curl -sS -o /tmp/rds-combined-ca-bundle.pem \
+    curl -sS -o /usr/local/share/ca-certificates/rds-combined-ca-bundle.pem \
         "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" && \
-    echo "e5bb2084ccf45087bda1c9bffdea0eb15ee67f0b91646106e466714f9de3c7e3  /tmp/rds-combined-ca-bundle.pem" | sha256sum -c - && \
-    mv /tmp/rds-combined-ca-bundle.pem /usr/local/share/ca-certificates/rds-combined-ca-bundle.pem && \
     update-ca-certificates
 
 ARG BIN

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -124,8 +124,10 @@ RUN apt-get update && \
     mkdir -p /app/share && \
     mv ./share/GeoLite2-City.mmdb /app/share/ && \
     rm -rf ./share && \
-    curl -sS -o /usr/local/share/ca-certificates/rds-combined-ca-bundle.pem \
+    curl -sS -o /tmp/rds-combined-ca-bundle.pem \
         "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" && \
+    echo "e5bb2084ccf45087bda1c9bffdea0eb15ee67f0b91646106e466714f9de3c7e3  /tmp/rds-combined-ca-bundle.pem" | sha256sum -c - && \
+    mv /tmp/rds-combined-ca-bundle.pem /usr/local/share/ca-certificates/rds-combined-ca-bundle.pem && \
     update-ca-certificates
 
 ARG BIN

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -124,8 +124,10 @@ RUN apt-get update && \
     mkdir -p /app/share && \
     mv ./share/GeoLite2-City.mmdb /app/share/ && \
     rm -rf ./share && \
-    curl -sS -o /usr/local/share/ca-certificates/rds-combined-ca-bundle.pem \
+    curl -fsS -o /tmp/rds-combined-ca-bundle.crt \
         "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" && \
+    echo "e5bb2084ccf45087bda1c9bffdea0eb15ee67f0b91646106e466714f9de3c7e3  /tmp/rds-combined-ca-bundle.crt" | sha256sum -c - && \
+    mv /tmp/rds-combined-ca-bundle.crt /usr/local/share/ca-certificates/rds-combined-ca-bundle.crt && \
     update-ca-certificates
 
 ARG BIN

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -123,7 +123,10 @@ RUN apt-get update && \
     chmod -R 755 ./share/GeoLite2-City.mmdb && \
     mkdir -p /app/share && \
     mv ./share/GeoLite2-City.mmdb /app/share/ && \
-    rm -rf ./share
+    rm -rf ./share && \
+    curl -sS -o /usr/local/share/ca-certificates/rds-combined-ca-bundle.pem \
+        "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" && \
+    update-ca-certificates
 
 ARG BIN
 ENV BIN=$BIN

--- a/rust/pgapi/Cargo.toml
+++ b/rust/pgapi/Cargo.toml
@@ -21,18 +21,17 @@ regex = { workspace = true }
 reqwest = { workspace = true }
 rmcp = { version = "3", features = ["server", "macros", "transport-streamable-http-server"] }
 rust_decimal = { version = "1", features = ["db-tokio-postgres"] }
+native-tls = "0.2"
+postgres-native-tls = "0.5"
 rustls = { workspace = true }
-rustls-native-certs = "0.8"
 schemars = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
-tokio-postgres-rustls = "0.13"
 tower-http = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-webpki-roots = "1"
 
 [lints]
 workspace = true

--- a/rust/pgapi/Cargo.toml
+++ b/rust/pgapi/Cargo.toml
@@ -21,14 +21,14 @@ regex = { workspace = true }
 reqwest = { workspace = true }
 rmcp = { version = "3", features = ["server", "macros", "transport-streamable-http-server"] }
 rust_decimal = { version = "1", features = ["db-tokio-postgres"] }
-native-tls = "0.2"
-postgres-native-tls = "0.5"
 rustls = { workspace = true }
+rustls-native-certs = "0.8"
 schemars = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
+tokio-postgres-rustls = "0.13"
 tower-http = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/rust/pgapi/src/db.rs
+++ b/rust/pgapi/src/db.rs
@@ -165,43 +165,6 @@ pub fn row_to_json(r: &tokio_postgres::Row) -> Result<Value> {
 }
 
 fn tls_connector() -> postgres_native_tls::MakeTlsConnector {
-    let mut builder = native_tls::TlsConnector::builder();
-    load_rds_ca_certs(&mut builder);
-    let connector = builder.build().expect("failed to build TLS connector");
+    let connector = native_tls::TlsConnector::new().expect("failed to build TLS connector");
     postgres_native_tls::MakeTlsConnector::new(connector)
-}
-
-fn load_rds_ca_certs(builder: &mut native_tls::TlsConnectorBuilder) {
-    let path = match std::env::var("RDS_CA_CERT_PATH") {
-        Ok(p) if !p.is_empty() => p,
-        _ => {
-            tracing::warn!("RDS_CA_CERT_PATH not set; TLS will use system certs only");
-            return;
-        }
-    };
-    let pem = match std::fs::read_to_string(&path) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::warn!(path, error = %e, "could not read RDS CA bundle");
-            return;
-        }
-    };
-    let mut added = 0u32;
-    for block in pem.split("-----END CERTIFICATE-----") {
-        let trimmed = block.trim();
-        if trimmed.is_empty() || !trimmed.contains("-----BEGIN CERTIFICATE-----") {
-            continue;
-        }
-        let cert_pem = format!("{trimmed}\n-----END CERTIFICATE-----\n");
-        match native_tls::Certificate::from_pem(cert_pem.as_bytes()) {
-            Ok(cert) => {
-                builder.add_root_certificate(cert);
-                added += 1;
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "skipping malformed certificate in RDS CA bundle");
-            }
-        }
-    }
-    tracing::info!(path, added, "loaded RDS CA certificates");
 }

--- a/rust/pgapi/src/db.rs
+++ b/rust/pgapi/src/db.rs
@@ -20,24 +20,7 @@ impl Db {
     pub async fn connect(url: &str) -> Result<Self> {
         let mut cfg: tokio_postgres::Config = url.parse().context("parsing PGAPI_DATABASE_URL")?;
         cfg.ssl_mode(tokio_postgres::config::SslMode::Require);
-        let mut roots = rustls::RootCertStore::empty();
-        let native = rustls_native_certs::load_native_certs();
-        for err in &native.errors {
-            tracing::warn!(error = %err, "failed to load a native certificate");
-        }
-        for cert in native.certs {
-            if let Err(e) = roots.add(cert) {
-                tracing::warn!(error = %e, "failed to add a native certificate to root store");
-            }
-        }
-        if roots.is_empty() {
-            tracing::info!("no native certs found, falling back to webpki-roots");
-            roots.roots = webpki_roots::TLS_SERVER_ROOTS.to_vec();
-        }
-        let tls_cfg = rustls::ClientConfig::builder()
-            .with_root_certificates(roots)
-            .with_no_client_auth();
-        let tls = tokio_postgres_rustls::MakeRustlsConnect::new(tls_cfg);
+        let tls = tls_connector();
         let mgr = Manager::from_config(
             cfg,
             tls,
@@ -179,4 +162,46 @@ pub fn row_to_json(r: &tokio_postgres::Row) -> Result<Value> {
         m.insert(col.name().to_string(), v.unwrap_or(Value::Null));
     }
     Ok(Value::Object(m))
+}
+
+fn tls_connector() -> postgres_native_tls::MakeTlsConnector {
+    let mut builder = native_tls::TlsConnector::builder();
+    load_rds_ca_certs(&mut builder);
+    let connector = builder.build().expect("failed to build TLS connector");
+    postgres_native_tls::MakeTlsConnector::new(connector)
+}
+
+fn load_rds_ca_certs(builder: &mut native_tls::TlsConnectorBuilder) {
+    let path = match std::env::var("RDS_CA_CERT_PATH") {
+        Ok(p) if !p.is_empty() => p,
+        _ => {
+            tracing::warn!("RDS_CA_CERT_PATH not set; TLS will use system certs only");
+            return;
+        }
+    };
+    let pem = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(path, error = %e, "could not read RDS CA bundle");
+            return;
+        }
+    };
+    let mut added = 0u32;
+    for block in pem.split("-----END CERTIFICATE-----") {
+        let trimmed = block.trim();
+        if trimmed.is_empty() || !trimmed.contains("-----BEGIN CERTIFICATE-----") {
+            continue;
+        }
+        let cert_pem = format!("{trimmed}\n-----END CERTIFICATE-----\n");
+        match native_tls::Certificate::from_pem(cert_pem.as_bytes()) {
+            Ok(cert) => {
+                builder.add_root_certificate(cert);
+                added += 1;
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "skipping malformed certificate in RDS CA bundle");
+            }
+        }
+    }
+    tracing::info!(path, added, "loaded RDS CA certificates");
 }

--- a/rust/pgapi/src/db.rs
+++ b/rust/pgapi/src/db.rs
@@ -164,7 +164,19 @@ pub fn row_to_json(r: &tokio_postgres::Row) -> Result<Value> {
     Ok(Value::Object(m))
 }
 
-fn tls_connector() -> postgres_native_tls::MakeTlsConnector {
-    let connector = native_tls::TlsConnector::new().expect("failed to build TLS connector");
-    postgres_native_tls::MakeTlsConnector::new(connector)
+fn tls_connector() -> tokio_postgres_rustls::MakeRustlsConnect {
+    let mut roots = rustls::RootCertStore::empty();
+    let native = rustls_native_certs::load_native_certs();
+    for err in &native.errors {
+        tracing::warn!(error = %err, "failed to load a native certificate");
+    }
+    for cert in native.certs {
+        if let Err(e) = roots.add(cert) {
+            tracing::warn!(error = %e, "failed to add a native certificate to root store");
+        }
+    }
+    let tls_cfg = rustls::ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    tokio_postgres_rustls::MakeRustlsConnect::new(tls_cfg)
 }

--- a/rust/pgcollector/Cargo.toml
+++ b/rust/pgcollector/Cargo.toml
@@ -24,19 +24,18 @@ once_cell = { workspace = true }
 prometheus = "0.13"
 regex = { workspace = true }
 rust_decimal = { version = "1", features = ["db-tokio-postgres"] }
+native-tls = "0.2"
+postgres-native-tls = "0.5"
 rustls = { workspace = true }
-rustls-native-certs = "0.8"
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = "0.9"
 shellexpand = "3"
 tokio = { workspace = true }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
-tokio-postgres-rustls = "0.13"
 toml = "0.8"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-webpki-roots = "1"
 
 [lints]
 workspace = true

--- a/rust/pgcollector/Cargo.toml
+++ b/rust/pgcollector/Cargo.toml
@@ -24,15 +24,15 @@ once_cell = { workspace = true }
 prometheus = "0.13"
 regex = { workspace = true }
 rust_decimal = { version = "1", features = ["db-tokio-postgres"] }
-native-tls = "0.2"
-postgres-native-tls = "0.5"
 rustls = { workspace = true }
+rustls-native-certs = "0.8"
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = "0.9"
 shellexpand = "3"
 tokio = { workspace = true }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
+tokio-postgres-rustls = "0.13"
 toml = "0.8"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/rust/pgcollector/src/pg.rs
+++ b/rust/pgcollector/src/pg.rs
@@ -20,25 +20,46 @@ pub fn tls_policy(url: &str) -> tokio_postgres::config::SslMode {
     }
 }
 
-pub fn tls_connector() -> tokio_postgres_rustls::MakeRustlsConnect {
-    let mut roots = rustls::RootCertStore::empty();
-    let native = rustls_native_certs::load_native_certs();
-    for err in &native.errors {
-        tracing::warn!(error = %err, "failed to load a native certificate");
-    }
-    for cert in native.certs {
-        if let Err(e) = roots.add(cert) {
-            tracing::warn!(error = %e, "failed to add a native certificate to root store");
+pub fn tls_connector() -> postgres_native_tls::MakeTlsConnector {
+    let mut builder = native_tls::TlsConnector::builder();
+    load_rds_ca_certs(&mut builder);
+    let connector = builder.build().expect("failed to build TLS connector");
+    postgres_native_tls::MakeTlsConnector::new(connector)
+}
+
+fn load_rds_ca_certs(builder: &mut native_tls::TlsConnectorBuilder) {
+    let path = match std::env::var("RDS_CA_CERT_PATH") {
+        Ok(p) if !p.is_empty() => p,
+        _ => {
+            tracing::warn!("RDS_CA_CERT_PATH not set; TLS will use system certs only");
+            return;
+        }
+    };
+    let pem = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(path, error = %e, "could not read RDS CA bundle");
+            return;
+        }
+    };
+    let mut added = 0u32;
+    for block in pem.split("-----END CERTIFICATE-----") {
+        let trimmed = block.trim();
+        if trimmed.is_empty() || !trimmed.contains("-----BEGIN CERTIFICATE-----") {
+            continue;
+        }
+        let cert_pem = format!("{trimmed}\n-----END CERTIFICATE-----\n");
+        match native_tls::Certificate::from_pem(cert_pem.as_bytes()) {
+            Ok(cert) => {
+                builder.add_root_certificate(cert);
+                added += 1;
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "skipping malformed certificate in RDS CA bundle");
+            }
         }
     }
-    if roots.is_empty() {
-        tracing::info!("no native certs found, falling back to webpki-roots");
-        roots.roots = webpki_roots::TLS_SERVER_ROOTS.to_vec();
-    }
-    let tls_cfg = rustls::ClientConfig::builder()
-        .with_root_certificates(roots)
-        .with_no_client_auth();
-    tokio_postgres_rustls::MakeRustlsConnect::new(tls_cfg)
+    tracing::info!(path, added, "loaded RDS CA certificates");
 }
 
 pub async fn connect(

--- a/rust/pgcollector/src/pg.rs
+++ b/rust/pgcollector/src/pg.rs
@@ -20,9 +20,21 @@ pub fn tls_policy(url: &str) -> tokio_postgres::config::SslMode {
     }
 }
 
-pub fn tls_connector() -> postgres_native_tls::MakeTlsConnector {
-    let connector = native_tls::TlsConnector::new().expect("failed to build TLS connector");
-    postgres_native_tls::MakeTlsConnector::new(connector)
+pub fn tls_connector() -> tokio_postgres_rustls::MakeRustlsConnect {
+    let mut roots = rustls::RootCertStore::empty();
+    let native = rustls_native_certs::load_native_certs();
+    for err in &native.errors {
+        tracing::warn!(error = %err, "failed to load a native certificate");
+    }
+    for cert in native.certs {
+        if let Err(e) = roots.add(cert) {
+            tracing::warn!(error = %e, "failed to add a native certificate to root store");
+        }
+    }
+    let tls_cfg = rustls::ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    tokio_postgres_rustls::MakeRustlsConnect::new(tls_cfg)
 }
 
 pub async fn connect(

--- a/rust/pgcollector/src/pg.rs
+++ b/rust/pgcollector/src/pg.rs
@@ -21,45 +21,8 @@ pub fn tls_policy(url: &str) -> tokio_postgres::config::SslMode {
 }
 
 pub fn tls_connector() -> postgres_native_tls::MakeTlsConnector {
-    let mut builder = native_tls::TlsConnector::builder();
-    load_rds_ca_certs(&mut builder);
-    let connector = builder.build().expect("failed to build TLS connector");
+    let connector = native_tls::TlsConnector::new().expect("failed to build TLS connector");
     postgres_native_tls::MakeTlsConnector::new(connector)
-}
-
-fn load_rds_ca_certs(builder: &mut native_tls::TlsConnectorBuilder) {
-    let path = match std::env::var("RDS_CA_CERT_PATH") {
-        Ok(p) if !p.is_empty() => p,
-        _ => {
-            tracing::warn!("RDS_CA_CERT_PATH not set; TLS will use system certs only");
-            return;
-        }
-    };
-    let pem = match std::fs::read_to_string(&path) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::warn!(path, error = %e, "could not read RDS CA bundle");
-            return;
-        }
-    };
-    let mut added = 0u32;
-    for block in pem.split("-----END CERTIFICATE-----") {
-        let trimmed = block.trim();
-        if trimmed.is_empty() || !trimmed.contains("-----BEGIN CERTIFICATE-----") {
-            continue;
-        }
-        let cert_pem = format!("{trimmed}\n-----END CERTIFICATE-----\n");
-        match native_tls::Certificate::from_pem(cert_pem.as_bytes()) {
-            Ok(cert) => {
-                builder.add_root_certificate(cert);
-                added += 1;
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "skipping malformed certificate in RDS CA bundle");
-            }
-        }
-    }
-    tracing::info!(path, added, "loaded RDS CA certificates");
 }
 
 pub async fn connect(


### PR DESCRIPTION
## Problem

pgcollector and pgapi crash-loop with `UnknownIssuer` TLS errors when connecting to RDS Aurora. rustls verifies server certificates, but RDS sends only the leaf certificate — the intermediate CA is not included in the TLS handshake. The system trust store has Amazon Root CA 1 (the root) but not the RDS-specific intermediate, so rustls cannot build a complete chain.

Both crates had a `webpki-roots` fallback for when no native certs were found, but that bundle also lacks the RDS intermediates, so it didn't help either.

## Changes

- Download the AWS RDS global CA bundle at image build time in `rust/Dockerfile` and run `update-ca-certificates` to merge the RDS intermediate CAs into the system trust store. rustls picks them up via `rustls-native-certs` with no code changes.
- Remove `webpki-roots` from both crates. The system trust store now always has the needed certs, so the empty-roots fallback is unnecessary.
- Extract pgapi's inline TLS setup into a `tls_connector()` function, matching pgcollector's existing pattern.
- The Dockerfile change affects all Rust service images. The RDS CAs are public Amazon-issued certificates already documented at https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html.

## How did you test this code?

Agent-authored. Ran `cargo check` for both crates. Did not run integration tests against a live RDS instance. Full verification will happen when the image is deployed to the dev environment via Kargo.

Not checked: no database-backed tests available in this sandbox.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session. Diagnosed the root cause (rustls cert verification + RDS not sending intermediate CAs in the handshake). Explored several approaches: native-tls with `danger_accept_invalid_certs` (PR #94845, superseded), native-tls with a ConfigMap-mounted CA bundle, and finally baking the bundle into the Docker image. The last approach is the simplest — one Dockerfile line, no charts changes, no env vars, no manual cert parsing. Skills invoked: `/writing-pr-descriptions`.

https://claude.ai/code/session_018mk53g7s2h8LME92fxbdNv