### PR TITLE
feat(signals): let people scope the inbox to themselves for a shareable link

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6339,7 +6339,7 @@ snapshots:
     scenes-app-customer-analytics-dashboard--customer-tasks--dark:
         hash: v1.k794b7964.bf4411a8550fe620b82da8dbf7db11efbe3915634ecdcf3baa8b2bffc0aad593.frezJ_q91GKzahZb8GfRbUeRbERSv-ReB2HIBNJN6Ow
     scenes-app-customer-analytics-dashboard--customer-tasks--light:
-        hash: v1.k794b7964.acedcb03c7c39d27c2b9f0ed3f1b1ac44fe3fdc58f68a0ed0d0b9e475e70ca96.nKLpWDvqLrHFG2HwFEAexR8rc63-OmxYQogH_Utdg9I
+        hash: v1.k794b7964.60a97139d05e6353174d50bce8ad84e23d4ea39806dcbde6d81b4d259356a1c8.YTy9rPEtfJxKbOKmMJxP_wLyhtlalHtNLi0HqnPKfe0
     scenes-app-customer-analytics-dashboard--feature-request-details--dark:
         hash: v1.k794b7964.dd76e36d821568ab1a8ea103274a39792a5916586913dcc54d4b8c6022aed968.ofepc5cJ-e3ysJbDmjbn2yyefm6X7NwNtnjOfyB4WmA
     scenes-app-customer-analytics-dashboard--feature-request-details--light:

--- a/products/signals/frontend/inbox/components/shell/InboxScopeFilter.test.tsx
+++ b/products/signals/frontend/inbox/components/shell/InboxScopeFilter.test.tsx
@@ -1,3 +1,5 @@
+import { MOCK_DEFAULT_USER } from 'lib/api.mock'
+
 import '@testing-library/jest-dom'
 
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
@@ -7,11 +9,23 @@ import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
 import { inboxFiltersLogic } from '../../logics/inboxFiltersLogic'
+import type { InboxPerson } from './InboxPeoplePicker'
 import { InboxScopeFilter } from './InboxScopeFilter'
 
 jest.mock('posthog-js')
