### PR TITLE
fix(agent): drop underscore-named custom headers on direct Bedrock

### DIFF
--- a/products/desktop/packages/agent/src/adapters/claude/session/options.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/options.test.ts
@@ -458,6 +458,65 @@ describe("buildSessionOptions", () => {
     });
   });
 
+  describe("ANTHROPIC_CUSTOM_HEADERS on the direct-Bedrock path", () => {
+    const originalProjectId = process.env.POSTHOG_PROJECT_ID;
+    const originalCustomHeaders = process.env.ANTHROPIC_CUSTOM_HEADERS;
+    const originalUseBedrock = process.env.CLAUDE_CODE_USE_BEDROCK;
+
+    beforeEach(() => {
+      delete process.env.POSTHOG_PROJECT_ID;
+      delete process.env.ANTHROPIC_CUSTOM_HEADERS;
+      process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+    });
+
+    afterEach(() => {
+      for (const [key, value] of [
+        ["POSTHOG_PROJECT_ID", originalProjectId],
+        ["ANTHROPIC_CUSTOM_HEADERS", originalCustomHeaders],
+        ["CLAUDE_CODE_USE_BEDROCK", originalUseBedrock],
+      ] as const) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    });
+
+    // AWS strips underscore-named headers before validating the SigV4
+    // signature, so signing them yields 403 SignatureDoesNotMatch. On direct
+    // Bedrock they reach no gateway, so they are dropped; hyphen-only headers
+    // sign fine and stay.
+    it("drops underscore-named x-posthog-property headers and keeps hyphen-only ones", () => {
+      process.env.POSTHOG_PROJECT_ID = "42";
+      process.env.ANTHROPIC_CUSTOM_HEADERS =
+        "x-posthog-property-task_id: task-abc";
+
+      const headers = buildSessionOptions({
+        ...makeParams(),
+        taskId: "task-123",
+      }).env?.ANTHROPIC_CUSTOM_HEADERS;
+
+      expect(headers).not.toContain("x-posthog-property-task_id");
+      expect(headers).not.toContain("x-posthog-property-$ai_session_id");
+      expect(headers).toContain("X-PostHog-Project-Id: 42");
+      expect(headers).toContain("x-posthog-use-bedrock-fallback: true");
+    });
+
+    it("keeps underscore-named headers when not on the direct-Bedrock path", () => {
+      delete process.env.CLAUDE_CODE_USE_BEDROCK;
+
+      const headers = buildSessionOptions({
+        ...makeParams(),
+        taskId: "task-123",
+      }).env?.ANTHROPIC_CUSTOM_HEADERS;
+
+      expect(headers).toContain(
+        "x-posthog-property-$ai_session_id: task-123",
+      );
+    });
+  });
+
   describe("machineAuth (own Claude subscription)", () => {
     const STRIPPED_KEYS = [
       "ANTHROPIC_BASE_URL",

--- a/products/desktop/packages/agent/src/adapters/claude/session/options.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/options.test.ts
@@ -511,9 +511,7 @@ describe("buildSessionOptions", () => {
         taskId: "task-123",
       }).env?.ANTHROPIC_CUSTOM_HEADERS;
 
-      expect(headers).toContain(
-        "x-posthog-property-$ai_session_id: task-123",
-      );
+      expect(headers).toContain("x-posthog-property-$ai_session_id: task-123");
     });
   });
 

--- a/products/desktop/packages/agent/src/adapters/claude/session/options.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/options.ts
@@ -219,6 +219,40 @@ function buildEnvironment(
   return env;
 }
 
+/**
+ * `CLAUDE_CODE_USE_BEDROCK` puts the CLI on the direct-Bedrock path: it
+ * SigV4-signs its requests and calls bedrock-runtime directly, with no PostHog
+ * LLM gateway in the request path. Any set, non-falsy value enables it
+ * (hogland's guest profile sets it to "1").
+ */
+function usesDirectBedrock(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized !== "" && normalized !== "0" && normalized !== "false";
+}
+
+/**
+ * AWS strips any header whose NAME contains "_" before it validates a SigV4
+ * signature, but the Claude CLI signs custom headers verbatim — so a signed
+ * `x-posthog-property-task_id` makes AWS recompute a different signature and
+ * reject the request with 403 SignatureDoesNotMatch. On the direct-Bedrock
+ * path these `x-posthog-property-*` attribution headers reach no gateway (the
+ * only consumer that reads them), so dropping the underscore-named ones there
+ * unbreaks signing and loses no attribution that path could have captured.
+ * Hyphen-only headers (X-PostHog-Project-Id, x-posthog-use-bedrock-fallback,
+ * x-posthog-provider, x-posthog-flag-*) sign fine and are kept.
+ */
+function dropUnderscoreNamedHeaderLines(customHeaders: string): string {
+  return customHeaders
+    .split("\n")
+    .filter((line) => {
+      const separator = line.indexOf(":");
+      const name = separator === -1 ? line : line.slice(0, separator);
+      return !name.includes("_");
+    })
+    .join("\n");
+}
+
 function applyGatewayAuth(
   env: Record<string, string>,
   gateway: GatewayEnv | undefined,
@@ -267,7 +301,14 @@ function applyGatewayAuth(
       `x-posthog-flag-${BEDROCK_LLM_GATEWAY_FLAG}: ${bedrockGatewayVariant}`,
     );
   }
