### PR TITLE
fix(tasks): route hogland agent through the LLM gateway, not direct Bedrock

### DIFF
--- a/products/tasks/backend/logic/services/agent_server_launcher.py
+++ b/products/tasks/backend/logic/services/agent_server_launcher.py
@@ -169,6 +169,7 @@ class AgentServerLaunchMixin(SandboxBase):
             rtk_enabled=rtk_enabled,
             benjamin_enabled=benjamin_enabled,
             peer_messaging=peer_messaging,
+            unset_bedrock=self.disable_direct_bedrock,
         )
         create_pr_flag = f" --createPr {shlex.quote('true' if create_pr else 'false')}"
         # Only append when opted in: agent-server builds without the option reject unknown

--- a/products/tasks/backend/logic/services/hogland_sandbox.py
+++ b/products/tasks/backend/logic/services/hogland_sandbox.py
@@ -191,6 +191,13 @@ class HoglandSandbox(AgentServerLaunchMixin):
     _box: Hogbox
     _sandbox_url: str | None
 
+    # hogland boxes boot with the `bedrock` feature, which puts the Claude CLI in
+    # direct-Bedrock mode. Unset those vars at agent launch so the CLI routes
+    # through the PostHog LLM gateway instead — avoids AWS Bedrock Marketplace
+    # model-access and SigV4 header-signing issues, and keeps gateway-based AI
+    # observability attribution (matching the Modal backend).
+    disable_direct_bedrock = True
+
     def __init__(self, box: Hogbox, config: SandboxConfig, sandbox_url: str | None = None):
         self.id = box.id
         self.config = config

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -282,6 +282,7 @@ def build_agent_runtime_env_prefix(
     rtk_enabled: bool = True,
     benjamin_enabled: bool = False,
     peer_messaging: bool = False,
+    unset_bedrock: bool = False,
 ) -> str:
     env_vars = {
         "POSTHOG_CODE_INTERACTION_ORIGIN": interaction_origin,
@@ -311,7 +312,15 @@ def build_agent_runtime_env_prefix(
     assignments = " ".join(
         f"{name}={shlex.quote(value)}" for name, value in env_vars.items() if value is not None and value != ""
     )
-    return f"env {assignments} " if assignments else ""
+    # Route the agent through the PostHog LLM gateway instead of direct Bedrock:
+    # unset the box profile's Bedrock vars so the Claude CLI falls back to the
+    # gateway (ANTHROPIC_BASE_URL/ANTHROPIC_AUTH_TOKEN). Direct Bedrock from the
+    # box needs AWS Marketplace model access plus SigV4-signing the
+    # x-posthog-property-* headers (which AWS strips), so the gateway path avoids
+    # both and matches the Modal backend.
+    unset_flags = "-u CLAUDE_CODE_USE_BEDROCK -u AWS_CONTAINER_CREDENTIALS_FULL_URI" if unset_bedrock else ""
+    body = f"{unset_flags} {assignments}".strip()
+    return f"env {body} " if body else ""
 
 
 class SandboxBase(ABC):
@@ -319,6 +328,11 @@ class SandboxBase(ABC):
     config: SandboxConfig
     supports_creation_cancellation = False
     creation_timeout_seconds = 300
+    # When True, the agent runtime is launched with the box's Bedrock env unset,
+    # so the Claude CLI routes through the PostHog LLM gateway instead of direct
+    # Bedrock. hogland opts in (see HoglandSandbox); Modal/Docker already use the
+    # gateway.
+    disable_direct_bedrock = False
 
     @staticmethod
     def creation_cancellation_scope(cancel_event: threading.Event) -> AbstractContextManager[None]:

--- a/products/tasks/backend/logic/services/tests/test_hogland_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_hogland_sandbox.py
@@ -24,6 +24,7 @@ from products.tasks.backend.logic.services.sandbox import (
     SandboxConfig,
     SandboxStatus,
     SandboxTemplate,
+    build_agent_runtime_env_prefix,
     get_sandbox_class_for_sandbox_id,
 )
 
@@ -330,3 +331,20 @@ class TestHoglandAuthPrecedence:
 
         with override_settings(HOGLAND_API_TOKEN_FILE=file_setting, HOGLAND_API_TOKEN=static_token):
             assert get_hogland_api_token() == expected
+
+
+class TestHoglandBedrockDisabled:
+    def test_hogland_opts_out_of_direct_bedrock(self):
+        # hogland boxes boot with the bedrock feature (CLAUDE_CODE_USE_BEDROCK=1);
+        # the sandbox opts in to unsetting it so the agent uses the LLM gateway.
+        assert HoglandSandbox.disable_direct_bedrock is True
+
+    def test_env_prefix_unsets_bedrock_vars_when_requested(self):
+        prefix = build_agent_runtime_env_prefix(unset_bedrock=True)
+        assert "-u CLAUDE_CODE_USE_BEDROCK" in prefix
+        assert "-u AWS_CONTAINER_CREDENTIALS_FULL_URI" in prefix
+
+    def test_env_prefix_keeps_bedrock_vars_by_default(self):
+        prefix = build_agent_runtime_env_prefix()
+        assert "CLAUDE_CODE_USE_BEDROCK" not in prefix
+        assert "AWS_CONTAINER_CREDENTIALS_FULL_URI" not in prefix


### PR DESCRIPTION
## Problem

hogland task boxes fail because the in-box agent talks to **AWS Bedrock directly** — hogland boots boxes with the `bedrock` feature, which exports `CLAUDE_CODE_USE_BEDROCK=1`. That direct-Bedrock path has hit a chain of Bedrock-specific failures that the Modal backend never sees:
1. SigV4 rejects the `x-posthog-property-*` custom headers (fixed in #95455), and now
2. AWS Bedrock **Marketplace model-access is denied** for the box's role — something the tasks team can't resolve without an AWS-account change.

Modal boxes don't use Bedrock; they route through the **PostHog LLM gateway** and work fine. hogland used the gateway too until the Bedrock rollout a few days ago.

## Changes

- **hogland task runs now route the agent's LLM calls through the PostHog LLM gateway instead of direct Bedrock** — the same path Modal uses. At agent-server launch the box's Bedrock env is unset (`env -u CLAUDE_CODE_USE_BEDROCK -u AWS_CONTAINER_CREDENTIALS_FULL_URI`), so the Claude CLI falls back to the gateway (`ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN`) the agent already configures.
- This **sidesteps the Bedrock Marketplace/model-access blocker and the SigV4 header issue entirely**, and restores gateway-based **AI-observability attribution** for hogland runs (direct Bedrock bypassed the gateway, so those runs weren't attributed).
- Mechanical: `build_agent_runtime_env_prefix` gains `unset_bedrock`; `SandboxBase.disable_direct_bedrock` (default `False`) is set `True` on `HoglandSandbox`; the launcher threads it through. Modal/Docker are unchanged.
- **Worker-side only** — this runs on the temporal worker when it launches the agent, not baked into the golden, so it deploys with the normal backend (no golden re-bake, no `@posthog/agent` publish).

## How did you test this code?

- Added 3 unit tests (`test_hogland_sandbox.py`, all pass locally): `HoglandSandbox.disable_direct_bedrock is True`; the env prefix emits `-u CLAUDE_CODE_USE_BEDROCK -u AWS_CONTAINER_CREDENTIALS_FULL_URI` when `unset_bedrock=True` and neither var by default.
- Root-caused by end-to-end repro on hogland: direct-Bedrock tasks fail (first SigV4, then the Marketplace access denial); the gateway path (Modal) works. This puts hogland on the working gateway path.
- Full end-to-end confirmation (re-enable the flag, run a hogland task) will follow once this deploys — no golden re-bake required.

## Docs update

Not needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Follow-on to #95455. After the SigV4 header fix, hogland tasks hit a *second*, AWS-side Bedrock blocker (Marketplace model-access). Rather than chase each Bedrock-specific issue, this routes hogland tasks through the PostHog LLM gateway — the path Modal already uses successfully and that hogland itself used before the recent Bedrock rollout — which also fixes the AI-observability attribution gap direct Bedrock introduced. hogland's own design intends direct Bedrock (per-box AWS creds, no SaaS keys), so this is a deliberate tasks-product choice to opt our boxes out; worth a heads-up to the hogland team.
