### PR TITLE
feat(pulse): add a setup empty state to the pulse scene

### DIFF
--- a/docs/internal/product-empty-state-adoption.md
+++ b/docs/internal/product-empty-state-adoption.md
@@ -114,7 +114,7 @@ deeper, so the product is half-migrated.
 
 ### Tier 4: everything else
 
-Still on `ProductIntroduction`: pulse, engineering analytics,
+Still on `ProductIntroduction`: engineering analytics,
 comments, ingestion warnings (v1 and v2),
 Max conversation history, and data pipelines destinations and transformations
 (`frontend/src/scenes/data-pipelines/DataPipelinesHogFunctions.tsx` covers the last two).

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1916,6 +1916,10 @@ snapshots:
         hash: v1.k794b7964.ba387f94bf7380934a79b9a58f19d27dbe5561163315728c3a2d813a747757f0.XpF43f3StaHvZq-5TpAo3Uw5ABra8ikrJrLcMaCFqlM
     components-product-empty-state--product-tours-needs-setup--light:
         hash: v1.k794b7964.bcb7662c9b7c8b359951611d5d8c707b752df3cf4b51d4b55db0031a895fbb1d.LLNYGfrenmzwrDMW0v_HX5rZG8y7Zh-H_GoHbWDymRU
+    components-product-empty-state--pulse-needs-setup--dark:
+        hash: v1.k794b7964.bd2d483068c315b50470af80852f8f62ce8555992ae68e1001202e8e81dcac78.Y9erf8kVRfgMPhVGKX_GzF_Z883Qbexj_oj0C3wum6I
+    components-product-empty-state--pulse-needs-setup--light:
+        hash: v1.k794b7964.a2c52e420aaa52404df68dfeddcbb967d4656c9c5f708944d9d5a4809190bc94.A4KCBgE0Es3MIwO9Ui8lr1Wy51GBY3weQ1qjJU5hnXc
     components-product-empty-state--replay-vision-needs-setup--dark:
         hash: v1.k794b7964.78d06d6c9f11d54919ad81abffe6a5d409dd1b4e7ba08a822a17485f8503617f.owccqODY_2d4-T-mAhHHfXx-rjYgbeohS0xVOLc5FXQ
     components-product-empty-state--replay-vision-needs-setup--light:

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
@@ -31,6 +31,7 @@ import { metricsEmptyState } from 'products/metrics/frontend/emptyState/metricsE
 import { notebooksEmptyState } from 'products/notebooks/frontend/emptyState/notebooksEmptyState'
 import { productAnalyticsEmptyState } from 'products/product_analytics/frontend/emptyState/productAnalyticsEmptyState'
 import { productToursEmptyState } from 'products/product_tours/frontend/emptyState/productToursEmptyState'
+import { pulseEmptyState } from 'products/pulse/frontend/emptyState/pulseEmptyState'
 import { sessionReplayEmptyState } from 'products/replay/frontend/emptyState/sessionReplayEmptyState'
 import { replayVisionEmptyState } from 'products/replay_vision/frontend/emptyState/replayVisionEmptyState'
 import { llmSkillsEmptyState } from 'products/skills/frontend/emptyState/llmSkillsEmptyState'
@@ -376,6 +377,16 @@ export const DataCatalogNeedsSetup: ProductEmptyStateStory = productEmptyStateSt
 // Notebooks detection counts notebooks on mount - answer "none yet".
 export const NotebooksNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(notebooksEmptyState, 'needs-setup', {
     mocks: { get: { '/api/projects/:team_id/notebooks/': [200, { count: 0, results: [] }] } },
+})
+
+// Pulse detection counts briefs on mount; its run button also reads the focus configs.
+export const PulseNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(pulseEmptyState, 'needs-setup', {
+    mocks: {
+        get: {
+            '/api/projects/:team_id/pulse/briefs/': [200, emptyEntityList],
+            '/api/projects/:team_id/pulse/brief_configs/': [200, emptyEntityList],
+        },
+    },
 })
 
 export const HeatmapsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(heatmapsEmptyState, 'needs-setup')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4205,6 +4205,9 @@ importers:
 
   products/pulse:
     dependencies:
+      '@posthog/brand':
+        specifier: 'catalog:'
+        version: 0.11.0(react@18.3.1)
       '@posthog/icons':
         specifier: 'catalog:'
         version: 0.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/products/pulse/frontend/BriefsView.tsx
+++ b/products/pulse/frontend/BriefsView.tsx
@@ -1,6 +1,5 @@
 import { useActions, useValues } from 'kea'
 
-import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 
@@ -30,16 +29,14 @@ export function BriefsView(): JSX.Element {
         )
     }
 
+    // The scene-level empty state covers a project with no briefs at all. This branch is the
+    // per-focus case: briefs exist, but none for the selected focus yet.
     if (visibleBriefs.length === 0) {
         return (
-            <ProductIntroduction
-                productName="Pulse"
-                thingName="brief"
-                titleOverride="No briefs yet"
-                description="Run your first brief to see what happened in your product, why it happened, and what to build next."
-                isEmpty
-                actionElementOverride={<RunBriefButton />}
-            />
+            <div className="flex flex-col items-center gap-3 border rounded p-8 text-center">
+                <span className="text-secondary">No briefs for this focus yet.</span>
+                <RunBriefButton />
+            </div>
         )
     }
 

--- a/products/pulse/frontend/PulseScene.tsx
+++ b/products/pulse/frontend/PulseScene.tsx
@@ -14,15 +14,19 @@ import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+import { ProductKey } from '~/queries/schema/schema-general'
 
 import { BriefConfigModal } from './BriefConfigModal'
 import { BriefsView } from './BriefsView'
+import { pulseEmptyState } from './emptyState/pulseEmptyState'
 import { pulseLogic } from './pulseLogic'
 import { RunBriefButton } from './RunBriefButton'
 
 export const scene: SceneExport = {
     component: PulseScene,
     logic: pulseLogic,
+    productKey: ProductKey.PULSE,
+    emptyState: pulseEmptyState,
 }
 
 const PULSE_DESCRIPTION =

