### PR TITLE
feat(customer-analytics): add account property sidebar components

### DIFF
--- a/docs/internal/customer-analytics-property-editors.md
+++ b/docs/internal/customer-analytics-property-editors.md
@@ -1,0 +1,8 @@
+# Account property editors
+
+Percent editors show percentage units, so a stored `0.184` appears as `18.4%`.
+Saving converts the entered percentage back to its stored fraction.
+
+Date-only properties preserve the calendar date from the API, including when the API
+returns a UTC-midnight timestamp. Datetime properties retain local timezone handling.
+The date picker keeps an attempted selection available after a failed save.

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6324,6 +6324,34 @@ snapshots:
         hash: v1.k794b7964.31ffca7eb6c59cf545dd8f16e7a532149448b95c65444aa14d5e776a0875dafd.lULK4-DoenY3SeZK1Sfr50doCkqdIbyl9U35M4ah00g
     scenes-app-customer-analytics-account-detail--narrow--light:
         hash: v1.k794b7964.5a6763d49a273274f686f1517da9d2ba4af64b5be6897a9886addc04f429c209.JZ6O0iGKO-5AKZyg0XnVZ8JoOZ2-Jg4i9E746aSUm2I
+    scenes-app-customer-analytics-account-detail-property-sidebar--custom-property-editors--dark:
+        hash: v1.k794b7964.66592dcf1b3fd0392d3fb40b6137fe122b85b735099f7b073568caa1b7556210.EcnIneYAPaWxcrA3krEwqQ3-1VM66r-alaQvyVFbRxc
+    scenes-app-customer-analytics-account-detail-property-sidebar--custom-property-editors--light:
+        hash: v1.k794b7964.03e50dbd07b401ac7c838fc66a46e21d5e570f9250a60ef0a7eafa80b6c366be.yq0aD06ESQqYG8filudQGPguWppxOS74yM0broHj3zM
+    scenes-app-customer-analytics-account-detail-property-sidebar--date-and-datetime-editors--dark:
+        hash: v1.k794b7964.15ba9785e2a6635181b7354b217d53d4ae05cc2db587671341defcba11f73def.4H1fw_nmfXD5eT4m5j-b05td3b9G5C6v9gUZbaMCRDU
+    scenes-app-customer-analytics-account-detail-property-sidebar--date-and-datetime-editors--light:
+        hash: v1.k794b7964.34b994fa9a3b92bb93f70bbcd7f95c6410187da93539e4ff5c9834ffaa6618e7.Fvdistl0g6mQAeJ9qgXVqZWJmMSUopy5YEBZTr7VAW4
+    scenes-app-customer-analytics-account-detail-property-sidebar--empty--dark:
+        hash: v1.k794b7964.c4a38e5e46e71a34d9afdfedf083087e5387710d526fdc6066a0a6b4eea4f720.m3rWBzL-w_OU7qA7inUpJpnKHBY76Fet3r_ho2z1kU4
+    scenes-app-customer-analytics-account-detail-property-sidebar--empty--light:
+        hash: v1.k794b7964.0fedccb0aed3ba24d39e42f7700b77096ca9f7ae3fffb2df4aa573ea4e6d764b.cCX43P0wrfkD6GYGsquNyoq5I2lPwdwAtTrpPmO6H1Y
+    scenes-app-customer-analytics-account-detail-property-sidebar--filled-and-scrollable--dark:
+        hash: v1.k794b7964.75d86eaa79d518fdce67a3d91053dcbdff1ee6efae7e533c31533cdd57ee6700.9jA6_-_9pS7ApCzy-uJitof965VYwovXPMrLIPgXMxI
+    scenes-app-customer-analytics-account-detail-property-sidebar--filled-and-scrollable--light:
+        hash: v1.k794b7964.6697caf7d48ede16cf590979eda41cf45991adc22a6c479fdb93db46913fd800.JTcXD-8tNV94GfJgIjp9WObCJShaCxQCn_ichggYrZs
+    scenes-app-customer-analytics-account-detail-property-sidebar--pin-and-reorder--dark:
+        hash: v1.k794b7964.ae32ab54e49606fc28e9a68b1274acc5193d58e55a144e66a36de73ed5352687.lFgL26WepIZ4NNnjQP38vqOEAleJXw1HwqLgjJqSvi4
+    scenes-app-customer-analytics-account-detail-property-sidebar--pin-and-reorder--light:
+        hash: v1.k794b7964.8420fad14d255f759ccd21afaa0be6ca96d766137a82c5728cec9db20c15b8b8._y_uXtoiOe7swPzh20jiT73CvO_OObD00tAvNDGLcnM
+    scenes-app-customer-analytics-account-detail-property-sidebar--pin-limit-reached--dark:
+        hash: v1.k794b7964.d3afd5646da096155f6b42a780861e21b42b566068d627c3eee9676a45264521.3F6N7XjfPwHz6SuKLjzojj5uuXE75a5X1JPG1PFBVJk
+    scenes-app-customer-analytics-account-detail-property-sidebar--pin-limit-reached--light:
+        hash: v1.k794b7964.81d64cf5202b63aad63a21e1f49fd7d1a16dbdc643678482ffb88b283b718d3d.59FqoIvlL2QE-juvVuI1KNGT_iFCHvAyttZYBDXWpb8
+    scenes-app-customer-analytics-account-detail-property-sidebar--relationship-editors--dark:
+        hash: v1.k794b7964.1eb38510939dfa28bcf6cafc8a809d5038528955c71bfe4016173727a3a248d4.IfHF45YAUohDOAmlUVS7euQgkjeEwYHEU_fQ-SWivQ4
+    scenes-app-customer-analytics-account-detail-property-sidebar--relationship-editors--light:
+        hash: v1.k794b7964.8ae8988856cff9280a8c90da459c409ef2dfd83cb87745192a8aa5f6b49e6256.pmCK41cTE3iu_ERpqFCXqGCyM7CxnAtoAoClocqBFBc
     scenes-app-customer-analytics-accounts--default--dark:
         hash: v1.k794b7964.97f0ca87971b15063d49547b9dcd6ac408805eeeba4818861c79efe4a00546bb.Beg7zqqVXErdSTxwwKNImW-swYpMUtoQYSdy1HMF6vw
     scenes-app-customer-analytics-accounts--default--light:

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.test.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.test.tsx
@@ -1,0 +1,103 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { dayjs } from 'lib/dayjs'
+
+import { initKeaTests } from '~/test/init'
+
+import type { CustomPropertyDefinitionApi } from 'products/customer_analytics/frontend/generated/api.schemas'
+
+import { AccountCustomPropertyEditor } from './AccountCustomPropertyEditor'
+import { AccountPropertyValue } from './AccountPropertyValue'
+
+describe('AccountCustomPropertyEditor', () => {
+    const definition: CustomPropertyDefinitionApi = {
+        id: 'property-1',
+        name: 'Property',
+        display_type: 'percent',
+        is_canonical: false,
+        has_workflow_reference: false,
+        source: null,
+        created_at: '2026-01-01T00:00:00Z',
+        created_by: 1,
+        updated_at: null,
+        references: [],
+    }
+
+    beforeEach(() => initKeaTests())
+    afterEach(cleanup)
+
+    it.each([
+        [0.184, '18.4', '25', 0.25],
+        [0, '0', '0', 0],
+        [null, '', '10', 0.1],
+    ])('edits stored percent %s in percentage units', (value, shown, entered, expected) => {
+        const onSave = jest.fn()
+        const { container } = render(
+            <AccountCustomPropertyEditor definition={definition} value={value} onSave={onSave} onCancel={jest.fn()} />
+        )
+        const input = container.querySelector('input')!
+        expect(input.value).toBe(shown)
+        fireEvent.change(input, { target: { value: entered } })
+        fireEvent.click(screen.getByText('Save'))
+        expect(onSave).toHaveBeenCalledWith(expected)
+    })
+
+    it.each(['date', 'datetime'] as const)(
+        'retains an attempted %s selection when the save does not succeed',
+        (display_type) => {
+            const onSave = jest.fn()
+            const value = '2026-01-01T00:00:00+00:00'
+            const { container } = render(
+                <AccountCustomPropertyEditor
+                    definition={{ ...definition, display_type }}
+                    value={value}
+                    onSave={onSave}
+                    onCancel={jest.fn()}
+                />
+            )
+            fireEvent.click(container.querySelector('[data-attr="account-property-date-input"]')!)
+            const calendar = document.querySelector('[data-attr="lemon-calendar-select"]')!
+            const day = [...calendar.querySelectorAll('[data-attr="lemon-calendar-day"]')].find(
+                (el) => el.textContent === '15'
+            )!
+            fireEvent.click(day)
+            fireEvent.click(calendar.querySelector('[data-attr="lemon-calendar-select-apply"]')!)
+            expect(onSave).toHaveBeenCalledTimes(1)
+            const attempted = onSave.mock.calls[0][0]
+            expect(dayjs(attempted).date()).toBe(15)
+            expect(container.querySelector('[data-attr="account-property-date-input"]')).toHaveTextContent(
+                dayjs(attempted).format(display_type === 'datetime' ? 'MMM D, YYYY HH:mm' : 'MMM D, YYYY')
+            )
+        }
+    )
+
+    it('keeps a UTC-midnight date on the same calendar day in the display and editor', () => {
+        const dateDefinition = { ...definition, display_type: 'date' as const }
+        const value = '2026-01-01T00:00:00+00:00'
+        const { container } = render(
+            <>
+                <AccountPropertyValue
+                    property={{
+                        key: 'custom:property-1',
+                        kind: 'custom',
+                        definition: dateDefinition,
+                        value,
+                        provenance: 'manual',
+                    }}
+                />
+                <AccountCustomPropertyEditor
+                    definition={dateDefinition}
+                    value={value}
+                    onSave={jest.fn()}
+                    onCancel={jest.fn()}
+                />
+            </>
+        )
+        expect(screen.getAllByText('Jan 1, 2026')).toHaveLength(2)
+        fireEvent.click(container.querySelector('[data-attr="account-property-date-input"]')!)
+        const selected = document.querySelector('[data-attr="lemon-calendar-day"].LemonButton--primary')
+        expect(selected).toHaveTextContent('1')
+    })
+})

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.test.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.test.tsx
@@ -97,6 +97,27 @@ describe('AccountCustomPropertyEditor', () => {
         expect(container.querySelector('[data-attr="account-property-save"]')).toHaveAttribute('aria-disabled', 'true')
     })
 
