### PR TITLE
fix(event-definitions): trial a project-first search plan

### DIFF
--- a/docs/internal/taxonomic-filter-search.md
+++ b/docs/internal/taxonomic-filter-search.md
@@ -15,3 +15,13 @@ The legacy implementation separates these requests in `infiniteListLogic.ts`; th
 The event definitions API counts matching rows separately and applies `LIMIT` and `OFFSET` in PostgreSQL. The count describes all matches, including matches outside the requested page. Explicit ordering uses the project-unique event name as a final tie-breaker so equal timestamps do not cause skipped or repeated results between pages.
 
 Tag-filtered requests retain ORM pagination after resolving matching event IDs. Both paths preserve the same response fields and project scope, including legacy definitions whose `project_id` is null.
+
+## Project-first event search trial
+
+The `event-definition-project-first-search` flag selects a project-first SQL plan for nonempty event searches. Its distinct ID is the project ID as a string. Evaluation is local and sends no flag events; an unavailable or disabled flag keeps the default plan. Empty searches retain the default plan without evaluating the flag.
+
+The trial puts the project restriction inside an `OFFSET 0` subquery. This prevents PostgreSQL from pushing substring matching into the global trigram index. It streams the project's base rows once, then joins enterprise metadata for matching rows. The count and page use the same source and filters. No migration is required.
+
+This is a workload-dependent tradeoff: globally common terms can require expensive trigram posting-list reads, while globally rare terms can be much faster through that index than through a large project scan. Keep the flag disabled by default and compare a small project cohort with a control before expanding it.
+
+Validate both count and ordered pages for case-insensitive and multi-term searches, empty results, legacy project scope, hidden/stale/verified filters, tags, and pagination boundaries. Compare `EXPLAIN (ANALYZE, BUFFERS)` for count plus page with alternating baseline and trial runs across small and large projects, selective and common terms, and warm and cold cache conditions. Record PostgreSQL version and cache limitations. In the canary, compare endpoint p50/p95, error rates, database time and read blocks by project size and search type; roll back the flag if latency or database load regresses.

--- a/ee/api/test/test_event_definition.py
+++ b/ee/api/test/test_event_definition.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from django.utils import timezone
 
+import pydantic.v1  # noqa: F401
 import dateutil.parser
 from parameterized import parameterized
 from rest_framework import status
@@ -23,6 +24,7 @@ from ee.models.event_definition import EnterpriseEventDefinition
 from ee.models.license import License, LicenseManager
 
 
+# Pydantic v1 must define its date subclasses before freeze_time replaces datetime.date.
 @freeze_time("2020-01-02")
 class TestEventDefinitionEnterpriseAPI(APIBaseTest):
     demo_team: Team = None  # type: ignore