-  env.ANTHROPIC_CUSTOM_HEADERS = headerLines.join("\n");
+  const customHeaders = headerLines.join("\n");
+  // On the direct-Bedrock path the CLI SigV4-signs these headers, and AWS
+  // rejects any underscore-named one (see dropUnderscoreNamedHeaderLines). Strip
+  // them there so signing succeeds; every other path keeps them for gateway
+  // attribution.
+  env.ANTHROPIC_CUSTOM_HEADERS = usesDirectBedrock(env.CLAUDE_CODE_USE_BEDROCK)
+    ? dropUnderscoreNamedHeaderLines(customHeaders)
+    : customHeaders;
 
   // Explicit gateway values win over whatever happens to be in process.env.
   // This prevents concurrent Agent instances from clobbering each other's


### PR DESCRIPTION
## Problem

Task runs on the **hogland** sandbox backend fail every time: the in-box agent's Claude calls go **direct to AWS Bedrock**, and every request comes back `403 The request signature we calculated does not match the signature you provided` (SigV4 `SignatureDoesNotMatch`).

Root cause: the agent forwards PostHog attribution as `ANTHROPIC_CUSTOM_HEADERS` — headers like `x-posthog-property-task_id` and `x-posthog-property-$ai_session_id`, whose **names contain underscores**. On the direct-Bedrock path the CLI SigV4-signs those headers, but **AWS strips any header whose name contains `_` before it validates the signature**, then recomputes a different signature and rejects the request. Modal runs are unaffected because they go through the PostHog LLM gateway (which accepts underscore-named headers), not direct Bedrock — so this only ever breaks hogland.

## Changes

- On the direct-Bedrock path **only** (`CLAUDE_CODE_USE_BEDROCK` set), drop `ANTHROPIC_CUSTOM_HEADERS` lines whose header **name** contains `_`. Hogland tasks now authenticate to Bedrock and run instead of failing with a 403.
- Those `x-posthog-property-*` headers are attribution metadata read only by the PostHog LLM gateway, which is **not** in the request path on direct Bedrock — so dropping them there loses no attribution that path could have captured, and it's the single chokepoint (`applyGatewayAuth`) both desktop and cloud sessions funnel through.
- Hyphen-only headers (`X-PostHog-Project-Id`, `x-posthog-use-bedrock-fallback`, `x-posthog-provider`, `x-posthog-flag-*`) sign fine and are kept. Every non-Bedrock path is byte-for-byte unchanged.
- Mechanical: added `usesDirectBedrock` + `dropUnderscoreNamedHeaderLines` helpers and unit tests.

Known follow-up (not this PR): because hogland goes direct to Bedrock and bypasses the gateway, hogland task LLM calls currently get no gateway-based AI-observability attribution at all (Modal runs do). If we want that attribution on hogland, it needs to travel via a signing-safe mechanism (e.g. the agent-server's own event ingest), not gateway headers that never reach a gateway.

## How did you test this code?

- Root-caused by reproducing inside a live hogland box: an A/B proved the Bedrock request **succeeds** with hyphen-only headers and returns **403 SignatureDoesNotMatch** the instant one underscore-named header (`x-posthog-property-task_id`) is added. The bearer token and the CLI version were both ruled out (2.1.251 and 2.1.258 both fail; removing the bearer alone doesn't help).
- Added unit tests in `options.test.ts`: on the direct-Bedrock path the underscore-named `x-posthog-property-*` headers are dropped while hyphen-only headers are kept; off that path they're kept.
- This checkout has no `products/desktop` node_modules so the vitest suite couldn't run locally; the filter algorithm was verified standalone and CI runs the suite.

## Docs update

Not needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Investigating why hogland task sandboxes failed. Earlier theories (a hogpanion/NBD issue, then a stale Claude CLI in the golden) were disproven by reproduction — the golden CLI bump was moot because the agent-server runs a **bundled** SDK binary, not the golden's `/usr/local/bin/claude`, and both versions 403 anyway. The verified cause is the underscore-named-header × AWS-SigV4 interaction, captured on the wire with a one-variable A/B. Fix is the minimal, targeted drop on the direct-Bedrock path.
