### PR TITLE
perf(notebooks): share one markdown parse across collectors

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.test.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.test.ts
@@ -173,4 +173,53 @@ describe('buildNotebookDependencyGraph', () => {
         expect(graph.downstreamUsageByNode['a'].df1.map((usage) => usage.nodeId)).toEqual(['b'])
         expect(graph.upstreamSourcesByNode['b'].df1.nodeId).toEqual('a')
     })
+
+    it('serves the shared markdown parse to a second collector on the same content', () => {
+        // The parse is cached on the content node so collectors share one parse per edit. A
+        // cache keyed by anything other than the node would hand the second collector the wrong
+        // cells; single-collector tests never exercise two collectors reading one content.
+        const markdown = [
+            serializeMarkdownNotebookComponent('SQLV2', {
+                nodeId: 'a',
+                returnVariable: 'sql_df',
+                code: 'select id from events',
+            }),
+            serializeMarkdownNotebookComponent('PythonV2', {
+                nodeId: 'py',
+                returnVariable: 'new_events',
+                code: 'new_events = sql_df.head()',
+            }),
+        ].join('\n\n')
+        const content = buildMarkdownNotebookContent(markdown)
+        // Populate the cache from one collector, then read it from another.
+        expect(collectNotebookFrameNodes(content).map((frame) => frame.name)).toEqual(['sql_df', 'new_events'])
+        const graph = buildNotebookDependencyGraph(content)
+        expect(graph.downstreamUsageByNode['a'].sql_df.map((usage) => usage.nodeId)).toEqual(['py'])
+    })
+
+    it('does not serve one content its parse for a later content with different markdown', () => {
+        // Each edit builds a new content node, so the cache must key on it and stay fresh. A
+        // cache that leaked the first parse would report the first document's cells forever.
+        const graphA = buildNotebookDependencyGraph(
+            buildMarkdownNotebookContent(
+                serializeMarkdownNotebookComponent('SQLV2', {
+                    nodeId: 'a',
+                    returnVariable: 'df_a',
+                    code: 'select id from events',
+                })
+            )
+        )
+        const graphB = buildNotebookDependencyGraph(
+            buildMarkdownNotebookContent(
+                serializeMarkdownNotebookComponent('SQLV2', {
+                    nodeId: 'b',
+                    returnVariable: 'df_b',
+                    code: 'select id from persons',
+                })
+            )
+        )
+        expect(Object.keys(graphA.nodesById)).toEqual(['a'])
+        expect(Object.keys(graphB.nodesById)).toEqual(['b'])
+        expect(graphB.nodesById['b'].exports).toEqual(['df_b'])
+    })
 })

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.test.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.test.ts
@@ -1,3 +1,5 @@
+import * as markdownNotebookParser from 'lib/components/MarkdownNotebook/markdown'
+
 import { buildMarkdownNotebookContent, serializeMarkdownNotebookComponent } from '../Notebook/markdownNotebookV2'
 import { NotebookNodeType } from '../types'
 import {
@@ -7,6 +9,10 @@ import {
 } from './notebookNodeContent'
 
 describe('buildNotebookDependencyGraph', () => {
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
     const sqlV2Node = (nodeId: string, returnVariable: string, code: string): Record<string, unknown> => ({
         type: NotebookNodeType.SQLV2,
         attrs: { nodeId, returnVariable, code },
@@ -174,10 +180,11 @@ describe('buildNotebookDependencyGraph', () => {
         expect(graph.upstreamSourcesByNode['b'].df1.nodeId).toEqual('a')
     })
 
-    it('serves the shared markdown parse to a second collector on the same content', () => {
-        // The parse is cached on the content node so collectors share one parse per edit. A
-        // cache keyed by anything other than the node would hand the second collector the wrong
-        // cells; single-collector tests never exercise two collectors reading one content.
+    it('parses the markdown once for two collectors reading the same content', () => {
+        // The parse is cached on the content node so collectors share one parse per edit. The
+        // cell assertions alone would still pass with the cache gone, so count the parses too:
+        // that is the per-keystroke work this guards. A cache keyed by anything other than the
+        // node would also hand the second collector the wrong cells.
         const markdown = [
             serializeMarkdownNotebookComponent('SQLV2', {
                 nodeId: 'a',
@@ -191,10 +198,12 @@ describe('buildNotebookDependencyGraph', () => {
             }),
         ].join('\n\n')
         const content = buildMarkdownNotebookContent(markdown)
+        const parseSpy = jest.spyOn(markdownNotebookParser, 'parseMarkdownNotebook')
         // Populate the cache from one collector, then read it from another.
         expect(collectNotebookFrameNodes(content).map((frame) => frame.name)).toEqual(['sql_df', 'new_events'])
         const graph = buildNotebookDependencyGraph(content)
         expect(graph.downstreamUsageByNode['a'].sql_df.map((usage) => usage.nodeId)).toEqual(['py'])
+        expect(parseSpy).toHaveBeenCalledTimes(1)
     })
 
     it('does not serve one content its parse for a later content with different markdown', () => {

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.ts
@@ -328,6 +328,24 @@ export const getUniqueSqlV2ReturnVariable = (
 // tiptap-shaped nodes so the collectors and the dependency graph see the same cells in both
 // notebook formats. Scoped to the revamped-notebook cell types (SQLV2 + kernel Python):
 // expanding the other node types would change their (markdown-blind) summaries and naming.
+// Each collector that expands a markdown notebook parses the same markdown string, so one edit
+// parses the whole document once per collector. Cache the parse on the node object. Every
+// collector in a recompute reads the same content node, so they share one parse. The next edit
+// builds a new content node, so the old entry drops with it — the parse never goes stale.
+const parsedMarkdownNotebookByNode = new WeakMap<object, ReturnType<typeof parseMarkdownNotebook>>()
+
+const parseMarkdownNotebookNodeCached = (node: {
+    attrs: { markdown: string }
+}): ReturnType<typeof parseMarkdownNotebook> => {
+    const cached = parsedMarkdownNotebookByNode.get(node)
+    if (cached) {
+        return cached
+    }
+    const parsed = parseMarkdownNotebook(node.attrs.markdown)
+    parsedMarkdownNotebookByNode.set(node, parsed)
+    return parsed
+}
+
 const expandMarkdownNotebookNodesOfTypes = (node: any, nodeTypes: NotebookNodeType[]): JSONContent[] => {
     if (typeof node?.attrs?.markdown !== 'string') {
         return []
@@ -342,7 +360,7 @@ const expandMarkdownNotebookNodesOfTypes = (node: any, nodeTypes: NotebookNodeTy
             nodeTypeByTag.set(tag, nodeType)
         }
     }
-    return parseMarkdownNotebook(node.attrs.markdown).nodes.flatMap((block): JSONContent[] => {
+    return parseMarkdownNotebookNodeCached(node).nodes.flatMap((block): JSONContent[] => {
         if (block.type !== 'component') {
             return []
         }


### PR DESCRIPTION
## Problem

Typing in a notebook with many cells lags: each keystroke re-parses the whole notebook markdown several times.

On every edit the notebook rebuilds about ten derived values from its content — the dependency graph, the dataframe list, per-cell summaries. Several of those collectors each call `parseMarkdownNotebook` over the entire document, so one keystroke parses the whole notebook three times before React re-renders. The cost grows with cell count.

## Changes

- A notebook with many cells stays responsive while typing; the per-edit selector work drops about two thirds.
- The markdown parse is cached on the content node, keyed by object identity, so collectors share one parse per edit.
- The cache lives only in the collector file; the editor's own mutable parse path is untouched.
- A new edit builds a new content node, so the old entry drops with it — the parse never goes stale.

Measured on synthetic notebooks (median of 300 runs, one selector cascade per edit):

| cells | parses per edit | cascade ms (before → after) |
| --- | --- | --- |
| 5 | 3 → 1 | 0.25 → 0.08 |
| 10 | 3 → 1 | 0.42 → 0.15 |
| 25 | 3 → 1 | 0.95 → 0.30 |

## How did you test this code?

Added two cases to `notebookNodeContent.test.ts`, each catching a regression the existing single-collector tests miss:

- A second collector reading one content object gets the right cells. This guards against a cache keyed by anything other than the node.
- A later content with different markdown is not served the first parse. This guards cross-edit freshness.

Existing collector tests already cover base correctness through the markdown-notebook expand path.

Not run in this sandbox: the notebook UI end to end, because there is no browser session with a live notebook here.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/writing-ui-components`, `/stacking-prs`.

This is the first of a Tier-1 performance set from a notebooks slowdown analysis; it targets the typing-lag mechanism (redundant per-keystroke parsing). The before/after table came from a throwaway benchmark, run against the cached and the reverted source, then removed — it is not in the diff.
