### PR TITLE
fix(engineering-analytics): reuse workflow deploy attribution

### DIFF
--- a/products/engineering_analytics/README.md
+++ b/products/engineering_analytics/README.md
@@ -104,6 +104,8 @@ Shortening ready-for-review-to-merge is the headline metric this serves.
 The warehouse snapshots overwrite state on update, so transition timing is unrecoverable from them.
 Immutable lifecycle events are the only thing the deferred events destination is for.
 Deploys left that deferral: unlike the snapshots, `github_deployment_statuses` is an append-oriented, webhook-fed status history (one row per transition), so DORA reads don't need the events destination.
+When a deployment's merge SHA is absent from the PR snapshot, Health reuses workflow-run `commit_pr_number` attribution for the exact deployed commit on the same repository's default branch.
+This fallback depends on the merge-message PR suffix and synced workflow history; unresolved deployments remain unattributed.
 Change failure rate and time-to-restore still lack an incident link, so they ship as honest deploy-status proxies — the caveat rides in the field docs (`failed_deployment_share`, `median_failed_deploy_to_next_success_seconds`), the aggregate-endpoint pattern; a typed `metric_quality` field is reserved for deep tools like `pr_lifecycle`.
 
 ## Locked decisions

--- a/products/engineering_analytics/README.md
+++ b/products/engineering_analytics/README.md
@@ -104,8 +104,9 @@ Shortening ready-for-review-to-merge is the headline metric this serves.
 The warehouse snapshots overwrite state on update, so transition timing is unrecoverable from them.
 Immutable lifecycle events are the only thing the deferred events destination is for.
 Deploys left that deferral: unlike the snapshots, `github_deployment_statuses` is an append-oriented, webhook-fed status history (one row per transition), so DORA reads don't need the events destination.
-When a deployment's merge SHA is absent from the PR snapshot, Health reuses workflow-run `commit_pr_number` attribution for the exact deployed commit on the same repository's default branch, and only for a PR that merged into that same branch.
-That last condition drops a cherry-pick: a commit forward-ported onto the default branch keeps the original subject line, so its `(#N)` suffix still names the release-branch PR it came from.
+When a deployment's merge SHA is absent from the PR snapshot, Health reuses workflow-run `commit_pr_number` attribution for the exact deployed commit on the same repository's default branch.
+The candidate PR must have merged into that branch, and must carry no merge commit of its own — one that names some other commit is evidence the suffix is wrong, not evidence the deploy carries that PR.
+That drops a cherry-pick: a commit forward-ported onto the default branch keeps the original subject line, so its `(#N)` suffix still names the PR it came from, which landed elsewhere.
 This fallback depends on the merge-message PR suffix and synced workflow history; unresolved deployments remain unattributed.
 Change failure rate and time-to-restore still lack an incident link, so they ship as honest deploy-status proxies — the caveat rides in the field docs (`failed_deployment_share`, `median_failed_deploy_to_next_success_seconds`), the aggregate-endpoint pattern; a typed `metric_quality` field is reserved for deep tools like `pr_lifecycle`.
 

--- a/products/engineering_analytics/README.md
+++ b/products/engineering_analytics/README.md
@@ -104,7 +104,8 @@ Shortening ready-for-review-to-merge is the headline metric this serves.
 The warehouse snapshots overwrite state on update, so transition timing is unrecoverable from them.
 Immutable lifecycle events are the only thing the deferred events destination is for.
 Deploys left that deferral: unlike the snapshots, `github_deployment_statuses` is an append-oriented, webhook-fed status history (one row per transition), so DORA reads don't need the events destination.
-When a deployment's merge SHA is absent from the PR snapshot, Health reuses workflow-run `commit_pr_number` attribution for the exact deployed commit on the same repository's default branch.
+When a deployment's merge SHA is absent from the PR snapshot, Health reuses workflow-run `commit_pr_number` attribution for the exact deployed commit on the same repository's default branch, and only for a PR that merged into that same branch.
+That last condition drops a cherry-pick: a commit forward-ported onto the default branch keeps the original subject line, so its `(#N)` suffix still names the release-branch PR it came from.
 This fallback depends on the merge-message PR suffix and synced workflow history; unresolved deployments remain unattributed.
 Change failure rate and time-to-restore still lack an incident link, so they ship as honest deploy-status proxies — the caveat rides in the field docs (`failed_deployment_share`, `median_failed_deploy_to_next_success_seconds`), the aggregate-endpoint pattern; a typed `metric_quality` field is reserved for deep tools like `pr_lifecycle`.
 

