### PR TITLE
fix(rbac): preview object rules on resources without display model

### DIFF
--- a/posthog/api/resource_transfer.py
+++ b/posthog/api/resource_transfer.py
@@ -230,8 +230,7 @@ class ResourceTransferViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
 
         model = visitor.get_model()
 
-        # model_to_resource accepts both instances and classes at runtime via _meta
-        resource_type = model_to_resource(model)  # type: ignore[arg-type]
+        resource_type = model_to_resource(model)
         if resource_type is not None:
             ac = UserAccessControl(user=user, team=team)
             if not ac.check_access_level_for_resource(resource_type, required_level="viewer"):

--- a/products/access_control/backend/facade/resolution_preview.py
+++ b/products/access_control/backend/facade/resolution_preview.py
@@ -13,6 +13,7 @@ migration command are the only callers.
 from collections.abc import Iterator
 from dataclasses import replace
 from typing import Literal, Optional, cast
+from uuid import UUID
 
 from django.db.models import Model
 
@@ -23,7 +24,12 @@ from posthog.models.organization import OrganizationMembership
 from posthog.models.team.team import Team
 from posthog.scopes import APIScopeObject
 
-from products.access_control.backend.facade.object_names import display_model, resolve_object_names
+from products.access_control.backend.facade.object_names import (
+    display_model,
+    model_has_field,
+    resolve_object_names,
+    resources_with_object_access_controls,
+)
 from products.access_control.backend.facade.subject_access_control import SubjectAccessControl
 from products.access_control.backend.facade.user_access_control import (
     RESOURCE_FALLBACK_MAP,
@@ -217,32 +223,67 @@ def _build_subjects(team: Team, user_access_control: UserAccessControl, rows: li
     return _Subjects(subjects=subjects, role_names=role_names, member_names=member_names)
 
 
+def object_models(resource: str) -> list[type[Model]]:
+    """The model classes whose rows an object rule on `resource` can point at.
+
+    The display model when the settings UI can name the resource's objects. Otherwise every
+    team-scoped model behind the resource's routes, so rules the UI cannot name still resolve.
+    Empty when nothing backs the resource, for example a resource whose ids are not rows.
+    """
+    display = display_model(resource)
+    if display is not None:
+        return [display.model]
+    models = resources_with_object_access_controls().get(cast(APIScopeObject, resource)) or frozenset()
+    return sorted((model for model in models if model_has_field(model, "team")), key=lambda model: model.__name__)
+
+
+def can_load_objects(resource: str) -> bool:
+    """Whether the preview can evaluate object rules on `resource`. When it cannot, the rows are
+    dropped from the comparison and an empty preview does not prove the organization is unaffected."""
+    return resource == "project" or bool(object_models(resource))
+
+
+def organizations_with_unevaluable_rules() -> set[UUID]:
+    """Organizations with object rules the preview cannot evaluate, because nothing backs the
+    resource. Their previews are incomplete, so callers deciding from an empty preview skip them."""
+    object_resources = set(AccessControl.objects.exclude(resource_id=None).values_list("resource", flat=True))
+    unloadable = {resource for resource in object_resources if not can_load_objects(resource)}
+    if not unloadable:
+        return set()
+    return set(
+        AccessControl.objects.filter(resource__in=unloadable)
+        .exclude(resource_id=None)
+        .values_list("team__organization_id", flat=True)
+        .distinct()
+    )
+
+
 def _load_objects(team: Team, resource: str, object_ids: list[str]) -> dict[str, _LoadedObject]:
-    """Map {object_id -> loaded object} for one resource. Empty when the resource has no
-    display model, which also means resolution has no model class to work with."""
+    """Map {object_id -> loaded object} for one resource. Empty when nothing backs the resource."""
     if resource == "project":
         # Project rules point at the team itself
         if str(team.pk) not in object_ids:
             return {}
         return {str(team.pk): _LoadedObject(instance=team, name=team.name, short_id=None)}
 
-    display = display_model(resource)
-    if display is None:
-        return {}
     names = resolve_object_names(resource, object_ids, team.pk)
-    try:
-        instances = display.model._base_manager.filter(team_id=team.pk, pk__in=object_ids)
-    except Exception as e:
-        capture_exception(e, {"resource": resource})
-        return {}
     result: dict[str, _LoadedObject] = {}
-    for obj in instances:
-        object_id = str(obj.pk)
-        name = names.get(object_id)
-        short_id = getattr(obj, "short_id", None)
-        result[object_id] = _LoadedObject(
-            instance=obj, name=name.name if name else None, short_id=str(short_id) if short_id else None
-        )
+    for model in object_models(resource):
+        try:
+            instances = list(model._base_manager.filter(team_id=team.pk, pk__in=object_ids))
+        except Exception as e:
+            capture_exception(e, {"resource": resource, "model": model.__name__})
+            continue
+        for obj in instances:
+            object_id = str(obj.pk)
+            name = names.get(object_id)
+            short_id = getattr(obj, "short_id", None)
+            result.setdefault(
+                object_id,
+                _LoadedObject(
+                    instance=obj, name=name.name if name else None, short_id=str(short_id) if short_id else None
+                ),
+            )
     return result
 
 
@@ -388,11 +429,18 @@ def iter_resolution_changes(
     """Yield (team, changes) for every team with access rules, ordered by organization.
 
     Resolution is evaluated as one acting active member per organization; teams of
-    organizations with no active member are skipped. With `only_pending`, organizations
-    already on the most-specific resolution are skipped too: they are migrated already.
+    organizations with no active member are skipped, and so are organizations with object
+    rules the preview cannot evaluate, because their preview would be incomplete. With
+    `only_pending`, organizations already on the most-specific resolution are skipped too:
+    they are migrated already.
     """
     team_ids = AccessControl.objects.values_list("team_id", flat=True).distinct()
-    teams = Team.objects.filter(id__in=team_ids).select_related("organization").order_by("organization_id")
+    teams = (
+        Team.objects.filter(id__in=team_ids)
+        .exclude(organization_id__in=organizations_with_unevaluable_rules())
+        .select_related("organization")
+        .order_by("organization_id")
+    )
     if organization_id is not None:
         teams = teams.filter(organization_id=organization_id)
     if only_pending:

--- a/products/access_control/backend/facade/resolution_preview.py
+++ b/products/access_control/backend/facade/resolution_preview.py
@@ -13,7 +13,6 @@ migration command are the only callers.
 from collections.abc import Iterator
 from dataclasses import replace
 from typing import Literal, Optional, cast
-from uuid import UUID
 
 from django.db.models import Model
 
@@ -224,38 +223,16 @@ def _build_subjects(team: Team, user_access_control: UserAccessControl, rows: li
 
 
 def object_models(resource: str) -> list[type[Model]]:
-    """The model classes whose rows an object rule on `resource` can point at.
+    """Return the model classes that an object rule on `resource` can point at.
 
-    The display model when the settings UI can name the resource's objects. Otherwise every
-    team-scoped model behind the resource's routes, so rules the UI cannot name still resolve.
-    Empty when nothing backs the resource, for example a resource whose ids are not rows.
+    Return the display model when one exists. Otherwise return every team-scoped model
+    behind the resource's routes. Return an empty list when no model backs the resource.
     """
     display = display_model(resource)
     if display is not None:
         return [display.model]
     models = resources_with_object_access_controls().get(cast(APIScopeObject, resource)) or frozenset()
     return sorted((model for model in models if model_has_field(model, "team")), key=lambda model: model.__name__)
-
-
-def can_load_objects(resource: str) -> bool:
-    """Whether the preview can evaluate object rules on `resource`. When it cannot, the rows are
-    dropped from the comparison and an empty preview does not prove the organization is unaffected."""
-    return resource == "project" or bool(object_models(resource))
-
-
-def organizations_with_unevaluable_rules() -> set[UUID]:
-    """Organizations with object rules the preview cannot evaluate, because nothing backs the
-    resource. Their previews are incomplete, so callers deciding from an empty preview skip them."""
-    object_resources = set(AccessControl.objects.exclude(resource_id=None).values_list("resource", flat=True))
-    unloadable = {resource for resource in object_resources if not can_load_objects(resource)}
-    if not unloadable:
-        return set()
-    return set(
-        AccessControl.objects.filter(resource__in=unloadable)
-        .exclude(resource_id=None)
-        .values_list("team__organization_id", flat=True)
-        .distinct()
-    )
 
 
 def _load_objects(team: Team, resource: str, object_ids: list[str]) -> dict[str, _LoadedObject]:
@@ -434,10 +411,18 @@ def iter_resolution_changes(
     `only_pending`, organizations already on the most-specific resolution are skipped too:
     they are migrated already.
     """
+    # The preview cannot compare object rules on a resource with no model. Skip those
+    # organizations: an empty preview does not show that nothing changes for them.
+    object_resources = set(AccessControl.objects.exclude(resource_id=None).values_list("resource", flat=True))
+    unbacked = {resource for resource in object_resources if resource != "project" and not object_models(resource)}
+    skipped = (
+        AccessControl.objects.filter(resource__in=unbacked).exclude(resource_id=None).values("team__organization_id")
+    )
+
     team_ids = AccessControl.objects.values_list("team_id", flat=True).distinct()
     teams = (
         Team.objects.filter(id__in=team_ids)
-        .exclude(organization_id__in=organizations_with_unevaluable_rules())
+        .exclude(organization_id__in=skipped)
         .select_related("organization")
         .order_by("organization_id")
     )

--- a/products/access_control/backend/facade/resolution_preview.py
+++ b/products/access_control/backend/facade/resolution_preview.py
@@ -36,6 +36,7 @@ from products.access_control.backend.facade.user_access_control import (
     RESOURCES_WITHOUT_RESOURCE_LEVEL_CONTROLS,
     ResolvedAccess,
     UserAccessControl,
+    model_to_resource,
     ordered_access_levels,
 )
 from products.access_control.backend.models.access_control import AccessControl
@@ -226,13 +227,17 @@ def object_models(resource: str) -> list[type[Model]]:
     """Return the model classes that an object rule on `resource` can point at.
 
     Return the display model when one exists. Otherwise return every team-scoped model
-    behind the resource's routes. Return an empty list when no model backs the resource.
+    behind the resource's routes that the resolver maps back to `resource`. Return an
+    empty list when no such model exists: the preview cannot resolve those rules.
     """
     display = display_model(resource)
     if display is not None:
         return [display.model]
     models = resources_with_object_access_controls().get(cast(APIScopeObject, resource)) or frozenset()
-    return sorted((model for model in models if model_has_field(model, "team")), key=lambda model: model.__name__)
+    return sorted(
+        (model for model in models if model_has_field(model, "team") and model_to_resource(model) == resource),
+        key=lambda model: model.__name__,
+    )
 
 
 def _load_objects(team: Team, resource: str, object_ids: list[str]) -> dict[str, _LoadedObject]:
@@ -406,28 +411,26 @@ def iter_resolution_changes(
     """Yield (team, changes) for every team with access rules, ordered by organization.
 
     Resolution is evaluated as one acting active member per organization; teams of
-    organizations with no active member are skipped, and so are organizations with object
-    rules the preview cannot evaluate, because their preview would be incomplete. With
-    `only_pending`, organizations already on the most-specific resolution are skipped too:
-    they are migrated already.
+    organizations with no active member are skipped. Without `organization_id`, organizations
+    with object rules the preview cannot resolve are skipped too, because their preview would
+    be incomplete. With `only_pending`, organizations already on the most-specific resolution
+    are skipped: they are migrated already.
     """
-    # The preview cannot compare object rules on a resource with no model. Skip those
-    # organizations: an empty preview does not show that nothing changes for them.
-    object_resources = set(AccessControl.objects.exclude(resource_id=None).values_list("resource", flat=True))
-    unbacked = {resource for resource in object_resources if resource != "project" and not object_models(resource)}
-    skipped = (
-        AccessControl.objects.filter(resource__in=unbacked).exclude(resource_id=None).values("team__organization_id")
-    )
-
     team_ids = AccessControl.objects.values_list("team_id", flat=True).distinct()
-    teams = (
-        Team.objects.filter(id__in=team_ids)
-        .exclude(organization_id__in=skipped)
-        .select_related("organization")
-        .order_by("organization_id")
-    )
+    teams = Team.objects.filter(id__in=team_ids).select_related("organization").order_by("organization_id")
     if organization_id is not None:
         teams = teams.filter(organization_id=organization_id)
+    else:
+        # The preview cannot resolve object rules on a resource with no model. Skip those
+        # organizations: an empty preview does not show that nothing changes for them.
+        object_rules = AccessControl.objects.exclude(resource_id=None).exclude(resource__in=_SKIPPED_RESOURCES)
+        object_resources = set(object_rules.values_list("resource", flat=True))
+        unresolvable = {
+            resource for resource in object_resources if resource != "project" and not object_models(resource)
+        }
+        teams = teams.exclude(
+            organization_id__in=object_rules.filter(resource__in=unresolvable).values("team__organization_id")
+        )
     if only_pending:
         teams = teams.exclude(organization__uses_most_specific_access_resolution=True)
 

--- a/products/access_control/backend/facade/resolution_preview.py
+++ b/products/access_control/backend/facade/resolution_preview.py
@@ -226,18 +226,23 @@ def _build_subjects(team: Team, user_access_control: UserAccessControl, rows: li
 def object_models(resource: str) -> list[type[Model]]:
     """Return the model classes that an object rule on `resource` can point at.
 
-    Return the display model when one exists. Otherwise return every team-scoped model
+    Return the display model first when one exists, then every other team-scoped model
     behind the resource's routes that the resolver maps back to `resource`. Return an
     empty list when no such model exists: the preview cannot resolve those rules.
     """
     display = display_model(resource)
-    if display is not None:
-        return [display.model]
-    models = resources_with_object_access_controls().get(cast(APIScopeObject, resource)) or frozenset()
-    return sorted(
-        (model for model in models if model_has_field(model, "team") and model_to_resource(model) == resource),
+    route_models = resources_with_object_access_controls().get(cast(APIScopeObject, resource)) or frozenset()
+    models = sorted(
+        (
+            model
+            for model in route_models
+            if model_has_field(model, "team")
+            and model_to_resource(model) == resource
+            and (display is None or model is not display.model)
+        ),
         key=lambda model: model.__name__,
     )
+    return [display.model, *models] if display is not None else models
 
 
 def _load_objects(team: Team, resource: str, object_ids: list[str]) -> dict[str, _LoadedObject]:

--- a/products/access_control/backend/facade/user_access_control.py
+++ b/products/access_control/backend/facade/user_access_control.py
@@ -344,6 +344,11 @@ def model_to_resource(model: Model) -> Optional[APIScopeObject]:
         return "replay_scanner"
     if name in ("visionalertconfiguration", "visionalertevent"):
         return "vision_alert"
+    # These scopes are served by several viewsets, each with its own model
+    if name in ("parserrecipe", "reviewqueue", "reviewqueueitem", "scoredefinition", "tracereview"):
+        return "llm_analytics"
+    if name in ("dataqualitycheck", "dataqualitysuiterun"):
+        return "warehouse_objects"
 
     if name not in API_SCOPE_OBJECTS or name in INTERNAL_API_SCOPE_OBJECTS:
         return None

--- a/products/access_control/backend/facade/user_access_control.py
+++ b/products/access_control/backend/facade/user_access_control.py
@@ -288,9 +288,9 @@ class ResolvedAccess:
     subject_name: Optional[str] = None
 
 
-def model_to_resource(model: Model) -> Optional[APIScopeObject]:
+def model_to_resource(model: Model | type[Model]) -> Optional[APIScopeObject]:
     """
-    Given a model, return the resource type it represents
+    Given a model instance or class, return the resource type it represents
     """
     if hasattr(model, "_meta"):
         name = model._meta.model_name

--- a/products/access_control/backend/tests/test_migrate_to_most_specific_access.py
+++ b/products/access_control/backend/tests/test_migrate_to_most_specific_access.py
@@ -88,6 +88,17 @@ class TestMigrateToMostSpecificAccess(BaseUserAccessControlTest):
         }
         assert "would be migrated" in out.getvalue()
 
+    def test_object_rules_the_preview_cannot_evaluate_stay_on_legacy(self) -> None:
+        # Nothing backs the account resource, so the preview cannot evaluate its object rows
+        # and an empty preview proves nothing for this organization
+        team = self.unchanged_organization.teams.get()
+        AccessControl.objects.create(team=team, resource="account", resource_id="1", access_level="none")
+        out = StringIO()
+        call_command("migrate_to_most_specific_access", stdout=out)
+
+        assert self._resolution_flags()["Unchanged org"] is False
+        assert f"{self.unchanged_organization.id}\tUnchanged org" in out.getvalue().split("could not be evaluated")[1]
+
     def test_rules_written_after_the_classification_block_the_switch(self) -> None:
         candidates = find_organizations_to_migrate()
         team = self.unchanged_organization.teams.get()

--- a/products/access_control/backend/tests/test_migrate_to_most_specific_access.py
+++ b/products/access_control/backend/tests/test_migrate_to_most_specific_access.py
@@ -13,6 +13,7 @@ from products.access_control.backend.facade.most_specific_migration import (
     enable_most_specific_resolution,
     find_organizations_to_migrate,
 )
+from products.access_control.backend.facade.resolution_preview import iter_resolution_changes
 from products.access_control.backend.models.access_control import AccessControl
 from products.access_control.backend.tests.test_user_access_control import BaseUserAccessControlTest
 from products.dashboards.backend.models.dashboard import Dashboard
@@ -88,9 +89,8 @@ class TestMigrateToMostSpecificAccess(BaseUserAccessControlTest):
         }
         assert "would be migrated" in out.getvalue()
 
-    def test_object_rules_the_preview_cannot_evaluate_stay_on_legacy(self) -> None:
-        # Nothing backs the account resource, so the preview cannot evaluate its object rows
-        # and an empty preview proves nothing for this organization
+    def test_object_rules_the_preview_cannot_resolve_stay_on_legacy(self) -> None:
+        # No model backs the account resource, so an empty preview proves nothing for this organization
         team = self.unchanged_organization.teams.get()
         AccessControl.objects.create(team=team, resource="account", resource_id="1", access_level="none")
         out = StringIO()
@@ -98,6 +98,22 @@ class TestMigrateToMostSpecificAccess(BaseUserAccessControlTest):
 
         assert self._resolution_flags()["Unchanged org"] is False
         assert f"{self.unchanged_organization.id}\tUnchanged org" in out.getvalue().split("could not be evaluated")[1]
+
+    def test_object_rules_on_a_resource_the_preview_skips_do_not_block_the_switch(self) -> None:
+        # Plugin rules are left out of the comparison on purpose, so they say nothing about resolvability
+        team = self.unchanged_organization.teams.get()
+        AccessControl.objects.create(team=team, resource="plugin", resource_id="1", access_level="none")
+        call_command("migrate_to_most_specific_access", stdout=StringIO())
+
+        assert self._resolution_flags()["Unchanged org"] is True
+
+    def test_single_organization_preview_still_sees_rules_it_cannot_resolve(self) -> None:
+        team = self.unchanged_organization.teams.get()
+        AccessControl.objects.create(team=team, resource="account", resource_id="1", access_level="none")
+
+        teams = [team for team, _ in iter_resolution_changes(str(self.unchanged_organization.id))]
+
+        assert teams == [team]
 
     def test_rules_written_after_the_classification_block_the_switch(self) -> None:
         candidates = find_organizations_to_migrate()

--- a/products/access_control/backend/tests/test_resolution_preview.py
+++ b/products/access_control/backend/tests/test_resolution_preview.py
@@ -120,6 +120,22 @@ class TestBuildResolutionPreview(BaseUserAccessControlTest):
         assert [(change.scope, change.object_id) for change in member_changes] == [("object", str(playlist.id))]
         assert (member_changes[0].current.access_level, member_changes[0].proposed.access_level) == ("editor", "none")
 
+    def test_object_rules_on_a_resource_without_a_display_model_are_compared(self):
+        # Exports have no display model, so the settings UI cannot name them, but the route
+        # model still backs the resource and the rule resolves like any other object rule
+        from products.exports.backend.models.exported_asset import ExportedAsset
+
+        asset = ExportedAsset.objects.create(team=self.team, created_by=self.other_user, export_format="text/csv")
+        self._create_access_control(resource="export", resource_id=str(asset.id), access_level="viewer")
+        self._create_access_control(resource="export", access_level="editor")
+
+        changes = self._changes()
+
+        assert [(change.scope, change.object_id, change.object_name) for change in changes] == [
+            ("object", str(asset.id), None)
+        ]
+        assert (changes[0].current.access_level, changes[0].proposed.access_level) == ("editor", "viewer")
+
     def test_creator_pairs_are_skipped(self):
         # Creators keep the highest level under both ladders, so their override never applies
         dashboard = Dashboard.objects.create(team=self.team, created_by=self.other_user)

--- a/products/access_control/backend/tests/test_resolution_preview.py
+++ b/products/access_control/backend/tests/test_resolution_preview.py
@@ -1,5 +1,8 @@
 import pytest
 
+from django.apps import apps
+
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models.organization import OrganizationMembership
@@ -120,19 +123,26 @@ class TestBuildResolutionPreview(BaseUserAccessControlTest):
         assert [(change.scope, change.object_id) for change in member_changes] == [("object", str(playlist.id))]
         assert (member_changes[0].current.access_level, member_changes[0].proposed.access_level) == ("editor", "none")
 
-    def test_object_rules_on_a_resource_without_a_display_model_are_compared(self):
-        # Exports have no display model, so the settings UI cannot name them, but the route
-        # model still backs the resource and the rule resolves like any other object rule
-        from products.exports.backend.models.exported_asset import ExportedAsset
-
-        asset = ExportedAsset.objects.create(team=self.team, created_by=self.other_user, export_format="text/csv")
-        self._create_access_control(resource="export", resource_id=str(asset.id), access_level="viewer")
-        self._create_access_control(resource="export", access_level="editor")
+    @parameterized.expand(
+        [
+            ("export", "exports", "exportedasset", {"export_format": "text/csv"}),
+            ("llm_analytics", "ai_observability", "scoredefinition", {"name": "Helpfulness", "kind": "numeric"}),
+        ]
+    )
+    def test_object_rules_on_a_resource_without_a_display_model_are_compared(
+        self, resource, app_label, model_name, fields
+    ):
+        # The settings UI cannot name these objects, but the route model still backs the
+        # resource and the rule resolves like any other object rule
+        model = apps.get_model(app_label, model_name)
+        obj = model.objects.create(team=self.team, created_by=self.other_user, **fields)
+        self._create_access_control(resource=resource, resource_id=str(obj.id), access_level="viewer")
+        self._create_access_control(resource=resource, access_level="editor")
 
         changes = self._changes()
 
         assert [(change.scope, change.object_id, change.object_name) for change in changes] == [
-            ("object", str(asset.id), None)
+            ("object", str(obj.id), None)
         ]
         assert (changes[0].current.access_level, changes[0].proposed.access_level) == ("editor", "viewer")
 

--- a/products/access_control/backend/tests/test_resolution_preview.py
+++ b/products/access_control/backend/tests/test_resolution_preview.py
@@ -11,6 +11,7 @@ from posthog.models.team.team import Team
 from posthog.models.utils import generate_random_token_personal, hash_key_value
 
 from products.access_control.backend.facade.resolution_preview import build_resolution_preview
+from products.access_control.backend.facade.user_access_control import RESOURCE_INHERITANCE_MAP
 from products.access_control.backend.models.access_control import AccessControl
 from products.access_control.backend.tests.test_user_access_control import BaseUserAccessControlTest
 from products.dashboards.backend.models.dashboard import Dashboard
@@ -127,17 +128,26 @@ class TestBuildResolutionPreview(BaseUserAccessControlTest):
         [
             ("export", "exports", "exportedasset", {"export_format": "text/csv"}),
             ("llm_analytics", "ai_observability", "scoredefinition", {"name": "Helpfulness", "kind": "numeric"}),
+            # warehouse_view has a display model (saved queries) and other route models beside it
+            (
+                "warehouse_view",
+                "data_tools",
+                "datawarehouseexpression",
+                {"table_name": "events", "field_name": "amount", "expression": "1"},
+            ),
         ]
     )
-    def test_object_rules_on_a_resource_without_a_display_model_are_compared(
+    def test_object_rules_on_models_the_settings_ui_cannot_name_are_compared(
         self, resource, app_label, model_name, fields
     ):
-        # The settings UI cannot name these objects, but the route model still backs the
+        # The settings UI cannot name these objects, but a route model still backs the
         # resource and the rule resolves like any other object rule
         model = apps.get_model(app_label, model_name)
-        obj = model.objects.create(team=self.team, created_by=self.other_user, **fields)
+        manager = model.objects.for_team(self.team.id) if hasattr(model.objects, "for_team") else model.objects
+        obj = manager.create(team=self.team, created_by=self.other_user, **fields)
         self._create_access_control(resource=resource, resource_id=str(obj.id), access_level="viewer")
-        self._create_access_control(resource=resource, access_level="editor")
+        # An inheriting resource takes its resource-level rules from its parent
+        self._create_access_control(resource=RESOURCE_INHERITANCE_MAP.get(resource, resource), access_level="editor")
 
         changes = self._changes()
 

--- a/products/access_control/backend/tests/test_user_access_control_pbt.py
+++ b/products/access_control/backend/tests/test_user_access_control_pbt.py
@@ -242,7 +242,11 @@ def build_instance(model_cls: type[models.Model], team: Team, user: User, _depth
         elif isinstance(field, models.IntegerField | models.FloatField | models.DecimalField):
             kwargs[field.name] = 0
         elif isinstance(field, models.CharField | models.TextField):
-            kwargs[field.name] = f"pbt-{field.name}-{next(_unique_counter)}"
+            if field.choices:
+                kwargs[field.name] = field.choices[0][0]
+            else:
+                value = f"pbt-{field.name}-{next(_unique_counter)}"
+                kwargs[field.name] = value[: field.max_length] if field.max_length else value
         else:
             raise ValueError(f"Cannot generically fill {model_cls.__name__}.{field.name} ({type(field).__name__})")
 


### PR DESCRIPTION
## Problem

This is a safeguard. A check of both production regions found no organization with a rule that this change affects. The change closes a gap that the API can open. 

The access resolution preview compares the legacy resolution with the most-specific resolution for every access rule in a team. The migration command in #94555 uses the same comparison. When the comparison reports no change for an organization, the command switches that organization to the most-specific resolution.

The comparison was incomplete. For an object rule, the preview must load the object the rule points at. It loaded objects only for resources that have a display model, which is the set of resources the settings UI can name. For all other resources, the preview dropped the object rules from the comparison.

With such a rule in place, two errors follow:

- On the preview page, an admin sees "nothing changes" for a team with an object rule on an export or a sharing configuration, even when that rule resolves differently after the switch.
- The migration command switches the organization to the most-specific resolution because its preview is empty, when the preview is empty only because the rules were dropped.

The settings UI cannot create such a rule. The per-object access control endpoint on each resource's API can. Four resources have models behind their routes but no display model: `export`, `sharing_configuration`, `llm_analytics`, and `warehouse_objects`. Three more resources have no model at all: `account`, `customer_analytics`, and `customer_journey`. The preview cannot load objects for these three.

For `llm_analytics` and `warehouse_objects` there is a second gap. The resolver did not map their models to a resource, so enforcement ignored object rules on them. A rule on a score definition or a data quality check had no effect, in either resolution.

Stacked on #94555.

## Changes

- **The preview loads objects through the route models when there is no display model.** `object_models(resource)` returns the display model when one exists, otherwise every team-scoped model behind the resource's routes (`resources_with_object_access_controls`). 
	- A rule on an export now shows up in the preview like any other object rule, with the raw id as the name.
- **Object rules on `llm_analytics` and `warehouse_objects` are enforced.** `model_to_resource` now maps the five AI observability models and the two data quality models to their scope. The per-object permission check and the list filter honor rules on them, and the preview can compare them. Both production regions hold no such rule today, so nothing changes for an existing organization.
- **The migration command skips organizations the preview cannot evaluate.** `iter_resolution_changes` leaves out organizations with object rules on a resource nothing backs (`account`, `customer_analytics`, `customer_journey`), so the migration in #94555 reports them as not evaluable instead of switching them on an incomplete comparison. Resources the comparison skips on purpose (`plugin`, `organization`) do not count. The single-organization preview command does not apply the skip, so it still shows the organization.
- No change for resources that already had a display model.

## How did you test this code?

Tests: `test_resolution_preview.py` adds cases where an object rule on an export and on a score definition resolve differently and asserts the preview reports them, with no name. `test_migrate_to_most_specific_access.py` adds cases that an organization with `account` object rules stays on legacy, that a `plugin` rule does not block the switch, and that the single-organization path still yields the team. The property-based suite now builds the new models, so its generic field filler respects `choices` and `max_length`. Ran the access-control suites and the AI observability and data quality API tests locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No

