### PR TITLE
feat(nav): label each second-level nav panel with a data-attr

### DIFF
--- a/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
@@ -20,6 +20,8 @@ import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 import { navigation3000Logic } from '../navigation-3000/navigationLogic'
 
 interface PanelLayoutPanelProps {
+    /** Names the panel in the DOM, so click maps and analytics can scope to one second-level nav. */
+    panelName: string
     searchPlaceholder?: string
     panelActionsNewSceneLayout?: (ButtonPrimitiveProps | null | undefined)[]
     children: React.ReactNode
@@ -57,6 +59,7 @@ const panelLayoutPanelVariants = cva({
 })
 
 export function PanelLayoutPanel({
+    panelName,
     searchField,
     panelActionsNewSceneLayout,
     children,
@@ -84,6 +87,7 @@ export function PanelLayoutPanel({
                 })
             )}
             ref={containerRef}
+            data-attr={`nav-panel-${panelName}`}
         >
             <div
                 className={cn(

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.stories.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.stories.tsx
@@ -4,7 +4,7 @@ import { FEATURE_FLAGS } from 'lib/constants'
 
 import { ProjectTree, ProjectTreeProps } from './ProjectTree'
 
-interface StoryProps extends Omit<ProjectTreeProps, 'panelName'> {
+type StoryProps = ProjectTreeProps & {
     enableCustomProductsFlag?: boolean
 }
 
@@ -30,7 +30,7 @@ const meta: Meta<(props: StoryProps) => JSX.Element> = {
             <div className="w-[280px] h-[600px] border rounded bg-surface-primary overflow-hidden">
                 <div className="p-2 border-b text-sm font-semibold text-secondary">Custom Products Sidebar</div>
                 <div className="h-[calc(100%-40px)] overflow-auto group/colorful-product-icons colorful-product-icons-true">
-                    <ProjectTree panelName="custom-products" root="custom-products://" onlyTree {...props} />
+                    <ProjectTree root="custom-products://" onlyTree {...props} />
                 </div>
             </div>
         )
@@ -58,7 +58,7 @@ export const AllProducts: Story = {
             <div className="w-[280px] h-[600px] border rounded bg-surface-primary overflow-hidden">
                 <div className="p-2 border-b text-sm font-semibold text-secondary">All Products Sidebar</div>
                 <div className="h-[calc(100%-40px)] overflow-auto group/colorful-product-icons colorful-product-icons-true">
-                    <ProjectTree panelName="products" root="products://" onlyTree />
+                    <ProjectTree root="products://" onlyTree />
                 </div>
             </div>
         )

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.stories.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.stories.tsx
@@ -4,7 +4,7 @@ import { FEATURE_FLAGS } from 'lib/constants'
 
 import { ProjectTree, ProjectTreeProps } from './ProjectTree'
 
-interface StoryProps extends ProjectTreeProps {
+interface StoryProps extends Omit<ProjectTreeProps, 'panelName'> {
     enableCustomProductsFlag?: boolean
 }
 
@@ -30,7 +30,7 @@ const meta: Meta<(props: StoryProps) => JSX.Element> = {
             <div className="w-[280px] h-[600px] border rounded bg-surface-primary overflow-hidden">
                 <div className="p-2 border-b text-sm font-semibold text-secondary">Custom Products Sidebar</div>
                 <div className="h-[calc(100%-40px)] overflow-auto group/colorful-product-icons colorful-product-icons-true">
-                    <ProjectTree root="custom-products://" onlyTree {...props} />
+                    <ProjectTree panelName="custom-products" root="custom-products://" onlyTree {...props} />
                 </div>
             </div>
         )
@@ -58,7 +58,7 @@ export const AllProducts: Story = {
             <div className="w-[280px] h-[600px] border rounded bg-surface-primary overflow-hidden">
                 <div className="p-2 border-b text-sm font-semibold text-secondary">All Products Sidebar</div>
                 <div className="h-[calc(100%-40px)] overflow-auto group/colorful-product-icons colorful-product-icons-true">
-                    <ProjectTree root="products://" onlyTree />
+                    <ProjectTree panelName="products" root="products://" onlyTree />
                 </div>
             </div>
         )

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -39,12 +39,9 @@ import { TreeSearchField } from './TreeSearchField'
 import { TreeSortDropdownMenu } from './TreeSortDropdownMenu'
 import { calculateMovePath } from './utils'
 
-export interface ProjectTreeProps {
+interface ProjectTreeBaseProps {
     logicKey?: string // key override?
     root?: string
-    /** Names the panel in the DOM; must be a pinned, stable identifier (not derived from root). */
-    panelName: string
-    onlyTree?: boolean
     showRecents?: boolean // whether to show recents in the tree
     searchPlaceholder?: string
     treeSize?: LemonTreeSize
@@ -62,6 +59,17 @@ export interface ProjectTreeProps {
     /** True while this tree's nav panel is active — refocuses search on panel re-activation. */
     isActiveInPanel?: boolean
 }
+
+/** A bare tree has no panel to label, so `panelName` is only required when the panel renders. */
+export type ProjectTreeProps = ProjectTreeBaseProps &
+    (
+        | { onlyTree: true; panelName?: string }
+        | {
+              onlyTree?: false
+              /** Names the panel in the DOM. Pin it at the call site; a `data-attr` value is API and must not change. */
+              panelName: string
+          }
+    )
 
 export const PROJECT_TREE_KEY = 'project-tree'
 let counter = 0
@@ -97,20 +105,20 @@ const isItemActive = (item: TreeDataItem): boolean => {
     return false
 }
 
-export function ProjectTree({
-    logicKey,
-    root,
-    panelName,
-    onlyTree = false,
-    searchPlaceholder,
-    treeSize = 'default',
-    showRecents,
-    selectModeOverride,
-    checkedItemsOverride,
-    onItemCheckedOverride,
-    onItemClicked,
-    isActiveInPanel,
-}: ProjectTreeProps): JSX.Element {
+export function ProjectTree(props: ProjectTreeProps): JSX.Element {
+    const {
+        logicKey,
+        root,
+        onlyTree = false,
+        searchPlaceholder,
+        treeSize = 'default',
+        showRecents,
+        selectModeOverride,
+        checkedItemsOverride,
+        onItemCheckedOverride,
+        onItemClicked,
+        isActiveInPanel,
+    } = props
     const [uniqueKey] = useState(() => `project-tree-${counter++}`)
     const { viableItems, shortcutEntryIdMap } = useValues(projectTreeDataLogic)
     const { reorderShortcutByDrag } = useActions(projectTreeDataLogic)
@@ -591,13 +599,13 @@ export function ProjectTree({
         />
     )
 
-    if (onlyTree) {
+    if (props.onlyTree) {
         return tree
     }
 
     return (
         <PanelLayoutPanel
-            panelName={panelName}
+            panelName={props.panelName}
             searchField={
                 <BindLogic logic={projectTreeLogic} props={projectTreeLogicProps}>
                     <TreeSearchField

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -594,6 +594,7 @@ export function ProjectTree({
 
     return (
         <PanelLayoutPanel
+            panelName={(root ?? 'project://').replace('://', '')}
             searchField={
                 <BindLogic logic={projectTreeLogic} props={projectTreeLogicProps}>
                     <TreeSearchField

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -42,6 +42,8 @@ import { calculateMovePath } from './utils'
 export interface ProjectTreeProps {
     logicKey?: string // key override?
     root?: string
+    /** Names the panel in the DOM; must be a pinned, stable identifier (not derived from root). */
+    panelName: string
     onlyTree?: boolean
     showRecents?: boolean // whether to show recents in the tree
     searchPlaceholder?: string
@@ -98,6 +100,7 @@ const isItemActive = (item: TreeDataItem): boolean => {
 export function ProjectTree({
     logicKey,
     root,
+    panelName,
     onlyTree = false,
     searchPlaceholder,
     treeSize = 'default',
@@ -594,7 +597,7 @@ export function ProjectTree({
 
     return (
         <PanelLayoutPanel
-            panelName={(root ?? 'project://').replace('://', '')}
+            panelName={panelName}
             searchField={
                 <BindLogic logic={projectTreeLogic} props={projectTreeLogicProps}>
                     <TreeSearchField

--- a/frontend/src/layout/panel-layout/navbar/PanelLayoutPanels.tsx
+++ b/frontend/src/layout/panel-layout/navbar/PanelLayoutPanels.tsx
@@ -63,7 +63,10 @@ export function PanelLayoutPanels(): JSX.Element | null {
                 />
             ),
             Chat: (
-                <div className="pointer-events-auto flex flex-col h-full min-h-screen max-h-screen bg-surface-tertiary border-r overflow-hidden w-[var(--project-panel-width)]">
+                <div
+                    className="pointer-events-auto flex flex-col h-full min-h-screen max-h-screen bg-surface-tertiary border-r overflow-hidden w-[var(--project-panel-width)]"
+                    data-attr="nav-panel-chat"
+                >
                     <Suspense
                         fallback={
                             <div className="flex flex-col gap-px px-1 pt-2">

--- a/frontend/src/layout/panel-layout/navbar/PanelLayoutPanels.tsx
+++ b/frontend/src/layout/panel-layout/navbar/PanelLayoutPanels.tsx
@@ -34,6 +34,7 @@ export function PanelLayoutPanels(): JSX.Element | null {
         () => ({
             DataAndPeople: (
                 <ProjectTree
+                    panelName="data-and-people"
                     root="data-and-people://"
                     searchPlaceholder="Search data"
                     isActiveInPanel={activePanelIdentifier === 'DataAndPeople'}
@@ -41,6 +42,7 @@ export function PanelLayoutPanels(): JSX.Element | null {
             ),
             Project: (
                 <ProjectTree
+                    panelName="project"
                     root="project://"
                     logicKey={PROJECT_TREE_KEY}
                     searchPlaceholder="Search files"
@@ -50,6 +52,7 @@ export function PanelLayoutPanels(): JSX.Element | null {
             ),
             Products: (
                 <ProjectTree
+                    panelName="products"
                     root="products://"
                     searchPlaceholder="Search tools"
                     isActiveInPanel={activePanelIdentifier === 'Products'}
@@ -57,6 +60,7 @@ export function PanelLayoutPanels(): JSX.Element | null {
             ),
             Shortcuts: (
                 <ProjectTree
+                    panelName="shortcuts"
                     root="shortcuts://"
                     searchPlaceholder="Search starred items"
                     isActiveInPanel={activePanelIdentifier === 'Shortcuts'}

--- a/frontend/src/layout/panel-layout/navbar/tabs/NavTabBrowse.tsx
+++ b/frontend/src/layout/panel-layout/navbar/tabs/NavTabBrowse.tsx
@@ -452,7 +452,6 @@ export function NavTabBrowse(): JSX.Element {
                             <span className="text-xs text-tertiary px-2 py-1 block">No tools shown</span>
                         ) : (
                             <ProjectTree
-                                panelName="custom-products"
                                 root={!uiCustomizationEnabled && isEditMode ? 'products://' : 'custom-products://'}
                                 onItemClicked={(item) => {
                                     // In edit mode a row click toggles a checkbox, which is not navigation

--- a/frontend/src/layout/panel-layout/navbar/tabs/NavTabBrowse.tsx
+++ b/frontend/src/layout/panel-layout/navbar/tabs/NavTabBrowse.tsx
@@ -452,6 +452,7 @@ export function NavTabBrowse(): JSX.Element {
                             <span className="text-xs text-tertiary px-2 py-1 block">No tools shown</span>
                         ) : (
                             <ProjectTree
+                                panelName="custom-products"
                                 root={!uiCustomizationEnabled && isEditMode ? 'products://' : 'custom-products://'}
                                 onItemClicked={(item) => {
                                     // In edit mode a row click toggles a checkbox, which is not navigation

--- a/frontend/src/lib/components/NotificationsMenu/NotificationsPanel.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/NotificationsPanel.tsx
@@ -119,7 +119,7 @@ export function NotificationsPanel(): JSX.Element {
               ]
 
     return (
-        <PanelLayoutPanel searchField={header} panelActionsNewSceneLayout={panelActions}>
+        <PanelLayoutPanel panelName="notifications" searchField={header} panelActionsNewSceneLayout={panelActions}>
             <ScrollableShadows
                 direction="vertical"
                 styledScrollbars


### PR DESCRIPTION
## Problem

Someone who opens a second-level nav panel, such as Data, cannot narrow a heatmap or click map to the clicks inside that panel. The panel container carries no attribute to select it with. Every panel shares the same generic markup, and several panels stay mounted at once, so a structural selector cannot separate them either.

## Changes

- The container of each second-level nav panel now carries `data-attr="nav-panel-<name>"`, so a click map can scope to `[data-attr="nav-panel-data-and-people"]` alone.
- The name comes from the panel: `nav-panel-data-and-people`, `nav-panel-project`, `nav-panel-products`, `nav-panel-shortcuts`, `nav-panel-notifications`, `nav-panel-chat`.
- `PanelLayoutPanel` takes the name as a required prop, so a new panel cannot ship without a label. The chat panel renders its own container and sets the attribute directly.

Nothing looks different. The change only adds an attribute to existing elements, so no screenshot shows it.

## How did you test this code?

Not tested in a browser or by an automated suite. This sandbox has no `node_modules`, so the frontend typecheck and Jest did not run. The change adds one attribute per panel container and one required prop with both call sites updated.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a request in Slack for a selector on the open second-level nav.

Skills invoked: `/writing-pr-descriptions`.

The first option was a single shared value on every panel. Panels stay mounted and hidden after a visit, so one shared value matches several elements in the DOM at once and cannot isolate the open one. A per-panel value keeps each container unique.

No open PR covers this; `gh pr list --search "nav panel data-attr"` returned unrelated work. Nothing in this PR comes from a non-public source.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0113360FFV/p1788547819739589?thread_ts=1788547819.739589&cid=C0113360FFV)*
