### PR TITLE
feat(capture-logs): add has_labels and retention_days to the metrics avro record

### DIFF
--- a/rust/capture-logs/src/endpoints/prometheus.rs
+++ b/rust/capture-logs/src/endpoints/prometheus.rs
@@ -192,6 +192,8 @@ pub fn write_request_to_kafka_rows(req: WriteRequest) -> (Vec<KafkaMetricRow>, u
                 instrumentation_scope: String::new(),
                 attributes: sample_attributes,
                 series_fingerprint,
+                has_labels: true,
+                retention_days: None,
             });
         }
     }

--- a/rust/capture-logs/src/metric_record.rs
+++ b/rust/capture-logs/src/metric_record.rs
@@ -52,6 +52,8 @@ pub struct KafkaMetricRow {
     /// ClickHouse (which never recomputes it). Links a sample to its series at read
     /// time. i64 carries the u64 hash bits to fit Avro's `long`.
     pub series_fingerprint: i64,
+    pub has_labels: bool,
+    pub retention_days: Option<i32>,
 }
 
 /// Flatten an OTEL Metric into one or more KafkaMetricRow records.
@@ -338,6 +340,8 @@ fn build_number_row(
         instrumentation_scope: instrumentation_scope.to_string(),
         attributes,
         series_fingerprint,
+        has_labels: true,
+        retention_days: None,
     };
 
     Ok((row, was_overridden))
@@ -620,6 +624,44 @@ mod tests {
         )
         .expect("build_number_row should succeed");
         row
+    }
+
+    #[test]
+    fn test_has_labels_and_retention_days_serialise_into_avro_payload() {
+        use crate::metrics_avro_schema::METRICS_AVRO_SCHEMA;
+        use apache_avro::types::Value;
+        use apache_avro::{Codec, Reader, Schema, Writer};
+
+        let mut row = build_test_row(&[]);
+        row.has_labels = false;
+        row.retention_days = Some(30);
+
+        let schema = Schema::parse_str(METRICS_AVRO_SCHEMA).expect("schema parses");
+        let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Null);
+        writer.append_ser(&row).expect("append_ser ok");
+        let payload = writer.into_inner().expect("flush ok");
+
+        let reader = Reader::new(payload.as_slice()).expect("reader ok");
+        let mut found_has_labels = None;
+        let mut found_retention_days = None;
+        for value in reader {
+            let Value::Record(fields) = value.expect("decode ok") else {
+                panic!("expected a record");
+            };
+            for (name, field_value) in fields {
+                match (name.as_str(), field_value) {
+                    ("has_labels", Value::Boolean(v)) => found_has_labels = Some(v),
+                    ("retention_days", Value::Union(_, inner)) => {
+                        if let Value::Int(v) = *inner {
+                            found_retention_days = Some(v);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        assert_eq!(found_has_labels, Some(false));
+        assert_eq!(found_retention_days, Some(30));
     }
 
     #[test]

--- a/rust/capture-logs/src/metrics_avro_schema.rs
+++ b/rust/capture-logs/src/metrics_avro_schema.rs
@@ -122,6 +122,18 @@ pub const METRICS_AVRO_SCHEMA: &str = r#"
     "type": ["null", "long"],
     "default": null,
     "doc": "Stable per-series identity assigned at ingest (hash of metric_name, metric_type, service_name, and sorted resource/data-point attributes). Stored verbatim by ClickHouse, never recomputed. u64 bits carried as a signed long."
+    },
+    {
+    "name": "has_labels",
+    "type": "boolean",
+    "default": true,
+    "doc": "True when this record carries the series labels (attributes). ClickHouse writes the series and attribute rollups only from records with has_labels set; a record without the field counts as labelled."
+    },
+    {
+    "name": "retention_days",
+    "type": ["null", "int"],
+    "default": null,
+    "doc": "Per-row retention in days. Null when unset - ClickHouse then falls back to the batch `retention-days` header, then to its default. capture-logs always writes null; it does not evaluate team rules."
     }
 ]
 }"#;


### PR DESCRIPTION
## Problem

The metrics2 ClickHouse chain ([#95391](https://github.com/PostHog/posthog/pull/95391)) writes its series and attribute rollups only from records that carry `has_labels`, and expires rows on a per-record `retention_days`. The metrics Avro record has neither field, so ClickHouse falls back to defaults for every record.

## Changes

Nothing user-visible changes. Every metric record now carries two more Avro fields.

- `has_labels: boolean`, always `true` for now. A later change gates it to once per series per hour so label maps stop travelling on every datapoint.
- `retention_days: ["null", "int"]`, always null from capture, the same contract as the logs record. ClickHouse falls back to the batch `retention-days` header, then to its default.
- Both fields have Avro defaults, so a ClickHouse table that predates them reads the old shape without error.

## How did you test this code?

- `test_has_labels_and_retention_days_serialise_into_avro_payload` encodes a row against `METRICS_AVRO_SCHEMA` and reads both fields back. It catches a name or type mismatch between the struct and the schema, which the existing tests do not cover for these fields.
- `cargo test -p capture-logs --lib metric_record`, `cargo clippy -p capture-logs --all-targets -- -D warnings`, and `cargo fmt --check` pass locally.
- Not run: an end-to-end publish to Kafka and consume in ClickHouse.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (PostHog Desktop) wrote this PR as step one of the metrics storage v2 rollout the assignee designed in the session. Skills invoked: `/writing-pr-descriptions`. No customer data or session material is in the diff.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