-// The people picker isn't needed to exercise the trigger label, and it pulls in a popover + avatars.
-jest.mock('./InboxPeoplePicker', () => ({ InboxPeoplePicker: () => null }))
+// The real picker pulls in a popover and avatars. This stand-in lists the roster rows as plain text,
+// which is all these tests read from it.
+jest.mock('./InboxPeoplePicker', () => ({
+    InboxPeoplePicker: ({ people }: { people: InboxPerson[] }) => (
+        <ul>
+            {people.map((person) => (
+                <li key={person.uuid}>
+                    {person.name} {person.trailing}
+                </li>
+            ))}
+        </ul>
+    ),
+}))
 
 describe('InboxScopeFilter', () => {
     beforeEach(() => {
@@ -21,6 +35,7 @@ describe('InboxScopeFilter', () => {
             get: {
                 '/api/projects/:team_id/signals/reports/available_reviewers': {
                     'uuid-ada': { name: 'Ada', email: 'ada@example.com' },
+                    [MOCK_DEFAULT_USER.uuid]: { name: MOCK_DEFAULT_USER.first_name, email: MOCK_DEFAULT_USER.email },
                 },
             },
         })
@@ -46,10 +61,20 @@ describe('InboxScopeFilter', () => {
         render(<InboxScopeFilter />)
 
         inboxFiltersLogic.actions.setScope('teammate:uuid-ada')
-        await waitFor(() => expect(screen.getByText('Ada')).toBeInTheDocument())
+        await waitFor(() => expect(screen.getByLabelText('Report scope: Ada')).toBeInTheDocument())
 
         inboxFiltersLogic.actions.setScope('teammate:uuid-off-roster')
-        await waitFor(() => expect(screen.getByText('Teammate')).toBeInTheDocument())
-        expect(screen.queryByText('Ada')).toBeNull()
+        await waitFor(() => expect(screen.getByLabelText('Report scope: Teammate')).toBeInTheDocument())
+        expect(screen.queryByLabelText('Report scope: Ada')).toBeNull()
+    })
+
+    // "For you" resolves to whoever opens the link, so a URL that opens to *your* reports for a
+    // teammate can only come from your own roster row. Hiding that row as a duplicate of "For you"
+    // makes your view the one scope nobody can share.
+    it('keeps the signed-in user in the roster so their scope can be shared by URL', async () => {
+        inboxFiltersLogic.mount()
+        render(<InboxScopeFilter />)
+
+        await waitFor(() => expect(screen.getByText(`${MOCK_DEFAULT_USER.first_name} (you)`)).toBeInTheDocument())
     })
 })

--- a/products/signals/frontend/inbox/components/shell/InboxScopeFilter.tsx
+++ b/products/signals/frontend/inbox/components/shell/InboxScopeFilter.tsx
@@ -92,15 +92,16 @@ export function InboxScopeFilter(): JSX.Element {
                     setSearch(value)
                     searchAvailableReviewers(value)
                 }}
-                // The pinned "For you" row already stands for the signed-in user, so their own
-                // roster row would be a second control writing a different scope for the same view.
-                people={reviewers
-                    .filter((reviewer) => reviewer.user_uuid !== user?.uuid)
-                    .map((reviewer) => ({
-                        uuid: reviewer.user_uuid,
-                        name: reviewer.name,
-                        email: reviewer.email,
-                    }))}
+                // The signed-in user keeps their own roster row next to the pinned "For you" row. Both
+                // show the same reports, but only the roster row writes `scope=teammate:<uuid>` to the
+                // URL. "For you" is the default, so it leaves the URL bare and resolves to whoever opens
+                // the link. The roster row is the only way to share a link that opens to your reports.
+                people={reviewers.map((reviewer) => ({
+                    uuid: reviewer.user_uuid,
+                    name: reviewer.name,
+                    email: reviewer.email,
+                    trailing: reviewer.user_uuid === user?.uuid ? '(you)' : undefined,
+                }))}
                 loading={availableReviewersLoading}
                 selectedUuid={scope === INBOX_SCOPE_ENTIRE_PROJECT ? null : (selectedTeammateUuid ?? undefined)}
                 forYou={{ active: isForYou, onPick: () => pick(INBOX_SCOPE_FOR_YOU) }}


### PR DESCRIPTION
## Problem

- A person on the Self-driving inbox Reports tab cannot share a link that opens to their own reports.
- "For you" is the default scope, so it writes nothing to the URL and resolves to whoever opens the link.
- Every other scope serializes as `scope=entire-project` or `scope=teammate:<uuid>`, so those links do open to the same view for a teammate.
- The scope picker hid the signed-in user's row from the teammate list, so the only way to see your reports was "For you".

## Changes

- The scope picker now lists the signed-in user among the teammates, marked "(you)", matching the members list convention.
- Picking your own row writes `scope=teammate:<uuid>`, which opens to your reports for anyone who follows the link.
- "For you" stays pinned at the top as the personal default. Both rows show the same reports; only the roster row makes the link shareable.
- No screenshot: the local dev stack was not running in this session. The visible change is one extra row in the scope dropdown, named after you with "(you)" after it.

## How did you test this code?

- Added one case to `InboxScopeFilter.test.tsx` that renders the picker's roster and expects the signed-in user's row. It fails if someone re-adds the filter that hid that row.
- The picker mock in that file now renders the roster rows as text, and the existing trigger assertions moved to the accessible label so a roster row cannot collide with the trigger text.
- Not checked: the change in a browser.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Skills invoked: `/writing-ui-components`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

The gap surfaced while reviewing #95589, which puts the Findings and Scratchpad filters in the URL. The Reports filters were already in the URL; the scope for your own reports was the one view with no URL form. Alternatives considered: a "Copy link" action that resolves "For you" to a UUID at copy time, and writing the UUID for "For you" always. The first adds a toolbar control; the second makes every default URL non-clean.

No duplicate: `gh pr list --state open --search "inbox scope"` found no other PR for this.

https://claude.ai/code/session_01GLNCPAjPuJ6NRUECQsWbrj
