### PR TITLE
feat(engineering-analytics): add a setup empty state to the engineering analytics scene

### DIFF
--- a/docs/internal/product-empty-state-adoption.md
+++ b/docs/internal/product-empty-state-adoption.md
@@ -114,9 +114,8 @@ deeper, so the product is half-migrated.
 
 ### Tier 4: everything else
 
-Still on `ProductIntroduction`: engineering analytics,
-comments, ingestion warnings (v1 and v2),
-and Max conversation history.
+Still on `ProductIntroduction`: comments, ingestion warnings (v1 and v2), and Max conversation
+history.
 
 Hand-rolled empty states: review hog, streamlit apps, groups (`GroupsIntroduction`), persons, and
 the LLM analytics sessions tab.

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1836,6 +1836,10 @@ snapshots:
         hash: v1.k794b7964.de021a6d2a8c7ec6bc031fc7c9586a2d9f12e80804b9a92ec1a9f464c096314e.jqj7jfnrY7rf7IO2Uqrc784pV_YXfH52sTArLcXn8c0
     components-product-empty-state--endpoints-needs-setup--light:
         hash: v1.k794b7964.f704e98aa8d0102c164b7db7390449584c4b84f461cc5bbeac426e48a16dc200.S0QeUPtO_6LQsU5lZ09MyJMaf_Q_CPBBuYbvKzik1cU
+    components-product-empty-state--engineering-analytics-needs-setup--dark:
+        hash: v1.k794b7964.f7882e375c8b2730c69d683328d88541ef262da3287cfd29f169da8726a56ffc.03tjEZ1wDOe8_yDAZMUx1bTS8YVSLa5q_fhO3sz3oYE
+    components-product-empty-state--engineering-analytics-needs-setup--light:
+        hash: v1.k794b7964.77d16ba7ab8cbf85db31ec8d482970fe3ad311978901ffea75688390a3894824.GTpSlL6ZixDiYCyrG1IhtXxM1_i25Hk2pW_PYVPs4X8
     components-product-empty-state--error-tracking-needs-setup--dark:
         hash: v1.k794b7964.a3fcfa83eb816f90ccc0a031486d1d493e3893df6d9b23ab8138efbbfe833374.AIGP2LVUdagSan_3zq5NEx5QT3To4HN4BwQv06ML7Nw
     components-product-empty-state--error-tracking-needs-setup--light:

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
@@ -22,6 +22,7 @@ import { dataCatalogEmptyState } from 'products/data_catalog/frontend/emptyState
 import { dataWarehouseEmptyState } from 'products/data_warehouse/frontend/emptyState/dataWarehouseEmptyState'
 import { earlyAccessFeaturesEmptyState } from 'products/early_access_features/frontend/emptyState/earlyAccessFeaturesEmptyState'
 import { endpointsEmptyState } from 'products/endpoints/frontend/emptyState/endpointsEmptyState'
+import { engineeringAnalyticsEmptyState } from 'products/engineering_analytics/frontend/emptyState/engineeringAnalyticsEmptyState'
 import { errorTrackingEmptyState } from 'products/error_tracking/frontend/emptyState/errorTrackingEmptyState'
 import { experimentsEmptyState } from 'products/experiments/frontend/emptyState/experimentsEmptyState'
 import { featureFlagsEmptyState } from 'products/feature_flags/frontend/emptyState/featureFlagsEmptyState'
@@ -413,6 +414,13 @@ export const TransformationsNeedsSetup: ProductEmptyStateStory = productEmptySta
     transformationsEmptyState,
     'needs-setup',
     { mocks: { get: { '/api/projects/:team_id/hog_functions/': [200, emptyEntityList] } } }
+)
+
+// Engineering analytics detection lists GitHub sources on mount - answer "none yet".
+export const EngineeringAnalyticsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(
+    engineeringAnalyticsEmptyState,
+    'needs-setup',
+    { mocks: { get: { '/api/projects/:team_id/engineering_analytics/sources/': [200, []] } } }
 )
 
 export const HeatmapsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(heatmapsEmptyState, 'needs-setup')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3241,6 +3241,9 @@ importers:
 
   products/engineering_analytics:
     dependencies:
