### PR TITLE
fix(workflows): keep the conversion goal when a patch carries part of it

### DIFF
--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -795,6 +795,10 @@ def _describe_action_errors(errors: list[Any], actions: list[dict]) -> str:
     return f"Can't enable this workflow. Fix {'; '.join(parts) or 'the invalid steps'} and try again."
 
 
+def _is_mcp_client(request: Request) -> bool:
+    return request.headers.get("x-posthog-client") == "mcp"
+
+
 def _should_validate_strictly(context: dict, is_draft: Optional[bool]) -> bool:
     # Non-draft saves always validate fully. Drafts stay lenient for the web UI builder (which saves
     # incomplete graphs mid-edit) and for internal re-saves (e.g. the refresh management command), which
@@ -902,6 +906,18 @@ def _existing_email_from_by_action(instance: "HogFlow") -> dict[str, list[dict]]
             if isinstance(from_value, dict):
                 result.setdefault(stored_action["id"], []).append(from_value)
     return result
+
+
+def _relocate_legacy_conversion_event_object(conversion: dict) -> dict:
+    # Before the conversion.events slot existed, an event-based goal could be saved as an object in
+    # conversion.filters (e.g. {"events": [...], "source": "events"}). The property slot only takes an
+    # array, so that shape is invisible to the matcher and breaks the property picker — move it to the
+    # events slot (mirrors the one-time backfill in migration 0009). Every other shape is returned
+    # unchanged. Shared by the write path and the partial-update merge so both see one shape.
+    filters = conversion.get("filters")
+    if not isinstance(filters, dict) or not filters.get("events"):
+        return conversion
+    return {**conversion, "events": [*(conversion.get("events") or []), {"filters": filters}], "filters": []}
 
 
 def _event_config_has_event_or_action(event_config: dict) -> bool:
@@ -1956,12 +1972,11 @@ class HogFlowConversionSerializer(serializers.Serializer):
         # bytecode is server-computed; never trust a client-supplied value (the matcher executes it).
         if isinstance(data, dict) and "bytecode" in data:
             data = {k: v for k, v in data.items() if k != "bytecode"}
-        # Legacy shape guard (mirrors the one-time backfill in migration 0009): some clients sent an
-        # event-based goal as an object in 'filters' (e.g. {"events": [...], "source": "events"}).
-        # That belongs in 'events' — relocate it before field validation so the old shape is still
-        # accepted and compiled (filters only takes an array of property conditions) instead of 400ing.
-        if isinstance(data, dict) and isinstance(data.get("filters"), dict) and data["filters"].get("events"):
-            data = {**data, "events": [*(data.get("events") or []), {"filters": data["filters"]}], "filters": []}
+        # Legacy shape guard: some clients sent an event-based goal as an object in 'filters'. Relocate
+        # it before field validation so the old shape is still accepted and compiled (filters only takes
+        # an array of property conditions) instead of 400ing.
+        if isinstance(data, dict):
+            data = _relocate_legacy_conversion_event_object(data)
         return super().to_internal_value(data)
 
     def to_representation(self, value):
@@ -2842,6 +2857,29 @@ class HogFlowSerializer(HogFlowMinimalSerializer):
         request = self.context.get("request")
         return bool(request is not None and getattr(request, "data", None) and request.data.get("stage_draft"))
 
+    def _writes_to_draft(self, instance: HogFlow) -> bool:
+        # Which object this save lands in, mirroring the routing in perform_update: a content edit on an
+        # active workflow stages a draft for MCP callers and for a body that opts into stage_draft.
+        # Everything else — including an internal re-save with no request — writes the live row.
+        request = self.context.get("request")
+        if request is None or instance.status != HogFlow.State.ACTIVE:
+            return False
+        if not set(getattr(request, "data", None) or {}) & set(DRAFT_CONTENT_FIELDS):
+            return False
+        return _is_mcp_client(request) or self._stages_draft()
+
+    def _stored_conversion_base(self, instance: Optional[HogFlow]) -> Optional[dict]:
+        # The conversion a partial patch merges into: whichever copy this save is about to overwrite.
+        # A draft write composes on the staged draft (the same rule the graph endpoint follows) — it
+        # holds the newer goal, and may have deliberately cleared it, so live is the wrong base there.
+        # A live write reads live even when a draft exists, because the draft is not what it replaces.
+        if instance is None:
+            return None
+        if self._writes_to_draft(instance) and isinstance(instance.draft, dict):
+            draft_conversion = instance.draft.get("conversion")
+            return draft_conversion if isinstance(draft_conversion, dict) else None
+        return instance.conversion if isinstance(instance.conversion, dict) else None
+
     def to_internal_value(self, data):
         # When used as a nested field (the `configuration` override on test invocations) DRF never
         # binds `self.instance`, so fall back to the flow passed in via context so recovery still works.