--- a/products/pulse/frontend/emptyState/PulsePreview.scss
+++ b/products/pulse/frontend/emptyState/PulsePreview.scss
@@ -1,0 +1,277 @@
+@import '../../../../frontend/src/lib/components/ProductEmptyState/previewMixins';
+
+.PulsePreview {
+    --pulse-preview-accent: var(--empty-state-accent, var(--color-product-activity-light));
+
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    // Hidden selection. Direct children of .PulsePreview so `:checked ~` reaches both cards.
+    &__radio {
+        position: absolute;
+        width: 0;
+        height: 0;
+        pointer-events: none;
+        opacity: 0;
+    }
+
+    &__brief,
+    &__detail {
+        overflow: hidden;
+        background: var(--color-bg-surface-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius);
+    }
+
+    // The two opportunity details are stacked on one grid cell and crossfaded, so selecting
+    // one never changes the card's size (no layout shift).
+    &__swap {
+        display: grid;
+    }
+
+    &__swap > * {
+        grid-area: 1 / 1;
+        min-width: 0;
+    }
+
+    &__when-dropoff {
+        @include preview-swap-visible;
+    }
+
+    &__when-invites {
+        @include preview-swap-hidden;
+    }
+
+    &__head {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__title {
+        font-size: 0.75rem;
+        font-weight: 600;
+    }
+
+    &__period {
+        flex: 1;
+        font-size: 0.625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    // Brief sections
+
+    &__section {
+        display: flex;
+        flex-direction: column;
+        gap: 0.375rem;
+        padding: 0.5rem 0.75rem;
+
+        & + & {
+            border-top: 1px solid var(--color-border-primary);
+        }
+    }
+
+    &__section-title {
+        font-size: 0.6875rem;
+        font-weight: 600;
+    }
+
+    &__text {
+        margin: 0;
+        font-size: 0.625rem;
+        line-height: 1.4;
+        color: var(--color-text-secondary);
+    }
+
+    &__citations {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.25rem;
+    }
+
+    &__citation {
+        padding: 0.0625rem 0.375rem;
+        font-size: 0.5625rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        background: var(--color-bg-fill-tertiary);
+        border-radius: 999px;
+    }
+
+    // Opportunity rows
+
+    &__rows {
+        display: flex;
+        flex-direction: column;
+        gap: 0.125rem;
+    }
+
+    &__row {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.3125rem 0.5rem;
+        border-radius: var(--radius);
+        transition: background $preview-swap-duration ease;
+    }
+
+    &__row--focus {
+        cursor: pointer;
+    }
+
+    &__dot {
+        width: 8px;
+        height: 8px;
+        border: 2px solid var(--color-border-primary);
+        border-radius: 50%;
+        transition:
+            border-color $preview-swap-duration ease,
+            background $preview-swap-duration ease;
+    }
+
+    &__row-title {
+        overflow: hidden;
+        font-size: 0.6875rem;
+        font-weight: 500;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__delta {
+        padding: 0.0625rem 0.375rem;
+        font-size: 0.5625rem;
+        font-weight: 700;
+        white-space: nowrap;
+        border-radius: 999px;
+
+        &--down {
+            color: var(--color-danger);
+            background: color-mix(in oklab, var(--color-danger) 12%, transparent);
+        }
+
+        &--up {
+            color: var(--color-success);
+            background: color-mix(in oklab, var(--color-success) 12%, transparent);
+        }
+    }
+
+    // Detail card
+
+    &__detail {
+        padding: 0.625rem 0.75rem 0.75rem;
+    }
+
+    &__spark-caption {
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    &__action {
+        display: flex;
+        flex-direction: column;
+        gap: 0.125rem;
+        margin: 0.5rem 0 0;
+        font-size: 0.625rem;
+        line-height: 1.4;
+        color: var(--color-text-secondary);
+    }
+
+    &__action-label {
+        font-size: 0.5625rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.02em;
+
+        @include preview-accent-text(var(--pulse-preview-accent));
+    }
+
+    &__spark-area {
+        fill: color-mix(in oklab, var(--pulse-preview-accent) 13%, transparent);
+        stroke: none;
+    }
+
+    &__spark-line {
+        fill: none;
+        stroke: color-mix(in oklab, var(--pulse-preview-accent) 32%, transparent);
+        stroke-width: 2;
+    }
+
+    // The moving bit: a short bright segment cycling along the line.
+    &__spark-trace {
+        fill: none;
+        stroke: var(--pulse-preview-accent);
+        stroke-dasharray: 16 84;
+        stroke-linecap: round;
+        stroke-width: 2;
+        animation: PulsePreview__trace 3.2s linear infinite;
+    }
+
+    @include preview-sparkline;
+}
+
+// Selected row: painted from the radios, so the list and the detail always agree.
+
+.PulsePreview__radio--dropoff:checked ~ .PulsePreview__brief .PulsePreview__row--dropoff,
+.PulsePreview__radio--invites:checked ~ .PulsePreview__brief .PulsePreview__row--invites {
+    background: color-mix(in oklab, var(--pulse-preview-accent) 8%, transparent);
+
+    .PulsePreview__dot {
+        background: var(--pulse-preview-accent);
+        border-color: var(--pulse-preview-accent);
+    }
+}
+
+// Second opportunity selected
+
+.PulsePreview__radio--invites:checked ~ .PulsePreview__detail .PulsePreview__when-invites {
+    @include preview-swap-visible;
+}
+
+.PulsePreview__radio--invites:checked ~ .PulsePreview__detail .PulsePreview__when-dropoff {
+    @include preview-swap-hidden;
+}
+
+// The radios stay keyboard-focusable while visually hidden, so the row each one labels
+// needs a visible focus indicator (WCAG 2.4.7).
+.PulsePreview__radio--dropoff:focus-visible ~ .PulsePreview__brief .PulsePreview__row--dropoff,
+.PulsePreview__radio--invites:focus-visible ~ .PulsePreview__brief .PulsePreview__row--invites {
+    outline: 2px solid var(--pulse-preview-accent);
+    outline-offset: -2px;
+}
+
+// Nudge attention at the unselected opportunity so the list reads as clickable.
+.PulsePreview:not(.PulsePreview--static)
+    .PulsePreview__radio--dropoff:checked
+    ~ .PulsePreview__brief
+    .PulsePreview__row--invites
+    .PulsePreview__dot {
+    animation: PulsePreview__pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes PulsePreview__pulse {
+    0%,
+    100% {
+        box-shadow: 0 0 0 0 color-mix(in oklab, var(--pulse-preview-accent) 40%, transparent);
+    }
+
+    50% {
+        box-shadow: 0 0 0 4px color-mix(in oklab, var(--pulse-preview-accent) 16%, transparent);
+    }
+}
+
+// pathLength is normalized to 100, so the dash offset loops cleanly regardless of length.
+@keyframes PulsePreview__trace {
+    to {
+        stroke-dashoffset: -100;
+    }
+}
+
+// Storybook snapshots and reduced motion drop all ambient motion; selecting an opportunity
+// still swaps the detail (transitions only).
+@include preview-motion-guards('PulsePreview');

--- a/products/pulse/frontend/emptyState/PulsePreview.tsx
+++ b/products/pulse/frontend/emptyState/PulsePreview.tsx
@@ -1,0 +1,157 @@
+import './PulsePreview.scss'
+
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { cn } from 'lib/utils/css-classes'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+
+// Hand-authored daily series behind each opportunity: a metric sliding down, and one climbing.
+const LINE_DROPOFF = 'M 0 10 L 14 12 L 28 11 L 42 16 L 56 19 L 70 24 L 84 27 L 100 31'
+const LINE_INVITES = 'M 0 30 L 14 29 L 28 26 L 42 24 L 56 18 L 70 15 L 84 11 L 100 8'
+
+function areaPath(line: string): string {
+    return `${line} L 100 40 L 0 40 Z`
+}
+
+/**
+ * Example-data preview for the Pulse empty state: a generated brief with two opportunities,
+ * and the detail card for the selected one (summary, metric, suggested action). A hidden
+ * radio pair drives the selection via `:checked ~` styles - no timers or state, per the
+ * preview rules in the `building-product-empty-states` skill. Both details share one grid
+ * cell and crossfade, so switching never moves the card.
+ */
+export function PulsePreview(): JSX.Element {
+    const isStatic = inStorybook() || inStorybookTestRunner()
+
+    return (
+        <div className={cn('PulsePreview', isStatic && 'PulsePreview--static')}>
+            {/* Selected opportunity, before both cards so `:checked ~` can style them. */}
+            <input
+                type="radio"
+                name="pulse-preview-opportunity"
+                id="pulse-preview-dropoff"
+                className="PulsePreview__radio PulsePreview__radio--dropoff"
+                defaultChecked
+            />
+            <input
+                type="radio"
+                name="pulse-preview-opportunity"
+                id="pulse-preview-invites"
+                className="PulsePreview__radio PulsePreview__radio--invites"
+            />
+
+            <div className="PulsePreview__brief">
+                <div className="PulsePreview__head">
+                    <span className="PulsePreview__title">Weekly brief</span>
+                    <span className="PulsePreview__period">Aug 25 to Sep 1</span>
+                    <LemonTag size="small">example data</LemonTag>
+                </div>
+
+                <div className="PulsePreview__section">
+                    <span className="PulsePreview__section-title">What changed</span>
+                    <p className="PulsePreview__text">
+                        Signups held steady at 1,140 a week, but 31% fewer of them reached the dashboard within a day.
+                        The drop starts with last Tuesday's release.
+                    </p>
+                    <div className="PulsePreview__citations">
+                        <span className="PulsePreview__citation">Activation funnel</span>
+                        <span className="PulsePreview__citation">Release 2.14</span>
+                    </div>
+                </div>
+
+                <div className="PulsePreview__section">
+                    <span className="PulsePreview__section-title">Opportunities</span>
+                    <div className="PulsePreview__rows">
+                        <label
+                            htmlFor="pulse-preview-dropoff"
+                            className="PulsePreview__row PulsePreview__row--dropoff PulsePreview__row--focus"
+                        >
+                            <span className="PulsePreview__dot" />
+                            <span className="PulsePreview__row-title">Fix the day-one drop-off</span>
+                            <span className="PulsePreview__delta PulsePreview__delta--down">-31%</span>
+                        </label>
+                        <label
+                            htmlFor="pulse-preview-invites"
+                            className="PulsePreview__row PulsePreview__row--invites PulsePreview__row--focus"
+                        >
+                            <span className="PulsePreview__dot" />
+                            <span className="PulsePreview__row-title">Invites convert, nobody sends them</span>
+                            <span className="PulsePreview__delta PulsePreview__delta--up">+2.4x</span>
+                        </label>
+                    </div>
+                </div>
+            </div>
+
+            <div className="PulsePreview__detail">
+                <div className="PulsePreview__swap">
+                    <div className="PulsePreview__when-dropoff">
+                        <div className="PulsePreview__spark-head">
+                            <span className="PulsePreview__spark-title">Reached dashboard within a day</span>
+                            <span className="PulsePreview__spark-caption">Baseline 62%</span>
+                        </div>
+                        <div className="PulsePreview__spark-value">
+                            43%
+                            <span className="PulsePreview__delta PulsePreview__delta--down">-31%</span>
+                        </div>
+                        <svg
+                            className="PulsePreview__spark-svg"
+                            viewBox="0 0 100 40"
+                            preserveAspectRatio="none"
+                            aria-hidden="true"
+                        >
+                            <path className="PulsePreview__spark-area" d={areaPath(LINE_DROPOFF)} />
+                            <path
+                                className="PulsePreview__spark-line"
+                                d={LINE_DROPOFF}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                            <path
+                                className="PulsePreview__spark-trace"
+                                d={LINE_DROPOFF}
+                                pathLength={100}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                        </svg>
+                        <p className="PulsePreview__action">
+                            <span className="PulsePreview__action-label">Suggested action</span>
+                            Watch three replays of new users stuck on the empty dashboard, then ship a starter template.
+                        </p>
+                    </div>
+                    <div className="PulsePreview__when-invites">
+                        <div className="PulsePreview__spark-head">
+                            <span className="PulsePreview__spark-title">Invited teammates who activate</span>
+                            <span className="PulsePreview__spark-caption">Baseline 1x</span>
+                        </div>
+                        <div className="PulsePreview__spark-value">
+                            2.4x
+                            <span className="PulsePreview__delta PulsePreview__delta--up">vs solo signups</span>
+                        </div>
+                        <svg
+                            className="PulsePreview__spark-svg"
+                            viewBox="0 0 100 40"
+                            preserveAspectRatio="none"
+                            aria-hidden="true"
+                        >
+                            <path className="PulsePreview__spark-area" d={areaPath(LINE_INVITES)} />
+                            <path
+                                className="PulsePreview__spark-line"
+                                d={LINE_INVITES}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                            <path
+                                className="PulsePreview__spark-trace"
+                                d={LINE_INVITES}
+                                pathLength={100}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                        </svg>
+                        <p className="PulsePreview__action">
+                            <span className="PulsePreview__action-label">Suggested action</span>
+                            Only 6% of new users invite anyone. Add an invite step to onboarding and test it with an
+                            experiment.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/products/pulse/frontend/emptyState/PulsePrimaryAction.tsx
+++ b/products/pulse/frontend/emptyState/PulsePrimaryAction.tsx
@@ -1,0 +1,40 @@
+import { useActions, useValues } from 'kea'
+
+import { Link } from 'lib/lemon-ui/Link'
+import { urls } from 'scenes/urls'
+
+import { BriefConfigModal } from '../BriefConfigModal'
+import { pulseLogic } from '../pulseLogic'
+import { RunBriefButton } from '../RunBriefButton'
+
+/**
+ * Create path for the Pulse empty state. The run button and the focus modal are what the
+ * scene header offers, and the gate replaces the scene, so the empty state renders both
+ * itself. The AI consent line replaces the scene's banner for the same reason.
+ */
+export function PulsePrimaryAction(): JSX.Element {
+    const { showAiConsentBanner } = useValues(pulseLogic)
+    const { openConfigModal } = useActions(pulseLogic)
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex flex-wrap items-center gap-2">
+                <RunBriefButton />
+                <span className="text-secondary text-sm">or</span>
+                <Link onClick={() => openConfigModal(null)} data-attr="pulse-empty-state-new-config">
+                    set a focus first
+                </Link>
+            </div>
+            {showAiConsentBanner && (
+                <span className="text-secondary text-xs">
+                    Pulse runs AI over your project data. Approve AI data processing in{' '}
+                    <Link to={urls.settings('organization-details', 'organization-ai-consent')}>
+                        organization settings
+                    </Link>{' '}
+                    to run a brief.
+                </span>
+            )}
+            <BriefConfigModal />
+        </div>
+    )
+}

--- a/products/pulse/frontend/emptyState/pulseEmptyState.tsx
+++ b/products/pulse/frontend/emptyState/pulseEmptyState.tsx
@@ -1,0 +1,39 @@
+import * as doctorPng from '@posthog/brand/hoggies/png/doctor-1'
+import { IconPulse } from '@posthog/icons'
+
+import { pngHoggie } from 'lib/brand/hoggies'
+import type { SceneProductEmptyState } from 'lib/components/ProductEmptyState/types'
+import { FEATURE_FLAGS } from 'lib/constants'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { PulsePreview } from './PulsePreview'
+import { PulsePrimaryAction } from './PulsePrimaryAction'
+import { pulseSetupLogic } from './pulseSetupLogic'
+
+const HedgehogDoctor = pngHoggie(doctorPng)
+
+export const pulseEmptyState: SceneProductEmptyState = {
+    statusLogic: pulseSetupLogic,
+    // The whole product is behind this flag; the scene's own 404 gate handles the flag-off case.
+    featureFlag: FEATURE_FLAGS.PULSE,
+    config: {
+        productKey: ProductKey.PULSE,
+        productName: 'Pulse',
+        icon: <IconPulse />,
+        accentColor: 'var(--color-product-activity-light)',
+        accentColorDark: 'var(--color-product-activity-dark)',
+        hedgehog: HedgehogDoctor,
+        text: {
+            'needs-setup': {
+                headline: 'Get a brief on what changed and what to do about it',
+                lead: 'Pulse reads your product data, writes a brief on what moved and why, and turns the findings into opportunities with a suggested next step and the numbers behind it. Run a brief for the whole project, or set a focus such as onboarding completion to get briefs about one goal.',
+                hint: 'Your first brief takes a few minutes to generate:',
+            },
+        },
+        PrimaryAction: PulsePrimaryAction,
+        skippable: false,
+        previewLabel: 'Your brief, once generated',
+        Preview: PulsePreview,
+    },
+}

--- a/products/pulse/frontend/emptyState/pulseSetupLogic.test.ts
+++ b/products/pulse/frontend/emptyState/pulseSetupLogic.test.ts
@@ -1,0 +1,67 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { productSetupStatusLogic } from 'lib/components/ProductEmptyState/productSetupStatusLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+
+import * as generatedApi from '../generated/api'
+import { pulseLogic } from '../pulseLogic'
+import { pulseSetupLogic } from './pulseSetupLogic'
+
+// Guards the mapping into the app-wide setup-status layer: if it breaks, the scene
+// empty-state gate strands on its spinner or shows the wrong surface.
+describe('pulseSetupLogic', () => {
+    let briefsSpy: jest.SpyInstance
+    let configsSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        briefsSpy = jest.spyOn(generatedApi, 'pulseBriefsList')
+        configsSpy = jest
+            .spyOn(generatedApi, 'pulseBriefConfigsList')
+            .mockResolvedValue({ count: 0, next: null, previous: null, results: [] })
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        briefsSpy.mockRestore()
+        configsSpy.mockRestore()
+    })
+
+    it.each([
+        [0, 'needs-setup'],
+        [1, 'has-data'],
+        [7, 'has-data'],
+    ])('pushes a brief count of %i as status %s', async (count, expected) => {
+        briefsSpy.mockResolvedValue({ count, next: null, previous: null, results: [] })
+        const logic = pulseSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.PULSE }).values.status).toBe(expected)
+    })
+
+    it('re-detects when a brief is generated without leaving the scene', async () => {
+        let briefCount = 0
+        briefsSpy.mockImplementation(async () => ({ count: briefCount, next: null, previous: null, results: [] }))
+        const logic = pulseSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.PULSE }).values.status).toBe('needs-setup')
+
+        // The empty state's run button generates the brief in place, so without the recheck
+        // wiring the gate would keep hiding it until the user re-entered the scene.
+        briefCount = 1
+        pulseLogic.mount()
+        pulseLogic.actions.generateBriefSuccess(null)
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.PULSE }).values.status).toBe('has-data')
+    })
+
+    it('fails open to unknown when the count query fails before any answer', async () => {
+        briefsSpy.mockRejectedValue(new Error('network down'))
+        const logic = pulseSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.PULSE }).values.status).toBe('unknown')
+    })
+})