--- a/products/engineering_analytics/backend/logic/queries/dora.py
+++ b/products/engineering_analytics/backend/logic/queries/dora.py
@@ -162,7 +162,9 @@ _FREQUENCY_SERIES_SELECT = """
 # merge_commit_sha exception (SPEC §6): gated on merged_at (an open PR carries a throwaway
 # test-merge SHA) and collapsed to one row per deployment (min breaks a shared-SHA tie).
 # Missing merge SHAs can resolve through the shared workflow-run attribution, restricted to the
-# same repo's default branch. Direct merge-SHA evidence wins over inferred commit-message evidence.
+# same repo's default branch. Direct merge-SHA evidence wins over inferred commit-message evidence,
+# so the candidate PR must carry no merge commit at all: one that names a commit other than the
+# deployed SHA is evidence the suffix is lying, not evidence the deploy carries that PR.
 # The candidate PR must also merge INTO that branch: a cherry-pick keeps the original subject line,
 # so a release-branch PR's (#N) suffix can ride a default-branch commit and hand the deploy an
 # earlier head merge than the one it really contains.
@@ -195,6 +197,7 @@ _DEPLOY_HEADS_CTE = """
         WHERE d.first_success_at IS NOT NULL
             AND d.sha != ''
             AND d.id NOT IN (SELECT id FROM merge_heads)
+            AND hp.merge_commit_sha = ''
             AND r.run_started_at >= {merge_scan_floor}
             AND NOT r.is_merge_queue
             AND hp.default_branch != ''

--- a/products/engineering_analytics/backend/logic/queries/dora.py
+++ b/products/engineering_analytics/backend/logic/queries/dora.py
@@ -85,6 +85,7 @@ _DEPLOYS_CTE = """
             d.id AS id,
             any(d.sha) AS sha,
             any(d.environment) AS environment,
+            any(d.created_at) AS created_at,
             minOrNullIf(s.created_at, s.state = 'success') AS first_success_at,
             minOrNullIf(s.created_at, s.state IN ('failure', 'error')) AS first_failure_at
         FROM __DEPLOYMENTS_SOURCE__ AS d
@@ -165,6 +166,9 @@ _FREQUENCY_SERIES_SELECT = """
 # The candidate PR must also merge INTO that branch: a cherry-pick keeps the original subject line,
 # so a release-branch PR's (#N) suffix can ride a default-branch commit and hand the deploy an
 # earlier head merge than the one it really contains.
+# The merge is bounded by the deployment REQUEST, not its success: GitHub fixes the deployed SHA
+# when it creates the record, so a PR merging while the deploy runs cannot have produced that
+# commit. Crediting it would over-attribute — every merge at or before it reads as contained.
 # Bot merges stay in as heads on purpose: a bot's merge commit still names what a deploy contains.
 _DEPLOY_HEADS_CTE = """
     merge_heads AS (
@@ -199,7 +203,7 @@ _DEPLOY_HEADS_CTE = """
             AND r.repo_owner = hp.repo_owner AND r.repo_name = hp.repo_name
             AND hp.merged_at IS NOT NULL
             AND hp.merged_at >= {merge_scan_floor}
-            AND hp.merged_at <= d.first_success_at
+            AND hp.merged_at <= d.created_at
         GROUP BY d.id
         HAVING uniqExact(r.commit_pr_number) = 1
     ),

--- a/products/engineering_analytics/backend/logic/queries/dora.py
+++ b/products/engineering_analytics/backend/logic/queries/dora.py
@@ -206,6 +206,7 @@ _DEPLOY_HEADS_CTE = """
             AND r.repo_owner = hp.repo_owner AND r.repo_name = hp.repo_name
             AND hp.merged_at IS NOT NULL
             AND hp.merged_at >= {merge_scan_floor}
+            AND hp.merged_at <= r.created_at
             AND hp.merged_at <= d.created_at
         GROUP BY d.id
         HAVING uniqExact(r.commit_pr_number) = 1

--- a/products/engineering_analytics/backend/logic/queries/dora.py
+++ b/products/engineering_analytics/backend/logic/queries/dora.py
@@ -162,6 +162,9 @@ _FREQUENCY_SERIES_SELECT = """
 # test-merge SHA) and collapsed to one row per deployment (min breaks a shared-SHA tie).
 # Missing merge SHAs can resolve through the shared workflow-run attribution, restricted to the
 # same repo's default branch. Direct merge-SHA evidence wins over inferred commit-message evidence.