+    it('refuses to save a blank text value, offering Clear value instead', () => {
+        const onSave = jest.fn()
+        const { container } = render(
+            <AccountCustomPropertyEditor
+                definition={{ ...definition, display_type: 'text' }}
+                value="Enterprise"
+                onSave={onSave}
+                onCancel={jest.fn()}
+            />
+        )
+        const input = container.querySelector('input')!
+        fireEvent.change(input, { target: { value: '' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        fireEvent.click(screen.getByText('Save'))
+        expect(onSave).not.toHaveBeenCalled()
+        expect(container.querySelector('[data-attr="account-property-clear"]')).not.toHaveAttribute(
+            'aria-disabled',
+            'true'
+        )
+    })
+
     it('issues no further writes while a save is in flight', () => {
         const onSave = jest.fn()
         const { container } = render(

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.test.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.test.tsx
@@ -30,6 +30,8 @@ describe('AccountCustomPropertyEditor', () => {
 
     it.each([
         [0.184, '18.4', '25', 0.25],
+        [0.29, '29', '25', 0.25],
+        [0.58, '58', '0.5', 0.005],
         [0, '0', '0', 0],
         [null, '', '10', 0.1],
     ])('edits stored percent %s in percentage units', (value, shown, entered, expected) => {
@@ -42,6 +44,15 @@ describe('AccountCustomPropertyEditor', () => {
         fireEvent.change(input, { target: { value: entered } })
         fireEvent.click(screen.getByText('Save'))
         expect(onSave).toHaveBeenCalledWith(expected)
+    })
+
+    it.each([0.007, 0.009])('saves stored percent %s unchanged when nothing is edited', (value) => {
+        const onSave = jest.fn()
+        render(
+            <AccountCustomPropertyEditor definition={definition} value={value} onSave={onSave} onCancel={jest.fn()} />
+        )
+        fireEvent.click(screen.getByText('Save'))
+        expect(onSave).toHaveBeenCalledWith(value)
     })
 
     it.each(['date', 'datetime'] as const)(

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.test.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.test.tsx
@@ -55,6 +55,48 @@ describe('AccountCustomPropertyEditor', () => {
         expect(onSave).toHaveBeenCalledWith(value)
     })
 
+    it.each(['example.com', 'ftp://example.com/file'])('refuses to save %s as a link', (entered) => {
+        const onSave = jest.fn()
+        const { container } = render(
+            <AccountCustomPropertyEditor
+                definition={{ ...definition, display_type: 'link' }}
+                value={null}
+                onSave={onSave}
+                onCancel={jest.fn()}
+            />
+        )
+        const input = container.querySelector('input')!
+        fireEvent.change(input, { target: { value: entered } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        fireEvent.click(screen.getByText('Save'))
+        expect(onSave).not.toHaveBeenCalled()
+        expect(container.querySelector('[data-attr="account-property-save"]')).toHaveAttribute('aria-disabled', 'true')
+
+        fireEvent.change(input, { target: { value: 'https://example.com/account' } })
+        fireEvent.click(screen.getByText('Save'))
+        expect(onSave).toHaveBeenCalledWith('https://example.com/account')
+    })
+
+    it('refuses to save a select property with no option picked', () => {
+        const onSave = jest.fn()
+        const selectDefinition = {
+            ...definition,
+            display_type: 'select' as const,
+            options: [{ id: 'option-1', label: 'Enterprise' }],
+        }
+        const { container } = render(
+            <AccountCustomPropertyEditor
+                definition={selectDefinition}
+                value={null}
+                onSave={onSave}
+                onCancel={jest.fn()}
+            />
+        )
+        fireEvent.click(screen.getByText('Save'))
+        expect(onSave).not.toHaveBeenCalled()
+        expect(container.querySelector('[data-attr="account-property-save"]')).toHaveAttribute('aria-disabled', 'true')
+    })
+
     it.each(['date', 'datetime'] as const)(
         'retains an attempted %s selection when the save does not succeed',
         (display_type) => {

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.test.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.test.tsx
@@ -79,10 +79,10 @@ describe('AccountCustomPropertyEditor', () => {
 
     it('refuses to save a select property with no option picked', () => {
         const onSave = jest.fn()
-        const selectDefinition = {
+        const selectDefinition: CustomPropertyDefinitionApi = {
             ...definition,
             display_type: 'select' as const,
-            options: [{ id: 'option-1', label: 'Enterprise' }],
+            options: [{ id: 'option-1', label: 'Enterprise', color: 'preset-1' }],
         }
         const { container } = render(
             <AccountCustomPropertyEditor

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.test.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.test.tsx
@@ -97,6 +97,25 @@ describe('AccountCustomPropertyEditor', () => {
         expect(container.querySelector('[data-attr="account-property-save"]')).toHaveAttribute('aria-disabled', 'true')
     })
 
+    it('issues no further writes while a save is in flight', () => {
+        const onSave = jest.fn()
+        const { container } = render(
+            <AccountCustomPropertyEditor
+                definition={{ ...definition, display_type: 'text' }}
+                value="Enterprise"
+                saving
+                onSave={onSave}
+                onCancel={jest.fn()}
+            />
+        )
+        const input = container.querySelector('input')!
+        fireEvent.keyDown(input, { key: 'Enter' })
+        fireEvent.click(screen.getByText('Save'))
+        fireEvent.click(screen.getByText('Clear value'))
+        expect(onSave).not.toHaveBeenCalled()
+        expect(input).toBeDisabled()
+    })
+
     it.each(['date', 'datetime'] as const)(
         'retains an attempted %s selection when the save does not succeed',
         (display_type) => {

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.tsx
@@ -1,0 +1,159 @@
+import { useState } from 'react'
+
+import { LemonButton, LemonDialog, LemonInput, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
+
+import { dayjs } from 'lib/dayjs'
+import { LemonCalendarSelectInput } from 'lib/lemon-ui/LemonCalendar/LemonCalendarSelect'
+
+import type { CustomPropertyDefinitionApi } from 'products/customer_analytics/frontend/generated/api.schemas'
+
+import type { AccountCustomPropertyValue } from './accountPropertyTypes'
+
+const NUMERIC_DISPLAY_TYPES = new Set(['number', 'currency', 'percent'])
+
+export interface AccountCustomPropertyEditorProps {
+    definition: CustomPropertyDefinitionApi
+    value: AccountCustomPropertyValue
+    saving?: boolean
+    onSave: (value: AccountCustomPropertyValue) => void
+    onCancel: () => void
+}
+
+export function AccountCustomPropertyEditor({
+    definition,
+    value,
+    saving = false,
+    onSave,
+    onCancel,
+}: AccountCustomPropertyEditorProps): JSX.Element {
+    const [draft, setDraft] = useState<string | boolean>(
+        definition.display_type === 'boolean' ? value === true || String(value) === 'true' : String(value ?? '')
+    )
+    const isDate = definition.display_type === 'date' || definition.display_type === 'datetime'
+    const isNumeric = NUMERIC_DISPLAY_TYPES.has(definition.display_type)
+    const numericDraft = typeof draft === 'string' && draft !== '' ? Number(draft) : undefined
+    const canSave = !isNumeric || (numericDraft !== undefined && Number.isFinite(numericDraft))
+
+    const save = (): void => {
+        if (typeof draft === 'boolean') {
+            onSave(draft)
+        } else if (isNumeric && numericDraft !== undefined && Number.isFinite(numericDraft)) {
+            onSave(numericDraft)
+        } else if (!isNumeric) {
+            onSave(draft)
+        }
+    }
+
+    const confirmClear = (): void => {
+        LemonDialog.open({
+            title: `Clear ${definition.name}?`,
+            content: 'This will remove the current value. You can set it again later.',
+            primaryButton: {
+                children: 'Clear value',
+                status: 'danger',
+                onClick: () => onSave(null),
+            },
+            secondaryButton: {
+                children: 'Cancel',
+            },
+        })
+    }
+
+    if (isDate) {
+        const isDatetime = definition.display_type === 'datetime'
+        return (
+            <LemonCalendarSelectInput
+                value={typeof draft === 'string' && draft ? dayjs(draft) : null}
+                onChange={(next) => {
+                    if (next) {
+                        onSave(isDatetime ? next.toISOString() : next.format('YYYY-MM-DD'))
+                    } else {
+                        confirmClear()
+                    }
+                }}
+                granularity={isDatetime ? 'minute' : 'day'}
+                format={isDatetime ? 'MMM D, YYYY HH:mm' : 'MMM D, YYYY'}
+                use24HourFormat
+                clearable
+                onClickOutside={onCancel}
+                onClose={onCancel}
+                buttonProps={{
+                    size: 'small',
+                    fullWidth: true,
+                    loading: saving,
+                    'data-attr': 'account-property-date-input',
+                }}
+            />
+        )
+    }
+
+    return (
+        <div className="flex flex-col gap-2 w-full">
+            {definition.display_type === 'boolean' ? (
+                <LemonSwitch
+                    checked={draft === true}
+                    onChange={setDraft}
+                    size="small"
+                    label={draft === true ? 'Yes' : 'No'}
+                    data-attr="account-property-value-input"
+                />
+            ) : definition.display_type === 'select' ? (
+                <LemonSelect
+                    value={typeof draft === 'string' ? draft : ''}
+                    onChange={(next) => setDraft(next ?? '')}
+                    options={(definition.options ?? []).map((option) => ({ value: option.label, label: option.label }))}
+                    size="small"
+                    fullWidth
+                    data-attr="account-property-value-input"
+                />
+            ) : isNumeric ? (
+                <LemonInput
+                    type="number"
+                    value={numericDraft}
+                    onChange={(next) => setDraft(next === undefined ? '' : String(next))}
+                    onPressEnter={save}
+                    size="small"
+                    step="any"
+                    fullWidth
+                    autoFocus
+                    data-attr="account-property-value-input"
+                />
+            ) : (
+                <LemonInput
+                    type={definition.display_type === 'link' ? 'url' : 'text'}
+                    value={typeof draft === 'string' ? draft : ''}
+                    onChange={setDraft}
+                    onPressEnter={save}
+                    size="small"
+                    fullWidth
+                    autoFocus
+                    data-attr="account-property-value-input"
+                />
+            )}
+            <div className="flex flex-wrap items-center justify-end gap-1 w-full">
+                <LemonButton
+                    size="xsmall"
+                    status="danger"
+                    onClick={confirmClear}
+                    disabledReason={value === null ? 'This property has no value' : undefined}
+                    data-attr="account-property-clear"
+                >
+                    Clear value
+                </LemonButton>
+                <LemonButton size="xsmall" onClick={onCancel} data-attr="account-property-cancel">
+                    Cancel
+                </LemonButton>
+                <LemonButton
+                    type="primary"
+                    size="xsmall"
+                    onClick={save}
+                    loading={saving}
+                    disabledReason={!canSave ? 'Enter a number to save' : undefined}
+                    data-attr="account-property-save"
+                >
+                    Save
+                </LemonButton>
+            </div>
+        </div>
+    )
+}

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.tsx
@@ -43,7 +43,10 @@ const saveErrorFor = (draft: string | boolean, definition: CustomPropertyDefinit
     if (definition.display_type === 'select') {
         return (definition.options ?? []).some((option) => option.label === draft) ? undefined : 'Pick an option'
     }
-    return undefined
+    // Saving a blank string stores an active row that every UI surface reads as "Not set", while
+    // is_set filters and workflow audiences still match the account. Clearing is the only way to
+    // unset a property, because it soft-deletes the row instead of writing a blank one.
+    return draft === '' ? 'Enter a value, or use Clear value to unset it' : undefined
 }
 
 export interface AccountCustomPropertyEditorProps {

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.tsx
@@ -74,7 +74,7 @@ export function AccountCustomPropertyEditor({
     const saveError = saveErrorFor(draft, definition)
 
     const save = (): void => {
-        if (saveError) {
+        if (saving || saveError) {
             return
         }
         if (typeof draft === 'boolean') {
@@ -87,6 +87,9 @@ export function AccountCustomPropertyEditor({
     }
 
     const confirmClear = (): void => {
+        if (saving) {
+            return
+        }
         LemonDialog.open({
             title: `Clear ${definition.name}?`,
             content: 'This will remove the current value. You can set it again later.',
@@ -157,6 +160,7 @@ export function AccountCustomPropertyEditor({
                     value={numericDraft}
                     onChange={(next) => setDraft(next === undefined ? '' : String(next))}
                     onPressEnter={save}
+                    disabled={saving}
                     size="small"
                     step="any"
                     fullWidth
@@ -169,6 +173,7 @@ export function AccountCustomPropertyEditor({
                     value={typeof draft === 'string' ? draft : ''}
                     onChange={setDraft}
                     onPressEnter={save}
+                    disabled={saving}
                     status={definition.display_type === 'link' && draft !== '' && saveError ? 'danger' : 'default'}
                     size="small"
                     fullWidth
@@ -181,7 +186,7 @@ export function AccountCustomPropertyEditor({
                     size="xsmall"
                     status="danger"
                     onClick={confirmClear}
-                    disabledReason={value === null ? 'This property has no value' : undefined}
+                    disabledReason={saving ? 'Saving' : value === null ? 'This property has no value' : undefined}
                     data-attr="account-property-clear"
                 >
                     Clear value

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.tsx
@@ -27,7 +27,11 @@ export function AccountCustomPropertyEditor({
     onCancel,
 }: AccountCustomPropertyEditorProps): JSX.Element {
     const [draft, setDraft] = useState<string | boolean>(
-        definition.display_type === 'boolean' ? value === true || String(value) === 'true' : String(value ?? '')
+        definition.display_type === 'boolean'
+            ? value === true || String(value) === 'true'
+            : definition.display_type === 'percent' && value !== null && value !== ''
+              ? String(Number(value) * 100)
+              : String(value ?? '')
     )
     const isDate = definition.display_type === 'date' || definition.display_type === 'datetime'
     const isNumeric = NUMERIC_DISPLAY_TYPES.has(definition.display_type)
@@ -38,7 +42,7 @@ export function AccountCustomPropertyEditor({
         if (typeof draft === 'boolean') {
             onSave(draft)
         } else if (isNumeric && numericDraft !== undefined && Number.isFinite(numericDraft)) {
-            onSave(numericDraft)
+            onSave(definition.display_type === 'percent' ? numericDraft / 100 : numericDraft)
         } else if (!isNumeric) {
             onSave(draft)
         }
@@ -63,10 +67,12 @@ export function AccountCustomPropertyEditor({
         const isDatetime = definition.display_type === 'datetime'
         return (
             <LemonCalendarSelectInput
-                value={typeof draft === 'string' && draft ? dayjs(draft) : null}
+                value={typeof draft === 'string' && draft ? dayjs(isDatetime ? draft : draft.slice(0, 10)) : null}
                 onChange={(next) => {
                     if (next) {
-                        onSave(isDatetime ? next.toISOString() : next.format('YYYY-MM-DD'))
+                        const nextValue = isDatetime ? next.toISOString() : next.format('YYYY-MM-DD')
+                        setDraft(nextValue)
+                        onSave(nextValue)
                     } else {
                         confirmClear()
                     }
@@ -109,6 +115,7 @@ export function AccountCustomPropertyEditor({
             ) : isNumeric ? (
                 <LemonInput
                     type="number"
+                    suffix={definition.display_type === 'percent' ? <span>%</span> : undefined}
                     value={numericDraft}
                     onChange={(next) => setDraft(next === undefined ? '' : String(next))}
                     onPressEnter={save}

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.tsx
@@ -11,6 +11,13 @@ import type { AccountCustomPropertyValue } from './accountPropertyTypes'
 
 const NUMERIC_DISPLAY_TYPES = new Set(['number', 'currency', 'percent'])
 
+// Percent values are stored as fractions and scaled by 100 for the input, which leaves binary
+// artifacts: 0.29 * 100 is 28.999999999999996, so the field disagrees with the row's 29%. Scaling
+// back on save needs the same treatment, because a stored 0.007 displays as 0.7 and divides to
+// 0.006999999999999999. 15 significant digits clear the artifact and, unlike a fixed number of
+// decimal places, keep very small fractions intact.
+const clearFloatArtifacts = (value: number): number => Number(value.toPrecision(15))
+
 export interface AccountCustomPropertyEditorProps {
     definition: CustomPropertyDefinitionApi
     value: AccountCustomPropertyValue
@@ -30,7 +37,7 @@ export function AccountCustomPropertyEditor({
         definition.display_type === 'boolean'
             ? value === true || String(value) === 'true'
             : definition.display_type === 'percent' && value !== null && value !== ''
-              ? String(Number(value) * 100)
+              ? String(clearFloatArtifacts(Number(value) * 100))
               : String(value ?? '')
     )
     const isDate = definition.display_type === 'date' || definition.display_type === 'datetime'
@@ -42,7 +49,7 @@ export function AccountCustomPropertyEditor({
         if (typeof draft === 'boolean') {
             onSave(draft)
         } else if (isNumeric && numericDraft !== undefined && Number.isFinite(numericDraft)) {
-            onSave(definition.display_type === 'percent' ? numericDraft / 100 : numericDraft)
+            onSave(definition.display_type === 'percent' ? clearFloatArtifacts(numericDraft / 100) : numericDraft)
         } else if (!isNumeric) {
             onSave(draft)
         }

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountCustomPropertyEditor.tsx
@@ -18,6 +18,34 @@ const NUMERIC_DISPLAY_TYPES = new Set(['number', 'currency', 'percent'])
 // decimal places, keep very small fractions intact.
 const clearFloatArtifacts = (value: number): number => Number(value.toPrecision(15))
 
+const isHttpUrl = (value: string): boolean => {
+    try {
+        const { protocol } = new URL(value)
+        return protocol === 'http:' || protocol === 'https:'
+    } catch {
+        return false
+    }
+}
+
+// The server coerces each value to its display type and rejects a mismatch, so Save applies the
+// same rules first. The checks stay no stricter than the server's, because a client that refuses a
+// value the API would accept is worse than one that lets a rare rejection through.
+const saveErrorFor = (draft: string | boolean, definition: CustomPropertyDefinitionApi): string | undefined => {
+    if (typeof draft === 'boolean') {
+        return undefined
+    }
+    if (NUMERIC_DISPLAY_TYPES.has(definition.display_type)) {
+        return draft !== '' && Number.isFinite(Number(draft)) ? undefined : 'Enter a number to save'
+    }
+    if (definition.display_type === 'link') {
+        return isHttpUrl(draft) ? undefined : 'Enter a valid HTTP or HTTPS URL'
+    }
+    if (definition.display_type === 'select') {
+        return (definition.options ?? []).some((option) => option.label === draft) ? undefined : 'Pick an option'
+    }
+    return undefined
+}
+
 export interface AccountCustomPropertyEditorProps {
     definition: CustomPropertyDefinitionApi
     value: AccountCustomPropertyValue
@@ -43,9 +71,12 @@ export function AccountCustomPropertyEditor({
     const isDate = definition.display_type === 'date' || definition.display_type === 'datetime'
     const isNumeric = NUMERIC_DISPLAY_TYPES.has(definition.display_type)
     const numericDraft = typeof draft === 'string' && draft !== '' ? Number(draft) : undefined
-    const canSave = !isNumeric || (numericDraft !== undefined && Number.isFinite(numericDraft))
+    const saveError = saveErrorFor(draft, definition)
 
     const save = (): void => {
+        if (saveError) {
+            return
+        }
         if (typeof draft === 'boolean') {
             onSave(draft)
         } else if (isNumeric && numericDraft !== undefined && Number.isFinite(numericDraft)) {
@@ -138,6 +169,7 @@ export function AccountCustomPropertyEditor({
                     value={typeof draft === 'string' ? draft : ''}
                     onChange={setDraft}
                     onPressEnter={save}
+                    status={definition.display_type === 'link' && draft !== '' && saveError ? 'danger' : 'default'}
                     size="small"
                     fullWidth
                     autoFocus
@@ -162,7 +194,7 @@ export function AccountCustomPropertyEditor({
                     size="xsmall"
                     onClick={save}
                     loading={saving}
-                    disabledReason={!canSave ? 'Enter a number to save' : undefined}
+                    disabledReason={saveError}
                     data-attr="account-property-save"
                 >
                     Save

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountPinnedProperties.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountPinnedProperties.tsx
@@ -1,0 +1,84 @@
+import * as businessEvolutionPng from '@posthog/brand/hoggies/png/business-evolution'
+import { IconGear, IconPin } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { pngHoggie } from 'lib/brand/hoggies'
+
+import { AccountPropertyRow, AccountPropertyRowProps } from './AccountPropertyRow'
+import type { AccountSidebarProperty } from './accountPropertyTypes'
+
+const HedgehogBusiness = pngHoggie(businessEvolutionPng)
+
+export interface AccountPinnedPropertiesProps {
+    properties: AccountSidebarProperty[]
+    editingPropertyKey?: string | null
+    savingPropertyKey?: string | null
+    availableMembers?: AccountPropertyRowProps['availableMembers']
+    onConfigure: () => void
+    onEdit: (property: AccountSidebarProperty) => void
+    onCancelEdit: () => void
+    onSaveCustomProperty: AccountPropertyRowProps['onSaveCustomProperty']
+    onSaveRelationship: AccountPropertyRowProps['onSaveRelationship']
+}
+
+export function AccountPinnedProperties({
+    properties,
+    editingPropertyKey = null,
+    savingPropertyKey = null,
+    availableMembers,
+    onConfigure,
+    onEdit,
+    onCancelEdit,
+    onSaveCustomProperty,
+    onSaveRelationship,
+}: AccountPinnedPropertiesProps): JSX.Element {
+    return (
+        <section className="flex flex-col flex-1 min-h-0 overflow-hidden" data-attr="account-pinned-properties">
+            <div className="flex items-center shrink-0 px-5 pt-4">
+                <span className="text-xxs font-semibold uppercase tracking-wider text-secondary">Properties</span>
+                {properties.length > 0 ? (
+                    <LemonButton
+                        size="xsmall"
+                        icon={<IconGear />}
+                        className="ml-auto"
+                        tooltip="Choose pinned properties"
+                        aria-label="Configure pinned properties"
+                        onClick={onConfigure}
+                        data-attr="account-configure-pinned-properties"
+                    />
+                ) : null}
+            </div>
+            {properties.length === 0 ? (
+                <div className="flex flex-col items-center gap-3 px-5 py-6 text-center">
+                    <HedgehogBusiness className="w-16 h-16" />
+                    <p className="text-sm text-secondary mb-0">Pin the account details you use most.</p>
+                    <LemonButton
+                        type="primary"
+                        size="small"
+                        icon={<IconPin />}
+                        onClick={onConfigure}
+                        data-attr="account-pin-properties-empty"
+                    >
+                        Pin properties
+                    </LemonButton>
+                </div>
+            ) : (
+                <div className="flex flex-col gap-4 min-h-0 overflow-y-auto px-5 pt-4 pb-5">
+                    {properties.map((property) => (
+                        <AccountPropertyRow
+                            key={property.key}
+                            property={property}
+                            editing={editingPropertyKey === property.key}
+                            saving={savingPropertyKey === property.key}
+                            availableMembers={availableMembers}
+                            onEdit={() => onEdit(property)}
+                            onCancel={onCancelEdit}
+                            onSaveCustomProperty={onSaveCustomProperty}
+                            onSaveRelationship={onSaveRelationship}
+                        />
+                    ))}
+                </div>
+            )}
+        </section>
+    )
+}

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountPropertyComponents.stories.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountPropertyComponents.stories.tsx
@@ -1,0 +1,273 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
+
+import type {
+    AccountRelationshipDefinitionApi,
+    CustomPropertyDefinitionApi,
+    CustomPropertyDisplayTypeEnumApi,
+} from 'products/customer_analytics/frontend/generated/api.schemas'
+
+import { AccountPinnedProperties } from './AccountPinnedProperties'
+import { AccountPropertyConfigurator } from './AccountPropertyConfigurator'
+import { AccountPropertyRow } from './AccountPropertyRow'
+import type {
+    AccountCustomProperty,
+    AccountCustomPropertyValue,
+    AccountPropertyOption,
+    AccountRelationshipMember,
+    AccountRelationshipProperty,
+    AccountSidebarProperty,
+} from './accountPropertyTypes'
+
+const MEMBERS: AccountRelationshipMember[] = [
+    { id: 1, name: 'Riley Chen', email: 'riley@example.com' },
+    { id: 2, name: 'Jordan Bell', email: 'jordan@example.com' },
+    { id: 3, name: 'Sam Rivera', email: 'sam@example.com' },
+]
+
+function customDefinition(
+    id: string,
+    name: string,
+    displayType: CustomPropertyDisplayTypeEnumApi,
+    overrides: Partial<CustomPropertyDefinitionApi> = {}
+): CustomPropertyDefinitionApi {
+    return {
+        id,
+        name,
+        description: null,
+        display_type: displayType,
+        target_type: 'account',
+        group_type_index: null,
+        is_big_number: false,
+        is_canonical: false,
+        options: null,
+        source: null,
+        created_at: '2026-08-01T12:00:00Z',
+        created_by: 1,
+        updated_at: null,
+        references: [],
+        has_workflow_reference: false,
+        ...overrides,
+    }
+}
+
+function customProperty(
+    id: string,
+    name: string,
+    displayType: CustomPropertyDisplayTypeEnumApi,
+    value: AccountCustomPropertyValue,
+    overrides: Partial<AccountCustomProperty> = {}
+): AccountCustomProperty {
+    return {
+        key: `custom:${id}`,
+        kind: 'custom',
+        definition: customDefinition(id, name, displayType),
+        value,
+        provenance: 'manual',
+        ...overrides,
+    }
+}
+
+function relationshipProperty(
+    id: string,
+    name: string,
+    members: AccountRelationshipMember[],
+    isSingleHolder: boolean
+): AccountRelationshipProperty {
+    const definition: AccountRelationshipDefinitionApi = {
+        id,
+        name,
+        description: null,
+        is_single_holder: isSingleHolder,
+    }
+    return { key: `relationship:${id}`, kind: 'relationship', definition, members }
+}
+
+const DISPLAY_PROPERTIES: AccountSidebarProperty[] = [
+    customProperty('arr', 'Annual recurring revenue', 'currency', 125000),
+    customProperty('growth', 'Monthly growth', 'percent', 0.184),
+    customProperty('plan', 'Plan', 'select', 'Enterprise', {
+        definition: customDefinition('plan', 'Plan', 'select', {
+            options: [{ id: 'enterprise', label: 'Enterprise', color: 'preset-5' }],
+        }),
+    }),
+    customProperty('renewal', 'Renewal date', 'date', '2026-11-14'),
+    customProperty('health', 'Healthy', 'boolean', true, {
+        provenance: 'workflow',
+        definition: customDefinition('health', 'Healthy', 'boolean', { has_workflow_reference: true }),
+    }),
+    customProperty('warehouse', 'Warehouse tier', 'text', 'Gold', { provenance: 'warehouse' }),
+    customProperty('canonical', 'First seen', 'datetime', '2026-08-20T15:30:00Z', {
+        provenance: 'canonical',
+        definition: customDefinition('canonical', 'First seen', 'datetime', { is_canonical: true }),
+    }),
+    relationshipProperty('csm', 'Customer success manager', [MEMBERS[0]], true),
+]
+
+const noop = (): void => {}
+
+const meta: Meta = {
+    title: 'Scenes-App/Customer Analytics/Account detail/Property sidebar',
+    component: AccountPinnedProperties,
+    parameters: {
+        layout: 'centered',
+        mockDate: '2026-09-04T12:00:00Z',
+        testOptions: { viewport: { width: 420, height: 800 } },
+    },
+    decorators: [
+        (Story) => (
+            <div className="w-96 h-176 border rounded flex flex-col min-h-0 bg-surface-primary">
+                <Story />
+            </div>
+        ),
+    ],
+}
+export default meta
+
+type Story = StoryObj
+
+export const Empty: Story = {
+    render: () => (
+        <AccountPinnedProperties
+            properties={[]}
+            onConfigure={noop}
+            onEdit={noop}
+            onCancelEdit={noop}
+            onSaveCustomProperty={noop}
+            onSaveRelationship={noop}
+        />
+    ),
+}
+
+export const FilledAndScrollable: Story = {
+    render: () => (
+        <AccountPinnedProperties
+            properties={[
+                ...DISPLAY_PROPERTIES,
+                ...DISPLAY_PROPERTIES.map((property) => ({ ...property, key: `${property.key}:2` })),
+            ]}
+            availableMembers={MEMBERS}
+            onConfigure={noop}
+            onEdit={noop}
+            onCancelEdit={noop}
+            onSaveCustomProperty={noop}
+            onSaveRelationship={noop}
+        />
+    ),
+}
+
+export const CustomPropertyEditors: Story = {
+    render: () => (
+        <div className="flex flex-col gap-5 p-4 overflow-y-auto">
+            {[
+                customProperty('text', 'Account summary', 'text', 'Rolling out to the product team'),
+                customProperty('link', 'Success plan', 'link', 'https://example.com/success-plan'),
+                customProperty('amount', 'Expansion potential', 'currency', 45000),
+                customProperty('active', 'Active', 'boolean', true),
+                customProperty('segment', 'Segment', 'select', 'Mid-market', {
+                    definition: customDefinition('segment', 'Segment', 'select', {
+                        options: [
+                            { id: 'smb', label: 'SMB', color: 'preset-1' },
+                            { id: 'mid', label: 'Mid-market', color: 'preset-3' },
+                            { id: 'ent', label: 'Enterprise', color: 'preset-5' },
+                        ],
+                    }),
+                }),
+            ].map((property) => (
+                <AccountPropertyRow
+                    key={property.key}
+                    property={property}
+                    editing
+                    onEdit={noop}
+                    onCancel={noop}
+                    onSaveCustomProperty={noop}
+                    onSaveRelationship={noop}
+                />
+            ))}
+        </div>
+    ),
+}
+
+export const DateAndDatetimeEditors: Story = {
+    render: () => (
+        <div className="flex flex-col gap-5 p-4">
+            {[
+                customProperty('date', 'Renewal date', 'date', '2026-11-14'),
+                customProperty('datetime', 'Next check-in', 'datetime', '2026-09-18T14:30:00Z'),
+            ].map((property) => (
+                <AccountPropertyRow
+                    key={property.key}
+                    property={property}
+                    editing
+                    onEdit={noop}
+                    onCancel={noop}
+                    onSaveCustomProperty={noop}
+                    onSaveRelationship={noop}
+                />
+            ))}
+        </div>
+    ),
+}
+
+export const RelationshipEditors: Story = {
+    render: () => (
+        <div className="flex flex-col gap-5 p-4">
+            {[
+                relationshipProperty('owner', 'Account owner', [MEMBERS[0]], true),
+                relationshipProperty('team', 'Account team', [MEMBERS[0], MEMBERS[1]], false),
+            ].map((property) => (
+                <AccountPropertyRow
+                    key={property.key}
+                    property={property}
+                    editing
+                    availableMembers={MEMBERS}
+                    onEdit={noop}
+                    onCancel={noop}
+                    onSaveCustomProperty={noop}
+                    onSaveRelationship={noop}
+                />
+            ))}
+        </div>
+    ),
+}
+
+const CONFIG_OPTIONS: AccountPropertyOption[] = DISPLAY_PROPERTIES.map((property) => ({
+    key: property.key,
+    label: property.definition.name,
+    kind: property.kind,
+}))
+
+export const PinAndReorder: Story = {
+    render: function Render() {
+        const [pinnedPropertyKeys, setPinnedPropertyKeys] = useState(CONFIG_OPTIONS.slice(0, 3).map(({ key }) => key))
+        return (
+            <AccountPropertyConfigurator
+                isOpen
+                options={CONFIG_OPTIONS}
+                pinnedPropertyKeys={pinnedPropertyKeys}
+                onChange={setPinnedPropertyKeys}
+                onSave={noop}
+                onCancel={noop}
+            />
+        )
+    },
+}
+
+const LIMIT_OPTIONS: AccountPropertyOption[] = Array.from({ length: 51 }, (_, index) => ({
+    key: `custom:limit-${index}`,
+    label: `Property ${index + 1}`,
+    kind: 'custom',
+}))
+
+export const PinLimitReached: Story = {
+    render: () => (
+        <AccountPropertyConfigurator
+            isOpen
+            options={LIMIT_OPTIONS}
+            pinnedPropertyKeys={LIMIT_OPTIONS.slice(0, 50).map(({ key }) => key)}
+            onChange={noop}
+            onSave={noop}
+            onCancel={noop}
+        />
+    ),
+}

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountPropertyConfigurator.test.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountPropertyConfigurator.test.tsx
@@ -1,0 +1,50 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { initKeaTests } from '~/test/init'
+
+import { AccountPropertyConfigurator } from './AccountPropertyConfigurator'
+import type { AccountPropertyOption } from './accountPropertyTypes'
+
+describe('AccountPropertyConfigurator', () => {
+    const options: AccountPropertyOption[] = [
+        { key: 'custom:plan', label: 'Plan', kind: 'custom' },
+        { key: 'relationship:owner', label: 'Owner', kind: 'relationship' },
+    ]
+
+    beforeEach(() => initKeaTests())
+    afterEach(cleanup)
+
+    const renderConfigurator = (saving: boolean): { onSave: jest.Mock; onChange: jest.Mock } => {
+        const onSave = jest.fn()
+        const onChange = jest.fn()
+        render(
+            <AccountPropertyConfigurator
+                isOpen
+                options={options}
+                pinnedPropertyKeys={['custom:plan']}
+                saving={saving}
+                onChange={onChange}
+                onSave={onSave}
+                onCancel={jest.fn()}
+            />
+        )
+        return { onSave, onChange }
+    }
+
+    it('saves the pinned keys when idle', () => {
+        const { onSave } = renderConfigurator(false)
+        fireEvent.click(screen.getByText('Save'))
+        expect(onSave).toHaveBeenCalledWith(['custom:plan'])
+    })
+
+    it('issues no writes while a save is in flight', () => {
+        const { onSave, onChange } = renderConfigurator(true)
+        fireEvent.click(screen.getByText('Save'))
+        fireEvent.click(screen.getByLabelText('Remove Plan'))
+        expect(onSave).not.toHaveBeenCalled()
+        expect(onChange).not.toHaveBeenCalled()
+        expect(screen.getByLabelText('Reorder Plan')).toBeDisabled()
+    })
+})

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountPropertyConfigurator.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountPropertyConfigurator.tsx
@@ -1,0 +1,139 @@
+import { DndContext } from '@dnd-kit/core'
+import { restrictToParentElement, restrictToVerticalAxis } from '@dnd-kit/modifiers'
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
+
+import { LemonButton, LemonInputSelect, LemonModal } from '@posthog/lemon-ui'
+
+import { AccountPropertyConfiguratorItem } from './AccountPropertyConfiguratorItem'
+import { AccountPropertyOption, MAX_PINNED_ACCOUNT_PROPERTIES } from './accountPropertyTypes'
+
+export interface AccountPropertyConfiguratorProps {
+    isOpen: boolean
+    options: AccountPropertyOption[]
+    pinnedPropertyKeys: string[]
+    onChange: (pinnedPropertyKeys: string[]) => void
+    onSave: (pinnedPropertyKeys: string[]) => void
+    onCancel: () => void
+}
+
+export function AccountPropertyConfigurator({
+    isOpen,
+    options,
+    pinnedPropertyKeys,
+    onChange,
+    onSave,
+    onCancel,
+}: AccountPropertyConfiguratorProps): JSX.Element {
+    const optionsByKey = new Map(options.map((option) => [option.key, option]))
+    const selectedOptions = pinnedPropertyKeys.map(
+        (key): AccountPropertyOption =>
+            optionsByKey.get(key) ?? {
+                key,
+                label: key,
+                kind: 'custom',
+            }
+    )
+    const availableOptions = options.filter((option) => !pinnedPropertyKeys.includes(option.key))
+    const pinLimitReached = pinnedPropertyKeys.length >= MAX_PINNED_ACCOUNT_PROPERTIES
+
+    const addPinnedProperty = (keys: string[]): void => {
+        const key = keys[0]
+        if (key && !pinLimitReached && !pinnedPropertyKeys.includes(key)) {
+            onChange([...pinnedPropertyKeys, key])
+        }
+    }
+
+    const movePinnedProperty = (activeKey: string, overKey: string): void => {
+        const fromIndex = pinnedPropertyKeys.indexOf(activeKey)
+        const toIndex = pinnedPropertyKeys.indexOf(overKey)
+        if (fromIndex < 0 || toIndex < 0 || fromIndex === toIndex) {
+            return
+        }
+        const reordered = [...pinnedPropertyKeys]
+        const [moved] = reordered.splice(fromIndex, 1)
+        reordered.splice(toIndex, 0, moved)
+        onChange(reordered)
+    }
+
+    return (
+        <LemonModal
+            isOpen={isOpen}
+            title="Pin properties"
+            onClose={onCancel}
+            footer={
+                <>
+                    <LemonButton type="secondary" onClick={onCancel} data-attr="account-pinned-properties-cancel">
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        onClick={() => onSave(pinnedPropertyKeys)}
+                        data-attr="account-pinned-properties-save"
+                    >
+                        Save
+                    </LemonButton>
+                </>
+            }
+        >
+            <div className="flex flex-col gap-2 min-w-80">
+                <p className="text-sm text-secondary mb-0">
+                    Choose up to {MAX_PINNED_ACCOUNT_PROPERTIES} properties. Drag selected properties to reorder them.
+                </p>
+                {selectedOptions.length > 0 ? (
+                    <DndContext
+                        onDragEnd={({ active, over }) => {
+                            if (over) {
+                                movePinnedProperty(String(active.id), String(over.id))
+                            }
+                        }}
+                        modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+                    >
+                        <SortableContext items={pinnedPropertyKeys} strategy={verticalListSortingStrategy}>
+                            <div
+                                className="flex max-h-80 flex-col gap-1 overflow-y-auto"
+                                data-attr="account-pinned-properties-list"
+                            >
+                                {selectedOptions.map((option) => (
+                                    <AccountPropertyConfiguratorItem
+                                        key={option.key}
+                                        option={option}
+                                        onRemove={() =>
+                                            onChange(pinnedPropertyKeys.filter((key) => key !== option.key))
+                                        }
+                                    />
+                                ))}
+                            </div>
+                        </SortableContext>
+                    </DndContext>
+                ) : (
+                    <span className="text-sm text-muted">No properties pinned.</span>
+                )}
+                <LemonInputSelect
+                    mode="single"
+                    limit={1}
+                    value={[]}
+                    onChange={addPinnedProperty}
+                    options={availableOptions.map((option) => ({
+                        key: option.key,
+                        label: option.label,
+                        labelComponent: (
+                            <span className="flex w-full items-center justify-between gap-2">
+                                <span className="truncate">{option.label}</span>
+                                <span className="text-xs text-secondary">
+                                    {option.kind === 'custom' ? 'Custom property' : 'Relationship'}
+                                </span>
+                            </span>
+                        ),
+                    }))}
+                    placeholder="Add a property"
+                    title="Available properties"
+                    fullWidth
+                    disabledReason={
+                        pinLimitReached ? `You can pin up to ${MAX_PINNED_ACCOUNT_PROPERTIES} properties` : undefined
+                    }
+                    data-attr="account-pinned-property-selector"
+                />
+            </div>
+        </LemonModal>
+    )
+}

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountPropertyConfigurator.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountPropertyConfigurator.tsx
@@ -11,6 +11,7 @@ export interface AccountPropertyConfiguratorProps {
     isOpen: boolean
     options: AccountPropertyOption[]
     pinnedPropertyKeys: string[]
+    saving?: boolean
     onChange: (pinnedPropertyKeys: string[]) => void
     onSave: (pinnedPropertyKeys: string[]) => void
     onCancel: () => void
@@ -20,6 +21,7 @@ export function AccountPropertyConfigurator({
     isOpen,
     options,
     pinnedPropertyKeys,
+    saving = false,
     onChange,
     onSave,
     onCancel,
@@ -68,6 +70,7 @@ export function AccountPropertyConfigurator({
                     <LemonButton
                         type="primary"
                         onClick={() => onSave(pinnedPropertyKeys)}
+                        loading={saving}
                         data-attr="account-pinned-properties-save"
                     >
                         Save
@@ -97,6 +100,7 @@ export function AccountPropertyConfigurator({
                                     <AccountPropertyConfiguratorItem
                                         key={option.key}
                                         option={option}
+                                        disabled={saving}
                                         onRemove={() =>
                                             onChange(pinnedPropertyKeys.filter((key) => key !== option.key))
                                         }
@@ -129,7 +133,11 @@ export function AccountPropertyConfigurator({
                     title="Available properties"
                     fullWidth
                     disabledReason={
-                        pinLimitReached ? `You can pin up to ${MAX_PINNED_ACCOUNT_PROPERTIES} properties` : undefined
+                        saving
+                            ? 'Saving'
+                            : pinLimitReached
+                              ? `You can pin up to ${MAX_PINNED_ACCOUNT_PROPERTIES} properties`
+                              : undefined
                     }
                     data-attr="account-pinned-property-selector"
                 />

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountPropertyConfiguratorItem.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountPropertyConfiguratorItem.tsx
@@ -1,0 +1,54 @@
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+
+import { IconX } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { SortableDragIcon } from 'lib/lemon-ui/icons'
+
+import type { AccountPropertyOption } from './accountPropertyTypes'
+
+export interface AccountPropertyConfiguratorItemProps {
+    option: AccountPropertyOption
+    onRemove: () => void
+}
+
+export function AccountPropertyConfiguratorItem({
+    option,
+    onRemove,
+}: AccountPropertyConfiguratorItemProps): JSX.Element {
+    const { setNodeRef, attributes, listeners, transform, transition, isDragging } = useSortable({ id: option.key })
+
+    return (
+        <div
+            ref={setNodeRef}
+            // eslint-disable-next-line react/forbid-dom-props
+            style={{ transform: CSS.Transform.toString(transform), transition }}
+            className={`flex items-center gap-2 rounded border bg-surface-primary px-2 py-1.5 ${
+                isDragging ? 'opacity-50' : ''
+            }`}
+            data-attr="account-pinned-property-row"
+        >
+            <button
+                type="button"
+                className="flex cursor-grab items-center text-secondary active:cursor-grabbing"
+                aria-label={`Reorder ${option.label}`}
+                {...attributes}
+                {...listeners}
+            >
+                <SortableDragIcon />
+            </button>
+            <span className="min-w-0 flex-1 truncate text-sm font-medium">{option.label}</span>
+            <span className="shrink-0 text-xs text-secondary">
+                {option.kind === 'custom' ? 'Custom property' : 'Relationship'}
+            </span>
+            <LemonButton
+                size="xsmall"
+                icon={<IconX />}
+                tooltip={`Remove ${option.label}`}
+                aria-label={`Remove ${option.label}`}
+                onClick={onRemove}
+            />
+        </div>
+    )
+}

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountPropertyConfiguratorItem.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountPropertyConfiguratorItem.tsx
@@ -10,14 +10,19 @@ import type { AccountPropertyOption } from './accountPropertyTypes'
 
 export interface AccountPropertyConfiguratorItemProps {
     option: AccountPropertyOption
+    disabled?: boolean
     onRemove: () => void
 }
 
 export function AccountPropertyConfiguratorItem({
     option,
+    disabled = false,
     onRemove,
 }: AccountPropertyConfiguratorItemProps): JSX.Element {
-    const { setNodeRef, attributes, listeners, transform, transition, isDragging } = useSortable({ id: option.key })
+    const { setNodeRef, attributes, listeners, transform, transition, isDragging } = useSortable({
+        id: option.key,
+        disabled,
+    })
 
     return (
         <div
@@ -31,8 +36,11 @@ export function AccountPropertyConfiguratorItem({
         >
             <button
                 type="button"
-                className="flex cursor-grab items-center text-secondary active:cursor-grabbing"
+                className={`flex items-center text-secondary ${
+                    disabled ? 'cursor-not-allowed' : 'cursor-grab active:cursor-grabbing'
+                }`}
                 aria-label={`Reorder ${option.label}`}
+                disabled={disabled}
                 {...attributes}
                 {...listeners}
             >
@@ -48,6 +56,7 @@ export function AccountPropertyConfiguratorItem({
                 tooltip={`Remove ${option.label}`}
                 aria-label={`Remove ${option.label}`}
                 onClick={onRemove}
+                disabledReason={disabled ? 'Saving' : undefined}
             />
         </div>
     )

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountPropertyRow.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountPropertyRow.tsx
@@ -1,0 +1,100 @@
+import { IconBolt, IconDatabase, IconLogomark, IconPencil } from '@posthog/icons'
+import { LemonButton, Tooltip } from '@posthog/lemon-ui'
+
+import { AccountCustomPropertyEditor } from './AccountCustomPropertyEditor'
+import {
+    AccountCustomProperty,
+    AccountCustomPropertyValue,
+    AccountRelationshipMember,
+    AccountRelationshipProperty,
+    AccountSidebarProperty,
+    isCustomPropertyEditable,
+} from './accountPropertyTypes'
+import { AccountPropertyValue } from './AccountPropertyValue'
+import { AccountRelationshipEditor } from './AccountRelationshipEditor'
+
+const PROVENANCE = {
+    workflow: { icon: <IconBolt />, title: 'Updated by a workflow' },
+    warehouse: { icon: <IconDatabase />, title: 'Synced from the data warehouse' },
+    canonical: { icon: <IconLogomark />, title: 'Managed by PostHog' },
+} as const
+
+export interface AccountPropertyRowProps {
+    property: AccountSidebarProperty
+    editing?: boolean
+    saving?: boolean
+    availableMembers?: AccountRelationshipMember[]
+    onEdit: () => void
+    onCancel: () => void
+    onSaveCustomProperty: (property: AccountCustomProperty, value: AccountCustomPropertyValue) => void
+    onSaveRelationship: (property: AccountRelationshipProperty, memberIds: number[]) => void
+}
+
+export function AccountPropertyRow({
+    property,
+    editing = false,
+    saving = false,
+    availableMembers = [],
+    onEdit,
+    onCancel,
+    onSaveCustomProperty,
+    onSaveRelationship,
+}: AccountPropertyRowProps): JSX.Element {
+    const editable =
+        property.kind === 'custom' ? isCustomPropertyEditable(property.provenance) : property.editable !== false
+    const provenance =
+        property.kind === 'custom' && property.provenance !== 'manual' ? PROVENANCE[property.provenance] : null
+
+    return (
+        <div className="flex flex-col gap-1 min-w-0" data-attr="account-property-row">
+            <div className="flex items-center gap-1 min-w-0">
+                <span className="text-xs text-secondary truncate">{property.definition.name}</span>
+                {provenance ? (
+                    <Tooltip title={provenance.title}>
+                        <span className="flex items-center text-secondary text-xs">{provenance.icon}</span>
+                    </Tooltip>
+                ) : null}
+                {editable && !editing ? (
+                    <LemonButton
+                        size="xsmall"
+                        icon={<IconPencil />}
+                        tooltip="Edit value"
+                        aria-label={`Edit ${property.definition.name}`}
+                        onClick={onEdit}
+                        className="ml-auto"
+                        data-attr="account-property-edit"
+                    />
+                ) : null}
+            </div>
+            {editing && editable ? (
+                <div className="flex flex-col gap-1.5">
+                    {property.kind === 'custom' ? (
+                        <AccountCustomPropertyEditor
+                            key={property.key}
+                            definition={property.definition}
+                            value={property.value}
+                            saving={saving}
+                            onSave={(value) => onSaveCustomProperty(property, value)}
+                            onCancel={onCancel}
+                        />
+                    ) : (
+                        <AccountRelationshipEditor
+                            key={property.key}
+                            definition={property.definition}
+                            members={property.members}
+                            availableMembers={availableMembers}
+                            saving={saving}
+                            onSave={(memberIds) => onSaveRelationship(property, memberIds)}
+                            onCancel={onCancel}
+                        />
+                    )}
+                    {property.kind === 'custom' && property.provenance === 'workflow' ? (
+                        <span className="text-xs text-secondary">A workflow may overwrite this value.</span>
+                    ) : null}
+                </div>
+            ) : (
+                <AccountPropertyValue property={property} />
+            )}
+        </div>
+    )
+}

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountPropertyValue.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountPropertyValue.tsx
@@ -1,0 +1,83 @@
+import { IconCheck, IconX } from '@posthog/icons'
+import { LemonColorGlyph, Link, ProfilePicture } from '@posthog/lemon-ui'
+
+import { DataColorToken } from 'lib/colors'
+import { TZLabel } from 'lib/components/TZLabel'
+import { dayjs } from 'lib/dayjs'
+
+import { formatCustomPropertyValue } from '../../CustomerAnalyticsConfigurationScene/account/customPropertyTypes'
+import type { AccountSidebarProperty } from './accountPropertyTypes'
+
+export interface AccountPropertyValueProps {
+    property: AccountSidebarProperty
+}
+
+export function AccountPropertyValue({ property }: AccountPropertyValueProps): JSX.Element {
+    if (property.kind === 'relationship') {
+        if (property.members.length === 0) {
+            return <span className="text-sm text-muted">Unassigned</span>
+        }
+
+        return (
+            <div className="flex flex-col gap-1 min-w-0">
+                {property.members.map((member) => (
+                    <span key={member.id} className="inline-flex items-center gap-2 min-w-0">
+                        <ProfilePicture user={{ email: member.email }} size="sm" />
+                        <span className="text-sm font-medium truncate" title={member.email}>
+                            {member.name || member.email}
+                        </span>
+                    </span>
+                ))}
+            </div>
+        )
+    }
+
+    const { definition, value } = property
+    if (value === null || value === '') {
+        return <span className="text-sm text-muted">Not set</span>
+    }
+
+    const raw = String(value)
+    if (definition.display_type === 'boolean') {
+        const isTrue = value === true || raw === 'true'
+        return (
+            <span className="inline-flex items-center gap-1 text-sm font-medium">
+                {isTrue ? <IconCheck className="text-success" /> : <IconX className="text-danger" />}
+                {isTrue ? 'Yes' : 'No'}
+            </span>
+        )
+    }
+    if (definition.display_type === 'link') {
+        return (
+            <Link to={raw} target="_blank" className="text-sm font-medium truncate">
+                {raw}
+            </Link>
+        )
+    }
+    if (definition.display_type === 'date' || definition.display_type === 'datetime') {
+        const parsed = dayjs(raw)
+        if (!parsed.isValid()) {
+            return <span className="text-sm font-medium truncate">{raw}</span>
+        }
+        return definition.display_type === 'datetime' ? (
+            <span className="text-sm font-medium">
+                <TZLabel time={parsed} formatDate="MMM D, YYYY" formatTime="HH:mm" />
+            </span>
+        ) : (
+            <span className="text-sm font-medium">{parsed.format('MMM D, YYYY')}</span>
+        )
+    }
+    if (definition.display_type === 'select') {
+        const option = definition.options?.find((candidate) => candidate.label === raw)
+        return (
+            <span className="inline-flex items-center gap-1.5 min-w-0 text-sm font-medium">
+                {option ? <LemonColorGlyph colorToken={option.color as DataColorToken} size="small" /> : null}
+                <span className="truncate">{raw}</span>
+            </span>
+        )
+    }
+
+    return (
+        <span className="text-sm font-medium tabular-nums truncate">{formatCustomPropertyValue(raw, definition)}</span>
+    )
+}

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountPropertyValue.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountPropertyValue.tsx
@@ -55,7 +55,7 @@ export function AccountPropertyValue({ property }: AccountPropertyValueProps): J
         )
     }
     if (definition.display_type === 'date' || definition.display_type === 'datetime') {
-        const parsed = dayjs(raw)
+        const parsed = dayjs(definition.display_type === 'date' ? raw.slice(0, 10) : raw)
         if (!parsed.isValid()) {
             return <span className="text-sm font-medium truncate">{raw}</span>
         }

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountRelationshipEditor.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/AccountRelationshipEditor.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react'
+
+import { LemonButton, LemonDialog, LemonInputSelect } from '@posthog/lemon-ui'
+
+import type { AccountRelationshipDefinitionApi } from 'products/customer_analytics/frontend/generated/api.schemas'
+
+import type { AccountRelationshipMember } from './accountPropertyTypes'
+
+export interface AccountRelationshipEditorProps {
+    definition: AccountRelationshipDefinitionApi
+    members: AccountRelationshipMember[]
+    availableMembers: AccountRelationshipMember[]
+    saving?: boolean
+    onSave: (memberIds: number[]) => void
+    onCancel: () => void
+}
+
+export function AccountRelationshipEditor({
+    definition,
+    members,
+    availableMembers,
+    saving = false,
+    onSave,
+    onCancel,
+}: AccountRelationshipEditorProps): JSX.Element {
+    const [draftMemberIds, setDraftMemberIds] = useState<number[]>(members.map((member) => member.id))
+
+    const confirmClear = (): void => {
+        LemonDialog.open({
+            title: `Clear ${definition.name}?`,
+            content: 'This will remove all current assignments. You can assign people again later.',
+            primaryButton: {
+                children: 'Clear value',
+                status: 'danger',
+                onClick: () => onSave([]),
+            },
+            secondaryButton: {
+                children: 'Cancel',
+            },
+        })
+    }
+
+    return (
+        <div className="flex flex-col gap-2 w-full">
+            <LemonInputSelect<number>
+                mode={definition.is_single_holder === false ? 'multiple' : 'single'}
+                value={draftMemberIds}
+                onChange={setDraftMemberIds}
+                options={availableMembers.map((member) => ({
+                    key: String(member.id),
+                    value: member.id,
+                    label: member.name ? `${member.name} (${member.email})` : member.email,
+                }))}
+                placeholder="Select a team member"
+                size="small"
+                fullWidth
+                singleValueAsSnack
+                disabledReason={saving ? 'Saving' : undefined}
+                data-attr="account-relationship-members-input"
+            />
+            <div className="flex flex-wrap items-center justify-end gap-1 w-full">
+                <LemonButton
+                    size="xsmall"
+                    status="danger"
+                    onClick={confirmClear}
+                    disabledReason={members.length === 0 ? 'This relationship is unassigned' : undefined}
+                    data-attr="account-relationship-clear"
+                >
+                    Clear value
+                </LemonButton>
+                <LemonButton size="xsmall" onClick={onCancel} data-attr="account-relationship-cancel">
+                    Cancel
+                </LemonButton>
+                <LemonButton
+                    type="primary"
+                    size="xsmall"
+                    onClick={() => onSave(draftMemberIds)}
+                    loading={saving}
+                    data-attr="account-relationship-save"
+                >
+                    Save
+                </LemonButton>
+            </div>
+        </div>
+    )
+}

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/accountPropertyTypes.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsAccountScene/components/accountPropertyTypes.ts
@@ -1,0 +1,44 @@
+import type {
+    AccountRelationshipDefinitionApi,
+    CustomPropertyDefinitionApi,
+} from 'products/customer_analytics/frontend/generated/api.schemas'
+
+export const MAX_PINNED_ACCOUNT_PROPERTIES = 50
+
+export type AccountCustomPropertyValue = string | number | boolean | null
+
+export type AccountCustomPropertyProvenance = 'manual' | 'workflow' | 'warehouse' | 'canonical'
+
+export interface AccountRelationshipMember {
+    id: number
+    email: string
+    name?: string
+}
+
+export interface AccountCustomProperty {
+    key: string
+    kind: 'custom'
+    definition: CustomPropertyDefinitionApi
+    value: AccountCustomPropertyValue
+    provenance: AccountCustomPropertyProvenance
+}
+
+export interface AccountRelationshipProperty {
+    key: string
+    kind: 'relationship'
+    definition: AccountRelationshipDefinitionApi
+    members: AccountRelationshipMember[]
+    editable?: boolean
+}
+
+export type AccountSidebarProperty = AccountCustomProperty | AccountRelationshipProperty
+
+export interface AccountPropertyOption {
+    key: string
+    label: string
+    kind: AccountSidebarProperty['kind']
+}
+
+export function isCustomPropertyEditable(provenance: AccountCustomPropertyProvenance): boolean {
+    return provenance === 'manual' || provenance === 'workflow'
+}


### PR DESCRIPTION
## Problem

Account detail users need consistent property rows for every account property and relationship type.

This stack layer defines reusable states before production data integration.

## Changes

- Account detail reviewers can inspect display, edit, empty, scroll, relationship, reorder, and limit states in Storybook.
- Editors use type-specific inputs and right-align the Clear, Cancel, Save actions.
- Percent editors convert between displayed percentages and stored fractions.
- Date-only values keep their calendar day, and date pickers retain attempted saves for retry.
- Every clear action opens a confirmation, including date and datetime values.
- The empty state shows a hedgehog and primary Pin properties action without the configured-state gear.
- The vertical selector supports drag reordering and caps selections at 50 properties.
- [The next stack layer](https://github.com/PostHog/posthog/pull/95503) connects configuration to the account page.
- This layer does not change the live account page, so no production before-and-after screenshot applies.

**Storybook states**

![Empty property sidebar](https://raw.githubusercontent.com/PostHog/pr-assets/4cf076f6b2103038c4c51b90c103908b626055ed/2026/09/8cfcb120-33bf-4960-805e-cace21e6e3ed.png)

![Property editors](https://raw.githubusercontent.com/PostHog/pr-assets/6b126ac88dcb3538d3ebba5b7da8466db4b3170f/2026/09/35dd4acd-34f6-4331-b8df-b59d773a9e4f.png)

![Vertical pin-and-reorder selector](https://raw.githubusercontent.com/PostHog/pr-assets/5c428814fd206118efbbe7fee27db1271d0a8686/2026/09/908f406f-a131-4ae8-a744-3b16a11dbbd7.png)

## How did you test this code?

- Editor regressions ran in America/Los_Angeles, covering percent conversion, UTC-midnight dates, and retained date/datetime drafts.

- Chromium rendered all seven stories and exercised the edit, clear-confirmation, date, relationship, reorder, and limit states.
- Ran `pnpm --filter=@posthog/frontend typescript:check`.
- Ran `hogli ci:preflight --strict` after the final rebase.
- Not tested: production account behavior, because this layer adds only standalone components.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Added [the property editor conventions](https://github.com/PostHog/posthog/blob/codex/account-properties-components/docs/internal/customer-analytics-property-editors.md).

## 🤖 Agent context

Review follow-up used /stacking-prs, /resolve-conflicts, /writing-tests, and /writing-code-comments. Existing commits and approved visual baselines remain in the restacked history.

**Autonomy:** Human-driven (agent-assisted)

- Codex Desktop used a focused component subagent, Storybook, and Chromium.
- Skills: /pr-description, /writing-pr-descriptions, /launch-subagents, /writing-ui-components, /write-snapshot-test, /writing-user-facing-copy, /browser-use, /running-ci-preflight, and /stacking-prs.
- PRs #94321–#94323 contain exploratory visualizations. This PR defines reusable component contracts.
- All fixtures and screenshots use invented data.