### PR TITLE
fix(engineering-analytics): clarify health metric filter scopes

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6741,25 +6741,29 @@ snapshots:
     scenes-app-engineering-analytics-delivery-pipeline--without-deploys--light:
         hash: v1.k794b7964.5eaee687a224ef9cd7d3707391948732cacb11769bdd619f315a101abcb85de1.ymQC-4XF77SeJ0AN5SrtlyYKs8Ve29MBfz4J8FGLWtg
     scenes-app-engineering-analytics-health--health--dark:
-        hash: v1.k794b7964.beb194c79dcda2d45e0b6cd70af895f086f3a69a0a710aab0060d162ed3ef5ec._Vs4eQgavmmj4cIZC4j2KGrex5m6E1xY_h1QWB2m7o0
+        hash: v1.k794b7964.f360c920cb938b520b6be36feb1c1f09e17bf75c9fc1867062c9196d3095648c.p0RcxBr1mTWBq9zZRmCKht04bJMXAB0Gw1gOtEvctL0
     scenes-app-engineering-analytics-health--health--light:
-        hash: v1.k794b7964.4c6326fdacae22c513cc4c22ba4dbeec18e64d7573befbd827a9a067b4032236.LjsN9asnLhIwhjL1nmRKaRPVMJz8p3XXMEniUPRCOJo
+        hash: v1.k794b7964.c8f5e1bd6dd76487d604f6047196430fcdb1089c50b9f39596ca80757c59740e.a-xn5Ef0rSu9fYwDJVgIuLzafToROwBE8jWojJaEOmw
+    scenes-app-engineering-analytics-health--health-without-attributed-pull-requests--dark:
+        hash: v1.k794b7964.ade08d76e0e86e94837e2336d129092631dc8be77dff7c9b0049c6011b482b84.MhzKqJFl7699ZEH8SnnqEgzPTlKZ1ztmWsRR2_L0ZEc
+    scenes-app-engineering-analytics-health--health-without-attributed-pull-requests--light:
+        hash: v1.k794b7964.f2d943eccccec7f01157f2c7dc4806db7ccb408be9f33b854dba0e19db54fab1.Wo_17c5n-muEgIRJEYEARPH8Li6c2H3kS2Ai6CVyaHo
     scenes-app-engineering-analytics-health--health-without-deploy-data--dark:
-        hash: v1.k794b7964.fcf17a2c752c6a453a760c7becc9ce9392456414f4a7e1e8a38b66660074c558.B4MjMp8wzV3OLnnbsaCK3yFK4eOuKiMT6fSGlvr8v68
+        hash: v1.k794b7964.19d11f17e9a84ed24f41001e49e34211992af3fd06e22d3d8e4956ea54451692.bHLFcWqNX7duZvoYdWlAWdK6Hbf3hNcKuEofZN8Jeg4
     scenes-app-engineering-analytics-health--health-without-deploy-data--light:
-        hash: v1.k794b7964.5fb1127eed77a6a9db9aceba7b679ddfa5b1e6c6cfcfd1eed7ba64de0bb08de7.G8glZpP9JYR21nolZhaVBuN5ySWpHQbAU1f-5TCUeJA
+        hash: v1.k794b7964.f61c143e7770fda3b369c4e5cb914147af2686af80214ae600d721540600da5d.1wwIy897x1GM2iIWDtAKgsh_c5DIB99fgGGjCxMmri0
     scenes-app-engineering-analytics-lead-time-box-plot--default--dark:
         hash: v1.k794b7964.a88a986e975778b0ad232c7e8f75211b0d66acb126082b2f781fd9d5641ff28d.P4_7HWOcC-Z8pGr_2GTGkAc_fzupx_TRaZdlauEmVQE
     scenes-app-engineering-analytics-lead-time-box-plot--default--light:
         hash: v1.k794b7964.040d7b8b88503881e75c0e7d6c0bc8588c6096f1315f75b5071c2721d13f567a.jAkjFsaMTKwsbxZsBriJ6JoPzwYGQSXgG9ERQd0H06E
     scenes-app-engineering-analytics-repo-overview--repo-overview--dark:
-        hash: v1.k794b7964.09ef64d9006267921169bce24946a123da357220b073672855c5748cbfd70a8a.rmBqV1xBSmBbQ4ytQu1Wfbn8rU8G-_ygxdg4Iv2ZYa0
+        hash: v1.k794b7964.1a470083e7a94ff46652f4368277eae5d35c927d65b58685e43ce34881e1e728.SEm3E8XvqrTHtJNRhVGX-9aaaw6xdWyzTNb_mw6c380
     scenes-app-engineering-analytics-repo-overview--repo-overview--light:
-        hash: v1.k794b7964.9d8340734437cceaf8eafb5841d32cf348aba3984880deb43a087ca52a7c141e.i--Tf67fIXrujVAuex5BOv6a_g07DMjU4zt0M-wvE5s
+        hash: v1.k794b7964.f709ff67c44f86f69d951fc6fbb18b17b6090f6c5793bf6bc16fc803e0a0498c.SmWuVYGMNsp3hU9ipmoQyalTt57uRsG0DrLJlw7LzPU
     scenes-app-engineering-analytics-repo-overview--repo-overview-with-trunk-queue-data--dark:
-        hash: v1.k794b7964.09ef64d9006267921169bce24946a123da357220b073672855c5748cbfd70a8a.ZiDTQAtUGNSPIkKZAW9-A9Wg_gWA56jWWWnsyrEC73A
+        hash: v1.k794b7964.1a470083e7a94ff46652f4368277eae5d35c927d65b58685e43ce34881e1e728.JjIWr0Wfj8Nzl407D1c7pkfeDecNV2UVZEKUSyLdGrE
     scenes-app-engineering-analytics-repo-overview--repo-overview-with-trunk-queue-data--light:
-        hash: v1.k794b7964.9d8340734437cceaf8eafb5841d32cf348aba3984880deb43a087ca52a7c141e.a_ZXGTwAUt8Kl-DWfRAgHk82rJGHJ-xmR4V-kLHpsqo
+        hash: v1.k794b7964.f709ff67c44f86f69d951fc6fbb18b17b6090f6c5793bf6bc16fc803e0a0498c.CCyr3jIgq9vy0b1RORwsIhSMVbL0qyRKSNgdK6Y_oZg
     scenes-app-engineering-analytics-run-activity-chart--default--dark:
         hash: v1.k794b7964.7f17c5ac7c6862493f7c4d59e6e3c3146c42e3d7b08908ee1716d387c129ba64.lPsE9KrOSZee9wJq8zjqYnvk09numvEFWOn4mdCOgJE
     scenes-app-engineering-analytics-run-activity-chart--default--light:

