### PR TITLE
fix(langsmith): stop retrying a request LangSmith rejects

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/langsmith/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/langsmith/source.py
@@ -99,6 +99,11 @@ Leave the **Host** field blank for the US cloud (`api.smith.langchain.com`). Set
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
+            # LangSmith rejects the request itself — a filter or parameter its deployment doesn't
+            # accept — rather than the credentials. The request shape is fixed per endpoint, so
+            # every retry sends the identical query and is rejected identically. `_fetch_page`
+            # logs the response body, which is the only place the vendor's reason survives.
+            "400 Client Error": "LangSmith rejected PostHog's request for this table. Check that the Host field matches your LangSmith region or deployment, then contact support if it keeps failing.",
             "401 Client Error": "Your LangSmith API key is invalid or has been revoked. Create a new API key in your LangSmith settings, then reconnect.",
             "403 Client Error": "Your LangSmith API key does not have access to this workspace. Check the key's workspace scope, then reconnect.",
             REPEATED_CURSOR_ERROR: "LangSmith kept returning the same pagination cursor, so the import was stopped to avoid looping. This usually means the host is misconfigured. Check the Host field, then reconnect.",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/langsmith/tests/test_langsmith_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/langsmith/tests/test_langsmith_source.py
@@ -112,6 +112,14 @@ class TestLangSmithSource:
         non_retryable = self.source.get_non_retryable_errors()
         assert any(RESPONSE_TOO_LARGE_ERROR in key for key in non_retryable)
 
+    def test_rejected_request_is_non_retryable(self):
+        # A 4xx means LangSmith rejected the request we built, so every retry re-sends the same
+        # query for the whole activity budget and stores the raw requests error for the customer.
+        non_retryable = self.source.get_non_retryable_errors()
+        message = non_retryable["400 Client Error"]
+        assert message is not None
+        assert "Host field" in message
+
     def test_documented_tables_render_from_static_catalog(self):
         # lists_tables_without_credentials must expose the table catalog (+ canonical descriptions)
         # for the public docs <SourceTables /> component without needing credentials.


### PR DESCRIPTION
## Problem

When LangSmith rejects a request PostHog built — not the credentials, the query itself — the customer's sync error panel shows the bare `requests` failure: a status line followed by the full query URL. It tells them nothing to change, and the sync keeps failing.

Only 401 and 403 were classified for this source, so an outright rejection fell through to the unclassified path: the activity re-sent the identical query for its whole retry budget, every run, and stored the raw error each time.

## Changes

- A rejected request now stops the sync straight away and tells the customer that LangSmith refused the request, pointing them at the Host field — the setting most likely to put a sync on a region or self-hosted deployment that does not accept the query. The raw error still reaches error tracking, and `_fetch_page` already logs LangSmith's own response body, which is where the vendor's reason survives.
- Mechanical: one entry in `get_non_retryable_errors`, alongside the existing 401 and 403.

## How did you test this code?

Added a source test asserting the rejection is classified and carries actionable copy. The existing suite only covered the oversized-response and credential cases, so nothing guarded a rejected request against silently reverting to the retry-forever path.

Ran `products/warehouse_sources/backend/temporal/data_imports/sources/langsmith/tests/` locally. No manual end-to-end sync was run — that needs a LangSmith account.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written with Claude Code while triaging a day of warehouse sync job failures. Skills invoked: `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

The vendor's own reason for the rejection is not in the raised exception, only in the logged response body, so the copy cannot name the specific cause. It names the one setting a customer can act on and falls back to support. Widening the exception to carry the response body was considered and dropped: it would push vendor text into a customer-facing field for no gain, since the body is already logged.

No duplicate: searched open PRs for this source, its module path, and the exception type — nothing open touches it.

Public artifact: the failure class that prompted this came from production job records. Nothing from them is committed; the test asserts only on copy written for this PR.
