### PR TITLE
fix(surveys): load results for a survey with one answer expression

### DIFF
--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -1184,6 +1184,37 @@ describe('survey utils', () => {
             expect(query!.match(/argMaxIf\(q0_raw/g)).toHaveLength(1)
         })
 
+        it.each([
+            ['rating', { id: 'q-rating', type: SurveyQuestionType.Rating, question: 'How was it?' }],
+            ['open', { id: 'q-open', type: SurveyQuestionType.Open, question: 'Why?' }],
+            [
+                'required single choice',
+                {
+                    id: 'q-choice',
+                    type: SurveyQuestionType.SingleChoice,
+                    question: 'Pick one',
+                    choices: ['a', 'b'],
+                },
+            ],
+        ])('unrolls a lone %s question without concatenating a single array', (_type, question) => {
+            const survey = { ...buildSurvey(true), questions: [question] } as Survey
+
+            const query = buildAggregateQuery(survey, buildFilters(survey))
+
+            // HogQL rejects `arrayConcat` with one argument before the query runs, so these
+            // one-question surveys used to break the results tab with an arity error.
+            expect(query).not.toContain('arrayConcat')
+            expect(query).toContain('arrayJoin(if(isNotNull(q0_answer)')
+        })
+
+        it('still concatenates when the questions emit more than one entry', () => {
+            const survey = buildSurvey(true)
+
+            const query = buildAggregateQuery(survey, buildFilters(survey))
+
+            expect(query).toContain('arrayJoin(arrayConcat(')
+        })
+
         it('does not alias the merged timestamp back onto the column the merge orders by', () => {
             const survey = buildSurvey(true)
 

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -892,14 +892,21 @@ export function buildAggregateQuery(survey: Survey, filters: SurveyQueryFilters)
 
     const mergedSubmissions = buildMergedSubmissionsSubquery(survey, filters, questions)
 
+    // `arrayConcat` needs two arguments at the least. A survey whose questions emit one entry,
+    // such as a lone rating or open question, has nothing to concatenate.
+    const questionLabels =
+        labelPairs.length === 1
+            ? labelPairs[0]
+            : `arrayConcat(
+                ${labelPairs.join(',\n                ')}
+            )`
+
     return `SELECT
             tupleElement(question_label, 1) AS question_id,
             tupleElement(question_label, 2) AS label,
             count() AS cnt
         FROM (
-            SELECT arrayJoin(arrayConcat(
-                ${labelPairs.join(',\n                ')}
-            )) AS question_label
+            SELECT arrayJoin(${questionLabels}) AS question_label
             FROM (
                 ${mergedSubmissions}
             )


### PR DESCRIPTION
## Problem

- Anyone opening the results tab of a one-question survey sees "Load consolidated survey results failed: Function 'arrayConcat' expects at least 2 arguments, found 1" instead of their charts. A single rating or NPS question is one of the most common survey shapes, and the product offers no workaround.
- `buildAggregateQuery` builds one label-pair expression per question, then wraps the list in `arrayJoin(arrayConcat(...))`. A survey that emits exactly one expression renders `arrayConcat` with one argument.
- HogQL declares `arrayConcat` with a minimum of two arguments in [`posthog/hogql/functions/clickhouse/arrays.py`](https://github.com/PostHog/posthog/blob/master/posthog/hogql/functions/clickhouse/arrays.py#L57), so it rejects the query before execution.
- Three question shapes emit one expression: a rating question, an open question, and a required single-choice question.
- Responses are safe. The responses tab runs a separate query and still lists every answer.

## Changes

- The results tab loads again for a survey whose questions emit one expression. That expression now goes straight to `arrayJoin`, without the `arrayConcat` wrapper.
- Surveys emitting two or more expressions keep the concatenated shape, so the single-read merge over the submissions is unchanged.
- No visual change. The charts render as they did before the query broke.

```diff
-            SELECT arrayJoin(arrayConcat(
-                ${labelPairs.join(',\n                ')}
-            )) AS question_label
+            SELECT arrayJoin(${questionLabels}) AS question_label
```

## How did you test this code?

- Added cases to the existing `submission merging in the results queries` block in `frontend/src/scenes/surveys/utils.test.ts`. They catch a regression no existing test caught: every prior case builds a three-question survey, so the one-expression path was never exercised.
  - Three parameterized cases, one per one-expression shape, assert the query holds no `arrayConcat`.
  - One case asserts a multi-question survey still concatenates, so the new branch cannot swallow the other one.
- Ran `frontend/src/scenes/surveys/utils.test.ts` locally.
- Not checked: the tab was not opened against a live stack, and no query was executed against ClickHouse.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Opus 5 in a PostHog Desktop cloud task, from a support ticket about the error on the results tab.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Considered lowering the declared minimum for `arrayConcat` in the HogQL function table instead. Rejected: the declaration matches ClickHouse, and a one-argument concat means nothing. The caller is what is wrong.
- Duplicate search: `gh pr list --state open --search` surfaced related in-flight work on this error. This PR was opened at the requester's direction.
- Public artifact: the diff, the tests, and this description hold no material from the agent session. The survey fixtures are invented.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