--- a/products/pulse/frontend/emptyState/pulseSetupLogic.ts
+++ b/products/pulse/frontend/emptyState/pulseSetupLogic.ts
@@ -1,0 +1,25 @@
+import { createSetupDetectionLogic } from 'lib/components/ProductEmptyState/setupDetectionLogic'
+import { projectLogic } from 'scenes/projectLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { pulseBriefsList } from '../generated/api'
+import { pulseLogic } from '../pulseLogic'
+
+/**
+ * Setup detection for the Pulse empty state. Pulse is creation-first: the scene shows
+ * generated briefs, so a project with none has nothing to read yet. A brief that is
+ * still generating counts, because the scene renders its progress.
+ */
+export const pulseSetupLogic = createSetupDetectionLogic({
+    productKey: ProductKey.PULSE,
+    path: ['products', 'pulse', 'frontend', 'emptyState', 'pulseSetupLogic'],
+    detect: async () => {
+        const projectId = String(projectLogic.findMounted()?.values.currentProjectId)
+        const response = await pulseBriefsList(projectId, { limit: 1 })
+        return response.count > 0 ? 'has-data' : 'needs-setup'
+    },
+    // The empty state runs the first brief in place, without leaving the scene, so no
+    // remount would re-run detection and the gate would keep hiding the new brief.
+    recheckActionTypes: () => [pulseLogic.actionTypes.generateBriefSuccess],
+})

