### PR TITLE
feat(clickhouse): keep per-query cpu and killed-query info on the driver client

### DIFF
--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -13,6 +13,7 @@ from django.conf import settings
 from clickhouse_driver import Client as SyncClient
 from clickhouse_pool import ChPool
 
+from posthog.clickhouse.client.metered_client import MeteredChPool
 from posthog.dataclasses import frozen
 
 if TYPE_CHECKING:
@@ -385,7 +386,7 @@ def default_client(host=settings.CLICKHOUSE_HOST):
     )
 
 
-class RefreshingChPool(ChPool):
+class RefreshingChPool(MeteredChPool):
     """ChPool that stamps the current credential onto every pulled client.
 
     The pool is keyed on identity rather than the credential, so one pool survives credential
@@ -433,7 +434,7 @@ def _make_ch_pool(
         # kwargs["password"] is only the lazy seed here; RefreshingChPool re-stamps every pulled client.
         return RefreshingChPool(credential_provider=credential_provider, **kwargs)
 
-    return ChPool(**kwargs)
+    return MeteredChPool(**kwargs)
 
 
 make_ch_pool = cache(_make_ch_pool)

--- a/posthog/clickhouse/client/metered_client.py
+++ b/posthog/clickhouse/client/metered_client.py
@@ -1,0 +1,136 @@
+"""clickhouse_driver client that keeps the CPU time ClickHouse reports for each query.
+
+ClickHouse streams a ProfileEvents block on the query's connection every `interactive_delay`,
+one row per host and counter, and the initiator forwards the remote shards' counters in the
+same stream. The driver parses each block to stay in sync with the protocol and then drops it.
+This client keeps the CPU counter on `last_query`, next to the byte progress the driver already
+keeps, so the caller can meter CPU at the same point it meters bytes and without a second trip
+to the query log.
+
+The driver also clears `last_query` when it disconnects after a server-side error, before the
+exception reaches the caller. This client keeps that query info as `last_failed_query` so a
+query killed by a timeout or a read limit can still be metered for what it read.
+
+The pool only creates this client while the CLICKHOUSE_METERED_CLIENT instance setting is on.
+Callers must treat `cpu_microseconds` and `last_failed_query` as optional.
+
+Exports:
+* MeteredClient
+* MeteredChPool
+* cpu_microseconds_from_profile_events
+* metered_client_enabled
+"""
+
+import time
+from functools import lru_cache
+from typing import Any, Optional
+
+from clickhouse_driver import Client
+from clickhouse_driver.connection import Connection
+from clickhouse_driver.protocol import ServerPacketTypes
+from clickhouse_pool import ChPool
+
+from posthog.exceptions_capture import capture_exception
+from posthog.settings import TEST
+
+CPU_COUNTER = "OSCPUVirtualTimeMicroseconds"
+_METERED_MARKER = "_posthog_metered"
+
+
+def metered_client_enabled() -> bool:
+    """The CLICKHOUSE_METERED_CLIENT instance setting, re-read once a minute. Decided per new
+    connection, so flipping it reaches the pool as connections are opened, without a deploy."""
+    if TEST:
+        return True
+    return _metered_client_enabled(round(time.time() / 60))
+
+
+@lru_cache(maxsize=1)
+def _metered_client_enabled(_ttl: int) -> bool:
+    from posthog.models.instance_setting import (
+        get_instance_setting,  # noqa: PLC0415 - avoids a Django model import at client import time
+    )
+
+    try:
+        return bool(get_instance_setting("CLICKHOUSE_METERED_CLIENT"))
+    except Exception:
+        # posthog_instancesetting may not exist yet during initial Postgres migrations.
+        return False
+
+
+def cpu_microseconds_from_profile_events(block: Any) -> int:
+    columns = [name for name, _ in block.columns_with_types]
+    try:
+        name_index = columns.index("name")
+        type_index = columns.index("type")
+        value_index = columns.index("value")
+    except ValueError:
+        return 0
+    total = 0
+    for row in block.get_rows():
+        # An `increment` row is the delta since the previous block. A `gauge` row is an
+        # absolute value, so adding it would count the same CPU on every block.
+        if row[name_index] == CPU_COUNTER and row[type_index] == "increment":
+            total += int(row[value_index])
+    return total
+
+
+class MeteredClient(Client):
+    last_failed_query: Optional[Any] = None
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._meter_connection(self.connection)
+
+    def get_connection(self) -> Connection:
+        # The driver rotates through `self.connections` when alternative hosts are configured,
+        # so every connection it hands back has to carry the hook, not only the first one.
+        connection = super().get_connection()
+        self._meter_connection(connection)
+        return connection
+
+    def execute(self, *args: Any, **kwargs: Any) -> Any:
+        # Cleared per query so a connect failure can never surface an older query's info.
+        self.last_failed_query = None
+        return super().execute(*args, **kwargs)
+
+    def disconnect_connection(self) -> None:
+        # The driver disconnects more than once on a failure, and only the first call still
+        # has the query info.
+        if self.last_query is not None:
+            self.last_failed_query = self.last_query
+        super().disconnect_connection()
+
+    def _meter_connection(self, connection: Connection) -> None:
+        if getattr(connection, _METERED_MARKER, False):
+            return
+        receive_packet = connection.receive_packet
+
+        def receive_packet_and_meter_cpu() -> Any:
+            packet = receive_packet()
+            if packet.type == ServerPacketTypes.PROFILE_EVENTS and getattr(packet, "block", None) is not None:
+                query_info = self.last_query
+                if query_info is not None:
+                    # A parser failure must never fail the query it is metering.
+                    try:
+                        query_info.cpu_microseconds = getattr(query_info, "cpu_microseconds", 0) + (
+                            cpu_microseconds_from_profile_events(packet.block)
+                        )
+                    except Exception as e:
+                        capture_exception(e)
+            return packet
+
+        connection.receive_packet = receive_packet_and_meter_cpu  # ty: ignore[invalid-assignment]
+        setattr(connection, _METERED_MARKER, True)
+
+
+class MeteredChPool(ChPool):
+    def _connect(self, key: Optional[str] = None) -> Client:
+        client_class = MeteredClient if metered_client_enabled() else Client
+        client = client_class(**self.connection_args)
+        if key is not None:
+            self._used[key] = client
+            self._rused[id(client)] = key
+        else:
+            self._pool.append(client)
+        return client

--- a/posthog/clickhouse/client/test/test_connection.py
+++ b/posthog/clickhouse/client/test/test_connection.py
@@ -1,8 +1,6 @@
 import pytest
 from unittest.mock import patch
 
-from clickhouse_pool import ChPool
-
 from posthog.clickhouse.client import connection
 from posthog.clickhouse.client.connection import (
     ClickHouseCredentials,
@@ -17,6 +15,7 @@ from posthog.clickhouse.client.connection import (
     set_default_clickhouse_workload_type,
 )
 from posthog.clickhouse.client.execute import sync_execute
+from posthog.clickhouse.client.metered_client import MeteredChPool
 
 
 def _file_backed_default(monkeypatch, path, *, fallback="fallback"):
@@ -44,7 +43,7 @@ def test_connection_pool_creation_without_offline_cluster(settings):
     settings.CLICKHOUSE_OFFLINE_CLUSTER_HOST = None
 
     online_pool = get_pool(Workload.ONLINE)
-    assert type(online_pool) is ChPool  # a user with no password file keeps a plain, non-refreshing pool
+    assert type(online_pool) is MeteredChPool  # a user with no password file keeps a plain, non-refreshing pool
     assert get_pool(Workload.ONLINE) is online_pool
     assert get_pool(Workload.OFFLINE) is online_pool
     assert get_pool(Workload.DEFAULT) is online_pool

--- a/posthog/clickhouse/client/test/test_metered_client.py
+++ b/posthog/clickhouse/client/test/test_metered_client.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+
+from posthog.test.base import BaseTest, ClickhouseTestMixin
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from clickhouse_driver import Client
+from parameterized import parameterized
+
+from posthog.clickhouse.client.connection import get_client_from_pool
+from posthog.clickhouse.client.metered_client import MeteredChPool, MeteredClient, cpu_microseconds_from_profile_events
+
+PROFILE_EVENTS_COLUMNS = [("host_name", "String"), ("type", "String"), ("name", "String"), ("value", "Int64")]
+
+
+class TestCpuMicrosecondsFromProfileEvents(SimpleTestCase):
+    @parameterized.expand(
+        [
+            (
+                "increments_across_hosts_only",
+                PROFILE_EVENTS_COLUMNS,
+                [
+                    ("initiator", "increment", "OSCPUVirtualTimeMicroseconds", 1000),
+                    ("shard-1", "increment", "OSCPUVirtualTimeMicroseconds", 2500),
+                    ("shard-1", "gauge", "OSCPUVirtualTimeMicroseconds", 999999),
+                    ("shard-1", "increment", "SelectedRows", 42),
+                ],
+                3500,
+            ),
+            ("unexpected_columns", [("host_name", "String")], [("initiator",)], 0),
+        ]
+    )
+    def test_sums_cpu(self, _name, columns, rows, expected):
+        block = SimpleNamespace(columns_with_types=columns, get_rows=lambda: rows)
+        assert cpu_microseconds_from_profile_events(block) == expected
+
+
+class TestMeteredClient(ClickhouseTestMixin, BaseTest):
+    def test_pool_clients_report_cpu_per_query(self):
+        with get_client_from_pool() as client:
+            assert isinstance(client, MeteredClient)
+            client.execute("SELECT sum(cityHash64(number)) FROM (SELECT number FROM system.numbers LIMIT 2000000)")
+            heavy = client.last_query.cpu_microseconds
+            client.execute("SELECT 1")
+            assert heavy > 0
+            assert client.last_query.cpu_microseconds < heavy
+
+    def test_query_killed_by_the_server_keeps_its_progress_and_cpu(self):
+        with get_client_from_pool() as client:
+            try:
+                client.execute(
+                    "SELECT sum(cityHash64(number)) FROM numbers_mt(3000000000)",
+                    settings={"max_execution_time": 1, "max_threads": 2},
+                )
+            except Exception:
+                pass
+            assert client.last_query is None
+            assert client.last_failed_query.progress.bytes > 0
+            assert client.last_failed_query.cpu_microseconds > 0
+            client.execute("SELECT 1")
+            assert client.last_failed_query is None
+
+    def test_pool_hands_out_plain_clients_when_the_setting_is_off(self):
+        with patch("posthog.clickhouse.client.metered_client.metered_client_enabled", return_value=False):
+            pool = MeteredChPool(host="localhost", port=1, connections_min=1, connections_max=1)
+            client = pool.pull()
+        assert type(client) is Client
+        pool.push(client)

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -287,6 +287,12 @@ CONSTANCE_CONFIG = {
         "Enable hedged requests for online APP queries to ClickHouse.",
         bool,
     ),
+    "CLICKHOUSE_METERED_CLIENT": (
+        get_from_env("CLICKHOUSE_METERED_CLIENT", False, type_cast=str_to_bool),
+        "Create new pooled ClickHouse connections with the client that keeps per-query CPU from ProfileEvents "
+        "and the query info of a query the server killed. Applies to connections opened after the change.",
+        bool,
+    ),
     "RATE_LIMITING_ALLOW_LIST_TEAMS": (
         get_from_env("RATE_LIMITING_ALLOW_LIST_TEAMS", ""),
         "Whether teams are on an allow list to bypass rate limiting. Comma separated list of team-ids",
@@ -407,6 +413,7 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "CLICKHOUSE_KILL_SWITCH_LIGHT_TEAMS",
     "CLICKHOUSE_KILL_SWITCH_FULL_TEAMS",
     "CLICKHOUSE_HEDGED_APP_QUERIES",
+    "CLICKHOUSE_METERED_CLIENT",
     "REDIRECT_APP_TO_US",
     "WEB_ANALYTICS_WARMING_DAYS",
     "WEB_ANALYTICS_WARMING_SELECTION_TTL_SECONDS",


### PR DESCRIPTION
## Problem

Metering API query cost needs two numbers the ClickHouse driver throws away today. The server streams per-host CPU in ProfileEvents packets on every query connection, remote shards included, and the driver parses each block to stay in sync with the protocol and then drops it. And when a query is killed server-side, by the timeout or a read limit, the driver clears `last_query` while disconnecting, before the exception reaches the caller, so the bytes it read before dying are never seen. The free-tier quota has been under-counting killed queries for that reason.

## Changes

- Nothing changes for anyone until the `CLICKHOUSE_METERED_CLIENT` instance setting is turned on. It is off by default and on in tests.
- With it on, new pooled connections are created with a client subclass that keeps CPU microseconds on `last_query` next to the byte progress, and keeps the query info of a killed query as `last_failed_query`.
- The setting is read once a minute and decided per new connection, so flipping it reaches the pool as connections are opened, without a deploy.
- Mechanical: both pool classes derive from the metered pool, and one pool test now expects that class.

Nothing reads the new attributes yet. The follow-up PR in this stack meters them into the API query budget.

## How did you test this code?

- `test_metered_client.py`: the pool hands out the metered client and its CPU is per query; a query the server kills keeps its progress and CPU on `last_failed_query` and `last_query` is cleared; with the setting off the pool creates the plain driver client; gauge rows and other counters are not summed into CPU.
- Measured locally against ClickHouse 26.6: CPU summed from the packets matched `query_log` within 0.3% on an 18-packet query, and an A/B of 300 small and 20 medium queries showed no latency difference, since the packets were already being sent and parsed.
- Not checked: forwarding of remote shards' ProfileEvents end to end, because the dev ClickHouse is one node. The ClickHouse source forwards them, and the first production query with the setting on should be compared against leaf CPU in the query log.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The setting is described in its own help text.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1) implemented this from a design the assignee directed, session https://claude.ai/code/session_01FqmSQ8ar12jzR6e6MM5v3K. Skills invoked: /writing-tests, /writing-code-comments, /stacking-prs, /writing-pr-descriptions. This is the bottom of a two-layer stack; it was split out of the budget PR so the driver change can be reviewed and rolled out on its own.

Decisions: the hook wraps the connection's packet receive rather than overriding the client's packet dispatch, so inserts and selects both carry it, and it re-applies on connection rotation. The driver disconnects twice on a failure, so the killed-query info is kept from the first call only and cleared at the start of each query so a connect failure can never surface an older query's info.

Nothing in the diff or this description comes from customer material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqmSQ8ar12jzR6e6MM5v3K
