### PR TITLE
fix(flags): omit person properties from flag evaluations

### DIFF
--- a/docs/internal/clickhouse-deletion-coverage.md
+++ b/docs/internal/clickhouse-deletion-coverage.md
@@ -103,6 +103,8 @@ That decision predates this document; the older `posthog/models/async_deletion/d
 
 ### Property removal does not reach `flag_evaluations`
 
+The ingestion mapper omits `person_properties` and `group0..group4_properties` from flag-evaluation rows. ClickHouse fills these omitted string columns with empty values; existing rows keep their stored values. Event `properties` and `person_id` are still sent.
+
 The events property-removal path rewrites rows in a staging table and resets each affected materialized column with `ALTER TABLE … UPDATE <col> = ''`.
 That works because `materialize()` creates columns as `DEFAULT <expr>`, which is assignable.
 

--- a/nodejs/src/ingestion/common/flag-evaluations/flag-evaluation-row.test.ts
+++ b/nodejs/src/ingestion/common/flag-evaluations/flag-evaluation-row.test.ts
@@ -35,19 +35,14 @@ describe('mapProcessedEventToFlagEvaluationRow', () => {
         expect(row.person_id).toBe('person-uuid-1')
         expect(row.timestamp).toBe('2024-01-15 10:30:00.123')
         expect(row.properties).toBe(eventsRow.properties)
-        expect(row.person_properties).toBe(eventsRow.person_properties)
         // Both rows derive created_at from the event, so they agree. Reading the
         // wall clock per serialization instead would stamp two different values.
         expect(row.created_at).toBe(eventsRow.created_at)
         expect(row.created_at).toBe('2024-01-15 10:31:00.456')
         expect(parseJSON(row.properties!).$feature_flag).toBe('my-flag')
-        expect(parseJSON(row.person_properties!).email).toBe('a@example.com')
     })
 
-    it('emits exactly the kafka_flag_evaluations column set', () => {
-        // An extra key (elements_chain, person_mode, a materialized column name)
-        // is not a column on the Kafka table; keep the wire format in lockstep
-        // with posthog/models/flag_evaluations/sql.py.
+    it('omits person properties from the flag evaluation wire format', () => {
         const row = mapProcessedEventToFlagEvaluationRow(processedEvent)
 
         expect(Object.keys(row).sort()).toEqual([
@@ -55,7 +50,6 @@ describe('mapProcessedEventToFlagEvaluationRow', () => {
             'distinct_id',
             'event',
             'person_id',
-            'person_properties',
             'properties',
             'team_id',
             'timestamp',

--- a/nodejs/src/ingestion/common/flag-evaluations/flag-evaluation-row.ts
+++ b/nodejs/src/ingestion/common/flag-evaluations/flag-evaluation-row.ts
@@ -6,16 +6,18 @@ import { ProcessedEvent, RawKafkaEvent } from '~/types'
  * Keep in sync with posthog/models/flag_evaluations/sql.py.
  *
  * The table mirrors the events schema, so the row is the events wire format
- * narrowed to exactly the columns the Kafka engine table declares. Going
+ * narrowed to selected columns declared by the Kafka engine table. Going
  * through serializeEvent keeps every shared field byte-identical to what the
  * events table receives for the same event, rather than a second hand-rolled
  * mapping that could drift from it.
  *
  * Deliberately not sent:
+ * - `person_properties`: flag evaluations omit person properties, so ClickHouse
+ *   fills the column with an empty string.
  * - `inserted_at`: omitted keys zero-fill in ClickHouse, and the MV treats the
  *   epoch sentinel as "absent" and stamps the Kafka message timestamp instead.
- * - `group0..group4_properties`: the events producer does not send them either
- *   (they are not in RawKafkaEvent); they zero-fill empty in both tables.
+ * - `group0..group4_properties`: serializeEvent omits them, so they zero-fill
+ *   empty in both tables.
  * - `flag_key`, `response`, `session_id`, `request_id`, `$group_0..4`: the Kafka
  *   table does not declare these, and the shard computes them from `properties`
  *   as DEFAULT columns. A DEFAULT only fills when the insert omits the column,
@@ -24,15 +26,7 @@ import { ProcessedEvent, RawKafkaEvent } from '~/types'
  */
 export type FlagEvaluationRow = Pick<
     RawKafkaEvent,
-    | 'uuid'
-    | 'event'
-    | 'properties'
-    | 'timestamp'
-    | 'team_id'
-    | 'distinct_id'
-    | 'created_at'
-    | 'person_id'
-    | 'person_properties'
+    'uuid' | 'event' | 'properties' | 'timestamp' | 'team_id' | 'distinct_id' | 'created_at' | 'person_id'
 >
 
 export function mapProcessedEventToFlagEvaluationRow(event: ProcessedEvent): FlagEvaluationRow {
@@ -46,6 +40,5 @@ export function mapProcessedEventToFlagEvaluationRow(event: ProcessedEvent): Fla
         distinct_id: serialized.distinct_id,
         created_at: serialized.created_at,
         person_id: serialized.person_id,
-        person_properties: serialized.person_properties,
     }
 }


### PR DESCRIPTION
## Problem

Flag-evaluation storage retains person properties even though property-removal requests do not clear them from this table.

## Changes

- New flag-evaluation rows omit person properties; ClickHouse fills the existing column with an empty string.
- Existing rows, table schemas, and ordinary event ingestion stay unchanged.
- The type, regression assertions, and deletion-coverage documentation reflect the omitted field. These updates are mechanical.

## How did you test this code?

Ran the mapper tests, which check the emitted keys and preserve coverage of shared event fields. ClickHouse ingestion and production verification remain unchecked; local mypy could not run because it is unavailable. CI patch coverage is pending.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the internal ClickHouse deletion-coverage guide.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used shell, Git, GitHub CLI, and browser tools, with agents for tests, cleanup, and review. Skills: posthog-context, writing-tests, simplify, comment-cleanup, running-ci-preflight, commit, create-pr, writing-pr-descriptions, and plain-writing.

The duplicate search found no matching mapper change; related PRs #95459, #92995, and #92994 address other changes. The diff contains no private session material.