@@ -3076,6 +3114,30 @@ class HogFlowSerializer(HogFlowMinimalSerializer):
 
         conversion = data.get("conversion")
         if conversion is not None:
+            # DRF replaces a nested object rather than merging it, so a PATCH carrying one part of the
+            # conversion arrives without the rest and the lines below would store it as empty — leaving a
+            # workflow that measures nothing, with no error to say so. Carry the omitted parts over from
+            # the stored value; a caller that means to clear one sends it explicitly as [].
+            #
+            # The base is the copy this save overwrites — the staged draft for a draft write, live for a
+            # live one (see _stored_conversion_base). Reading the wrong one would revert a staged goal,
+            # or un-clear one a draft deliberately emptied.
+            stored_base = self._stored_conversion_base(instance) if self.partial else None
+            if stored_base is not None:
+                # Copy before merging: the compile loop below rewrites each event entry in place, and a
+                # carried-over entry is still the stored object. A staged edit that also touches metadata
+                # saves the live row for that metadata, which would take the recompile with it.
+                #
+                # Normalize a legacy goal (event object in `filters`) too: carried over raw it would land
+                # past the to_internal_value relocation, and skipping it would drop the only copy of a
+                # goal the patch never asked to change.
+                stored_conversion = _relocate_legacy_conversion_event_object(deepcopy(stored_base))
+                for key in ("filters", "events", "window_minutes"):
+                    stored = stored_conversion.get(key)
+                    if key in conversion or stored is None:
+                        continue
+                    conversion[key] = stored
+                data["conversion"] = conversion
             filters = conversion.get("filters")
             if filters:
                 serializer = HogFunctionFiltersSerializer(data={"properties": filters}, context=self.context)
