### PR TITLE
feat(tasks): relay the user's Claude subscription token into cloud runs

### DIFF
--- a/products/desktop/packages/agent/src/acp-extensions.ts
+++ b/products/desktop/packages/agent/src/acp-extensions.ts
@@ -100,6 +100,10 @@ export const POSTHOG_NOTIFICATIONS = {
   CODEX_GOAL: "_posthog/codex_goal",
   /** Desktop → sandbox reply to an MCP relay request (docs/CLOUD-MCP-RELAY.md). */
   MCP_RESPONSE: "_posthog/mcp_response",
+  /** Sandbox → Desktop request for a credential (Claude subscription token relay). */
+  CREDENTIAL_REQUEST: "_posthog/credential_request",
+  /** Desktop → sandbox reply carrying the credential or an error. */
+  CREDENTIAL_RESPONSE: "_posthog/credential_response",
 } as const;
 
 export type SteerDeclineCause =

--- a/products/desktop/packages/agent/src/adapters/claude/UPSTREAM.md
+++ b/products/desktop/packages/agent/src/adapters/claude/UPSTREAM.md
@@ -47,6 +47,9 @@ Fork of `@anthropic-ai/claude-agent-acp`. Upstream repo: https://github.com/anth
 - SettingsManager `PreToolUse` hook for permission rules
 - `ensureLocalSettings` / `clearStatsigCache`
 - `ELECTRON_RUN_AS_NODE` / `ENABLE_TOOL_SEARCH` env vars
+- `machine-auth.ts` (`MachineClaudeAuth`, `applyMachineClaudeAuth`): strips gateway/telemetry env
+  and sets `CLAUDE_CONFIG_DIR` or `CLAUDE_CODE_OAUTH_TOKEN` so a session bills the user's own
+  Claude plan instead of the PostHog gateway
 
 ## Intentional Divergences
 

