### PR TITLE
feat(heatmaps): add a setup empty state to the heatmaps scene

### DIFF
--- a/docs/internal/product-empty-state-adoption.md
+++ b/docs/internal/product-empty-state-adoption.md
@@ -34,42 +34,47 @@ tiles, or `FeaturePreviewSceneGate` rather than scene empty states.
 
 Rows marked "in review" are not on `master` yet. See "Regenerating the lists" for a live count.
 
-| Product                | Scene                                                                               | Status                |
-| ---------------------- | ----------------------------------------------------------------------------------- | --------------------- |
-| MCP analytics          | `products/mcp_analytics/frontend/MCPAnalyticsScene.tsx`                             | on master (reference) |
-| LLM analytics          | `products/ai_observability/frontend/AIObservabilityScene.tsx`                       | on master             |
-| LLM prompts            | `products/ai_observability/frontend/prompts/LLMPromptsScene.tsx`                    | on master             |
-| Support                | `products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx`            | on master             |
-| Early access features  | `products/early_access_features/frontend/EarlyAccessFeatures.tsx`                   | on master             |
-| Endpoints              | `products/endpoints/frontend/EndpointsScene.tsx`                                    | on master             |
-| Experiments            | `products/experiments/frontend/scenes/ExperimentsScene.tsx`                         | on master             |
-| Feature flags          | `frontend/src/scenes/feature-flags/FeatureFlags.tsx`                                | on master             |
-| Links                  | `products/links/frontend/LinksScene.tsx`                                            | on master             |
-| Product tours          | `frontend/src/scenes/product-tours/ProductTours.tsx`                                | on master             |
-| Replay vision          | `products/replay_vision/frontend/replay_scanners/ReplayScannersScene.tsx`           | on master             |
-| Skills                 | `products/skills/frontend/LLMSkillsScene.tsx`                                       | on master             |
-| User interviews        | `products/user_interviews/frontend/UserInterviews.tsx`                              | on master             |
-| Web scripts            | `frontend/src/scenes/data-pipelines/WebScriptsScene.tsx`                            | on master             |
-| Error tracking         | `products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx` | on master             |
-| Logs                   | `products/logs/frontend/LogsScene.tsx`                                              | on master             |
-| Tracing                | `products/tracing/frontend/TracingScene.tsx`                                        | on master             |
-| Metrics                | `products/metrics/frontend/MetricsScene.tsx`                                        | on master             |
-| Surveys                | `frontend/src/scenes/surveys/Surveys.tsx`                                           | on master             |
-| Session replay         | `frontend/src/scenes/session-recordings/SessionRecordings.tsx`                      | on master             |
-| Web vitals             | `frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx`                           | on master             |
-| Data warehouse sources | `products/data_warehouse/frontend/scenes/SourcesScene/SourcesScene.tsx`             | on master             |
-| Workflows              | `products/workflows/frontend/WorkflowsScene.tsx`                                    | on master             |
-| Marketing analytics    | `frontend/src/scenes/marketing-analytics/MarketingAnalyticsScene.tsx`               | on master             |
-| Customer analytics     | `products/customer_analytics/frontend/CustomerAnalyticsScene.tsx`                   | on master             |
-| Actions                | `products/actions/frontend/pages/Actions.tsx`                                       | on master             |
-| Annotations            | `frontend/src/scenes/annotations/Annotations.tsx`                                   | on master             |
-| Cohorts                | `frontend/src/scenes/cohorts/Cohorts.tsx`                                           | on master             |
-| Dashboards             | `frontend/src/scenes/dashboard/dashboards/Dashboards.tsx`                           | on master             |
-| Product analytics      | `frontend/src/scenes/saved-insights/SavedInsights.tsx`                              | on master             |
-| Notebooks              | `frontend/src/scenes/notebooks/NotebooksScene.tsx`                                  | on master             |
-| Alerts                 | `products/alerts/frontend/AlertsScene.tsx`                                          | on master             |
-| Data catalog           | `products/data_catalog/frontend/DataCatalogScene.tsx`                               | on master             |
-| Subscriptions          | `products/subscriptions/frontend/scenes/SubscriptionsScene.tsx`                     | on master             |
+| Product                | Scene                                                                                | Status                |
+| ---------------------- | ------------------------------------------------------------------------------------ | --------------------- |
+| MCP analytics          | `products/mcp_analytics/frontend/MCPAnalyticsScene.tsx`                              | on master (reference) |
+| LLM analytics          | `products/ai_observability/frontend/AIObservabilityScene.tsx`                        | on master             |
+| LLM prompts            | `products/ai_observability/frontend/prompts/LLMPromptsScene.tsx`                     | on master             |
+| Support                | `products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx`             | on master             |
+| Early access features  | `products/early_access_features/frontend/EarlyAccessFeatures.tsx`                    | on master             |
+| Endpoints              | `products/endpoints/frontend/EndpointsScene.tsx`                                     | on master             |
+| Experiments            | `products/experiments/frontend/scenes/ExperimentsScene.tsx`                          | on master             |
+| Feature flags          | `frontend/src/scenes/feature-flags/FeatureFlags.tsx`                                 | on master             |
+| Links                  | `products/links/frontend/LinksScene.tsx`                                             | on master             |
+| Product tours          | `frontend/src/scenes/product-tours/ProductTours.tsx`                                 | on master             |
+| Replay vision          | `products/replay_vision/frontend/replay_scanners/ReplayScannersScene.tsx`            | on master             |
+| Skills                 | `products/skills/frontend/LLMSkillsScene.tsx`                                        | on master             |
+| User interviews        | `products/user_interviews/frontend/UserInterviews.tsx`                               | on master             |
+| Web scripts            | `frontend/src/scenes/data-pipelines/WebScriptsScene.tsx`                             | on master             |
+| Error tracking         | `products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx`  | on master             |
+| Logs                   | `products/logs/frontend/LogsScene.tsx`                                               | on master             |
+| Tracing                | `products/tracing/frontend/TracingScene.tsx`                                         | on master             |
+| Metrics                | `products/metrics/frontend/MetricsScene.tsx`                                         | on master             |
+| Surveys                | `frontend/src/scenes/surveys/Surveys.tsx`                                            | on master             |
+| Session replay         | `frontend/src/scenes/session-recordings/SessionRecordings.tsx`                       | on master             |
+| Web vitals             | `frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx`                            | on master             |
+| Data warehouse sources | `products/data_warehouse/frontend/scenes/SourcesScene/SourcesScene.tsx`              | on master             |
+| Workflows              | `products/workflows/frontend/WorkflowsScene.tsx`                                     | on master             |
+| Marketing analytics    | `frontend/src/scenes/marketing-analytics/MarketingAnalyticsScene.tsx`                | on master             |
+| Customer analytics     | `products/customer_analytics/frontend/CustomerAnalyticsScene.tsx`                    | on master             |
+| Actions                | `products/actions/frontend/pages/Actions.tsx`                                        | on master             |
+| Annotations            | `frontend/src/scenes/annotations/Annotations.tsx`                                    | on master             |
+| Cohorts                | `frontend/src/scenes/cohorts/Cohorts.tsx`                                            | on master             |
+| Dashboards             | `frontend/src/scenes/dashboard/dashboards/Dashboards.tsx`                            | on master             |
+| Product analytics      | `frontend/src/scenes/saved-insights/SavedInsights.tsx`                               | on master             |
+| Notebooks              | `frontend/src/scenes/notebooks/NotebooksScene.tsx`                                   | on master             |
+| Alerts                 | `products/alerts/frontend/AlertsScene.tsx`                                           | on master             |
+| Data catalog           | `products/data_catalog/frontend/DataCatalogScene.tsx`                                | on master             |
+| Subscriptions          | `products/subscriptions/frontend/scenes/SubscriptionsScene.tsx`                      | on master             |
+| AI datasets            | `products/ai_observability/frontend/datasets/AIObservabilityDatasetsScene.tsx`       | on master             |
+| AI evaluations         | `products/ai_observability/frontend/evaluations/AIObservabilityEvaluationsScene.tsx` | on master             |
+| AI clusters            | `products/ai_observability/frontend/clusters/AIObservabilityClustersScene.tsx`       | on master             |
+| Business knowledge     | `products/business_knowledge/frontend/scenes/BusinessKnowledgeScene.tsx`             | on master             |
+| Heatmaps               | `products/web_analytics/frontend/heatmaps/scenes/heatmaps/HeatmapsScene.tsx`         | on master             |
 
 Only four products resolve their status at app boot, via a `setupProbe` in their manifest:
 LLM analytics, error tracking, MCP analytics, web analytics.