@@ -3846,7 +3908,7 @@ class HogFlowViewSet(
 
     @staticmethod
     def _is_mcp_request(request: Request) -> bool:
-        return request.headers.get("x-posthog-client") == "mcp"
+        return _is_mcp_client(request)
 
     @extend_schema(
         request=HogInvocationRerunRequestSerializer,

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -2868,6 +2868,14 @@ class HogFlowSerializer(HogFlowMinimalSerializer):
             return False
         return _is_mcp_client(request) or self._stages_draft()
 
+    def _merges_partial_conversion(self) -> bool:
+        # Only a PATCH of the workflow itself can carry part of a conversion. The custom actions
+        # revalidate a complete stored snapshot with partial=True as well — publish re-runs the draft,
+        # which is a full content snapshot — and merging live fields into one of those would put back
+        # what the snapshot leaves out, so a restored revision would not roll all the way back.
+        view = self.context.get("view")
+        return self.partial and getattr(view, "action", None) == "partial_update"
+
     def _stored_conversion_base(self, instance: Optional[HogFlow]) -> Optional[dict]:
         # The conversion a partial patch merges into: whichever copy this save is about to overwrite.
         # A draft write composes on the staged draft (the same rule the graph endpoint follows) — it
@@ -3122,7 +3130,7 @@ class HogFlowSerializer(HogFlowMinimalSerializer):
             # The base is the copy this save overwrites — the staged draft for a draft write, live for a
             # live one (see _stored_conversion_base). Reading the wrong one would revert a staged goal,
             # or un-clear one a draft deliberately emptied.
-            stored_base = self._stored_conversion_base(instance) if self.partial else None
+            stored_base = self._stored_conversion_base(instance) if self._merges_partial_conversion() else None
             if stored_base is not None:
                 # Copy before merging: the compile loop below rewrites each event entry in place, and a
                 # carried-over entry is still the stored object. A staged edit that also touches metadata

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -3138,8 +3138,13 @@ class HogFlowSerializer(HogFlowMinimalSerializer):
                 #
                 # Normalize a legacy goal (event object in `filters`) too: carried over raw it would land
                 # past the to_internal_value relocation, and skipping it would drop the only copy of a
-                # goal the patch never asked to change.
-                stored_conversion = _relocate_legacy_conversion_event_object(deepcopy(stored_base))
+                # goal the patch never asked to change. Only when the patch leaves `filters` alone,
+                # though — a legacy goal lives in that slot and is read back from it, so a patch that
+                # replaces `filters` is editing the goal itself. Relocating it there would move it out
+                # of reach of the field the caller just replaced and keep measuring.
+                stored_conversion = deepcopy(stored_base)
+                if "filters" not in conversion:
+                    stored_conversion = _relocate_legacy_conversion_event_object(stored_conversion)
                 for key in ("filters", "events", "window_minutes"):
                     stored = stored_conversion.get(key)
                     if key in conversion or stored is None:

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -1055,6 +1055,247 @@ class TestHogFlowAPI(APIBaseTest):
         assert moved["bytecode"], moved
         assert "purchase" in moved["bytecode"]
 
+    def test_hog_flow_conversion_partial_patch_keeps_the_goal(self):
+        # DRF replaces a nested object rather than merging it, so a PATCH carrying only part of the
+        # conversion used to store an empty goal. The workflow kept measuring nothing, with a 200 and
+        # no error to say so.
+        hog_flow, _ = self._create_hog_flow_with_action(
+            {"template_id": "template-webhook", "inputs": {"url": {"value": "https://example.com"}}}
+        )
+        hog_flow["status"] = "active"
+        hog_flow["conversion"] = {
+            "filters": [],
+            "window_minutes": 60,
+            "events": [{"filters": {"events": [{"id": "purchase", "name": "purchase", "type": "events"}]}}],
+        }
+        created = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert created.status_code == 201, created.json()
+        flow_id = created.json()["id"]
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
+            {"conversion": {"window_minutes": 120}},
+            format="json",
+        )
+
+        assert response.status_code == 200, response.json()
+        conversion = response.json()["conversion"]
+        assert conversion["window_minutes"] == 120
+        assert len(conversion["events"]) == 1, conversion
+
+    def test_hog_flow_conversion_partial_patch_keeps_a_legacy_goal(self):
+        # Rows written before the conversion.events slot existed hold the event goal as an object in the
+        # property slot. A window-only patch dropped it, so the merge relocates that shape the way the
+        # write path does instead of leaving it behind.
+        event_obj = {
+            "events": [{"id": "purchase", "name": "purchase", "type": "events", "order": 0}],
+            "source": "events",
+        }
+        hog_flow, _ = self._create_hog_flow_with_action(
+            {"template_id": "template-webhook", "inputs": {"url": {"value": "https://example.com"}}}
+        )
+        hog_flow["status"] = "active"
+        created = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert created.status_code == 201, created.json()
+        flow_id = created.json()["id"]
+        flow = HogFlow.objects.get(id=flow_id)
+        flow.conversion = {"filters": event_obj, "window_minutes": 60}
+        flow.save()
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
+            {"conversion": {"window_minutes": 120}},
+            format="json",
+        )
+
+        assert response.status_code == 200, response.json()
+        conversion = response.json()["conversion"]
+        assert conversion["window_minutes"] == 120
+        assert len(conversion["events"]) == 1, conversion
+        assert conversion["events"][0]["filters"]["events"] == event_obj["events"]
+        assert conversion["filters"] == [], conversion
+
+    def test_hog_flow_conversion_goal_only_patch_keeps_the_window(self):
+        # The mirror of the case above: an edit to the goal must not drop the window.
+        hog_flow, _ = self._create_hog_flow_with_action(
+            {"template_id": "template-webhook", "inputs": {"url": {"value": "https://example.com"}}}
+        )
+        hog_flow["status"] = "active"
+        hog_flow["conversion"] = {
+            "filters": [],
+            "window_minutes": 60,
+            "events": [{"filters": {"events": [{"id": "purchase", "name": "purchase", "type": "events"}]}}],
+        }
+        created = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        flow_id = created.json()["id"]
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
+            {
+                "conversion": {
+                    "events": [{"filters": {"events": [{"id": "signup", "name": "signup", "type": "events"}]}}]
+                }
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200, response.json()
+        assert response.json()["conversion"]["window_minutes"] == 60, response.json()["conversion"]
+
+    def test_hog_flow_conversion_staged_patch_does_not_resurrect_a_cleared_goal(self):
+        # A staged draft that deliberately emptied the goal is the base for the next staged edit, so the
+        # merge must not reach past it to the live goal and bring the deleted one back.
+        hog_flow, _ = self._create_hog_flow_with_action(
+            {"template_id": "template-webhook", "inputs": {"url": {"value": "https://example.com"}}}
+        )
+        hog_flow["status"] = "active"
+        hog_flow["conversion"] = {
+            "filters": [],
+            "window_minutes": 60,
+            "events": [{"filters": {"events": [{"id": "purchase", "name": "purchase", "type": "events"}]}}],
+        }
+        created = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        flow_id = created.json()["id"]
+        flow = HogFlow.objects.get(id=flow_id)
+        flow.draft = {"conversion": {"filters": [], "window_minutes": 60, "events": []}}
+        flow.save()
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
+            {"conversion": {"window_minutes": 120}},
+            format="json",
+            HTTP_X_POSTHOG_CLIENT="mcp",
+        )
+
+        assert response.status_code == 200, response.json()
+        flow.refresh_from_db()
+        assert flow.draft["conversion"]["events"] == [], flow.draft["conversion"]
+        assert flow.draft["conversion"]["window_minutes"] == 120, flow.draft["conversion"]
+
+    def test_hog_flow_conversion_second_staged_patch_keeps_the_staged_goal(self):
+        # A staged edit composes on the draft, so a second window-only patch has to read the goal the
+        # first one staged. Reading live instead would stage an empty goal and the workflow would
+        # publish measuring nothing.
+        hog_flow, _ = self._create_hog_flow_with_action(
+            {"template_id": "template-webhook", "inputs": {"url": {"value": "https://example.com"}}}
+        )
+        hog_flow["status"] = "active"
+        hog_flow["conversion"] = {
+            "filters": [],
+            "window_minutes": 60,
+            "events": [{"filters": {"events": [{"id": "purchase", "name": "purchase", "type": "events"}]}}],
+        }
+        created = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert created.status_code == 201, created.json()
+        flow_id = created.json()["id"]
+
+        first = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
+            {"conversion": {"window_minutes": 120}},
+            format="json",
+            HTTP_X_POSTHOG_CLIENT="mcp",
+        )
+        assert first.status_code == 200, first.json()
+        flow = HogFlow.objects.get(id=flow_id)
+        assert len(flow.draft["conversion"]["events"]) == 1, flow.draft["conversion"]
+
+        second = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
+            {"conversion": {"window_minutes": 180}},
+            format="json",
+            HTTP_X_POSTHOG_CLIENT="mcp",
+        )
+        assert second.status_code == 200, second.json()
+        flow.refresh_from_db()
+        assert flow.draft["conversion"]["window_minutes"] == 180, flow.draft["conversion"]
+        assert len(flow.draft["conversion"]["events"]) == 1, flow.draft["conversion"]
+
+    def test_hog_flow_conversion_live_patch_keeps_the_goal_when_a_draft_exists(self):
+        # A patch without stage_draft lands on the live row even when the workflow holds a draft, so the
+        # merge base is live. An unrelated staged draft must not stop the live goal being carried over.
+        hog_flow, _ = self._create_hog_flow_with_action(
+            {"template_id": "template-webhook", "inputs": {"url": {"value": "https://example.com"}}}
+        )
+        hog_flow["status"] = "active"
+        hog_flow["conversion"] = {
+            "filters": [],
+            "window_minutes": 60,
+            "events": [{"filters": {"events": [{"id": "purchase", "name": "purchase", "type": "events"}]}}],
+        }
+        created = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        flow_id = created.json()["id"]
+        flow = HogFlow.objects.get(id=flow_id)
+        flow.draft = {"name": "staged rename"}
+        flow.save()
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
+            {"conversion": {"window_minutes": 120}},
+            format="json",
+        )
+
+        assert response.status_code == 200, response.json()
+        flow.refresh_from_db()
+        assert flow.conversion["window_minutes"] == 120, flow.conversion
+        assert len(flow.conversion["events"]) == 1, flow.conversion
+
+    def test_hog_flow_conversion_staged_patch_leaves_the_live_goal_alone(self):
+        # A staged edit that also renames the workflow saves the live row for the rename. The goal it
+        # carried over must not ride along: it is compiled on the way through, and the live workflow
+        # would start matching on the recompile before anyone published the draft.
+        hog_flow, _ = self._create_hog_flow_with_action(
+            {"template_id": "template-webhook", "inputs": {"url": {"value": "https://example.com"}}}
+        )
+        hog_flow["status"] = "active"
+        created = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert created.status_code == 201, created.json()
+        flow_id = created.json()["id"]
+        flow = HogFlow.objects.get(id=flow_id)
+        # The conversion backfill relocates a goal without compiling it, so a stored goal can carry no
+        # bytecode — the shape where a recompile is visibly different from what is stored.
+        stored_conversion = {
+            "filters": [],
+            "window_minutes": 60,
+            "events": [{"filters": {"events": [{"id": "purchase", "name": "purchase", "type": "events"}]}}],
+        }
+        flow.conversion = stored_conversion
+        flow.save()
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
+            {"conversion": {"window_minutes": 120}, "name": "Renamed"},
+            format="json",
+            HTTP_X_POSTHOG_CLIENT="mcp",
+        )
+
+        assert response.status_code == 200, response.json()
+        flow.refresh_from_db()
+        assert flow.name == "Renamed"
+        assert flow.conversion == stored_conversion, flow.conversion
+        assert flow.draft["conversion"]["window_minutes"] == 120, flow.draft["conversion"]
+        assert len(flow.draft["conversion"]["events"]) == 1, flow.draft["conversion"]
+
+    def test_hog_flow_conversion_goal_can_still_be_cleared_explicitly(self):
+        hog_flow, _ = self._create_hog_flow_with_action(
+            {"template_id": "template-webhook", "inputs": {"url": {"value": "https://example.com"}}}
+        )
+        hog_flow["conversion"] = {
+            "filters": [],
+            "window_minutes": 60,
+            "events": [{"filters": {"events": [{"id": "purchase", "name": "purchase", "type": "events"}]}}],
+        }
+        created = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        flow_id = created.json()["id"]
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
+            {"conversion": {"window_minutes": 120, "events": []}},
+            format="json",
+        )
+
+        assert response.status_code == 200, response.json()
+        assert response.json()["conversion"]["events"] == []
+
     def test_hog_flow_conversion_client_supplied_bytecode_is_ignored(self):
         # Top-level conversion bytecode is read-only: the matcher executes it, so a client must not
         # be able to persist bytecode that didn't come from server-side compilation of filters.

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -1229,7 +1229,8 @@ class TestHogFlowAPI(APIBaseTest):
         )
         assert first.status_code == 200, first.json()
         flow = HogFlow.objects.get(id=flow_id)