--- a/products/desktop/packages/agent/src/adapters/claude/machine-auth.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/machine-auth.ts
@@ -3,6 +3,8 @@ import * as path from "node:path";
 
 export interface MachineClaudeAuth {
   configDir?: string;
+  /** Long-lived OAuth token (`sk-ant-oat01-…`) that bills the user's Claude plan. */
+  oauthToken?: string;
 }
 
 export const MACHINE_AUTH_STRIPPED_KEYS = [
@@ -43,6 +45,9 @@ export function applyMachineClaudeAuth(
 ): void {
   for (const key of MACHINE_AUTH_STRIPPED_KEYS) {
     delete env[key];
+  }
+  if (auth.oauthToken) {
+    env.CLAUDE_CODE_OAUTH_TOKEN = auth.oauthToken;
   }
   if (auth.configDir) {
     env.CLAUDE_CONFIG_DIR = auth.configDir;

--- a/products/desktop/packages/agent/src/adapters/claude/session/options.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/options.test.ts
@@ -619,6 +619,32 @@ describe("buildSessionOptions", () => {
 
       expect(options.fallbackModel).toBeUndefined();
     });
+
+    it("sets the relayed OAuth token over any ambient value", () => {
+      const env = buildSessionOptions({
+        ...makeParams(),
+        machineAuth: { oauthToken: "sk-ant-oat01-fake-test-token" },
+        gatewayEnv: {
+          anthropicBaseUrl: "https://gateway.example.com",
+          anthropicAuthToken: "gateway-token",
+          openaiBaseUrl: "https://gateway.example.com/v1",
+          openaiApiKey: "gateway-token",
+          anthropicCustomHeaders: "x-posthog-property-task_id: task-abc",
+          posthogProjectId: "42",
+        },
+      }).env;
+
+      expect(env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-fake-test-token");
+      for (const key of STRIPPED_KEYS) {
+        expect(env?.[key]).toBeUndefined();
+      }
+      expect(env?.OPENAI_BASE_URL).toBeUndefined();
+      expect(env?.OPENAI_API_KEY).toBeUndefined();
+      for (const [key, value] of Object.entries(env ?? {})) {
+        expect(value).not.toContain("x-posthog-");
+        expect(key).not.toMatch(/X-PostHog/i);
+      }
+    });
   });
 
   describe("per-session context wiki env", () => {

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -126,6 +126,7 @@ import {
   normalizeCloudPromptContent,
   promptBlocksToText,
 } from "./cloud-prompt";
+import { CredentialRelay } from "./credential-relay";
 import { TaskRunEventStreamSender } from "./event-stream-sender";
 import { type JwtPayload, JwtValidationError, validateJwt } from "./jwt";
 import { type McpRelayResponse, McpRelayServer } from "./mcp-relay-server";
@@ -252,6 +253,15 @@ interface BuiltPrompt {
 }
 
 export const PREWARMED_RESUME_IDLE_CAPABILITY = "prewarmedResumeIdle";
+/** Advertised in GET /health; the backend fails an own-subscription run when absent. */
+export const CLAUDE_SUBSCRIPTION_RELAY_CAPABILITY = "claude_subscription_relay";
+
+/** Section-9 copy, shared with the backend's old-sandbox guard. Names the next
+ * step; never carries the token or any part of it. */
+export const CLAUDE_SUBSCRIPTION_TOKEN_MISSING_MESSAGE =
+  "This task is set to use your Claude plan, but the token did not arrive from PostHog Desktop. " +
+  "Open PostHog Desktop, check Settings > Claude subscription, and run the task again. " +
+  'To use PostHog credits instead, turn off "Use your Claude plan for cloud tasks".';
 
 function hiddenTextBlock(text: string): ContentBlock {
   return {
@@ -498,6 +508,9 @@ export class AgentServer {
   private readonly posthogExecPermissionRegex: RegExp;
   private readonly posthogExecPermissionRegexSource: string;
   private mcpRelayServer: McpRelayServer | null = null;
+  private readonly credentialRelay = new CredentialRelay({
+    emitEvent: (event) => this.broadcastEvent(event),
+  });
 
   /**
    * Start loopback relay endpoints for the run's designated desktop-only MCP
@@ -673,7 +686,10 @@ export class AgentServer {
         bootMs: this.sessionReadyBootMs,
         sessionInitMs: this.sessionInitMs,
         boot,
-        capabilities: [PREWARMED_RESUME_IDLE_CAPABILITY],
+        capabilities: [
+          PREWARMED_RESUME_IDLE_CAPABILITY,
+          CLAUDE_SUBSCRIPTION_RELAY_CAPABILITY,
+        ],
       });
     });
 
@@ -1012,6 +1028,8 @@ export class AgentServer {
       await this.eventStreamSender?.stop();
     }
 
+    this.credentialRelay.stop();
+
     if (this.server) {
       this.server.close();
       this.server = null;
@@ -1081,6 +1099,51 @@ export class AgentServer {
       this.logger.error(
         "Failed to flush telemetry after fatal error",
         telemetryError,
+      );
+    }
+  }
+
+  /**
+   * Mark the run failed when the creating Desktop never delivered the Claude
+   * subscription token. Never falls back to the PostHog gateway: billing the
+   * user's credits after they opted for their own plan is the worst outcome.
+   */
+  private async reportClaudeSubscriptionTokenMissing(
+    payload: JwtPayload,
+    reason: string,
+  ): Promise<void> {
+    try {
+      await this.posthogAPI.updateTaskRun(payload.task_id, payload.run_id, {
+        status: "failed",
+        error_message: CLAUDE_SUBSCRIPTION_TOKEN_MISSING_MESSAGE,
+      });
+    } catch (error) {
+      this.logger.error(
+        "Failed to mark run failed after credential relay failure",
+        error,
+      );
+    }
+    try {
+      // The session is not up yet, so broadcastEvent buffers into the durable
+      // stream rather than a live SSE controller.
+      this.broadcastEvent({
+        type: "notification",
+        timestamp: new Date().toISOString(),
+        notification: {
+          jsonrpc: "2.0" as const,
+          method: POSTHOG_NOTIFICATIONS.INITIALIZATION_FAILED,
+          params: {
+            runtimeAdapter: this.getRuntimeAdapter(),
+            initializationPhase: "credential_relay",
+            reason,
+          },
+        },
+      });
+      await this.eventStreamSender?.stop();
+    } catch (error) {
+      this.logger.error(
+        "Failed to flush events after credential relay failure",
+        error,
       );
     }
   }
@@ -1596,6 +1659,26 @@ export class AgentServer {
         return { resolved: true };
       }
 
+      case POSTHOG_NOTIFICATIONS.CREDENTIAL_RESPONSE:
+      case "credential_response": {
+        // Params carry the Claude subscription token; log the requestId only.
+        const resolved = this.credentialRelay.resolve({
+          requestId: String(params.requestId),
+          token: typeof params.token === "string" ? params.token : undefined,
+          error: typeof params.error === "string" ? params.error : undefined,
+        });
+        this.logger.debug("Credential relay response received", {
+          requestId: String(params.requestId),
+          resolved,
+        });
+        if (!resolved) {
+          throw new Error(
+            `No pending credential request found for id: ${String(params.requestId)}`,
+          );
+        }
+        return { resolved: true };
+      }
+
       default:
         throw new Error(`Unknown method: ${method}`);
     }
@@ -1846,6 +1929,28 @@ export class AgentServer {
       sinks: telemetry ? [telemetry] : undefined,
     });
 
+    // Own-subscription runs bill the user's Claude plan: ask the creating
+    // Desktop for the token before the adapter exists, so the Claude env is
+    // built with CLAUDE_CODE_OAUTH_TOKEN and no gateway variables. A queued
+    // user_message waits: executeCommand runs only after this.session exists.
+    let claudeSubscriptionToken: string | null = null;
+    if (
+      this.config.claudeModelAccess === "own-subscription" &&
+      runtimeAdapter === "claude"
+    ) {
+      try {
+        claudeSubscriptionToken = await this.credentialRelay.request(
+          "claude_subscription_token",
+        );
+      } catch (error) {
+        // The message names the next step; the token itself is never in it.
+        const reason = error instanceof Error ? error.message : String(error);
+        this.logger.warn("Claude subscription token relay failed", { reason });
+        await this.reportClaudeSubscriptionTokenMissing(payload, reason);
+        throw error;
+      }
+    }
+
     const acpConnection = createAcpConnection({
       adapter: runtimeAdapter,
       taskRunId: payload.run_id,
@@ -1856,7 +1961,14 @@ export class AgentServer {
       onWireMessage: (message, eventId) =>
         this.handleAcpTransportMessage(message, eventId),
       logger: this.logger,
-      claudeGatewayEnv: runtimeAdapter !== "codex" ? gatewayEnv : undefined,
+      claudeGatewayEnv:
+        runtimeAdapter !== "codex" && claudeSubscriptionToken === null
+          ? gatewayEnv
+          : undefined,
+      claudeMachineAuth:
+        runtimeAdapter !== "codex" && claudeSubscriptionToken !== null
+          ? { oauthToken: claudeSubscriptionToken }
+          : undefined,
       codexOptions:
         runtimeAdapter === "codex"
           ? {

--- a/products/desktop/packages/agent/src/server/bin.ts
+++ b/products/desktop/packages/agent/src/server/bin.ts
@@ -47,6 +47,9 @@ const envSchema = z.object({
   POSTHOG_SANDBOX_ID: z.string().min(1).optional(),
   POSTHOG_CODE_RUNTIME_ADAPTER: z.enum(["claude", "codex"]).optional(),
   POSTHOG_CODE_MODEL: z.string().optional(),
+  POSTHOG_CODE_CLAUDE_MODEL_ACCESS: z
+    .enum(["posthog-gateway", "own-subscription"])
+    .optional(),
   POSTHOG_CODE_REASONING_EFFORT: z
     .enum(["off", "minimal", ...EFFORT_LEVELS])
     .optional(),
@@ -286,6 +289,7 @@ program
       ),
       runtimeAdapter: env.POSTHOG_CODE_RUNTIME_ADAPTER,
       model: env.POSTHOG_CODE_MODEL,
+      claudeModelAccess: env.POSTHOG_CODE_CLAUDE_MODEL_ACCESS,
       reasoningEffort: env.POSTHOG_CODE_REASONING_EFFORT,
       contextWindow: env.POSTHOG_CODE_CONTEXT_WINDOW,
       fastMode: env.POSTHOG_CODE_FAST_MODE,

--- a/products/desktop/packages/agent/src/server/credential-relay.test.ts
+++ b/products/desktop/packages/agent/src/server/credential-relay.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CredentialRelay } from "./credential-relay";
+
+describe("CredentialRelay", () => {
+  let events: Record<string, unknown>[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    events = [];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function makeRelay(timeoutMs?: number): CredentialRelay {
+    return new CredentialRelay({
+      emitEvent: (event) => events.push(event),
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    });
+  }
+
+  it("resolves with the token when the matching response arrives", async () => {
+    const relay = makeRelay();
+    const tokenPromise = relay.request("claude_subscription_token");
+
+    expect(events).toHaveLength(1);
+    const event = events[0] as {
+      type: string;
+      requestId: string;
+      credential: string;
+    };
+    expect(event.type).toBe("credential_request");
+    expect(event.credential).toBe("claude_subscription_token");
+
+    relay.resolve({
+      requestId: event.requestId,
+      token: "sk-ant-oat01-fake-test-token",
+    });
+    await expect(tokenPromise).resolves.toBe("sk-ant-oat01-fake-test-token");
+  });
+
+  it("rejects when the response carries an error", async () => {
+    const relay = makeRelay();
+    const tokenPromise = relay.request("claude_subscription_token");
+    const { requestId } = events[0] as { requestId: string };
+
+    relay.resolve({ requestId, error: "no_token" });
+    await expect(tokenPromise).rejects.toThrow("no_token");
+  });
+
+  it("rejects on timeout", async () => {
+    const relay = makeRelay(120_000);
+    const tokenPromise = relay.request("claude_subscription_token");
+
+    const assertion = expect(tokenPromise).rejects.toThrow(
+      "timed out waiting for PostHog Desktop",
+    );
+    await vi.advanceTimersByTimeAsync(120_000);
+    await assertion;
+  });
+
+  it("ignores a response with an unknown requestId", async () => {
+    const relay = makeRelay();
+    const tokenPromise = relay.request("claude_subscription_token");
+    const { requestId } = events[0] as { requestId: string };
+
+    const resolved = relay.resolve({
+      requestId: "not-a-pending-request",
+      token: "sk-ant-oat01-fake-test-token",
+    });
+
+    expect(resolved).toBe(false);
+    relay.resolve({ requestId, token: "sk-ant-oat01-fake-test-token" });
+    await expect(tokenPromise).resolves.toBe("sk-ant-oat01-fake-test-token");
+  });
+
+  it("emits no event containing the token", async () => {
+    const relay = makeRelay();
+    const tokenPromise = relay.request("claude_subscription_token");
+    const { requestId } = events[0] as { requestId: string };
+
+    relay.resolve({ requestId, token: "sk-ant-oat01-fake-test-token" });
+    await tokenPromise;
+
+    const serialized = JSON.stringify(events);
+    expect(serialized).not.toContain("sk-ant-oat01-fake-test-token");
+  });
+});

--- a/products/desktop/packages/agent/src/server/credential-relay.ts
+++ b/products/desktop/packages/agent/src/server/credential-relay.ts
@@ -1,0 +1,88 @@
+import { randomUUID } from "node:crypto";
+
+/** How long the sandbox waits for the Desktop to answer a credential request. */
+export const CREDENTIAL_RELAY_TIMEOUT_MS = 120_000;
+
+export interface CredentialRelayConfig {
+  /** Broadcast an event over the durable stream + SSE (agent-server seam). */
+  emitEvent: (event: Record<string, unknown>) => void;
+  timeoutMs?: number;
+}
+
+interface PendingRequest {
+  resolve: (token: string) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+/**
+ * Requests a credential (the user's Claude subscription token) from the
+ * creating Desktop and waits for a `credential_response` command, mirroring
+ * the MCP relay's request/response correlation (docs/CLOUD-MCP-RELAY.md).
+ * The token lives in the pending promise only: never written to disk, never
+ * logged, never put in an event.
+ */
+export class CredentialRelay {
+  private readonly pending = new Map<string, PendingRequest>();
+
+  constructor(private readonly config: CredentialRelayConfig) {}
+
+  request(credential: string): Promise<string> {
+    const requestId = randomUUID();
+    const timeoutMs = this.config.timeoutMs ?? CREDENTIAL_RELAY_TIMEOUT_MS;
+    const expiresAt = new Date(Date.now() + timeoutMs).toISOString();
+
+    const tokenPromise = new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(requestId);
+        reject(
+          new Error(
+            "The credential request timed out waiting for PostHog Desktop.",
+          ),
+        );
+      }, timeoutMs);
+      timer.unref?.();
+      this.pending.set(requestId, { resolve, reject, timer });
+    });
+    // The caller awaits; an unhandled rejection from a dropped reference would
+    // kill the process, so keep a no-op catch on the side promise.
+    tokenPromise.catch(() => {});
+
+    this.config.emitEvent({
+      type: "credential_request",
+      requestId,
+      credential,
+      expiresAt,
+    });
+    return tokenPromise;
+  }
+
+  /** Resolve a pending request from a `credential_response` command. */
+  resolve(params: {
+    requestId: string;
+    token?: string;
+    error?: string;
+  }): boolean {
+    const pending = this.pending.get(params.requestId);
+    if (!pending) return false;
+    this.pending.delete(params.requestId);
+    clearTimeout(pending.timer);
+    if (params.error) {
+      pending.reject(new Error(params.error));
+    } else if (params.token) {
+      pending.resolve(params.token);
+    } else {
+      pending.reject(new Error("The credential response had no token."));
+    }
+    return true;
+  }
+
+  /** Abandon any pending requests (session shutdown). */
+  stop(): void {
+    for (const [requestId, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error("Session is shutting down."));
+      this.pending.delete(requestId);
+    }
+  }
+}

--- a/products/desktop/packages/agent/src/server/schemas.test.ts
+++ b/products/desktop/packages/agent/src/server/schemas.test.ts
@@ -343,6 +343,70 @@ describe("validateCommandParams", () => {
       }).success,
     ).toBe(false);
   });
+
+  // The token in these cases is a clearly fake test value.
+  it.each([
+    "credential_response",
+    "posthog/credential_response",
+    "_posthog/credential_response",
+  ])("accepts a valid %s carrying only a token", (method) => {
+    const result = validateCommandParams(method, {
+      requestId: "req-1",
+      credential: "claude_subscription_token",
+      token: "sk-ant-oat01-fake-test-token",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a credential_response carrying only an error", () => {
+    const result = validateCommandParams("credential_response", {
+      requestId: "req-1",
+      credential: "claude_subscription_token",
+      error: "no_token",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a credential_response without requestId", () => {
+    const result = validateCommandParams("credential_response", {
+      credential: "claude_subscription_token",
+      token: "sk-ant-oat01-fake-test-token",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a credential_response with both token and error", () => {
+    const result = validateCommandParams("credential_response", {
+      requestId: "req-1",
+      credential: "claude_subscription_token",
+      token: "sk-ant-oat01-fake-test-token",
+      error: "no_token",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a credential_response with neither token nor error", () => {
+    const result = validateCommandParams("credential_response", {
+      requestId: "req-1",
+      credential: "claude_subscription_token",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a credential_response naming a different credential", () => {
+    const result = validateCommandParams("credential_response", {
+      requestId: "req-1",
+      credential: "something_else",
+      token: "sk-ant-oat01-fake-test-token",
+    });
+
+    expect(result.success).toBe(false);
+  });
 });
 
 describe("relayMcpServerNamesSchema", () => {

--- a/products/desktop/packages/agent/src/server/schemas.ts
+++ b/products/desktop/packages/agent/src/server/schemas.ts
@@ -115,6 +115,22 @@ export const mcpResponseParamsSchema = z
     error: "Exactly one of payload or error is required",
   });
 
+/**
+ * Desktop → sandbox reply to a `credential_request` event. The token is a
+ * long-lived Claude OAuth token; it lives in memory only and must never be
+ * persisted or logged.
+ */
+export const credentialResponseParamsSchema = z
+  .object({
+    requestId: z.string().min(1, "requestId is required"),
+    credential: z.literal("claude_subscription_token"),
+    token: z.string().min(1).optional(),
+    error: z.string().optional(),
+  })
+  .refine((params) => Boolean(params.token) !== Boolean(params.error), {
+    error: "Exactly one of token or error is required",
+  });
+
 export const closeParamsSchema = z.object({}).optional();
 
 export const commandParamsSchemas = {
@@ -134,6 +150,9 @@ export const commandParamsSchemas = {
   mcp_response: mcpResponseParamsSchema,
   "posthog/mcp_response": mcpResponseParamsSchema,
   "_posthog/mcp_response": mcpResponseParamsSchema,
+  credential_response: credentialResponseParamsSchema,
+  "posthog/credential_response": credentialResponseParamsSchema,
+  "_posthog/credential_response": credentialResponseParamsSchema,
   side_question: sideQuestionParamsSchema,
   "posthog/side_question": sideQuestionParamsSchema,
 } as const;

--- a/products/desktop/packages/agent/src/server/types.ts
+++ b/products/desktop/packages/agent/src/server/types.ts
@@ -59,6 +59,12 @@ export interface AgentServerConfig {
   piRpcHostPath?: string;
   runtimeAdapter?: Adapter;
   model?: string;
+  /**
+   * How the Claude runtime pays for model use. "own-subscription" makes the
+   * server request a Claude token from the creating Desktop (credential
+   * relay) instead of using the PostHog gateway.
+   */
+  claudeModelAccess?: "posthog-gateway" | "own-subscription";
   reasoningEffort?: EffortLevel | "off" | "minimal";
   contextWindow?: "200k" | "1m";
   fastMode?: boolean;

--- a/products/desktop/packages/shared/src/feature-flag-keys.json
+++ b/products/desktop/packages/shared/src/feature-flag-keys.json
@@ -7,6 +7,7 @@
   "CHANNEL_REPORTS_FLAG": "posthog-desktop-channel-reports",
   "CHANNELS_LAYOUT_FLAG": "code-spaces-layout",
   "CLAUDE_OWN_SUBSCRIPTION_FLAG": "posthog-code-claude-own-subscription",
+  "CLAUDE_OWN_SUBSCRIPTION_CLOUD_FLAG": "posthog-code-claude-own-subscription-cloud",
   "CLOUD_COMPUTE_BILLING_FLAG": "posthog-desktop-cloud-compute-billing",
   "CODEX_OWN_SUBSCRIPTION_FLAG": "posthog-code-codex-own-subscription",
   "CONTEXT_LAYER_FLAG": "context-layer",

--- a/products/desktop/packages/shared/src/flags.ts
+++ b/products/desktop/packages/shared/src/flags.ts
@@ -45,6 +45,10 @@ export const CODEX_OWN_SUBSCRIPTION_FLAG =
   featureFlagKeys.CODEX_OWN_SUBSCRIPTION_FLAG;
 export const CLAUDE_OWN_SUBSCRIPTION_FLAG =
   featureFlagKeys.CLAUDE_OWN_SUBSCRIPTION_FLAG;
+// Gates the cloud variant (Desktop relays a Claude token to the sandbox);
+// rolls out and rolls back independently of the local flag.
+export const CLAUDE_OWN_SUBSCRIPTION_CLOUD_FLAG =
+  featureFlagKeys.CLAUDE_OWN_SUBSCRIPTION_CLOUD_FLAG;
 // Gates importing and relaying local MCP servers into cloud task runs.
 export const LOCAL_MCP_IMPORT_FLAG = featureFlagKeys.LOCAL_MCP_IMPORT_FLAG;
 /**

--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -216,6 +216,10 @@ TASK_SIGNALS_CLONING_BLOBLESS_FEATURE_FLAG = "task-signals-cloning-blobless"
 # an image rebuild.
 RTK_DISABLED_FEATURE_FLAG = "tasks-rtk-disabled"
 BENJAMIN_FEATURE_FLAG = "task-cloud-run-benjamin-plus"
+# Gates the cloud own-subscription path: a run marked claude_model_access="own-subscription"
+# makes the sandbox request a Claude token from the creating Desktop. Fail-closed — flag off
+# means the run uses the PostHog gateway even when the run state asks for the subscription.
+CLAUDE_OWN_SUBSCRIPTION_CLOUD_FEATURE_FLAG = "posthog-code-claude-own-subscription-cloud"
 # Gates whether long-running process_task runs continue-as-new to bound history/replay cost.
 CONTINUE_AS_NEW_FEATURE_FLAG = "tasks-cloud-run-continue-as-new"
 PR_BABYSIT_SNAPSHOT_FEATURE_FLAG = "tasks-pr-babysit-snapshot"

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -4671,6 +4671,7 @@ def bootstrap_task_run(
         "fast_mode": fast_mode,
         "rtk_enabled": validated_data.get("rtk_enabled"),
         "benjamin_enabled": validated_data.get("benjamin_enabled"),
+        "claude_model_access": validated_data.get("claude_model_access"),
     }.items():
         if value is not None:
             extra_state = extra_state or {}
@@ -7077,6 +7078,7 @@ def run_task(
         ("initial_permission_mode", initial_permission_mode),
         ("rtk_enabled", validated_data.get("rtk_enabled")),
         ("benjamin_enabled", validated_data.get("benjamin_enabled")),
+        ("claude_model_access", validated_data.get("claude_model_access")),
     ):
         if value is not None:
             extra_state = extra_state or {}

--- a/products/tasks/backend/logic/services/agent_server_launcher.py
+++ b/products/tasks/backend/logic/services/agent_server_launcher.py
@@ -150,6 +150,7 @@ class AgentServerLaunchMixin(SandboxBase):
         benjamin_enabled: bool = False,
         peer_messaging: bool = False,
         posthog_exec_permission_regex: str | None = None,
+        claude_model_access: str | None = None,
     ) -> str:
         env_prefix = build_agent_runtime_env_prefix(
             interaction_origin=interaction_origin,
@@ -169,6 +170,7 @@ class AgentServerLaunchMixin(SandboxBase):
             rtk_enabled=rtk_enabled,
             benjamin_enabled=benjamin_enabled,
             peer_messaging=peer_messaging,
+            claude_model_access=claude_model_access,
         )
         create_pr_flag = f" --createPr {shlex.quote('true' if create_pr else 'false')}"
         # Only append when opted in: agent-server builds without the option reject unknown
@@ -298,6 +300,7 @@ class AgentServerLaunchMixin(SandboxBase):
         rtk_enabled: bool = True,
         benjamin_enabled: bool = False,
         peer_messaging: bool = False,
+        claude_model_access: str | None = None,
     ) -> int | None:
         """Start the agent-server HTTP server in the sandbox.
 
@@ -381,6 +384,7 @@ class AgentServerLaunchMixin(SandboxBase):
             benjamin_enabled=benjamin_enabled,
             peer_messaging=peer_messaging,
             posthog_exec_permission_regex=exec_permission_regex,
+            claude_model_access=claude_model_access,
         )
 
         logger.info(f"Starting agent-server in sandbox {self.id} for {repository or 'no-repo'}")

--- a/products/tasks/backend/logic/services/docker_sandbox.py
+++ b/products/tasks/backend/logic/services/docker_sandbox.py
@@ -886,6 +886,7 @@ class DockerSandbox(SandboxBase):
         benjamin_enabled: bool = False,
         peer_messaging: bool = False,
         posthog_exec_permission_regex: str | None = None,
+        claude_model_access: str | None = None,
     ) -> str:
         # The host proxy URL (e.g. localhost:8003) is unreachable from inside the container;
         # rewrite it the same way POSTHOG_API_URL is for Docker sandboxes.
@@ -909,6 +910,7 @@ class DockerSandbox(SandboxBase):
             rtk_enabled=rtk_enabled,
             benjamin_enabled=benjamin_enabled,
             peer_messaging=peer_messaging,
+            claude_model_access=claude_model_access,
         )
         create_pr_flag = f" --createPr {shlex.quote('true' if create_pr else 'false')}"
         # Only append when opted in: agent-server builds without the option reject unknown
@@ -1004,6 +1006,7 @@ class DockerSandbox(SandboxBase):
         rtk_enabled: bool = True,
         benjamin_enabled: bool = False,
         peer_messaging: bool = False,
+        claude_model_access: str | None = None,
     ) -> None:
         """Start the agent-server HTTP server in the sandbox.
 
@@ -1084,6 +1087,7 @@ class DockerSandbox(SandboxBase):
             benjamin_enabled=benjamin_enabled,
             peer_messaging=peer_messaging,
             posthog_exec_permission_regex=exec_permission_regex,
+            claude_model_access=claude_model_access,
         )
 
         logger.info(f"Starting agent-server in sandbox {self.id} for {repository or 'no-repo'}")
@@ -1141,6 +1145,7 @@ class DockerSandbox(SandboxBase):
                 benjamin_enabled=benjamin_enabled,
                 peer_messaging=peer_messaging,
                 posthog_exec_permission_regex=exec_permission_regex,
+                claude_model_access=claude_model_access,
             )
             if self._launch_and_check(command):
                 logger.info(f"Agent-server started on port {self._host_port} (without --baseBranch)")

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -282,6 +282,7 @@ def build_agent_runtime_env_prefix(
     rtk_enabled: bool = True,
     benjamin_enabled: bool = False,
     peer_messaging: bool = False,
+    claude_model_access: str | None = None,
 ) -> str:
     env_vars = {
         "POSTHOG_CODE_INTERACTION_ORIGIN": interaction_origin,
@@ -307,6 +308,10 @@ def build_agent_runtime_env_prefix(
         # both states so a stale "1" in a resumed sandbox can't outlive a flag rollback;
         # the peers endpoints re-check authorization server-side regardless.
         "POSTHOG_AGENT_PEER_MESSAGING": "1" if peer_messaging else "0",
+        # Marker, not a secret: tells the agent-server whether the Claude runtime uses the
+        # user's Claude plan (token relayed from Desktop) or the PostHog gateway. Set in
+        # both states so a resumed sandbox can't keep a stale own-subscription marker.
+        "POSTHOG_CODE_CLAUDE_MODEL_ACCESS": claude_model_access,
     }
     assignments = " ".join(
         f"{name}={shlex.quote(value)}" for name, value in env_vars.items() if value is not None and value != ""
@@ -560,6 +565,7 @@ class SandboxBase(ABC):
         rtk_enabled: bool = True,
         benjamin_enabled: bool = False,
         peer_messaging: bool = False,
+        claude_model_access: str | None = None,
     ) -> int | None:
         """Start the agent-server HTTP server in the sandbox.
 

--- a/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
@@ -698,6 +698,33 @@ class TestModalSandboxAgentServer:
         assert expected_env in command
 
     @pytest.mark.parametrize(
+        "claude_model_access, expected_env",
+        [
+            ("own-subscription", "POSTHOG_CODE_CLAUDE_MODEL_ACCESS=own-subscription"),
+            ("posthog-gateway", "POSTHOG_CODE_CLAUDE_MODEL_ACCESS=posthog-gateway"),
+            (None, None),
+        ],
+    )
+    def test_start_agent_server_claude_model_access_env(self, mock_sandbox: Any, claude_model_access, expected_env):
+        mock_sandbox.execute = MagicMock(
+            return_value=ExecutionResult(stdout="ok:1", stderr="", exit_code=0, error=None),
+        )
+
+        mock_sandbox.start_agent_server(
+            repository="posthog/posthog",
+            task_id="task-123",
+            run_id="run-456",
+            mode="background",
+            claude_model_access=claude_model_access,
+        )
+
+        command = _agent_server_launch_command(mock_sandbox.execute)
+        if expected_env is not None:
+            assert expected_env in command
+        else:
+            assert "POSTHOG_CODE_CLAUDE_MODEL_ACCESS" not in command
+
+    @pytest.mark.parametrize(
         "keep_stream_open, expected_env_present",
         [
             (True, True),

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -3093,6 +3093,18 @@ class TaskRunCreateRequestSerializer(ImportedMcpServersFieldMixin, RelayedMcpSer
             "for this run."
         ),
     )
+    claude_model_access = serializers.ChoiceField(
+        choices=["posthog-gateway", "own-subscription"],
+        required=False,
+        allow_null=True,
+        default=None,
+        help_text=(
+            "How the Claude runtime pays for model use. 'own-subscription' makes the sandbox "
+            "request a Claude token from the creating PostHog Desktop at run start; the token is "
+            "sent in flight and never stored on PostHog servers. Omitted or null uses the "
+            "PostHog gateway."
+        ),
+    )
 
     def validate(self, attrs):
         errors: dict[str, str] = {}
@@ -3282,6 +3294,18 @@ class TaskRunBootstrapCreateRequestSerializer(
             "Whether the Benjamin-Plus token-efficiency instruction applies to this run. Omitted "
             "or null lets the server decide from the feature flag; true or false pins the choice "
             "for this run."
+        ),
+    )
+    claude_model_access = serializers.ChoiceField(
+        choices=["posthog-gateway", "own-subscription"],
+        required=False,
+        allow_null=True,
+        default=None,
+        help_text=(
+            "How the Claude runtime pays for model use. 'own-subscription' makes the sandbox "
+            "request a Claude token from the creating PostHog Desktop at run start; the token is "
+            "sent in flight and never stored on PostHog servers. Omitted or null uses the "
+            "PostHog gateway."
         ),
     )
 
@@ -3749,6 +3773,7 @@ class TaskRunCommandRequestSerializer(serializers.Serializer):
         "permission_response",
         "set_config_option",
         "mcp_response",
+        "credential_response",
         "pi/rpc",
         "queue_get",
         "queue_clear",
@@ -3758,6 +3783,7 @@ class TaskRunCommandRequestSerializer(serializers.Serializer):
     # Cap on the serialized mcp_response params (docs/CLOUD-MCP-RELAY.md): the relayed JSON-RPC
     # response payload plus envelope must fit in 300 KB. Params are forwarded to the sandbox
     # verbatim and never persisted or captured — they carry data from the user's private systems.
+    # credential_response params carry a provider token and get the same treatment.
     MAX_MCP_RESPONSE_PARAMS_BYTES = 300_000
 
     # A side question is forwarded into an agent turn, so its length is the direct lever on
@@ -3875,6 +3901,19 @@ class TaskRunCommandRequestSerializer(serializers.Serializer):
                 )
             if len(json.dumps(params)) > self.MAX_MCP_RESPONSE_PARAMS_BYTES:
                 raise serializers.ValidationError({"params": "mcp_response params exceed the 300 KB limit"})
+        elif method == "credential_response":
+            self._require_nonempty_string(params, "requestId")
+            self._require_nonempty_string(params, "credential")
+            token = params.get("token")
+            error = params.get("error")
+            if (token is None) == (error is None):
+                raise serializers.ValidationError(
+                    {"params": "credential_response requires exactly one of token or error"}
+                )
+            if token is not None and not isinstance(token, str):
+                raise serializers.ValidationError({"params": "token must be a string"})
+            if error is not None and not isinstance(error, str):
+                raise serializers.ValidationError({"params": "error must be a string"})
         return attrs
 
 

--- a/products/tasks/backend/temporal/process_task/README.md
+++ b/products/tasks/backend/temporal/process_task/README.md
@@ -149,6 +149,19 @@ Per-team configuration for sandbox execution: network access level (trusted/full
 | GitHub App      | Installation access tokens via the team's GitHub integration                                                      |
 | API permissions | `PostHogFeatureFlagPermission` + `APIScopePermission` on all endpoints                                            |
 
+### Claude subscription token relay
+
+A run created with `claude_model_access: "own-subscription"` (gated by the
+`posthog-code-claude-own-subscription-cloud` feature flag, fail-closed) bills the
+user's Claude plan instead of PostHog credits. The sandbox's agent-server asks
+the creating PostHog Desktop for the token with a `credential_request` event and
+receives it through the `/command/` proxy as a `credential_response` command.
+The token is a relayed secret: it moves in flight only, and no Postgres field,
+Redis key, log line, or analytics event ever holds it. If no token arrives
+within 120 seconds the run fails with instructions; it never falls back to
+PostHog credits silently. A sandbox build predating the relay fails the same
+way, guarded by the `claude_subscription_relay` capability in `GET /health`.
+
 ## Sandbox providers
 
 |                   | DockerSandbox                                                  | ModalSandbox                                                          |

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -19,6 +19,7 @@ from products.tasks.backend.constants import (
     AGENT_PEER_MESSAGING_FEATURE_FLAG,
     AGENT_PROXY_KEEP_STREAM_OPEN_FEATURE_FLAG,
     BENJAMIN_FEATURE_FLAG,
+    CLAUDE_OWN_SUBSCRIPTION_CLOUD_FEATURE_FLAG,
     CONTINUE_AS_NEW_FEATURE_FLAG,
     DESKTOP_WORKSPACE_WARM_FEATURE_FLAG,
     DEV_STACK_IMAGE_NAME,
@@ -156,6 +157,10 @@ class TaskProcessingContext:
     # and out-of-band consumers route deterministically for the run's whole life.
     sandbox_backend: str = "modal"
     dev_stack_preview_enabled: bool = False
+    # How the Claude runtime pays for model use. "own-subscription" makes the sandbox request
+    # a Claude token from the creating Desktop; "posthog-gateway" bills PostHog credits.
+    # Resolved fail-closed: flag off or non-Claude adapter always resolves to the gateway.
+    claude_model_access: str = "posthog-gateway"
 
     @property
     def mode(self) -> str:
@@ -447,6 +452,41 @@ def _is_rtk_enabled(
         return state_override
 
     return True
+
+
+def _resolve_claude_model_access(
+    *,
+    distinct_id: str,
+    organization_id: str,
+    run_id: str,
+    state: dict | None = None,
+) -> str:
+    """Resolve how the Claude runtime pays for model use. Fails closed: the
+    own-subscription path requires the run state to ask for it AND the cloud
+    feature flag to be on. Any flag-service error keeps the run on the PostHog
+    gateway, never silently on the subscription."""
+    if (state or {}).get("claude_model_access") != "own-subscription":
+        return "posthog-gateway"
+    try:
+        enabled = bool(
+            posthoganalytics.feature_enabled(
+                CLAUDE_OWN_SUBSCRIPTION_CLOUD_FEATURE_FLAG,
+                distinct_id=distinct_id,
+                groups={"organization": organization_id},
+                group_properties={"organization": {"id": organization_id}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception as e:
+        log_with_activity_context("claude_own_subscription_flag_check_failed", run_id=run_id, error=str(e))
+        enabled = False
+    if enabled:
+        log_with_activity_context(
+            "claude_own_subscription_flag_checked", run_id=run_id, claude_model_access="own-subscription"
+        )
+        return "own-subscription"
+    return "posthog-gateway"
 
 
 def _is_benjamin_enabled(
@@ -1350,6 +1390,16 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         origin_product=task.origin_product,
         state=state,
     )
+    claude_model_access = _resolve_claude_model_access(
+        distinct_id=distinct_id,
+        organization_id=organization_id,
+        run_id=run_id,
+        state=state,
+    )
+    # The subscription path sets CLAUDE_CODE_OAUTH_TOKEN in the Claude env; a non-Claude
+    # adapter has no such env, so the marker must not survive as own-subscription.
+    if (state or {}).get("runtime_adapter") not in (None, "claude"):
+        claude_model_access = "posthog-gateway"
     emit_agent_log(
         run_id,
         "debug",
@@ -1482,6 +1532,7 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         custom_image_name=custom_image_name,
         rtk_enabled=rtk_enabled,
         benjamin_enabled=benjamin_enabled,
+        claude_model_access=claude_model_access,
         continue_as_new_enabled=_is_continue_as_new_enabled(
             distinct_id=distinct_id,
             organization_id=organization_id,

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -24,6 +24,7 @@ from posthog.temporal.oauth import PosthogMcpScopes
 from products.tasks.backend.exceptions import (
     OAuthTokenError,
     ProcessTaskError,
+    ProcessTaskFatalError,
     SandboxExecutionError,
     SandboxMissingRepositoryError,
 )
@@ -558,6 +559,7 @@ def _invoke_start_agent_server(
             rtk_enabled=ctx.rtk_enabled,
             benjamin_enabled=ctx.benjamin_enabled,
             peer_messaging=ctx.peer_messaging_enabled,
+            claude_model_access=ctx.claude_model_access,
         )
         return health_duration_ms if isinstance(health_duration_ms, int) else None
 
@@ -579,6 +581,40 @@ def _invoke_start_agent_server(
                 "error": str(e),
             },
             cause=e,
+        )
+
+
+CLAUDE_SUBSCRIPTION_RELAY_CAPABILITY = "claude_subscription_relay"
+
+
+def _enforce_claude_subscription_relay_capability(sandbox: SandboxBase, ctx: TaskProcessingContext) -> None:
+    """A sandbox image predating the credential relay ignores the own-subscription
+    marker and would silently bill PostHog credits. Fail the run instead; the error
+    is non-retryable, so no silent fallback ever happens."""
+    if ctx.claude_model_access != "own-subscription":
+        return
+    try:
+        result = sandbox.execute(
+            f"curl -s --max-time 5 {sandbox.agent_server_health_url()}",
+            timeout_seconds=10,
+        )
+        payload = json.loads(result.stdout or "{}")
+        capabilities = payload.get("capabilities")
+        supported = isinstance(capabilities, list) and CLAUDE_SUBSCRIPTION_RELAY_CAPABILITY in capabilities
+    except Exception:
+        logger.warning("claude_subscription_relay_capability_probe_failed", task_id=ctx.task_id, run_id=ctx.run_id)
+        supported = False
+    if not supported:
+        emit_agent_log(
+            ctx.run_id,
+            "warn",
+            "Agent-server build predates the Claude subscription relay; failing own-subscription run",
+        )
+        raise ProcessTaskFatalError(
+            "This sandbox build cannot use your Claude plan yet. Run the task again. "
+            'If the problem repeats, turn off "Use your Claude plan for cloud tasks".',
+            {"task_id": ctx.task_id, "run_id": ctx.run_id},
+            cause=RuntimeError("agent-server lacks claude_subscription_relay capability"),
         )
 
 
@@ -740,6 +776,7 @@ def start_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
                 invoke_ms = invoke_timer.elapsed_ms
                 health_poll_ms = health_timer.elapsed_ms
             _record_agent_server_launch(sandbox, ctx, params)
+            _enforce_claude_subscription_relay_capability(sandbox, ctx)
 
         _record_network_enforcement_observation(ctx)
 
@@ -895,6 +932,7 @@ def await_agent_server_ready(input: StartAgentServerInput) -> StartAgentServerOu
                     ) as health_timer:
                         sandbox.wait_for_agent_server_ready(agentsh_domains)
                     _record_agent_server_launch(sandbox, ctx, params)
+                    _enforce_claude_subscription_relay_capability(sandbox, ctx)
         except Exception:
             if attempt > 1:
                 increment_agent_server_readiness_retry(

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -15,6 +15,7 @@ from products.skills.backend.models.skills import LLMSkill
 from products.tasks.backend.constants import (
     AGENT_PROXY_KEEP_STREAM_OPEN_FEATURE_FLAG,
     BENJAMIN_FEATURE_FLAG,
+    CLAUDE_OWN_SUBSCRIPTION_CLOUD_FEATURE_FLAG,
     CONTINUE_AS_NEW_FEATURE_FLAG,
     DESKTOP_WORKSPACE_WARM_FEATURE_FLAG,
     DEV_STACK_IMAGE_NAME,
@@ -45,6 +46,7 @@ from products.tasks.backend.temporal.process_task.activities.get_task_processing
     _is_pr_babysit_snapshot_enabled,
     _is_rtk_enabled,
     _is_sandbox_event_ingest_enabled,
+    _resolve_claude_model_access,
     _resolve_modal_vm_sandbox,
     _resolve_sandbox_backend,
     get_task_processing_context,
@@ -906,6 +908,58 @@ class TestGetTaskProcessingContextActivity:
                     state={"rtk_enabled": False},
                 )
                 is False
+            )
+
+    @pytest.mark.parametrize(
+        "flag_value, state, expected",
+        [
+            (True, {"claude_model_access": "own-subscription"}, "own-subscription"),
+            (False, {"claude_model_access": "own-subscription"}, "posthog-gateway"),
+            (None, {"claude_model_access": "own-subscription"}, "posthog-gateway"),
+            (True, {"claude_model_access": "posthog-gateway"}, "posthog-gateway"),
+            (True, {}, "posthog-gateway"),
+        ],
+    )
+    def test_claude_model_access_requires_state_ask_and_flag(self, flag_value, state, expected):
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            return_value=flag_value,
+        ) as feature_enabled_mock:
+            assert (
+                _resolve_claude_model_access(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                    state=state,
+                )
+                == expected
+            )
+
+        if state.get("claude_model_access") == "own-subscription":
+            feature_enabled_mock.assert_called_once_with(
+                CLAUDE_OWN_SUBSCRIPTION_CLOUD_FEATURE_FLAG,
+                distinct_id="distinct-id",
+                groups={"organization": "organization-id"},
+                group_properties={"organization": {"id": "organization-id"}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        else:
+            feature_enabled_mock.assert_not_called()
+
+    def test_claude_model_access_fails_closed_on_flag_error(self):
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            side_effect=RuntimeError("flag service failed"),
+        ):
+            assert (
+                _resolve_claude_model_access(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                    state={"claude_model_access": "own-subscription"},
+                )
+                == "posthog-gateway"
             )
 
     @pytest.mark.parametrize("launched_value", [True, False])

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_start_agent_server.py
@@ -5,6 +5,7 @@ from django.db import OperationalError
 
 from products.tasks.backend.exceptions import (
     OAuthTokenError,
+    ProcessTaskFatalError,
     SandboxExecutionError,
     SandboxMissingRepositoryError,
     SandboxTimeoutError,
@@ -15,6 +16,7 @@ from products.tasks.backend.temporal.process_task.activities.start_agent_server 
     CollectAgentShadowResultInput,
     StartAgentServerInput,
     _agentsh_domains_for,
+    _enforce_claude_subscription_relay_capability,
     _ensure_repository_on_disk,
     _include_personal_mcp_for_task,
     _invoke_start_agent_server,
@@ -68,6 +70,7 @@ def _context(
     network_policy_fingerprint: str | None = None,
     use_modal_vm_sandbox: bool = False,
     use_modal_network_allowlist: bool = False,
+    claude_model_access: str = "posthog-gateway",
 ) -> TaskProcessingContext:
     return TaskProcessingContext(
         task_id="task-id",
@@ -85,6 +88,7 @@ def _context(
         network_policy_fingerprint=network_policy_fingerprint,
         use_modal_vm_sandbox=use_modal_vm_sandbox,
         use_modal_network_allowlist=use_modal_network_allowlist,
+        claude_model_access=claude_model_access,
         _branch=branch,
     )
 
@@ -537,6 +541,49 @@ def test_ensure_repository_on_disk_skips_repo_less_runs(mocker) -> None:
     _ensure_repository_on_disk(_context(repository=None), sandbox)
 
     sandbox.execute.assert_not_called()
+
+
+def test_enforce_claude_subscription_relay_capability_skips_gateway_runs(mocker) -> None:
+    sandbox = mocker.Mock()
+
+    _enforce_claude_subscription_relay_capability(sandbox, _context(claude_model_access="posthog-gateway"))
+
+    sandbox.execute.assert_not_called()
+
+
+def test_enforce_claude_subscription_relay_capability_allows_advertised_build(mocker) -> None:
+    sandbox = mocker.Mock()
+    sandbox.agent_server_health_url.return_value = "http://127.0.0.1:8080/health"
+    sandbox.execute.return_value = ExecutionResult(
+        stdout='{"capabilities": ["prewarmedResumeIdle", "claude_subscription_relay"]}',
+        stderr="",
+        exit_code=0,
+    )
+
+    _enforce_claude_subscription_relay_capability(sandbox, _context(claude_model_access="own-subscription"))
+
+    sandbox.execute.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "stdout",
+    [
+        '{"capabilities": ["prewarmedResumeIdle"]}',
+        '{"capabilities": []}',
+        "{}",
+        "not-json",
+    ],
+)
+def test_enforce_claude_subscription_relay_capability_fails_old_builds(mocker, stdout) -> None:
+    # A sandbox image predating the relay would ignore the marker and silently
+    # bill PostHog credits, so an absent capability must fail the run instead.
+    sandbox = mocker.Mock()
+    sandbox.agent_server_health_url.return_value = "http://127.0.0.1:8080/health"
+    sandbox.execute.return_value = ExecutionResult(stdout=stdout, stderr="", exit_code=0)
+    mocker.patch("products.tasks.backend.temporal.process_task.activities.start_agent_server.emit_agent_log")
+
+    with pytest.raises(ProcessTaskFatalError, match="cannot use your Claude plan yet"):
+        _enforce_claude_subscription_relay_capability(sandbox, _context(claude_model_access="own-subscription"))
 
 
 def test_agent_shadow_flag_uses_server_side_organization_targeting(mocker) -> None:

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -451,6 +451,10 @@ class RunState(BaseModel, extra="allow"):
     reasoning_effort: ReasoningEffort | None = None
     context_window: str | None = None
     fast_mode: bool | None = None
+    # Marker, not a secret: "own-subscription" makes the sandbox request a Claude
+    # token from the creating Desktop at run start (the token itself never touches
+    # PostHog servers). Resolved server-side against the cloud feature flag.
+    claude_model_access: Literal["posthog-gateway", "own-subscription"] | None = None
     resume_from_run_id: str | None = None
     same_run_resume: bool = False
     same_run_resume_idle: bool = False

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -3461,6 +3461,8 @@ class TestTaskAPI(BaseTaskAPITest):
             ("rtk_enabled", False),
             ("benjamin_enabled", True),
             ("benjamin_enabled", False),
+            ("claude_model_access", "own-subscription"),
+            ("claude_model_access", "posthog-gateway"),
         ]
     )
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
@@ -3475,10 +3477,10 @@ class TestTaskAPI(BaseTaskAPITest):
 
         assert response.status_code == status.HTTP_200_OK
         task_run = TaskRun.objects.get(id=response.json()["latest_run"]["id"])
-        assert task_run.state[field] is value
+        assert task_run.state[field] == value
         mock_workflow.assert_called_once()
 
-    @parameterized.expand([("rtk_enabled",), ("benjamin_enabled",)])
+    @parameterized.expand([("rtk_enabled",), ("benjamin_enabled",), ("claude_model_access",)])
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
     def test_run_endpoint_omits_agent_toggle_when_not_set(self, field, mock_workflow):
         task = self.create_task()
@@ -11534,6 +11536,70 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
         call_kwargs = mock_post.call_args[1]
         self.assertEqual(call_kwargs["json"]["method"], "mcp_response")
         self.assertEqual(call_kwargs["json"]["params"]["error"], {"code": -32001, "message": "server process exited"})
+
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
+    @patch("products.tasks.backend.presentation.views.api.http_requests.post")
+    def test_command_proxies_credential_response_and_never_persists_the_token(self, mock_post):
+        reset_sandbox_jwt_key_cache()
+        # Clearly fake test value, shaped like a real Claude setup token.
+        token = "sk-ant-oat01-fake-test-token-0000000000000000"
+        self._mock_agent_response(
+            mock_post,
+            {"jsonrpc": "2.0", "id": "req-8", "result": {"acknowledged": True}},
+        )
+
+        task = self.create_task()
+        run = self._create_run_with_sandbox(task)
+        state_before = dict(run.state or {})
+
+        with self.assertLogs(level="DEBUG") as captured:
+            response = self.client.post(
+                self._command_url(task, run),
+                {
+                    "jsonrpc": "2.0",
+                    "method": "credential_response",
+                    "params": {
+                        "requestId": "cred-1",
+                        "credential": "claude_subscription_token",
+                        "token": token,
+                    },
+                    "id": "req-8",
+                },
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        call_kwargs = mock_post.call_args[1]
+        self.assertEqual(call_kwargs["json"]["method"], "credential_response")
+        self.assertEqual(call_kwargs["json"]["params"]["token"], token)
+        # In flight only: the run's state is unchanged and no log record carries the token.
+        run.refresh_from_db()
+        self.assertEqual(run.state, state_before)
+        for record in captured.records:
+            self.assertNotIn(token, record.getMessage())
+
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
+    def test_command_rejects_credential_response_with_token_and_error(self):
+        task = self.create_task()
+        run = self._create_run_with_sandbox(task)
+
+        response = self.client.post(
+            self._command_url(task, run),
+            {
+                "jsonrpc": "2.0",
+                "method": "credential_response",
+                "params": {
+                    "requestId": "cred-2",
+                    "credential": "claude_subscription_token",
+                    "token": "sk-ant-oat01-fake-test-token-0000000000000000",
+                    "error": "no_token",
+                },
+                "id": "req-9",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def _create_posthog_ai_task(self, created_by: User | None = None):
         return Task.objects.create(

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -2552,6 +2552,17 @@ export const InitialPermissionModeEnumApi = {
 } as const
 
 /**
+ * * `posthog-gateway` - posthog-gateway
+ * * `own-subscription` - own-subscription
+ */
+export type ClaudeModelAccessEnumApi = (typeof ClaudeModelAccessEnumApi)[keyof typeof ClaudeModelAccessEnumApi]
+
+export const ClaudeModelAccessEnumApi = {
+    PosthogGateway: 'posthog-gateway',
+    OwnSubscription: 'own-subscription',
+} as const
+
+/**
  * Request body for creating a new task run
  */
 export interface ClaudeTaskRunCreateSchemaApi {
@@ -2651,6 +2662,11 @@ export interface ClaudeTaskRunCreateSchemaApi {
      * @nullable
      */
     benjamin_enabled?: boolean | null
+    /** How the Claude runtime pays for model use. 'own-subscription' makes the sandbox request a Claude token from the creating PostHog Desktop at run start; the token is sent in flight and never stored on PostHog servers. Omitted or null uses the PostHog gateway.
+     *
+     * * `posthog-gateway` - posthog-gateway
+     * * `own-subscription` - own-subscription */
+    claude_model_access?: ClaudeModelAccessEnumApi | null
 }
 
 /**
@@ -2777,6 +2793,11 @@ export interface CodexTaskRunCreateSchemaApi {
      * @nullable
      */
     benjamin_enabled?: boolean | null
+    /** How the Claude runtime pays for model use. 'own-subscription' makes the sandbox request a Claude token from the creating PostHog Desktop at run start; the token is sent in flight and never stored on PostHog servers. Omitted or null uses the PostHog gateway.
+     *
+     * * `posthog-gateway` - posthog-gateway
+     * * `own-subscription` - own-subscription */
+    claude_model_access?: ClaudeModelAccessEnumApi | null
 }
 
 export interface TaskRunResumeRequestSchemaApi {
@@ -3148,6 +3169,11 @@ export interface TaskRunBootstrapCreateRequestApi {
      * @nullable
      */
     benjamin_enabled?: boolean | null
+    /** How the Claude runtime pays for model use. 'own-subscription' makes the sandbox request a Claude token from the creating PostHog Desktop at run start; the token is sent in flight and never stored on PostHog servers. Omitted or null uses the PostHog gateway.
+     *
+     * * `posthog-gateway` - posthog-gateway
+     * * `own-subscription` - own-subscription */
+    claude_model_access?: ClaudeModelAccessEnumApi | null
 }
 
 /**
@@ -3722,6 +3748,7 @@ export const JsonrpcEnumApi = {
  * * `permission_response` - permission_response
  * * `set_config_option` - set_config_option
  * * `mcp_response` - mcp_response
+ * * `credential_response` - credential_response
  * * `pi/rpc` - pi/rpc
  * * `queue_get` - queue_get
  * * `queue_clear` - queue_clear
@@ -3737,6 +3764,7 @@ export const TaskRunCommandRequestMethodEnumApi = {
     PermissionResponse: 'permission_response',
     SetConfigOption: 'set_config_option',
     McpResponse: 'mcp_response',
+    CredentialResponse: 'credential_response',
     PiRpc: 'pi/rpc',
     QueueGet: 'queue_get',
     QueueClear: 'queue_clear',
@@ -3759,6 +3787,7 @@ export interface TaskRunCommandRequestApi {
      * * `permission_response` - permission_response
      * * `set_config_option` - set_config_option
      * * `mcp_response` - mcp_response
+     * * `credential_response` - credential_response
      * * `pi/rpc` - pi/rpc
      * * `queue_get` - queue_get
      * * `queue_clear` - queue_clear

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -1864,6 +1864,17 @@ export const TasksRunCreateBody = /* @__PURE__ */ zod.union([
                 .describe(
                     'Whether the Benjamin-Plus token-efficiency instruction applies to this run. Omitted or null lets the server decide from the feature flag; true or false pins the choice for this run.'
                 ),
+            claude_model_access: zod
+                .union([
+                    zod
+                        .enum(['posthog-gateway', 'own-subscription'])
+                        .describe('\* `posthog-gateway` - posthog-gateway\n\* `own-subscription` - own-subscription'),
+                    zod.null(),
+                ])
+                .optional()
+                .describe(
+                    "How the Claude runtime pays for model use. 'own-subscription' makes the sandbox request a Claude token from the creating PostHog Desktop at run start; the token is sent in flight and never stored on PostHog servers. Omitted or null uses the PostHog gateway.\n\n\* `posthog-gateway` - posthog-gateway\n\* `own-subscription` - own-subscription"
+                ),
         })
         .describe('Request body for creating a new task run'),
     zod
@@ -2016,6 +2027,17 @@ export const TasksRunCreateBody = /* @__PURE__ */ zod.union([
                 .nullish()
                 .describe(
                     'Whether the Benjamin-Plus token-efficiency instruction applies to this run. Omitted or null lets the server decide from the feature flag; true or false pins the choice for this run.'
+                ),
+            claude_model_access: zod
+                .union([
+                    zod
+                        .enum(['posthog-gateway', 'own-subscription'])
+                        .describe('\* `posthog-gateway` - posthog-gateway\n\* `own-subscription` - own-subscription'),
+                    zod.null(),
+                ])
+                .optional()
+                .describe(
+                    "How the Claude runtime pays for model use. 'own-subscription' makes the sandbox request a Claude token from the creating PostHog Desktop at run start; the token is sent in flight and never stored on PostHog servers. Omitted or null uses the PostHog gateway.\n\n\* `posthog-gateway` - posthog-gateway\n\* `own-subscription` - own-subscription"
                 ),
         })
         .describe('Request body for creating a new task run'),
@@ -2461,6 +2483,17 @@ export const TasksRunsCreateBody = /* @__PURE__ */ zod
             .nullish()
             .describe(
                 'Whether the Benjamin-Plus token-efficiency instruction applies to this run. Omitted or null lets the server decide from the feature flag; true or false pins the choice for this run.'
+            ),
+        claude_model_access: zod
+            .union([
+                zod
+                    .enum(['posthog-gateway', 'own-subscription'])
+                    .describe('\* `posthog-gateway` - posthog-gateway\n\* `own-subscription` - own-subscription'),
+                zod.null(),
+            ])
+            .optional()
+            .describe(
+                "How the Claude runtime pays for model use. 'own-subscription' makes the sandbox request a Claude token from the creating PostHog Desktop at run start; the token is sent in flight and never stored on PostHog servers. Omitted or null uses the PostHog gateway.\n\n\* `posthog-gateway` - posthog-gateway\n\* `own-subscription` - own-subscription"
             ),
     })
     .describe('Request body for creating a task run without starting execution yet.')
@@ -3098,16 +3131,17 @@ export const TasksRunsCommandCreateBody = /* @__PURE__ */ zod
                 'permission_response',
                 'set_config_option',
                 'mcp_response',
+                'credential_response',
                 'pi/rpc',
                 'queue_get',
                 'queue_clear',
                 'side_question',
             ])
             .describe(
-                '\* `user_message` - user_message\n\* `cancel` - cancel\n\* `close` - close\n\* `permission_response` - permission_response\n\* `set_config_option` - set_config_option\n\* `mcp_response` - mcp_response\n\* `pi\/rpc` - pi\/rpc\n\* `queue_get` - queue_get\n\* `queue_clear` - queue_clear\n\* `side_question` - side_question'
+                '\* `user_message` - user_message\n\* `cancel` - cancel\n\* `close` - close\n\* `permission_response` - permission_response\n\* `set_config_option` - set_config_option\n\* `mcp_response` - mcp_response\n\* `credential_response` - credential_response\n\* `pi\/rpc` - pi\/rpc\n\* `queue_get` - queue_get\n\* `queue_clear` - queue_clear\n\* `side_question` - side_question'
             )
             .describe(
-                'Command method to execute on the agent server\n\n\* `user_message` - user_message\n\* `cancel` - cancel\n\* `close` - close\n\* `permission_response` - permission_response\n\* `set_config_option` - set_config_option\n\* `mcp_response` - mcp_response\n\* `pi\/rpc` - pi\/rpc\n\* `queue_get` - queue_get\n\* `queue_clear` - queue_clear\n\* `side_question` - side_question'
+                'Command method to execute on the agent server\n\n\* `user_message` - user_message\n\* `cancel` - cancel\n\* `close` - close\n\* `permission_response` - permission_response\n\* `set_config_option` - set_config_option\n\* `mcp_response` - mcp_response\n\* `credential_response` - credential_response\n\* `pi\/rpc` - pi\/rpc\n\* `queue_get` - queue_get\n\* `queue_clear` - queue_clear\n\* `side_question` - side_question'
             ),
         params: zod.record(zod.string(), zod.unknown()).optional().describe('Parameters for the command'),
         id: zod.unknown().optional().describe('Optional JSON-RPC request ID (string or number)'),

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -17303,6 +17303,18 @@ export namespace Schemas {
     }
 
     /**
+     * * `posthog-gateway` - posthog-gateway
+     * * `own-subscription` - own-subscription
+     */
+    export type ClaudeModelAccessEnum = typeof ClaudeModelAccessEnum[keyof typeof ClaudeModelAccessEnum];
+
+
+    export const ClaudeModelAccessEnum = {
+      PosthogGateway: 'posthog-gateway',
+      OwnSubscription: 'own-subscription',
+    } as const;
+
+    /**
      * * `claude` - claude
      */
     export type ClaudeRuntimeAdapterEnum = typeof ClaudeRuntimeAdapterEnum[keyof typeof ClaudeRuntimeAdapterEnum];
@@ -17537,6 +17549,11 @@ export namespace Schemas {
          * @nullable
          */
       benjamin_enabled?: boolean | null;
+      /** How the Claude runtime pays for model use. 'own-subscription' makes the sandbox request a Claude token from the creating PostHog Desktop at run start; the token is sent in flight and never stored on PostHog servers. Omitted or null uses the PostHog gateway.
+       *
+       * * `posthog-gateway` - posthog-gateway
+       * * `own-subscription` - own-subscription */
+      claude_model_access?: ClaudeModelAccessEnum | null;
     }
 
     export type ClickhouseEventProperties = { [key: string]: unknown };
@@ -17935,6 +17952,11 @@ export namespace Schemas {
          * @nullable
          */
       benjamin_enabled?: boolean | null;
+      /** How the Claude runtime pays for model use. 'own-subscription' makes the sandbox request a Claude token from the creating PostHog Desktop at run start; the token is sent in flight and never stored on PostHog servers. Omitted or null uses the PostHog gateway.
+       *
+       * * `posthog-gateway` - posthog-gateway
+       * * `own-subscription` - own-subscription */
+      claude_model_access?: ClaudeModelAccessEnum | null;
     }
 
     export type PropertyGroupOperatorEnum = typeof PropertyGroupOperatorEnum[keyof typeof PropertyGroupOperatorEnum];
@@ -85865,6 +85887,11 @@ export namespace Schemas {
          * @nullable
          */
       benjamin_enabled?: boolean | null;
+      /** How the Claude runtime pays for model use. 'own-subscription' makes the sandbox request a Claude token from the creating PostHog Desktop at run start; the token is sent in flight and never stored on PostHog servers. Omitted or null uses the PostHog gateway.
+       *
+       * * `posthog-gateway` - posthog-gateway
+       * * `own-subscription` - own-subscription */
+      claude_model_access?: ClaudeModelAccessEnum | null;
     }
 
     export interface TaskRunCancelRequest {
@@ -85890,6 +85917,7 @@ export namespace Schemas {
      * * `permission_response` - permission_response
      * * `set_config_option` - set_config_option
      * * `mcp_response` - mcp_response
+     * * `credential_response` - credential_response
      * * `pi/rpc` - pi/rpc
      * * `queue_get` - queue_get
      * * `queue_clear` - queue_clear
@@ -85905,6 +85933,7 @@ export namespace Schemas {
       PermissionResponse: 'permission_response',
       SetConfigOption: 'set_config_option',
       McpResponse: 'mcp_response',
+      CredentialResponse: 'credential_response',
       PiRpc: 'pi/rpc',
       QueueGet: 'queue_get',
       QueueClear: 'queue_clear',
@@ -85927,6 +85956,7 @@ export namespace Schemas {
        * * `permission_response` - permission_response
        * * `set_config_option` - set_config_option
        * * `mcp_response` - mcp_response
+       * * `credential_response` - credential_response
        * * `pi/rpc` - pi/rpc
        * * `queue_get` - queue_get
        * * `queue_clear` - queue_clear


### PR DESCRIPTION
## Problem

A user who pays for Claude Pro, Max, Team, or Enterprise cannot use that plan for PostHog cloud runs; every cloud Claude run bills PostHog credits. This PR adds the sandbox and backend half of letting a cloud run bill the user's Claude plan instead.

## Changes

- A run created with `claude_model_access: "own-subscription"` makes the sandbox request a Claude token from the creating PostHog Desktop at session start, through a new `credential_request` event and `credential_response` command on the same channel as the MCP relay. The run marker is gated fail-closed by the `posthog-code-claude-own-subscription-cloud` flag: flag off means the PostHog gateway.
- The agent-server keeps the token in memory only and sets `CLAUDE_CODE_OAUTH_TOKEN` in the Claude Code environment, with all gateway variables stripped, so Claude Code bills the user's plan.
- No token within 120 seconds fails the run with instructions; it never falls back to PostHog credits. A sandbox build predating the relay fails the same way, guarded by the `claude_subscription_relay` capability advertised in `GET /health`.
- The token moves in flight only. No `TaskRun.state` key, Postgres field, Redis key, log line, or analytics event can hold it: checked in `TaskRunCommandRequestSerializer`, `capture_relay_command_telemetry` (allowlist excludes the method), the `/command/` proxy path, and the agent-server command handler (logs `requestId` only).
- Resume snapshots need no change: they capture `/tmp/workspace` only, and the token lives in agent-server memory and the Claude Code child env. `ai_gateway_token.py` is unchanged this PR; skipping the gateway token mint for own-subscription runs is a follow-up.
- The rest is mechanical: `POSTHOG_CODE_CLAUDE_MODEL_ACCESS` in the per-exec launch prefix, generated OpenAPI types, and a credentials note in the process_task README.

## How did you test this code?

- Resolver tests (`test_get_task_processing_context.py`): parameterized cases lock the fail-closed rule — state ask + flag on → `own-subscription`; flag off, flag error, no state ask, or non-Claude adapter → `posthog-gateway`. Catches a rollout regression where the marker bypassed the flag.
- Env prefix tests (`test_modal_sandbox.py`): the launch command carries `POSTHOG_CODE_CLAUDE_MODEL_ACCESS` in both states and omits it when unset. Catches a stale marker surviving a resumed sandbox.
- Command proxy tests (`test_api.py`): `credential_response` is forwarded verbatim to the sandbox, `TaskRun.state` is unchanged, and the token appears in no captured log record; both `token` and `error` together are rejected. Catches the token leaking into persisted state or logs.
- Capability guard tests (`test_start_agent_server.py`): missing `claude_subscription_relay` in `/health` plus `own-subscription` raises the fatal user-facing message; gateway runs skip the probe. Catches a silent fallback to PostHog credits on old sandbox images.
- Agent-server tests: `credential-relay.test.ts` (resolve, reject on error, fake-timer timeout, unknown requestId ignored, no event carries the token) and `options.test.ts` (relayed OAuth token overrides ambient env; no `ANTHROPIC_*` or `x-posthog-` values). Schema tests cover the `credential_response` param shape.
- Not run: the full `test_get_task_processing_context.py` and `test_modal_sandbox.py` files in this sandbox (unrelated tests there hang on external services without a Temporal server); the changed tests were run scoped and pass. mypy, ruff, and `hogli ci:preflight --fix` pass with no failures.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- `products/tasks/backend/temporal/process_task/README.md` gains a "Claude subscription token relay" section under Authentication and security. The Desktop design doc note lands in the stacked Desktop PR.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- No duplicate: searched open PRs and issues for "claude own subscription cloud" and "cloud token relay"; PR #94079 covers Pi runs billing a connected subscription, a different runtime and mechanism, and no other PR covers the Claude relay.
- Public artifact: the plan came from a task brief in this session; no customer conversation, ticket, or log fed the code. All token values in tests are invented (`sk-ant-oat01-fake-test-token-…`), and the only `sk-ant-oat01` occurrences in the diff are the prefix check, placeholder copy, and those fake values.
- Tools: PostHog Desktop cloud task with `gh` for PR search. Skills invoked: `/improving-drf-endpoints`, `/writing-dataclasses`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Decisions: the old-sandbox guard probes `GET /health` for the capability after the server is ready, matching the auto-publish probe precedent; the failure is a `ProcessTaskFatalError` so the workflow writes the message as `error_message` without retry storms. The Desktop half is a stacked PR so the guard protects the deploy interval.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*