@@ -115,10 +120,10 @@ Max conversation history, and data pipelines destinations and transformations
 (`frontend/src/scenes/data-pipelines/DataPipelinesHogFunctions.tsx` covers the last two).
 
 Hand-rolled empty states: review hog, streamlit apps, groups (`GroupsIntroduction`), persons, and
-the LLM analytics sessions and evaluations tabs.
+the LLM analytics sessions tab.
 
 Bare string or nothing: the data warehouse overview scene, SQL editor, data modeling,
-heatmaps, business knowledge, legal documents, MCP gateway, visual review, live debugger, batch
+legal documents, MCP gateway, visual review, live debugger, batch
 exports, experiments shared metrics, skills community, and several LLM analytics sub-tabs.
 
 ## Out of scope

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1852,6 +1852,10 @@ snapshots:
         hash: v1.k794b7964.75f63a26a820ea1d1261897b278f1cbe04c46ba50431f7b0b087803000a73591.xzu_boakPi1km0kgLmyNk5EuD4YG0CdPl6LYEiJjp8I
     components-product-empty-state--feature-flags-needs-setup--light:
         hash: v1.k794b7964.34d494ddf930bbfa26d1233de53e3ecbb2abd594f02e6320efdc170b55bfb858.MdeFEd9dR9MxST9SByounoWeAdLp4nhfKm-sS3Xln7A