-        assert len(flow.draft["conversion"]["events"]) == 1, flow.draft["conversion"]
+        staged = flow.draft or {}
+        assert len(staged["conversion"]["events"]) == 1, staged["conversion"]
 
         second = self.client.patch(
             f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
@@ -1239,8 +1240,9 @@ class TestHogFlowAPI(APIBaseTest):
         )
         assert second.status_code == 200, second.json()
         flow.refresh_from_db()
-        assert flow.draft["conversion"]["window_minutes"] == 180, flow.draft["conversion"]
-        assert len(flow.draft["conversion"]["events"]) == 1, flow.draft["conversion"]
+        staged = flow.draft or {}
+        assert staged["conversion"]["window_minutes"] == 180, staged["conversion"]
+        assert len(staged["conversion"]["events"]) == 1, staged["conversion"]
 
     def test_hog_flow_conversion_live_patch_keeps_the_goal_when_a_draft_exists(self):
         # A patch without stage_draft lands on the live row even when the workflow holds a draft, so the
@@ -1268,8 +1270,9 @@ class TestHogFlowAPI(APIBaseTest):
 
         assert response.status_code == 200, response.json()
         flow.refresh_from_db()
-        assert flow.conversion["window_minutes"] == 120, flow.conversion
-        assert len(flow.conversion["events"]) == 1, flow.conversion
+        live = flow.conversion or {}
+        assert live["window_minutes"] == 120, live
+        assert len(live["events"]) == 1, live
 
     def test_hog_flow_conversion_staged_patch_leaves_the_live_goal_alone(self):
         # A staged edit that also renames the workflow saves the live row for the rename. The goal it
