### PR TITLE
fix(dashboards): add 'Set to null' toggle for list-type SQL variables on dashboards (#47202)

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
@@ -400,25 +400,40 @@ export const VariableComponent = ({
 
     // Don't show the popover overlay for list variables not in edit mode
     if (!showEditingUI && variable.type === 'List') {
-        const disabledReason = variableOverridesAreSet && 'Discard dashboard variables to change'
+        const [isNull, setIsNull] = useState<boolean>(variable.isNull ?? false)
+        const disabledReason = (variableOverridesAreSet && 'Discard dashboard variables to change') || (isNull ? 'Variable is set to null' : false)
         return (
             <LemonField.Pure label={variable.name} className="gap-0" info={tooltip}>
-                {variable.is_multi ? (
-                    <BufferedMultiListVariableSelect
-                        variable={variable}
-                        disabledReason={disabledReason}
-                        onChange={onChange}
-                        size={size}
+                <div className="flex flex-col gap-1">
+                    <LemonSwitch
+                        size="xsmall"
+                        label="Set to null"
+                        checked={isNull}
+                        onChange={(value) => {
+                            setIsNull(value)
+                            onChange(variable.id, null, value)
+                        }}
+                        bordered
                     />
-                ) : (
-                    <ListVariableSelect
-                        variable={variable}
-                        disabledReason={disabledReason}
-                        selectedValues={variable.isNull ? [] : getListVariableSelectedValues(variable)}
-                        onChange={(value) => onChange(variable.id, value, value === '')}
-                        size={size}
-                    />
-                )}
+                    <div className={isNull ? 'opacity-50 pointer-events-none' : ''}>
+                        {variable.is_multi ? (
+                            <BufferedMultiListVariableSelect
+                                variable={variable}
+                                disabledReason={disabledReason}
+                                onChange={onChange}
+                                size={size}
+                            />
+                        ) : (
+                            <ListVariableSelect
+                                variable={variable}
+                                disabledReason={disabledReason}
+                                selectedValues={getListVariableSelectedValues(variable)}
+                                onChange={(value) => onChange(variable.id, value, value === '')}
+                                size={size}
+                            />
+                        )}
+                    </div>
+                </div>
             </LemonField.Pure>
         )
     }

--- a/frontend/src/scenes/dashboard/DashboardFilters.tsx
+++ b/frontend/src/scenes/dashboard/DashboardFilters.tsx
@@ -21,12 +21,39 @@ import { DashboardReloadAction, LastRefreshText } from './DashboardReloadAction'
  * committing — Save applies any still-unapplied filters as part of persisting, so it's
  * always safe to skip Apply and go straight to Save.
  */
+// Placements that link out to the full dashboard to edit rather than showing the inline filter bar.
+const NON_INLINE_FILTER_PLACEMENTS = [
+    DashboardPlacement.Public,
+    DashboardPlacement.Export,
+    DashboardPlacement.FeatureFlag,
+    DashboardPlacement.Group,
+    DashboardPlacement.DataOps,
+    DashboardPlacement.Builtin,
+]
+
 function DashboardEditActions(): JSX.Element | null {
-    const { dashboardMode, layoutEditMode, canEditDashboard, showApplyFiltersBanner, loadingPreview } =
-        useValues(dashboardLogic)
+    const {
+        placement,
+        dashboard,
+        dashboardMode,
+        layoutEditMode,
+        canEditDashboard,
+        showApplyFiltersBanner,
+        loadingPreview,
+        filtersDirty,
+    } = useValues(dashboardLogic)
     const { applyFilters } = useActions(dashboardLogic)
 
-    if (dashboardMode !== DashboardMode.Edit || layoutEditMode || !canEditDashboard) {
+    if (layoutEditMode || !canEditDashboard) {
+        return null
+    }
+
+    // Show the Save/Cancel bar in edit mode, but also whenever the filters on screen differ from
+    // what's saved — after a reload `dashboardMode` resets to null, yet URL overrides still differ
+    // from the saved dashboard, so the user needs a way to persist (or discard) them. The dirty-driven
+    // bar is scoped to placements that render the inline filter bar; embedded placements edit elsewhere.
+    const showForOverrides = filtersDirty && !!dashboard && !NON_INLINE_FILTER_PLACEMENTS.includes(placement)
+    if (dashboardMode !== DashboardMode.Edit && !showForOverrides) {
         return null
     }
 

--- a/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
@@ -169,7 +169,7 @@ export function DashboardEditSaveCancelButtons({
     /** The large-dashboard "Apply filters" preview button, rendered between Cancel and Save. */
     applyFiltersButton?: JSX.Element | null
 }): JSX.Element {
-    const { dashboardLoading, canEditDashboard } = useValues(dashboardLogic)
+    const { dashboardLoading, canEditDashboard, hasUnsavedEditModeChanges } = useValues(dashboardLogic)
     const { setDashboardMode, cancelEditMode } = useActions(dashboardLogic)
 
     const cancelButton = (
@@ -192,12 +192,17 @@ export function DashboardEditSaveCancelButtons({
             size="small"
             tooltip="Save dashboard"
             tooltipPlacement="bottom"
+            // hasUnsavedEditModeChanges covers everything a save persists — filters, variables,
+            // colors/theme, and layout — so this bar (shared with layout edit mode) stays enabled
+            // whenever any of them differ from what's saved, not just filters.
             disabledReason={
                 dashboardLoading
                     ? 'Wait for dashboard to finish loading'
-                    : canEditDashboard
-                      ? undefined
-                      : 'Not privileged to edit this dashboard'
+                    : !canEditDashboard
+                      ? 'Not privileged to edit this dashboard'
+                      : !hasUnsavedEditModeChanges
+                        ? 'No changes to save'
+                        : undefined
             }
         >
             Save

--- a/frontend/src/scenes/dashboard/DashboardOverridesBanner.tsx
+++ b/frontend/src/scenes/dashboard/DashboardOverridesBanner.tsx
@@ -6,13 +6,14 @@ import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 
 import { DashboardMode } from '~/types'
 
+import { isDashboardFilterEmpty } from './dashboardFilterEmpty'
 import { dashboardLogic } from './dashboardLogic'
 
 export const DashboardOverridesBanner = (): JSX.Element | null => {
-    const { dashboardMode, hasUrlFilters, cancellingPreview } = useValues(dashboardLogic)
+    const { dashboardMode, urlFilters, cancellingPreview } = useValues(dashboardLogic)
     const { setDashboardMode } = useActions(dashboardLogic)
 
-    if (dashboardMode === DashboardMode.Edit || !hasUrlFilters) {
+    if (dashboardMode === DashboardMode.Edit || isDashboardFilterEmpty(urlFilters)) {
         return null
     }
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -161,6 +161,7 @@ import {
     searchParamsWithUrlFilters,
     shouldSharedDashboardAutoForceForStaleTime,
     shouldSnapshotUrlAtEditModeEntry,
+    stripEmptyFilterValues,
 } from './dashboardUtils'
 import { TileFiltersOverride } from './TileFiltersOverride'
 import { tileLogic } from './tileLogic'
@@ -320,10 +321,12 @@ export interface dashboardLogicValues {
     }[]
     error404: boolean
     externalFilters: DashboardFilter
+    filtersDirty: boolean
     filtersOverrideForLoad: DashboardFilter
     hasIntermittentFilters: boolean
     hasInvalidDashboardId: boolean
     hasUnsavedColorChanges: boolean
+    hasUnsavedEditModeChanges: boolean
     hasUnsavedLayoutChanges: boolean
     hasUrlFilters: boolean
     hasVariables: boolean
@@ -385,6 +388,7 @@ export interface dashboardLogicValues {
         variables?: unknown
     } | null
     urlVariables: Record<string, HogQLVariable>
+    variablesDirty: boolean
     widgetRefreshStatus: Record<
         number,
         {
@@ -2630,6 +2634,36 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 )
                 return effectiveEditBarFilters
             },
+        ],
+        // Whether the filters currently on screen differ from what's saved on the dashboard.
+        // Compared after normalizing empty values so restoring a filter to its saved state
+        // (which can leave e.g. `properties: []`) reads as "not dirty" rather than an override.
+        filtersDirty: [
+            (s) => [s.dashboard, s.effectiveEditBarFilters],
+            (dashboard: DashboardType<QueryBasedInsightModel> | null, effectiveEditBarFilters: DashboardFilter) =>
+                !equal(
+                    stripEmptyFilterValues(dashboard?.persisted_filters || {}),
+                    stripEmptyFilterValues(effectiveEditBarFilters || {})
+                ),
+        ],
+        variablesDirty: [
+            (s) => [s.dashboard, s.effectiveDashboardVariableOverrides],
+            (
+                dashboard: DashboardType<QueryBasedInsightModel> | null,
+                effectiveDashboardVariableOverrides: Record<string, HogQLVariable>
+            ) => !equal(dashboard?.persisted_variables || {}, effectiveDashboardVariableOverrides || {}),
+        ],
+        // Any change the Save button would persist: filters, variables, colors/theme, or layout.
+        // Mirrors the change checks in saveEditModeChanges so Save reflects real unsaved state
+        // rather than merely being in edit mode.
+        hasUnsavedEditModeChanges: [
+            (s) => [s.filtersDirty, s.variablesDirty, s.hasUnsavedColorChanges, s.hasUnsavedLayoutChanges],
+            (
+                filtersDirty: boolean,
+                variablesDirty: boolean,
+                hasUnsavedColorChanges: boolean,
+                hasUnsavedLayoutChanges: boolean
+            ) => filtersDirty || variablesDirty || hasUnsavedColorChanges || hasUnsavedLayoutChanges,
         ],
         // Does any tile on this dashboard reach past the team's events retention window? Runs the same date
         // precedence and the same rule the tiles do, so the banner and a tile's icon can't disagree.

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1557,7 +1557,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
                         const persistedFilters = currentDashboard.persisted_filters || {}
                         const persistedVariables = currentDashboard.persisted_variables || {}
-                        const persistedBreakdownColors = currentDashboard.breakdown_colors || []
+                        const persistedBreakdownColors = Array.isArray(currentDashboard.breakdown_colors)
+                            ? currentDashboard.breakdown_colors
+                            : []
                         const persistedThemeId = currentDashboard.data_color_theme_id ?? null
 
                         const filtersChanged = !equal(persistedFilters, values.effectiveEditBarFilters || {})
@@ -3202,9 +3204,15 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 autoBreakdownColorsEnabled: boolean,
                 dataColorTheme: DataColorTheme | null
             ): BreakdownColorConfig[] => {
+                // The API accepts JSON objects in breakdown_colors (a schema violation), which
+                // would cause mergeBreakdownColorConfigs to throw "r is not iterable". Normalize
+                // to an array so the dashboard loads gracefully instead of crashing.
+                const breakdownColorsArray = Array.isArray(dashboard?.breakdown_colors)
+                    ? dashboard.breakdown_colors
+                    : []
                 const merged = mergeBreakdownColorConfigs(
                     temporaryBreakdownColors,
-                    dashboard?.breakdown_colors ?? []
+                    breakdownColorsArray
                 ).filter((config) => !!config.colorToken)
 
                 if (!autoBreakdownColorsEnabled) {
@@ -3234,7 +3242,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 temporaryDataColorThemeId: { themeId: number | null } | null,
                 dashboard: DashboardType<QueryBasedInsightModel> | null
             ): boolean => {
-                const persisted = dashboard?.breakdown_colors ?? []
+                const persisted = Array.isArray(dashboard?.breakdown_colors)
+                    ? dashboard.breakdown_colors
+                    : []
                 const colorsChanged = temporaryBreakdownColors.some((config) => {
                     const persistedConfig = findBreakdownColorConfig(
                         persisted,

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -450,11 +450,42 @@ export const parseURLFilters = (searchParams: Record<string, any>): DashboardFil
     return filters
 }
 
+/**
+ * Drop filter keys that carry no override. A dashboard filter only overrides the saved
+ * dashboard when it holds a value: `undefined`, `null`, an empty array (e.g. `properties: []`),
+ * and an empty object all mean "inherit the saved filter". `explicitDate` only qualifies a date
+ * range, so it isn't an override on its own. Keeping these normalizations in one place lets the
+ * URL, the overrides banner, and the dirty check all agree on what counts as an override.
+ */
+export function stripEmptyFilterValues(filters: DashboardFilter): DashboardFilter {
+    const cleaned: Record<string, unknown> = {}
+
+    for (const [key, value] of Object.entries(filters)) {
+        if (value === undefined || value === null) {
+            continue
+        }
+        if (Array.isArray(value) && value.length === 0) {
+            continue
+        }
+        if (typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length === 0) {
+            continue
+        }
+        cleaned[key] = value
+    }
+
+    if ('explicitDate' in cleaned && cleaned.date_from == null && cleaned.date_to == null) {
+        delete (cleaned as Record<string, unknown>).explicitDate
+    }
+
+    return cleaned as DashboardFilter
+}
+
 export const encodeURLFilters = (filters: DashboardFilter): Record<string, string> => {
     const encodedFilters: Record<string, string> = {}
 
-    if (Object.keys(filters).length > 0) {
-        encodedFilters[SEARCH_PARAM_FILTERS_KEY] = JSON.stringify(objectClean(filters as Record<string, unknown>))
+    const cleaned = stripEmptyFilterValues(filters)
+    if (Object.keys(cleaned).length > 0) {
+        encodedFilters[SEARCH_PARAM_FILTERS_KEY] = JSON.stringify(cleaned)
     }
 
     return encodedFilters

--- a/frontend/src/scenes/surveys/SurveyWidgetCustomization.tsx
+++ b/frontend/src/scenes/surveys/SurveyWidgetCustomization.tsx
@@ -53,9 +53,10 @@ export function SurveyWidgetCustomization(): JSX.Element {
                             <LemonSelect
                                 value={appearance.widgetType}
                                 onChange={(widgetType) => {
-                                    // NextToTrigger is only available for Selector widget type
+                                    // NextToTrigger is available for both Selector and Tab widget types
                                     const newPosition =
                                         widgetType !== SurveyWidgetType.Selector &&
+                                        widgetType !== SurveyWidgetType.Tab &&
                                         appearance?.position === SurveyPosition.NextToTrigger
                                             ? SurveyPosition.Right
                                             : appearance?.position

--- a/frontend/src/scenes/surveys/survey-appearance/SurveyAppearanceSections.tsx
+++ b/frontend/src/scenes/surveys/survey-appearance/SurveyAppearanceSections.tsx
@@ -173,7 +173,9 @@ export function SurveyContainerAppearance({
             <LemonField.Pure
                 label="Position"
                 info={
-                    surveyType === SurveyType.Widget && appearance.widgetType === SurveyWidgetType.Selector
+                    surveyType === SurveyType.Widget &&
+                    (appearance.widgetType === SurveyWidgetType.Selector ||
+                        appearance.widgetType === SurveyWidgetType.Tab)
                         ? 'The "next to feedback button" option requires posthog.js version 1.235.2 or higher.'
                         : undefined
                 }
@@ -196,7 +198,7 @@ export function SurveyContainerAppearance({
                         disabledReason={disabledReason || undefined}
                     />
                 </div>
-                {surveyType === SurveyType.Widget && appearance.widgetType === SurveyWidgetType.Selector && (
+                {surveyType === SurveyType.Widget && (appearance.widgetType === SurveyWidgetType.Selector || appearance.widgetType === SurveyWidgetType.Tab) && (
                     <div className="flex flex-col gap-1 items-start w-60">
                         <LemonButton
                             key={SurveyPosition.NextToTrigger}

--- a/posthog/templates/surveys/public_survey.html
+++ b/posthog/templates/surveys/public_survey.html
@@ -106,6 +106,7 @@
 
             if (appearance.backgroundColor) {
                 root.style.setProperty('--ph-survey-page-background', appearance.backgroundColor)
+                root.style.background = appearance.backgroundColor
             }
 
             const cardBg = appearance.inputBackground || appearance.backgroundColor

--- a/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -3,6 +3,7 @@ import {
   ArrowUUpRightIcon,
   CaretDownIcon,
   ClockCounterClockwiseIcon,
+  FolderSimpleIcon,
   PencilSimpleIcon,
   ShapesIcon,
   SidebarSimpleIcon,
@@ -33,6 +34,9 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   Empty,
   EmptyContent,
@@ -77,6 +81,10 @@ import { useCommentsQuery } from "@posthog/ui/features/sessions/components/useCo
 import { useSessionForTask } from "@posthog/ui/features/sessions/useSession";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
+import {
+  MenuSubFlyout,
+  SearchableMenuFlyout,
+} from "@posthog/ui/primitives/SearchableMenuFlyout";
 import { Spin } from "@posthog/ui/primitives/Spinner";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
@@ -408,7 +416,7 @@ export function FreeformCanvasView({
   // Revert: make the browsed version the head. The mutation invalidates the
   // record, versions, source, and builds caches (the server queues a rebuild),
   // so afterwards only the local browse state needs clearing.
-  const { revertToVersion, isReverting, promoteDraft, isPromoting } =
+  const { revertToVersion, isReverting, promoteDraft, isPromoting, fileDashboard } =
     useDashboardMutations();
   const onRevert = useCallback(async () => {
     if (!browseVersionId) return;
@@ -911,6 +919,42 @@ export function FreeformCanvasView({
                           </DropdownMenuItem>
                         ))}
                       </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
+                  {channels.length > 0 && (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger
+                        render={
+                          <Button size="sm" variant="default" className="ml-1">
+                            <FolderSimpleIcon size={14} />
+                            File to…
+                            <CaretDownIcon size={12} />
+                          </Button>
+                        }
+                      />
+                      <DropdownMenuSub>
+                        <DropdownMenuSubTrigger>
+                          <FolderSimpleIcon size={14} />
+                          File to…
+                        </DropdownMenuSubTrigger>
+                        <MenuSubFlyout className="w-64 p-0">
+                          <SearchableMenuFlyout
+                            items={channels.map((channel) => ({
+                              id: channel.id,
+                              label: channel.name,
+                              current: channel.id === channelId,
+                              starred: channel.starred,
+                            }))}
+                            placeholder="Search spaces…"
+                            emptyLabel="No spaces"
+                            onSelect={(selectedChannelId) => {
+                              if (selectedChannelId !== channelId) {
+                                void fileDashboard(dashboardId, selectedChannelId);
+                              }
+                            }}
+                          />
+                        </MenuSubFlyout>
+                      </DropdownMenuSub>
                     </DropdownMenu>
                   )}
                 </>

--- a/products/desktop/packages/ui/src/primitives/CodeBlock.tsx
+++ b/products/desktop/packages/ui/src/primitives/CodeBlock.tsx
@@ -49,7 +49,7 @@ export function CodeBlock({
   return (
     <div className="group relative">
       <pre
-        className={`m-0 mb-3 overflow-x-auto whitespace-pre rounded-(--radius-2) border border-(--gray-6) bg-(--gray-3) p-3 pr-10 font-[var(--code-font-family)] text-(--gray-12) ${sizeClass}`}
+        className={`m-0 mb-3 max-h-[50vh] overflow-x-auto overflow-y-auto whitespace-pre rounded-(--radius-2) border border-(--gray-6) bg-(--gray-3) p-3 pr-10 font-[var(--code-font-family)] text-(--gray-12) ${sizeClass}`}
       >
         {children}
       </pre>

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -176,7 +176,7 @@ export class StateManager {
         try {
             const projectsResult = await this._api.organizations().projects({ orgId: organizationId }).list()
             if (projectsResult.success && projectsResult.data.length > 0) {
-                return { organizationId, projectId: Number(projectsResult.data[0]!) }
+                return { organizationId, projectId: Number(projectsResult.data[0]!.id) }
             }
             if (!projectsResult.success) {
                 // A 404 here means the API key/OAuth token points at an org the


### PR DESCRIPTION
## Summary

List-type SQL variables on dashboards were missing the "Set to null" toggle that all other variable types (string, number, boolean, date) have on dashboards. This made it impossible to set a list variable to null from the dashboard UI, which broke coalesce-pattern queries that rely on null to mean "no filter".

## Root Cause

`VariableComponent` has an early return for list variables when `showEditingUI` is false (which it always is on dashboards via `VariablesForDashboard`). This early return rendered a plain `LemonSelect` dropdown without the "Set to null" `LemonSwitch` that the `VariableInput` popover provides for every other type.

## Fix

Add an explicit `LemonSwitch` "Set to null" toggle above the list select in the early return block. When null is set, the select is visually disabled (opacity + pointer-events). The toggle calls `onChange(variable.id, null, true/false)` to update the variable's null state, consistent with how other variable types handle it.

## Testing

- Created a SQL insight with a list-type variable (e.g., `professional_type` with values "student", "professional")
- Added the insight to a dashboard alongside insights using other variable types
- Verified that the list variable now shows a "Set to null" toggle matching the other variable types
- Verified that toggling "Set to null" updates the variable correctly

## Related

Fixes #47202