+    components-product-empty-state--heatmaps-needs-setup--dark:
+        hash: v1.k794b7964.0f8d204fc21b6a4a4c4a44713855b69d2b6771869fdf56d6f3f0352f2c6099dd.OfNvsrwPP74BsmuHwheLT7PfzqvWozBGArKPtYQqiOE
+    components-product-empty-state--heatmaps-needs-setup--light:
+        hash: v1.k794b7964.72acaab1bc71bf2486109cf133c3fb66f21039afac6b3a26a7806636371a73af.T6jgYO3dwmpgalMH-yLm7MyfozQQIdyhWhtzXPd0UGM
     components-product-empty-state--hog-layout-responsive--dark:
         hash: v1.k794b7964.8c137beea63f1365924e6f66a2d70092161a78859f5de68c0f01fbaa8ece1cdb.Cc2QUvwJ0APGb2C7S5ETG1EfPK0rUmD5RiypJLrfX2c
     components-product-empty-state--hog-layout-responsive--light:

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
@@ -378,10 +378,7 @@ export const NotebooksNeedsSetup: ProductEmptyStateStory = productEmptyStateStor
     mocks: { get: { '/api/projects/:team_id/notebooks/': [200, { count: 0, results: [] }] } },
 })
 
-// Heatmaps detection counts saved heatmaps on mount - answer "none yet".
-export const HeatmapsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(heatmapsEmptyState, 'needs-setup', {
-    mocks: { get: { '/api/projects/:team_id/saved/': [200, { count: 0, results: [] }] } },
-})
+export const HeatmapsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(heatmapsEmptyState, 'needs-setup')
 
 // Data warehouse detection lists sources and tables on mount - answer "none yet".
 export const DataWarehouseNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
@@ -39,6 +39,7 @@ import { surveysEmptyState } from 'products/surveys/frontend/emptyState/surveysE
 import { tracingEmptyState } from 'products/tracing/frontend/emptyState/tracingEmptyState'
 import { userInterviewsEmptyState } from 'products/user_interviews/frontend/emptyState/userInterviewsEmptyState'
 import { webVitalsEmptyState } from 'products/web_analytics/frontend/emptyState/webVitalsEmptyState'
+import { heatmapsEmptyState } from 'products/web_analytics/frontend/heatmaps/emptyState/heatmapsEmptyState'
 import { workflowsEmptyState } from 'products/workflows/frontend/emptyState/workflowsEmptyState'
 
 import { ProductEmptyState } from './ProductEmptyState'
@@ -375,6 +376,11 @@ export const DataCatalogNeedsSetup: ProductEmptyStateStory = productEmptyStateSt
 // Notebooks detection counts notebooks on mount - answer "none yet".
 export const NotebooksNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(notebooksEmptyState, 'needs-setup', {
     mocks: { get: { '/api/projects/:team_id/notebooks/': [200, { count: 0, results: [] }] } },
+})
+
+// Heatmaps detection counts saved heatmaps on mount - answer "none yet".
+export const HeatmapsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(heatmapsEmptyState, 'needs-setup', {
+    mocks: { get: { '/api/projects/:team_id/saved/': [200, { count: 0, results: [] }] } },
 })
 
 // Data warehouse detection lists sources and tables on mount - answer "none yet".

