### PR TITLE
fix(mysql): tell a user what to do when the password is rejected

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -76,6 +76,12 @@ _VALIDATE_CONNECTION_HINTS: list[tuple[str, str]] = [
     ("Unknown database", "Database does not exist. Check the database name is correct."),
 ]
 
+# Error 1045 is the same failure the Postgres, Supabase, and Neon sources already word this
+# way. Keeping one wording means a wrong password reads the same whichever database it is.
+_INVALID_CREDENTIALS_ERROR = (
+    "The database rejected the username or password. Check the user and password for this source and try again."
+)
+
 _HOST_IS_URL_ERROR = (
     "Enter just the hostname in the host field (for example, db.example.com), not a full URL or "
     "connection string. Remove any scheme (like http:// or mysql://) and any username, password, "
@@ -200,7 +206,7 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # user's host grant) is wrong. Surface it as an auth failure — mirroring the Postgres
             # source — so the user fixes credentials instead of the generic "check connection
             # details" message sending them to check the host/port.
-            "Access denied for user": "Invalid user or password",
+            "Access denied for user": _INVALID_CREDENTIALS_ERROR,
             # MySQL/MariaDB error 1049 (ER_BAD_DB_ERROR): the configured database doesn't exist on
             # the server — it was renamed or dropped after the source was set up, or the connection
             # was reconfigured to point at a different server. `validate_credentials` already

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -45,7 +45,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysq
     _safe_convert_datetime,
     _sanitize_identifier,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.mysql.source import MySQLSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.mysql.source import (
+    _INVALID_CREDENTIALS_ERROR,
+    MySQLSource,
+)
 from products.warehouse_sources.backend.types import IncrementalFieldType
 
 # ---------------------------------------------------------------------------
@@ -2447,7 +2450,7 @@ class TestMySQLSourceValidateCredentials:
             # that sends the user to inspect the host/port instead. Mirrors Postgres.
             (
                 pymysql.err.OperationalError(1045, "Access denied for user 'u'@'1.2.3.4' (using password: YES)"),
-                "Invalid user or password",
+                _INVALID_CREDENTIALS_ERROR,
             ),
         ],
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/planetscale_mysql/test_planetscale_mysql_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/planetscale_mysql/test_planetscale_mysql_source.py
@@ -166,7 +166,7 @@ def test_validate_credentials_never_opens_an_ssh_tunnel():
         ("Connection refused", "port 3306"),
         ("Can't connect to MySQL server on 'x' (timed out)", "timed out"),
         ("(1049, \"Unknown database 'x'\")", "does not exist on this PlanetScale branch"),
-        ("(1045, \"Access denied for user 'x'\")", "Invalid user or password"),
+        ("(1045, \"Access denied for user 'x'\")", "rejected the username or password"),
         ("branch is missing or sleeping: abc", "deleted or put to sleep"),
     ],
 )


### PR DESCRIPTION
## Problem

Someone whose MySQL username or password is wrong gets told "Invalid user or password" and nothing else — no next step, and no hint that the MySQL host grant (`user@host`) counts as the same failure. Postgres, Supabase, and Neon answer the identical rejection with a sentence that says what to check. The four sources fail the same way, so they should read the same way, and yesterday several MySQL setups hit the short version.

## Changes

- A rejected MySQL username or password now reads "The database rejected the username or password. Check the user and password for this source and try again." — the wording the other database sources already use. It shows in the source wizard when setup fails, and in the sync error panel when a live sync hits the same rejection.
- PlanetScale is a MySQL source and inherits this message, so it improves there too. Its test asserted the old literal, so that one string moved with it — no PlanetScale behavior changed.
- Which errors are retryable is untouched. Only the text attached to MySQL error 1045 changed.

## How did you test this code?

- Updated the existing 1045 case in the MySQL connection-error test and the matching PlanetScale case to assert the new wording, so a later edit that drops MySQL back to its own phrasing fails. These are the only two places that pinned the old string.
- Ran the MySQL, PlanetScale, and Supabase source test modules against a local dev stack; they pass.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Claude Code wrote this during a triage pass over failed data-warehouse source creations. Most source types in that pass already had clear, actionable messages and needed no change; MySQL was the one whose auth message had drifted from its siblings.

No duplicate: `gh pr list --state open --search "mysql"` and the maintainer's own open PR list turned up nothing touching MySQL credential error copy.

Public artifact: nothing from the session reaches the diff or this description. The change is copy only, with no new fixtures or sample data, and no customer values carried across.

Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