+# The candidate PR must also merge INTO that branch: a cherry-pick keeps the original subject line,
+# so a release-branch PR's (#N) suffix can ride a default-branch commit and hand the deploy an
+# earlier head merge than the one it really contains.
 # Bot merges stay in as heads on purpose: a bot's merge commit still names what a deploy contains.
 _DEPLOY_HEADS_CTE = """
     merge_heads AS (
@@ -192,6 +195,7 @@ _DEPLOY_HEADS_CTE = """
             AND NOT r.is_merge_queue
             AND hp.default_branch != ''
             AND r.head_branch = hp.default_branch
+            AND hp.base_branch = r.head_branch
             AND r.repo_owner = hp.repo_owner AND r.repo_name = hp.repo_name
             AND hp.merged_at IS NOT NULL
             AND hp.merged_at >= {merge_scan_floor}

--- a/products/engineering_analytics/backend/logic/queries/dora.py
+++ b/products/engineering_analytics/backend/logic/queries/dora.py
@@ -6,8 +6,9 @@ Four quadrants, honestly named (SPEC §4):
   window, within the environment scope. Computed directly.
 - Lead time: ``merge_to_deploy_seconds`` — a merged PR's wait until the first
   successful deployment that *contains* its merge. Containment is resolved through
-  the deploy's head commit: the deploy's SHA is some merged PR's ``merge_commit_sha``,
-  and every merge at or before that head merge is on board. Success time alone
+  the deploy's head commit: its SHA resolves to a merged PR through ``merge_commit_sha``
+  or the workflow-run builder's ``commit_pr_number`` fallback. Every merge at or before
+  that head merge is on board. Success time alone
   cannot decide this — deploys ship pre-built images, so a deploy routinely
   succeeds *after* a merge it does not contain. The field name says merge-to-deploy,
   not the full commit-to-deploy DORA definition (pre-merge time is measured elsewhere).
@@ -48,7 +49,10 @@ from products.engineering_analytics.backend.logic.queries._buckets import (
     window_buckets,
 )
 from products.engineering_analytics.backend.logic.queries._curated import CuratedGitHubSource, opt_float
-from products.engineering_analytics.backend.logic.queries._workflow_filters import window_pair_predicates
+from products.engineering_analytics.backend.logic.queries._workflow_filters import (
+    run_started_floor_constant,
+    window_pair_predicates,
+)
 
 # PRs merged this long before the scan window are outside lead-time attribution: the PR snapshot
 # holds every PR ever, so the deployed-PR join needs a floor. On a continuous-deploy repo a merge
@@ -156,10 +160,11 @@ _FREQUENCY_SERIES_SELECT = """
 # merged PR, and that PR's merged_at says which merges the deploy contains. The sanctioned
 # merge_commit_sha exception (SPEC §6): gated on merged_at (an open PR carries a throwaway
 # test-merge SHA) and collapsed to one row per deployment (min breaks a shared-SHA tie).
-# Deploys whose SHA is no PR's merge commit (direct pushes) resolve no head and attribute nothing.
+# Missing merge SHAs can resolve through the shared workflow-run attribution, restricted to the
+# same repo's default branch. Direct merge-SHA evidence wins over inferred commit-message evidence.
 # Bot merges stay in as heads on purpose: a bot's merge commit still names what a deploy contains.
 _DEPLOY_HEADS_CTE = """
