### PR TITLE
feat(cdp): add setup empty states to destinations and transformations

### DIFF
--- a/docs/internal/product-empty-state-adoption.md
+++ b/docs/internal/product-empty-state-adoption.md
@@ -116,8 +116,7 @@ deeper, so the product is half-migrated.
 
 Still on `ProductIntroduction`: engineering analytics,
 comments, ingestion warnings (v1 and v2),
-Max conversation history, and data pipelines destinations and transformations
-(`frontend/src/scenes/data-pipelines/DataPipelinesHogFunctions.tsx` covers the last two).
+and Max conversation history.
 
 Hand-rolled empty states: review hog, streamlit apps, groups (`GroupsIntroduction`), persons, and
 the LLM analytics sessions tab.

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1816,6 +1816,10 @@ snapshots:
         hash: v1.k794b7964.01f60a890684cbe8ce2e6710438881a14cea589f0329a0c7bb81e6ba3c7d705c.RDQRVZbNasaNJAmELuFQwrgwmPHFLSDnpqwMR65kwLc
     components-product-empty-state--datasets-needs-setup--light:
         hash: v1.k794b7964.7822854706ae6666084d7fc87da5c4fcdd8203bf699cff091e4127311c0d36c6.THvugQSJkiPaI4f_IXmCG5wi_pP4W2uFYHeqWhBzZ9k
+    components-product-empty-state--destinations-needs-setup--dark:
+        hash: v1.k794b7964.257dac1f2339b456e84031f7b087d081d4bdc6373545f755a1d59901d2b12be3.UrYCWLgZjZ81WivesRcKLD0sOzNOwWIBQUomKBs13xo
+    components-product-empty-state--destinations-needs-setup--light:
+        hash: v1.k794b7964.e215096b71a24d85fa746ec02cbbbf72715f8008381b65e645a34e0328585d71.eNKn5uPbgOhor19ppzPwUqXtogIXg4N0JePmDjq5dgw
     components-product-empty-state--early-access-features-needs-setup--dark:
         hash: v1.k794b7964.ce612c03290780c1098886d9e2e0f9d920bfa899c591fadfecabf969b1897fe6.RlwNrGim39bhZH0hO39-bt6bWPUPJU-5XgIq2smDxSk
     components-product-empty-state--early-access-features-needs-setup--light:
@@ -1956,6 +1960,10 @@ snapshots:
         hash: v1.k794b7964.31166d2274ea22226bc3281a0fe2f39caef85292a870fa58b0339964bcb2cb6b.xl8D1Zuw7EzZn8ptdhasdeA8LNEskINpumcYVM619Jg
     components-product-empty-state--tracing-needs-setup--light:
         hash: v1.k794b7964.186a74ebee46c9341b2dffbc73c647d7be5f38bdbabbeaf4098237c96ca56c35.i2DjPIjhqrqsIkHPC5Kkd28o97GAL-z6XDcrnjfsE54
+    components-product-empty-state--transformations-needs-setup--dark:
+        hash: v1.k794b7964.a09118f4e9969306bb2ac6477d7ae051ab7eeeac59b6c87ce5e4f998ea5d8688.Jnuv05RYowSxts1UpR_VYN1SYieAk8Ok8COTLPhaiM4
+    components-product-empty-state--transformations-needs-setup--light:
+        hash: v1.k794b7964.9e5fe5cec95fd5a51beff5b88ee3f59161e745544d954447681cbe52100da410.fsdC2KYRbTnlRWfpzf5bWt3EmN9t1FPr7wz3-J577Gk
     components-product-empty-state--user-interviews-needs-setup--dark:
         hash: v1.k794b7964.5834b5549690d205c2ec9d9b9765f392eeba757749a0cf243c810311f3733079.Ju4u90HdGqU4tcIDHMsmpInKHheBwMYRvpYnd8oGa30
     components-product-empty-state--user-interviews-needs-setup--light:
@@ -6725,9 +6733,9 @@ snapshots:
     scenes-app-data-management-revenue-analytics-event-configuration-modal--default--light:
         hash: v1.k794b7964.380602ae2b746844554126dce9f27bca9ec04854e281d8467c8de724f4fd49fc.ySrW_TUWEFnfdhQOLX6USTN5uxF1kODMuE5iXuYWtQU
     scenes-app-data-pipelines-destinations-incident-replay-banner--default--dark:
-        hash: v1.k794b7964.34c3e603edea48081c522ebbbb268946fdb1333b895d0187e3044f5d25cc9c67.YPyFmrFdGkJ0JY6gYtcZK8_ih879ZKJuG6CxpXGQVfA
+        hash: v1.k794b7964.e473b8fe8f528606bceba2f9d46d78c8df3f5cd3175c8746aa20d4ae3cfa68a6.PViFZdv24uzTmitBcq0xYDFNupLKX-wieQJtpM3zdrI
     scenes-app-data-pipelines-destinations-incident-replay-banner--default--light:
-        hash: v1.k794b7964.03edf8cad74902dd6afe1b4bcc00171859977e00ca7e415577e4eabeb09e1118.oPgM8rRVPuEyMe_usepFHtxRTIqefhpHQOS3ImXr4_I
+        hash: v1.k794b7964.4304bd76f4383695934d5f63aa85e968e9d47caebf2fa08143f1317868506882.M9dN3mtOfOdRQuQe9ga5GzGCNK1s48y8S7OQfvwd4cQ
     scenes-app-data-pipelines-event-filtering--add-condition-and-test-case--dark:
         hash: v1.k794b7964.054b485fa44909bda3f635ba9d134cea4dfa7e60bbc65206ba752f23b7729c42._2cxQzZ_XmaTvoI9Z7hIKh5kpuDY5rxQG0-1RNRyDgE
     scenes-app-data-pipelines-event-filtering--add-condition-and-test-case--light:

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
@@ -11,6 +11,8 @@ import { llmPromptsEmptyState } from 'products/ai_observability/frontend/emptySt
 import { alertsEmptyState } from 'products/alerts/frontend/emptyState/alertsEmptyState'
 import { annotationsEmptyState } from 'products/annotations/frontend/emptyState/annotationsEmptyState'
 import { businessKnowledgeEmptyState } from 'products/business_knowledge/frontend/emptyState/businessKnowledgeEmptyState'
+import { destinationsEmptyState } from 'products/cdp/frontend/emptyState/destinationsEmptyState'
+import { transformationsEmptyState } from 'products/cdp/frontend/emptyState/transformationsEmptyState'
 import { webScriptsEmptyState } from 'products/cdp/frontend/emptyState/webScriptsEmptyState'
 import { cohortsEmptyState } from 'products/cohorts/frontend/emptyState/cohortsEmptyState'
 import { supportEmptyState } from 'products/conversations/frontend/emptyState/supportEmptyState'
@@ -388,6 +390,30 @@ export const PulseNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(pu
         },
     },
 })
