### PR TITLE
fix(data-warehouse): explain a sync that lost its connection

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
@@ -177,6 +177,57 @@ Any_Source_Errors: dict[str, str | None] = {
 }
 
 
+# Customer-facing copy for a failure that stayed retryable and still exhausted its retry budget.
+# Nothing is disabled and the schema syncs again on its next schedule, so the copy explains that
+# rather than asking for a re-enable.
+TRANSIENT_SOURCE_CONNECTION_MESSAGE = (
+    "PostHog lost its connection to your source and couldn't reconnect. Check that it stays "
+    "reachable and doesn't drop idle connections; the next sync runs on schedule."
+)
+
+TRANSIENT_POOLER_MESSAGE = (
+    "Your database's connection pooler couldn't reach your database and refused the connection. "
+    "Check that the database is running; the next sync runs on schedule."
+)
+
+TRANSIENT_EGRESS_MESSAGE = (
+    "PostHog couldn't reach your source over the network. This is on PostHog's side and usually "
+    "clears on its own; the next sync runs on schedule."
+)
+
+# A retryable failure that outlives its retries keeps whatever the driver said, so `latest_error`
+# ends up holding raw connection text — a psycopg "connection to server at <host>, port <port>
+# failed: ..." line, a pymysql `(2013, ...)` tuple, a urllib3 connection-pool dump. None of it
+# names something the customer can act on, and all of it echoes their host and port back at them.
+# Unlike `Any_Source_Errors` above, matching here only rewrites the stored message: the error stays
+# retryable and the schema stays enabled. Keys are the same stable, host-free fragments the sources
+# already classify these conditions by, so they can't collide with a customer value.
+Transient_Error_Messages: dict[str, str] = {
+    # libpq/psycopg losing an established connection, at connect or mid-stream, in every wording
+    # `_CONNECTION_DROPPED_ERROR_SUBSTRINGS` (postgres.py) retries in-process first.
+    "server closed the connection unexpectedly": TRANSIENT_SOURCE_CONNECTION_MESSAGE,
+    "SSL connection has been closed unexpectedly": TRANSIENT_SOURCE_CONNECTION_MESSAGE,
+    "SSL SYSCALL error": TRANSIENT_SOURCE_CONNECTION_MESSAGE,
+    "connection to server was lost": TRANSIENT_SOURCE_CONNECTION_MESSAGE,
+    # pymysql error 2013, retried in-process by `_connect_with_transient_retry` (mysql.py). The
+    # deterministic filesort variant carries its own marker and is classified non-retryable first.
+    "Lost connection to MySQL server": TRANSIENT_SOURCE_CONNECTION_MESSAGE,
+    # A TLS session cut at the socket, which clickhouse-connect surfaces through urllib3 rather
+    # than as a driver error (see the ClickHouse source's `get_retryable_errors`).
+    "UNEXPECTED_EOF_WHILE_READING": TRANSIENT_SOURCE_CONNECTION_MESSAGE,
+    # Supavisor refusing a connect because its own lookup of the tenant's database failed — the
+    # pooler's bookkeeping, not the customer's credentials, which postgres.py retries in-process.
+    "(ECIRCUITBREAKER) failed to retrieve database credentials": TRANSIENT_POOLER_MESSAGE,
+    "(EAUTHQUERY)": TRANSIENT_POOLER_MESSAGE,
+    # PostHog's own egress proxy refusing the CONNECT. Nothing on the customer's side is wrong, so
+    # this message asks nothing of them.
+    "Cannot connect to proxy": TRANSIENT_EGRESS_MESSAGE,
+    "Tunnel connection failed: 502": TRANSIENT_EGRESS_MESSAGE,
+    "Tunnel connection failed: 503": TRANSIENT_EGRESS_MESSAGE,
+    "Tunnel connection failed: 504": TRANSIENT_EGRESS_MESSAGE,
+}
+
+
 UNEXPECTED_ERROR_MESSAGE = "An unexpected error has occurred"
 
 CANCELLED_RUN_MESSAGE = (
@@ -225,6 +276,21 @@ def _is_app_db_failure(internal_error: str) -> bool:
     """
     normalized = internal_error.lower()
     return normalized.startswith(APP_DB_ERROR_PREFIX) and READ_ONLY_TRANSACTION_PHRASE in normalized
+
+
+def _transient_error_message(internal_error: str) -> str | None:
+    """Customer-facing copy for a transient failure that outlived its retries, if we have any.
+
+    First match wins, mirroring how the non-retryable path picks its friendly message.
+    """
+    return next(
+        (
+            message
+            for pattern, message in Transient_Error_Messages.items()
+            if error_message_matches(internal_error, [pattern])
+        ),
+        None,
+    )
 
 
 def _fail_stale_running_schema(
@@ -379,6 +445,10 @@ async def update_external_data_job_model(inputs: UpdateExternalDataJobStatusInpu
                 disable_error_message=inputs.latest_error or AUTO_DISABLED_JOB_ERROR,
                 disable_exclude_workflow_id=activity.info().workflow_id,
             )
+        elif not platform_failure:
+            transient_message = _transient_error_message(internal_error_normalized)
+            if transient_message is not None:
+                inputs.latest_error = transient_message
 
     await database_sync_to_async_pool(update_external_job_status)(
         job_id=job_id,

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/test_external_data_job_activities.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/test_external_data_job_activities.py
@@ -18,6 +18,9 @@ from products.warehouse_sources.backend.models.external_data_schema import Exter
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.temporal.data_imports.external_data_job import (
     CANCELLED_RUN_MESSAGE,
+    TRANSIENT_EGRESS_MESSAGE,
+    TRANSIENT_POOLER_MESSAGE,
+    TRANSIENT_SOURCE_CONNECTION_MESSAGE,
     UNEXPECTED_ERROR_MESSAGE,
     UpdateExternalDataJobStatusInputs,
     _customer_facing_error,
@@ -258,3 +261,82 @@ def test_read_only_transaction_disables_the_schema_only_when_the_source_raised_i
     assert mock_update_should_sync.called is expect_disabled
     customer_message = mock_update_job_status.call_args.kwargs["latest_error"] or ""
     assert ("tries to write to your database" in customer_message) is expect_disabled
+
+
+# transaction=True for the same reason as the tests above: the activity resolves the source through
+# database_sync_to_async_pool, and the pool thread's connection can't see a test transaction.
+@parameterized.expand(
+    [
+        # psycopg's connect-time wrapper around a dropped TLS session. The address is a
+        # documentation-reserved one, standing in for the host the driver echoes back.
+        (
+            "postgres_ssl_drop",
+            ExternalDataSourceType.POSTGRES,
+            'connection failed: connection to server at "198.51.100.7", port 5432 failed: '
+            "SSL SYSCALL error: EOF detected",
+            TRANSIENT_SOURCE_CONNECTION_MESSAGE,
+        ),
+        # pymysql renders a mid-query drop as a bare code/message tuple.
+        (
+            "mysql_lost_connection",
+            ExternalDataSourceType.MYSQL,
+            "(2013, 'Lost connection to MySQL server during query')",
+            TRANSIENT_SOURCE_CONNECTION_MESSAGE,
+        ),
+        # Supavisor refusing the connect after its own credential lookup failed.
+        (
+            "pooler_credential_lookup",
+            ExternalDataSourceType.POSTGRES,
+            "FATAL: (ECIRCUITBREAKER) failed to retrieve database credentials after multiple "
+            "attempts, new connections are temporarily blocked",
+            TRANSIENT_POOLER_MESSAGE,
+        ),
+        # PostHog's own egress proxy refusing the CONNECT.
+        (
+            "egress_proxy_bad_gateway",
+            ExternalDataSourceType.SALESFORCE,
+            "ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 502 Bad gateway'))",
+            TRANSIENT_EGRESS_MESSAGE,
+        ),
+    ]
+)
+@pytest.mark.django_db(transaction=True)
+def test_transient_failure_replaces_the_raw_driver_text_without_disabling_the_schema(
+    _name: str, source_type: ExternalDataSourceType, internal_error: str, expected_message: str
+) -> None:
+    org = Organization.objects.create(name="org")
+    team = Team.objects.create(organization=org, name="team")
+    source = ExternalDataSource.objects.create(team=team, source_type=source_type.value)
+    schema = ExternalDataSchema.objects.create(team=team, source=source, name="table")
+    job = ExternalDataJob.objects.create(
+        team=team, pipeline=source, schema=schema, status=ExternalDataJob.Status.RUNNING, rows_synced=0
+    )
+
+    env = ActivityEnvironment()
+    inputs = UpdateExternalDataJobStatusInputs(
+        team_id=team.id,
+        job_id=str(job.id),
+        schema_id=str(schema.id),
+        source_id=str(source.id),
+        status=ExternalDataJob.Status.FAILED,
+        internal_error=internal_error,
+        latest_error=internal_error,
+    )
+
+    with (
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.external_data_job.get_rows", return_value=0
+        ),
+        mock.patch("products.warehouse_sources.backend.temporal.data_imports.external_data_job.finish_row_tracking"),
+        mock.patch("posthoganalytics.capture"),
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.external_data_job.update_should_sync"
+        ) as mock_update_should_sync,
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.external_data_job.update_external_job_status"
+        ) as mock_update_job_status,
+    ):
+        asyncio.run(env.run(update_external_data_job_model, inputs))
+
+    mock_update_should_sync.assert_not_called()
+    assert mock_update_job_status.call_args.kwargs["latest_error"] == expected_message


### PR DESCRIPTION
## Problem

A customer whose source database drops PostHog's connection sees the raw driver text in the sync error panel: a psycopg `connection to server at <host>, port <port> failed: ...` line, a pymysql `(2013, ...)` tuple, or a urllib3 connection-pool dump. It names nothing they can act on, and it echoes their own host and port back at them.

These failures are correctly classified as transient — the sources retry them in-process, then Temporal retries the activity — but once that budget is spent the run finalizes as failed and stores whatever the driver said. Dropped connections are the largest single group of failed warehouse sync jobs, and every one of them ends this way.

## Changes

- The sync error panel now says the connection to the source was lost and could not be re-established, and that the next scheduled sync will try again. Three variants cover a dropped source connection, a connection pooler that could not reach the database behind it, and PostHog's own egress network — the last asks nothing of the customer, because nothing on their side is wrong.
- Retryability is unchanged. Matching here only rewrites the stored message: the schema stays enabled, and `internal_error` keeps the full driver text for error tracking.
- Mechanical: a new `Transient_Error_Messages` map beside the existing `Any_Source_Errors`, keyed on the same stable, host-free fragments the sources already use to classify these conditions, plus its lookup in the finalization activity.

## How did you test this code?

Added a parameterized activity test covering a dropped Postgres TLS session, a MySQL mid-query drop, a pooler that could not fetch its credentials, and an egress proxy refusal. It asserts the customer-facing message replaces the driver text **and** that the schema is not disabled — no existing test covers the rewrite, and none guards the "message changed, retryability didn't" pairing that a future edit to this map could break.

Ran `products/warehouse_sources/backend/temporal/data_imports/tests/test_external_data_job_activities.py` locally against the dev stack. No manual end-to-end sync was run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written with Claude Code while triaging a day of warehouse sync job failures. Skills invoked: `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

The obvious alternative was to mark these errors non-retryable so they stop burning jobs. That was rejected: they genuinely recover, and disabling a sync on a network blip is worse than a bad message. Splitting the copy three ways — source, pooler, PostHog's own network — came out of the failure classes themselves, which point at three different places to look.

No duplicate: searched open PRs for the message fragments, the module path, and the exception types, and listed every open PR on this area. The nearest neighbours are per-source retryability fixes; none change what a transient failure stores in the error panel.

Public artifact: the failure classes that prompted this came from production job records. Nothing from them is committed — the test fixtures are written from the shape each driver produces, with a documentation-reserved address standing in for any host.
