### PR TITLE
fix(llm-gateway): tighten the per-user wizard cost cap on the legacy path

### DIFF
--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -47,10 +47,15 @@ DEFAULT_PRODUCT_COST_LIMITS: dict[str, "ProductCostLimit"] = {
 }
 
 DEFAULT_USER_COST_LIMITS: dict[str, "UserCostLimit"] = {
+    # The wizard CLI mints per-run tokens on the Go gateway since 2026-09-01; what still reaches
+    # this product directly is stale clients, CI, and lifted OAuth tokens. Sized to the stale
+    # clients: over 30 days of stamped wizard traffic a legitimate user peaked at $22.69 in an
+    # hour (p99 $8.82) and $49 in the month (p99.9 $29.71), while lifted tokens ran $100 per
+    # account in about an hour. CI runs above this and needs a team_rate_limit_multipliers entry.
     "wizard": UserCostLimit(
-        burst_limit_usd=100.0,
-        burst_window_seconds=2592000,  # 30 days
-        sustained_limit_usd=100.0,
+        burst_limit_usd=25.0,
+        burst_window_seconds=3600,
+        sustained_limit_usd=30.0,
         sustained_window_seconds=2592000,  # 30 days
     ),
     "background_agents": UserCostLimit(

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -829,7 +829,7 @@ class TestUnconfiguredProductsUseDefaults:
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
         throttle = UserCostBurstThrottle(redis=None)
-        context = make_context(product="wizard")
+        context = make_context(product="unconfigured_product")
 
         await throttle.record_cost(context, 99.0)
         result = await throttle.allow_request(context)
@@ -927,7 +927,7 @@ class TestUnconfiguredProductsUseDefaults:
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
         throttle = UserCostBurstThrottle(redis=None)
-        context = make_context(product="wizard")
+        context = make_context(product="unconfigured_product")
 
         await throttle.record_cost(context, 99.0)
         assert (await throttle.allow_request(context)).allowed is True
@@ -935,7 +935,7 @@ class TestUnconfiguredProductsUseDefaults:
         monkeypatch.setenv(
             "LLM_GATEWAY_USER_COST_LIMITS",
             '{"posthog_code": {"burst_limit_usd": 100, "burst_window_seconds": 86400, "sustained_limit_usd": 1000, "sustained_window_seconds": 2592000}, '
-            '"wizard": {"burst_limit_usd": 50, "burst_window_seconds": 3600, "sustained_limit_usd": 200, "sustained_window_seconds": 86400}}',
+            '"unconfigured_product": {"burst_limit_usd": 50, "burst_window_seconds": 3600, "sustained_limit_usd": 200, "sustained_window_seconds": 86400}}',
         )
         get_settings.cache_clear()
 
@@ -1184,7 +1184,7 @@ class TestPostHogCodeUserThrottling:
         throttle = UserCostBurstThrottle(redis=None)
         context = make_context(product="wizard")
 
-        await throttle.record_cost(context, 50.0)
+        await throttle.record_cost(context, 20.0)
         result = await throttle.allow_request(context)
         assert result.allowed is True
 


### PR DESCRIPTION
## Problem

Product `wizard` on this gateway allows $100 per user per 30 days with no burst limit. Since the wizard CLI moved to per-run tokens on the Go gateway (2026-09-01), what still hits this product directly is stale clients, CI, and lifted OAuth tokens. Over the last 7 days 72% of that spend was known farm accounts, each burning $100 in about an hour.

## Changes

- `wizard` `UserCostLimit`: burst $25 per hour, sustained $30 per 30 days. Over 30 days of stamped (real client) wizard traffic a legitimate user peaked at $22.69 in an hour (p99 $8.82) and $49 in the month (p99.9 $29.71).
- Deploy prerequisite: the wizard CI user spends about $22 a day on this path and needs a `team_rate_limit_multipliers` entry, or it will hit the sustained cap within two days.
- Mechanical: three tests that used `wizard` as a stand-in for "a product on default limits" now use `unconfigured_product`, or spend under the new cap.

## How did you test this code?

Gateway unit suite, ruff check and format pass locally. No new tests: the cap values are configuration and the throttle behaviour is already covered. Not run: integration tests.

## Automatic notifications

- [ ] Publish to changelog?

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*