--- a/products/web_analytics/frontend/heatmaps/emptyState/HeatmapsPreview.scss
+++ b/products/web_analytics/frontend/heatmaps/emptyState/HeatmapsPreview.scss
@@ -48,6 +48,7 @@
 
     &__head {
         display: flex;
+        flex-wrap: wrap;
         gap: 0.5rem;
         align-items: center;
         padding: 0.5rem 0.75rem;

--- a/products/web_analytics/frontend/heatmaps/emptyState/HeatmapsPreview.scss
+++ b/products/web_analytics/frontend/heatmaps/emptyState/HeatmapsPreview.scss
@@ -1,0 +1,439 @@
+@import '../../../../../frontend/src/lib/components/ProductEmptyState/previewMixins';
+
+.HeatmapsPreview {
+    --heatmaps-preview-accent: var(--empty-state-accent, var(--color-product-heatmaps-light));
+
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    // Hidden overlay choice. Direct children of .HeatmapsPreview so `:checked ~` reaches both cards.
+    &__radio {
+        position: absolute;
+        width: 0;
+        height: 0;
+        pointer-events: none;
+        opacity: 0;
+    }
+
+    &__panel,
+    &__stat {
+        overflow: hidden;
+        background: var(--color-bg-surface-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius);
+    }
+
+    // Clicks/scroll pairs are stacked on one grid cell and crossfaded, so switching the
+    // overlay never changes any element's size (no layout shift).
+    &__swap {
+        display: grid;
+    }
+
+    &__swap > * {
+        grid-area: 1 / 1;
+        min-width: 0;
+    }
+
+    &__when-clicks,
+    &__overlay--clicks {
+        @include preview-swap-visible;
+    }
+
+    &__when-scroll,
+    &__overlay--scroll {
+        @include preview-swap-hidden;
+    }
+
+    &__head {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__title {
+        flex: 1;
+        font-size: 0.75rem;
+        font-weight: 600;
+    }
+
+    // Segmented overlay switch
+
+    &__segments {
+        display: flex;
+        padding: 2px;
+        background: var(--color-bg-fill-tertiary);
+        border-radius: var(--radius);
+    }
+
+    &__segment {
+        padding: 0.125rem 0.5rem;
+        font-size: 0.625rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        border-radius: calc(var(--radius) - 2px);
+        transition:
+            background $preview-swap-duration ease,
+            color $preview-swap-duration ease;
+    }
+
+    // Fake browser chrome and page
+
+    &__chrome {
+        display: flex;
+        gap: 0.25rem;
+        align-items: center;
+        padding: 0.375rem 0.625rem;
+        background: var(--color-bg-fill-primary);
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__url {
+        flex: 1;
+        padding: 0.125rem 0.5rem;
+        margin-left: 0.375rem;
+        font-family: var(--font-mono);
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+        background: var(--color-bg-surface-primary);
+        border-radius: 999px;
+    }
+
+    &__page {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 0.625rem 0.875rem 0.875rem;
+        overflow: hidden;
+        background: var(--color-bg-surface-primary);
+    }
+
+    &__nav {
+        display: flex;
+        gap: 0.375rem;
+        align-items: center;
+    }
+
+    &__logo {
+        width: 14px;
+        height: 14px;
+        background: color-mix(in oklab, var(--heatmaps-preview-accent) 40%, var(--color-bg-fill-tertiary));
+        border-radius: 4px;
+    }
+
+    &__nav-item {
+        width: 22px;
+        height: 5px;
+        background: var(--color-bg-fill-tertiary);
+        border-radius: 999px;
+
+        &--wide {
+            width: 34px;
+            margin-left: auto;
+        }
+    }
+
+    &__hero {
+        display: flex;
+        flex-direction: column;
+        gap: 0.375rem;
+        align-items: flex-start;
+    }
+
+    &__line {
+        height: 6px;
+        background: var(--color-bg-fill-tertiary);
+        border-radius: 999px;
+
+        &--title {
+            width: 62%;
+            height: 9px;
+            background: var(--color-bg-fill-secondary, var(--color-bg-fill-tertiary));
+        }
+
+        &--sub {
+            width: 44%;
+        }
+    }
+
+    &__button {
+        padding: 0.1875rem 0.5rem;
+        margin-top: 0.125rem;
+        font-size: 0.5625rem;
+        font-weight: 600;
+        color: var(--color-bg-surface-primary);
+        background: var(--color-text-primary);
+        border-radius: 4px;
+    }
+
+    &__plans {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 0.375rem;
+    }
+
+    &__plan {
+        height: 34px;
+        background: var(--color-bg-fill-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: 4px;
+
+        &--featured {
+            border-color: color-mix(in oklab, var(--heatmaps-preview-accent) 50%, var(--color-border-primary));
+        }
+    }
+
+    // Overlays sit on top of the whole page and share one cell.
+
+    &__overlays {
+        position: absolute;
+        inset: 0;
+        display: grid;
+    }
+
+    &__overlay {
+        position: relative;
+        grid-area: 1 / 1;
+    }
+
+    // Click heat: radial blobs, hottest on the primary button.
+
+    &__blob {
+        position: absolute;
+        border-radius: 50%;
+        transform: translate(-50%, -50%);
+        animation: HeatmapsPreview__breathe 3.6s ease-in-out infinite;
+
+        &--hot {
+            top: 51%;
+            left: 15%;
+            width: 58px;
+            height: 58px;
+            background: radial-gradient(
+                circle,
+                rgb(239 68 68 / 85%) 0%,
+                rgb(249 115 22 / 65%) 30%,
+                rgb(250 204 21 / 40%) 55%,
+                transparent 75%
+            );
+        }
+
+        &--warm {
+            top: 45%;
+            left: 34%;
+            width: 40px;
+            height: 40px;
+            background: radial-gradient(circle, rgb(249 115 22 / 55%) 0%, rgb(250 204 21 / 35%) 45%, transparent 75%);
+            animation-delay: -1.2s;
+        }
+
+        &--nav {
+            top: 11%;
+            left: 88%;
+            width: 34px;
+            height: 34px;
+            background: radial-gradient(circle, rgb(250 204 21 / 55%) 0%, rgb(34 197 94 / 30%) 50%, transparent 75%);
+            animation-delay: -2.4s;
+        }
+
+        &--plan {
+            top: 82%;
+            left: 50%;
+            width: 46px;
+            height: 46px;
+            background: radial-gradient(circle, rgb(249 115 22 / 60%) 0%, rgb(250 204 21 / 35%) 45%, transparent 75%);
+            animation-delay: -0.6s;
+        }
+    }
+
+    &__rage {
+        position: absolute;
+        top: 82%;
+        left: 50%;
+        display: flex;
+        gap: 0.25rem;
+        align-items: center;
+        transform: translate(-50%, -50%);
+    }
+
+    &__rage-ring {
+        width: 10px;
+        height: 10px;
+        border: 2px solid rgb(239 68 68);
+        border-radius: 50%;
+        animation: HeatmapsPreview__ring 1.6s ease-out infinite;
+    }
+
+    &__rage-label {
+        padding: 0.0625rem 0.3125rem;
+        font-size: 0.5rem;
+        font-weight: 600;
+        color: var(--color-bg-surface-primary);
+        white-space: nowrap;
+        background: rgb(239 68 68);
+        border-radius: 999px;
+    }
+
+    // Scroll depth: horizontal bands from "everyone saw this" to "few got here".
+
+    &__band {
+        position: absolute;
+        right: 0;
+        left: 0;
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        padding-right: 0.5rem;
+        font-size: 0.5625rem;
+        font-weight: 700;
+        color: var(--color-text-primary);
+
+        &--1 {
+            top: 0;
+            height: 24%;
+            background: rgb(239 68 68 / 32%);
+        }
+
+        &--2 {
+            top: 24%;
+            height: 26%;
+            background: rgb(249 115 22 / 30%);
+        }
+
+        &--3 {
+            top: 50%;
+            height: 24%;
+            background: rgb(250 204 21 / 30%);
+        }
+
+        &--4 {
+            top: 74%;
+            height: 26%;
+            background: rgb(59 130 246 / 26%);
+        }
+    }
+
+    // Stat card
+
+    &__stat {
+        padding: 0.625rem 0.75rem 0.75rem;
+    }
+
+    &__spark-caption {
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    &__footer {
+        margin-top: 0.375rem;
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    &__spark-area {
+        fill: color-mix(in oklab, var(--heatmaps-preview-accent) 13%, transparent);
+        stroke: none;
+    }
+
+    &__spark-line {
+        fill: none;
+        stroke: color-mix(in oklab, var(--heatmaps-preview-accent) 32%, transparent);
+        stroke-width: 2;
+    }
+
+    // The moving bit: a short bright segment cycling along the line.
+    &__spark-trace {
+        fill: none;
+        stroke: var(--heatmaps-preview-accent);
+        stroke-dasharray: 16 84;
+        stroke-linecap: round;
+        stroke-width: 2;
+        animation: HeatmapsPreview__trace 3.2s linear infinite;
+    }
+
+    @include preview-chrome-dot;
+    @include preview-sparkline;
+}
+
+// The sparkline mixin lays the value out as a flex row, which would place the two crossfading
+// values side by side; the swap needs them stacked on one grid cell.
+.HeatmapsPreview__spark-value.HeatmapsPreview__swap {
+    display: grid;
+}
+
+// Selected segment: painted from the radios, so the switch and the overlay always agree.
+
+.HeatmapsPreview__radio--clicks:checked
+    ~ .HeatmapsPreview__panel
+    .HeatmapsPreview__segment[for='heatmaps-preview-clicks'],
+.HeatmapsPreview__radio--scroll:checked
+    ~ .HeatmapsPreview__panel
+    .HeatmapsPreview__segment[for='heatmaps-preview-scroll'] {
+    background: var(--color-bg-surface-primary);
+    box-shadow: 0 1px 2px rgb(0 0 0 / 10%);
+
+    @include preview-accent-text(var(--heatmaps-preview-accent));
+}
+
+// Scroll depth selected
+
+.HeatmapsPreview__radio--scroll:checked ~ * .HeatmapsPreview__when-scroll,
+.HeatmapsPreview__radio--scroll:checked ~ * .HeatmapsPreview__overlay--scroll {
+    @include preview-swap-visible;
+}
+
+.HeatmapsPreview__radio--scroll:checked ~ * .HeatmapsPreview__when-clicks,
+.HeatmapsPreview__radio--scroll:checked ~ * .HeatmapsPreview__overlay--clicks {
+    @include preview-swap-hidden;
+}
+
+// The radios stay keyboard-focusable while visually hidden, so the segment each one
+// labels needs a visible focus indicator (WCAG 2.4.7).
+.HeatmapsPreview__radio--clicks:focus-visible
+    ~ .HeatmapsPreview__panel
+    .HeatmapsPreview__segment[for='heatmaps-preview-clicks'],
+.HeatmapsPreview__radio--scroll:focus-visible
+    ~ .HeatmapsPreview__panel
+    .HeatmapsPreview__segment[for='heatmaps-preview-scroll'] {
+    outline: 2px solid var(--heatmaps-preview-accent);
+    outline-offset: -2px;
+}
+
+@keyframes HeatmapsPreview__breathe {
+    0%,
+    100% {
+        transform: translate(-50%, -50%) scale(1);
+    }
+
+    50% {
+        transform: translate(-50%, -50%) scale(1.12);
+    }
+}
+
+@keyframes HeatmapsPreview__ring {
+    0% {
+        opacity: 0.9;
+        transform: scale(0.6);
+    }
+
+    100% {
+        opacity: 0;
+        transform: scale(2.2);
+    }
+}
+
+// pathLength is normalized to 100, so the dash offset loops cleanly regardless of length.
+@keyframes HeatmapsPreview__trace {
+    to {
+        stroke-dashoffset: -100;
+    }
+}
+
+// Storybook snapshots and reduced motion drop all ambient motion; switching the overlay
+// still works (transitions only).
+@include preview-motion-guards('HeatmapsPreview');

--- a/products/web_analytics/frontend/heatmaps/emptyState/HeatmapsPreview.tsx
+++ b/products/web_analytics/frontend/heatmaps/emptyState/HeatmapsPreview.tsx
@@ -1,0 +1,139 @@
+import './HeatmapsPreview.scss'
+
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { cn } from 'lib/utils/css-classes'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+
+// Hand-authored daily series of clicks on the page's primary button.
+const LINE = 'M 0 30 L 14 27 L 28 29 L 42 22 L 56 24 L 70 16 L 84 14 L 100 9'
+
+function areaPath(line: string): string {
+    return `${line} L 100 40 L 0 40 Z`
+}
+
+/**
+ * Example-data preview for the heatmaps empty state: a saved heatmap of a landing page
+ * with two overlays, clicks and scroll depth, plus the stat card for its primary button.
+ * A hidden radio pair drives the overlay switch via `:checked ~` styles - no timers or
+ * state, per the preview rules in the `building-product-empty-states` skill. Both
+ * overlays share one grid cell and crossfade, so switching never moves the page.
+ */
+export function HeatmapsPreview(): JSX.Element {
+    const isStatic = inStorybook() || inStorybookTestRunner()
+
+    return (
+        <div className={cn('HeatmapsPreview', isStatic && 'HeatmapsPreview--static')}>
+            {/* Overlay choice, before both cards so `:checked ~` can style them. */}
+            <input
+                type="radio"
+                name="heatmaps-preview-overlay"
+                id="heatmaps-preview-clicks"
+                className="HeatmapsPreview__radio HeatmapsPreview__radio--clicks"
+                defaultChecked
+            />
+            <input
+                type="radio"
+                name="heatmaps-preview-overlay"
+                id="heatmaps-preview-scroll"
+                className="HeatmapsPreview__radio HeatmapsPreview__radio--scroll"
+            />
+
+            <div className="HeatmapsPreview__panel">
+                <div className="HeatmapsPreview__head">
+                    <span className="HeatmapsPreview__title">Pricing page</span>
+                    <div className="HeatmapsPreview__segments" role="group" aria-label="Overlay">
+                        <label htmlFor="heatmaps-preview-clicks" className="HeatmapsPreview__segment">
+                            Clicks
+                        </label>
+                        <label htmlFor="heatmaps-preview-scroll" className="HeatmapsPreview__segment">
+                            Scroll depth
+                        </label>
+                    </div>
+                    <LemonTag size="small">example data</LemonTag>
+                </div>
+
+                <div className="HeatmapsPreview__chrome" aria-hidden="true">
+                    <span className="HeatmapsPreview__chrome-dot" />
+                    <span className="HeatmapsPreview__chrome-dot" />
+                    <span className="HeatmapsPreview__chrome-dot" />
+                    <span className="HeatmapsPreview__url">example.com/pricing</span>
+                </div>
+
+                <div className="HeatmapsPreview__page" aria-hidden="true">
+                    <div className="HeatmapsPreview__nav">
+                        <span className="HeatmapsPreview__logo" />
+                        <span className="HeatmapsPreview__nav-item" />
+                        <span className="HeatmapsPreview__nav-item" />
+                        <span className="HeatmapsPreview__nav-item HeatmapsPreview__nav-item--wide" />
+                    </div>
+                    <div className="HeatmapsPreview__hero">
+                        <span className="HeatmapsPreview__line HeatmapsPreview__line--title" />
+                        <span className="HeatmapsPreview__line HeatmapsPreview__line--sub" />
+                        <span className="HeatmapsPreview__button">Start free</span>
+                    </div>
+                    <div className="HeatmapsPreview__plans">
+                        <span className="HeatmapsPreview__plan" />
+                        <span className="HeatmapsPreview__plan HeatmapsPreview__plan--featured" />
+                        <span className="HeatmapsPreview__plan" />
+                    </div>
+
+                    <div className="HeatmapsPreview__overlays">
+                        <div className="HeatmapsPreview__overlay HeatmapsPreview__overlay--clicks">
+                            <span className="HeatmapsPreview__blob HeatmapsPreview__blob--hot" />
+                            <span className="HeatmapsPreview__blob HeatmapsPreview__blob--warm" />
+                            <span className="HeatmapsPreview__blob HeatmapsPreview__blob--nav" />
+                            <span className="HeatmapsPreview__blob HeatmapsPreview__blob--plan" />
+                            <span className="HeatmapsPreview__rage">
+                                <span className="HeatmapsPreview__rage-ring" />
+                                <span className="HeatmapsPreview__rage-label">Rage clicks</span>
+                            </span>
+                        </div>
+                        <div className="HeatmapsPreview__overlay HeatmapsPreview__overlay--scroll">
+                            <span className="HeatmapsPreview__band HeatmapsPreview__band--1">100%</span>
+                            <span className="HeatmapsPreview__band HeatmapsPreview__band--2">81%</span>
+                            <span className="HeatmapsPreview__band HeatmapsPreview__band--3">46%</span>
+                            <span className="HeatmapsPreview__band HeatmapsPreview__band--4">17%</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div className="HeatmapsPreview__stat">
+                <div className="HeatmapsPreview__spark-head">
+                    <span className="HeatmapsPreview__spark-title HeatmapsPreview__swap">
+                        <span className="HeatmapsPreview__when-clicks">Clicks on "Start free"</span>
+                        <span className="HeatmapsPreview__when-scroll">Visitors reaching the plans</span>
+                    </span>
+                    <span className="HeatmapsPreview__spark-caption">Last 7 days</span>
+                </div>
+                <div className="HeatmapsPreview__spark-value HeatmapsPreview__swap">
+                    <span className="HeatmapsPreview__when-clicks">1,284</span>
+                    <span className="HeatmapsPreview__when-scroll">46%</span>
+                </div>
+                <svg
+                    className="HeatmapsPreview__spark-svg"
+                    viewBox="0 0 100 40"
+                    preserveAspectRatio="none"
+                    aria-hidden="true"
+                >
+                    <path className="HeatmapsPreview__spark-area" d={areaPath(LINE)} />
+                    <path className="HeatmapsPreview__spark-line" d={LINE} vectorEffect="non-scaling-stroke" />
+                    <path
+                        className="HeatmapsPreview__spark-trace"
+                        d={LINE}
+                        pathLength={100}
+                        vectorEffect="non-scaling-stroke"
+                    />
+                </svg>
+                <span className="HeatmapsPreview__footer HeatmapsPreview__swap">
+                    <span className="HeatmapsPreview__when-clicks">
+                        37 rage clicks on the plan toggle. Nothing there responds to a click.
+                    </span>
+                    <span className="HeatmapsPreview__when-scroll">
+                        More than half of visitors leave before they see a price.
+                    </span>
+                </span>
+            </div>
+        </div>
+    )
+}

--- a/products/web_analytics/frontend/heatmaps/emptyState/heatmapsEmptyState.tsx
+++ b/products/web_analytics/frontend/heatmaps/emptyState/heatmapsEmptyState.tsx
@@ -1,0 +1,45 @@
+import * as cursorPng from '@posthog/brand/hoggies/png/cursor'
+
+import { pngHoggie } from 'lib/brand/hoggies'
+import type { SceneProductEmptyState } from 'lib/components/ProductEmptyState/types'
+import { IconHeatmap } from 'lib/lemon-ui/icons'
+import { urls } from 'scenes/urls'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { AccessControlLevel, AccessControlResourceType } from '~/types'
+
+import { HeatmapsPreview } from './HeatmapsPreview'
+import { heatmapsSetupLogic } from './heatmapsSetupLogic'
+
+const HedgehogCursor = pngHoggie(cursorPng)
+
+export const heatmapsEmptyState: SceneProductEmptyState = {
+    statusLogic: heatmapsSetupLogic,
+    config: {
+        productKey: ProductKey.HEATMAPS,
+        productName: 'Heatmaps',
+        icon: <IconHeatmap />,
+        accentColor: 'var(--color-product-heatmaps-light)',
+        accentColorDark: 'var(--color-product-heatmaps-dark)',
+        hedgehog: HedgehogCursor,
+        text: {
+            'needs-setup': {
+                headline: 'See where people click, scroll, and give up',
+                lead: 'A heatmap lays clicks, rage clicks, dead clicks, mouse movement, and scroll depth over a screenshot of one of your pages. Save a heatmap for a page you care about, pick the viewport widths to compare, and open it whenever you want to know how far people get and which elements they actually use.',
+            },
+        },
+        primaryAction: {
+            label: 'Create your first heatmap',
+            to: urls.heatmap('new'),
+            accessControl: {
+                resourceType: AccessControlResourceType.Heatmap,
+                minAccessLevel: AccessControlLevel.Editor,
+            },
+            dataAttr: 'heatmaps-new-heatmap-button',
+        },
+        skippable: false,
+        docsUrl: 'https://posthog.com/docs/toolbar/heatmaps',
+        previewLabel: 'Your heatmap, once saved',
+        Preview: HeatmapsPreview,
+    },
+}

--- a/products/web_analytics/frontend/heatmaps/emptyState/heatmapsSetupLogic.test.ts
+++ b/products/web_analytics/frontend/heatmaps/emptyState/heatmapsSetupLogic.test.ts
@@ -1,0 +1,44 @@
+import { expectLogic } from 'kea-test-utils'
+
+import api from 'lib/api'
+import { productSetupStatusLogic } from 'lib/components/ProductEmptyState/productSetupStatusLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+
+import { heatmapsSetupLogic } from './heatmapsSetupLogic'
+
+// Guards the mapping into the app-wide setup-status layer: if it breaks, the scene
+// empty-state gate strands on its spinner or shows the wrong surface.
+describe('heatmapsSetupLogic', () => {
+    let listSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        listSpy = jest.spyOn(api.savedHeatmaps, 'list')
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        listSpy.mockRestore()
+    })
+
+    it.each([
+        [0, 'needs-setup'],
+        [1, 'has-data'],
+        [12, 'has-data'],
+    ])('pushes a saved heatmap count of %i as status %s', async (count, expected) => {
+        listSpy.mockResolvedValue({ count, results: [] })
+        const logic = heatmapsSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.HEATMAPS }).values.status).toBe(expected)
+    })
+
+    it('fails open to unknown when the count query fails before any answer', async () => {
+        listSpy.mockRejectedValue(new Error('network down'))
+        const logic = heatmapsSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.HEATMAPS }).values.status).toBe('unknown')
+    })
+})

