### PR TITLE
feat(toolbar): remove the sampling control from click maps

### DIFF
--- a/frontend/src/toolbar/TELEMETRY.md
+++ b/frontend/src/toolbar/TELEMETRY.md
@@ -330,26 +330,3 @@ Fired after a successful screenshot/media upload.
 | `source` | `'toolbar'` | Always `'toolbar'` |
 
 **File:** `screenshot-upload/screenshotUploadLogic.ts`
-
-## Heatmap sampling (page's PostHog instance)
-
-These events use the **page's** `posthog.capture()`, not `toolbarPosthogJS`.
-They are sent to the customer's project, not PostHog's internal project.
-
-### `sampling_enabled_on_heatmap`
-
-Fired when sampling is enabled on the heatmap. No properties.
-
-### `sampling_disabled_on_heatmap`
-
-Fired when sampling is disabled on the heatmap. No properties.
-
-### `sampling_percentage_updated_on_heatmap`
-
-Fired when the sampling percentage is changed.
-
-| Property         | Type     | Description                                |
-| ---------------- | -------- | ------------------------------------------ |
-| `samplingFactor` | `number` | New sampling factor (e.g., 0.1, 0.25, 0.5) |
-
-**File:** `stats/HeatmapToolbarMenu.tsx`

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -1349,10 +1349,6 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
         setCommonFilters: () => {
             actions.loadAllEnabled()
         },
-        setSamplingFactor: () => {
-            actions.maybeLoadClickmap()
-        },
-
         toggleClickmapsEnabled: () => {
             if (values.clickmapsEnabled) {
                 actions.maybeLoadClickmap()

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -393,7 +393,6 @@ export interface heatmapToolbarMenuLogicValues {
         processed: number
         total: number
     } | null
-    samplingFactor: number
     scrollDepthPosthogJsError: 'disabled' | 'version' | null
     wantedDataAttributes: string[]
     windowHeight: number
@@ -567,9 +566,6 @@ export interface heatmapToolbarMenuLogicActions {
         processed: number
         total: number
     }
-    setSamplingFactor: (samplingFactor: number) => {
-        samplingFactor: number
-    }
     startAreaSelection: () => {
         value: true
     }
@@ -690,7 +686,6 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
         enableHeatmap: true,
         disableHeatmap: true,
         toggleClickmapsEnabled: (enabled: boolean) => ({ enabled }),
-        setSamplingFactor: (samplingFactor: number) => ({ samplingFactor }),
         loadMoreElementStats: true,
         setMatchLinksByHref: (matchLinksByHref: boolean) => ({ matchLinksByHref }),
         loadAllEnabled: true,
@@ -813,13 +808,6 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                 toggleClickmapsEnabled: (_, { enabled }) => enabled,
             },
         ],
