### PR TITLE
fix(aio): preserve omitted evaluation settings in mcp updates

### DIFF
--- a/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
+++ b/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
@@ -383,6 +383,13 @@ see the [`improving-drf-endpoints` skill](https://github.com/PostHog/posthog/blo
   and the generated tool gets an empty schema with zero parameters.
   `ModelViewSet` with `serializer_class` works automatically.
 
+### Defaults in partially updated settings
+
+For JSON settings that merge on PATCH, leave nested `default` values out of the shared request schema.
+Orval turns them into Zod defaults, so MCP sends values the caller omitted and overwrites stored settings.
+For example, evaluation updates must preserve `allows_na` when the caller changes only `true_is_failure`, and vice versa.
+Apply creation defaults in backend validation and describe them in the field's help text.
+
 ### Root-router viewsets
 
 Viewsets mounted at root URLs (no `team_id`/`project_id` in the path) set

--- a/products/ai_observability/backend/api/evaluations.py
+++ b/products/ai_observability/backend/api/evaluations.py
@@ -131,6 +131,8 @@ class _EvaluationConfigField(serializers.JSONField):
     pass
 
 
+# Keep defaults in BooleanOutputConfig: nested schema defaults become explicit MCP PATCH values
+# and overwrite stored settings even when the caller omits them.
 @extend_schema_field(
     {
         "type": "object",
@@ -138,7 +140,6 @@ class _EvaluationConfigField(serializers.JSONField):
             "allows_na": {
                 "type": "boolean",
                 "description": "Whether the evaluation can return N/A for non-applicable generations.",
-                "default": False,
             },
             "true_is_failure": {
                 "type": "boolean",
@@ -147,7 +148,6 @@ class _EvaluationConfigField(serializers.JSONField):
                     "pass/fail evaluations, where a true result satisfied the criteria. Set it to true for "
                     "detector-style evaluations, so a true result is counted and labeled as a fail."
                 ),
-                "default": False,
             },
         },
         "additionalProperties": False,

--- a/products/ai_observability/frontend/generated/api.zod.ts
+++ b/products/ai_observability/frontend/generated/api.zod.ts
@@ -259,8 +259,6 @@ export const EvaluationRunsCreateBody = /* @__PURE__ */ zod.object({
 export const evaluationsCreateBodyNameMax = 400
 
 export const evaluationsCreateBodyEvaluationConfigThreeSourceDefault = `user_messages`
-export const evaluationsCreateBodyOutputConfigAllowsNaDefault = false
-export const evaluationsCreateBodyOutputConfigTrueIsFailureDefault = false
 export const evaluationsCreateBodyConditionsItemIdMax = 100
 
 export const evaluationsCreateBodyConditionsItemRolloutPercentageDefault = 100
@@ -335,11 +333,11 @@ export const EvaluationsCreateBody = /* @__PURE__ */ zod
             .object({
                 allows_na: zod
                     .boolean()
-                    .default(evaluationsCreateBodyOutputConfigAllowsNaDefault)
+                    .optional()
                     .describe('Whether the evaluation can return N\/A for non-applicable generations.'),
                 true_is_failure: zod
                     .boolean()
-                    .default(evaluationsCreateBodyOutputConfigTrueIsFailureDefault)
+                    .optional()
                     .describe(
                         'Whether a true result means the evaluation found a problem. False (the default) suits pass\/fail evaluations, where a true result satisfied the criteria. Set it to true for detector-style evaluations, so a true result is counted and labeled as a fail.'
                     ),
@@ -467,8 +465,6 @@ export const EvaluationsCreateBody = /* @__PURE__ */ zod
 export const evaluationsUpdateBodyNameMax = 400
 
 export const evaluationsUpdateBodyEvaluationConfigThreeSourceDefault = `user_messages`
-export const evaluationsUpdateBodyOutputConfigAllowsNaDefault = false
-export const evaluationsUpdateBodyOutputConfigTrueIsFailureDefault = false
 export const evaluationsUpdateBodyConditionsItemIdMax = 100
 
 export const evaluationsUpdateBodyConditionsItemRolloutPercentageDefault = 100
@@ -543,11 +539,11 @@ export const EvaluationsUpdateBody = /* @__PURE__ */ zod
             .object({
                 allows_na: zod
                     .boolean()
-                    .default(evaluationsUpdateBodyOutputConfigAllowsNaDefault)
+                    .optional()
                     .describe('Whether the evaluation can return N\/A for non-applicable generations.'),
                 true_is_failure: zod
                     .boolean()
-                    .default(evaluationsUpdateBodyOutputConfigTrueIsFailureDefault)
+                    .optional()
                     .describe(
                         'Whether a true result means the evaluation found a problem. False (the default) suits pass\/fail evaluations, where a true result satisfied the criteria. Set it to true for detector-style evaluations, so a true result is counted and labeled as a fail.'
                     ),
@@ -675,8 +671,6 @@ export const EvaluationsUpdateBody = /* @__PURE__ */ zod
 export const evaluationsPartialUpdateBodyNameMax = 400
 
 export const evaluationsPartialUpdateBodyEvaluationConfigThreeSourceDefault = `user_messages`
-export const evaluationsPartialUpdateBodyOutputConfigAllowsNaDefault = false
-export const evaluationsPartialUpdateBodyOutputConfigTrueIsFailureDefault = false
 export const evaluationsPartialUpdateBodyConditionsItemIdMax = 100
 
 export const evaluationsPartialUpdateBodyConditionsItemRolloutPercentageDefault = 100
@@ -753,11 +747,11 @@ export const EvaluationsPartialUpdateBody = /* @__PURE__ */ zod
             .object({
                 allows_na: zod
                     .boolean()
-                    .default(evaluationsPartialUpdateBodyOutputConfigAllowsNaDefault)
+                    .optional()
                     .describe('Whether the evaluation can return N\/A for non-applicable generations.'),
                 true_is_failure: zod
                     .boolean()
-                    .default(evaluationsPartialUpdateBodyOutputConfigTrueIsFailureDefault)
+                    .optional()
                     .describe(
                         'Whether a true result means the evaluation found a problem. False (the default) suits pass\/fail evaluations, where a true result satisfied the criteria. Set it to true for detector-style evaluations, so a true result is counted and labeled as a fail.'
                     ),

--- a/services/mcp/src/generated/ai_observability/api.ts
+++ b/services/mcp/src/generated/ai_observability/api.ts
@@ -561,8 +561,6 @@ export const EvaluationsCreateParams = () => zod.object({
 export const evaluationsCreateBodyNameMax = 400
 
 export const evaluationsCreateBodyEvaluationConfigThreeSourceDefault = `user_messages`
-export const evaluationsCreateBodyOutputConfigAllowsNaDefault = false
-export const evaluationsCreateBodyOutputConfigTrueIsFailureDefault = false
 export const evaluationsCreateBodyConditionsItemIdMax = 100
 
 export const evaluationsCreateBodyConditionsItemRolloutPercentageDefault = 100
@@ -637,11 +635,11 @@ export const EvaluationsCreateBody = () => zod
             .object({
                 allows_na: zod
                     .boolean()
-                    .default(evaluationsCreateBodyOutputConfigAllowsNaDefault)
+                    .optional()
                     .describe('Whether the evaluation can return N\/A for non-applicable generations.'),
                 true_is_failure: zod
                     .boolean()
-                    .default(evaluationsCreateBodyOutputConfigTrueIsFailureDefault)
+                    .optional()
                     .describe(
                         'Whether a true result means the evaluation found a problem. False (the default) suits pass\/fail evaluations, where a true result satisfied the criteria. Set it to true for detector-style evaluations, so a true result is counted and labeled as a fail.'
                     ),
@@ -787,8 +785,6 @@ export const EvaluationsPartialUpdateParams = () => zod.object({
 export const evaluationsPartialUpdateBodyNameMax = 400
 
 export const evaluationsPartialUpdateBodyEvaluationConfigThreeSourceDefault = `user_messages`
-export const evaluationsPartialUpdateBodyOutputConfigAllowsNaDefault = false
-export const evaluationsPartialUpdateBodyOutputConfigTrueIsFailureDefault = false
 export const evaluationsPartialUpdateBodyConditionsItemIdMax = 100
 
 export const evaluationsPartialUpdateBodyConditionsItemRolloutPercentageDefault = 100
@@ -865,11 +861,11 @@ export const EvaluationsPartialUpdateBody = () => zod
             .object({
                 allows_na: zod
                     .boolean()
-                    .default(evaluationsPartialUpdateBodyOutputConfigAllowsNaDefault)
+                    .optional()
                     .describe('Whether the evaluation can return N\/A for non-applicable generations.'),
                 true_is_failure: zod
                     .boolean()
-                    .default(evaluationsPartialUpdateBodyOutputConfigTrueIsFailureDefault)
+                    .optional()
                     .describe(
                         'Whether a true result means the evaluation found a problem. False (the default) suits pass\/fail evaluations, where a true result satisfied the criteria. Set it to true for detector-style evaluations, so a true result is counted and labeled as a fail.'
                     ),

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-evaluation-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-evaluation-create.json
@@ -166,12 +166,10 @@
             "description": "Output config. For 'boolean' output_type: {allows_na} to permit N/A results, and {true_is_failure} to declare that a true result means the evaluation found a problem.",
             "properties": {
                 "allows_na": {
-                    "default": false,
                     "description": "Whether the evaluation can return N/A for non-applicable generations.",
                     "type": "boolean"
                 },
                 "true_is_failure": {
-                    "default": false,
                     "description": "Whether a true result means the evaluation found a problem. False (the default) suits pass/fail evaluations, where a true result satisfied the criteria. Set it to true for detector-style evaluations, so a true result is counted and labeled as a fail.",
                     "type": "boolean"
                 }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-evaluation-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-evaluation-update.json
@@ -169,12 +169,10 @@
             "description": "Output config. For 'boolean' output_type: {allows_na} to permit N/A results, and {true_is_failure} to declare that a true result means the evaluation found a problem.",
             "properties": {
                 "allows_na": {
-                    "default": false,
                     "description": "Whether the evaluation can return N/A for non-applicable generations.",
                     "type": "boolean"
                 },
                 "true_is_failure": {
-                    "default": false,
                     "description": "Whether a true result means the evaluation found a problem. False (the default) suits pass/fail evaluations, where a true result satisfied the criteria. Set it to true for detector-style evaluations, so a true result is counted and labeled as a fail.",
                     "type": "boolean"
                 }

--- a/services/mcp/tests/unit/llma-evaluation-output-config.test.ts
+++ b/services/mcp/tests/unit/llma-evaluation-output-config.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { GENERATED_TOOLS } from '@/tools/generated/ai_observability'
+import type { Context } from '@/tools/types'
+
+describe('llma-evaluation-update output settings', () => {
+    it.each([
+        { output_config: { true_is_failure: true } },
+        { output_config: { true_is_failure: false } },
+        { output_config: { allows_na: true } },
+        { output_config: { allows_na: false } },
+        { output_config: {} },
+        { name: 'Renamed evaluation' },
+    ])('only sends the supplied settings for %j', async (body) => {
+        const request = vi.fn().mockResolvedValue({})
+        const context = {
+            api: { request },
+            stateManager: { getProjectId: vi.fn().mockResolvedValue('17') },
+        } as unknown as Context
+        const tool = GENERATED_TOOLS['llma-evaluation-update']!()
+
+        await tool.handler(context, tool.schema.parse({ id: 'evaluation-1', ...body }) as never)
+
+        expect(request).toHaveBeenCalledExactlyOnceWith({
+            method: 'PATCH',
+            path: '/api/projects/17/evaluations/evaluation-1/',
+            body,
+        })
+    })
+})


### PR DESCRIPTION
## Problem

MCP users can silently reset an evaluation's N/A or polarity setting when updating only the other setting.
This completes the MCP-side fix following #92753.

## Changes

- MCP evaluation updates preserve omitted output settings.
- Creation still uses the existing backend defaults.
- The shared MCP runtime and generator stay unchanged.
- Regenerated validation schemas and snapshots are mechanical. No visual changes.

## How did you test this code?

- Automated MCP request tests cover partial settings, empty settings, and rename-only updates.
- Existing backend tests cover creation defaults and partial-update preservation.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Documented nested defaults and partial updates in the MCP implementation guide.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Codex used git, gh, and Flox. The open-PR search found no competing fix. No customer data or private operational material appears in this change.

Skills: implementing-mcp-tools, improving-drf-endpoints, writing-tests, writing-code-comments, writing-user-facing-copy, posthog-efficient-validation, running-ci-preflight, and writing-pr-descriptions.
