### PR TITLE
fix(workflows): keep the conversion goal when a patch carries part of it

### DIFF
--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -3076,6 +3076,26 @@ class HogFlowSerializer(HogFlowMinimalSerializer):
 
         conversion = data.get("conversion")
         if conversion is not None:
+            # DRF replaces a nested object rather than merging it, so a PATCH carrying one part of the
+            # conversion arrives without the rest and the lines below would store it as empty — leaving a
+            # workflow that measures nothing, with no error to say so. Carry the omitted parts over from
+            # the stored value; a caller that means to clear one sends it explicitly as [].
+            #
+            # Only when nothing is staged. A content edit on an active workflow routes to the draft, and
+            # the draft is where a previous edit's goal lives — merging from live there would revert it,
+            # and would un-clear a goal the draft deliberately emptied. With no draft, _write_draft bases
+            # itself on a snapshot of live, so live is the right base for both routes.
+            if self.partial and instance and not instance.draft and isinstance(instance.conversion, dict):
+                for key in ("filters", "events", "window_minutes"):
+                    stored = instance.conversion.get(key)
+                    if key in conversion or stored is None:
+                        continue
+                    # A legacy goal stored an event object in `filters`; to_internal_value relocates that
+                    # shape on the way in, and copying it raw here would put it back past that check.
+                    if key == "filters" and not isinstance(stored, list):
+                        continue
+                    conversion[key] = stored
+                data["conversion"] = conversion
             filters = conversion.get("filters")
             if filters:
                 serializer = HogFunctionFiltersSerializer(data={"properties": filters}, context=self.context)

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -1055,6 +1055,108 @@ class TestHogFlowAPI(APIBaseTest):
         assert moved["bytecode"], moved
         assert "purchase" in moved["bytecode"]
 
+    def test_hog_flow_conversion_partial_patch_keeps_the_goal(self):
+        # DRF replaces a nested object rather than merging it, so a PATCH carrying only part of the
+        # conversion used to store an empty goal. The workflow kept measuring nothing, with a 200 and
+        # no error to say so.
+        hog_flow, _ = self._create_hog_flow_with_action(
+            {"template_id": "template-webhook", "inputs": {"url": {"value": "https://example.com"}}}
+        )
+        hog_flow["status"] = "active"
+        hog_flow["conversion"] = {
+            "filters": [],
+            "window_minutes": 60,
+            "events": [{"filters": {"events": [{"id": "purchase", "name": "purchase", "type": "events"}]}}],
+        }
+        created = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert created.status_code == 201, created.json()
+        flow_id = created.json()["id"]
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
+            {"conversion": {"window_minutes": 120}},
+            format="json",
+        )
+
+        assert response.status_code == 200, response.json()
+        conversion = response.json()["conversion"]
+        assert conversion["window_minutes"] == 120
+        assert len(conversion["events"]) == 1, conversion
+
+    def test_hog_flow_conversion_goal_only_patch_keeps_the_window(self):
+        # The mirror of the case above: an edit to the goal must not drop the window.
+        hog_flow, _ = self._create_hog_flow_with_action(
+            {"template_id": "template-webhook", "inputs": {"url": {"value": "https://example.com"}}}
+        )
+        hog_flow["status"] = "active"
+        hog_flow["conversion"] = {
+            "filters": [],
+            "window_minutes": 60,
+            "events": [{"filters": {"events": [{"id": "purchase", "name": "purchase", "type": "events"}]}}],
+        }
+        created = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        flow_id = created.json()["id"]
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
+            {
+                "conversion": {
+                    "events": [{"filters": {"events": [{"id": "signup", "name": "signup", "type": "events"}]}}]
+                }
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200, response.json()
+        assert response.json()["conversion"]["window_minutes"] == 60, response.json()["conversion"]
+
+    def test_hog_flow_conversion_merge_skips_a_workflow_with_a_staged_draft(self):
+        # A staged draft holds the newer goal. Merging from the live column there would revert it, and
+        # would un-clear a goal the draft deliberately emptied, so the merge stands aside.
+        hog_flow, _ = self._create_hog_flow_with_action(
+            {"template_id": "template-webhook", "inputs": {"url": {"value": "https://example.com"}}}
+        )
+        hog_flow["status"] = "active"
+        hog_flow["conversion"] = {
+            "filters": [],
+            "window_minutes": 60,
+            "events": [{"filters": {"events": [{"id": "purchase", "name": "purchase", "type": "events"}]}}],
+        }
+        created = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        flow_id = created.json()["id"]
+        flow = HogFlow.objects.get(id=flow_id)
+        flow.draft = {"conversion": {"filters": [], "window_minutes": 60, "events": []}}
+        flow.save()
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
+            {"conversion": {"window_minutes": 120}},
+            format="json",
+        )
+
+        assert response.status_code == 200, response.json()
+
+    def test_hog_flow_conversion_goal_can_still_be_cleared_explicitly(self):
+        hog_flow, _ = self._create_hog_flow_with_action(
+            {"template_id": "template-webhook", "inputs": {"url": {"value": "https://example.com"}}}
+        )
+        hog_flow["conversion"] = {
+            "filters": [],
+            "window_minutes": 60,
+            "events": [{"filters": {"events": [{"id": "purchase", "name": "purchase", "type": "events"}]}}],
+        }
+        created = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        flow_id = created.json()["id"]
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
+            {"conversion": {"window_minutes": 120, "events": []}},
+            format="json",
+        )
+
+        assert response.status_code == 200, response.json()
+        assert response.json()["conversion"]["events"] == []
+
     def test_hog_flow_conversion_client_supplied_bytecode_is_ignored(self):
         # Top-level conversion bytecode is read-only: the matcher executes it, so a client must not
         # be able to persist bytecode that didn't come from server-side compilation of filters.


