### PR TITLE
fix(data-imports): survive a team deleted mid table-size calculation

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/calculate_table_size.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/calculate_table_size.py
@@ -1,7 +1,7 @@
 import dataclasses
 
 from django.conf import settings
-from django.db import close_old_connections
+from django.db import DatabaseError, close_old_connections
 
 from structlog.contextvars import bind_contextvars
 from temporalio import activity
@@ -71,13 +71,28 @@ def calculate_table_size_activity(inputs: CalculateTableSizeActivityInputs) -> N
     logger.debug(f"Table size delta in MiB = {table_size_delta:.2f}")
 
     job.storage_delta_mib = table_size_delta
-    job.save(update_fields=["storage_delta_mib", "updated_at"])
+    try:
+        job.save(update_fields=["storage_delta_mib", "updated_at"])
+    except DatabaseError:
+        # get_size_of_folder() (an S3 listing) can run long enough for the job's team to be
+        # deleted meanwhile, cascading away this row before the UPDATE lands. Not a defect —
+        # exit the same way the DoesNotExist checks above do.
+        if not ExternalDataJob.objects.filter(id=job.id).exists():
+            logger.debug(f"Job was deleted while calculating table size, exiting early. Job id = {job.id}")
+            return
+        raise
 
     table.size_in_s3_mib = total_mib
-    # Scoped to the field this activity actually changes: an unscoped save() compares this
-    # possibly-stale in-memory url_pattern (table was loaded before the potentially long
-    # get_size_of_folder() call above) against the row's current DB value, and a credential-less
-    # table with no other change in flight trips the url_pattern guard on that false mismatch.
-    table.save(update_fields=["size_in_s3_mib", "updated_at"])
+    try:
+        # Scoped to the field this activity actually changes: an unscoped save() compares this
+        # possibly-stale in-memory url_pattern (table was loaded before the potentially long
+        # get_size_of_folder() call above) against the row's current DB value, and a credential-less
+        # table with no other change in flight trips the url_pattern guard on that false mismatch.
+        table.save(update_fields=["size_in_s3_mib", "updated_at"])
+    except DatabaseError:
+        if not DataWarehouseTable.objects.filter(id=table.id).exists():
+            logger.debug(f"Table was deleted while calculating table size, exiting early. Table id = {table.id}")
+            return
+        raise
 
     logger.debug("Table model updated")

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_calculate_table_size.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_calculate_table_size.py
@@ -63,3 +63,25 @@ class TestCalculateTableSizeActivity:
         table.refresh_from_db()
         assert table.size_in_s3_mib == 12.5
         assert table.url_pattern == "https://posthog-owned.example/team/stripe_charge_repartitioned"
+
+    def test_survives_a_concurrent_team_deletion(self) -> None:
+        # get_size_of_folder() (an S3 listing) can take long enough for the team owning this job
+        # to be deleted meanwhile, cascading away the job and table rows before this activity's
+        # own save() runs. Django's update_fields save() used to surface that as an unhandled
+        # DatabaseError ("Save with update_fields did not affect any rows") instead of the same
+        # clean early exit the DoesNotExist checks give a schema/job deleted before this activity
+        # even starts.
+        team = _team()
+        schema, table, job = _schema_table_job(team)
+
+        def _slow_listing(_folder: str) -> float:
+            team.delete()
+            return 12.5
+
+        with patch.object(calc, "get_size_of_folder", side_effect=_slow_listing):
+            calculate_table_size_activity(
+                CalculateTableSizeActivityInputs(team_id=team.id, schema_id=str(schema.id), job_id=str(job.id))
+            )
+
+        assert not ExternalDataJob.objects.filter(id=job.id).exists()
+        assert not DataWarehouseTable.objects.filter(id=table.id).exists()


### PR DESCRIPTION
## Problem

A data warehouse sync's trailing storage-size bookkeeping can crash with an unhandled `DatabaseError` if the owning team is deleted while it runs, surfaced by [this error tracking issue](https://us.posthog.com/project/2/error_tracking/01a07298-aef4-7a31-b8cf-01ee975fed2b).

`calculate_table_size_activity` reads the job and table rows, then lists the table's S3 folder (can take a while), then saves the computed size back onto those rows. Deleting a team cascades away its `ExternalDataJob` and `DataWarehouseTable` rows. If that happens during the S3 listing, the later `save(update_fields=...)` call finds 0 matching rows and Django raises `DatabaseError: Save with update_fields did not affect any rows`, instead of the clean early exit the function already uses when the job or schema is missing at the start.

## Changes

- `calculate_table_size_activity` now checks whether the job/table row still exists before treating a failed `update_fields` save as an error, exiting the same way the existing `DoesNotExist` checks do at the top of the function.
- Mechanical: no change to the happy path or to any other activity.

## How did you test this code?

Extended `TestCalculateTableSizeActivity` with `test_survives_a_concurrent_team_deletion`, which deletes the owning team mid-`get_size_of_folder()` and asserts the activity exits cleanly instead of raising. Ran both tests in the class locally; both pass.

Not run: the wider `warehouse_sources` suite, CI covers that.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None; no user-facing behavior or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a production error tracking webhook by Claude Code. Read the issue's stack trace and sampled event via PostHog's error-tracking MCP tools, then traced the call path in `products/warehouse_sources/backend/temporal/data_imports/workflow_activities/calculate_table_size.py` and its Temporal retry policy to confirm the race (team deletion cascading mid-activity) and that it self-heals on retry via the existing `DoesNotExist` checks, before deciding a small defensive fix was worth landing to avoid the wasted retry and the error-tracking noise. No open PR addressed this (searched by exception type, message, and module path).

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