-    deploy_heads AS (
+    merge_heads AS (
         SELECT
             d.id AS id,
             any(d.first_success_at) AS first_success_at,
@@ -171,6 +176,33 @@ _DEPLOY_HEADS_CTE = """
             AND hp.merged_at IS NOT NULL
             AND hp.merged_at >= {merge_scan_floor}
         GROUP BY d.id
+    ),
+    workflow_heads AS (
+        SELECT
+            d.id AS id,
+            any(d.first_success_at) AS first_success_at,
+            min(hp.merged_at) AS head_merged_at
+        FROM deploys AS d
+        INNER JOIN __RUNS_SOURCE__ AS r ON r.head_sha = d.sha
+        INNER JOIN __PR_SOURCE__ AS hp ON hp.number = r.commit_pr_number
+        WHERE d.first_success_at IS NOT NULL
+            AND d.sha != ''
+            AND d.id NOT IN (SELECT id FROM merge_heads)
+            AND r.run_started_at >= {merge_scan_floor}
+            AND NOT r.is_merge_queue
+            AND hp.default_branch != ''
+            AND r.head_branch = hp.default_branch
+            AND r.repo_owner = hp.repo_owner AND r.repo_name = hp.repo_name
+            AND hp.merged_at IS NOT NULL
+            AND hp.merged_at >= {merge_scan_floor}
+            AND hp.merged_at <= d.first_success_at
+        GROUP BY d.id
+        HAVING uniqExact(r.commit_pr_number) = 1
+    ),
+    deploy_heads AS (
+        SELECT id, first_success_at, head_merged_at FROM merge_heads
+        UNION ALL
+        SELECT id, first_success_at, head_merged_at FROM workflow_heads
     )
 """
 
@@ -550,9 +582,11 @@ def _query_lead_time(scan: _DoraScan, *, github_team: str | None, members_source
         scan.placeholders["github_team"] = ast.Constant(value=github_team)
         team_filter = _TEAM_FILTER.replace("__MEMBERS_SOURCE__", members_source)
     pr_source = scan.curated.pr_source()
-    attribution_ctes = f"{scan.deploys_cte}, {_DEPLOY_HEADS_CTE}, {_DEPLOYED_PRS_CTE}".replace(
-        "__PR_SOURCE__", pr_source
-    ).replace("__TEAM_FILTER__", team_filter)
+    attribution_ctes = (
+        f"{scan.deploys_cte}, {_DEPLOY_HEADS_CTE}, {_DEPLOYED_PRS_CTE}".replace("__PR_SOURCE__", pr_source)
+        .replace("__RUNS_SOURCE__", scan.curated.run_source(started_floor=True))
+        .replace("__TEAM_FILTER__", team_filter)
+    )
 
     windows = window_pair_predicates("deployed_at", date_to=scan.date_to)
     merged_window = window_pair_predicates("merged_at", date_to=scan.date_to)
@@ -640,6 +674,7 @@ def query_dora_overview(
         "environment_scan_floor": ast.Constant(value=_environment_scan_floor(date_from, end)),
         "deploy_scan_floor": ast.Constant(value=prev_from - _DEPLOY_SCAN_SLACK),
         "merge_scan_floor": ast.Constant(value=prev_from - _MERGE_SCAN_LOOKBACK),
+        "run_started_floor": run_started_floor_constant(prev_from - _MERGE_SCAN_LOOKBACK),
     }
     if date_to is not None:
         placeholders["date_to"] = ast.Constant(value=date_to)

--- a/products/engineering_analytics/backend/tests/test_dora.py
+++ b/products/engineering_analytics/backend/tests/test_dora.py
@@ -351,6 +351,7 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
             "open-sha",
             "future-sha",
             "backport-sha",
+            "inflight-sha",
             "missing-sha",
         ]
         started_at = "2026-01-12 08:01:00"
@@ -384,6 +385,10 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
                     # commit keeps the (#5) subject, so only the base ref separates it from a real
                     # default-branch merge.
                     (5, "2026-01-12 08:00:00", "release-1.2"),
+                    # Merged while the deployment was already running: every deployment here was
+                    # created 09:00 and succeeded 10:00, so this SHA was fixed before the merge and
+                    # the artifact cannot carry it.
+                    (6, "2026-01-12 09:30:00", "main"),
                 ]
             ],
             run_rows=[
@@ -408,6 +413,7 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
                         ("open-sha", 3, "main", "PostHog/posthog"),
                         ("future-sha", 4, "main", "PostHog/posthog"),
                         ("backport-sha", 5, "main", "PostHog/posthog"),
+                        ("inflight-sha", 6, "main", "PostHog/posthog"),
                     ],
                     start=1,
                 )

--- a/products/engineering_analytics/backend/tests/test_dora.py
+++ b/products/engineering_analytics/backend/tests/test_dora.py
@@ -22,10 +22,12 @@ from products.engineering_analytics.backend.logic.views.source_schema import (
     DEPLOYMENTS_COLUMNS,
     PULL_REQUESTS_COLUMNS,
     TEAM_MEMBERS_COLUMNS,
+    WORKFLOW_RUNS_COLUMNS,
 )
 from products.engineering_analytics.backend.presentation.serializers.dora import DoraEnvironmentQuerySerializer
 from products.engineering_analytics.backend.tests._github_fixtures import (
     _pr_row,
+    _run_row,
     connect_github_source_without_data,
     create_github_warehouse_table,
 )