@@ -1304,8 +1307,9 @@ class TestHogFlowAPI(APIBaseTest):
         flow.refresh_from_db()
         assert flow.name == "Renamed"
         assert flow.conversion == stored_conversion, flow.conversion
-        assert flow.draft["conversion"]["window_minutes"] == 120, flow.draft["conversion"]
-        assert len(flow.draft["conversion"]["events"]) == 1, flow.draft["conversion"]
+        staged = flow.draft or {}
+        assert staged["conversion"]["window_minutes"] == 120, staged["conversion"]
+        assert len(staged["conversion"]["events"]) == 1, staged["conversion"]
 
     def test_hog_flow_conversion_goal_can_still_be_cleared_explicitly(self):
         hog_flow, _ = self._create_hog_flow_with_action(

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -1115,6 +1115,38 @@ class TestHogFlowAPI(APIBaseTest):
         assert conversion["events"][0]["filters"]["events"] == event_obj["events"]
         assert conversion["filters"] == [], conversion
 
+    def test_hog_flow_conversion_legacy_goal_clears_when_the_patch_replaces_filters(self):
+        # A legacy goal is read back from the property slot, so replacing that slot is how a caller
+        # clears it. Relocating it into `events` on the way through would keep it measuring behind a
+        # field the caller just emptied, and a GET would not show where it went.
+        event_obj = {
+            "events": [{"id": "purchase", "name": "purchase", "type": "events", "order": 0}],
+            "source": "events",
+        }
+        hog_flow, _ = self._create_hog_flow_with_action(
+            {"template_id": "template-webhook", "inputs": {"url": {"value": "https://example.com"}}}
+        )
+        hog_flow["status"] = "active"
+        created = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert created.status_code == 201, created.json()
+        flow_id = created.json()["id"]
+        flow = HogFlow.objects.get(id=flow_id)
+        flow.conversion = {"filters": event_obj, "window_minutes": 60}
+        flow.save()
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
+            {"conversion": {"filters": []}},
+            format="json",
+        )
+
+        assert response.status_code == 200, response.json()
+        conversion = response.json()["conversion"]
+        assert conversion["events"] == [], conversion
+        assert conversion["filters"] == [], conversion
+        # The rest of the goal is still merged: only the slot the caller replaced is dropped.
+        assert conversion["window_minutes"] == 60, conversion
+
     def test_hog_flow_conversion_goal_only_patch_keeps_the_window(self):
         # The mirror of the case above: an edit to the goal must not drop the window.
         hog_flow, _ = self._create_hog_flow_with_action(

--- a/products/workflows/backend/api/test/test_hog_flow_draft_publish.py
+++ b/products/workflows/backend/api/test/test_hog_flow_draft_publish.py
@@ -467,6 +467,40 @@ class TestHogFlowDraftPublish(APIBaseTest):
         entry = ActivityLog.objects.filter(scope="HogFlow", item_id=flow_id).order_by("-created_at").first()
         assert entry is not None and entry.activity == "published"
 
+    def test_publish_does_not_carry_live_conversion_fields_into_the_draft(self):
+        # The draft is a full content snapshot, so publish replaces the conversion wholesale. A live
+        # edit landing after the draft was staged must not survive the publish — otherwise a rollback
+        # keeps measuring over a window the restored snapshot never had.
+        flow_id = self._create_active_flow()
+        goal = {"filters": {"events": [{"id": "purchase", "name": "purchase", "type": "events"}]}}
+        set_goal = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
+            {"conversion": {"events": [goal]}},
+            format="json",
+        )
+        assert set_goal.status_code == 200, set_goal.json()
+
+        flow = self._stage_draft(flow_id)
+        assert "window_minutes" not in flow.draft["conversion"], flow.draft["conversion"]
+
+        widen = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
+            {"conversion": {"window_minutes": 60}},
+            format="json",
+        )
+        assert widen.status_code == 200, widen.json()
+        confirm_token = self._publish_preview(flow_id).json()["confirm_token"]
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}/publish",
+            {"confirm": True, "confirm_token": confirm_token},
+        )
+        assert response.status_code == 200, response.json()
+
+        flow.refresh_from_db()
+        assert "window_minutes" not in flow.conversion, flow.conversion
+        assert len(flow.conversion["events"]) == 1, flow.conversion
+
     def test_publish_with_stale_token_after_draft_reedit_is_rejected_with_409(self):
         flow_id = self._create_active_flow()
         self._stage_draft(flow_id)

