### PR TITLE
fix(ui): add scroll to CodeBlock for long command approval content (Fixes #76233)

### DIFF
--- a/products/desktop/packages/ui/src/primitives/CodeBlock.tsx
+++ b/products/desktop/packages/ui/src/primitives/CodeBlock.tsx
@@ -49,7 +49,7 @@ export function CodeBlock({
   return (
     <div className="group relative">
       <pre
-        className={`m-0 mb-3 overflow-x-auto whitespace-pre rounded-(--radius-2) border border-(--gray-6) bg-(--gray-3) p-3 pr-10 font-[var(--code-font-family)] text-(--gray-12) ${sizeClass}`}
+        className={`m-0 mb-3 max-h-[50vh] overflow-x-auto overflow-y-auto whitespace-pre rounded-(--radius-2) border border-(--gray-6) bg-(--gray-3) p-3 pr-10 font-[var(--code-font-family)] text-(--gray-12) ${sizeClass}`}
       >
         {children}
       </pre>


### PR DESCRIPTION
## What

The plan text in `PlanApprovalCard` can be very long and overflow the bottom of the app. The `CodeBlock` `<pre>` element now has `max-h-[50vh] overflow-y-auto` to constrain height and enable scrolling.

## How

Added `max-h-[50vh] overflow-y-auto` to the `<pre>` element class in `CodeBlock.tsx`. The outer `ScrollView` in `PlanApprovalCard` has `max-h-[320px]` but the code block inside had no height constraint, causing overflow. This fix constrains the code block height to 50vh and enables vertical scrolling within it.

## Testing

- [ ] Open a task with a long implementation plan
- [ ] Verify the plan text scrolls within the CodeBlock instead of overflowing

Fixes #76233