### PR DESCRIPTION
## Problem

A workflow silently stops recording conversions after an edit that only meant to change part of its conversion goal.

- DRF replaces a nested object rather than merging it, so a PATCH carrying `{"conversion": {"window_minutes": 120}}` arrives without `filters` or `events`.
- Validation then writes `bytecode: []` and `events: []` into that partial object, and the stored goal is gone.
- The worker's `pinConversionGoal` returns null when neither is set, so no watcher is written and nothing is measured.
- The request returns 200. No error, no metric, nothing in the UI says the goal went away.

The documented agent path leads straight to it: the MCP `workflows-update` tool makes every conversion sub-field optional, and the workflows skill tells agents to change the conversion goal through it.

## Changes

- A partial update now carries `filters` and `events` over from the stored conversion when the request omits them, so an edit to one part of the goal leaves the rest alone.
- Clearing still works: a caller that means to drop the events sends `events: []` explicitly.

The same hazard is already treated as serious for the sibling fields. The MCP update path blocks `actions` and `edges` outright, with the comment "a partial actions list has destroyed live graphs". `conversion` carried no equivalent guard.

## How did you test this code?

Driven through the real API against a local backend, first on master and then on master with this commit.

**On master, reproducing it.** Created an active workflow with an event goal and `window_minutes: 60`, then sent `PATCH {"conversion": {"window_minutes": 120}}`. The response was 200 and the goal was gone: `events` went from 1 to 0.

**On master with this commit.** The same request returns 200, the window updates to 120, and `events` is still 1.

Then the part that matters, on the patched workflow:

- Enrolled a person through capture. A conversion watcher was written, expiring in 120 minutes, so the workflow is still measuring after the edit.
- Sent the goal event. The watcher was claimed and the conversion counted.
- Sent `PATCH {"conversion": {"window_minutes": 120, "events": []}}` and confirmed the goal still clears, so the merge does not trap a caller who means to remove it.

The regression test fails on master and passes with the fix; I checked that by reverting the serializer and re-running rather than trusting a green test. The explicit-clear test passes either way by design, guarding the merge from going too far.

Split out of #93258 because the bug predates that change and is live now, so it should not wait on the rest of that work.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this. Skills invoked: `/writing-pr-descriptions`.

Found by a review comment on #93258 pointing out that a window-only PATCH would replace the nested object. The behavior predates that PR, so the fix is split out here to land on its own. The tests use `window_minutes` rather than the duration-string field, which only exists on that branch.

No customer conversation, ticket, or log fed this PR. The test workflows were invented for the session.

