### PR TITLE
fix(warehouse-sources): stop reporting an exhausted monday.com retry as an exception

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/monday/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/monday/source.py
@@ -46,6 +46,14 @@ class MondaySource(SimpleSource[MondaySourceConfig]):
             "monday.com GraphQL error: User unauthorized": "monday.com rejected the request. Please check that your API token has access to the requested data.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `get_rows` already retries `MondayRetryableError` in-process with exponential backoff
+        # (edge 404s, 429s, 5xx, and monday.com's own transient internal server errors — see
+        # `_execute` in monday.py). Once that budget is exhausted the error still carries the
+        # "(retryable)" tag those raises were given for this exact purpose, so Temporal's activity
+        # retry can pick it back up without paging anyone on a monday.com-side blip.
+        return {"(retryable)"}
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/monday/tests/test_monday_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/monday/tests/test_monday_source.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest import mock
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import error_message_matches
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.monday import MondaySourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.monday.settings import ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.monday.source import MondaySource
@@ -34,6 +35,17 @@ class TestMondaySource:
     def test_non_retryable_errors_does_not_match_unrelated(self, other_error):
         non_retryable_errors = self.source.get_non_retryable_errors()
         assert not any(key in other_error for key in non_retryable_errors)
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "monday.com API error (retryable): status=500",
+            "monday.com internal server error (retryable): Internal Server Error; Internal server error",
+        ],
+    )
+    def test_retryable_errors_match_transient_monday_errors(self, observed_error):
+        retryable_errors = self.source.get_retryable_errors()
+        assert error_message_matches(observed_error, retryable_errors)
 
     def test_get_schemas_are_full_refresh_only(self):
         schemas = self.source.get_schemas(self.config, self.team_id)


### PR DESCRIPTION
## Problem

The monday.com data warehouse source pages error tracking every time monday.com's API has a transient internal server error, even though the source already retries that error in-process and only re-raises once its own retry budget is exhausted.

`get_rows` retries `MondayRetryableError` (edge 404s, 429s, 5xx, and monday.com's own "Internal Server Error" GraphQL response) with exponential backoff up to 5 attempts. `MondaySource` never overrode `get_retryable_errors()`, so an exhausted retry still reached error tracking as an uncaught exception instead of a warning, per [this error tracking issue](https://us.posthog.com/project/2/error_tracking/01a070bd-a7eb-7c12-bd07-7846b12e5f02).

## Changes

- `MondaySource.get_retryable_errors()` now matches the `(retryable)` tag already present on these exhausted-retry messages, so Temporal's activity retry picks the sync back up and the failure logs as a warning instead of an exception.
- This mirrors the same pattern already used by other sources (Stripe, Mailchimp, Google Analytics) for errors that survive their own in-process retry loop.

## How did you test this code?

Added two cases to `test_monday_source.py` asserting `get_retryable_errors()` matches the exhausted-retry messages `_execute` raises for a 5xx/edge status and for monday.com's own internal server error GraphQL response - the same messages seen in the linked error tracking issue.

Ran the full `monday` source test suite locally: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/monday/tests/` (30 passed). Also ran `ruff check`/`ruff format --check` on the touched files.

Not run: the broader `warehouse_sources` suite and mypy, since this change is scoped to one source's classification method and one test file.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - no user-facing behavior or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error tracking webhook for the `monday` data warehouse source. Confirmed the stack trace originates in `monday.py`'s `_execute`, read `get_rows`'s retry decorator, and found the source never wired up `get_retryable_errors()` despite already tagging its exhausted-retry messages `(retryable)` for exactly this purpose (see the docstring on `common/base.py`'s `get_retryable_errors`, and `GoogleAnalyticsSource`'s use of the same tag). Searched open PRs for the exception type, "monday", and the maintainer's own open PRs; none address this. No skills invoked beyond `/writing-pr-descriptions` for this body.
