### PR TITLE
fix(mysql): retry a vtgate dial timeout hit during metadata discovery

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -528,15 +528,17 @@ def _is_transient_packet_sequence_error(e: BaseException) -> bool:
     return any(_PACKET_SEQUENCE_ERROR_PHRASE in str(arg) for arg in e.args)
 
 
-# Vitess/PlanetScale vtgate surfaces a backend tablet it can't reach at connect time as pymysql
+# Vitess/PlanetScale vtgate surfaces a backend tablet it can't reach as pymysql
 # OperationalError(1815, 'internal connection error: dial tcp <addr>: connect: connection timed
 # out, after N attempts, reqid=...'): the vtgate handshake succeeds but dialing the tablet behind
 # it times out — a failover, a restart, or a momentary network blip that a fresh attempt recovers
 # from. 1815 is MySQL's generic ER_INTERNAL_ERROR, so key on the Go-network `dial tcp` +
 # `connection timed out` signature (no plain MySQL error carries the `dial tcp` token) rather than
-# the bare code; the volatile tablet address, attempt count, and reqid stay untouched. This is the
-# connect-time sibling of the `code = Unavailable` tablet-unavailable case, which instead lands on
-# the first query after connect (see `_is_transient_tablet_unavailable`).
+# the bare code; the volatile tablet address, attempt count, and reqid stay untouched. Like the
+# `code = Unavailable` tablet-unavailable case (see `_is_transient_tablet_unavailable`), this can
+# land either at connect time or on the first query against a freshly opened connection (e.g.
+# `get_table_metadata`'s information_schema lookup), so both `_connect_with_transient_retry` and
+# `_retry_on_transient_tablet_unavailable` check it.
 _VITESS_DIAL_TOKEN = "dial tcp"
 _VITESS_DIAL_TIMEOUT_TOKEN = "connection timed out"
 
@@ -712,8 +714,8 @@ def _retry_on_transient_tablet_unavailable(
     whole operation (which reopens the connection) with a bounded backoff instead of
     failing sync setup on the first blip and surfacing it as captured error-tracking
     noise. Non-transient errors re-raise immediately — the predicates only match the gRPC
-    `Unavailable` status, a mid-reparent primary, or a plain peer-reset connection drop,
-    all self-healing.
+    `Unavailable` status, a mid-reparent primary, a dial-timeout reaching a backend tablet,
+    a TiProxy failover, or a plain peer-reset connection drop, all self-healing.
     """
     attempt = 0
     while True:
@@ -724,6 +726,7 @@ def _retry_on_transient_tablet_unavailable(
             if attempt >= max_attempts or not (
                 _is_transient_tablet_unavailable(e)
                 or _is_transient_vitess_reparent(e)
+                or _is_transient_vitess_dial_timeout(e)
                 or _is_transient_tiproxy_unavailable(e)
                 or _is_transient_metadata_query_reset(e)
             ):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -1753,6 +1753,22 @@ class TestRetryOnTransientTabletUnavailable:
 
         assert operation.call_count == 2
 
+    def test_retries_vitess_dial_timeout_then_succeeds(self, mocker):
+        # A vtgate dial timeout to a backend tablet (error 1815) can land on a metadata query
+        # against an already-open connection, not just at connect time — `connect()` succeeding
+        # doesn't retry it, so this wrapper must.
+        mocker.patch("products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.time.sleep")
+        dial_timeout = pymysql.err.OperationalError(
+            1815,
+            "internal connection error: dial tcp 10.0.0.1:8083: connect: connection timed out, "
+            "after 1 attempts, reqid=csYTzBMNB2hB8111yzcg4A",
+        )
+        operation = MagicMock(side_effect=[dial_timeout, "ok"])
+
+        assert _retry_on_transient_tablet_unavailable(operation, MagicMock()) == "ok"
+
+        assert operation.call_count == 2
+
     def test_gives_up_after_max_attempts(self, mocker):
         mocker.patch("products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.time.sleep")
         operation = MagicMock(side_effect=self._unavailable())


### PR DESCRIPTION
## Problem

A MySQL sync backed by Vitess/PlanetScale can fail and surface an exception in error tracking even though the underlying condition is a transient network blip that should have self-healed on retry.

`OperationalError(1815, 'internal connection error: dial tcp <addr>: connect: connection timed out, ...')` is a vtgate reporting it timed out dialing a backend tablet. The code already retries this error when it happens at connect time, but the same error can also land on the first metadata query run against a connection that already connected successfully, and that path had no retry.

## Changes

- `_retry_on_transient_tablet_unavailable` (used by `MySQLImplementation.build_pipeline`'s metadata-discovery step, e.g. `get_table_metadata`) now also retries the vtgate dial-timeout error, matching the retry the connect path already had.
- Comments updated to reflect that the dial-timeout error can land at either connect time or on the first post-connect query, not only at connect time as previously documented.

## How did you test this code?

Added `test_retries_vitess_dial_timeout_then_succeeds` to `TestRetryOnTransientTabletUnavailable`, covering the metadata-discovery path that had no coverage for this error before. Ran the full `test_mysql.py` suite locally (291 passed) and `ruff check`/`ruff format --check` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal retry classification, no user-facing or documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Investigated via PostHog error tracking (issue `01a072bc-78c9-7ce3-b7f2-c645e7d73169`, MySQL source, `mysql.py`), which pointed at `get_table_metadata` as the raising frame rather than the connect path.
- No duplicate found: searched open PRs by exception type, message phrase, and module path (`gh pr list --state open --search ...`, and the maintainer's own open PRs), nothing addresses this.
- Skills invoked: `writing-tests`, `writing-pr-descriptions`.