@@ -178,7 +180,7 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
 
         response = self.client.get(
             "/api/projects/@current/event_definitions/",
-            data={"search": "event", "tags": '["deprecated"]', "limit": 1, "offset": 1, "ordering": "name"},
+            data={"search": "event", "tags": '["deprecated"]', "limit": "1", "offset": "1", "ordering": "name"},
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["count"] == 2

--- a/ee/api/test/test_event_definition.py
+++ b/ee/api/test/test_event_definition.py
@@ -130,6 +130,7 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
         self.assertEqual(enterprise_event.team.id, event.team.id)  # type: ignore
 
     def test_search_event_definition(self):
+        self.enterContext(patch("posthog.api.event_definition.posthoganalytics.feature_enabled", return_value=True))
         super(LicenseManager, cast(LicenseManager, License.objects)).create(
             plan="enterprise", valid_until=datetime(2500, 1, 19, 3, 14, 7)
         )
@@ -175,6 +176,14 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
         response_data = response.json()
         self.assertEqual(len(response_data["results"]), 0)
 
+        response = self.client.get(
+            "/api/projects/@current/event_definitions/",
+            data={"search": "event", "tags": '["deprecated"]', "limit": 1, "offset": 1, "ordering": "name"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["count"] == 2
+        assert [row["name"] for row in response.json()["results"]] == ["regular event"]
+
     @parameterized.expand(
         [
             # $pageview is a core PostHog event, so it's treated as verified
@@ -186,6 +195,7 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
     def test_filter_event_definitions_by_verified(
         self, _name: str, verified_param: Optional[str], expected_names: list[str]
     ):
+        self.enterContext(patch("posthog.api.event_definition.posthoganalytics.feature_enabled", return_value=True))
         super(LicenseManager, cast(LicenseManager, License.objects)).create(
             plan="enterprise", valid_until=datetime(2500, 1, 19, 3, 14, 7)
         )
@@ -195,14 +205,15 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
                 verified=event_definition["verified"] or False
             )
 
-        url = "/api/projects/@current/event_definitions/"
-        if verified_param is not None:
-            url += f"?verified={verified_param}"
-
-        response = self.client.get(url)
-
-        assert response.status_code == status.HTTP_200_OK
-        assert sorted([r["name"] for r in response.json()["results"]]) == expected_names
+        for search in ("", "e"):
+            with self.subTest(search=search):
+                params = {"search": search}
+                if verified_param is not None:
+                    params["verified"] = verified_param
+                response = self.client.get("/api/projects/@current/event_definitions/", data=params)
+                assert response.status_code == status.HTTP_200_OK
+                assert response.json()["count"] == len(expected_names)
+                assert sorted([r["name"] for r in response.json()["results"]]) == expected_names
 
     def test_update_event_definition(self):
         super(LicenseManager, cast(LicenseManager, License.objects)).create(
@@ -600,6 +611,7 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
         self.assertListEqual(sorted(response.json()["tags"]), ["a", "b"])
 
     def test_exclude_hidden_events(self):
+        self.enterContext(patch("posthog.api.event_definition.posthoganalytics.feature_enabled", return_value=True))
         super(LicenseManager, cast(LicenseManager, License.objects)).create(
             plan="enterprise", valid_until=datetime(2500, 1, 19, 3, 14, 7)
         )
@@ -620,6 +632,14 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
         assert "visible_event" in event_names
         assert "hidden_event1" not in event_names
         assert "hidden_event2" not in event_names
+
+        response = self.client.get(
+            f"/api/projects/{self.demo_team.pk}/event_definitions/",
+            data={"exclude_hidden": "true", "search": "event"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["count"] == 1
+        assert [row["name"] for row in response.json()["results"]] == ["visible_event"]
 
         # Test with exclude_hidden=false (should be same as not setting it)
         response = self.client.get(f"/api/projects/{self.demo_team.pk}/event_definitions/?exclude_hidden=false")

--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -54,6 +54,7 @@ def _event_definitions_source_sql(
     event_type: EventDefinitionType,
     is_enterprise: bool,
     conditions: str,
+    project_first: bool = False,
 ) -> str:
     """FROM/JOIN/WHERE shared by the page fetch and the count that pages it."""
     # LEFT, not FULL OUTER. The two return the same rows here, on two independent grounds:
@@ -79,10 +80,19 @@ def _event_definitions_source_sql(
     # `event_definition_proj_uniq`, so the planner can seek that index for the project scope and
     # for any `name` equality in `conditions`. The equivalent form
     # `project_id = X OR (project_id IS NULL AND team_id = X)` matches no index at all.
+    source = "posthog_eventdefinition"
+    scope = "COALESCE(project_id, team_id) = %(project_id)s"
+    if project_first:
+        # OFFSET 0 prevents predicate pushdown: ILIKE must run after the project scan, so it
+        # cannot read the global trigram posting lists. Unlike a materialized name list,
+        # this streams base rows once and joins enterprise metadata only for search matches.
+        source = f"(SELECT * FROM posthog_eventdefinition WHERE {scope} OFFSET 0) AS posthog_eventdefinition"
+        scope = "true"
+
     return f"""
-            FROM posthog_eventdefinition
+            FROM {source}
             {enterprise_join}
-            WHERE COALESCE(project_id, team_id) = %(project_id)s
+            WHERE {scope}
             {conditions}
         """
 
@@ -91,13 +101,14 @@ def create_event_definitions_count_sql(
     event_type: EventDefinitionType,
     is_enterprise: bool = False,
     conditions: str = "",
+    project_first: bool = False,
 ) -> str:
     """Counts the rows `create_event_definitions_sql` pages over.
 
     Selecting no column lets Postgres drop the enterprise join whenever `conditions` reads only
     base-table columns, so the common count is an index-only scan.
     """
-    return f"SELECT count(*) {_event_definitions_source_sql(event_type, is_enterprise, conditions)}"
+    return f"SELECT count(*) {_event_definitions_source_sql(event_type, is_enterprise, conditions, project_first)}"
 
 
 def create_event_definitions_sql(
@@ -106,6 +117,7 @@ def create_event_definitions_sql(
     conditions: str = "",
     order_expressions: Optional[list[tuple[str, Literal["ASC", "DESC"]]]] = None,
     paginated: bool = True,
+    project_first: bool = False,
 ) -> str:
     if order_expressions is None:
         order_expressions = []
@@ -144,7 +156,7 @@ def create_event_definitions_sql(
 
     return f"""
             SELECT {",".join(selected_fields)}
-            {_event_definitions_source_sql(event_type, is_enterprise, conditions)}
+            {_event_definitions_source_sql(event_type, is_enterprise, conditions, project_first)}
             ORDER BY {",".join(additional_ordering)}
             {limit_clause}
         """
@@ -354,6 +366,16 @@ class EventDefinitionViewSet(
 
         search = self.request.GET.get("search", None)
         search_query, search_kwargs = term_search_filter_sql(self.search_fields, search)
+        project_first = (
+            bool(search_query)
+            and posthoganalytics.feature_enabled(
+                "event-definition-project-first-search",
+                str(self.project_id),
+                only_evaluate_locally=True,
+                send_feature_flag_events=False,
+            )
+            is True
+        )
 
         params = {"project_id": self.project_id, "is_posthog_event": "$%", **search_kwargs}
         order_expressions = self._ordering_params_from_request()
@@ -421,6 +443,7 @@ class EventDefinitionViewSet(
             conditions=search_query,
             order_expressions=order_expressions,
             paginated=not tags_list,
+            project_first=project_first,
         )
 
         if tags_list:
@@ -437,6 +460,7 @@ class EventDefinitionViewSet(
             event_type,
             is_enterprise=EE_AVAILABLE,
             conditions=search_query,
+            project_first=project_first,
         )
         # The count has to run on the connection the page fetch will use, or it describes a
         # different row set than the one it bounds.

--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -72,7 +72,13 @@ class TestEventDefinitionAPI(APIBaseTest):
             )
             assert abs((dateutil.parser.isoparse(response_item["created_at"]) - timezone.now()).total_seconds()) < 1
 
-    def test_list_event_definitions_scopes_by_project_across_environments(self):
+    @parameterized.expand([("listing", "", False), ("search", "e", False), ("project_first", "e", True)])
+    def test_list_event_definitions_scopes_by_project_across_environments(
+        self, _name: str, search: str, project_first: bool
+    ):
+        self.enterContext(
+            patch("posthog.api.event_definition.posthoganalytics.feature_enabled", return_value=project_first)
+        )
         # Rows written before the project backfill have project_id NULL and scope by team_id; rows written
         # since carry project_id. Both must be visible from any environment of the project, and a sibling
         # project's rows must not. Guards the scope predicate against a rewrite to only one of the columns.
@@ -84,10 +90,14 @@ class TestEventDefinitionAPI(APIBaseTest):
         EventDefinition.objects.create(
             team=other_project_team, project_id=other_project_team.project_id, name="from_other_project"
         )
+        EventDefinition.objects.create(
+            team=other_project_team, project_id=other_project_team.project_id, name="from_other_env"
+        )
 
-        response = self.client.get("/api/projects/@current/event_definitions/")
+        response = self.client.get("/api/projects/@current/event_definitions/", data={"search": search})
 
         assert response.status_code == status.HTTP_200_OK
+        assert response.json()["count"] == len(self.EXPECTED_EVENT_DEFINITIONS) + 1
         result_names = {r["name"] for r in response.json()["results"]}
         assert "from_other_env" in result_names
         assert "from_other_project" not in result_names
@@ -266,7 +276,11 @@ class TestEventDefinitionAPI(APIBaseTest):
             assert len(response.json()["results"]) == (100 if i < 2 else 6)  # Each page has 100 except the last one
             assert response.json()["results"][0]["name"] == f"z_event_{event_checkpoints[i]}"
 
-    def test_list_reads_only_the_requested_page_from_postgres(self):
+    @parameterized.expand([("default", False), ("project_first", True)])
+    def test_list_reads_only_the_requested_page_from_postgres(self, _name: str, project_first: bool):
+        flag = self.enterContext(
+            patch("posthog.api.event_definition.posthoganalytics.feature_enabled", return_value=project_first)
+        )
         EventDefinition.objects.bulk_create(
             [EventDefinition(team=self.demo_team, name=f"z_event_{i}") for i in range(1, 301)]
         )
@@ -283,6 +297,7 @@ class TestEventDefinitionAPI(APIBaseTest):
         ]
         assert page_fetches
         assert all("LIMIT 10" in sql for sql in page_fetches)
+        assert not any(call.args[0] == "event-definition-project-first-search" for call in flag.call_args_list)
 
         expected_names = sorted(f"z_event_{i}" for i in range(1, 301))
         for offset in (0, 11, 300, 301):
@@ -315,7 +330,11 @@ class TestEventDefinitionAPI(APIBaseTest):
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.json() == self.permission_denied_response("You don't have access to the project.")
 
-    def test_query_event_definitions(self):
+    @parameterized.expand([("default", False), ("project_first", True)])
+    def test_query_event_definitions(self, _name: str, project_first: bool):
+        self.enterContext(
+            patch("posthog.api.event_definition.posthoganalytics.feature_enabled", return_value=project_first)
+        )
         # Regular search
         response = self.client.get("/api/projects/@current/event_definitions/?search=app")
         assert response.status_code == status.HTTP_200_OK
@@ -717,9 +736,18 @@ class TestEventDefinitionAPI(APIBaseTest):
 
 
 class TestCreateEventDefinitionsSql(SimpleTestCase):
-    @parameterized.expand([("enterprise", True), ("open source", False)])
-    def test_selects_columns_in_a_stable_order(self, _name: str, is_enterprise: bool):
-        sql = create_event_definitions_sql(EventDefinitionType.EVENT, is_enterprise=is_enterprise)
+    @parameterized.expand(
+        [
+            ("enterprise", True, False),
+            ("open source", False, False),
+            ("enterprise search", True, True),
+            ("open source search", False, True),
+        ]
+    )
+    def test_selects_columns_in_a_stable_order(self, _name: str, is_enterprise: bool, project_first: bool):
+        sql = create_event_definitions_sql(
+            EventDefinitionType.EVENT, is_enterprise=is_enterprise, project_first=project_first
+        )
         select_clause = sql.split("SELECT ", 1)[1].split("FROM", 1)[0]
         columns = [column.strip() for column in select_clause.split(",")]
         assert columns == sorted(columns)
@@ -752,9 +780,15 @@ class TestEventDefinitionExcludeStale(APIBaseTest):
                 "?exclude_stale=true",
                 {"fresh_event", "never_seen_event"},
             ),
+            (
+                "search hides stale events but keeps never-seen",
+                "?exclude_stale=true&search=event",
+                {"fresh_event", "never_seen_event"},
+            ),
         ]
     )
     def test_exclude_stale_filter(self, _description: str, query_string: str, expected_names: set[str]) -> None:
+        self.enterContext(patch("posthog.api.event_definition.posthoganalytics.feature_enabled", return_value=True))
         now = timezone.now()
         EventDefinition.objects.create(team=self.team, name="fresh_event", last_seen_at=now - timedelta(days=1))
         EventDefinition.objects.create(team=self.team, name="stale_event", last_seen_at=now - timedelta(days=45))


### PR DESCRIPTION
## Problem

Event searches can still wait on a global trigram-index scan after [SQL pagination](https://github.com/PostHog/posthog/pull/93023) limits returned rows.

## Changes

- Adds a disabled-by-default project-first search trial for event pickers and the events table.
- Enabled projects scan their own event rows before substring filtering; count and page queries use the same filters.
- The flag evaluates locally without capture events; empty searches bypass evaluation.
- Mechanical: both query builders accept the same optional plan selection.

> [!WARNING]
> Do not merge or enable this trial. Synthetic benchmarks regress for large projects and selective terms. Whole-project scans fail the large-project performance goal.

Before:

```mermaid
flowchart LR
    Search[Event search] --> Planner[Planner chooses project or global-name scan] --> Page[Count and fetch page]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    class Search phYellow;
    class Planner,Page phBlue;
```

After, when the trial flag is enabled:

```mermaid
flowchart LR
    Search[Event search] --> Project[Scan project rows] --> Filter[Match names] --> Page[Count and fetch page]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    class Search phYellow;
    class Project,Filter,Page phBlue;
```

## How did you test this code?

- Compared counts and ordered pages in PostgreSQL across 495 synthetic cases, including legacy scope, filters, event types, search terms, and offsets.
- Alternating benchmark runs covered projects with 20, 5,000, and 100,000 definitions; timings varied by term selectivity and join plan.
- Extended existing API tests for both flag states, tenant isolation, search pagination, enterprise filters, and tags.
- SQL unit tests, Python lint, the full mypy check, and all three API suites pass in isolated validation.

- Preloaded Pydantic date classes before frozen clocks so the changed search test also passes in isolation.
- Regenerated schemas for the stack and master are identical. Strict generation reports the same two enum-name warnings; no generated types change.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Documented the flag, plan tradeoffs, validation matrix, canary comparisons, and rollback criteria in `docs/internal/taxonomic-filter-search.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used git, hogli, and PostgreSQL validation. Skills: `/stacking-prs`, `/improving-drf-endpoints`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/hogli`, `/query-clickhouse-via-metabase`, `/running-ci-preflight`, `/setting-up-devbox`, `/debugging-ci-failures`.

The duplicate search found #93023 and #90647; neither adds this project-first plan trial. Both materialized and streaming project scans regressed in benchmarks. This trial is no longer recommended.

Operational investigation informed the optimization. Committed test data is synthetic; private traces and measurements remain outside the repository and PR.