-        samplingFactor: [
-            1,
-            { persist: true },
-            {
-                setSamplingFactor: (_, { samplingFactor }) => samplingFactor,
-            },
-        ],
         elementMetrics: [
             new Map<HTMLElement, { visible: boolean }>(),
             {
@@ -902,7 +890,6 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                                   date_from: values.commonFilters.date_from,
                                   date_to: values.commonFilters.date_to,
                                   paginate_response: true,
-                                  sampling_factor: values.samplingFactor,
                                   limit: limit ?? ELEMENT_STATS_PAGE_LIMIT,
                                   // the matchers only read the configured data attributes from each
                                   // element's attributes map, so let the server drop the rest

--- a/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
+++ b/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
@@ -1,5 +1,4 @@
 import { useActions, useValues } from 'kea'
-import posthog from 'posthog-js'
 import React from 'react'
 
 import { IconMagicWand, IconTarget } from '@posthog/icons'
@@ -10,8 +9,6 @@ import { HeatmapsSettings } from 'lib/components/heatmaps/HeatMapsSettings'
 import { heatmapDateOptions } from 'lib/components/IframedToolbarBrowser/utils'
 import { IconSync } from 'lib/lemon-ui/icons'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
-import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
-import { LemonSegmentedButton } from 'lib/lemon-ui/LemonSegmentedButton'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 
@@ -104,7 +101,6 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
         clickmapsEnabled,
         heatmapFixedPositionMode,
         heatmapColorPalette,
-        samplingFactor,
         elementsLoading,
         processingProgress,
         areaSelectionActive,
@@ -118,7 +114,6 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
         toggleClickmapsEnabled,
         setHeatmapFixedPositionMode,
         setHeatmapColorPalette,
-        setSamplingFactor,
         startAreaSelection,
         cancelAreaSelection,
         selectHeatmapAreaFilter,
@@ -294,46 +289,6 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
                                 Tip: Hold <kbd className="border rounded px-1 py-0.5 bg-surface-tertiary">shift</kbd> to
                                 interact with the page beneath the clickmap.
                             </p>
-                            <div className="flex items-center justify-between pb-2">
-                                <div className="flex items-center gap-1">
-                                    <LemonLabel
-                                        info="Sampling computes the result on a proportion of data of the users in the dataset, making click maps load significantly faster."
-                                        infoLink="https://posthog.com/docs/toolbar/heatmaps"
-                                    >
-                                        Sampling
-                                    </LemonLabel>
-                                    <LemonSwitch
-                                        className="m-2"
-                                        onChange={(checked) => {
-                                            if (checked) {
-                                                setSamplingFactor(0.1)
-                                                posthog.capture('sampling_enabled_on_heatmap')
-                                                return
-                                            }
-                                            setSamplingFactor(1)
-                                            posthog.capture('sampling_disabled_on_heatmap')
-                                        }}
-                                        checked={samplingFactor !== 1}
-                                    />
-                                </div>
-                                {samplingFactor !== 1 && (
-                                    <div className="flex items-center gap-2">
-                                        <LemonSegmentedButton
-                                            options={[0.1, 1, 10, 25, 50].map((percentage) => ({
-                                                value: percentage / 100,
-                                                label: `${percentage}%`,
-                                            }))}
-                                            value={samplingFactor}
-                                            onChange={(newValue) => {
-                                                setSamplingFactor(newValue)
-                                                posthog.capture('sampling_percentage_updated_on_heatmap', {
-                                                    samplingFactor: newValue,
-                                                })
-                                            }}
-                                        />
-                                    </div>
-                                )}
-                            </div>
                             <div className="flex items-center gap-2">
                                 <LemonButton
                                     icon={<IconSync />}


### PR DESCRIPTION
## Problem

The click map section asked people to choose a sampling percentage to make the query faster. The queries are fast enough now, so the control only offers a way to make a click map less accurate, and it takes up the space above the controls people do use.

## Changes

- The sampling switch and the percentage buttons are gone from the click map section.
- Click maps always run on the full data set. Toolbar requests stop sending `sampling_factor`, which the API already treats as no sampling, so results for anyone who left the control at 100% are unchanged.
- Anyone who had sampling switched on gets full results from now on. The stored factor goes with the control, so a saved 10% does not linger.
- The three sampling events the control captured are removed, and `TELEMETRY.md` drops their section.
- The API keeps its `sampling_factor` parameter. Only the toolbar stops sending one.

No screenshot. The change removes a control inside the toolbar, which needs a live site and a project with heatmap data to render, and a removal leaves nothing new to show.

## How did you test this code?

- `pnpm --filter=@posthog/frontend exec jest src/toolbar/elements/heatmapToolbarMenuLogic.test.ts src/toolbar/stats` — 44 passed.
- `pnpm --filter=@posthog/frontend fix` (oxlint + oxfmt) is clean.

No test was added. The change removes a control and its state, and the existing click map loading tests already cover the request path that lost the parameter.

Not verified: `pnpm --filter=@posthog/frontend typescript:check`. `tsgo` is OOM-killed in this sandbox (it reaches about 15 GB on a 16 GB box), so CI runs that check first. Not tested by hand in a browser either, since the toolbar needs a live site and a project with heatmap data.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`frontend/src/toolbar/TELEMETRY.md` drops the heatmap sampling section in this PR. The public heatmaps guide at posthog.com/docs/toolbar/heatmaps does not mention the sampling control, in its text or its screenshots, so the website needs no change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code), from a request to drop the control now that the queries behind it are fast.

Skills invoked: `/writing-pr-descriptions`.

The state went with the control rather than being pinned to 1 behind the scenes. A hidden factor that only ever holds one value is a value nobody can explain later, and the API's own default already covers it.

This branch touches `HeatmapToolbarMenu.tsx`, which two sibling PRs also touch, so whichever lands second needs a rebase.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0113360FFV/p1788547819739589?thread_ts=1788547819.739589&cid=C0113360FFV)*