--- a/products/web_analytics/frontend/heatmaps/emptyState/heatmapsSetupLogic.ts
+++ b/products/web_analytics/frontend/heatmaps/emptyState/heatmapsSetupLogic.ts
@@ -1,0 +1,19 @@
+import api from 'lib/api'
+import { createSetupDetectionLogic } from 'lib/components/ProductEmptyState/setupDetectionLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+/**
+ * Setup detection for the heatmaps empty state. Heatmaps are creation-first: the
+ * scene lists saved heatmaps, so a project with none has nothing to show yet, even
+ * when heatmap data is already being collected. Re-checks on every mount (the gate
+ * mounts it), which covers returning from the "new heatmap" page.
+ */
+export const heatmapsSetupLogic = createSetupDetectionLogic({
+    productKey: ProductKey.HEATMAPS,
+    path: ['products', 'web_analytics', 'frontend', 'heatmaps', 'emptyState', 'heatmapsSetupLogic'],
+    detect: async () => {
+        const response = await api.savedHeatmaps.list({ limit: 1 })
+        return response.count > 0 ? 'has-data' : 'needs-setup'
+    },
+})

--- a/products/web_analytics/frontend/heatmaps/scenes/heatmaps/HeatmapsScene.tsx
+++ b/products/web_analytics/frontend/heatmaps/scenes/heatmaps/HeatmapsScene.tsx
@@ -21,12 +21,14 @@ import { ProductKey } from '~/queries/schema/schema-general'
 import { AccessControlLevel, AccessControlResourceType, HeatmapScreenshotType } from '~/types'
 
 import { HeatmapsWarnings } from '../../components/HeatmapsWarnings'
