### PR TITLE
fix(data-warehouse): say why Mailgun rejected a key during source setup

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mailgun/mailgun.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mailgun/mailgun.py
@@ -282,7 +282,21 @@ def get_domain_names(api_key: str, base_url: str, logger: FilteringBoundLogger) 
         skip += config.page_size
 
 
-def validate_credentials(api_key: str, region: str) -> bool:
+# Mailgun keys are scoped to one region, so a good key checked against the wrong region is
+# rejected exactly like a bad key. Naming both leaves something to act on either way.
+INVALID_KEY_ERROR = (
+    "Mailgun rejected the API key. Check that you copied the private API key from Settings > API "
+    "security, and that the region matches where your account is hosted."
+)
+FORBIDDEN_ERROR = (
+    "Mailgun denied access with this API key. Use a key that can read your sending domains, then try again."
+)
+UNREACHABLE_ERROR = (
+    "Couldn't reach Mailgun to check your API key. This is usually temporary, so try again in a few minutes."
+)
+
+
+def validate_credentials(api_key: str, region: str) -> tuple[bool, str | None]:
     """Confirm the private API key is valid for the region. A 1-item domain listing is a cheap probe."""
     try:
         response = make_tracked_session().get(
@@ -291,9 +305,16 @@ def validate_credentials(api_key: str, region: str) -> bool:
             auth=("api", api_key),
             timeout=10,
         )
-        return response.status_code == 200
     except Exception:
-        return False
+        return False, UNREACHABLE_ERROR
+
+    if response.status_code == 200:
+        return True, None
+    if response.status_code == 403:
+        return False, FORBIDDEN_ERROR
+    if response.status_code >= 500:
+        return False, UNREACHABLE_ERROR
+    return False, INVALID_KEY_ERROR
 
 
 def get_rows(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mailgun/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mailgun/source.py
@@ -216,10 +216,7 @@ Note: Mailgun only retains events for a limited period (1 day on free plans, up 
         schema_name: Optional[str] = None,
         api_version: str | None = None,
     ) -> tuple[bool, str | None]:
-        if validate_mailgun_credentials(config.api_key, config.region):
-            return True, None
-
-        return False, "Invalid Mailgun API key or region"
+        return validate_mailgun_credentials(config.api_key, config.region)
 
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[MailgunResumeConfig]:
         return ResumableSourceManager[MailgunResumeConfig](inputs, MailgunResumeConfig)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mailgun/tests/test_mailgun.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mailgun/tests/test_mailgun.py
@@ -12,7 +12,10 @@ import requests
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import table_from_py_list
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import WebhookCreationResult
 from products.warehouse_sources.backend.temporal.data_imports.sources.mailgun.mailgun import (
+    FORBIDDEN_ERROR,
+    INVALID_KEY_ERROR,
     MAX_RETRY_AFTER_SECONDS,
+    UNREACHABLE_ERROR,
     MailgunResumeConfig,
     MailgunRetryableError,
     _epoch_to_datetime,
@@ -275,22 +278,23 @@ class TestValidateCredentials:
     @pytest.mark.parametrize(
         "status_code, expected",
         [
-            (200, True),
-            (401, False),
-            (403, False),
-            (500, False),
+            (200, (True, None)),
+            (401, (False, INVALID_KEY_ERROR)),
+            (404, (False, INVALID_KEY_ERROR)),
+            (403, (False, FORBIDDEN_ERROR)),
+            (500, (False, UNREACHABLE_ERROR)),
         ],
     )
     @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.mailgun.mailgun.make_tracked_session")
     def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
         mock_session.return_value.get.return_value = _response({}, status_code)
 
-        assert validate_credentials("key", "us") is expected
+        assert validate_credentials("key", "us") == expected
 
     @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.mailgun.mailgun.make_tracked_session")
     def test_validate_credentials_swallows_exceptions(self, mock_session):
         mock_session.return_value.get.side_effect = Exception("boom")
-        assert validate_credentials("key", "us") is False
+        assert validate_credentials("key", "us") == (False, UNREACHABLE_ERROR)
 
     @pytest.mark.parametrize(
         "region, expected_host",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mailgun/tests/test_mailgun_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mailgun/tests/test_mailgun_source.py
@@ -96,22 +96,19 @@ class TestMailgunSource:
         assert self.source.get_schemas(self.config, self.team_id, names=["nope"]) == []
 
     @pytest.mark.parametrize(
-        "mock_return, expected_valid, expected_message",
+        "mock_return",
         [
-            (True, True, None),
-            (False, False, "Invalid Mailgun API key or region"),
+            (True, None),
+            (False, "Mailgun rejected the API key."),
         ],
     )
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.mailgun.source.validate_mailgun_credentials"
     )
-    def test_validate_credentials(self, mock_validate, mock_return, expected_valid, expected_message):
+    def test_validate_credentials(self, mock_validate, mock_return):
         mock_validate.return_value = mock_return
 
-        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
-
-        assert is_valid is expected_valid
-        assert error_message == expected_message
+        assert self.source.validate_credentials(self.config, self.team_id) == mock_return
         mock_validate.assert_called_once_with(self.config.api_key, self.config.region)
 
     def test_version_declaration_defaults_to_v4_with_v3_supported(self):


### PR DESCRIPTION
## Problem

A person connecting Mailgun as a warehouse source sees "Invalid Mailgun API key or region" whatever went wrong, so they cycle the key field and the region field with no idea which one to change.

- The credential probe returned a bare boolean, so the caller had no cause to report.
- One message covered a rejected key, a key without domain read access, and Mailgun being unreachable.
- Mailgun scopes a key to one region, so a valid key checked against the wrong region is rejected exactly like a bad key.

## Changes

- The setup error now names a cause. A rejected key points at the private API key under Settings > API security and at the region. A permission failure says the key needs to read sending domains. An unreachable Mailgun is reported as temporary.
- `validate_credentials` returns `tuple[bool, str | None]`, the shape other sources already use.
- The connection attempt itself is unchanged: same endpoint, same timeout, same success condition.
- No UI changed, so there is nothing to screenshot. The strings are built in the source module and rendered by the existing wizard toast.

## How did you test this code?

- Extended the existing status-mapping case list to assert the message per status, and added a 404 row so an unexpected 4xx still falls back to the key-and-region message. This catches a later change that collapses the three causes back into one string.
- Ran the two Mailgun test modules locally. No call to the real Mailgun API was possible from this sandbox, so the status-to-message mapping rests on those tests alone.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Claude Code wrote this during an automated pass over Replay Vision summaries of the warehouse new-source onboarding flow. A session that failed the Mailgun credential step repeatedly, seeing the same message each time, is what pointed here.

No duplicate: `gh pr list --state open --search mailgun` and the maintainer's open PR list hold nothing touching Mailgun credential validation.

Public artifact: nothing from the session reaches the diff or this description. The change is copy and control flow only, with no new fixtures or sample data.

Skills invoked: `/writing-pr-descriptions`, `/writing-user-facing-copy`, `/writing-tests`.
