### PR TITLE
fix(databricks): stop retrying a workspace-entitlement rejection

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/databricks/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/databricks/source.py
@@ -48,6 +48,9 @@ DatabricksErrors = {
     "Name or service not known": "Can't resolve the server hostname. Check the server hostname and try again.",
     "Failed to resolve": "Can't resolve the server hostname. Check the server hostname and try again.",
     "is blocked by Databricks IP ACL for workspace": "PostHog's IP address is blocked by your Databricks workspace's IP access control list. Add PostHog's IP addresses to the workspace's IP ACL, then try again.",
+    # Workspace-level entitlement, not a Unity Catalog grant — a separate admin setting from
+    # PERMISSION_DENIED/INSUFFICIENT_PERMISSIONS above.
+    "databricks-sql-access or workspace-consume entitlements": "Your Databricks credentials don't have the databricks-sql-access or workspace-consume entitlement. Grant one of those entitlements to the connecting user or service principal in your Databricks workspace admin settings, then try again.",
 }
 
 
@@ -186,6 +189,9 @@ class DatabricksSource(SQLSource[DatabricksSourceConfig], ValidateDatabaseHostMi
             # Workspace-level IP ACL rejection — a customer-side network config that retrying can
             # never satisfy. Match the stable phrase, ignoring the appended IP and workspace id.
             "is blocked by Databricks IP ACL for workspace": "PostHog's IP address is blocked by your Databricks workspace's IP access control list. Add PostHog's IP addresses to the workspace's IP ACL, then resync.",
+            # Workspace-level entitlement, not a Unity Catalog grant — a separate admin setting from
+            # PERMISSION_DENIED/INSUFFICIENT_PERMISSIONS above.
+            "databricks-sql-access or workspace-consume entitlements": "Your Databricks credentials don't have the databricks-sql-access or workspace-consume entitlement. Grant one of those entitlements to the connecting user or service principal in your Databricks workspace admin settings, then resync.",
         }
 
     def validate_credentials(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/databricks/tests/test_databricks.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/databricks/tests/test_databricks.py
@@ -512,6 +512,8 @@ class TestDatabricksSource:
             # Workspace IP ACL rejection — matched on the stable phrase, ignoring the appended IP
             # address and workspace id.
             "Error during request to server: : Source IP address: 44.208.188.173 is blocked by Databricks IP ACL for workspace: 1557520918149316. ",
+            # Workspace-level entitlement missing on the connecting user/service principal.
+            "Error during request to server: : This API is disabled for users without the databricks-sql-access or workspace-consume entitlements. Contact your administrator for more information.. ",
         ],
     )
     def test_permanent_failures_are_non_retryable(self, source, error_msg):
@@ -554,6 +556,12 @@ class TestDatabricksSource:
                 "IP access control list",
             ),
             ("[RESOURCE_DOES_NOT_EXIST] Warehouse abc123 does not exist.", "SQL warehouse"),
+            (
+                "Error during request to server: : This API is disabled for users without the"
+                " databricks-sql-access or workspace-consume entitlements. Contact your administrator"
+                " for more information.. ",
+                "entitlement",
+            ),
             ("something totally unexpected", "Could not connect to Databricks"),
         ],
     )


### PR DESCRIPTION
## Problem

A Databricks sync keeps retrying when the connecting user or service
principal lacks the `databricks-sql-access` or `workspace-consume`
entitlement, since Databricks rejects every retry identically. An
[error tracking issue](https://us.posthog.com/project/2/error_tracking/01a06dba-7fad-7901-a44e-c3ce17bab928)
shows this raised from `connect()` in the Databricks source.

## Changes

- Syncs stop retrying once Databricks reports the missing entitlement, and
  surface a message naming the fix (grant the entitlement in the workspace
  admin settings) instead of retrying until the job times out.
- The same message now appears when a user first sets up the source with
  credentials missing this entitlement.
- Both changes add the same stable error phrase to an existing lookup table,
  matching the pattern already used for other Databricks permission errors.

## How did you test this code?

- Added two parametrized test cases (one per error map) asserting the new
  phrase is recognized. Ran the full Databricks source test suite locally:
  `pytest products/warehouse_sources/backend/temporal/data_imports/sources/databricks/tests/test_databricks.py`
  — 77 passed.
- Not run: a live Databricks connection, since this only changes error-string
  matching around raised exceptions.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking MCP tools (`query-error-tracking-issue`,
`query-error-tracking-issue-events`) to confirm the stack trace originates in
`products/warehouse_sources/backend/temporal/data_imports/sources/databricks/databricks.py`
and that the message is a stable Databricks entitlement rejection with no
volatile parts. Checked open PRs (by search terms and by the automation's own
`posthog/` branches) for an existing fix; found none. Mirrored the
`get_non_retryable_errors` pattern from
`products/warehouse_sources/backend/temporal/data_imports/sources/stripe/source.py`
and the existing Databricks permission-error entries in
`DatabricksErrors`/`get_non_retryable_errors`.