+import { heatmapsEmptyState } from '../../emptyState/heatmapsEmptyState'
 import { HEATMAPS_PER_PAGE, heatmapsSceneLogic } from './heatmapsSceneLogic'
 
 export const scene: SceneExport = {
     component: HeatmapsScene,
     logic: heatmapsSceneLogic,
     productKey: ProductKey.HEATMAPS,
+    emptyState: heatmapsEmptyState,
 }
 
 export function HeatmapsScene(): JSX.Element {


### PR DESCRIPTION
## Problem

A new user who opens Heatmaps before saving one lands on an empty table with a "New heatmap" button and a beta banner. Nothing explains what a heatmap shows or why they would save one. Heatmaps is one of the most visited product landing pages that still had no first-run screen, so this is the biggest remaining gap in the empty-state rollout tracked in #91027.

## Changes

- A project with no saved heatmaps now sees the shared setup empty state instead of the empty table. It explains what a heatmap overlays on a page and points at one action: "Create your first heatmap".
- The preview on the right is a saved heatmap of an example pricing page. Clicking "Clicks" or "Scroll depth" swaps the overlay and the stat card without moving the page. The rage-click marker and the sparkline animate at rest, and stop under reduced motion and in Storybook.
- The screen cannot be skipped. The scene behind it is an empty list, so skipping would reveal nothing.
- Detection counts saved heatmaps with `limit: 1` on each visit of the scene. A project with at least one saved heatmap never sees the screen. Heatmap data collection is not part of the check: the scene's existing warning banner still covers a project that saved a heatmap without enabling collection.
- The create button carries the same access control and `data-attr` as the scene's own "New heatmap" button.
- Mechanical: the adoption tracker gains rows for heatmaps and for the four AI observability scenes that #94568 adopted without recording them.

Before, the "Clicks" overlay:

![heatmaps-before](https://raw.githubusercontent.com/PostHog/pr-assets/82bca801d2229e72416d072b236f44e92ae928d2/2026/09/9ee1d850-b17b-4312-84df-08c382f4b24a.png)

After clicking "Scroll depth":

![heatmaps-after](https://raw.githubusercontent.com/PostHog/pr-assets/1e1ed3356a6b265b0d78605727dfd7fd19fbf3dd/2026/09/a08bfbc2-d1d6-4c5a-b429-da2ac49d1000.png)

## How did you test this code?

- `heatmapsSetupLogic.test.ts` covers the count-to-status mapping (0, 1, many) and the fail-open path when the list request fails. Without it a broken mapping would strand the scene on the gate's spinner or gate a project that has heatmaps.
- The new story renders the shipped config in Storybook and gives visual regression coverage. The screenshots above come from that story through Playwright, before and after the overlay switch.
- Not run: the app itself against a real project. Detection was exercised through the jest test only.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The internal adoption tracker is updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Fable 5.1) in a session that reviewed which product scenes still lacked an empty state. Layer 1 of stack #95413. Skills invoked: `/building-product-empty-states`, `/stacking-prs`, `/writing-ui-components`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`. Decisions: detection uses the counted `api.savedHeatmaps.list` client because the generated `savedList` types its response as an array without `count`; the crossfading stat value needed an explicit grid override because the shared sparkline mixin lays the value out as a flex row. `gh pr list --search "heatmaps empty state"` found no open PR covering this.
