### PR TITLE
fix(signals): dispatch a scout without a grant with the plain preset string

### DIFF
--- a/posthog/temporal/oauth.py
+++ b/posthog/temporal/oauth.py
@@ -305,6 +305,20 @@ def scout_scope_posture(
     }
 
 
+def scout_mcp_scopes(posture: ScoutScopePosture) -> PosthogMcpScopes:
+    """The value to dispatch a scout run with: the plain preset unless the posture adds a grant.
+
+    The preset string and a posture with no extras resolve to the same token, so the string loses
+    nothing. It is also the shape every worker version reads the same way. The dict is newer, and
+    a worker that predates it decodes the dict as `list[str]` and mints a token from its keys, so
+    the run loses every scout tool. Sending the dict only when a grant needs it keeps a worker
+    that lags one deploy behind from taking the whole fleet down with it.
+    """
+    if not posture["extra_write_scopes"]:
+        return posture["preset"]
+    return posture
+
+
 def _grantable_write_scopes(raw: object) -> list[str]:
     """Intersect a stored grant with the allowlist, tolerating any shape JSON can hold.
 

--- a/posthog/temporal/tests/test_oauth.py
+++ b/posthog/temporal/tests/test_oauth.py
@@ -34,6 +34,7 @@ from posthog.temporal.oauth import (
     create_wizard_oauth_access_token_for_user,
     has_write_scopes,
     resolve_scopes,
+    scout_mcp_scopes,
     scout_scope_posture,
 )
 
@@ -141,6 +142,24 @@ class TestResolveScopes(SimpleTestCase):
         result = resolve_scopes(scout_scope_posture("signals_scout", ["dashboard:write"]))
         assert set(result) == set(resolve_scopes("signals_scout")) | {"dashboard:write"}
         assert "insight:write" not in result
+
+    @parameterized.expand(
+        [
+            ("without_a_grant_sends_the_preset_string", [], "signals_scout_reports"),
+            (
+                "with_a_grant_sends_the_posture",
+                ["dashboard:write"],
+                {"preset": "signals_scout_reports", "extra_write_scopes": ["dashboard:write"]},
+            ),
+        ]
+    )
+    def test_scout_mcp_scopes_sends_the_dict_only_when_a_grant_needs_it(
+        self, _name: str, grant: list[str], expected: PosthogMcpScopes
+    ) -> None:
+        # The posture dict is a newer wire shape than the preset string. A sandbox worker that
+        # predates it decodes the dict as `list[str]` and mints a token from its keys, so a run
+        # dispatched as a dict when the string would do loses every scout tool on a lagging worker.
+        assert scout_mcp_scopes(scout_scope_posture("signals_scout_reports", grant)) == expected
 
     @parameterized.expand([(preset,) for preset in SCOUT_SCOPE_PRESETS])
     def test_scout_posture_without_a_grant_matches_the_plain_preset(self, preset: ScoutScopePreset) -> None:

--- a/products/signals/backend/scout_harness/runner.py
+++ b/products/signals/backend/scout_harness/runner.py
@@ -21,7 +21,7 @@ from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.models.utils import uuid7
 from posthog.sync import database_sync_to_async
-from posthog.temporal.oauth import scout_scope_posture
+from posthog.temporal.oauth import scout_mcp_scopes, scout_scope_posture
 
 from products.business_knowledge.backend.logic import is_maintained_for_team
 from products.data_catalog.backend.facade.api import approved_metric_names_for_team
@@ -692,8 +692,9 @@ async def _spawn_and_run(
         # A scout that opted into the report channel gets `signals_scout_reports` instead —
         # the same posture plus `signal_scout_report:write` — so the MCP server exposes the
         # emit_report/edit_report tools. Every other scout gets plain `signals_scout` and never
-        # sees them.
-        posthog_mcp_scopes=scope_posture,
+        # sees them. Dispatched as the preset string unless this scout holds a grant, so a scout
+        # without one never depends on the sandbox worker reading the posture dict.
+        posthog_mcp_scopes=scout_mcp_scopes(scope_posture),
         github_read_access=True,
         # `None` keeps the agent-server default; an override pins the whole run on one model
         # (the `scouts-model-selection` gate routes it here). The model the gateway actually serves

--- a/products/signals/backend/test/test_scout_harness.py
+++ b/products/signals/backend/test/test_scout_harness.py
@@ -1322,19 +1322,25 @@ async def test_run_passes_the_per_scout_server_selection_and_no_credential_owner
 @pytest.mark.asyncio
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "emit,acting_user_resolves,expected_grant",
+    "emit,acting_user_resolves,expected_grant,expected_mcp_scopes",
     [
-        pytest.param(True, True, ["dashboard:write"], id="live_run_holds_the_grant"),
+        pytest.param(
+            True,
+            True,
+            ["dashboard:write"],
+            {"preset": "signals_scout", "extra_write_scopes": ["dashboard:write"]},
+            id="live_run_holds_the_grant",
+        ),
         # Dry run is how a person previews a scout before trusting it, so a dry run that could
         # edit dashboards would do the thing they wanted to look at first.
-        pytest.param(False, True, [], id="dry_run_holds_no_grant"),
+        pytest.param(False, True, [], "signals_scout", id="dry_run_holds_no_grant"),
         # The grant was approved for the person the runs act as. When that identity no longer
         # resolves, the team fallback is a member who never approved it and cannot revoke it.
-        pytest.param(True, False, [], id="team_fallback_holds_no_grant"),
+        pytest.param(True, False, [], "signals_scout", id="team_fallback_holds_no_grant"),
     ],
 )
 async def test_run_mints_the_scouts_granted_write_scopes_and_stamps_them_on_the_run(
-    ateam, aerrors_skill, emit, acting_user_resolves, expected_grant
+    ateam, aerrors_skill, emit, acting_user_resolves, expected_grant, expected_mcp_scopes
 ):
     # The grant is what the run's token carries, so a composition that loses it leaves a scout
     # unable to do the job it was granted for, and one that passes the column through unfiltered
@@ -1375,9 +1381,11 @@ async def test_run_mints_the_scouts_granted_write_scopes_and_stamps_them_on_the_
     ):
         await arun_signals_scout(team_id=ateam.id, skill_name="signals-scout-errors")
 
-    posture = captured["context"].posthog_mcp_scopes
-    assert posture["preset"] == "signals_scout"
-    assert posture["extra_write_scopes"] == expected_grant
+    # A scout without a grant is dispatched as the plain preset string. The posture dict is the
+    # newer wire shape, and a sandbox worker one deploy behind reads it as a list of its keys,
+    # which mints a token with no scout scopes at all. Only a scout that holds a grant pays that
+    # compatibility cost.
+    assert captured["context"].posthog_mcp_scopes == expected_mcp_scopes
     # Stamped at run creation, because the config's grant can be widened or revoked afterwards and
     # would otherwise rewrite what past runs are recorded as having been able to change.
     metadata = await database_sync_to_async(


### PR DESCRIPTION
## Problem

Every scout run in the fleet loses its PostHog MCP tools when the sandbox worker runs an older deploy than the scout scheduler.

- #95132 started dispatching every scout with the scope posture dict in place of the preset string.
- The scheduler and the sandbox launcher run in different Temporal workers that deploy separately.
- A sandbox worker without #95132 decodes the dict as `list[str]`, so the token is minted from the keys `preset` and `extra_write_scopes`.
- That token carries no scout scope and no read scope. The MCP server rejects it, and the run cannot read its skill, query the project, or emit a report.
- The reorder of the type union in #95132 only helps on a worker that already has it, so it cannot protect the deploy that introduces the dict.

## Changes

- A scout with no extra write scopes is dispatched with the preset string again, which every worker version decodes the same way.
- A scout that holds a grant still gets the posture dict, because only the dict can carry the grant.
- `scout_mcp_scopes` in `posthog/temporal/oauth.py` makes that choice, and `_spawn_and_run` calls it.
- Nothing else changes: the prompt, the run row, and the analytics events still read the same posture.

> [!NOTE]
> A scout that holds a grant keeps depending on the sandbox worker having #95132. The grant feature is new and opt-in, so this limits the blast radius of a lagging worker to those scouts instead of the fleet.

## How did you test this code?

- `test_scout_mcp_scopes_sends_the_dict_only_when_a_grant_needs_it` in `posthog/temporal/tests/test_oauth.py` fails if the dispatcher goes back to sending the dict for every scout.
- `test_run_mints_the_scouts_granted_write_scopes_and_stamps_them_on_the_run` now asserts the exact value handed to the sandbox: the string for the two no-grant cases, the dict for the grant case.
- Not run locally: both test files, because the local database was down. CI covers them.
- Not checked: a live round trip through a lagging worker. The decode behavior comes from running Temporal's default payload converter on both union orders with the SDK in the repo's environment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1) wrote the change with a person directing. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`. No open PR fixes this: `gh pr list --state open --search` on the scout scope terms found none. The revert of #95132 was considered and rejected because the fix recovers the fleet through the same deploy path and keeps the grant feature working.

https://claude.ai/code/session_01GLNCPAjPuJ6NRUECQsWbrj