--- a/products/engineering_analytics/frontend/components/ScopePanel.tsx
+++ b/products/engineering_analytics/frontend/components/ScopePanel.tsx
@@ -19,8 +19,8 @@ export function ScopePanel({
     children: ReactNode
 }): JSX.Element {
     return (
-        <div className="relative mt-4 rounded-lg border border-primary p-4">
-            <div className="absolute -top-4 right-3 flex flex-wrap items-center justify-end gap-2 bg-primary px-2">
+        <div className="relative mt-4 flex flex-col rounded-lg border border-primary p-4">
+            <div className="-mt-8 -mr-1 flex max-w-full flex-wrap items-center justify-end gap-2 self-end bg-primary px-2">
                 {busy && <Spinner className="text-secondary" />}
                 {controls ?? (
                     <>

--- a/products/engineering_analytics/frontend/scenes/DoraDeploymentFrequency.tsx
+++ b/products/engineering_analytics/frontend/scenes/DoraDeploymentFrequency.tsx
@@ -1,0 +1,49 @@
+import { useValues } from 'kea'
+import { useMemo } from 'react'
+
+import { LemonSkeleton } from '@posthog/lemon-ui'
+import { TimeSeriesBarChart, useChartTheme, type TimeInterval } from '@posthog/quill-charts'
+
+import { Section } from '../components/Section'
+import { doraLogic } from './doraLogic'
+
+export function DoraDeploymentFrequency(): JSX.Element {
+    const { dora, doraLoading, environmentScopeLabel, frequencyCounts, frequencyIsoLabels } = useValues(doraLogic)
+    const chartTheme = useChartTheme()
+    const frequencySeries = useMemo(
+        () => [{ key: 'deployments', label: 'Deployments', data: frequencyCounts }],
+        [frequencyCounts]
+    )
+
+    return (
+        <Section
+            id="deployment-frequency"
+            title="Deployments over time"
+            note={`Successful deployments per bucket in the ${environmentScopeLabel} scope.`}
+            busy={doraLoading && !!dora}
+        >
+            {doraLoading && !dora ? (
+                <LemonSkeleton className="h-40 w-full" />
+            ) : frequencyCounts.length === 0 ? (
+                <div className="py-8 text-center text-sm text-secondary">No deploy data for this window.</div>
+            ) : (
+                // The chart's root is a `flex-1` child, so the sized wrapper must be a flex column.
+                <div className="flex h-40 flex-col" data-attr="engineering-analytics-dora-frequency-chart">
+                    <TimeSeriesBarChart
+                        series={frequencySeries}
+                        labels={frequencyIsoLabels}
+                        theme={chartTheme}
+                        config={{
+                            xAxis: {
+                                timezone: 'UTC',
+                                interval: (dora?.series_granularity ?? 'day') as TimeInterval,
+                            },
+                            yAxis: { format: 'numeric', decimalPlaces: 0 },
+                            minBarSize: 2,
+                        }}
+                    />
+                </div>
+            )}
+        </Section>
+    )
+}

--- a/products/engineering_analytics/frontend/scenes/DoraDeploymentHealth.tsx
+++ b/products/engineering_analytics/frontend/scenes/DoraDeploymentHealth.tsx
@@ -1,0 +1,50 @@
+import { useValues } from 'kea'
+
+import { Section } from '../components/Section'
+import { WindowComparisonCard } from '../components/WindowComparisonCard'
+import { compactAgeLabel } from '../lib/format'
+import { doraLogic } from './doraLogic'
+
+export function DoraDeploymentHealth(): JSX.Element {
+    const { dora, doraLoading } = useValues(doraLogic)
+    const firstLoad = doraLoading && !dora
+
+    return (
+        <Section id="dora-metrics" title="Deployment health">
+            <div className="@container">
+                <div className="grid grid-cols-1 gap-3 @min-[48rem]:grid-cols-3">
+                    <WindowComparisonCard
+                        title="Deployment frequency"
+                        tooltip="Successful deployments per day in the selected environment scope. Each regional deployment counts separately."
+                        value={dora?.deployments_per_day}
+                        previousValue={dora?.deployments_per_day_prev}
+                        formatValue={(value) => `${value.toFixed(1)}/day`}
+                        emptyText="No successful deployments in this window."
+                        loading={firstLoad}
+                    />
+                    <WindowComparisonCard
+                        title="Failed deployment share"
+                        tooltip="Deployments with a failure or error status divided by deployments that reached an outcome. A change failure proxy: successful deploys that broke production are not counted because no incident data is linked."
+                        value={dora?.failed_deployment_share}
+                        previousValue={dora?.failed_deployment_share_prev}
+                        formatValue={(value) => `${(value * 100).toFixed(1)}%`}
+                        deltaUnit="pt"
+                        goodWhenDown
+                        emptyText="No deployments reached an outcome in this window."
+                        loading={firstLoad}
+                    />
+                    <WindowComparisonCard
+                        title="Failed deploy to next success"
+                        tooltip="Median wait from a deployment's first failure status to the next successful deployment in the same environment. A time to restore proxy: recovery without a deploy is invisible, and unrecovered failures are excluded."
+                        value={dora?.median_failed_deploy_to_next_success_seconds}
+                        previousValue={dora?.median_failed_deploy_to_next_success_seconds_prev}
+                        formatValue={compactAgeLabel}
+                        goodWhenDown
+                        emptyText="No failed deployment recovered in this window."
+                        loading={firstLoad}
+                    />
+                </div>
+            </div>
+        </Section>
+    )
+}

--- a/products/engineering_analytics/frontend/scenes/DoraLeadTimeDistributionContent.tsx
+++ b/products/engineering_analytics/frontend/scenes/DoraLeadTimeDistributionContent.tsx
@@ -1,0 +1,100 @@
+import { useActions, useValues } from 'kea'
+
+import { IconChevronDown, IconChevronRight } from '@posthog/icons'
+import { LemonButton, LemonSkeleton } from '@posthog/lemon-ui'
+
+import { LeadTimeBoxPlot } from '../components/LeadTimeBoxPlot'
+import { compactAgeLabel } from '../lib/format'
+import { doraLogic } from './doraLogic'
+import { DoraUnattributedNotice } from './DoraUnattributedNotice'
+
+export function DoraLeadTimeDistributionContent(): JSX.Element {
+    const {
+        dora,
+        doraLoading,
+        githubTeam,
+        openToDeployBuckets,
+        openToMergeBuckets,
+        boxPlotBuckets,
+        showAllLeadTimeStages,
+        excludeOutliers,
+    } = useValues(doraLogic)
+    const { toggleLeadTimeStages } = useActions(doraLogic)
+    const leadTimeStages = [
+        {
+            title: 'Open to deploy',
+            seriesKey: 'open_to_deploy',
+            seriesLabel: 'Open to deploy',
+            buckets: openToDeployBuckets,
+            dataAttr: 'open-to-deploy-box-plot',
+            wrapperDataAttr: 'engineering-analytics-dora-open-to-deploy-box-plot',
+        },
+        {
+            title: 'Open to merge',
+            seriesKey: 'open_to_merge',
+            seriesLabel: 'Open to merge',
+            buckets: openToMergeBuckets,
+            dataAttr: 'open-to-merge-box-plot',
+            wrapperDataAttr: 'engineering-analytics-dora-open-to-merge-box-plot',
+        },
+        {
+            title: 'Merge to deploy',
+            seriesKey: 'merge_to_deploy',
+            seriesLabel: 'Merge to deploy',
+            buckets: boxPlotBuckets,
+            dataAttr: 'merge-to-deploy-box-plot',
+            wrapperDataAttr: 'engineering-analytics-dora-box-plot',
+        },
+    ]
+    const membershipDataMissing = !!githubTeam && !!dora && !dora.has_membership_data
+
+    if (doraLoading && !dora) {
+        return <LemonSkeleton className="h-40 w-full" />
+    }
+    if (!openToDeployBuckets.some((bucket) => bucket.count > 0)) {
+        return (
+            <div
+                className="py-8 text-center text-sm text-secondary"
+                data-attr="engineering-analytics-dora-unattributed-empty"
+            >
+                {membershipDataMissing
+                    ? 'Team membership data is not synced, so the team filter cannot be applied.'
+                    : 'No PRs could be matched to successful deployments in this window. Try a wider date range or check that pull requests and deployment statuses have synced.'}
+            </div>
+        )
+    }
+
+    return (
+        <>
+            <div className="flex flex-col gap-4">
+                {(showAllLeadTimeStages ? leadTimeStages : leadTimeStages.slice(0, 1)).map((stage) => (
+                    <div key={stage.seriesKey} data-attr={stage.wrapperDataAttr}>
+                        <h3 className="m-0 mb-1 text-xs font-semibold text-secondary">{stage.title}</h3>
+                        <LeadTimeBoxPlot
+                            seriesKey={stage.seriesKey}
+                            seriesLabel={stage.seriesLabel}
+                            buckets={stage.buckets}
+                            formatSeconds={compactAgeLabel}
+                            excludeOutliers={excludeOutliers}
+                            dataAttr={stage.dataAttr}
+                        />
+                    </div>
+                ))}
+            </div>
+            <div className="mt-2">
+                <LemonButton
+                    size="xsmall"
+                    type="tertiary"
+                    icon={showAllLeadTimeStages ? <IconChevronDown /> : <IconChevronRight />}
+                    onClick={toggleLeadTimeStages}
+                    data-attr="engineering-analytics-dora-stage-toggle"
+                >
+                    {showAllLeadTimeStages
+                        ? 'Hide open to merge and merge to deploy'
+                        : 'Show open to merge and merge to deploy'}
+                </LemonButton>
+            </div>
+            <DoraUnattributedNotice />
+        </>
+    )
+}

--- a/products/engineering_analytics/frontend/scenes/DoraLeadTimeDistributions.tsx
+++ b/products/engineering_analytics/frontend/scenes/DoraLeadTimeDistributions.tsx
@@ -1,0 +1,39 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonSwitch } from '@posthog/lemon-ui'
+
+import { ScopePanel } from '../components/ScopePanel'
+import { Section } from '../components/Section'
+import { DoraLeadTimeDistributionContent } from './DoraLeadTimeDistributionContent'
+import { doraLogic } from './doraLogic'
+
+export function DoraLeadTimeDistributions(): JSX.Element {
+    const { dora, doraLoading, excludeOutliers } = useValues(doraLogic)
+    const { setExcludeOutliers } = useActions(doraLogic)
+
+    return (
+        <div data-attr="engineering-analytics-dora-grouped-charts">
+            <ScopePanel
+                controls={
+                    <LemonSwitch
+                        size="small"
+                        bordered
+                        label="Exclude outliers"
+                        checked={excludeOutliers}
+                        onChange={setExcludeOutliers}
+                        data-attr="engineering-analytics-dora-exclude-outliers"
+                    />
+                }
+            >
+                <Section
+                    id="merge-to-deploy"
+                    title="Lead time distributions"
+                    note={`Box per bucket: whisker ${excludeOutliers ? 'p5 to p95' : 'min to max'}, box p25 to p75, line at the median, dot at the mean. Buckets key on deploy time.`}
+                    busy={doraLoading && !!dora}
+                >
+                    <DoraLeadTimeDistributionContent />
+                </Section>
+            </ScopePanel>
+        </div>
+    )
+}

--- a/products/engineering_analytics/frontend/scenes/DoraLeadTimeSection.tsx
+++ b/products/engineering_analytics/frontend/scenes/DoraLeadTimeSection.tsx
@@ -1,0 +1,34 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonSelect } from '@posthog/lemon-ui'
+
+import { ScopePanel } from '../components/ScopePanel'
+import { DoraLeadTimeDistributions } from './DoraLeadTimeDistributions'
+import { DoraLeadTimeSummary } from './DoraLeadTimeSummary'
+import { doraLogic } from './doraLogic'
+
+export function DoraLeadTimeSection(): JSX.Element {
+    const { dora, doraLoading, githubTeam, githubTeamOptions } = useValues(doraLogic)
+    const { setGithubTeam } = useActions(doraLogic)
+
+    return (
+        <ScopePanel
+            busy={doraLoading && !!dora}
+            controls={
+                <LemonSelect
+                    size="small"
+                    value={githubTeam}
+                    onChange={setGithubTeam}
+                    options={githubTeamOptions}
+                    disabledReason={
+                        dora?.has_membership_data ? undefined : 'Sync team membership to filter lead time by team'
+                    }
+                    data-attr="engineering-analytics-dora-team-select"
+                />
+            }
+        >
+            <DoraLeadTimeSummary />
+            <DoraLeadTimeDistributions />
+        </ScopePanel>
+    )
+}

--- a/products/engineering_analytics/frontend/scenes/DoraLeadTimeSummary.tsx
+++ b/products/engineering_analytics/frontend/scenes/DoraLeadTimeSummary.tsx
@@ -1,0 +1,30 @@
+import { useValues } from 'kea'
+
+import { Section } from '../components/Section'
+import { WindowComparisonCard } from '../components/WindowComparisonCard'
+import { compactAgeLabel } from '../lib/format'
+import { doraLogic } from './doraLogic'
+
+export function DoraLeadTimeSummary(): JSX.Element {
+    const { dora, doraLoading, githubTeam } = useValues(doraLogic)
+    const membershipDataMissing = !!githubTeam && !!dora && !dora.has_membership_data
+
+    return (
+        <Section id="lead-time" title="Lead time">
+            <WindowComparisonCard
+                title="Open to deploy"
+                tooltip={`Median from a PR's open to the first successful deployment containing it in any selected environment, over ${dora?.deployed_pr_count ?? 0} deployed PRs (bots and drafts excluded). Each PR counts once. The box plots split it into open to merge and merge to deploy.`}
+                value={dora?.median_open_to_deploy_seconds}
+                previousValue={dora?.median_open_to_deploy_seconds_prev}
+                formatValue={compactAgeLabel}
+                goodWhenDown
+                emptyText={
+                    membershipDataMissing
+                        ? 'Sync team membership to apply this filter.'
+                        : 'No PRs could be matched to successful deployments in this window. Try a wider date range or check the source sync.'
+                }
+                loading={doraLoading && !dora}
+            />
+        </Section>
+    )
+}

--- a/products/engineering_analytics/frontend/scenes/DoraUnattributedNotice.tsx
+++ b/products/engineering_analytics/frontend/scenes/DoraUnattributedNotice.tsx
@@ -1,0 +1,18 @@
+import { useValues } from 'kea'
+
+import { doraLogic } from './doraLogic'
+
+export function DoraUnattributedNotice(): JSX.Element | null {
+    const { dora } = useValues(doraLogic)
+
+    if (dora?.unattributed_merged_pr_share == null || dora.unattributed_merged_pr_share <= 0) {
+        return null
+    }
+
+    return (
+        <div className="mt-2 text-xs text-tertiary" data-attr="engineering-analytics-dora-unattributed">
+            {(dora.unattributed_merged_pr_share * 100).toFixed(1)}% of the {dora.merged_pr_count} PRs merged in this
+            window have no deploy attributed yet, usually because their deploy hasn't happened or synced.
+        </div>
+    )
+}

--- a/products/engineering_analytics/frontend/scenes/EngineeringAnalyticsHealth.stories.tsx
+++ b/products/engineering_analytics/frontend/scenes/EngineeringAnalyticsHealth.stories.tsx
@@ -187,6 +187,34 @@ export const Health: Story = {
     parameters: { pageUrl: urls.engineeringAnalyticsHealth() },
 }
 
+export const HealthWithoutAttributedPullRequests: Story = {
+    render: () => <App />,
+    parameters: {
+        pageUrl: urls.engineeringAnalyticsHealth(),
+        testOptions: {
+            waitForSelector: '[data-attr="engineering-analytics-dora-unattributed-empty"]',
+        },
+    },
+    decorators: [
+        mswDecorator({
+            get: {
+                'api/projects/:team_id/engineering_analytics/dora/': {
+                    ...DORA,
+                    deployed_pr_count: 0,
+                    deployed_pr_count_prev: 0,
+                    median_merge_to_deploy_seconds: null,
+                    median_merge_to_deploy_seconds_prev: null,
+                    median_open_to_deploy_seconds: null,
+                    median_open_to_deploy_seconds_prev: null,
+                    merge_to_deploy_series: leadTimeSeries(BUCKET_DAYS.map(() => null)),
+                    open_to_merge_series: leadTimeSeries(BUCKET_DAYS.map(() => null)),
+                    open_to_deploy_series: leadTimeSeries(BUCKET_DAYS.map(() => null)),
+                } satisfies DoraOverviewApi,
+            },
+        }),
+    ],
+}
+
 // The not-yet-synced state: the deploy endpoints aren't enabled on the GitHub source, so the tab
 // explains what to enable instead of showing zeros.
 export const HealthWithoutDeployData: Story = {

--- a/products/engineering_analytics/frontend/scenes/EngineeringAnalyticsHealth.tsx
+++ b/products/engineering_analytics/frontend/scenes/EngineeringAnalyticsHealth.tsx
@@ -1,81 +1,22 @@
 import { useActions, useValues } from 'kea'
-import { useMemo } from 'react'
 
-import { IconChevronDown, IconChevronRight } from '@posthog/icons'
-import { LemonBanner, LemonButton, LemonInputSelect, LemonSelect, LemonSkeleton, LemonSwitch } from '@posthog/lemon-ui'
-import { TimeSeriesBarChart, useChartTheme, type TimeInterval } from '@posthog/quill-charts'
+import { LemonBanner, LemonInputSelect, LemonSelect } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
 
 import { CIAnalyticsLoadError } from '../components/CIAnalyticsLoadError'
 import { ConnectGitHubSource } from '../components/ConnectGitHubSource'
-import { LeadTimeBoxPlot } from '../components/LeadTimeBoxPlot'
-import { MetricTile, percentChange, pointChange } from '../components/MetricTile'
-import { ScopeBar, SourceScopeChip } from '../components/ScopeBar'
-import { Section } from '../components/Section'
-import {
-    changeFailureBenchmark,
-    deploymentFrequencyBenchmark,
-    leadTimeBenchmark,
-    restoreTimeBenchmark,
-} from '../lib/doraBenchmark'
-import { compactAgeLabel } from '../lib/format'
+import { ScopeBar, ScopeDateFilter, SourceScopeChip } from '../components/ScopeBar'
+import { ScopePanel } from '../components/ScopePanel'
+import { DoraDeploymentFrequency } from './DoraDeploymentFrequency'
+import { DoraDeploymentHealth } from './DoraDeploymentHealth'
+import { DoraLeadTimeSection } from './DoraLeadTimeSection'
 import { doraLogic } from './doraLogic'
 
 export function EngineeringAnalyticsHealth(): JSX.Element {
-    const {
-        notConnected,
-        dora,
-        doraLoading,
-        doraFailed,
-        selectedEnvironments,
-        githubTeam,
-        granularity,
-        boxPlotBuckets,
-        openToMergeBuckets,
-        openToDeployBuckets,
-        frequencyCounts,
-        frequencyIsoLabels,
-        environmentScopeLabel,
-        environmentOptions,
-        githubTeamOptions,
-        showAllLeadTimeStages,
-        excludeOutliers,
-    } = useValues(doraLogic)
-    const { setEnvironments, setExcludeOutliers, setGithubTeam, setGranularity, toggleLeadTimeStages, loadDora } =
-        useActions(doraLogic)
-    const chartTheme = useChartTheme()
-    const frequencySeries = useMemo(
-        () => [{ key: 'deployments', label: 'Deployments', data: frequencyCounts }],
-        [frequencyCounts]
-    )
-    const leadTimeStages = [
-        {
-            title: 'Open to deploy',
-            seriesKey: 'open_to_deploy',
-            seriesLabel: 'Open to deploy',
-            buckets: openToDeployBuckets,
-            dataAttr: 'open-to-deploy-box-plot',
-            wrapperDataAttr: 'engineering-analytics-dora-open-to-deploy-box-plot',
-        },
-        {
-            title: 'Open to merge',
-            seriesKey: 'open_to_merge',
-            seriesLabel: 'Open to merge',
-            buckets: openToMergeBuckets,
-            dataAttr: 'open-to-merge-box-plot',
-            wrapperDataAttr: 'engineering-analytics-dora-open-to-merge-box-plot',
-        },
-        {
-            title: 'Merge to deploy',
-            seriesKey: 'merge_to_deploy',
-            seriesLabel: 'Merge to deploy',
-            buckets: boxPlotBuckets,
-            dataAttr: 'merge-to-deploy-box-plot',
-            wrapperDataAttr: 'engineering-analytics-dora-box-plot',
-        },
-    ]
-
+    const { notConnected, dora, doraLoading, doraFailed, selectedEnvironments, granularity, environmentOptions } =
+        useValues(doraLogic)
+    const { setEnvironments, setGranularity, loadDora } = useActions(doraLogic)
     if (notConnected) {
         return <ConnectGitHubSource />
     }
@@ -83,253 +24,63 @@ export function EngineeringAnalyticsHealth(): JSX.Element {
         return <CIAnalyticsLoadError onRetry={loadDora} />
     }
 
-    const firstLoad = doraLoading && !dora
     const deployDataMissing = !!dora && !dora.deploy_data_available
 
     return (
         <div className="flex flex-col gap-4">
-            <ScopeBar repoSlot={<SourceScopeChip />} />
-            {deployDataMissing ? (
+            <ScopeBar repoSlot={<SourceScopeChip />} showDate={false} />
+            {dora?.latest_deploy_status_at && (
+                <span className="text-xs text-tertiary" data-attr="engineering-analytics-dora-freshness">
+                    Latest deploy status synced {dayjs(dora.latest_deploy_status_at).fromNow()}.
+                </span>
+            )}
+            {deployDataMissing && (
                 <div data-attr="engineering-analytics-dora-no-deploy-data">
                     <LemonBanner type="info">
                         Deploy data isn't synced yet. Enable the deployments and deployment statuses endpoints on your
                         GitHub source to see DORA metrics.
                     </LemonBanner>
                 </div>
-            ) : (
-                <div className="flex flex-wrap items-center gap-2">
-                    <div className="min-w-60" data-attr="engineering-analytics-dora-environment-select">
-                        <LemonInputSelect
-                            size="small"
-                            mode="multiple"
-                            value={selectedEnvironments}
-                            onChange={setEnvironments}
-                            options={environmentOptions}
-                            placeholder={`Default environment (${environmentScopeLabel})`}
-                            allowCustomValues={false}
-                        />
-                    </div>
-                    {dora?.has_membership_data && (
+            )}
+            <ScopePanel
+                busy={doraLoading && !!dora}
+                controls={
+                    <>
+                        {!deployDataMissing && (
+                            <div className="w-60 max-w-full" data-attr="engineering-analytics-dora-environment-select">
+                                <LemonInputSelect
+                                    size="small"
+                                    mode="multiple"
+                                    title="Environments"
+                                    disablePrompting
+                                    value={selectedEnvironments}
+                                    onChange={setEnvironments}
+                                    options={environmentOptions}
+                                    placeholder={doraLoading ? 'Loading environments…' : 'Production environments'}
+                                    allowCustomValues={false}
+                                />
+                            </div>
+                        )}
+                        <ScopeDateFilter />
                         <LemonSelect
                             size="small"
-                            value={githubTeam}
-                            onChange={setGithubTeam}
-                            options={githubTeamOptions}
-                            data-attr="engineering-analytics-dora-team-select"
+                            value={granularity}
+                            onChange={setGranularity}
+                            options={[
+                                { value: null, label: 'Group automatically' },
+                                { value: 'hour' as const, label: 'Group by hour' },
+                                { value: 'day' as const, label: 'Group by day' },
+                                { value: 'week' as const, label: 'Group by week' },
+                            ]}
+                            data-attr="engineering-analytics-dora-granularity-select"
                         />
-                    )}
-                    {githubTeam && (
-                        <span className="text-xs text-tertiary">
-                            The team filter narrows the lead time figures. Deploy counts stay repo-wide.
-                        </span>
-                    )}
-                    {dora?.latest_deploy_status_at && (
-                        <span
-                            className="ml-auto text-xs text-tertiary"
-                            data-attr="engineering-analytics-dora-freshness"
-                        >
-                            Latest deploy status synced {dayjs(dora.latest_deploy_status_at).fromNow()}.
-                        </span>
-                    )}
-                </div>
-            )}
-            <Section id="dora-metrics" title="DORA metrics" busy={doraLoading && !!dora}>
-                <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
-                    <MetricTile
-                        label="Deployment frequency"
-                        tooltip={`Successful deployments per day in the ${environmentScopeLabel} scope: ${dora?.deployment_count ?? 0} in this window.`}
-                        value={dora?.deployments_per_day != null ? `${dora.deployments_per_day.toFixed(1)}/day` : '—'}
-                        delta={{ value: percentChange(dora?.deployments_per_day, dora?.deployments_per_day_prev) }}
-                        benchmark={deploymentFrequencyBenchmark(dora?.deployments_per_day)}
-                        sub={
-                            dora && dora.deploy_data_available && dora.deployment_count === 0
-                                ? 'No successful deployments in this window.'
-                                : undefined
-                        }
-                        loading={firstLoad}
-                    />
-                    <MetricTile
-                        label="Open to deploy"
-                        tooltip={`Median from a PR's open to the first successful deployment containing it, over ${dora?.deployed_pr_count ?? 0} deployed PRs (bots and drafts excluded). The full lead time: the box plots below split it into open to merge and merge to deploy.`}
-                        value={
-                            dora?.median_open_to_deploy_seconds != null
-                                ? compactAgeLabel(dora.median_open_to_deploy_seconds)
-                                : '—'
-                        }
-                        delta={{
-                            value: percentChange(
-                                dora?.median_open_to_deploy_seconds,
-                                dora?.median_open_to_deploy_seconds_prev
-                            ),
-                            goodWhenDown: true,
-                        }}
-                        benchmark={leadTimeBenchmark(dora?.median_open_to_deploy_seconds)}
-                        sub={
-                            dora && dora.median_open_to_deploy_seconds == null
-                                ? 'No PRs were deployed in this window.'
-                                : undefined
-                        }
-                        loading={firstLoad}
-                    />
-                    <MetricTile
-                        label="Failed deployment share"
-                        tooltip={`Deployments with a failure or error status over deployments that reached an outcome (${dora?.failed_deployment_count ?? 0} failed here). A change failure proxy: deploys that succeeded but broke production aren't counted, because no incident data is linked.`}
-                        value={
-                            dora?.failed_deployment_share != null
-                                ? `${(dora.failed_deployment_share * 100).toFixed(1)}%`
-                                : '—'
-                        }
-                        delta={{
-                            value: pointChange(dora?.failed_deployment_share, dora?.failed_deployment_share_prev),
-                            unit: 'pt',
-                            goodWhenDown: true,
-                        }}
-                        benchmark={changeFailureBenchmark(dora?.failed_deployment_share)}
-                        sub={
-                            dora && dora.failed_deployment_share == null
-                                ? 'No deployments reached an outcome in this window.'
-                                : undefined
-                        }
-                        loading={firstLoad}
-                    />
-                    <MetricTile
-                        label="Failed deploy to next success"
-                        tooltip="Median wait from a deployment's first failure status to the next successful deployment in the same environment. A time to restore proxy: recovery by anything other than a deploy is invisible, and unrecovered failures are excluded."
-                        value={
-                            dora?.median_failed_deploy_to_next_success_seconds != null
-                                ? compactAgeLabel(dora.median_failed_deploy_to_next_success_seconds)
-                                : '—'
-                        }
-                        delta={{
-                            value: percentChange(
-                                dora?.median_failed_deploy_to_next_success_seconds,
-                                dora?.median_failed_deploy_to_next_success_seconds_prev
-                            ),
-                            goodWhenDown: true,
-                        }}
-                        benchmark={restoreTimeBenchmark(dora?.median_failed_deploy_to_next_success_seconds)}
-                        sub={
-                            dora && dora.median_failed_deploy_to_next_success_seconds == null
-                                ? 'No failed deployment recovered in this window.'
-                                : undefined
-                        }
-                        loading={firstLoad}
-                    />
-                </div>
-            </Section>
-            <div
-                className="flex flex-col gap-4 rounded border bg-surface-primary p-4"
-                data-attr="engineering-analytics-dora-grouped-charts"
+                    </>
+                }
             >
-                <div className="flex items-center justify-end gap-2">
-                    <LemonSwitch
-                        size="small"
-                        bordered
-                        label="Exclude outliers"
-                        checked={excludeOutliers}
-                        onChange={setExcludeOutliers}
-                        data-attr="engineering-analytics-dora-exclude-outliers"
-                    />
-                    <LemonSelect
-                        size="small"
-                        value={granularity}
-                        onChange={setGranularity}
-                        options={[
-                            { value: null, label: 'Group automatically' },
-                            { value: 'hour' as const, label: 'Group by hour' },
-                            { value: 'day' as const, label: 'Group by day' },
-                            { value: 'week' as const, label: 'Group by week' },
-                        ]}
-                        data-attr="engineering-analytics-dora-granularity-select"
-                    />
-                </div>
-                <Section
-                    id="merge-to-deploy"
-                    title="Lead time distributions"
-                    note={`Box per bucket: whisker ${excludeOutliers ? 'p5 to p95' : 'min to max'}, box p25 to p75, line at the median, dot at the mean. Buckets key on deploy time.`}
-                    busy={doraLoading && !!dora}
-                >
-                    {firstLoad ? (
-                        <LemonSkeleton className="h-40 w-full" />
-                    ) : boxPlotBuckets.length === 0 ? (
-                        <div className="py-8 text-center text-sm text-secondary">
-                            {githubTeam && dora && !dora.has_membership_data
-                                ? 'Team membership data is not synced, so the team filter cannot be applied.'
-                                : 'No deploy data for this window.'}
-                        </div>
-                    ) : (
-                        <>
-                            <div className="flex flex-col gap-4">
-                                {(showAllLeadTimeStages ? leadTimeStages : leadTimeStages.slice(0, 1)).map((stage) => (
-                                    <div key={stage.seriesKey} data-attr={stage.wrapperDataAttr}>
-                                        <h3 className="m-0 mb-1 text-xs font-semibold text-secondary">{stage.title}</h3>
-                                        <LeadTimeBoxPlot
-                                            seriesKey={stage.seriesKey}
-                                            seriesLabel={stage.seriesLabel}
-                                            buckets={stage.buckets}
-                                            formatSeconds={compactAgeLabel}
-                                            excludeOutliers={excludeOutliers}
-                                            dataAttr={stage.dataAttr}
-                                        />
-                                    </div>
-                                ))}
-                            </div>
-                            <div className="mt-2">
-                                <LemonButton
-                                    size="xsmall"
-                                    type="tertiary"
-                                    icon={showAllLeadTimeStages ? <IconChevronDown /> : <IconChevronRight />}
-                                    onClick={toggleLeadTimeStages}
-                                    data-attr="engineering-analytics-dora-stage-toggle"
-                                >
-                                    {showAllLeadTimeStages
-                                        ? 'Hide open to merge and merge to deploy'
-                                        : 'Show open to merge and merge to deploy'}
-                                </LemonButton>
-                            </div>
-                            {dora?.unattributed_merged_pr_share != null && dora.unattributed_merged_pr_share > 0 && (
-                                <div
-                                    className="mt-2 text-xs text-tertiary"
-                                    data-attr="engineering-analytics-dora-unattributed"
-                                >
-                                    {(dora.unattributed_merged_pr_share * 100).toFixed(1)}% of the{' '}
-                                    {dora.merged_pr_count} PRs merged in this window have no deploy attributed yet,
-                                    usually because their deploy hasn't happened or synced.
-                                </div>
-                            )}
-                        </>
-                    )}
-                </Section>
-                <Section
-                    id="deployment-frequency"
-                    title="Deployments over time"
-                    note={`Successful deployments per bucket in the ${environmentScopeLabel} scope.`}
-                    busy={doraLoading && !!dora}
-                >
-                    {firstLoad ? (
-                        <LemonSkeleton className="h-40 w-full" />
-                    ) : frequencyCounts.length === 0 ? (
-                        <div className="py-8 text-center text-sm text-secondary">No deploy data for this window.</div>
-                    ) : (
-                        // The chart's root is a `flex-1` child, so the sized wrapper must be a flex column.
-                        <div className="flex h-40 flex-col" data-attr="engineering-analytics-dora-frequency-chart">
-                            <TimeSeriesBarChart
-                                series={frequencySeries}
-                                labels={frequencyIsoLabels}
-                                theme={chartTheme}
-                                config={{
-                                    xAxis: {
-                                        timezone: 'UTC',
-                                        interval: (dora?.series_granularity ?? 'day') as TimeInterval,
-                                    },
-                                    yAxis: { format: 'numeric', decimalPlaces: 0 },
-                                    minBarSize: 2,
-                                }}
-                            />
-                        </div>
-                    )}
-                </Section>
-            </div>
+                <DoraLeadTimeSection />
+                <DoraDeploymentHealth />
+                <DoraDeploymentFrequency />
+            </ScopePanel>
         </div>
     )
 }

--- a/products/engineering_analytics/frontend/scenes/EngineeringAnalyticsHealth.tsx
+++ b/products/engineering_analytics/frontend/scenes/EngineeringAnalyticsHealth.tsx
@@ -53,6 +53,7 @@ export function EngineeringAnalyticsHealth(): JSX.Element {
                                     mode="multiple"
                                     title="Environments"
                                     disablePrompting
+                                    displayMode={selectedEnvironments.length > 3 ? 'count' : 'snacks'}
                                     value={selectedEnvironments}
                                     onChange={setEnvironments}
                                     options={environmentOptions}


### PR DESCRIPTION
## Problem

Health users cannot tell which metrics each filter affects, and zero-sample plots appear blank.
[The picker layer](https://github.com/PostHog/posthog/pull/95596) supplies validated selections; this layer clarifies their scope.

## Changes

- Date, environment, and grouping controls share the outer scope panel.
- Team and outlier controls sit on the boundaries of the sections they affect.
- Metric cards compare the current and previous windows.
- Zero-sample plots explain missing deployment attribution.

Feature sections separate the rendering branches to meet the existing complexity limit. This extraction is mechanical.

<details>
<summary>Before and after the complete Health stack, using Storybook sample data</summary>

Before:

![Health before](https://raw.githubusercontent.com/PostHog/pr-assets/ebbd5292e1b50ab09f969337c28915a5bb0b5831/2026/09/1402f84b-ec8c-4d7f-9453-b5a4fc52b316.png)

After:

![Health after](https://raw.githubusercontent.com/PostHog/pr-assets/ff556ca875650752dff2a9e3fda90791817a6e9c/2026/09/f5235643-5c1e-40ab-895b-f12084274c9a.png)

</details>

## How did you test this code?

The complete stack matches the [reviewed full change](https://github.com/PostHog/posthog/commit/e9351a04aa34a181e6ffe8566eaff5321d1d4173).
Browser checks covered all three plots, outlier and stage controls, empty states, and responsive filter placement.
Storybook covers populated, unattributed, and unsynced deployment states. Live production data remains unverified.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The lower layer updates the existing API, MCP tool, and product skill descriptions. No standalone page snapshot document is added.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Codex split this reviewed change into a native stack. Backend fixes and picker state moved into the preceding layers; this PR keeps the presentation changes.
The committed fixtures and screenshots use synthetic sample data.

Skills: /stacking-prs, /writing-pr-descriptions, /pr-shepherd, /review-triage, /writing-ui-components, /writing-kea-logics, /writing-tests, /writing-user-facing-copy, /writing-code-comments, /hogli, /running-ci-preflight.