--- a/products/pulse/package.json
+++ b/products/pulse/package.json
@@ -13,6 +13,7 @@
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
+        "@posthog/brand": "catalog:",
         "@posthog/icons": "catalog:",
         "@types/react": "*",
         "react": "*"


### PR DESCRIPTION
## Problem

A person who opens Pulse for the first time sees a header with two buttons and a dashed "No briefs yet" panel. It does not say what a brief is or that generating one takes a few minutes, and it renders through the inline `ProductIntroduction` panel that the scene-level empty state replaces. Pulse is an alpha behind the `pulse` flag, so this reaches enrolled teams only. Layer 2 of stack #95413, after #95408.

## Changes

- A project with no briefs now sees the shared setup empty state. It explains what a brief contains and offers "Run brief now", with "set a focus first" as the alternative for a team that wants a scoped brief.
- Running the brief from the empty state works in place. The gate re-detects when generation succeeds, so the new brief appears without leaving the scene.
- The AI consent requirement shows as a line under the button when the organization has not approved AI data processing, with a link to the setting, in place of the scene's banner.
- The preview is an example weekly brief with two opportunities. Clicking an opportunity swaps the detail card to its metric, baseline, and suggested action without moving anything.
- The screen cannot be skipped. The scene behind it has nothing to show without a brief.
- Inside the scene, a focus with no briefs of its own now shows a one-line message and the run button instead of the old panel. This is the only case the gate does not cover.
- Mechanical: the pulse product declares `@posthog/brand` as a peer dependency for the hedgehog illustration, and the adoption tracker gains a Pulse row.