@@ -134,6 +136,7 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
         deployment_rows: list[dict[str, Any]],
         status_rows: list[dict[str, Any]],
         pr_rows: list[dict[str, Any]],
+        run_rows: list[dict[str, Any]] | None = None,
         member_rows: list[dict[str, Any]] | None = None,
         nullable_status_timestamps: bool = True,
     ) -> CuratedGitHubSource:
@@ -149,6 +152,7 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
         }
         statuses_table = create_github_warehouse_table(self, "github_deployment_statuses", status_columns, status_rows)
         pr_table = create_github_warehouse_table(self, "github_pull_requests", PULL_REQUESTS_COLUMNS, pr_rows)
+        runs_table = create_github_warehouse_table(self, "github_workflow_runs", WORKFLOW_RUNS_COLUMNS, run_rows or [])
         members_table = (
             create_github_warehouse_table(self, "github_team_members", TEAM_MEMBERS_COLUMNS, member_rows)
             if member_rows is not None
@@ -158,14 +162,16 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
             team=team,
             tables=GitHubTables(
                 pull_requests=pr_table,
-                workflow_runs="unused",
+                workflow_runs=runs_table,
                 team_members=members_table,
                 deployments=deployments_table,
                 deployment_statuses=statuses_table,
             ),
         )
 
-    def _seeded_curated(self, member_rows: list[dict[str, Any]] | None) -> CuratedGitHubSource:
+    def _seeded_curated(
+        self, member_rows: list[dict[str, Any]] | None, *, merge_shas_available: bool = True
+    ) -> CuratedGitHubSource:
         # Window 2026-01-10 → 2026-01-20; previous window 2025-12-31 → 2026-01-10.
         # prod: d1 succeeds Jan 12, d2 fails Jan 13, d3 succeeds Jan 13 (d2's recovery, 2h later),
         # d5 succeeded in the previous window, d6 never reached an outcome (no status rows).
@@ -202,7 +208,8 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
                     0,
                     "2026-01-11 08:00:00",
                     merged_at="2026-01-12 08:00:00",
-                    merge_commit_sha="sha-a",
+                    merge_commit_sha="sha-a" if merge_shas_available else None,
+                    default_branch="main",
                 ),
                 _pr_row(
                     2,
@@ -211,7 +218,8 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
                     0,
                     "2026-01-12 08:00:00",
                     merged_at="2026-01-13 09:30:00",
-                    merge_commit_sha="sha-c",
+                    merge_commit_sha="sha-c" if merge_shas_available else None,
+                    default_branch="main",
                 ),
                 # Bot merge in the same slot as PR 1: must not move the lead-time figures.
                 _pr_row(3, "dependabot[bot]", "closed", 0, "2026-01-11 08:00:00", merged_at="2026-01-12 08:00:00"),
@@ -225,20 +233,41 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
                     0,
                     "2026-01-05 06:00:00",
                     merged_at="2026-01-05 08:00:00",
-                    merge_commit_sha="sha-e",
+                    merge_commit_sha="sha-e" if merge_shas_available else None,
+                    default_branch="main",
                 ),
                 # Merged after d1's head merge but before d1's success: the success-time rule would
                 # wrongly hand it d1 (1h lead); containment makes it wait for d3 (27h lead).
                 _pr_row(6, "carol", "closed", 0, "2026-01-11 09:00:00", merged_at="2026-01-12 09:00:00"),
             ],
+            run_rows=[
+                _run_row(
+                    run_id,
+                    "build",
+                    sha,
+                    "completed",
+                    "success",
+                    started_at,
+                    started_at,
+                    commit_message=f"Update component (#{number})",
+                    pr_number=4,
+                )
+                for run_id, sha, number, started_at in [
+                    (101, "sha-a", 2 if merge_shas_available else 1, "2026-01-12 08:01:00"),
+                    (102, "sha-a", 2 if merge_shas_available else 1, "2026-01-12 08:02:00"),
+                    (103, "sha-c", 2, "2026-01-13 09:31:00"),
+                    (104, "sha-e", 5, "2026-01-05 08:01:00"),
+                ]
+            ],
             member_rows=member_rows,
         )
 
