### PR TITLE
chore(product-analytics): remove sql-box-plot-insight flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -200,7 +200,6 @@ export const FEATURE_FLAGS = {
     PERSON_PROPERTY_INCIDENT_ANNOTATION_JAN_2026: 'person-property-incident-annotation-jan-2026', // owner: #team-platform-features, shows system annotation for Jan 6-7 2026 person property incident
     REPLAY_EXCLUDE_FROM_HIDE_RECORDINGS_MENU: 'replay-exclude-from-hide-recordings-menu', // owner: #team-replay, used to exclude what other people are seeing in Replay
     SHOW_UPGRADE_TO_MANAGED_ACCOUNT: 'show-upgrade-to-managed-account', // owner: #team-billing, used to give free accounts a way to force upgrade to managed account
-    SQL_BOX_PLOT_INSIGHT: 'sql-box-plot-insight', // owner: @pauldambra #team-product-analytics
     WEBHOOKS_DENYLIST: 'webhooks-denylist', // owner: #team-ingestion, used to disable webhooks for certain companies
 
     // Legacy flags, TBD if they need to be removed

--- a/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.test.tsx
@@ -4,9 +4,6 @@ import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BindLogic } from 'kea'
 
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-
 import { DataVisualizationNode, HogQLQueryResponse, NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import { ChartDisplayType } from '~/types'
@@ -32,15 +29,10 @@ const cachedResults: HogQLQueryResponse = {
 describe('TableDisplay', () => {
     afterEach(() => {
         cleanup()
-        featureFlagLogic.unmount()
     })
 
-    it('offers box plots and saves the selected display when the feature is enabled', async () => {
+    it('offers box plots and saves the selected display', async () => {
         initKeaTests()
-        featureFlagLogic.mount()
-        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.SQL_BOX_PLOT_INSIGHT], {
-            [FEATURE_FLAGS.SQL_BOX_PLOT_INSIGHT]: true,
-        })
 
         let query: DataVisualizationNode = {
             kind: NodeKind.DataVisualizationNode,

--- a/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
@@ -3,9 +3,7 @@ import { useActions, useValues } from 'kea'
 import { IconGraph, IconLifecycle, IconPieChart, IconScatter, IconTrends } from '@posthog/icons'
 import { LemonSelect, LemonSelectOptions, LemonSelectProps } from '@posthog/lemon-ui'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { Icon123, IconAreaChart, IconHeatmap, IconTableChart } from 'lib/lemon-ui/icons'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { ChartDisplayType } from '~/types'
 
@@ -48,8 +46,7 @@ export function getTableDisplayOptions(
     columns: Column[],
     numericalColumns: Column[],
     autoVisualizationType: ChartDisplayType,
-    disabledReasonFor?: (displayType: ChartDisplayType) => string | undefined,
-    showBoxPlot = false
+    disabledReasonFor?: (displayType: ChartDisplayType) => string | undefined
 ): LemonSelectOptions<ChartDisplayType> {
     const canDisplayContinuousChart = columns.length > 1 && numericalColumns.length > 0
     const canDisplayScatterPlot = numericalColumns.length > 1
@@ -122,17 +119,13 @@ export function getTableDisplayOptions(
                         ? 'Requires at least two numeric columns, one for each axis'
                         : undefined,
                 },
-                ...(showBoxPlot
-                    ? [
-                          {
-                              value: ChartDisplayType.BoxPlot,
-                              icon: <IconGraph />,
-                              label: 'Box plot',
-                              disabledReason:
-                                  numericalColumns.length < 6 ? 'Requires six numeric summary columns' : undefined,
-                          },
-                      ]
-                    : []),
+                {
+                    value: ChartDisplayType.BoxPlot,
+                    icon: <IconGraph />,
+                    label: 'Box plot',
+                    disabledReason:
+                        numericalColumns.length < 6 ? 'Requires six numeric summary columns' : undefined,
+                },
                 {
                     value: ChartDisplayType.TwoDimensionalHeatmap,
                     icon: <IconHeatmap />,
@@ -173,7 +166,6 @@ export const TableDisplay = ({
 }: TableDisplayProps): JSX.Element => {
     const { setVisualizationType } = useActions(dataVisualizationLogic)
     const { autoVisualizationType, columns, numericalColumns, visualizationType } = useValues(dataVisualizationLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     return (
         <LemonSelect
@@ -184,13 +176,7 @@ export const TableDisplay = ({
             loading={loading}
             onChange={setVisualizationType}
             optionTooltipPlacement="left"
-            options={getTableDisplayOptions(
-                columns,
-                numericalColumns,
-                autoVisualizationType,
-                disabledReasonFor,
-                !!featureFlags[FEATURE_FLAGS.SQL_BOX_PLOT_INSIGHT]
-            )}
+            options={getTableDisplayOptions(columns, numericalColumns, autoVisualizationType, disabledReasonFor)}
             renderButtonContent={() => renderDisplayTypeLabel(visualizationType, autoVisualizationType)}
             size="small"
             value={visualizationType}

--- a/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
@@ -123,8 +123,7 @@ export function getTableDisplayOptions(
                     value: ChartDisplayType.BoxPlot,
                     icon: <IconGraph />,
                     label: 'Box plot',
-                    disabledReason:
-                        numericalColumns.length < 6 ? 'Requires six numeric summary columns' : undefined,
+                    disabledReason: numericalColumns.length < 6 ? 'Requires six numeric summary columns' : undefined,
                 },
                 {
                     value: ChartDisplayType.TwoDimensionalHeatmap,

--- a/frontend/src/scenes/insights/stories/SQLBoxPlot.stories.tsx
+++ b/frontend/src/scenes/insights/stories/SQLBoxPlot.stories.tsx
@@ -3,7 +3,6 @@ import { waitFor } from '@testing-library/dom'
 import userEvent from '@testing-library/user-event'
 import { useEffect, useRef } from 'react'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { createInsightStory } from 'scenes/insights/__mocks__/createInsightScene'
 
 import { mswDecorator } from '~/mocks/browser'
@@ -50,7 +49,6 @@ const meta: Meta = {
     title: 'Scenes-App/Insights/SQLBoxPlot',
     parameters: {
         layout: 'fullscreen',
-        featureFlags: [FEATURE_FLAGS.SQL_BOX_PLOT_INSIGHT],
         testOptions: {
             snapshotBrowsers: ['chromium'],
             viewport: { width: 1300, height: 720 },


### PR DESCRIPTION
## Problem

The SQL box plot is gated behind the `sql-box-plot-insight` feature flag. The feature is validated, so this removes the flag and makes the Box plot display option available to every user in the SQL editor.

## Changes

- The Box plot option now always appears in the SQL editor's chart display dropdown. Previously it only showed for users with the `sql-box-plot-insight` flag on.
- Mechanical: removed the flag constant, its gating in `TableDisplay`, and the flag setup in the test and story.

## How did you test this code?

Ran the affected jest suites (`TableDisplay`, `SqlBoxPlot`, `sqlBoxPlotAdapter`, `DisplayTab`) - all pass. TypeScript check and oxlint show no issues in the changed files. I did not run the full CI matrix; the draft PR will run it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This change was directed by a human and is attributable to pauldambra.

Agent: pi coding assistant. Skills invoked: `writing-pr-descriptions`.

The work removed a validated feature flag for the SQL box plot. No customer, ticket, or internal material appears in this PR.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