+
+// Destinations detection counts hog functions, legacy plugin destinations, and batch
+// exports on mount - answer "none yet" to each.
+export const DestinationsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(
+    destinationsEmptyState,
+    'needs-setup',
+    {
+        mocks: {
+            get: {
+                '/api/projects/:team_id/hog_functions/': [200, emptyEntityList],
+                '/api/projects/:team_id/pipeline_destination_configs/': [200, emptyEntityList],
+                // nosemgrep: no-environments-api-urls-frontend -- batch exports are env-scoped, so the msw mock must match /api/environments to intercept them
+                '/api/environments/:team_id/batch_exports/': [200, emptyEntityList],
+            },
+        },
+    }
+)
+
+// Transformations detection counts transformation hog functions on mount - answer "none yet".
+export const TransformationsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(
+    transformationsEmptyState,
+    'needs-setup',
+    { mocks: { get: { '/api/projects/:team_id/hog_functions/': [200, emptyEntityList] } } }
+)
 
 export const HeatmapsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(heatmapsEmptyState, 'needs-setup')
 

--- a/frontend/src/scenes/data-pipelines/DataPipelinesHogFunctions.tsx
+++ b/frontend/src/scenes/data-pipelines/DataPipelinesHogFunctions.tsx
@@ -1,16 +1,13 @@
 import { useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
-import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { humanizeHogFunctionType } from 'scenes/hog-functions/hog-function-utils'
 import { HogFunctionList } from 'scenes/hog-functions/list/HogFunctionsList'
-import { hogFunctionsListLogic } from 'scenes/hog-functions/list/hogFunctionsListLogic'
 import { HogFunctionTemplateList } from 'scenes/hog-functions/list/HogFunctionTemplateList'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
-import { ProductKey } from '~/queries/schema/schema-general'
 import { HogFunctionType, HogFunctionTypeType } from '~/types'
 
 import { nonHogFunctionsLogic } from './utils/nonHogFunctionsLogic'
@@ -19,34 +16,11 @@ import { nonHogFunctionTemplatesLogic } from './utils/nonHogFunctionTemplatesLog
 export type DataPipelinesHogFunctionsProps = {
     kind: HogFunctionTypeType
     additionalKinds?: HogFunctionTypeType[]
-    action?: JSX.Element
 }
 
-// `site_app` is intentionally absent: web scripts renders the scene-level product
-// empty state instead (products/cdp/frontend/emptyState).
-export const MAPPING: Partial<Record<HogFunctionTypeType, { key: ProductKey; description: string }>> = {
-    destination: {
-        key: ProductKey.PIPELINE_DESTINATIONS,
-        description: 'Destinations allow you to send your data to external systems.',
-    },
-    transformation: {
-        key: ProductKey.PIPELINE_TRANSFORMATIONS,
-        description:
-            'Transformations let you modify, filter, and enrich event data to improve data quality, privacy, and consistency.',
-    },
-}
-
-export function DataPipelinesHogFunctions({
-    kind,
-    additionalKinds,
-    action,
-}: DataPipelinesHogFunctionsProps): JSX.Element {
+export function DataPipelinesHogFunctions({ kind, additionalKinds }: DataPipelinesHogFunctionsProps): JSX.Element {
     const humanizedKind = humanizeHogFunctionType(kind)
     const logicKey = `data-pipelines-hog-functions-${kind}`
-
-    const { hogFunctions, loading } = useValues(
-        hogFunctionsListLogic({ logicKey, type: kind, additionalTypes: additionalKinds })
-    )
 
     const { hogFunctionPluginsDestinations, hogFunctionBatchExports, hogFunctionPluginsSiteApps } =
         useValues(nonHogFunctionsLogic)
@@ -66,10 +40,7 @@ export function DataPipelinesHogFunctions({
         }
     }, [kind]) // oxlint-disable-line react-hooks/exhaustive-deps
 
-    const productInfoMapping = MAPPING[kind]
-
-    // Each source is null until it loads, so keep them unflattened here: the list just needs
-    // everything in one array, but the empty state has to tell "none" apart from "not loaded yet".
+    // Each source is null until it loads; the list just needs everything in one array.
     const manualSources: (HogFunctionType[] | null)[] =
         kind === 'destination'
             ? [hogFunctionPluginsDestinations, hogFunctionBatchExports]
@@ -79,23 +50,8 @@ export function DataPipelinesHogFunctions({
 
     const manualFunctions = manualSources.length > 0 ? manualSources.flatMap((source) => source ?? []) : undefined
 
-    // A null source has not loaded yet. Counting it as empty flashes the CTA before the data arrives.
-    const isEmpty =
-        !loading && hogFunctions.length === 0 && manualSources.every((source) => source !== null && source.length === 0)
-
     return (
         <SceneContent>
-            {productInfoMapping ? (
-                <ProductIntroduction
-                    productName={`Pipeline ${humanizedKind}s`}
-                    thingName={humanizedKind}
-                    productKey={productInfoMapping.key}
-                    description={productInfoMapping.description}
-                    docsURL="https://posthog.com/docs/cdp"
-                    actionElementOverride={action}
-                    isEmpty={isEmpty}
-                />
-            ) : null}
             <SceneSection>
                 <HogFunctionList
                     logicKey={logicKey}

--- a/frontend/src/scenes/data-pipelines/DestinationsScene.tsx
+++ b/frontend/src/scenes/data-pipelines/DestinationsScene.tsx
@@ -16,6 +16,7 @@ import { ProductKey } from '~/queries/schema/schema-general'
 import { ActivityScope } from '~/types'
 
 import { DestinationsIncidentReplayBanner } from 'products/cdp/frontend/DestinationsIncidentReplayBanner'
+import { destinationsEmptyState } from 'products/cdp/frontend/emptyState/destinationsEmptyState'
 
 import { DataPipelinesHogFunctions } from './DataPipelinesHogFunctions'
 import { destinationsSceneLogic } from './destinationsSceneLogic'
@@ -24,6 +25,7 @@ export const scene: SceneExport = {
     component: DestinationsScene,
     logic: destinationsSceneLogic,
     productKey: ProductKey.PIPELINE_DESTINATIONS,
+    emptyState: destinationsEmptyState,
 }
 
 export function DestinationsScene(): JSX.Element {
@@ -59,7 +61,6 @@ export function DestinationsScene(): JSX.Element {
                 <DataPipelinesHogFunctions
                     kind="destination"
                     additionalKinds={['site_destination', 'internal_destination']}
-                    action={action}
                 />
             ),
         },

--- a/frontend/src/scenes/data-pipelines/TransformationsScene.tsx
+++ b/frontend/src/scenes/data-pipelines/TransformationsScene.tsx
@@ -11,6 +11,8 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 
+import { transformationsEmptyState } from 'products/cdp/frontend/emptyState/transformationsEmptyState'
+
 import { DataPipelinesHogFunctions } from './DataPipelinesHogFunctions'
 import { transformationsSceneLogic } from './transformationsSceneLogic'
 
@@ -18,6 +20,7 @@ export const scene: SceneExport = {
     component: TransformationsScene,
     logic: transformationsSceneLogic,
     productKey: ProductKey.PIPELINE_TRANSFORMATIONS,
+    emptyState: transformationsEmptyState,
 }
 
 export function TransformationsScene(): JSX.Element {
@@ -52,7 +55,7 @@ export function TransformationsScene(): JSX.Element {
                 }}
                 actions={action}
             />
-            <DataPipelinesHogFunctions kind="transformation" action={action} />
+            <DataPipelinesHogFunctions kind="transformation" />
         </SceneContent>
     )
 }

--- a/frontend/src/scenes/data-pipelines/WebScriptsScene.tsx
+++ b/frontend/src/scenes/data-pipelines/WebScriptsScene.tsx
@@ -56,7 +56,7 @@ export function WebScriptsScene(): JSX.Element {
         {
             key: 'all',
             label: 'All web scripts',
-            content: <DataPipelinesHogFunctions kind="site_app" action={action} />,
+            content: <DataPipelinesHogFunctions kind="site_app" />,
         },
         {
             key: 'history',

--- a/products/cdp/frontend/emptyState/DestinationsPreview.scss
+++ b/products/cdp/frontend/emptyState/DestinationsPreview.scss
@@ -1,0 +1,345 @@
+@import '../../../../frontend/src/lib/components/ProductEmptyState/previewMixins';
+
+.DestinationsPreview {
+    --destinations-preview-accent: var(--empty-state-accent, var(--color-product-data-pipeline-light));
+
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    // Hidden enabled state. A direct child of .DestinationsPreview so `:checked ~` reaches all cards.
+    &__checkbox {
+        position: absolute;
+        width: 0;
+        height: 0;
+        pointer-events: none;
+        opacity: 0;
+    }
+
+    &__panel,
+    &__chat,
+    &__stat {
+        overflow: hidden;
+        background: var(--color-bg-surface-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius);
+    }
+
+    // Off/on pairs are stacked on one grid cell and crossfaded, so enabling the
+    // destination never changes any element's size (no layout shift).
+    &__swap {
+        display: grid;
+    }
+
+    &__swap > * {
+        grid-area: 1 / 1;
+        min-width: 0;
+    }
+
+    &__when-on {
+        @include preview-swap-hidden;
+    }
+
+    &__when-off {
+        @include preview-swap-visible;
+    }
+
+    &__head {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__title {
+        font-size: 0.75rem;
+        font-weight: 600;
+    }
+
+    // Destinations list
+
+    &__rows {
+        display: flex;
+        flex-direction: column;
+        padding: 0.25rem 0.5rem;
+    }
+
+    &__row {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.375rem 0.5rem;
+        border-radius: var(--radius);
+    }
+
+    &__row--hero {
+        cursor: pointer;
+        background: color-mix(in oklab, var(--destinations-preview-accent) 8%, transparent);
+    }
+
+    &__icon {
+        width: 16px;
+        height: 16px;
+        border-radius: 4px;
+
+        &--warehouse {
+            background: rgb(66 133 244 / 70%);
+        }
+
+        &--chat {
+            background: rgb(74 21 75 / 70%);
+        }
+
+        &--webhook {
+            background: var(--color-bg-fill-tertiary);
+        }
+    }
+
+    &__name {
+        display: flex;
+        flex-direction: column;
+        gap: 0.0625rem;
+        overflow: hidden;
+        font-size: 0.6875rem;
+        font-weight: 500;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__meta {
+        font-size: 0.5625rem;
+        font-weight: 400;
+        color: var(--color-text-tertiary);
+    }
+
+    // Mini switch. The off fill is darker than the surface with an inset ring so it stays legible.
+    &__switch {
+        position: relative;
+        width: 22px;
+        height: 12px;
+        background: var(--color-bg-fill-tertiary);
+        border-radius: 999px;
+        box-shadow: inset 0 0 0 1px var(--color-border-primary);
+        transition: background $preview-swap-duration ease;
+
+        &::after {
+            position: absolute;
+            top: 2px;
+            left: 2px;
+            width: 8px;
+            height: 8px;
+            content: '';
+            background: var(--color-bg-surface-primary);
+            border-radius: 50%;
+            box-shadow: 0 1px 2px rgb(0 0 0 / 20%);
+            transition: transform $preview-swap-duration ease;
+        }
+
+        &--on {
+            background: var(--destinations-preview-accent);
+            box-shadow: none;
+
+            &::after {
+                transform: translateX(10px);
+            }
+        }
+    }
+
+    // Bottom row: chat window and stat card side by side.
+
+    &__bottom {
+        display: grid;
+        grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+        gap: 0.75rem;
+    }
+
+    &__chat-head {
+        display: flex;
+        gap: 0.375rem;
+        align-items: center;
+        padding: 0.375rem 0.625rem;
+        background: rgb(74 21 75 / 8%);
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__chat-dot {
+        width: 6px;
+        height: 6px;
+        background: var(--color-success);
+        border-radius: 50%;
+    }
+
+    &__chat-channel {
+        font-size: 0.625rem;
+        font-weight: 600;
+    }
+
+    &__chat-body {
+        padding: 0.5rem 0.625rem 0.625rem;
+    }
+
+    &__chat-empty {
+        display: flex;
+        flex-direction: column;
+        gap: 0.375rem;
+    }
+
+    &__ghost {
+        width: 80%;
+        height: 6px;
+        background: var(--color-bg-fill-tertiary);
+        border-radius: 999px;
+
+        &--short {
+            width: 55%;
+        }
+    }
+
+    &__chat-hint {
+        margin-top: 0.125rem;
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    &__message {
+        display: flex;
+        gap: 0.375rem;
+        align-items: flex-start;
+    }
+
+    &__avatar {
+        flex-shrink: 0;
+        width: 16px;
+        height: 16px;
+        background: var(--destinations-preview-accent);
+        border-radius: 4px;
+    }
+
+    &__message-body {
+        display: flex;
+        flex-direction: column;
+        gap: 0.0625rem;
+        min-width: 0;
+    }
+
+    &__message-author {
+        font-size: 0.5625rem;
+        font-weight: 700;
+    }
+
+    &__message-text {
+        font-size: 0.5625rem;
+        line-height: 1.35;
+        color: var(--color-text-secondary);
+    }
+
+    // Stat card
+
+    &__stat {
+        padding: 0.625rem 0.75rem 0.75rem;
+    }
+
+    &__spark-caption {
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    &__footer {
+        margin-top: 0.375rem;
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    &__spark-area {
+        fill: color-mix(in oklab, var(--destinations-preview-accent) 13%, transparent);
+        stroke: none;
+    }
+
+    &__spark-line {
+        fill: none;
+        stroke: color-mix(in oklab, var(--destinations-preview-accent) 32%, transparent);
+        stroke-width: 2;
+    }
+
+    // The moving bit: a short bright segment cycling along the line.
+    &__spark-trace {
+        fill: none;
+        stroke: var(--destinations-preview-accent);
+        stroke-dasharray: 16 84;
+        stroke-linecap: round;
+        stroke-width: 2;
+        animation: DestinationsPreview__trace 3.2s linear infinite;
+    }
+
+    @include preview-sparkline;
+}
+
+// The sparkline mixin lays the value out as a flex row, which would place the two crossfading
+// values side by side; the swap needs them stacked on one grid cell.
+.DestinationsPreview__spark-value.DestinationsPreview__swap {
+    display: grid;
+}
+
+// Enabled state (user switched the Slack destination on)
+
+.DestinationsPreview__checkbox:checked ~ * .DestinationsPreview__when-on {
+    @include preview-swap-visible;
+}
+
+.DestinationsPreview__checkbox:checked ~ * .DestinationsPreview__when-off {
+    @include preview-swap-hidden;
+}
+
+.DestinationsPreview__checkbox:checked ~ .DestinationsPreview__panel .DestinationsPreview__switch--hero {
+    background: var(--destinations-preview-accent);
+    box-shadow: none;
+
+    &::after {
+        transform: translateX(10px);
+    }
+}
+
+// The checkbox stays keyboard-focusable while visually hidden, so the row it labels
+// needs a visible focus indicator (WCAG 2.4.7).
+.DestinationsPreview__checkbox:focus-visible ~ .DestinationsPreview__panel .DestinationsPreview__row--hero {
+    outline: 2px solid var(--destinations-preview-accent);
+    outline-offset: -2px;
+}
+
+// Nudge attention at the paused destination until it's enabled.
+.DestinationsPreview:not(.DestinationsPreview--static)
+    .DestinationsPreview__checkbox:not(:checked)
+    ~ .DestinationsPreview__panel
+    .DestinationsPreview__switch--hero {
+    animation: DestinationsPreview__pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes DestinationsPreview__pulse {
+    0%,
+    100% {
+        box-shadow:
+            inset 0 0 0 1px var(--color-border-primary),
+            0 0 0 0 color-mix(in oklab, var(--destinations-preview-accent) 40%, transparent);
+    }
+
+    50% {
+        box-shadow:
+            inset 0 0 0 1px var(--color-border-primary),
+            0 0 0 4px color-mix(in oklab, var(--destinations-preview-accent) 16%, transparent);
+    }
+}
+
+// pathLength is normalized to 100, so the dash offset loops cleanly regardless of length.
+@keyframes DestinationsPreview__trace {
+    to {
+        stroke-dashoffset: -100;
+    }
+}
+
+// Storybook snapshots and reduced motion drop all ambient motion; enabling the destination
+// still posts the message (transitions only).
+@include preview-motion-guards('DestinationsPreview');

--- a/products/cdp/frontend/emptyState/DestinationsPreview.tsx
+++ b/products/cdp/frontend/emptyState/DestinationsPreview.tsx
@@ -1,0 +1,136 @@
+import './DestinationsPreview.scss'
+
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { cn } from 'lib/utils/css-classes'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+
+// Hand-authored 24-hour delivery series for the stat card.
+const LINE = 'M 0 28 L 14 24 L 28 26 L 42 18 L 56 20 L 70 12 L 84 10 L 100 6'
+
+function areaPath(line: string): string {
+    return `${line} L 100 40 L 0 40 Z`
+}
+
+/**
+ * Example-data preview for the destinations empty state: the destinations list wired to a
+ * mini chat window, so enabling the Slack destination makes the alert message appear in
+ * the channel and starts counting deliveries. One hidden checkbox drives it via `:checked ~`
+ * styles - no timers or state, per the preview rules in the `building-product-empty-states`
+ * skill. Off/on pairs share a `__swap` grid cell and crossfade, so nothing moves.
+ */
+export function DestinationsPreview(): JSX.Element {
+    const isStatic = inStorybook() || inStorybookTestRunner()
+
+    return (
+        <div className={cn('DestinationsPreview', isStatic && 'DestinationsPreview--static')}>
+            {/* Enabled state, before all cards so `:checked ~` can style them. */}
+            <input type="checkbox" id="destinations-preview-toggle" className="DestinationsPreview__checkbox" />
+
+            <div className="DestinationsPreview__panel">
+                <div className="DestinationsPreview__head">
+                    <span className="DestinationsPreview__title">Destinations</span>
+                    <LemonTag size="small">example data</LemonTag>
+                </div>
+
+                <div className="DestinationsPreview__rows">
+                    <div className="DestinationsPreview__row">
+                        <span className="DestinationsPreview__icon DestinationsPreview__icon--warehouse" />
+                        <span className="DestinationsPreview__name">
+                            Nightly export to BigQuery
+                            <span className="DestinationsPreview__meta">Batch, every day at 02:00</span>
+                        </span>
+                        <span
+                            className="DestinationsPreview__switch DestinationsPreview__switch--on"
+                            aria-hidden="true"
+                        />
+                    </div>
+
+                    <label
+                        htmlFor="destinations-preview-toggle"
+                        className="DestinationsPreview__row DestinationsPreview__row--hero"
+                    >
+                        <span className="DestinationsPreview__icon DestinationsPreview__icon--chat" />
+                        <span className="DestinationsPreview__name">
+                            Payment failed alerts to Slack
+                            <span className="DestinationsPreview__meta DestinationsPreview__swap">
+                                <span className="DestinationsPreview__when-off">Real time, paused</span>
+                                <span className="DestinationsPreview__when-on">Real time, on payment_failed</span>
+                            </span>
+                        </span>
+                        <span
+                            className="DestinationsPreview__switch DestinationsPreview__switch--hero"
+                            aria-hidden="true"
+                        />
+                    </label>
+
+                    <div className="DestinationsPreview__row">
+                        <span className="DestinationsPreview__icon DestinationsPreview__icon--webhook" />
+                        <span className="DestinationsPreview__name">
+                            Signups to the CRM
+                            <span className="DestinationsPreview__meta">Webhook, on user_signed_up</span>
+                        </span>
+                        <span
+                            className="DestinationsPreview__switch DestinationsPreview__switch--on"
+                            aria-hidden="true"
+                        />
+                    </div>
+                </div>
+            </div>
+
+            <div className="DestinationsPreview__bottom">
+                <div className="DestinationsPreview__chat" aria-hidden="true">
+                    <div className="DestinationsPreview__chat-head">
+                        <span className="DestinationsPreview__chat-dot" />
+                        <span className="DestinationsPreview__chat-channel"># payments</span>
+                    </div>
+                    <div className="DestinationsPreview__chat-body DestinationsPreview__swap">
+                        <div className="DestinationsPreview__when-off DestinationsPreview__chat-empty">
+                            <span className="DestinationsPreview__ghost" />
+                            <span className="DestinationsPreview__ghost DestinationsPreview__ghost--short" />
+                            <span className="DestinationsPreview__chat-hint">Enable the destination above</span>
+                        </div>
+                        <div className="DestinationsPreview__when-on DestinationsPreview__message">
+                            <span className="DestinationsPreview__avatar" />
+                            <span className="DestinationsPreview__message-body">
+                                <span className="DestinationsPreview__message-author">PostHog</span>
+                                <span className="DestinationsPreview__message-text">
+                                    Payment failed for <b>acme.example.com</b>. Card declined, 3rd attempt.
+                                </span>
+                            </span>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="DestinationsPreview__stat">
+                    <div className="DestinationsPreview__spark-head">
+                        <span className="DestinationsPreview__spark-title">Deliveries</span>
+                        <span className="DestinationsPreview__spark-caption">Last 24 hours</span>
+                    </div>
+                    <div className="DestinationsPreview__spark-value DestinationsPreview__swap">
+                        <span className="DestinationsPreview__when-off">3,412</span>
+                        <span className="DestinationsPreview__when-on">3,458</span>
+                    </div>
+                    <svg
+                        className="DestinationsPreview__spark-svg"
+                        viewBox="0 0 100 40"
+                        preserveAspectRatio="none"
+                        aria-hidden="true"
+                    >
+                        <path className="DestinationsPreview__spark-area" d={areaPath(LINE)} />
+                        <path className="DestinationsPreview__spark-line" d={LINE} vectorEffect="non-scaling-stroke" />
+                        <path
+                            className="DestinationsPreview__spark-trace"
+                            d={LINE}
+                            pathLength={100}
+                            vectorEffect="non-scaling-stroke"
+                        />
+                    </svg>
+                    <span className="DestinationsPreview__footer DestinationsPreview__swap">
+                        <span className="DestinationsPreview__when-off">2 destinations on. 9 retries, 0 failed.</span>
+                        <span className="DestinationsPreview__when-on">3 destinations on. 9 retries, 0 failed.</span>
+                    </span>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/products/cdp/frontend/emptyState/TransformationsPreview.scss
+++ b/products/cdp/frontend/emptyState/TransformationsPreview.scss
@@ -1,0 +1,315 @@
+@import '../../../../frontend/src/lib/components/ProductEmptyState/previewMixins';
+
+.TransformationsPreview {
+    --transformations-preview-accent: var(--empty-state-accent, var(--color-product-data-pipeline-light));
+
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    // Hidden enabled state. A direct child of .TransformationsPreview so `:checked ~` reaches all cards.
+    &__checkbox {
+        position: absolute;
+        width: 0;
+        height: 0;
+        pointer-events: none;
+        opacity: 0;
+    }
+
+    &__panel,
+    &__event,
+    &__stat {
+        overflow: hidden;
+        background: var(--color-bg-surface-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius);
+    }
+
+    // Off/on pairs are stacked on one grid cell and crossfaded, so enabling the
+    // transformation never changes any element's size (no layout shift).
+    &__swap {
+        display: grid;
+    }
+
+    &__swap > * {
+        grid-area: 1 / 1;
+        min-width: 0;
+    }
+
+    &__when-on {
+        @include preview-swap-hidden;
+    }
+
+    &__when-off {
+        @include preview-swap-visible;
+    }
+
+    &__head {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__title {
+        font-size: 0.75rem;
+        font-weight: 600;
+    }
+
+    &__order {
+        flex: 1;
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    // Transformation list
+
+    &__rows {
+        display: flex;
+        flex-direction: column;
+        padding: 0.25rem 0.5rem;
+    }
+
+    &__row {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.375rem 0.5rem;
+        border-radius: var(--radius);
+    }
+
+    &__row--hero {
+        cursor: pointer;
+        background: color-mix(in oklab, var(--transformations-preview-accent) 8%, transparent);
+    }
+
+    &__step {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 16px;
+        height: 16px;
+        font-size: 0.5625rem;
+        font-weight: 700;
+        color: var(--color-text-secondary);
+        background: var(--color-bg-fill-tertiary);
+        border-radius: 50%;
+    }
+
+    &__name {
+        display: flex;
+        flex-direction: column;
+        gap: 0.0625rem;
+        overflow: hidden;
+        font-size: 0.6875rem;
+        font-weight: 500;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__meta {
+        font-size: 0.5625rem;
+        font-weight: 400;
+        color: var(--color-text-tertiary);
+    }
+
+    // Mini switch. The off fill is darker than the surface with an inset ring so it stays legible.
+    &__switch {
+        position: relative;
+        width: 22px;
+        height: 12px;
+        background: var(--color-bg-fill-tertiary);
+        border-radius: 999px;
+        box-shadow: inset 0 0 0 1px var(--color-border-primary);
+        transition: background $preview-swap-duration ease;
+
+        &::after {
+            position: absolute;
+            top: 2px;
+            left: 2px;
+            width: 8px;
+            height: 8px;
+            content: '';
+            background: var(--color-bg-surface-primary);
+            border-radius: 50%;
+            box-shadow: 0 1px 2px rgb(0 0 0 / 20%);
+            transition: transform $preview-swap-duration ease;
+        }
+
+        &--on {
+            background: var(--transformations-preview-accent);
+            box-shadow: none;
+
+            &::after {
+                transform: translateX(10px);
+            }
+        }
+    }
+
+    // Bottom row: the event and the stat card side by side.
+
+    &__bottom {
+        display: grid;
+        grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+        gap: 0.75rem;
+    }
+
+    &__event-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.375rem 0.625rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__event-name {
+        font-family: var(--font-mono);
+        font-size: 0.625rem;
+        font-weight: 600;
+    }
+
+    &__event-when {
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    &__props {
+        display: flex;
+        flex-direction: column;
+        gap: 0.1875rem;
+        padding: 0.5rem 0.625rem 0.625rem;
+    }
+
+    &__prop {
+        display: flex;
+        gap: 0.375rem;
+        justify-content: space-between;
+        font-family: var(--font-mono);
+        font-size: 0.5625rem;
+    }
+
+    // Properties the transformation adds. They keep their rows in both states and fade in,
+    // so enabling never shifts the layout.
+    &__prop--added {
+        @include preview-swap-hidden;
+    }
+
+    &__key {
+        overflow: hidden;
+        color: var(--color-text-tertiary);
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__val {
+        flex-shrink: 0;
+    }
+
+    &__prop--added &__val {
+        @include preview-accent-text(var(--transformations-preview-accent));
+    }
+
+    // Stat card
+
+    &__stat {
+        padding: 0.625rem 0.75rem 0.75rem;
+    }
+
+    &__spark-caption {
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    &__footer {
+        margin-top: 0.375rem;
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    &__spark-area {
+        fill: color-mix(in oklab, var(--transformations-preview-accent) 13%, transparent);
+        stroke: none;
+    }
+
+    &__spark-line {
+        fill: none;
+        stroke: color-mix(in oklab, var(--transformations-preview-accent) 32%, transparent);
+        stroke-width: 2;
+    }
+
+    // The moving bit: a short bright segment cycling along the line.
+    &__spark-trace {
+        fill: none;
+        stroke: var(--transformations-preview-accent);
+        stroke-dasharray: 16 84;
+        stroke-linecap: round;
+        stroke-width: 2;
+        animation: TransformationsPreview__trace 3.2s linear infinite;
+    }
+
+    @include preview-sparkline;
+}
+
+// Enabled state (user switched GeoIP on)
+
+.TransformationsPreview__checkbox:checked ~ * .TransformationsPreview__when-on,
+.TransformationsPreview__checkbox:checked ~ * .TransformationsPreview__prop--added {
+    @include preview-swap-visible;
+}
+
+.TransformationsPreview__checkbox:checked ~ * .TransformationsPreview__when-off {
+    @include preview-swap-hidden;
+}
+
+.TransformationsPreview__checkbox:checked ~ .TransformationsPreview__panel .TransformationsPreview__switch--hero {
+    background: var(--transformations-preview-accent);
+    box-shadow: none;
+
+    &::after {
+        transform: translateX(10px);
+    }
+}
+
+// The checkbox stays keyboard-focusable while visually hidden, so the row it labels
+// needs a visible focus indicator (WCAG 2.4.7).
+.TransformationsPreview__checkbox:focus-visible ~ .TransformationsPreview__panel .TransformationsPreview__row--hero {
+    outline: 2px solid var(--transformations-preview-accent);
+    outline-offset: -2px;
+}
+
+// Nudge attention at the paused transformation until it's enabled.
+.TransformationsPreview:not(.TransformationsPreview--static)
+    .TransformationsPreview__checkbox:not(:checked)
+    ~ .TransformationsPreview__panel
+    .TransformationsPreview__switch--hero {
+    animation: TransformationsPreview__pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes TransformationsPreview__pulse {
+    0%,
+    100% {
+        box-shadow:
+            inset 0 0 0 1px var(--color-border-primary),
+            0 0 0 0 color-mix(in oklab, var(--transformations-preview-accent) 40%, transparent);
+    }
+
+    50% {
+        box-shadow:
+            inset 0 0 0 1px var(--color-border-primary),
+            0 0 0 4px color-mix(in oklab, var(--transformations-preview-accent) 16%, transparent);
+    }
+}
+
+// pathLength is normalized to 100, so the dash offset loops cleanly regardless of length.
+@keyframes TransformationsPreview__trace {
+    to {
+        stroke-dashoffset: -100;
+    }
+}
+
+// Storybook snapshots and reduced motion drop all ambient motion; enabling the transformation
+// still adds the properties (transitions only).
+@include preview-motion-guards('TransformationsPreview');

--- a/products/cdp/frontend/emptyState/TransformationsPreview.tsx
+++ b/products/cdp/frontend/emptyState/TransformationsPreview.tsx
@@ -1,0 +1,150 @@
+import './TransformationsPreview.scss'
+
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { cn } from 'lib/utils/css-classes'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+
+// Hand-authored 24-hour series of events that passed through the pipeline.
+const LINE = 'M 0 24 L 14 22 L 28 25 L 42 17 L 56 19 L 70 13 L 84 11 L 100 7'
+
+function areaPath(line: string): string {
+    return `${line} L 100 40 L 0 40 Z`
+}
+
+/**
+ * Example-data preview for the transformations empty state: the ordered transformation list
+ * next to one event as it comes out of the pipeline, so enabling GeoIP adds location
+ * properties to the event. One hidden checkbox drives it via `:checked ~` styles - no timers
+ * or state, per the preview rules in the `building-product-empty-states` skill. The added
+ * property lines occupy their rows in both states and only fade in, so nothing moves.
+ */
+export function TransformationsPreview(): JSX.Element {
+    const isStatic = inStorybook() || inStorybookTestRunner()
+
+    return (
+        <div className={cn('TransformationsPreview', isStatic && 'TransformationsPreview--static')}>
+            {/* Enabled state, before all cards so `:checked ~` can style them. */}
+            <input type="checkbox" id="transformations-preview-toggle" className="TransformationsPreview__checkbox" />
+
+            <div className="TransformationsPreview__panel">
+                <div className="TransformationsPreview__head">
+                    <span className="TransformationsPreview__title">Transformations</span>
+                    <span className="TransformationsPreview__order">Run in order</span>
+                    <LemonTag size="small">example data</LemonTag>
+                </div>
+
+                <div className="TransformationsPreview__rows">
+                    <div className="TransformationsPreview__row">
+                        <span className="TransformationsPreview__step">1</span>
+                        <span className="TransformationsPreview__name">
+                            Filter out bots
+                            <span className="TransformationsPreview__meta">Drops 3.1% of events</span>
+                        </span>
+                        <span
+                            className="TransformationsPreview__switch TransformationsPreview__switch--on"
+                            aria-hidden="true"
+                        />
+                    </div>
+
+                    <label
+                        htmlFor="transformations-preview-toggle"
+                        className="TransformationsPreview__row TransformationsPreview__row--hero"
+                    >
+                        <span className="TransformationsPreview__step">2</span>
+                        <span className="TransformationsPreview__name">
+                            Add GeoIP location
+                            <span className="TransformationsPreview__meta TransformationsPreview__swap">
+                                <span className="TransformationsPreview__when-off">Paused</span>
+                                <span className="TransformationsPreview__when-on">Adds 6 properties</span>
+                            </span>
+                        </span>
+                        <span
+                            className="TransformationsPreview__switch TransformationsPreview__switch--hero"
+                            aria-hidden="true"
+                        />
+                    </label>
+
+                    <div className="TransformationsPreview__row">
+                        <span className="TransformationsPreview__step">3</span>
+                        <span className="TransformationsPreview__name">
+                            Drop internal emails
+                            <span className="TransformationsPreview__meta">
+                                Removes email when it matches your domain
+                            </span>
+                        </span>
+                        <span
+                            className="TransformationsPreview__switch TransformationsPreview__switch--on"
+                            aria-hidden="true"
+                        />
+                    </div>
+                </div>
+            </div>
+
+            <div className="TransformationsPreview__bottom">
+                <div className="TransformationsPreview__event" aria-hidden="true">
+                    <div className="TransformationsPreview__event-head">
+                        <span className="TransformationsPreview__event-name">$pageview</span>
+                        <span className="TransformationsPreview__event-when">just now</span>
+                    </div>
+                    <div className="TransformationsPreview__props">
+                        <span className="TransformationsPreview__prop">
+                            <span className="TransformationsPreview__key">$current_url</span>
+                            <span className="TransformationsPreview__val">/pricing</span>
+                        </span>
+                        <span className="TransformationsPreview__prop">
+                            <span className="TransformationsPreview__key">$browser</span>
+                            <span className="TransformationsPreview__val">Firefox</span>
+                        </span>
+                        <span className="TransformationsPreview__prop TransformationsPreview__prop--added">
+                            <span className="TransformationsPreview__key">$geoip_city_name</span>
+                            <span className="TransformationsPreview__val">Lisbon</span>
+                        </span>
+                        <span className="TransformationsPreview__prop TransformationsPreview__prop--added">
+                            <span className="TransformationsPreview__key">$geoip_country_code</span>
+                            <span className="TransformationsPreview__val">PT</span>
+                        </span>
+                        <span className="TransformationsPreview__prop TransformationsPreview__prop--added">
+                            <span className="TransformationsPreview__key">$geoip_time_zone</span>
+                            <span className="TransformationsPreview__val">Europe/Lisbon</span>
+                        </span>
+                    </div>
+                </div>
+
+                <div className="TransformationsPreview__stat">
+                    <div className="TransformationsPreview__spark-head">
+                        <span className="TransformationsPreview__spark-title">Events transformed</span>
+                        <span className="TransformationsPreview__spark-caption">Last 24 hours</span>
+                    </div>
+                    <div className="TransformationsPreview__spark-value">128k</div>
+                    <svg
+                        className="TransformationsPreview__spark-svg"
+                        viewBox="0 0 100 40"
+                        preserveAspectRatio="none"
+                        aria-hidden="true"
+                    >
+                        <path className="TransformationsPreview__spark-area" d={areaPath(LINE)} />
+                        <path
+                            className="TransformationsPreview__spark-line"
+                            d={LINE}
+                            vectorEffect="non-scaling-stroke"
+                        />
+                        <path
+                            className="TransformationsPreview__spark-trace"
+                            d={LINE}
+                            pathLength={100}
+                            vectorEffect="non-scaling-stroke"
+                        />
+                    </svg>
+                    <span className="TransformationsPreview__footer TransformationsPreview__swap">
+                        <span className="TransformationsPreview__when-off">
+                            2 transformations on. 4.1k events dropped.
+                        </span>
+                        <span className="TransformationsPreview__when-on">
+                            3 transformations on. 4.1k events dropped.
+                        </span>
+                    </span>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/products/cdp/frontend/emptyState/destinationsEmptyState.tsx
+++ b/products/cdp/frontend/emptyState/destinationsEmptyState.tsx
@@ -1,0 +1,39 @@
+import * as trafficControllerPng from '@posthog/brand/hoggies/png/traffic-controller'
+import { IconSend } from '@posthog/icons'
+
+import { pngHoggie } from 'lib/brand/hoggies'
+import type { SceneProductEmptyState } from 'lib/components/ProductEmptyState/types'
+import { urls } from 'scenes/urls'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { DestinationsPreview } from './DestinationsPreview'
+import { destinationsSetupLogic } from './destinationsSetupLogic'
+
+const HedgehogTrafficController = pngHoggie(trafficControllerPng)
+
+export const destinationsEmptyState: SceneProductEmptyState = {
+    statusLogic: destinationsSetupLogic,
+    config: {
+        productKey: ProductKey.PIPELINE_DESTINATIONS,
+        productName: 'Destinations',
+        icon: <IconSend />,
+        accentColor: 'var(--color-product-data-pipeline-light)',
+        accentColorDark: 'var(--color-product-data-pipeline-dark)',
+        hedgehog: HedgehogTrafficController,
+        text: {
+            'needs-setup': {
+                headline: 'Send your events where your team already works',
+                lead: 'A destination forwards events from PostHog to another tool as they arrive, or in scheduled batches to a warehouse. Start from a template for Slack, webhooks, Salesforce, BigQuery, S3, and dozens more, filter which events it gets, and watch every delivery and failure from one list.',
+            },
+        },
+        primaryAction: {
+            label: 'Create your first destination',
+            to: urls.dataPipelinesNew('destination'),
+            dataAttr: 'new-destination',
+        },
+        docsUrl: 'https://posthog.com/docs/cdp/destinations',
+        previewLabel: 'Your destinations, once connected',
+        Preview: DestinationsPreview,
+    },
+}

--- a/products/cdp/frontend/emptyState/destinationsSetupLogic.test.ts
+++ b/products/cdp/frontend/emptyState/destinationsSetupLogic.test.ts
@@ -1,0 +1,63 @@
+import { expectLogic } from 'kea-test-utils'
+
+import api from 'lib/api'
+import { productSetupStatusLogic } from 'lib/components/ProductEmptyState/productSetupStatusLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+
+import * as generatedApi from '../generated/api'
+import { destinationsSetupLogic } from './destinationsSetupLogic'
+
+// Guards the mapping into the app-wide setup-status layer: if it breaks, the scene
+// empty-state gate strands on its spinner or shows the wrong surface.
+describe('destinationsSetupLogic', () => {
+    let hogFunctionsSpy: jest.SpyInstance
+    let pluginsSpy: jest.SpyInstance
+    let batchExportsSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        hogFunctionsSpy = jest.spyOn(generatedApi, 'hogFunctionsList')
+        pluginsSpy = jest.spyOn(api, 'get')
+        batchExportsSpy = jest.spyOn(api.batchExports, 'list')
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        hogFunctionsSpy.mockRestore()
+        pluginsSpy.mockRestore()
+        batchExportsSpy.mockRestore()
+    })
+
+    // The scene lists hog functions, legacy plugin destinations, and batch exports together,
+    // so the count is the sum of all three sources.
+    it.each([
+        [0, 0, 0, 'needs-setup'],
+        [1, 0, 0, 'has-data'],
+        [0, 2, 0, 'has-data'],
+        [0, 0, 1, 'has-data'],
+    ])(
+        'pushes %i hog functions, %i plugin destinations, and %i batch exports as status %s',
+        async (hogFunctions, plugins, batchExports, expected) => {
+            hogFunctionsSpy.mockResolvedValue({ count: hogFunctions, next: null, previous: null, results: [] })
+            pluginsSpy.mockResolvedValue({ count: plugins, results: [] })
+            batchExportsSpy.mockResolvedValue({ count: batchExports, results: [] })
+            const logic = destinationsSetupLogic()
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+            expect(productSetupStatusLogic({ productKey: ProductKey.PIPELINE_DESTINATIONS }).values.status).toBe(
+                expected
+            )
+        }
+    )
+
+    it('fails open to unknown when a count query fails before any answer', async () => {
+        hogFunctionsSpy.mockRejectedValue(new Error('network down'))
+        pluginsSpy.mockResolvedValue({ count: 0, results: [] })
+        batchExportsSpy.mockResolvedValue({ count: 0, results: [] })
+        const logic = destinationsSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.PIPELINE_DESTINATIONS }).values.status).toBe('unknown')
+    })
+})

--- a/products/cdp/frontend/emptyState/destinationsSetupLogic.ts
+++ b/products/cdp/frontend/emptyState/destinationsSetupLogic.ts
@@ -1,0 +1,34 @@
+import api, { type CountedPaginatedResponse } from 'lib/api'
+import { createSetupDetectionLogic } from 'lib/components/ProductEmptyState/setupDetectionLogic'
+import { projectLogic } from 'scenes/projectLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { hogFunctionsList } from '../generated/api'
+
+/**
+ * Setup detection for the destinations empty state. Destinations are creation-first, so
+ * "set up" means the project has at least one thing the scene would list: a destination
+ * hog function, a legacy plugin destination, or a batch export. Counting only hog functions
+ * would tell a project still exporting through plugins or batch exports to create its
+ * first destination and hide the ones delivering its data today.
+ */
+export const destinationsSetupLogic = createSetupDetectionLogic({
+    productKey: ProductKey.PIPELINE_DESTINATIONS,
+    path: ['products', 'cdp', 'frontend', 'emptyState', 'destinationsSetupLogic'],
+    detect: async () => {
+        const projectId = String(projectLogic.findMounted()?.values.currentProjectId)
+        const [hogFunctions, pluginDestinations, batchExports] = await Promise.all([
+            hogFunctionsList(projectId, {
+                type: ['destination', 'site_destination', 'internal_destination'],
+                limit: 1,
+            }),
+            api.get<CountedPaginatedResponse<unknown>>(
+                `api/projects/${projectId}/pipeline_destination_configs/?limit=1`
+            ),
+            api.batchExports.list({ limit: 1 }),
+        ])
+        const total = hogFunctions.count + (pluginDestinations.count ?? 0) + (batchExports.count ?? 0)
+        return total > 0 ? 'has-data' : 'needs-setup'
+    },
+})

--- a/products/cdp/frontend/emptyState/destinationsSetupLogic.ts
+++ b/products/cdp/frontend/emptyState/destinationsSetupLogic.ts
@@ -23,6 +23,9 @@ export const destinationsSetupLogic = createSetupDetectionLogic({
                 type: ['destination', 'site_destination', 'internal_destination'],
                 limit: 1,
             }),
+            // The legacy plugin config endpoints are not in the OpenAPI spec, so there is
+            // no generated client to call here.
+            // nosemgrep: prefer-codegen-api
             api.get<CountedPaginatedResponse<unknown>>(
                 `api/projects/${projectId}/pipeline_destination_configs/?limit=1`
             ),

--- a/products/cdp/frontend/emptyState/transformationsEmptyState.tsx
+++ b/products/cdp/frontend/emptyState/transformationsEmptyState.tsx
@@ -1,0 +1,39 @@
+import * as transformerPng from '@posthog/brand/hoggies/png/transformer'
+import { IconShuffle } from '@posthog/icons'
+
+import { pngHoggie } from 'lib/brand/hoggies'
+import type { SceneProductEmptyState } from 'lib/components/ProductEmptyState/types'
+import { urls } from 'scenes/urls'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { TransformationsPreview } from './TransformationsPreview'
+import { transformationsSetupLogic } from './transformationsSetupLogic'
+
+const HedgehogTransformer = pngHoggie(transformerPng)
+
+export const transformationsEmptyState: SceneProductEmptyState = {
+    statusLogic: transformationsSetupLogic,
+    config: {
+        productKey: ProductKey.PIPELINE_TRANSFORMATIONS,
+        productName: 'Transformations',
+        icon: <IconShuffle />,
+        accentColor: 'var(--color-product-data-pipeline-light)',
+        accentColorDark: 'var(--color-product-data-pipeline-dark)',
+        hedgehog: HedgehogTransformer,
+        text: {
+            'needs-setup': {
+                headline: 'Clean up events before they are stored',
+                lead: 'A transformation runs on every event as it is ingested, before anything else sees it. Use one to add GeoIP location, drop properties you do not want to keep, filter out bot traffic, or fix a property name the SDK got wrong. Start from a template, or write your own in Hog.',
+            },
+        },
+        primaryAction: {
+            label: 'Create your first transformation',
+            to: urls.dataPipelinesNew('transformation'),
+            dataAttr: 'new-transformation',
+        },
+        docsUrl: 'https://posthog.com/docs/cdp/transformations',
+        previewLabel: 'Your transformations, once enabled',
+        Preview: TransformationsPreview,
+    },
+}

--- a/products/cdp/frontend/emptyState/transformationsSetupLogic.test.ts
+++ b/products/cdp/frontend/emptyState/transformationsSetupLogic.test.ts
@@ -1,0 +1,48 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { productSetupStatusLogic } from 'lib/components/ProductEmptyState/productSetupStatusLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+
+import * as generatedApi from '../generated/api'
+import { transformationsSetupLogic } from './transformationsSetupLogic'
+
+// Guards the mapping into the app-wide setup-status layer: if it breaks, the scene
+// empty-state gate strands on its spinner or shows the wrong surface.
+describe('transformationsSetupLogic', () => {
+    let listSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        listSpy = jest.spyOn(generatedApi, 'hogFunctionsList')
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        listSpy.mockRestore()
+    })
+
+    it.each([
+        [0, 'needs-setup'],
+        [1, 'has-data'],
+        [5, 'has-data'],
+    ])('pushes a transformation count of %i as status %s', async (count, expected) => {
+        listSpy.mockResolvedValue({ count, next: null, previous: null, results: [] })
+        const logic = transformationsSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.PIPELINE_TRANSFORMATIONS }).values.status).toBe(
+            expected
+        )
+    })
+
+    it('fails open to unknown when the count query fails before any answer', async () => {
+        listSpy.mockRejectedValue(new Error('network down'))
+        const logic = transformationsSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.PIPELINE_TRANSFORMATIONS }).values.status).toBe(
+            'unknown'
+        )
+    })
+})

--- a/products/cdp/frontend/emptyState/transformationsSetupLogic.ts
+++ b/products/cdp/frontend/emptyState/transformationsSetupLogic.ts
@@ -1,0 +1,22 @@
+import { createSetupDetectionLogic } from 'lib/components/ProductEmptyState/setupDetectionLogic'
+import { projectLogic } from 'scenes/projectLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { hogFunctionsList } from '../generated/api'
+
+/**
+ * Setup detection for the transformations empty state. Transformations are creation-first
+ * and only ever hog functions, so one transformation of any kind means the scene has a
+ * list to show. Re-checks on every mount (the gate mounts it), which covers returning
+ * from the creation page.
+ */
+export const transformationsSetupLogic = createSetupDetectionLogic({
+    productKey: ProductKey.PIPELINE_TRANSFORMATIONS,
+    path: ['products', 'cdp', 'frontend', 'emptyState', 'transformationsSetupLogic'],
+    detect: async () => {
+        const projectId = String(projectLogic.findMounted()?.values.currentProjectId)
+        const response = await hogFunctionsList(projectId, { type: ['transformation'], limit: 1 })
+        return response.count > 0 ? 'has-data' : 'needs-setup'
+    },
+})


### PR DESCRIPTION
## Problem

A project with no destinations or no transformations opens the pipeline scene to a dashed `ProductIntroduction` panel above an empty list and a template gallery. The panel only restates the scene description. Destinations is the busier of the two landing pages that still used that panel, and both share one component, so they move together. Layer 3 of stack #95413, after #95409.

## Changes

- A project with no destinations now sees the shared setup empty state with "Create your first destination". The preview is a destinations list wired to an example chat channel: switching the paused Slack destination on posts the alert message and moves the delivery count.
- A project with no transformations sees the matching screen with "Create your first transformation". Its preview is the ordered transformation list next to one event: switching GeoIP on fades the location properties into the event.
- Both screens can be skipped, because the scene behind them still offers the template gallery.
- Destination detection counts hog function destinations, legacy plugin destinations, and batch exports together. Counting only hog functions would tell a project that exports through plugins or batch exports to create its first destination. Transformation detection counts transformation hog functions only, which is all that scene lists.
- The create buttons carry the scenes' existing `new-destination` and `new-transformation` data attributes.
- Mechanical: `DataPipelinesHogFunctions` loses the `ProductIntroduction`, its product mapping, its emptiness check, and the `action` prop that only fed the panel. The web scripts scene, which already had its own empty state, drops the same prop. The adoption tracker gains both rows.

Destinations before and after switching the Slack destination on:

![destinations-before](https://raw.githubusercontent.com/PostHog/pr-assets/f263eb9d9e0cc521880296ce3fba99b10c069ef5/2026/09/535cba3f-d64d-4c09-9a42-ab989430d3fa.png)

![destinations-after](https://raw.githubusercontent.com/PostHog/pr-assets/ce9f13489d5ad57bdb7641b162690758bc59e2ba/2026/09/daf1cd05-e376-47c3-a053-4ce9d3b8c150.png)

Transformations before and after switching GeoIP on:

![transformations-before](https://raw.githubusercontent.com/PostHog/pr-assets/e60720541f811d143c813d06c3f00f927ffe5ae0/2026/09/5d110d7b-2f48-460e-a073-bc30443d8b3a.png)

![transformations-after](https://raw.githubusercontent.com/PostHog/pr-assets/f1794d88f2c9bb1472b4340856c09c75e817bf59/2026/09/c63d9e8e-2b3f-4271-b323-5404ac597b3c.png)

## How did you test this code?

- `destinationsSetupLogic.test.ts` covers each of the three sources counting on its own and the fail-open path. It catches the regression where a project running only plugin destinations or batch exports is told to create its first destination.
- `transformationsSetupLogic.test.ts` covers the count-to-status mapping and the fail-open path.
- Both new stories render the shipped configs in Storybook. The screenshots above come from them through Playwright.
- Not run: the scenes against a real project.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The docs describe creating destinations and transformations, which is unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Fable 5.1). Skills invoked: `/building-product-empty-states`, `/stacking-prs`, `/writing-ui-components`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`. Decisions: two configs with their own product keys rather than one shared config, because the two scenes have different creation paths and previews; the legacy plugin count reads the paginated endpoint with `limit: 1` instead of loading every page as the list does. #87738, which touched the same empty state, was closed before this PR.