-    def test_dora_over_seeded_deploys(self):
+    @parameterized.expand([(True,), (False,)])
+    def test_dora_over_seeded_deploys(self, merge_shas_available: bool) -> None:
         # Guards the freshly written HogQL end to end over the real nullable string schema:
         # production scoping, success/failure keying, the recovery self-join, the merged-PR
         # deploy attribution (bots excluded), and both zero-filled series.
-        curated = self._seeded_curated(member_rows=None)
+        curated = self._seeded_curated(member_rows=None, merge_shas_available=merge_shas_available)
         result = query_dora_overview(
             curated=curated,
             date_from=datetime(2026, 1, 10, tzinfo=UTC),
@@ -310,6 +339,75 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
         assert otd[datetime(2026, 1, 13)].max_seconds == 183600.0
         assert otm[datetime(2026, 1, 15)].deployed_pr_count == 0
         assert otd[datetime(2026, 1, 15)].p50_seconds is None
+
+    def test_workflow_fallback_rejects_unrelated_or_ambiguous_commit_evidence(self) -> None:
+        shas = ["feature-sha", "foreign-sha", "conflict-sha", "open-sha", "future-sha", "missing-sha"]
+        started_at = "2026-01-12 08:01:00"
+        curated = self._curated(
+            self.team,
+            deployment_rows=[
+                _deployment_row(index, sha, "prod", "2026-01-12 09:00:00", production=True)
+                for index, sha in enumerate(shas, start=1)
+            ],
+            status_rows=[
+                _status_row(index + 10, index, "success", "prod", "2026-01-12 10:00:00")
+                for index in range(1, len(shas) + 1)
+            ],
+            pr_rows=[
+                _pr_row(
+                    number,
+                    "alice",
+                    "closed",
+                    0,
+                    "2026-01-11 08:00:00",
+                    merged_at=merged_at,
+                    default_branch="main",
+                )
+                for number, merged_at in [
+                    (1, "2026-01-12 08:00:00"),
+                    (2, "2026-01-12 08:00:00"),
+                    (3, None),
+                    (4, "2026-01-19 08:00:00"),
+                ]
+            ],
+            run_rows=[
+                _run_row(
+                    index,
+                    "build",
+                    sha,
+                    "completed",
+                    "success",
+                    started_at,
+                    started_at,
+                    commit_message=f"Update component (#{number})",
+                    head_branch=branch,
+                    full_name=repo,
+                )
+                for index, (sha, number, branch, repo) in enumerate(
+                    [
+                        ("feature-sha", 1, "feature", "PostHog/posthog"),
+                        ("foreign-sha", 1, "main", "example/other"),
+                        ("conflict-sha", 1, "main", "PostHog/posthog"),
+                        ("conflict-sha", 2, "main", "PostHog/posthog"),
+                        ("open-sha", 3, "main", "PostHog/posthog"),
+                        ("future-sha", 4, "main", "PostHog/posthog"),
+                    ],
+                    start=1,
+                )
+            ],
+        )
+
+        result = query_dora_overview(
+            curated=curated,
+            date_from=datetime(2026, 1, 10, tzinfo=UTC),
+            date_to=datetime(2026, 1, 20, tzinfo=UTC),
+        )
+
+        assert result.deployment_count == len(shas)
+        assert result.deployed_pr_count == 0
+        assert result.median_open_to_deploy_seconds is None
+        for series in [result.open_to_deploy_series, result.open_to_merge_series, result.merge_to_deploy_series]:
+            assert all(bucket.deployed_pr_count == 0 for bucket in series)
 
     def test_restore_recovery_excluded_when_it_lands_after_date_to(self):
         # d2 fails Jan 13 10:00, recovers via d3's success at Jan 13 12:00 (see _seeded_curated).

--- a/products/engineering_analytics/backend/tests/test_dora.py
+++ b/products/engineering_analytics/backend/tests/test_dora.py
@@ -352,6 +352,7 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
             "future-sha",
             "backport-sha",
             "inflight-sha",
+            "reland-sha",
             "missing-sha",
         ]
         started_at = "2026-01-12 08:01:00"
@@ -373,22 +374,27 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
                     0,
                     "2026-01-11 08:00:00",
                     merged_at=merged_at,
