### PR TITLE
fix(data-warehouse): say what to do when Stripe blocks a connected-account webhook

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/stripe.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/stripe.py
@@ -1487,6 +1487,18 @@ def _is_stripe_webhook_limit_error(error_str: str) -> bool:
     return "maximum of" in lowered and "webhook endpoint" in lowered
 
 
+def _is_stripe_connected_account_webhook_error(error_str: str) -> bool:
+    """Detect Stripe's refusal to manage webhook endpoints on a connected account.
+
+    A Connect request (platform key plus a ``stripe_account`` header, which every OAuth
+    connection uses) can never create the endpoint on the connected account, so the message
+    carries "permission" and would otherwise land in the generic permission branch and tell the
+    user to widen a scope or reconnect. Neither can lift the restriction.
+    """
+    lowered = error_str.lower()
+    return "connected account" in lowered and "webhook endpoint" in lowered
+
+
 def create_webhook(
     api_key: str,
     stripe_account_id: str | None,
@@ -1550,6 +1562,15 @@ def create_webhook(
                     "Stripe account. The 'Account id' in your source settings only applies to Stripe Connect "
                     "platform accounts — remove or correct it if your key belongs directly to the account, "
                     "then retry. Otherwise, set up the webhook manually below."
+                ),
+            )
+
+        if _is_stripe_connected_account_webhook_error(error_str):
+            return WebhookCreationResult(
+                success=False,
+                error=(
+                    "Stripe doesn't allow creating a webhook endpoint on a connected account. "
+                    "Set up the webhook manually below, on your platform account in Stripe."
                 ),
             )
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
@@ -1458,17 +1458,27 @@ class TestSchemaWebhookCapability:
 class TestCreateWebhookPermissionErrorCopy:
     # Regression test: a permission-denied webhook creation used to always tell the user to add
     # the "Write" permission to their API key, even when the source was connected via OAuth and
-    # has no API key to edit.
+    # has no API key to edit. Stripe's connected-account refusal also reads as a permission
+    # error, but neither a wider scope nor a reconnect can lift it.
     @parameterized.expand(
         [
-            ("api_key", "add the 'Write' permission for 'Webhook endpoints' to your API key"),
-            ("oauth", "reconnect your Stripe integration"),
+            (
+                "api_key",
+                "forbidden",
+                "add the 'Write' permission for 'Webhook endpoints' to your API key",
+            ),
+            ("oauth", "forbidden", "reconnect your Stripe integration"),
+            (
+                "oauth",
+                "You do not have permission to configure webhook endpoints on connected accounts.",
+                "on your platform account in Stripe",
+            ),
         ]
     )
-    def test_permission_error_message_matches_auth_method(self, auth_method, expected_phrase):
+    def test_permission_error_message_matches_auth_method(self, auth_method, stripe_message, expected_phrase):
         with patch.object(stripe_module, "StripeClient") as mock_client_cls:
             mock_client = mock_client_cls.return_value
-            mock_client.webhook_endpoints.create.side_effect = stripe_lib.PermissionError("forbidden")
+            mock_client.webhook_endpoints.create.side_effect = stripe_lib.PermissionError(stripe_message)
 
             result = create_webhook(
                 api_key="sk_test_123",


### PR DESCRIPTION
## Problem

A user connecting a Stripe source for a connected account clicks "Create webhook", the automatic setup fails, and the wizard tells them to do something that can never work.

Stripe refuses to manage webhook endpoints on a connected account. Every Stripe Connect setup hits this: OAuth connections always send a `stripe_account` header, and so does an API key paired with an "Account id" in the source settings.

That refusal carries the word "permission", so it fell into the generic permission branch. The user was told to add the "Write" permission for "Webhook endpoints" to their API key, or to reconnect and grant webhook access. Neither lifts the restriction, so the only working route, manual setup on the platform account, was never offered.

## Changes

- A blocked connected-account webhook now reads: "Stripe doesn't allow creating a webhook endpoint on a connected account. Set up the webhook manually below, on your platform account in Stripe."
- `_is_stripe_connected_account_webhook_error` classifies the refusal, matching the two stable phrases Stripe's message carries.
- The new branch runs before the generic permission branch in `create_webhook`, which is the only behavior change. Nothing else in the webhook path moves.
- No UI changes, so nothing looks different beyond the message text in the existing error banner.

## How did you test this code?

Extended `TestCreateWebhookPermissionErrorCopy` with a third parameterized case. It catches the regression where a connected-account refusal falls back to the API-key or reconnect copy, which no existing case covered: both existing cases raise a bare "forbidden" and only vary the auth method.

Ran that class and `TestCreateWebhookLimitErrorCopy` locally, plus ruff over both touched files. Not run: the wizard end to end, since this sandbox has no Stripe Connect account to reproduce the refusal against.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code while reviewing Replay Vision summaries of the data-warehouse new-source onboarding flow. One summary showed a user reach the Stripe webhook step, hit the permission failure, and then spend the rest of the session reading the manual instructions.

Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.

No duplicate: searched open PRs for "stripe webhook", "connected account", "webhook connected", and "stripe connect webhook", and listed every open PR by the maintainer. Nothing touches this branch of `create_webhook`.

Public artifact: the diff, the test, and this description carry no material from the session. The test's Stripe message is Stripe's own documented wording, and the fixtures use `sk_test_123` and `example.com`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
