### PR TITLE
chore(data-warehouse): read the team via get_team in the draft serializer

### DIFF
--- a/products/data_warehouse/backend/presentation/views/saved_query_draft.py
+++ b/products/data_warehouse/backend/presentation/views/saved_query_draft.py
@@ -28,7 +28,7 @@ class DataWarehouseSavedQueryDraftSerializer(serializers.ModelSerializer):
         return value
 
     def create(self, validated_data):
-        validated_data["team_id"] = self.context["team_id"]
+        validated_data["team_id"] = self.context["get_team"]().id
         validated_data["created_by"] = self.context["request"].user
         saved_query_id = validated_data.get("saved_query_id")
 


### PR DESCRIPTION
## Problem

The draft serializer read the team two different ways: the validator used `self.context["get_team"]()` and `create()` used `self.context["team_id"]`.
Both resolve to the same team today, but `context["team_id"]` is an alias of `project_id` that the routing mixin marks as a kludge, while `get_team` is the accessor the repo guide asks serializers to use.
Review on https://github.com/PostHog/posthog/pull/95600 asked for the two reads to match.

## Changes

- `create()` now reads the team through `self.context["get_team"]().id`, matching the validator above it.
- No behavior change: the request resolves the team before the serializer runs, and both accessors return the same id.

## How did you test this code?

- `pytest products/data_warehouse/backend/tests/api/test_saved_query_draft.py`: 9 passed.
- Not run: repo-wide mypy. The change swaps one context read for another of the same type.

## 🤖 Agent context

- Autonomy: human-driven (agent-assisted).
- Follow-up to https://github.com/PostHog/posthog/pull/95600, which merged with the two reads inconsistent.