Before, the first opportunity selected:

![pulse-before](https://raw.githubusercontent.com/PostHog/pr-assets/4c75e0a78b1f61aa1695122fdaeb34ea72f9745b/2026/09/7138ef6b-feed-49b0-97b6-173698250cd4.png)

After clicking the second opportunity:

![pulse-after](https://raw.githubusercontent.com/PostHog/pr-assets/68585bb2bce9d5e2ef978b0f17dec6c02c2e4221/2026/09/03e9813c-0306-4aa2-94b6-6b05cc1da53d.png)

## How did you test this code?

- `pulseSetupLogic.test.ts` covers the count-to-status mapping, the fail-open path, and the re-detection after `generateBriefSuccess`. The last case is the one a refactor is most likely to break: without it the gate keeps hiding a brief generated from the empty state until the user leaves and returns.
- The new story renders the shipped config in Storybook. The screenshots above come from it through Playwright.
- Not run: generating a real brief against the backend.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Pulse has no public docs yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Fable 5.1). Skills invoked: `/building-product-empty-states`, `/stacking-prs`, `/writing-ui-components`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`. Decisions: the empty state renders the focus modal itself, because the gate replaces the scene that normally renders it; the per-focus empty message stays inline, following the pattern alerts used for its per-kind tables. No open PR touches the Pulse first-run surface.
