### PR TITLE
chore(ci): deploy tasks workers on shared oauth changes

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -444,7 +444,7 @@ jobs:
             - name: Check for changes that affect Tasks Agent Temporal worker
               id: check_changes_tasks_agent_temporal_worker
               run: |
-                  if git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/common|^posthog/temporal/ai/posthog_code_slack_|^posthog/temporal/ai/slack_app/|^products/slack_app/backend|^products/tasks/backend|^posthog/tasks/|^posthog/settings/temporal.py$|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$|^posthog/clickhouse/migrations/'; then
+                  if git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/common|^posthog/temporal/oauth[.]py$|^posthog/temporal/ai/posthog_code_slack_|^posthog/temporal/ai/slack_app/|^products/slack_app/backend|^products/tasks/backend|^posthog/tasks/|^posthog/settings/temporal.py$|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$|^posthog/clickhouse/migrations/|^[.]github/workflows/container-images-cd[.]yml$'; then
                       echo "changed=true" >> $GITHUB_OUTPUT
                   else
                       echo "changed=false" >> $GITHUB_OUTPUT

--- a/docs/internal/tasks-agent-worker-deploys.md
+++ b/docs/internal/tasks-agent-worker-deploys.md
@@ -1,0 +1,9 @@
+# Tasks-agent worker deployments
+
+`container-images-cd.yml` dispatches the tasks-agent Temporal worker deployment when the commit changes a path in `check_changes_tasks_agent_temporal_worker`.
+
+The filter includes `posthog/temporal/oauth.py`. The worker imports this shared module to decode MCP scope payloads and mint sandbox tokens, so OAuth changes must deploy to the worker alongside their callers. Deploying only a caller can leave the worker decoding a new payload with an older scope type.
+
+Changes to `container-images-cd.yml` also trigger the tasks-agent deployment. This lets a deployment-filter correction refresh the worker without an unrelated application change. The existing production deployment gate still applies.
+
+When changing shared worker dependencies, check this filter as well as the product paths. To verify a rollout was requested, inspect the **Trigger Tasks Agent Temporal worker cloud deployment** step in the Container Images CD run. A successful image build alone does not prove that this worker received a deployment dispatch.


### PR DESCRIPTION
## Problem

Scouts can lose tools when a deployment updates scope payloads without updating the worker that decodes them.
The shared OAuth module does not match the tasks-agent deployment filter. [The #95132 deployment skipped that worker](https://github.com/PostHog/posthog/actions/runs/33966465164).

## Changes

- Deploy the tasks-agent worker when shared OAuth code changes, keeping payload decoding and token minting current.
- Deploy it when this workflow changes, so filter corrections also refresh the worker.
- Document the deployment check. This changes deployment selection only; the production gate remains unchanged.

Before:
```mermaid
flowchart LR
    A[Shared OAuth change] --> B[Tasks-agent deploy skipped]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B phGray;
```

After:
```mermaid
flowchart LR
    A[Shared OAuth or workflow change] --> B[Tasks-agent deploy dispatched]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    class A phYellow;
    class B phBlue;
```

## How did you test this code?

Local checks: seven matching/nonmatching filter cases, `hogli lint:workflows`, actionlint v1.7.12 with CI's error-only shellcheck setting, and `hogli ci:preflight --fix`.
No application code changed. Production rollout and scout recovery remain unverified.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Added `docs/internal/tasks-agent-worker-deploys.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Codex authored this change using shell tools and GitHub CLI. Skills: authoring-ci-workflows, gating-production-deploys, writing-pr-descriptions, running-ci-preflight.
Open-PR searches found no matching deployment-filter fix. Private context prompted investigation; committed content uses repository behavior and public deployment evidence only.
