### PR TITLE
feat(warehouse-sources): promote the WorkOS source to GA

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/workos/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/workos/source.py
@@ -77,7 +77,7 @@ class WorkOSSource(
             name=SchemaExternalDataSourceType.WORK_OS,
             category=DataWarehouseSourceCategory.ENGINEERING___MONITORING,
             label="WorkOS",
-            releaseStatus=ReleaseStatus.BETA,
+            releaseStatus=ReleaseStatus.GA,
             caption="""Enter your WorkOS API key to sync your WorkOS data into the PostHog Data warehouse.
 
 You can find your API key in the [WorkOS Dashboard](https://dashboard.workos.com/) under **API Keys**.


### PR DESCRIPTION
## Problem

Teams connecting WorkOS in the data warehouse source wizard see it marked beta, which reads as "may break" and holds back people who will not put a beta connector in front of their identity data.

The connector has cleared the GA bar on both counts we use:

- Live 3.1 months, past the 3-month threshold, on 39 teams.
- Import error rate of 0.4% over the last 7 days, well under the 2.5% ceiling.

## Changes

- The WorkOS source now shows as generally available in the source wizard and in the public source config API.
- `releaseStatus` moves from `ReleaseStatus.BETA` to `ReleaseStatus.GA` on `WorkOSSource.get_source_config`.

Nothing else changed. The source has no feature flag and no `unreleasedSource` flag, so no gating was touched. Sync logic, schemas, endpoints, and webhook handling are untouched.

## How did you test this code?

No new tests. The changed line is a declaration read by the source config API, and existing coverage (`test_source_categories.py`, `test_source_versions.py`) already loads every registered source config. No manual testing was done, and the connector's sync behavior was not exercised because the change cannot affect it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The posthog.com doc for WorkOS does not state a release stage; the badge comes from the source config.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code (PostHog Desktop cloud task). Skills invoked: `/implementing-warehouse-sources` for where release status lives and the `ReleaseStatus` enum convention, and `/writing-pr-descriptions` for this body.

No duplicate: searched open PRs for "WorkOS", "releaseStatus", and "promote", and listed every open PR by the warehouse sources maintainer. Nothing promotes WorkOS.

Public artifact: the diff is one enum value from this repository. The metrics quoted above are the promotion thresholds and the source's current standing against them, with no customer or account detail.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
