### PR TITLE
fix(propdefs): count cache replacements apart from evictions

### DIFF
--- a/rust/property-defs-rs/src/metrics_consts.rs
+++ b/rust/property-defs-rs/src/metrics_consts.rs
@@ -14,7 +14,14 @@ pub const CACHE_FILL_RATIO: &str = "prop_defs_cache_fill_ratio";
 pub const CACHE_LEN: &str = "prop_defs_cache_len";
 pub const CACHE_HITS: &str = "prop_defs_cache_hits";
 pub const CACHE_MISSES: &str = "prop_defs_cache_misses";
+// quick_cache fires its eviction hook for capacity evictions and for in-place
+// replacements of a resident key alike, so this counter is the sum of both.
+// CACHE_REPLACEMENTS counts the replacements on their own; capacity evictions
+// are EVICTIONS minus REPLACEMENTS.
 pub const CACHE_EVICTIONS: &str = "prop_defs_cache_evictions";
+// Inserts that moved a cached row identity forward in place: a newer eventdef
+// last_seen bucket, or a property type refreshed or upgraded from None.
+pub const CACHE_REPLACEMENTS: &str = "prop_defs_cache_replacements";
 pub const UPDATES_CACHE: &str = "prop_defs_updates_cache";
 // Kafka offset stores that failed. The producer loop continues past a failure, so a later
 // successful store on the same partition supersedes it and nothing is redelivered. Redelivery

--- a/rust/property-defs-rs/src/read_filter.rs
+++ b/rust/property-defs-rs/src/read_filter.rs
@@ -148,16 +148,15 @@ pub async fn filter_property_definitions(
         }
         keep[idx] = false;
         // Refresh the dedup cache with the stored type, so future typed sightings
-        // of this row hit in memory instead of re-probing the reader. Skip the
-        // refresh when the batch already carries the stored type: the producer
-        // cached that type when it queued the row, so there is nothing to move.
+        // of this row hit in memory instead of re-probing the reader. The cache
+        // decides whether this changes anything: the entry may have been evicted
+        // or removed while the batch waited, so the batch row is not proof of
+        // the cached state.
         if let Some(stored) = stored_type.and_then(|s| PropertyValueType::from_str(&s).ok()) {
             if let Update::Property(pd) = &batch.cached[idx] {
-                if pd.property_type.as_ref() != Some(&stored) {
-                    let mut refreshed = pd.clone();
-                    refreshed.property_type = Some(stored);
-                    cache.insert(Update::Property(refreshed));
-                }
+                let mut refreshed = pd.clone();
+                refreshed.property_type = Some(stored);
+                cache.insert(Update::Property(refreshed));
             }
         }
     }

--- a/rust/property-defs-rs/src/read_filter.rs
+++ b/rust/property-defs-rs/src/read_filter.rs
@@ -148,12 +148,16 @@ pub async fn filter_property_definitions(
         }
         keep[idx] = false;
         // Refresh the dedup cache with the stored type, so future typed sightings
-        // of this row hit in memory instead of re-probing the reader.
+        // of this row hit in memory instead of re-probing the reader. Skip the
+        // refresh when the batch already carries the stored type: the producer
+        // cached that type when it queued the row, so there is nothing to move.
         if let Some(stored) = stored_type.and_then(|s| PropertyValueType::from_str(&s).ok()) {
             if let Update::Property(pd) = &batch.cached[idx] {
-                let mut refreshed = pd.clone();
-                refreshed.property_type = Some(stored);
-                cache.insert(Update::Property(refreshed));
+                if pd.property_type.as_ref() != Some(&stored) {
+                    let mut refreshed = pd.clone();
+                    refreshed.property_type = Some(stored);
+                    cache.insert(Update::Property(refreshed));
+                }
             }
         }
     }

