### PR TITLE
fix(insights): drop two failed attempts at the scene title drag fault

### DIFF
--- a/frontend/src/layout/scenes/components/SceneTitleSection.test.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { cleanup, createEvent, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 
 import { SceneName } from './SceneTitleSection'
 
@@ -36,33 +36,5 @@ describe('SceneName', () => {
 
         rerender(<SceneName name="Generated name" canEdit onChange={jest.fn()} />)
         expect(screen.getByText('Generated name')).toBeInTheDocument()
-    })
-
-    // Guards click and drag text selection: the edit row is wider and taller than the field
-    // inside it, so a press that misses the glyphs by a few pixels lands on the row. Left
-    // unclaimed, some browsers read that press as their own gesture rather than a selection.
-    test('a press on the edit row beside the field focuses the field and is consumed', () => {
-        render(<SceneName name="Paying users" canEdit forceEdit onChange={jest.fn()} />)
-
-        const row = screen.getByTestId('scene-name-edit-row')
-        const textarea = screen.getByRole('textbox')
-        expect(textarea).not.toHaveFocus()
-
-        const press = createEvent.mouseDown(row)
-        fireEvent(row, press)
-
-        expect(textarea).toHaveFocus()
-        expect(press.defaultPrevented).toBe(true)
-    })
-
-    // The counterpart: a press on the field itself must reach the browser untouched,
-    // or it would never start a selection.
-    test('a press on the field itself is left alone', () => {
-        render(<SceneName name="Paying users" canEdit forceEdit onChange={jest.fn()} />)
-
-        const press = createEvent.mouseDown(screen.getByRole('textbox'))
-        fireEvent(screen.getByRole('textbox'), press)
-
-        expect(press.defaultPrevented).toBe(false)
     })
 })

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -519,7 +519,7 @@ export function SceneName({
         onChange && canEdit ? (
             <>
                 {isEditing ? (
-                    <div ref={containerRef} className="flex items-center gap-1 w-full">
+                    <div ref={containerRef} className="flex items-center gap-1 w-full" data-attr="scene-name-edit-row">
                         <TextareaPrimitive
                             variant="default"
                             name="name"

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -469,7 +469,6 @@ export function SceneName({
 
     const [isEditing, setIsEditing] = useState(forceEdit)
     const containerRef = useRef<HTMLDivElement>(null)
-    const nameInputRef = useRef<HTMLTextAreaElement>(null)
 
     const textClasses =
         'text-lg font-semibold my-0 pl-[var(--button-padding-x-sm)] min-h-[var(--button-height-sm)] leading-[1.4] select-auto'
@@ -520,21 +519,8 @@ export function SceneName({
         onChange && canEdit ? (
             <>
                 {isEditing ? (
-                    <div
-                        ref={containerRef}
-                        className="flex items-center gap-1 w-full"
-                        data-attr="scene-name-edit-row"
-                        onMouseDown={(e) => {
-                            // A press on the row around the field leaves the gesture unclaimed by the page,
-                            // which some browsers read as a window drag instead of a text selection.
-                            if (e.target === e.currentTarget) {
-                                e.preventDefault()
-                                nameInputRef.current?.focus()
-                            }
-                        }}
-                    >
+                    <div ref={containerRef} className="flex items-center gap-1 w-full">
                         <TextareaPrimitive
-                            ref={nameInputRef}
                             variant="default"
                             name="name"
                             value={name || ''}

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -2165,11 +2165,3 @@
         transform: translateY(0);
     }
 }
-
-// `-webkit-app-region` is an inherited property in Chromium, and a region marked as a drag
-// handle swallows click and drag text selection. Text entry must never become a drag handle.
-input,
-textarea,
-[contenteditable='true'] {
-    -webkit-app-region: no-drag;
-}


### PR DESCRIPTION
## Problem

Two changes shipped in [#93943](https://github.com/PostHog/posthog/pull/93943) to fix a report that press-and-drag on an insight title moved the browser window instead of selecting text. Neither fixed it — the fault was still reproducible after they went out — and neither guards a problem anyone reported. They are now dead weight in a component rendered by nearly every scene.

1. **A mousedown handler on the title edit row.** It claimed a press landing *beside* the field rather than on it. The report was about pressing *on* the title. The row is wider and taller than the field it serves, so the handler had to guess which presses were not its business, and it held the field's ref for a focus call that has nothing to focus in view mode.
2. **`-webkit-app-region: no-drag` on text entry.** This property only takes effect in an app-window context. The desktop app carries its own stylesheet and its own drag utilities, so in an ordinary browser tab the rule was inert.

A follow-up PR built on top of the first handler, and it was worth knowing how much that cost: reviewers found six defects on that branch, three of them from the handler alone, all the same shape — a `preventDefault()` swallowing a gesture that belonged to someone else. That PR was closed unmerged.

## Changes

- Remove the edit-row mousedown handler and the ref that existed only to serve it. The row keeps its `data-attr` — it is the only marker on that element, and a stable hook there is worth having whatever handlers the row does or does not carry.
- Remove the `-webkit-app-region` rule. Mechanical; it had no effect in the browser.
- Remove the two tests that pinned the row handler. One of them asserted a press on the field is *not* consumed, which becomes vacuous once nothing consumes presses there.

**Kept:** the caret rule in `TextareaPrimitive`, also from #93943. That one fixes something real and independent — focus was moving the caret to the end of the value on *every* focus, so a selection could be collapsed the moment the field regained focus. Its three tests are untouched.

## How did you test this code?

`src/layout/scenes` and `src/lib/ui` pass, 31 tests, including all three `TextareaPrimitive` caret tests that must survive this change. Oxlint, Oxfmt and Stylelint clean on the touched files.

Verified structurally rather than only by tests: apart from the retained `data-attr`, `SceneTitleSection.tsx` matches its pre-#93943 form, and `base.scss` differs from its pre-#93943 form only by colour tokens other people added since. A repo-wide search finds no surviving reference to the removed ref or the removed CSS property.

The underlying report is **not** fixed by this PR and is not meant to be. This removes two things that did not work; the fault itself remains open. The diagnosis that best explains it is recorded on the closed follow-up PR.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None; no user-facing docs cover this behaviour.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app. Both removals are of code it wrote itself in an earlier attempt, at the request of the person who reviewed it — the honest outcome of a fix that reviewed and approved cleanly, merged, and then did not work.

---
*Created with [PostHog](https://posthog.com?ref=pr)*

