### PR TITLE
fix(data-warehouse): validate draft saved_query_id against the team on update

### DIFF
--- a/products/data_warehouse/backend/presentation/views/saved_query_draft.py
+++ b/products/data_warehouse/backend/presentation/views/saved_query_draft.py
@@ -23,7 +23,7 @@ class DataWarehouseSavedQueryDraftSerializer(serializers.ModelSerializer):
     def validate_saved_query_id(self, value: uuid.UUID | None) -> uuid.UUID | None:
         if value is None:
             return None
-        if not DataWarehouseSavedQuery.objects.filter(id=value, team_id=self.context["team_id"]).exists():
+        if not DataWarehouseSavedQuery.objects.filter(id=value, team_id=self.context["get_team"]().id).exists():
             raise serializers.ValidationError("Saved query not found.")
         return value
 

--- a/products/data_warehouse/backend/presentation/views/saved_query_draft.py
+++ b/products/data_warehouse/backend/presentation/views/saved_query_draft.py
@@ -1,3 +1,5 @@
+import uuid
+
 from rest_framework import pagination, serializers, viewsets
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
@@ -18,6 +20,13 @@ class DataWarehouseSavedQueryDraftSerializer(serializers.ModelSerializer):
         fields = ["id", "created_at", "updated_at", "query", "saved_query_id", "name", "edited_history_id"]
         read_only_fields = ["id", "created_at", "updated_at", "name"]
 
+    def validate_saved_query_id(self, value: uuid.UUID | None) -> uuid.UUID | None:
+        if value is None:
+            return None
+        if not DataWarehouseSavedQuery.objects.filter(id=value, team_id=self.context["team_id"]).exists():
+            raise serializers.ValidationError("Saved query not found.")
+        return value
+
     def create(self, validated_data):
         validated_data["team_id"] = self.context["team_id"]
         validated_data["created_by"] = self.context["request"].user
@@ -25,10 +34,7 @@ class DataWarehouseSavedQueryDraftSerializer(serializers.ModelSerializer):
 
         name = "Untitled"
         if saved_query_id:
-            try:
-                saved_query = DataWarehouseSavedQuery.objects.get(id=saved_query_id, team_id=validated_data["team_id"])
-            except DataWarehouseSavedQuery.DoesNotExist:
-                raise serializers.ValidationError({"saved_query_id": "Saved query not found."})
+            saved_query = DataWarehouseSavedQuery.objects.get(id=saved_query_id, team_id=validated_data["team_id"])
             count = DataWarehouseSavedQueryDraft.objects.filter(
                 saved_query_id=saved_query_id,
                 team_id=validated_data["team_id"],

--- a/products/data_warehouse/backend/tests/api/test_saved_query_draft.py
+++ b/products/data_warehouse/backend/tests/api/test_saved_query_draft.py
@@ -1,4 +1,8 @@
+import uuid
+
 from posthog.test.base import APIBaseTest
+
+from parameterized import parameterized
 
 from posthog.models import Organization, Team
 
@@ -159,26 +163,34 @@ class TestDataWarehouseSavedQueryDraft(APIBaseTest):
         assert draft_obj.saved_query is not None
         self.assertEqual(draft_obj.saved_query.id, saved_query.id)
 
-    def test_cannot_create_draft_pointing_at_other_teams_saved_query(self):
-        """Regression: POST must not accept a saved_query_id from a different team."""
-        other_org = Organization.objects.create(name="Other Org (IDOR test)")
-        other_team = Team.objects.create(organization=other_org, name="Other Team")
+    @parameterized.expand(
+        [
+            ("create", "other_team"),
+            ("create", "nonexistent"),
+            ("update", "other_team"),
+            ("update", "nonexistent"),
+        ]
+    )
+    def test_rejects_saved_query_id_outside_team(self, method: str, id_kind: str):
+        other_org = Organization.objects.create(name="Other org")
+        other_team = Team.objects.create(organization=other_org, name="Other team")
         foreign_saved_query = DataWarehouseSavedQuery.objects.create(
             name="confidential_query",
             team=other_team,
             query={"kind": "HogQLQuery", "query": "select 1"},
         )
+        saved_query_id = str(foreign_saved_query.id) if id_kind == "other_team" else str(uuid.uuid4())
+        body = {"query": {"kind": "HogQLQuery", "query": "select 2"}, "saved_query_id": saved_query_id}
 
-        response = self.client.post(
-            f"/api/environments/{self.team.pk}/warehouse_saved_query_drafts/",
-            {
-                "query": {"kind": "HogQLQuery", "query": "select 2"},
-                "saved_query_id": str(foreign_saved_query.id),
-            },
-        )
+        if method == "create":
+            response = self.client.post(f"/api/environments/{self.team.pk}/warehouse_saved_query_drafts/", body)
+        else:
+            draft = DataWarehouseSavedQueryDraft.objects.create(team=self.team, created_by=self.user, query={})
+            response = self.client.patch(
+                f"/api/environments/{self.team.pk}/warehouse_saved_query_drafts/{draft.id}/", body
+            )
 
-        # The serializer scopes the saved_query lookup by team_id, so the foreign
-        # id is unknown — DRF returns 400.
         self.assertEqual(response.status_code, 400, response.content)
-        # And no draft should have been created bound to the foreign saved_query.
-        assert not DataWarehouseSavedQueryDraft.objects.filter(saved_query_id=foreign_saved_query.id).exists()
+        self.assertEqual(response.json()["attr"], "saved_query_id")
+        self.assertNotIn("confidential_query", response.content.decode())
+        self.assertFalse(DataWarehouseSavedQueryDraft.objects.filter(saved_query_id=saved_query_id).exists())


### PR DESCRIPTION
## Problem

- A member of one project could attach a draft to a saved query from another project by editing the draft.
- Creating a draft already refused a saved query outside the team, but updating a draft did not check `saved_query_id` at all.
- The draft then stored the foreign id, and a later update or read used it as if it belonged to the team.
- A draft update with an unknown id also went through instead of failing.

## Changes

- Updating a draft with a saved query from another team, or a saved query that does not exist, now returns 400 with `Saved query not found.`
- The check moved to field-level validation on the draft serializer, so create and update share it and a cross-team id is never persisted.
- No UI change. The SQL editor already only sends ids from the current project.

## How did you test this code?

- `test_rejects_saved_query_id_outside_team` in `products/data_warehouse/backend/tests/api/test_saved_query_draft.py` covers create and update, each with a foreign id and a random id.
- The two update cases fail on master with 200 and pass on this branch. The create cases pass on both.
- Each case checks for 400, that the error names `saved_query_id`, that the response carries no foreign saved query name, and that no draft row holds the id.
- Not run: the wider data warehouse suites, left to CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The endpoint is internal.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5.1) triaged an internal review finding that the draft endpoint looked up a saved query without a team filter.
- Master already scoped the create path. Reproducing the finding with a failing test showed the update path was the remaining gap.
- Skills invoked: /writing-tests, /improving-drf-endpoints, /writing-pr-descriptions.
- Duplicate search: `gh pr list --state open --search "saved query draft"` found no open PR fixing this.
- The committed test data is invented.
