### PR TITLE
feat(desktop): name the cohorts a cohort's criteria reference

### DIFF
--- a/products/desktop/packages/api-client/src/evidence-previews.test.ts
+++ b/products/desktop/packages/api-client/src/evidence-previews.test.ts
@@ -611,37 +611,41 @@ describe("evidence preview shaping", () => {
     ]);
   });
 
-  it("renders negated criteria as their negative meaning", () => {
-    const sections = cohortCriteriaSection({
-      properties: {
-        type: "AND",
-        values: [
-          {
-            type: "AND",
-            values: [
-              {
-                type: "behavioral",
-                value: "performed_event",
-                key: "checkout",
-                negation: true,
-              },
-              {
-                type: "cohort",
-                value: "Power users",
-                negation: true,
-              },
-              {
-                type: "person",
-                key: "email",
-                operator: "icontains",
-                value: "@example.com",
-                negation: true,
-              },
-            ],
-          },
-        ],
+  it("renders negated criteria and resolved cohort names", () => {
+    const sections = cohortCriteriaSection(
+      {
+        properties: {
+          type: "AND",
+          values: [
+            {
+              type: "AND",
+              values: [
+                {
+                  type: "behavioral",
+                  value: "performed_event",
+                  key: "checkout",
+                  negation: true,
+                },
+                {
+                  type: "cohort",
+                  value: 42,
+                  negation: true,
+                },
+                { type: "cohort", value: 77 },
+                {
+                  type: "person",
+                  key: "email",
+                  operator: "icontains",
+                  value: "@example.com",
+                  negation: true,
+                },
+              ],
+            },
+          ],
+        },
       },
-    });
+      new Map([["42", "Power users"]]),
+    );
     expect(sections).toEqual([
       {
         title: "Membership criteria",
@@ -649,7 +653,7 @@ describe("evidence preview shaping", () => {
           {
             label: "Criteria",
             value:
-              "Did not complete checkout and Is not in cohort Power users and email does not contain @example.com",
+              "Did not complete checkout and Is not in cohort Power users and Is in cohort 77 and email does not contain @example.com",
           },
         ],
       },

--- a/products/desktop/packages/api-client/src/evidence-previews.ts
+++ b/products/desktop/packages/api-client/src/evidence-previews.ts
@@ -1434,12 +1434,42 @@ function asCount(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-function describeCohortCriterion(criterion: QueryRecord): string | null {
+/** Cohort ids referenced by a cohort's criteria, so the caller can resolve their names. */
+export function referencedCohortIds(filters: unknown): string[] {
+  const ids = new Set<string>();
+  for (const group of criteriaGroups(filters)) {
+    for (const criterion of asRecords(group.values)) {
+      const id =
+        criterion.type === "cohort" ? conciseValue(criterion.value) : null;
+      if (id) ids.add(id);
+    }
+  }
+  return [...ids];
+}
+
+function asRecords(value: unknown): QueryRecord[] {
+  return (Array.isArray(value) ? value : []).filter(isRecord);
+}
+
+function criteriaGroups(filters: unknown): QueryRecord[] {
+  const properties =
+    isRecord(filters) && isRecord(filters.properties)
+      ? filters.properties
+      : null;
+  return asRecords(properties?.values);
+}
+
+function describeCohortCriterion(
+  criterion: QueryRecord,
+  cohortNames: ReadonlyMap<string, string>,
+): string | null {
   const type = String(criterion.type ?? "");
   if (type === "behavioral") return describeBehavioralCriterion(criterion);
   const negated = criterion.negation === true;
-  if (type === "cohort")
-    return `Is ${negated ? "not " : ""}in cohort ${conciseValue(criterion.value) ?? "?"}`;
+  if (type === "cohort") {
+    const id = conciseValue(criterion.value) ?? "?";
+    return `Is ${negated ? "not " : ""}in cohort ${cohortNames.get(id) ?? id}`;
+  }
   if (type === "static-cohort")
     return `Is ${negated ? "not " : ""}in a static cohort`;
   if (type === "person" || type === "event" || type === "group") {
@@ -1470,19 +1500,16 @@ function describeCohortCriterion(criterion: QueryRecord): string | null {
  */
 export function cohortCriteriaSection(
   filters: unknown,
+  cohortNames: ReadonlyMap<string, string> = new Map(),
 ): EvidenceDetailSection[] {
-  const properties =
+  const groups = criteriaGroups(filters);
+  const outerAny =
     isRecord(filters) && isRecord(filters.properties)
-      ? filters.properties
-      : null;
-  const groups = (
-    Array.isArray(properties?.values) ? properties.values : []
-  ).filter(isRecord);
-  const outerAny = properties?.type === "OR";
+      ? filters.properties.type === "OR"
+      : false;
   const fields = groups.flatMap((group, index) => {
-    const criteria = (Array.isArray(group.values) ? group.values : [])
-      .filter(isRecord)
-      .map(describeCohortCriterion)
+    const criteria = asRecords(group.values)
+      .map((criterion) => describeCohortCriterion(criterion, cohortNames))
       .filter((line): line is string => line !== null);
     if (criteria.length === 0) return [];
     const joiner = group.type === "OR" ? " or " : " and ";
@@ -1495,7 +1522,10 @@ export function cohortCriteriaSection(
   return detailSection("Membership criteria", fields);
 }
 
-export function shapeCohortPreview(cohort: Schemas.Cohort): EvidencePreview {
+export function shapeCohortPreview(
+  cohort: Schemas.Cohort,
+  cohortNames: ReadonlyMap<string, string> = new Map(),
+): EvidencePreview {
   const detail =
     typeof cohort.count === "number"
       ? count(cohort.count, "person", "people")
@@ -1545,7 +1575,7 @@ export function shapeCohortPreview(cohort: Schemas.Cohort): EvidencePreview {
         ],
         ["Created", cohort.created_at ? formatDay(cohort.created_at) : null],
       ]),
-      ...cohortCriteriaSection(cohort.filters),
+      ...cohortCriteriaSection(cohort.filters, cohortNames),
     ],
   };
 }

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -88,6 +88,7 @@ import {
   formatDay,
   gridRows,
   hogqlEscape,
+  referencedCohortIds,
   shapeActionPreview,
   shapeCohortPreview,
   shapeDashboardPreview,
@@ -1151,6 +1152,7 @@ function optionalString(value: unknown): string | null {
 const DRF_GENERIC_NOT_FOUND_DETAIL = "Not found.";
 /** One request per targeted distinct id; flags listing more stay raw past this. */
 const MAX_RESOLVED_FLAG_PEOPLE = 10;
+const MAX_RESOLVED_COHORTS = 10;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -6934,10 +6936,30 @@ export class PostHogAPIClient {
    * back to a static reference. Query-backed kinds (hogql, insight) resolve
    * in the UI instead, where chart shaping lives.
    */
+  /** Names of the cohorts a cohort's criteria reference, so the criteria read as prose. */
+  private async resolveCohortNames(
+    projectId: string,
+    filters: unknown,
+  ): Promise<Map<string, string>> {
+    const ids = referencedCohortIds(filters).slice(0, MAX_RESOLVED_COHORTS);
+    const entries = await Promise.all(
+      ids.map((id) =>
+        this.api
+          .get("/api/projects/{project_id}/cohorts/{id}/", {
+            path: { project_id: projectId, id: Number(id) },
+          })
+          .then((cohort) => [id, cohort.name ?? id] as const)
+          .catch(() => null),
+      ),
+    );
+    return new Map(entries.filter((entry) => entry !== null));
+  }
+
   /**
    * People behind the distinct ids a flag targets, keyed by distinct id. A
    * lookup that fails leaves its id unresolved so the raw id still renders.
    */
+
   private async resolveFlagPeople(
     projectId: string,
     flag: Schemas.FeatureFlag,
@@ -7286,7 +7308,10 @@ export class PostHogAPIClient {
           "/api/projects/{project_id}/cohorts/{id}/",
           { path: { project_id: projectId, id: numericId } },
         );
-        return shapeCohortPreview(cohort);
+        return shapeCohortPreview(
+          cohort,
+          await this.resolveCohortNames(projectId, cohort.filters),
+        );
       }
       case "action": {
         if (numericId === null) return null;

--- a/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPageView.stories.tsx
+++ b/products/desktop/packages/ui/src/features/posthog-objects/PostHogObjectPageView.stories.tsx
@@ -304,6 +304,43 @@ export const Survey: Story = {
   },
 };
 
+export const Cohort: Story = {
+  args: {
+    objectKind: "cohort",
+    objectId: "142",
+    fallbackName: "Beta testers",
+    url: "https://us.posthog.com/project/2/cohorts/142",
+    occurrenceCount: 1,
+    state: "ready",
+    preview: {
+      title: "Beta testers",
+      detail: "1,204 people",
+      facts: ["Dynamic"],
+      stats: [
+        { label: "People", value: "1.2K" },
+        { label: "Type", value: "Dynamic" },
+        { label: "Last calculated", value: "Aug 16" },
+      ],
+      sections: [
+        {
+          title: "Membership criteria",
+          fields: [
+            {
+              label: "Group 1",
+              value:
+                "Is in cohort Power users and Completed checkout in the last 30 days",
+            },
+            {
+              label: "Group 2 (or)",
+              value: "Is not in cohort Churn risk and plan is pro",
+            },
+          ],
+        },
+      ],
+    },
+  },
+};
+
 export const Experiment: Story = {
   args: {
     objectKind: "experiment",


### PR DESCRIPTION
## Problem

On the desktop app's cohort page, membership criteria that reference another cohort show its numeric id, for example "Is in cohort 42". A person cannot tell which cohort that is without opening PostHog.

## Changes

- Membership criteria now name the referenced cohort: "Is in cohort Power users".
- The cohort page fetches each referenced cohort, capped at ten. A failed lookup keeps the id in place, so the criteria still render.
- Mechanical: `cohortCriteriaSection` and `shapeCohortPreview` take a name map, and a new `referencedCohortIds` helper walks the criteria.

Before, the same criteria read "Is in cohort 42 and ..." and "Is not in cohort 57 and ...".

![cohort-page](https://raw.githubusercontent.com/PostHog/pr-assets/d11b27ca029c48d5f4e98264bd30e25bc100b8bb/2026/09/c444b6bf-b0c7-4b33-894c-c9e142ff1b09.png)

## How did you test this code?

- The existing negated-criteria test now uses cohort ids with a name map and one unresolved id. It catches a regression where a referenced cohort renders as its id, or an unresolved id renders as empty.
- The screenshot above comes from a new Storybook story with invented fixture data.
- Not run: the app against a live backend.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

Built in a PostHog Desktop task as the top layer of a stack on #93987. Kept to name resolution; the cohort criteria were already prose. Skills invoked: stacking-prs, writing-tests, writing-pr-descriptions.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