+      '@posthog/brand':
+        specifier: 'catalog:'
+        version: 0.11.0(react@18.3.1)
       '@posthog/icons':
         specifier: 'catalog:'
         version: 0.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/products/engineering_analytics/frontend/components/ConnectGitHubSource.tsx
+++ b/products/engineering_analytics/frontend/components/ConnectGitHubSource.tsx
@@ -1,28 +1,23 @@
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonBanner } from '@posthog/lemon-ui'
 
-import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { urls } from 'scenes/urls'
 
-import { ProductKey } from '~/queries/schema/schema-general'
-
+/**
+ * Shown by a tab whose data endpoints report no GitHub source. The scene-level empty state
+ * covers a project that never connected one; this covers a source removed while the scene
+ * is open, so the tab still says what to do instead of showing a failed load.
+ */
 export function ConnectGitHubSource(): JSX.Element {
     return (
-        <ProductIntroduction
-            productName="Engineering analytics"
-            productKey={ProductKey.ENGINEERING_ANALYTICS}
-            thingName="GitHub source"
-            titleOverride="Connect a GitHub source to get started"
-            description="Engineering analytics reads pull requests and workflow runs from a GitHub data warehouse source. Connect one to see CI health, pull request throughput, and cost."
-            isEmpty
-            actionElementOverride={
-                <LemonButton
-                    type="primary"
-                    to={urls.dataWarehouseSourceNew('Github')}
-                    data-attr="engineering-analytics-connect-github"
-                >
-                    Connect GitHub source
-                </LemonButton>
-            }
-        />
+        <LemonBanner
+            type="info"
+            action={{
+                children: 'Connect GitHub source',
+                to: urls.dataWarehouseSourceNew('Github'),
+                'data-attr': 'engineering-analytics-connect-github',
+            }}
+        >
+            No GitHub source is connected. Connect one to see pull requests and workflow runs here.
+        </LemonBanner>
     )
 }