+                    merge_commit_sha=merge_commit_sha,
                     base_ref=base_ref,
                     default_branch="main",
                 )
-                for number, merged_at, base_ref in [
-                    (1, "2026-01-12 08:00:00", "main"),
-                    (2, "2026-01-12 08:00:00", "main"),
-                    (3, None, "main"),
-                    (4, "2026-01-19 08:00:00", "main"),
+                for number, merged_at, base_ref, merge_commit_sha in [
+                    (1, "2026-01-12 08:00:00", "main", None),
+                    (2, "2026-01-12 08:00:00", "main", None),
+                    (3, None, "main", None),
+                    (4, "2026-01-19 08:00:00", "main", None),
                     # Merged into a release branch, then cherry-picked onto main: the forward-ported
                     # commit keeps the (#5) subject, so only the base ref separates it from a real
                     # default-branch merge.
-                    (5, "2026-01-12 08:00:00", "release-1.2"),
+                    (5, "2026-01-12 08:00:00", "release-1.2", None),
                     # Merged while the deployment was already running: every deployment here was
                     # created 09:00 and succeeded 10:00, so this SHA was fixed before the merge and
                     # the artifact cannot carry it.
-                    (6, "2026-01-12 09:30:00", "main"),
+                    (6, "2026-01-12 09:30:00", "main", None),
+                    # Landed its own merge commit, so the (#7) subject on a DIFFERENT default-branch
+                    # commit cannot be its merge: the snapshot already says where PR 7 landed, and
+                    # it is not the deployed SHA.
+                    (7, "2026-01-12 08:00:00", "main", "pr-7-merge-sha"),
                 ]
             ],
             run_rows=[
@@ -414,6 +420,7 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
                         ("future-sha", 4, "main", "PostHog/posthog"),
                         ("backport-sha", 5, "main", "PostHog/posthog"),
                         ("inflight-sha", 6, "main", "PostHog/posthog"),
+                        ("reland-sha", 7, "main", "PostHog/posthog"),
                     ],
                     start=1,
                 )

--- a/products/engineering_analytics/backend/tests/test_dora.py
+++ b/products/engineering_analytics/backend/tests/test_dora.py
@@ -353,6 +353,7 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
             "backport-sha",
             "inflight-sha",
             "reland-sha",
+            "workflow-before-merge-sha",
             "missing-sha",
         ]
         started_at = "2026-01-12 08:01:00"
@@ -395,6 +396,7 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
                     # commit cannot be its merge: the snapshot already says where PR 7 landed, and
                     # it is not the deployed SHA.
                     (7, "2026-01-12 08:00:00", "main", "pr-7-merge-sha"),
+                    (8, "2026-01-12 08:30:00", "main", None),
                 ]
             ],
             run_rows=[
@@ -424,6 +426,19 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
                     ],
                     start=1,
                 )
+            ]
+            + [
+                _run_row(
+                    10,
+                    "build",
+                    "workflow-before-merge-sha",
+                    "completed",
+                    "success",
+                    "2026-01-12 09:45:00",
+                    "2026-01-12 09:45:00",
+                    commit_message="Update component (#8)",
+                )
+                | {"created_at": "2026-01-12 08:01:00"}
             ],
         )
 

--- a/products/engineering_analytics/backend/tests/test_dora.py
+++ b/products/engineering_analytics/backend/tests/test_dora.py
@@ -209,6 +209,7 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
                     "2026-01-11 08:00:00",
                     merged_at="2026-01-12 08:00:00",
                     merge_commit_sha="sha-a" if merge_shas_available else None,
+                    base_ref="main",
                     default_branch="main",
                 ),
                 _pr_row(
@@ -219,6 +220,7 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
                     "2026-01-12 08:00:00",
                     merged_at="2026-01-13 09:30:00",
                     merge_commit_sha="sha-c" if merge_shas_available else None,
+                    base_ref="main",
                     default_branch="main",
                 ),
                 # Bot merge in the same slot as PR 1: must not move the lead-time figures.
@@ -234,6 +236,7 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
                     "2026-01-05 06:00:00",
                     merged_at="2026-01-05 08:00:00",
                     merge_commit_sha="sha-e" if merge_shas_available else None,
+                    base_ref="main",
                     default_branch="main",
                 ),
                 # Merged after d1's head merge but before d1's success: the success-time rule would