--- a/rust/property-defs-rs/src/update_cache.rs
+++ b/rust/property-defs-rs/src/update_cache.rs
@@ -49,10 +49,21 @@ struct SubCacheEntry<K: Eq + Hash + Clone, V: Clone> {
 }
 
 impl<K: Eq + Hash + Clone, V: Clone> SubCacheEntry<K, V> {
+    // Called after a peek found the key. quick_cache `replace` succeeds only on
+    // a resident key, so a counted replacement always fired `on_evict`. If a
+    // concurrent remove landed between the peek and this call, the replace
+    // fails and the value goes in as a fresh entry instead.
     fn replace(&self, key: K, value: V) -> InsertOutcome {
-        self.replacements.increment(1);
-        self.cache.insert(key, value);
-        InsertOutcome::Replaced
+        match self.cache.replace(key, value, false) {
+            Ok(()) => {
+                self.replacements.increment(1);
+                InsertOutcome::Replaced
+            }
+            Err((key, value)) => {
+                self.cache.insert(key, value);
+                InsertOutcome::Inserted
+            }
+        }
     }
 }
 
@@ -289,6 +300,11 @@ impl Cache {
     // shard write lock and fires `on_evict`, so a no-op re-insert (the read
     // filter refreshing a type the cache already holds, or a racing producer)
     // would cost lock time and inflate the eviction counter for nothing.
+    //
+    // The peek and the write are separate lock acquisitions. A concurrent
+    // producer can insert the same new key in between, which makes the second
+    // write an uncounted replacement. That race is the one already measured by
+    // DUPLICATES_IN_BATCH and is far too rare to move the replacement counter.
     pub fn insert(&self, key: Update) -> InsertOutcome {
         match key {
             Update::Event(def) => {

--- a/rust/property-defs-rs/src/update_cache.rs
+++ b/rust/property-defs-rs/src/update_cache.rs
@@ -5,13 +5,20 @@ use metrics::Counter;
 use quick_cache::{sync, DefaultHashBuilder, Equivalent, Lifecycle, UnitWeighter};
 
 use crate::{
-    metrics_consts::{CACHE_EVICTIONS, CACHE_HITS, CACHE_MISSES, UPDATES_CACHE},
+    metrics_consts::{
+        CACHE_EVICTIONS, CACHE_HITS, CACHE_MISSES, CACHE_REPLACEMENTS, UPDATES_CACHE,
+    },
     types::{EventProperty, GroupType, PropertyParentType, PropertyValueType, Update},
 };
 
 // Per-subcache eviction observer. The `stats` feature of quick_cache is not
 // enabled, so all cache hit/miss/eviction signal in this service comes from
 // explicit metrics emitted here and in `contains_key`.
+//
+// quick_cache also calls `on_evict` with the old entry when `insert` finds the
+// key already resident, so this counter includes the in-place replacements
+// `Cache::insert` makes on purpose. Those are counted separately as
+// CACHE_REPLACEMENTS; capacity evictions are the difference.
 //
 // Counter handles are resolved once at construction and reused: these paths run
 // per update (and `on_evict` runs under the shard write lock), so a registry
@@ -38,6 +45,26 @@ struct SubCacheEntry<K: Eq + Hash + Clone, V: Clone> {
     cache: SubCache<K, V>,
     hits: Counter,
     misses: Counter,
+    replacements: Counter,
+}
+
+impl<K: Eq + Hash + Clone, V: Clone> SubCacheEntry<K, V> {
+    fn replace(&self, key: K, value: V) -> InsertOutcome {
+        self.replacements.increment(1);
+        self.cache.insert(key, value);
+        InsertOutcome::Replaced
+    }
+}
+
+/// What `Cache::insert` did with an update.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InsertOutcome {
+    /// The row identity was not cached and is now.
+    Inserted,
+    /// The identity was cached with older state and the value moved forward.
+    Replaced,
+    /// The cached state already covers the update, so nothing was written.
+    Unchanged,
 }
 
 fn build_subcache<K: Eq + Hash + Clone, V: Clone>(
@@ -57,6 +84,7 @@ fn build_subcache<K: Eq + Hash + Clone, V: Clone>(
         cache,
         hits: metrics::counter!(CACHE_HITS, &[("cache", label)]),
         misses: metrics::counter!(CACHE_MISSES, &[("cache", label)]),
+        replacements: metrics::counter!(CACHE_REPLACEMENTS, &[("cache", label)]),
     }
 }
 
@@ -255,7 +283,13 @@ impl Cache {
     // cached fresher state; replacing that state would make the next sighting
     // miss and re-issue a write Postgres treats as a no-op. The peek-then-insert
     // pairs below race too, but losing that race costs one redundant upsert.
-    pub fn insert(&self, key: Update) {
+    //
+    // An update the cached state already covers returns Unchanged without
+    // touching quick_cache. A quick_cache insert over a resident key takes the
+    // shard write lock and fires `on_evict`, so a no-op re-insert (the read
+    // filter refreshing a type the cache already holds, or a racing producer)
+    // would cost lock time and inflate the eviction counter for nothing.
+    pub fn insert(&self, key: Update) -> InsertOutcome {
         match key {
             Update::Event(def) => {
                 let lookup = EventDefKeyRef {
@@ -263,22 +297,28 @@ impl Cache {
                     project_id: def.project_id,
                     name: &def.name,
                 };
-                if self
-                    .eventdefs
-                    .cache
-                    .peek(&lookup)
-                    .is_some_and(|bucket| bucket >= def.last_seen_at)
-                {
-                    return;
+                let cached = self.eventdefs.cache.peek(&lookup);
+                if cached.is_some_and(|bucket| bucket >= def.last_seen_at) {
+                    return InsertOutcome::Unchanged;
                 }
                 let key = EventDefKey {
                     team_id: def.team_id,
                     project_id: def.project_id,
                     name: def.name,
                 };
+                if cached.is_some() {
+                    return self.eventdefs.replace(key, def.last_seen_at);
+                }
                 self.eventdefs.cache.insert(key, def.last_seen_at);
+                InsertOutcome::Inserted
             }
-            Update::EventProperty(ep) => self.eventprops.cache.insert(ep, ()),
+            Update::EventProperty(ep) => {
+                if self.eventprops.cache.peek(&ep).is_some() {
+                    return InsertOutcome::Unchanged;
+                }
+                self.eventprops.cache.insert(ep, ());
+                InsertOutcome::Inserted
+            }
             Update::Property(def) => {
                 let lookup = PropDefKeyRef {
                     team_id: def.team_id,
@@ -287,14 +327,13 @@ impl Cache {
                     event_type: def.event_type,
                     group_name: def.group_type_index.as_ref().map(group_name),
                 };
-                if def.property_type.is_none()
-                    && self
-                        .propdefs
-                        .cache
-                        .peek(&lookup)
-                        .is_some_and(|cached| cached.is_some())
-                {
-                    return;
+                let cached = self.propdefs.cache.peek(&lookup);
+                let covered = match &cached {
+                    Some(cached) => *cached == def.property_type || def.property_type.is_none(),
+                    None => false,
+                };
+                if covered {
+                    return InsertOutcome::Unchanged;
                 }
                 let key = PropDefKey {
                     team_id: def.team_id,
@@ -305,7 +344,11 @@ impl Cache {
                         GroupType::Unresolved(name) | GroupType::Resolved(name, _) => name,
                     }),
                 };
+                if cached.is_some() {
+                    return self.propdefs.replace(key, def.property_type);
+                }
                 self.propdefs.cache.insert(key, def.property_type);
+                InsertOutcome::Inserted
             }
         }
     }

--- a/rust/property-defs-rs/src/update_cache.rs
+++ b/rust/property-defs-rs/src/update_cache.rs
@@ -49,11 +49,18 @@ struct SubCacheEntry<K: Eq + Hash + Clone, V: Clone> {
 }
 
 impl<K: Eq + Hash + Clone, V: Clone> SubCacheEntry<K, V> {
-    // Called after a peek found the key. quick_cache `replace` succeeds only on
-    // a resident key, so a counted replacement always fired `on_evict`. If a
-    // concurrent remove landed between the peek and this call, the replace
-    // fails and the value goes in as a fresh entry instead.
-    fn replace(&self, key: K, value: V) -> InsertOutcome {
+    // Writes exactly what a plain `insert` would, and reports whether the write
+    // replaced a resident entry. quick_cache `replace` with `soft: false` takes
+    // the same `insert_existing` path as `insert` on a resident key (same
+    // segment, same `referenced` bump, same `on_evict`), and only differs by
+    // failing when the key is not resident. That failure is how a concurrent
+    // remove between the caller's peek and this write stays uncounted: the
+    // value then goes in through `insert`, as it would have anyway.
+    fn write(&self, key: K, value: V, peeked_resident: bool) -> InsertOutcome {
+        if !peeked_resident {
+            self.cache.insert(key, value);
+            return InsertOutcome::Inserted;
+        }
         match self.cache.replace(key, value, false) {
             Ok(()) => {
                 self.replacements.increment(1);
@@ -67,14 +74,17 @@ impl<K: Eq + Hash + Clone, V: Clone> SubCacheEntry<K, V> {
     }
 }
 
-/// What `Cache::insert` did with an update.
+/// What `Cache::insert` did with an update. Only `Unchanged` skips the write,
+/// and it does so on exactly the guards that predate this bookkeeping.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum InsertOutcome {
-    /// The row identity was not cached and is now.
+    /// The row identity was not resident and is now.
     Inserted,
-    /// The identity was cached with older state and the value moved forward.
+    /// The identity was resident and quick_cache replaced the entry in place,
+    /// whether or not the value differs.
     Replaced,
-    /// The cached state already covers the update, so nothing was written.
+    /// A guard rejected the update before any write: an older or equal eventdef
+    /// bucket, or an untyped property over a typed one.
     Unchanged,
 }
 
@@ -295,11 +305,11 @@ impl Cache {
     // miss and re-issue a write Postgres treats as a no-op. The peek-then-insert
     // pairs below race too, but losing that race costs one redundant upsert.
     //
-    // An update the cached state already covers returns Unchanged without
-    // touching quick_cache. A quick_cache insert over a resident key takes the
-    // shard write lock and fires `on_evict`, so a no-op re-insert (the read
-    // filter refreshing a type the cache already holds, or a racing producer)
-    // would cost lock time and inflate the eviction counter for nothing.
+    // Every write that reaches quick_cache here is the same write with or
+    // without the outcome bookkeeping: an equal value re-inserted over a
+    // resident key still goes through, so the entry keeps the `referenced`
+    // credit quick_cache grants on that path. The peek only decides whether
+    // the write is issued as a `replace` (counted) or an `insert`.
     //
     // The peek and the write are separate lock acquisitions. A concurrent
     // producer can insert the same new key in between, which makes the second
@@ -322,18 +332,12 @@ impl Cache {
                     project_id: def.project_id,
                     name: def.name,
                 };
-                if cached.is_some() {
-                    return self.eventdefs.replace(key, def.last_seen_at);
-                }
-                self.eventdefs.cache.insert(key, def.last_seen_at);
-                InsertOutcome::Inserted
+                self.eventdefs
+                    .write(key, def.last_seen_at, cached.is_some())
             }
             Update::EventProperty(ep) => {
-                if self.eventprops.cache.peek(&ep).is_some() {
-                    return InsertOutcome::Unchanged;
-                }
-                self.eventprops.cache.insert(ep, ());
-                InsertOutcome::Inserted
+                let resident = self.eventprops.cache.peek(&ep).is_some();
+                self.eventprops.write(ep, (), resident)
             }
             Update::Property(def) => {
                 let lookup = PropDefKeyRef {
@@ -344,11 +348,7 @@ impl Cache {
                     group_name: def.group_type_index.as_ref().map(group_name),
                 };
                 let cached = self.propdefs.cache.peek(&lookup);
-                let covered = match &cached {
-                    Some(cached) => *cached == def.property_type || def.property_type.is_none(),
-                    None => false,
-                };
-                if covered {
+                if def.property_type.is_none() && matches!(cached, Some(Some(_))) {
                     return InsertOutcome::Unchanged;
                 }
                 let key = PropDefKey {
@@ -360,11 +360,8 @@ impl Cache {
                         GroupType::Unresolved(name) | GroupType::Resolved(name, _) => name,
                     }),
                 };
-                if cached.is_some() {
-                    return self.propdefs.replace(key, def.property_type);
-                }
-                self.propdefs.cache.insert(key, def.property_type);
-                InsertOutcome::Inserted
+                self.propdefs
+                    .write(key, def.property_type, cached.is_some())
             }
         }
     }

--- a/rust/property-defs-rs/tests/update_cache.rs
+++ b/rust/property-defs-rs/tests/update_cache.rs
@@ -277,23 +277,25 @@ fn test_propdef_type_variants_collapse_to_one_entry() {
     // Only the read filter inserts a differing non-null type, and it carries
     // the type Postgres stored, so the cache follows it.
     assert_eq!(cache.insert(retyped.clone()), InsertOutcome::Replaced);
-    assert_eq!(cache.insert(retyped), InsertOutcome::Unchanged);
     assert_eq!(cache.propdefs_len(), 1);
 }
 
-// A re-insert of state the cache already holds must not reach quick_cache: an
-// insert over a resident key takes the shard write lock and fires the eviction
-// hook, so the read filter refreshing every dropped row would show up as
-// eviction churn while the cache sits far below capacity.
+// Re-inserting an identical update writes exactly what it did before the
+// outcome bookkeeping existed: the eventdef bucket guard still rejects it, and
+// the other two subcaches still push it through quick_cache, which counts as a
+// replacement so the dashboard can subtract it from the eviction counter.
 #[rstest]
-#[case::eventdefs(make_event_def("unchanged_eventdefs"))]
-#[case::eventprops(make_event_prop("unchanged_eventprops_evt", "unchanged_eventprops_prop"))]
-#[case::propdefs(make_prop_def("unchanged_propdefs"))]
-fn test_reinsert_of_covered_update_is_unchanged(#[case] update: Update) {
+#[case::eventdefs(make_event_def("reinsert_eventdefs"), InsertOutcome::Unchanged)]
+#[case::eventprops(
+    make_event_prop("reinsert_eventprops_evt", "reinsert_eventprops_prop"),
+    InsertOutcome::Replaced
+)]
+#[case::propdefs(make_prop_def("reinsert_propdefs"), InsertOutcome::Replaced)]
+fn test_reinsert_of_identical_update(#[case] update: Update, #[case] expected: InsertOutcome) {
     let cache = Cache::new(10, 10, 10);
 
     assert_eq!(cache.insert(update.clone()), InsertOutcome::Inserted);
-    assert_eq!(cache.insert(update.clone()), InsertOutcome::Unchanged);
+    assert_eq!(cache.insert(update.clone()), expected);
     assert!(cache.contains_key(&update));
     assert_eq!(
         cache.eventdefs_len() + cache.eventprops_len() + cache.propdefs_len(),

--- a/rust/property-defs-rs/tests/update_cache.rs
+++ b/rust/property-defs-rs/tests/update_cache.rs
@@ -4,12 +4,12 @@ use chrono::Utc;
 use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
 use property_defs_rs::{
     batch_ingestion::PropertyDefinitionsBatch,
-    metrics_consts::{CACHE_EVICTIONS, CACHE_HITS, CACHE_MISSES},
+    metrics_consts::{CACHE_EVICTIONS, CACHE_HITS, CACHE_MISSES, CACHE_REPLACEMENTS},
     types::{
         EventDefinition, EventProperty, GroupType, PropertyDefinition, PropertyParentType,
         PropertyValueType, Update,
     },
-    update_cache::Cache,
+    update_cache::{Cache, InsertOutcome},
 };
 use rstest::rstest;
 
@@ -245,7 +245,7 @@ fn test_propdef_type_variants_collapse_to_one_entry() {
     let typed = make_prop_def_typed("plan", Some(PropertyValueType::String));
     let retyped = make_prop_def_typed("plan", Some(PropertyValueType::DateTime));
 
-    cache.insert(untyped.clone());
+    assert_eq!(cache.insert(untyped.clone()), InsertOutcome::Inserted);
     assert!(
         cache.contains_key(&untyped),
         "untyped resend cannot change the row"
@@ -255,7 +255,7 @@ fn test_propdef_type_variants_collapse_to_one_entry() {
         "typed sighting must upgrade the untyped row"
     );
 
-    cache.insert(typed.clone());
+    assert_eq!(cache.insert(typed.clone()), InsertOutcome::Replaced);
     assert_eq!(cache.propdefs_len(), 1, "variants must share one entry");
     assert!(cache.contains_key(&typed));
     assert!(
@@ -267,10 +267,66 @@ fn test_propdef_type_variants_collapse_to_one_entry() {
         "the upsert never overwrites a non-null type"
     );
 
-    cache.insert(untyped);
-    assert!(
-        cache.contains_key(&typed),
+    assert_eq!(
+        cache.insert(untyped),
+        InsertOutcome::Unchanged,
         "a racing untyped insert cannot downgrade the cached type"
+    );
+    assert!(cache.contains_key(&typed));
+
+    // Only the read filter inserts a differing non-null type, and it carries
+    // the type Postgres stored, so the cache follows it.
+    assert_eq!(cache.insert(retyped.clone()), InsertOutcome::Replaced);
+    assert_eq!(cache.insert(retyped), InsertOutcome::Unchanged);
+    assert_eq!(cache.propdefs_len(), 1);
+}
+
+// A re-insert of state the cache already holds must not reach quick_cache: an
+// insert over a resident key takes the shard write lock and fires the eviction
+// hook, so the read filter refreshing every dropped row would show up as
+// eviction churn while the cache sits far below capacity.
+#[rstest]
+#[case::eventdefs(make_event_def("unchanged_eventdefs"))]
+#[case::eventprops(make_event_prop("unchanged_eventprops_evt", "unchanged_eventprops_prop"))]
+#[case::propdefs(make_prop_def("unchanged_propdefs"))]
+fn test_reinsert_of_covered_update_is_unchanged(#[case] update: Update) {
+    let cache = Cache::new(10, 10, 10);
+
+    assert_eq!(cache.insert(update.clone()), InsertOutcome::Inserted);
+    assert_eq!(cache.insert(update.clone()), InsertOutcome::Unchanged);
+    assert!(cache.contains_key(&update));
+    assert_eq!(
+        cache.eventdefs_len() + cache.eventprops_len() + cache.propdefs_len(),
+        1
+    );
+}
+
+// The eviction counter includes in-place replacements, because quick_cache
+// fires its eviction hook for them. The replacement counter is what lets a
+// dashboard subtract them back out.
+#[test]
+fn test_replacement_advances_replacement_and_eviction_metrics() {
+    // Recorder install must precede Cache::new; see assert_miss_then_hit.
+    let pre_replaced = counter_value(CACHE_REPLACEMENTS, "eventdefs");
+    let pre_evicted = counter_value(CACHE_EVICTIONS, "eventdefs");
+
+    let cache = Cache::new(64, 64, 64);
+    let t1 = Utc::now();
+    cache.insert(make_event_def_at("replace_metric_evt", t1));
+    cache.insert(make_event_def_at(
+        "replace_metric_evt",
+        t1 + chrono::Duration::hours(2),
+    ));
+
+    let post_replaced = counter_value(CACHE_REPLACEMENTS, "eventdefs");
+    let post_evicted = counter_value(CACHE_EVICTIONS, "eventdefs");
+    assert!(
+        post_replaced > pre_replaced,
+        "replacements did not advance ({pre_replaced} -> {post_replaced})",
+    );
+    assert!(
+        post_evicted > pre_evicted,
+        "evictions did not advance on replace ({pre_evicted} -> {post_evicted})",
     );
 }
 
@@ -296,14 +352,14 @@ fn test_eventdef_bucket_rollover_replaces_entry() {
     let bucket1 = make_event_def_at("checkout", t1);
     let bucket2 = make_event_def_at("checkout", t2);
 
-    cache.insert(bucket1.clone());
+    assert_eq!(cache.insert(bucket1.clone()), InsertOutcome::Inserted);
     assert!(cache.contains_key(&bucket1));
     assert!(
         !cache.contains_key(&bucket2),
         "a new bucket must re-issue the write"
     );
 
-    cache.insert(bucket2.clone());
+    assert_eq!(cache.insert(bucket2.clone()), InsertOutcome::Replaced);
     assert_eq!(
         cache.eventdefs_len(),
         1,
@@ -315,11 +371,12 @@ fn test_eventdef_bucket_rollover_replaces_entry() {
         "an in-flight older bucket is covered by the newer cached one"
     );
 
-    cache.insert(bucket1);
-    assert!(
-        cache.contains_key(&bucket2),
+    assert_eq!(
+        cache.insert(bucket1),
+        InsertOutcome::Unchanged,
         "a racing older insert cannot replace the newer bucket"
     );
+    assert!(cache.contains_key(&bucket2));
 }
 
 // quick_cache enforces a minimum of 32 items per shard (`sync.rs` ~134:


### PR DESCRIPTION
## Problem

Anyone watching the propdefs dashboard sees the dedup caches "evicting" thousands of entries per second while every subcache sits far below capacity. Since the caches moved to identity keys (#94453), that counter has mostly been counting in-place replacements, not capacity evictions.

- quick_cache fires its eviction hook with the old entry whenever `insert` lands on a key that is already resident ([`insert_existing`](https://github.com/arthurprs/quick-cache/blob/v0.6.21/src/shard.rs)).
- The propdefs subcache is replaced on every row the read filter drops, because the filter re-inserts the stored type. In prod that tracked the read-filter drop rate at 0.88 to 0.99 with the cache 26% full.
- The eventdefs subcache is replaced once per active definition per last_seen period per pod, by design.

## Changes

- The dashboard can now separate capacity evictions from replacements: a new `prop_defs_cache_replacements{cache}` counter counts the inserts that moved a cached row forward, so capacity evictions are `evictions - replacements`. The paired panel change is [PostHog/grafana-dashboards#473](https://github.com/PostHog/grafana-dashboards/pull/473).
- A write over a key the peek found resident goes through quick_cache `replace` instead of `insert`. Both take the same `insert_existing` path (same segment, same `referenced` bump, same eviction hook), and `replace` reports whether the key was still resident, which is what makes the count exact.
- `Cache::insert` returns an `InsertOutcome` (`Inserted`, `Replaced`, `Unchanged`). Existing callers ignore it; tests use it. `Unchanged` fires only on the two guards that already existed on master.
- Mechanical: comments on `CACHE_EVICTIONS` and `Cache::insert` document the quick_cache behavior.

> [!NOTE]
> This is a metrics-only change. Every quick_cache write master issued still happens, with the same hotness and eviction bookkeeping; the read filter has no code change. The one new operation is a non-marking `peek` before eventprops writes. The panel that subtracts replacements reads empty until pods run this build; `prop_defs_cache_evictions` itself is unchanged.

## How did you test this code?

- `test_reinsert_of_identical_update` (all three subcaches): pins the write parity with master. The eventdef guard still rejects an equal bucket, and the other two subcaches still write and count a replacement.
- `test_eventdef_bucket_rollover_replaces_entry` and `test_propdef_type_variants_collapse_to_one_entry` now assert the outcome of each insert, so a rollover or None-to-typed upgrade that stops counting as a replacement fails.
- `test_replacement_advances_replacement_and_eviction_metrics`: the replacement counter advances, and documents that the eviction counter advances with it.
- Ran `cargo test -p property-defs-rs`, `cargo clippy --all-targets -D warnings`, and `cargo fmt --check` locally. Not run: anything against a live Kafka or Postgres.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5.1). Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Duplicate search over open PRs for propdefs cache and eviction changes found #92431 and #93065, which touch the event property write batch and not the cache.
- Root cause came from reading quick_cache 0.6.21 source and correlating prod-US Prometheus series (eviction rate vs read-filter drop rate vs fill ratio). No customer data is involved.