--- a/products/workflows/backend/api/test/test_hog_flow_draft_publish.py
+++ b/products/workflows/backend/api/test/test_hog_flow_draft_publish.py
@@ -481,7 +481,8 @@ class TestHogFlowDraftPublish(APIBaseTest):
         assert set_goal.status_code == 200, set_goal.json()
 
         flow = self._stage_draft(flow_id)
-        assert "window_minutes" not in flow.draft["conversion"], flow.draft["conversion"]
+        staged = flow.draft or {}
+        assert "window_minutes" not in staged["conversion"], staged["conversion"]
 
         widen = self.client.patch(
             f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
@@ -498,8 +499,9 @@ class TestHogFlowDraftPublish(APIBaseTest):
         assert response.status_code == 200, response.json()
 
         flow.refresh_from_db()
-        assert "window_minutes" not in flow.conversion, flow.conversion
-        assert len(flow.conversion["events"]) == 1, flow.conversion
+        live = flow.conversion or {}
+        assert "window_minutes" not in live, live
+        assert len(live["events"]) == 1, live
 
     def test_publish_with_stale_token_after_draft_reedit_is_rejected_with_409(self):
         flow_id = self._create_active_flow()


### PR DESCRIPTION
## Problem

A workflow silently stops recording conversions after an edit that only meant to change part of its conversion goal.

- DRF replaces a nested object rather than merging it, so a PATCH carrying `{"conversion": {"window_minutes": 120}}` arrives without `filters` or `events`.
- Validation then writes `bytecode: []` and `events: []` into that partial object, and the stored goal is gone.
- The worker's `pinConversionGoal` returns null when neither is set, so no watcher is written and nothing is measured.
- The request returns 200. No error, no metric, nothing in the UI says the goal went away.

The documented agent path leads straight to it: the MCP `workflows-update` tool makes every conversion sub-field optional, and the workflows skill tells agents to change the conversion goal through it.

## Changes

- A partial update carries `filters`, `events` and `window_minutes` over from the stored conversion when the request omits them, so an edit to one part of the goal leaves the rest alone. It works both ways round: a window-only patch keeps the goal, and a goal-only patch keeps the window.
- Clearing still works. A caller that means to drop the events sends `events: []` explicitly.
- The merge composes on whichever object the save lands in. `_writes_to_draft` mirrors the routing in `perform_update`, so a staged edit merges from the staged draft and a live edit merges from the live row. Without that, a second staged patch would revert the goal the first one staged, and a draft that deliberately cleared its goal would get it back.
- A legacy goal that stored an event object in `filters` is relocated rather than dropped. `_relocate_legacy_conversion_event_object` is now shared by the write path and the merge, so both see one shape.
- What the merge carries over is deep-copied. The compile step writes into those entries, and handing it the objects the model instance still holds would rewrite the stored row in place.

The same hazard is already treated as serious for the sibling fields. The MCP update path blocks `actions` and `edges` outright, with the comment "a partial actions list has destroyed live graphs". `conversion` carried no equivalent guard.

## How did you test this code?

Driven through the real API against a local backend, first on master and then on master with this change.

**On master, reproducing it.** Created an active workflow with an event goal and `window_minutes: 60`, then sent `PATCH {"conversion": {"window_minutes": 120}}`. The response was 200 and the goal was gone: `events` went from 1 to 0.

**With the change.** The same request returns 200, the window updates to 120, and `events` is still 1.

Then the part that matters, on the patched workflow:

- Enrolled a person through capture. A conversion watcher was written, expiring in 120 minutes, so the workflow is still measuring after the edit.
- Sent the goal event. The watcher was claimed and the conversion counted.
- Sent `PATCH {"conversion": {"window_minutes": 120, "events": []}}` and confirmed the goal still clears, so the merge does not trap a caller who means to remove it.

Nine tests cover the routing in both directions: a live patch with a draft present, a staged patch leaving the live goal alone, a second staged patch keeping what the first staged, and a staged clear that must not come back. The three that assert the core behaviour fail on master; I checked by reverting the serializer and re-running rather than trusting a green suite.

Not covered: the deep copy. I could not construct a request that observes the aliasing, so it ships as defensive rather than with a test that only looks like coverage.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this. Skills invoked: `/writing-pr-descriptions`, `/writing-tests`.

Split out of the conversion-window duration-string work because the bug predates that change and is live now, so it should not wait on the rest of it. The tests use `window_minutes` rather than the duration-string field, which only exists on that branch.

The draft handling went through two wrong shapes before this one. Merging from live unconditionally would have reverted a staged goal; skipping the merge whenever a draft existed still let a second staged patch stage an empty goal. Deciding the base from the routing, the way `perform_update` and the graph endpoint already do, is what makes both directions correct.

No customer conversation, ticket, or log fed this PR. The test workflows were invented for the session.
