### PR TITLE
fix(ingestion): stop a mid-batch person re-read overwriting a queued property write

### DIFF
--- a/nodejs/src/ingestion/common/persons/batch-writing-person-store.test.ts
+++ b/nodejs/src/ingestion/common/persons/batch-writing-person-store.test.ts
@@ -481,6 +481,95 @@ describe('BatchWritingPersonStore', () => {
             expect(mockRepo.fetchPerson).not.toHaveBeenCalled()
         })
 
+        /** A `$set` event's ops, with the fields these tests do not care about at their defaults. */
+        const ops = (overrides: Partial<EventOps>): EventOps => ({
+            set: {},
+            setOnce: {},
+            unset: [],
+            denied: false,
+            shouldForceUpdate: false,
+            eventName: '$set',
+            ...overrides,
+        })
+
+        it('does not let a mid-batch re-read overwrite a queued property write', async () => {
+            // #95302: a second event for the SAME person, arriving through a distinct ID the batch
+            // has not cached, sends the store back to Postgres. The row it gets back was folded on
+            // top of the writes already queued, so `$identify` with a `$set` lost its value to the
+            // stale database copy. The pipeline raised no error and the profile kept the old value,
+            // so clients resent it forever and it never converged.
+            const stored: InternalPerson = { ...person, properties: { plan: 'free' } }
+            const repo = createMockRepository()
+            repo.fetchPerson = jest.fn().mockResolvedValue(stored)
+            const store = new BatchWritingPersonsStore(repo, mockIngestionWarningsOutputs)
+
+            // Distinct ID A: read the person, then queue plan: 'pro' on it.
+            const fetchedByA = await store.fetchForUpdate(teamId, 'distinct-a', 0)
+            expect(fetchedByA!.properties).toEqual({ plan: 'free' })
+            await store.applyEventOps(
+                fetchedByA!,
+                ops({ set: { plan: 'pro' }, eventName: '$identify' }),
+                'distinct-a',
+                0
+            )
+
+            // Distinct ID B resolves to the same person but is not cached, so this re-reads Postgres.
+            const fetchedByB = await store.fetchForUpdate(teamId, 'distinct-b', 0)
+            expect(repo.fetchPerson).toHaveBeenCalledTimes(2)
+            expect(fetchedByB!.properties).toEqual({ plan: 'pro' })
+
+            // ...and the flush must write the queued value, not the row that was read over it.
+            await store.flush()
+            expect(repo.updatePersonsBatch).toHaveBeenCalledWith(
+                expect.arrayContaining([expect.objectContaining({ properties_to_set: { plan: 'pro' } })])
+            )
+            await store.shutdown()
+        })
+
+        it('still refreshes properties the batch has not queued a write for', async () => {
+            // The other half, and the reason the read is folded in at all: a key this batch never
+            // touched must take the value the database has, including one another pod wrote. Only
+            // the queued keys are protected.
+            const stored: InternalPerson = { ...person, properties: { plan: 'free', tier: 'gold' } }
+            const repo = createMockRepository()
+            repo.fetchPerson = jest.fn().mockResolvedValue(stored)
+            const store = new BatchWritingPersonsStore(repo, mockIngestionWarningsOutputs)
+
+            const fetchedByA = await store.fetchForUpdate(teamId, 'distinct-a', 0)
+            await store.applyEventOps(fetchedByA!, ops({ set: { plan: 'pro' } }), 'distinct-a', 0)
+
+            const fetchedByB = await store.fetchForUpdate(teamId, 'distinct-b', 0)
+            expect(fetchedByB!.properties).toEqual({ plan: 'pro', tier: 'gold' })
+
+            await store.flush()
+            await store.shutdown()
+        })
+
+        it('lets a later queued write win over an earlier one', async () => {
+            // Guard on the guard: protecting queued writes from a READ must not also protect them
+            // from a genuine later WRITE, which would freeze the first value of every key.
+            const stored: InternalPerson = { ...person, properties: { plan: 'free' } }
+            const repo = createMockRepository()
+            repo.fetchPerson = jest.fn().mockResolvedValue(stored)
+            const store = new BatchWritingPersonsStore(repo, mockIngestionWarningsOutputs)
+
+            const fetched = await store.fetchForUpdate(teamId, 'distinct-a', 0)
+            const [afterFirst] = await store.applyEventOps(fetched!, ops({ set: { plan: 'pro' } }), 'distinct-a', 0)
+            const [afterSecond] = await store.applyEventOps(
+                afterFirst,
+                ops({ set: { plan: 'enterprise' } }),
+                'distinct-a',
+                0
+            )
+
+            expect(afterSecond.properties).toEqual({ plan: 'enterprise' })
+            await store.flush()
+            expect(repo.updatePersonsBatch).toHaveBeenCalledWith(
+                expect.arrayContaining([expect.objectContaining({ properties_to_set: { plan: 'enterprise' } })])
+            )
+            await store.shutdown()
+        })
+
         it('should handle null results from database', async () => {
             const mockRepo = createMockRepository()
             mockRepo.fetchPerson = jest.fn().mockResolvedValue(undefined)

--- a/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
+++ b/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
@@ -458,9 +458,22 @@ class BatchWritingPersonsCache {
             is_identified: existingPersonUpdate.is_identified || person.is_identified,
         }
 
+        // `properties_to_set` is what this batch intends to WRITE, so an incoming snapshot's whole
+        // property blob belongs in it only when that snapshot represents a write. A re-read does not:
+        // when a second event reaches the same person through a distinct ID the batch has not cached,
+        // the store goes back to Postgres, and folding that row in here overwrote the values already
+        // queued with the stale ones it had just read. `$identify` with a `$set` followed by a
+        // `$create_alias` is ordinary browser SDK traffic, and it lost the set silently: no error, no
+        // retry, and the profile kept the old value however many times the client resent it.
+        //
+        // `needs_write` is what tells the two apart. `fromInternalPerson` builds a read with
+        // `needs_write: false` and an empty `properties_to_set`, while anything the batch means to
+        // write carries true. Only the queued keys are protected: `properties` above still takes the
+        // freshly read values, so a key this batch never touched is still refreshed from the row,
+        // including one another pod wrote.
         mergedPersonUpdate.properties_to_set = {
             ...existingPersonUpdate.properties_to_set,
-            ...person.properties,
+            ...(person.needs_write ? person.properties : {}),
             ...person.properties_to_set,
         }
         for (const key of person.properties_to_unset) {
@@ -1313,7 +1326,15 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
                     if (person !== undefined) {
                         const personUpdate = fromInternalPerson(person, distinctId)
                         cache.setCachedPersonForUpdate(teamId, distinctId, personUpdate)
-                        return person
+                        // Return what the cache HOLDS, not the row we just read. The two differ
+                        // whenever this batch already queued writes against the same person through
+                        // another distinct ID: `setCachedPersonForUpdate` folds this row under those
+                        // writes, and handing back the raw row instead would give the caller the
+                        // stale value the write was meant to replace. The null branch below already
+                        // re-reads the cache for the same reason; this is the same rule for the
+                        // branch that found a row.
+                        const merged = cache.getCachedPersonForUpdateByDistinctId(teamId, distinctId)
+                        return merged === undefined || merged === null ? person : toInternalPerson(merged)
                     } else {
                         // Before caching null, check if another async operation populated
                         // the cache while we were awaiting the DB query. This can happen when:


### PR DESCRIPTION
Fixes #95302.

## Two places let the read win, not one

The issue names the mechanism exactly: a distinct ID missing from the batch's map sends the store back to Postgres, and that row gets folded on top of writes the batch already queued. Tracing it, the stale value wins in **two** places, and fixing either alone leaves the bug reachable.

**1. `mergeUpdateIntoCachedPersonUpdate` treated a read as a write.**

```ts
mergedPersonUpdate.properties_to_set = {
    ...existingPersonUpdate.properties_to_set,   // queued: plan = 'pro'
    ...person.properties,                        // the row just read: plan = 'free'
    ...person.properties_to_set,                 // empty for a read
}
```

`properties_to_set` is what the batch intends to **write**, so an incoming snapshot's whole property blob belongs in it only when that snapshot *is* a write. A re-read is not one. `needs_write` is what tells them apart, and it is already exact: `fromInternalPerson` builds a read with `needs_write: false` and an empty `properties_to_set`, while anything the batch means to write carries `true`.

**2. `fetchForUpdate` returned the row instead of the cache.**

```ts
const personUpdate = fromInternalPerson(person, distinctId)
cache.setCachedPersonForUpdate(teamId, distinctId, personUpdate)
return person   // ← the raw row, not what the fold produced
```

So even with the cache correct, the caller got the stale value back and the rest of the batch read it. I found this because fixing only (1) left the test still red, which is the useful kind of failure.

Worth noting the `else` branch immediately below this already re-reads the cache after its await, with a comment explaining that otherwise "we would overwrite the other operation's cached person". That reasoning was applied to the branch that found no row and not to the branch that found one. This change makes the two symmetric.

## What stays the same

Only the **queued** keys are protected. `properties` still takes the freshly read values, so a key this batch never touched is still refreshed from the row, including one another pod wrote. And a later queued write still beats an earlier one, which matters because a guard that protected queued writes from everything would freeze the first value of every key for the life of the batch. Both are pinned by tests.

## Tests

Three cases in `batch-writing-person-store.test.ts`, following the unit-level reproduction from the issue:

1. read through distinct ID `A`, queue `plan: 'pro'`, read through uncached distinct ID `B` that resolves to the same person. `B` must see `'pro'`, and the flush must write `properties_to_set: { plan: 'pro' }`.
2. a key the batch never queued (`tier`) still comes back with the database's value.
3. a second queued write beats the first.

Written RED first. Without the fix, (1) and (2) fail with `plan: "free"` where `"pro"` was expected, which is the reported symptom reproduced. Case (3) passes either way by design, since it guards against over-correcting.

The full file is green at **108/108**, including the 105 that were already there, and the wider `src/ingestion/common/persons` + `src/common/persons` run is **418 passing across 13 suites**. `postgres-person-repository.test.ts` fails to start in both cases on this machine because it wants a live Postgres; it runs 0 tests with or without this change.

`prettier --check` and `eslint` clean on both files. `tsc --noEmit -p nodejs` reports nothing in either file; the errors it does report are unbuilt workspace siblings (`@posthog/hogvm`, `@posthog/replay-anonymizer`) in my partial checkout.

## One thing I did not add

The issue notes that "no current metric separates a write that carried the queued value from one that carried a stale one". I have not added one. Now that the read cannot clobber a queued write there is nothing left for such a metric to count, and picking a counter name and where it lands is a call about your ingestion metrics rather than mine. Happy to add one if you want the belt-and-braces version.
