### PR TITLE
fix(pgapi): pass allowed hosts to the MCP transport's DNS-rebinding guard

### DIFF
--- a/rust/pgapi/src/mcp.rs
+++ b/rust/pgapi/src/mcp.rs
@@ -348,9 +348,15 @@ impl ServerHandler for PgMcp {
 }
 
 pub fn service(state: Arc<AppState>) -> StreamableHttpService<PgMcp, LocalSessionManager> {
+    let mut config = StreamableHttpServerConfig::default();
+    if state.allowed_hosts.is_empty() {
+        config = config.disable_allowed_hosts();
+    } else {
+        config = config.with_allowed_hosts(state.allowed_hosts.clone());
+    }
     StreamableHttpService::new(
         move || Ok(PgMcp::new(state.clone())),
         LocalSessionManager::default().into(),
-        StreamableHttpServerConfig::default(),
+        config,
     )
 }


### PR DESCRIPTION
## Problem

- The MCP endpoint at `/mcp` rejects requests from the Tailscale hostname with 403, while the REST API at `/api/v1` works fine.
- rmcp's `StreamableHttpServerConfig::default()` allows only `localhost`, `127.0.0.1`, and `::1`. The `.ts.net` hostname hits that guard before pgapi's own auth middleware runs.

## Changes

- `mcp::service()` reads `state.allowed_hosts` (from `PGAPI_ALLOWED_HOSTS`) and passes it to rmcp's config, so both layers accept the same hostnames.
- When `allowed_hosts` is empty, the rmcp guard is disabled (matching the pgapi middleware's existing behavior of allowing any host).
- Mechanical: no user-visible change beyond the MCP endpoint becoming reachable on the configured hosts.

## How did you test this code?

- `cargo check`, `cargo clippy`, `cargo fmt` all pass.
- Confirmed the root cause by curling the deployed pgapi-dev: `/api/v1/me` returns 200 with Tailscale identity, `/mcp` returns 403 "Forbidden: Host header is not allowed" (the exact rmcp error string from `tower.rs:875`).
- Not run: integration tests against a live pgapi instance with the fix deployed.

- [ ] Publish to changelog?

## 🤖 Agent context

- Co-authored with Claude Code in an interactive session.
- Diagnosed the root cause by tracing the 403 through pgapi's auth middleware and into the rmcp crate's DNS-rebinding guard.

https://claude.ai/code/session_019p1miW3Jh3WZwXWTofTK8H