--- a/products/engineering_analytics/frontend/emptyState/EngineeringAnalyticsPreview.scss
+++ b/products/engineering_analytics/frontend/emptyState/EngineeringAnalyticsPreview.scss
@@ -1,0 +1,346 @@
+@import '../../../../frontend/src/lib/components/ProductEmptyState/previewMixins';
+
+.EngAnalyticsPreview {
+    --eng-preview-accent: var(--empty-state-accent, var(--color-product-data-warehouse-light));
+
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    // Hidden selection. Direct children of .EngAnalyticsPreview so `:checked ~` reaches both cards.
+    &__radio {
+        position: absolute;
+        width: 0;
+        height: 0;
+        pointer-events: none;
+        opacity: 0;
+    }
+
+    &__panel,
+    &__runs,
+    &__stat {
+        overflow: hidden;
+        background: var(--color-bg-surface-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius);
+    }
+
+    // The two run lists are stacked on one grid cell and crossfaded, so selecting a pull
+    // request never changes the card's size (no layout shift).
+    &__swap {
+        display: grid;
+    }
+
+    &__swap > * {
+        grid-area: 1 / 1;
+        min-width: 0;
+    }
+
+    &__when-green {
+        @include preview-swap-visible;
+    }
+
+    &__when-red {
+        @include preview-swap-hidden;
+    }
+
+    &__head {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__title {
+        font-size: 0.75rem;
+        font-weight: 600;
+    }
+
+    &__repo {
+        flex: 1;
+        font-family: var(--font-mono);
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    // Pull request rows
+
+    &__rows {
+        display: flex;
+        flex-direction: column;
+        padding: 0.25rem 0.5rem;
+    }
+
+    &__row {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.3125rem 0.5rem;
+        border-radius: var(--radius);
+        transition: background $preview-swap-duration ease;
+    }
+
+    &__row--focus {
+        cursor: pointer;
+    }
+
+    &__ci {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+
+        &--pass {
+            background: var(--color-success);
+        }
+
+        &--fail {
+            background: var(--color-danger);
+        }
+
+        &--running {
+            background: var(--color-warning);
+            animation: EngAnalyticsPreview__blink 1.6s ease-in-out infinite;
+        }
+    }
+
+    &__pr {
+        display: flex;
+        flex-direction: column;
+        gap: 0.0625rem;
+        min-width: 0;
+    }
+
+    &__pr-title {
+        overflow: hidden;
+        font-size: 0.6875rem;
+        font-weight: 500;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__pr-meta {
+        overflow: hidden;
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__pill {
+        padding: 0.0625rem 0.375rem;
+        font-size: 0.5625rem;
+        font-weight: 600;
+        color: var(--color-text-tertiary);
+        white-space: nowrap;
+        background: var(--color-bg-fill-tertiary);
+        border-radius: 999px;
+
+        &--pass {
+            color: var(--color-success);
+            background: color-mix(in oklab, var(--color-success) 12%, transparent);
+        }
+
+        &--fail {
+            color: var(--color-danger);
+            background: color-mix(in oklab, var(--color-danger) 12%, transparent);
+        }
+    }
+
+    // Bottom row: workflow runs and the stat card side by side.
+
+    &__bottom {
+        display: grid;
+        grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+        gap: 0.75rem;
+    }
+
+    &__runs-head {
+        padding: 0.375rem 0.625rem;
+        font-size: 0.625rem;
+        font-weight: 600;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__jobs {
+        display: flex;
+        flex-direction: column;
+        gap: 0.375rem;
+        padding: 0.5rem 0.625rem 0.625rem;
+    }
+
+    &__job {
+        display: grid;
+        grid-template-columns: 3.75rem minmax(0, 1fr) auto;
+        gap: 0.375rem;
+        align-items: center;
+        font-size: 0.5625rem;
+    }
+
+    &__job-name {
+        overflow: hidden;
+        color: var(--color-text-secondary);
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__job-time {
+        color: var(--color-text-tertiary);
+        white-space: nowrap;
+    }
+
+    &__bar {
+        height: 6px;
+        overflow: hidden;
+        background: var(--color-bg-fill-tertiary);
+        border-radius: 999px;
+    }
+
+    &__bar-fill {
+        display: block;
+        height: 100%;
+        border-radius: 999px;
+
+        &--pass {
+            background: var(--color-success);
+        }
+
+        &--fail {
+            background: var(--color-danger);
+        }
+
+        &--skip {
+            background: var(--color-border-primary);
+        }
+
+        &--w10 {
+            width: 10%;
+        }
+
+        &--w20 {
+            width: 20%;
+        }
+
+        &--w45 {
+            width: 45%;
+        }
+
+        &--w65 {
+            width: 65%;
+        }
+
+        &--w90 {
+            width: 90%;
+        }
+    }
+
+    // Stat card
+
+    &__stat {
+        padding: 0.625rem 0.75rem 0.75rem;
+    }
+
+    &__spark-caption {
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    &__footer {
+        display: block;
+        margin-top: 0.375rem;
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    &__spark-area {
+        fill: color-mix(in oklab, var(--eng-preview-accent) 13%, transparent);
+        stroke: none;
+    }
+
+    &__spark-line {
+        fill: none;
+        stroke: color-mix(in oklab, var(--eng-preview-accent) 32%, transparent);
+        stroke-width: 2;
+    }
+
+    // The moving bit: a short bright segment cycling along the line.
+    &__spark-trace {
+        fill: none;
+        stroke: var(--eng-preview-accent);
+        stroke-dasharray: 16 84;
+        stroke-linecap: round;
+        stroke-width: 2;
+        animation: EngAnalyticsPreview__trace 3.2s linear infinite;
+    }
+
+    @include preview-sparkline;
+}
+
+// Selected row: painted from the radios, so the list and the runs card always agree.
+
+.EngAnalyticsPreview__radio--green:checked ~ .EngAnalyticsPreview__panel .EngAnalyticsPreview__row--green,
+.EngAnalyticsPreview__radio--red:checked ~ .EngAnalyticsPreview__panel .EngAnalyticsPreview__row--red {
+    background: color-mix(in oklab, var(--eng-preview-accent) 8%, transparent);
+}
+
+// Failing pull request selected
+
+.EngAnalyticsPreview__radio--red:checked ~ .EngAnalyticsPreview__bottom .EngAnalyticsPreview__when-red {
+    @include preview-swap-visible;
+}
+
+.EngAnalyticsPreview__radio--red:checked ~ .EngAnalyticsPreview__bottom .EngAnalyticsPreview__when-green {
+    @include preview-swap-hidden;
+}
+
+// The radios stay keyboard-focusable while visually hidden, so the row each one labels
+// needs a visible focus indicator (WCAG 2.4.7).
+.EngAnalyticsPreview__radio--green:focus-visible ~ .EngAnalyticsPreview__panel .EngAnalyticsPreview__row--green,
+.EngAnalyticsPreview__radio--red:focus-visible ~ .EngAnalyticsPreview__panel .EngAnalyticsPreview__row--red {
+    outline: 2px solid var(--eng-preview-accent);
+    outline-offset: -2px;
+}
+
+// Nudge attention at the failing pull request until it's selected.
+.EngAnalyticsPreview:not(.EngAnalyticsPreview--static)
+    .EngAnalyticsPreview__radio--green:checked
+    ~ .EngAnalyticsPreview__panel
+    .EngAnalyticsPreview__row--red
+    .EngAnalyticsPreview__ci {
+    animation: EngAnalyticsPreview__pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes EngAnalyticsPreview__pulse {
+    0%,
+    100% {
+        box-shadow: 0 0 0 0 color-mix(in oklab, var(--color-danger) 40%, transparent);
+    }
+
+    50% {
+        box-shadow: 0 0 0 4px color-mix(in oklab, var(--color-danger) 16%, transparent);
+    }
+}
+
+@keyframes EngAnalyticsPreview__blink {
+    0%,
+    100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.35;
+    }
+}
+
+// pathLength is normalized to 100, so the dash offset loops cleanly regardless of length.
+@keyframes EngAnalyticsPreview__trace {
+    to {
+        stroke-dashoffset: -100;
+    }
+}
+
+// Storybook snapshots and reduced motion drop all ambient motion; selecting a pull request
+// still swaps its runs (transitions only).
+@include preview-motion-guards('EngAnalyticsPreview');

--- a/products/engineering_analytics/frontend/emptyState/EngineeringAnalyticsPreview.tsx
+++ b/products/engineering_analytics/frontend/emptyState/EngineeringAnalyticsPreview.tsx
@@ -1,0 +1,177 @@
+import './EngineeringAnalyticsPreview.scss'
+
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { cn } from 'lib/utils/css-classes'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+
+// Hand-authored weekly series of median time from open to merge, in hours, trending down.
+const LINE = 'M 0 9 L 14 12 L 28 10 L 42 16 L 56 18 L 70 23 L 84 26 L 100 30'
+
+function areaPath(line: string): string {
+    return `${line} L 100 40 L 0 40 Z`
+}
+
+/**
+ * Example-data preview for the engineering analytics empty state: the pull request list next
+ * to the CI runs of the selected pull request, plus the team's time-to-merge trend. A hidden
+ * radio pair drives the selection via `:checked ~` styles - no timers or state, per the
+ * preview rules in the `building-product-empty-states` skill. Both run lists share one grid
+ * cell and crossfade, so switching never moves the card.
+ */
+export function EngineeringAnalyticsPreview(): JSX.Element {
+    const isStatic = inStorybook() || inStorybookTestRunner()
+
+    return (
+        <div className={cn('EngAnalyticsPreview', isStatic && 'EngAnalyticsPreview--static')}>
+            {/* Selected pull request, before both cards so `:checked ~` can style them. */}
+            <input
+                type="radio"
+                name="eng-analytics-preview-pr"
+                id="eng-analytics-preview-pr-green"
+                className="EngAnalyticsPreview__radio EngAnalyticsPreview__radio--green"
+                defaultChecked
+            />
+            <input
+                type="radio"
+                name="eng-analytics-preview-pr"
+                id="eng-analytics-preview-pr-red"
+                className="EngAnalyticsPreview__radio EngAnalyticsPreview__radio--red"
+            />
+
+            <div className="EngAnalyticsPreview__panel">
+                <div className="EngAnalyticsPreview__head">
+                    <span className="EngAnalyticsPreview__title">Pull requests</span>
+                    <span className="EngAnalyticsPreview__repo">acme/web</span>
+                    <LemonTag size="small">example data</LemonTag>
+                </div>
+
+                <div className="EngAnalyticsPreview__rows">
+                    <label
+                        htmlFor="eng-analytics-preview-pr-green"
+                        className="EngAnalyticsPreview__row EngAnalyticsPreview__row--green EngAnalyticsPreview__row--focus"
+                    >
+                        <span className="EngAnalyticsPreview__ci EngAnalyticsPreview__ci--pass" />
+                        <span className="EngAnalyticsPreview__pr">
+                            <span className="EngAnalyticsPreview__pr-title">
+                                feat(checkout): remember the last payment method
+                            </span>
+                            <span className="EngAnalyticsPreview__pr-meta">#4821 by mara, merged in 6h 12m</span>
+                        </span>
+                        <span className="EngAnalyticsPreview__pill EngAnalyticsPreview__pill--pass">Merged</span>
+                    </label>
+
+                    <label
+                        htmlFor="eng-analytics-preview-pr-red"
+                        className="EngAnalyticsPreview__row EngAnalyticsPreview__row--red EngAnalyticsPreview__row--focus"
+                    >
+                        <span className="EngAnalyticsPreview__ci EngAnalyticsPreview__ci--fail" />
+                        <span className="EngAnalyticsPreview__pr">
+                            <span className="EngAnalyticsPreview__pr-title">
+                                fix(api): retry warehouse reads on timeout
+                            </span>
+                            <span className="EngAnalyticsPreview__pr-meta">#4819 by theo, open for 2d 4h</span>
+                        </span>
+                        <span className="EngAnalyticsPreview__pill EngAnalyticsPreview__pill--fail">CI failing</span>
+                    </label>
+
+                    <div className="EngAnalyticsPreview__row">
+                        <span className="EngAnalyticsPreview__ci EngAnalyticsPreview__ci--running" />
+                        <span className="EngAnalyticsPreview__pr">
+                            <span className="EngAnalyticsPreview__pr-title">
+                                chore(deps): bump the frontend toolchain
+                            </span>
+                            <span className="EngAnalyticsPreview__pr-meta">#4823 by bot, CI running</span>
+                        </span>
+                        <span className="EngAnalyticsPreview__pill">Open</span>
+                    </div>
+                </div>
+            </div>
+
+            <div className="EngAnalyticsPreview__bottom">
+                <div className="EngAnalyticsPreview__runs">
+                    <div className="EngAnalyticsPreview__runs-head EngAnalyticsPreview__swap">
+                        <span className="EngAnalyticsPreview__when-green">Workflow runs on #4821</span>
+                        <span className="EngAnalyticsPreview__when-red">Workflow runs on #4819</span>
+                    </div>
+                    <div className="EngAnalyticsPreview__swap">
+                        <div className="EngAnalyticsPreview__when-green EngAnalyticsPreview__jobs">
+                            <span className="EngAnalyticsPreview__job">
+                                <span className="EngAnalyticsPreview__job-name">Lint</span>
+                                <span className="EngAnalyticsPreview__bar">
+                                    <span className="EngAnalyticsPreview__bar-fill EngAnalyticsPreview__bar-fill--pass EngAnalyticsPreview__bar-fill--w20" />
+                                </span>
+                                <span className="EngAnalyticsPreview__job-time">1m 40s</span>
+                            </span>
+                            <span className="EngAnalyticsPreview__job">
+                                <span className="EngAnalyticsPreview__job-name">Unit tests</span>
+                                <span className="EngAnalyticsPreview__bar">
+                                    <span className="EngAnalyticsPreview__bar-fill EngAnalyticsPreview__bar-fill--pass EngAnalyticsPreview__bar-fill--w65" />
+                                </span>
+                                <span className="EngAnalyticsPreview__job-time">6m 05s</span>
+                            </span>
+                            <span className="EngAnalyticsPreview__job">
+                                <span className="EngAnalyticsPreview__job-name">E2E</span>
+                                <span className="EngAnalyticsPreview__bar">
+                                    <span className="EngAnalyticsPreview__bar-fill EngAnalyticsPreview__bar-fill--pass EngAnalyticsPreview__bar-fill--w90" />
+                                </span>
+                                <span className="EngAnalyticsPreview__job-time">8m 52s</span>
+                            </span>
+                        </div>
+                        <div className="EngAnalyticsPreview__when-red EngAnalyticsPreview__jobs">
+                            <span className="EngAnalyticsPreview__job">
+                                <span className="EngAnalyticsPreview__job-name">Lint</span>
+                                <span className="EngAnalyticsPreview__bar">
+                                    <span className="EngAnalyticsPreview__bar-fill EngAnalyticsPreview__bar-fill--pass EngAnalyticsPreview__bar-fill--w20" />
+                                </span>
+                                <span className="EngAnalyticsPreview__job-time">1m 38s</span>
+                            </span>
+                            <span className="EngAnalyticsPreview__job">
+                                <span className="EngAnalyticsPreview__job-name">Unit tests</span>
+                                <span className="EngAnalyticsPreview__bar">
+                                    <span className="EngAnalyticsPreview__bar-fill EngAnalyticsPreview__bar-fill--fail EngAnalyticsPreview__bar-fill--w45" />
+                                </span>
+                                <span className="EngAnalyticsPreview__job-time">failed, 3rd retry</span>
+                            </span>
+                            <span className="EngAnalyticsPreview__job">
+                                <span className="EngAnalyticsPreview__job-name">E2E</span>
+                                <span className="EngAnalyticsPreview__bar">
+                                    <span className="EngAnalyticsPreview__bar-fill EngAnalyticsPreview__bar-fill--skip EngAnalyticsPreview__bar-fill--w10" />
+                                </span>
+                                <span className="EngAnalyticsPreview__job-time">skipped</span>
+                            </span>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="EngAnalyticsPreview__stat">
+                    <div className="EngAnalyticsPreview__spark-head">
+                        <span className="EngAnalyticsPreview__spark-title">Median open to merge</span>
+                        <span className="EngAnalyticsPreview__spark-caption">8 weeks</span>
+                    </div>
+                    <div className="EngAnalyticsPreview__spark-value">
+                        9h 40m
+                        <span className="EngAnalyticsPreview__pill EngAnalyticsPreview__pill--pass">-31%</span>
+                    </div>
+                    <svg
+                        className="EngAnalyticsPreview__spark-svg"
+                        viewBox="0 0 100 40"
+                        preserveAspectRatio="none"
+                        aria-hidden="true"
+                    >
+                        <path className="EngAnalyticsPreview__spark-area" d={areaPath(LINE)} />
+                        <path className="EngAnalyticsPreview__spark-line" d={LINE} vectorEffect="non-scaling-stroke" />
+                        <path
+                            className="EngAnalyticsPreview__spark-trace"
+                            d={LINE}
+                            pathLength={100}
+                            vectorEffect="non-scaling-stroke"
+                        />
+                    </svg>
+                    <span className="EngAnalyticsPreview__footer">
+                        CI pass rate 94%. Unit tests flaky on 3 of 41 runs.
+                    </span>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/products/engineering_analytics/frontend/emptyState/engineeringAnalyticsEmptyState.tsx
+++ b/products/engineering_analytics/frontend/emptyState/engineeringAnalyticsEmptyState.tsx
@@ -1,0 +1,41 @@
+import * as codingGroupPng from '@posthog/brand/hoggies/png/coding-group'
+import { IconGitBranch } from '@posthog/icons'
+
+import { pngHoggie } from 'lib/brand/hoggies'
+import type { SceneProductEmptyState } from 'lib/components/ProductEmptyState/types'
+import { urls } from 'scenes/urls'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { EngineeringAnalyticsPreview } from './EngineeringAnalyticsPreview'
+import { engineeringAnalyticsSetupLogic } from './engineeringAnalyticsSetupLogic'
+
+const HedgehogCodingGroup = pngHoggie(codingGroupPng)
+
+export const engineeringAnalyticsEmptyState: SceneProductEmptyState = {
+    statusLogic: engineeringAnalyticsSetupLogic,
+    config: {
+        productKey: ProductKey.ENGINEERING_ANALYTICS,
+        productName: 'Engineering analytics',
+        icon: <IconGitBranch />,
+        // The nav item borrows the data warehouse color too: this product is a view over a warehouse source.
+        accentColor: 'var(--color-product-data-warehouse-light)',
+        accentColorDark: 'var(--color-product-data-warehouse-dark)',
+        hedgehog: HedgehogCodingGroup,
+        text: {
+            'needs-setup': {
+                headline: 'See how fast pull requests ship and where CI slows them down',
+                lead: 'Engineering analytics reads pull requests and workflow runs from a GitHub source in your data warehouse. It shows time from open to merge, CI pass rates and durations per workflow, flaky tests, and how each team compares, without any changes to your repositories.',
+                hint: 'Connect the GitHub source and the first sync fills the charts:',
+            },
+        },
+        primaryAction: {
+            label: 'Connect a GitHub source',
+            to: urls.dataWarehouseSourceNew('Github'),
+            dataAttr: 'engineering-analytics-connect-github',
+        },
+        skippable: false,
+        previewLabel: 'Your pull requests, once synced',
+        Preview: EngineeringAnalyticsPreview,
+    },
+}

--- a/products/engineering_analytics/frontend/emptyState/engineeringAnalyticsSetupLogic.test.ts
+++ b/products/engineering_analytics/frontend/emptyState/engineeringAnalyticsSetupLogic.test.ts
@@ -1,0 +1,51 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { productSetupStatusLogic } from 'lib/components/ProductEmptyState/productSetupStatusLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+
+import * as generatedApi from '../generated/api'
+import { engineeringAnalyticsSetupLogic } from './engineeringAnalyticsSetupLogic'
+
+// Guards the mapping into the app-wide setup-status layer: if it breaks, the scene
+// empty-state gate strands on its spinner or shows the wrong surface.
+describe('engineeringAnalyticsSetupLogic', () => {
+    let sourcesSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        sourcesSpy = jest.spyOn(generatedApi, 'engineeringAnalyticsSources')
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        sourcesSpy.mockRestore()
+    })
+
+    // An unsynced source still counts: the scene explains the sync, the empty state does not.
+    it.each([
+        [[], 'needs-setup'],
+        [[{ id: 's1', repo: 'acme/web', prefix: '', synced: false }], 'has-data'],
+        [
+            [
+                { id: 's1', repo: 'acme/web', prefix: '', synced: true },
+                { id: 's2', repo: 'acme/api', prefix: '', synced: true },
+            ],
+            'has-data',
+        ],
+    ])('pushes sources %j as status %s', async (sources, expected) => {
+        sourcesSpy.mockResolvedValue(sources)
+        const logic = engineeringAnalyticsSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.ENGINEERING_ANALYTICS }).values.status).toBe(expected)
+    })
+
+    it('fails open to unknown when the sources query fails before any answer', async () => {
+        sourcesSpy.mockRejectedValue(new Error('network down'))
+        const logic = engineeringAnalyticsSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.ENGINEERING_ANALYTICS }).values.status).toBe('unknown')
+    })
+})

--- a/products/engineering_analytics/frontend/emptyState/engineeringAnalyticsSetupLogic.ts
+++ b/products/engineering_analytics/frontend/emptyState/engineeringAnalyticsSetupLogic.ts
@@ -1,0 +1,21 @@
+import { createSetupDetectionLogic } from 'lib/components/ProductEmptyState/setupDetectionLogic'
+import { projectLogic } from 'scenes/projectLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { engineeringAnalyticsSources } from '../generated/api'
+
+/**
+ * Setup detection for the engineering analytics empty state. The product reads pull
+ * requests and workflow runs from a GitHub warehouse source, so a project is set up once
+ * it has one connected, synced or not: the scene explains an unsynced source itself.
+ */
+export const engineeringAnalyticsSetupLogic = createSetupDetectionLogic({
+    productKey: ProductKey.ENGINEERING_ANALYTICS,
+    path: ['products', 'engineering_analytics', 'frontend', 'emptyState', 'engineeringAnalyticsSetupLogic'],
+    detect: async () => {
+        const projectId = String(projectLogic.findMounted()?.values.currentProjectId)
+        const sources = await engineeringAnalyticsSources(projectId)
+        return sources.length > 0 ? 'has-data' : 'needs-setup'
+    },
+})

--- a/products/engineering_analytics/frontend/scenes/EngineeringAnalyticsScene.tsx
+++ b/products/engineering_analytics/frontend/scenes/EngineeringAnalyticsScene.tsx
@@ -8,7 +8,9 @@ import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+import { ProductKey } from '~/queries/schema/schema-general'
 
+import { engineeringAnalyticsEmptyState } from '../emptyState/engineeringAnalyticsEmptyState'
 import { doraLogic } from './doraLogic'
 import { EngineeringAnalyticsHealth } from './EngineeringAnalyticsHealth'
 import { engineeringAnalyticsLogic } from './engineeringAnalyticsLogic'
@@ -26,6 +28,8 @@ import { RepoOverviewScene } from './RepoOverviewScene'
 export const scene: SceneExport = {
     component: EngineeringAnalyticsScene,
     logic: engineeringAnalyticsSceneLogic,
+    productKey: ProductKey.ENGINEERING_ANALYTICS,
+    emptyState: engineeringAnalyticsEmptyState,
 }
 
 function RefreshButton({ extraLoading = false }: { extraLoading?: boolean }): JSX.Element {

--- a/products/engineering_analytics/package.json
+++ b/products/engineering_analytics/package.json
@@ -15,6 +15,7 @@
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
+        "@posthog/brand": "catalog:",
         "@posthog/icons": "catalog:",
         "@storybook/react": "catalog:",
         "@types/react": "*",


### PR DESCRIPTION
## Problem

A team that opens Engineering analytics without a GitHub source sees the scene's tabs load and then each tab replace itself with a "Connect a GitHub source" panel. The panel repeats on every tab, and it is the inline `ProductIntroduction` that the scene-level empty state replaces. The product is an alpha behind the `engineering-analytics` flag. Layer 4 of stack #95413, after #95410.

## Changes

- A project with no GitHub source now sees the shared setup empty state once, instead of the scene, with "Connect a GitHub source" leading to the new-source page. The screen cannot be skipped, because every tab needs the source.
- The preview is an example pull request list with the CI runs of the selected pull request and the team's time-to-merge trend. Clicking the failing pull request swaps its runs into the card without moving anything.
- Detection lists the project's GitHub sources on each visit. A source that is connected but not synced yet counts as set up, because the scene already explains an unsynced source.
- Inside the scene, the per-tab "not connected" state becomes a one-line banner with the connect button. It remains only for a source removed while the scene is open, so a tab still says what to do instead of showing a failed load.
- Mechanical: the engineering analytics product declares `@posthog/brand` as a peer dependency for the illustration, and the adoption tracker gains a row.

Today, the scene repeats the connect panel once per tab (screenshot from @rnegron):

<img width="2366" alt="Engineering analytics today, with the connect panel repeated on every tab" src="https://github.com/user-attachments/assets/df29cc24-eeaa-4228-8feb-630b73368dd5" />

After this change, the setup screen, with the merged pull request selected:

![ea-after-merged](https://raw.githubusercontent.com/PostHog/pr-assets/e802d402134ff8058c12029c7c56d12ca4541196/2026/09/5c440c9c-5f1f-47e9-8229-fa8b06c99248.png)

The same screen after clicking the failing pull request:

![ea-after-failing](https://raw.githubusercontent.com/PostHog/pr-assets/37529f106fa5ad80a72f437a2ab839dcfb1f8525/2026/09/ffdce5e6-d930-4a30-b3b3-b739b14faf70.png)

## How did you test this code?

- `engineeringAnalyticsSetupLogic.test.ts` covers no sources, one unsynced source, several sources, and the fail-open path. The unsynced case is the one worth guarding: treating it as "needs setup" would hide a source the user just connected.
- The new story renders the shipped config in Storybook. The screenshots above come from it through Playwright.
- Not run: the scene against a project with a real GitHub source.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Engineering analytics has no public docs yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Fable 5.1). Skills invoked: `/building-product-empty-states`, `/stacking-prs`, `/writing-ui-components`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`. Decisions: the accent reuses the data warehouse color the nav item already borrows, rather than adding an unblessed token; the empty state is not flag-gated because the scene itself is not, only its nav entry is. No open PR touches this scene's first-run state.