@@ -341,7 +344,15 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
         assert otd[datetime(2026, 1, 15)].p50_seconds is None
 
     def test_workflow_fallback_rejects_unrelated_or_ambiguous_commit_evidence(self) -> None:
-        shas = ["feature-sha", "foreign-sha", "conflict-sha", "open-sha", "future-sha", "missing-sha"]
+        shas = [
+            "feature-sha",
+            "foreign-sha",
+            "conflict-sha",
+            "open-sha",
+            "future-sha",
+            "backport-sha",
+            "missing-sha",
+        ]
         started_at = "2026-01-12 08:01:00"
         curated = self._curated(
             self.team,
@@ -361,13 +372,18 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
                     0,
                     "2026-01-11 08:00:00",
                     merged_at=merged_at,
+                    base_ref=base_ref,
                     default_branch="main",
                 )
-                for number, merged_at in [
-                    (1, "2026-01-12 08:00:00"),
-                    (2, "2026-01-12 08:00:00"),
-                    (3, None),
-                    (4, "2026-01-19 08:00:00"),
+                for number, merged_at, base_ref in [
+                    (1, "2026-01-12 08:00:00", "main"),
+                    (2, "2026-01-12 08:00:00", "main"),
+                    (3, None, "main"),
+                    (4, "2026-01-19 08:00:00", "main"),
+                    # Merged into a release branch, then cherry-picked onto main: the forward-ported
+                    # commit keeps the (#5) subject, so only the base ref separates it from a real
+                    # default-branch merge.
+                    (5, "2026-01-12 08:00:00", "release-1.2"),
                 ]
             ],
             run_rows=[
@@ -391,6 +407,7 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
                         ("conflict-sha", 2, "main", "PostHog/posthog"),
                         ("open-sha", 3, "main", "PostHog/posthog"),
                         ("future-sha", 4, "main", "PostHog/posthog"),
+                        ("backport-sha", 5, "main", "PostHog/posthog"),
                     ],
                     start=1,
                 )


### PR DESCRIPTION
## Problem

Engineering Analytics users see empty lead-time panels when GitHub omits merge SHAs from synced PRs.

Related: #95629. The connector compatibility issue remains open.

## Changes

- Health recovers its open-to-deploy card and three boxplots through the existing workflow-run `commit_pr_number` fallback.
- The fallback requires an exact deployed commit, the same repository's default branch, and an unambiguous merged PR.
- Existing merge-SHA matches retain priority.
- Mechanical: the query reuses the curated workflow builder and its bounded scan.

Before:

```mermaid
flowchart LR
    D[Deployment SHA] --> P[PR merge SHA] --> L[Lead-time panels]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class D,L phYellow;
    class P phGray;
```

After:

```mermaid
flowchart LR
    D[Deployment SHA] --> P[PR merge SHA]
    D -->|Missing merge match| W[Matching workflow commit]
    W --> N[Existing commit PR number]
    P --> L[Lead-time panels]
    N --> L
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class D,L phYellow;
    class P,W,N phGray;
```

## How did you test this code?

- Extended the existing duration assertions to cover absent merge SHAs, duplicate workflow runs, and current/previous periods.
- Added rejection coverage for conflicting merge SHAs, non-default PR targets, and merges after workflow or deployment creation.
- The rerun regression uses original workflow creation time; substituting run start causes false attribution.
- Local pytest stopped during setup because the configured database hostname `db` does not resolve. The database-backed suite runs in CI.
- Read-only HogQL execution of the actual query builders on synthetic fixtures returned the results below.

<details>
<summary>Synthetic query validation</summary>

Both merge-SHA and workflow-fallback paths returned:

| PR | Merge to deploy (seconds) | Open to deploy (seconds) |
| --- | --- | --- |
| 1 | 7200 | 93600 |
| 2 | 9000 | 100800 |
| 5 | 7200 | 14400 |
| 6 | 97200 | 183600 |

The unrelated/ambiguous evidence fixture returned zero attributed PRs.

</details>

The change updates backend data retrieval. No frontend layout changes; the updated page has not been browser-tested against a local backend.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The product README explains the fallback and its coverage limits.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the requested reuse. Skills: writing-clickhouse-queries, writing-tests, writing-code-comments, running-ci-preflight, writing-pr-descriptions, and pr-shepherd.

The focused duplicate search found no open Engineering Analytics deployment fix. Fixtures extend existing repository examples with synthetic workflow evidence.
