### PR TITLE
fix(slack): allow public channels to be reached by ID without membership check (#93124)

### DIFF
--- a/frontend/src/layout/navigation-3000/Navigation.scss
+++ b/frontend/src/layout/navigation-3000/Navigation.scss
@@ -49,7 +49,9 @@
     overflow: hidden;
     background: var(--color-bg-primary);
 
-    .storybook-test-runner & {
+    // Allow the shell to grow when the storybook test runner adds its class to the body.
+    // .storybook-test-runner is on the body; .Navigation3000 is a direct child.
+    .storybook-test-runner > & {
         height: auto;
         min-height: 100vh;
     }
@@ -732,8 +734,11 @@
     height: 100dvh; // see .Navigation3000 — keep bottom-anchored UI reachable on mobile
     overflow: hidden;
 
-    .storybook-test-runner & {
-        height: fit-content;
+    // Allow the layout to grow when the storybook test runner is active.
+    .storybook-test-runner > & {
+        height: auto;
+        min-height: 100vh;
+        overflow: visible;
     }
 
     /* Mobile layout - single column with overlay nav */

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
@@ -400,25 +400,40 @@ export const VariableComponent = ({
 
     // Don't show the popover overlay for list variables not in edit mode
     if (!showEditingUI && variable.type === 'List') {
-        const disabledReason = variableOverridesAreSet && 'Discard dashboard variables to change'
+        const [isNull, setIsNull] = useState<boolean>(variable.isNull ?? false)
+        const disabledReason = (variableOverridesAreSet && 'Discard dashboard variables to change') || (isNull ? 'Variable is set to null' : false)
         return (
             <LemonField.Pure label={variable.name} className="gap-0" info={tooltip}>
-                {variable.is_multi ? (
-                    <BufferedMultiListVariableSelect
-                        variable={variable}
-                        disabledReason={disabledReason}
-                        onChange={onChange}
-                        size={size}
+                <div className="flex flex-col gap-1">
+                    <LemonSwitch
+                        size="xsmall"
+                        label="Set to null"
+                        checked={isNull}
+                        onChange={(value) => {
+                            setIsNull(value)
+                            onChange(variable.id, null, value)
+                        }}
+                        bordered
                     />
-                ) : (
-                    <ListVariableSelect
-                        variable={variable}
-                        disabledReason={disabledReason}
-                        selectedValues={variable.isNull ? [] : getListVariableSelectedValues(variable)}
-                        onChange={(value) => onChange(variable.id, value, value === '')}
-                        size={size}
-                    />
-                )}
+                    <div className={isNull ? 'opacity-50 pointer-events-none' : ''}>
+                        {variable.is_multi ? (
+                            <BufferedMultiListVariableSelect
+                                variable={variable}
+                                disabledReason={disabledReason}
+                                onChange={onChange}
+                                size={size}
+                            />
+                        ) : (
+                            <ListVariableSelect
+                                variable={variable}
+                                disabledReason={disabledReason}
+                                selectedValues={getListVariableSelectedValues(variable)}
+                                onChange={(value) => onChange(variable.id, value, value === '')}
+                                size={size}
+                            />
+                        )}
+                    </div>
+                </div>
             </LemonField.Pure>
         )
     }

--- a/frontend/src/scenes/dashboard/DashboardFilters.tsx
+++ b/frontend/src/scenes/dashboard/DashboardFilters.tsx
@@ -21,12 +21,39 @@ import { DashboardReloadAction, LastRefreshText } from './DashboardReloadAction'
  * committing — Save applies any still-unapplied filters as part of persisting, so it's
  * always safe to skip Apply and go straight to Save.
  */
+// Placements that link out to the full dashboard to edit rather than showing the inline filter bar.
+const NON_INLINE_FILTER_PLACEMENTS = [
+    DashboardPlacement.Public,
+    DashboardPlacement.Export,
+    DashboardPlacement.FeatureFlag,
+    DashboardPlacement.Group,
+    DashboardPlacement.DataOps,
+    DashboardPlacement.Builtin,
+]
+
 function DashboardEditActions(): JSX.Element | null {
-    const { dashboardMode, layoutEditMode, canEditDashboard, showApplyFiltersBanner, loadingPreview } =
-        useValues(dashboardLogic)
+    const {
+        placement,
+        dashboard,
+        dashboardMode,
+        layoutEditMode,
+        canEditDashboard,
+        showApplyFiltersBanner,
+        loadingPreview,
+        filtersDirty,
+    } = useValues(dashboardLogic)
     const { applyFilters } = useActions(dashboardLogic)
 
-    if (dashboardMode !== DashboardMode.Edit || layoutEditMode || !canEditDashboard) {
+    if (layoutEditMode || !canEditDashboard) {
+        return null
+    }
+
+    // Show the Save/Cancel bar in edit mode, but also whenever the filters on screen differ from
+    // what's saved — after a reload `dashboardMode` resets to null, yet URL overrides still differ
+    // from the saved dashboard, so the user needs a way to persist (or discard) them. The dirty-driven
+    // bar is scoped to placements that render the inline filter bar; embedded placements edit elsewhere.
+    const showForOverrides = filtersDirty && !!dashboard && !NON_INLINE_FILTER_PLACEMENTS.includes(placement)
+    if (dashboardMode !== DashboardMode.Edit && !showForOverrides) {
         return null
     }
 

--- a/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
@@ -169,7 +169,7 @@ export function DashboardEditSaveCancelButtons({
     /** The large-dashboard "Apply filters" preview button, rendered between Cancel and Save. */
     applyFiltersButton?: JSX.Element | null
 }): JSX.Element {
-    const { dashboardLoading, canEditDashboard } = useValues(dashboardLogic)
+    const { dashboardLoading, canEditDashboard, hasUnsavedEditModeChanges } = useValues(dashboardLogic)
     const { setDashboardMode, cancelEditMode } = useActions(dashboardLogic)
 
     const cancelButton = (
@@ -192,12 +192,17 @@ export function DashboardEditSaveCancelButtons({
             size="small"
             tooltip="Save dashboard"
             tooltipPlacement="bottom"
+            // hasUnsavedEditModeChanges covers everything a save persists — filters, variables,
+            // colors/theme, and layout — so this bar (shared with layout edit mode) stays enabled
+            // whenever any of them differ from what's saved, not just filters.
             disabledReason={
                 dashboardLoading
                     ? 'Wait for dashboard to finish loading'
-                    : canEditDashboard
-                      ? undefined
-                      : 'Not privileged to edit this dashboard'
+                    : !canEditDashboard
+                      ? 'Not privileged to edit this dashboard'
+                      : !hasUnsavedEditModeChanges
+                        ? 'No changes to save'
+                        : undefined
             }
         >
             Save

--- a/frontend/src/scenes/dashboard/DashboardOverridesBanner.tsx
+++ b/frontend/src/scenes/dashboard/DashboardOverridesBanner.tsx
@@ -6,13 +6,14 @@ import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 
 import { DashboardMode } from '~/types'
 
+import { isDashboardFilterEmpty } from './dashboardFilterEmpty'
 import { dashboardLogic } from './dashboardLogic'
 
 export const DashboardOverridesBanner = (): JSX.Element | null => {
-    const { dashboardMode, hasUrlFilters, cancellingPreview } = useValues(dashboardLogic)
+    const { dashboardMode, urlFilters, cancellingPreview } = useValues(dashboardLogic)
     const { setDashboardMode } = useActions(dashboardLogic)
 
-    if (dashboardMode === DashboardMode.Edit || !hasUrlFilters) {
+    if (dashboardMode === DashboardMode.Edit || isDashboardFilterEmpty(urlFilters)) {
         return null
     }
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -161,6 +161,7 @@ import {
     searchParamsWithUrlFilters,
     shouldSharedDashboardAutoForceForStaleTime,
     shouldSnapshotUrlAtEditModeEntry,
+    stripEmptyFilterValues,
 } from './dashboardUtils'
 import { TileFiltersOverride } from './TileFiltersOverride'
 import { tileLogic } from './tileLogic'
@@ -320,10 +321,12 @@ export interface dashboardLogicValues {
     }[]
     error404: boolean
     externalFilters: DashboardFilter
+    filtersDirty: boolean
     filtersOverrideForLoad: DashboardFilter
     hasIntermittentFilters: boolean
     hasInvalidDashboardId: boolean
     hasUnsavedColorChanges: boolean
+    hasUnsavedEditModeChanges: boolean
     hasUnsavedLayoutChanges: boolean
     hasUrlFilters: boolean
     hasVariables: boolean
@@ -385,6 +388,7 @@ export interface dashboardLogicValues {
         variables?: unknown
     } | null
     urlVariables: Record<string, HogQLVariable>
+    variablesDirty: boolean
     widgetRefreshStatus: Record<
         number,
         {
@@ -2630,6 +2634,36 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 )
                 return effectiveEditBarFilters
             },
+        ],
+        // Whether the filters currently on screen differ from what's saved on the dashboard.
+        // Compared after normalizing empty values so restoring a filter to its saved state
+        // (which can leave e.g. `properties: []`) reads as "not dirty" rather than an override.
+        filtersDirty: [
+            (s) => [s.dashboard, s.effectiveEditBarFilters],
+            (dashboard: DashboardType<QueryBasedInsightModel> | null, effectiveEditBarFilters: DashboardFilter) =>
+                !equal(
+                    stripEmptyFilterValues(dashboard?.persisted_filters || {}),
+                    stripEmptyFilterValues(effectiveEditBarFilters || {})
+                ),
+        ],
+        variablesDirty: [
+            (s) => [s.dashboard, s.effectiveDashboardVariableOverrides],
+            (
+                dashboard: DashboardType<QueryBasedInsightModel> | null,
+                effectiveDashboardVariableOverrides: Record<string, HogQLVariable>
+            ) => !equal(dashboard?.persisted_variables || {}, effectiveDashboardVariableOverrides || {}),
+        ],
+        // Any change the Save button would persist: filters, variables, colors/theme, or layout.
+        // Mirrors the change checks in saveEditModeChanges so Save reflects real unsaved state
+        // rather than merely being in edit mode.
+        hasUnsavedEditModeChanges: [
+            (s) => [s.filtersDirty, s.variablesDirty, s.hasUnsavedColorChanges, s.hasUnsavedLayoutChanges],
+            (
+                filtersDirty: boolean,
+                variablesDirty: boolean,
+                hasUnsavedColorChanges: boolean,
+                hasUnsavedLayoutChanges: boolean
+            ) => filtersDirty || variablesDirty || hasUnsavedColorChanges || hasUnsavedLayoutChanges,
         ],
         // Does any tile on this dashboard reach past the team's events retention window? Runs the same date
         // precedence and the same rule the tiles do, so the banner and a tile's icon can't disagree.

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1557,7 +1557,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
                         const persistedFilters = currentDashboard.persisted_filters || {}
                         const persistedVariables = currentDashboard.persisted_variables || {}
-                        const persistedBreakdownColors = currentDashboard.breakdown_colors || []
+                        const persistedBreakdownColors = Array.isArray(currentDashboard.breakdown_colors)
+                            ? currentDashboard.breakdown_colors
+                            : []
                         const persistedThemeId = currentDashboard.data_color_theme_id ?? null
 
                         const filtersChanged = !equal(persistedFilters, values.effectiveEditBarFilters || {})
@@ -3202,9 +3204,15 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 autoBreakdownColorsEnabled: boolean,
                 dataColorTheme: DataColorTheme | null
             ): BreakdownColorConfig[] => {
+                // The API accepts JSON objects in breakdown_colors (a schema violation), which
+                // would cause mergeBreakdownColorConfigs to throw "r is not iterable". Normalize
+                // to an array so the dashboard loads gracefully instead of crashing.
+                const breakdownColorsArray = Array.isArray(dashboard?.breakdown_colors)
+                    ? dashboard.breakdown_colors
+                    : []
                 const merged = mergeBreakdownColorConfigs(
                     temporaryBreakdownColors,
-                    dashboard?.breakdown_colors ?? []
+                    breakdownColorsArray
                 ).filter((config) => !!config.colorToken)
 
                 if (!autoBreakdownColorsEnabled) {
@@ -3234,7 +3242,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 temporaryDataColorThemeId: { themeId: number | null } | null,
                 dashboard: DashboardType<QueryBasedInsightModel> | null
             ): boolean => {
-                const persisted = dashboard?.breakdown_colors ?? []
+                const persisted = Array.isArray(dashboard?.breakdown_colors)
+                    ? dashboard.breakdown_colors
+                    : []
                 const colorsChanged = temporaryBreakdownColors.some((config) => {
                     const persistedConfig = findBreakdownColorConfig(
                         persisted,

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -450,11 +450,42 @@ export const parseURLFilters = (searchParams: Record<string, any>): DashboardFil
     return filters
 }
 
+/**
+ * Drop filter keys that carry no override. A dashboard filter only overrides the saved
+ * dashboard when it holds a value: `undefined`, `null`, an empty array (e.g. `properties: []`),
+ * and an empty object all mean "inherit the saved filter". `explicitDate` only qualifies a date
+ * range, so it isn't an override on its own. Keeping these normalizations in one place lets the
+ * URL, the overrides banner, and the dirty check all agree on what counts as an override.
+ */
+export function stripEmptyFilterValues(filters: DashboardFilter): DashboardFilter {
+    const cleaned: Record<string, unknown> = {}
+
+    for (const [key, value] of Object.entries(filters)) {
+        if (value === undefined || value === null) {
+            continue
+        }
+        if (Array.isArray(value) && value.length === 0) {
+            continue
+        }
+        if (typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length === 0) {
+            continue
+        }
+        cleaned[key] = value
+    }
+
+    if ('explicitDate' in cleaned && cleaned.date_from == null && cleaned.date_to == null) {
+        delete (cleaned as Record<string, unknown>).explicitDate
+    }
+
+    return cleaned as DashboardFilter
+}
+
 export const encodeURLFilters = (filters: DashboardFilter): Record<string, string> => {
     const encodedFilters: Record<string, string> = {}
 
-    if (Object.keys(filters).length > 0) {
-        encodedFilters[SEARCH_PARAM_FILTERS_KEY] = JSON.stringify(objectClean(filters as Record<string, unknown>))
+    const cleaned = stripEmptyFilterValues(filters)
+    if (Object.keys(cleaned).length > 0) {
+        encodedFilters[SEARCH_PARAM_FILTERS_KEY] = JSON.stringify(cleaned)
     }
 
     return encodedFilters

--- a/frontend/src/scenes/surveys/SurveyWidgetCustomization.tsx
+++ b/frontend/src/scenes/surveys/SurveyWidgetCustomization.tsx
@@ -53,9 +53,10 @@ export function SurveyWidgetCustomization(): JSX.Element {
                             <LemonSelect
                                 value={appearance.widgetType}
                                 onChange={(widgetType) => {
-                                    // NextToTrigger is only available for Selector widget type
+                                    // NextToTrigger is available for both Selector and Tab widget types
                                     const newPosition =
                                         widgetType !== SurveyWidgetType.Selector &&
+                                        widgetType !== SurveyWidgetType.Tab &&
                                         appearance?.position === SurveyPosition.NextToTrigger
                                             ? SurveyPosition.Right
                                             : appearance?.position

--- a/frontend/src/scenes/surveys/survey-appearance/SurveyAppearanceSections.tsx
+++ b/frontend/src/scenes/surveys/survey-appearance/SurveyAppearanceSections.tsx
@@ -173,7 +173,9 @@ export function SurveyContainerAppearance({
             <LemonField.Pure
                 label="Position"
                 info={
-                    surveyType === SurveyType.Widget && appearance.widgetType === SurveyWidgetType.Selector
+                    surveyType === SurveyType.Widget &&
+                    (appearance.widgetType === SurveyWidgetType.Selector ||
+                        appearance.widgetType === SurveyWidgetType.Tab)
                         ? 'The "next to feedback button" option requires posthog.js version 1.235.2 or higher.'
                         : undefined
                 }
@@ -196,7 +198,7 @@ export function SurveyContainerAppearance({
                         disabledReason={disabledReason || undefined}
                     />
                 </div>
-                {surveyType === SurveyType.Widget && appearance.widgetType === SurveyWidgetType.Selector && (
+                {surveyType === SurveyType.Widget && (appearance.widgetType === SurveyWidgetType.Selector || appearance.widgetType === SurveyWidgetType.Tab) && (
                     <div className="flex flex-col gap-1 items-start w-60">
                         <LemonButton
                             key={SurveyPosition.NextToTrigger}

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -284,6 +284,7 @@ class TestSlackIntegration:
 
     @patch("posthog.models.integration.slack.WebClient")
     def test_get_channel_by_id_public_with_access(self, mock_webclient_class):
+        """Public channels: authed_user membership is not checked."""
         mock_client = MagicMock()
         mock_webclient_class.return_value = mock_client
 
@@ -291,14 +292,37 @@ class TestSlackIntegration:
             "channel": {"id": "C123", "name": "general", "is_private": False, "is_ext_shared": False, "num_members": 10}
         }
 
-        mock_client.conversations_members.return_value = {"members": ["test_user_id", "U2", "U3"]}
-
         slack = SlackIntegration(self.integration)
         channel = slack.get_channel_by_id("C123", True, "test_user_id")
 
         mock_client.conversations_info.assert_called_once_with(channel="C123", include_num_members=True)
-        mock_client.conversations_members.assert_called_once_with(channel="C123", limit=11)
+        # conversations_members is NOT called for public channels
+        mock_client.conversations_members.assert_not_called()
 
+        assert channel is not None
+        assert channel["id"] == "C123"
+        assert channel["name"] == "general"
+        assert not channel["is_private"]
+        assert not channel["is_private_without_access"]
+
+    @patch("posthog.models.integration.slack.WebClient")
+    def test_get_channel_by_id_public_without_access(self, mock_webclient_class):
+        """Public channels are reachable even when authed_user is not in the channel."""
+        mock_client = MagicMock()
+        mock_webclient_class.return_value = mock_client
+
+        mock_client.conversations_info.return_value = {
+            "channel": {"id": "C123", "name": "general", "is_private": False, "is_ext_shared": False, "num_members": 10}
+        }
+
+        slack = SlackIntegration(self.integration)
+        channel = slack.get_channel_by_id("C123", True, "some_other_user")
+
+        mock_client.conversations_info.assert_called_once_with(channel="C123", include_num_members=True)
+        # conversations_members is NOT called for public channels
+        mock_client.conversations_members.assert_not_called()
+
+        # Should succeed (public channel is always reachable)
         assert channel is not None
         assert channel["id"] == "C123"
         assert channel["name"] == "general"

--- a/posthog/hogql/functions/test/test_traffic_type_functions.py
+++ b/posthog/hogql/functions/test/test_traffic_type_functions.py
@@ -39,13 +39,17 @@ class TestTrafficTypeFunctions:
         assert isinstance(result, ast.Call)
         assert result.name == "if"
         assert len(result.args) == 3
-        # First arg: comparison (multiMatchAnyIndex(...) = 0)
-        assert isinstance(result.args[0], ast.CompareOperation)
-        # Second arg: default value
+        # First arg: cookieless-mode check (and(empty_ua, cookieless_mode))
+        assert isinstance(result.args[0], ast.Call)
+        assert result.args[0].name == "and"
+        # Second arg: default value when cookieless mode applies -> "Regular"
         assert isinstance(result.args[1], ast.Constant)
         assert result.args[1].value == "Regular"
-        # Third arg: array access
-        assert isinstance(result.args[2], ast.ArrayAccess)
+        # Third arg: inner if (original pattern matching logic) -> array access
+        inner_if = result.args[2]
+        assert isinstance(inner_if, ast.Call)
+        assert inner_if.name == "if"
+        assert isinstance(inner_if.args[2], ast.ArrayAccess)
 
     @parameterized.expand(
         [
@@ -73,8 +77,11 @@ class TestTrafficTypeFunctions:
         result = get_traffic_type(node=node, args=[user_agent_arg])
         assert isinstance(result, ast.Call)
 
-        # Check the comparison contains multiMatchAnyIndex
-        comparison = result.args[0]
+        # Result is now: if(cookieless_check, default, inner_if)
+        # multiMatchAnyIndex is in the inner_if
+        inner_if = result.args[2]
+        assert isinstance(inner_if, ast.Call)
+        comparison = inner_if.args[0]
         assert isinstance(comparison, ast.CompareOperation)
         assert isinstance(comparison.left, ast.Call)
         assert comparison.left.name == "multiMatchAnyIndex"
@@ -86,8 +93,10 @@ class TestTrafficTypeFunctions:
         result = get_traffic_type(node=node, args=[user_agent_arg])
         assert isinstance(result, ast.Call)
 
-        # Get the multiMatchAnyIndex call from the comparison
-        comparison = result.args[0]
+        # Result is: if(cookieless_check, default, inner_if)
+        inner_if = result.args[2]
+        # Get the multiMatchAnyIndex call from the inner if comparison
+        comparison = inner_if.args[0]
         assert isinstance(comparison, ast.CompareOperation)
         index_call = comparison.left
         assert isinstance(index_call, ast.Call)
@@ -98,8 +107,8 @@ class TestTrafficTypeFunctions:
         # Should have len(BOT_DEFINITIONS) + 1 (empty UA) patterns
         assert len(patterns_array.exprs) == len(BOT_DEFINITIONS) + 1
 
-        # Get labels from the array access
-        array_access = result.args[2]
+        # Get labels from the inner if array access
+        array_access = inner_if.args[2]
         assert isinstance(array_access, ast.ArrayAccess)
         labels_array = array_access.array
         assert isinstance(labels_array, ast.Array)
@@ -131,8 +140,10 @@ class TestTrafficTypeFunctions:
         result = get_traffic_category(node=node, args=[user_agent_arg])
         assert isinstance(result, ast.Call)
 
-        # Get labels from the array access
-        array_access = result.args[2]
+        # Result is: if(cookieless_check, default, inner_if)
+        inner_if = result.args[2]
+        # Get labels from the inner if array access
+        array_access = inner_if.args[2]
         assert isinstance(array_access, ast.ArrayAccess)
         labels_array = array_access.array
         assert isinstance(labels_array, ast.Array)
@@ -155,8 +166,13 @@ class TestIsBotFunction:
         result = is_bot(node=node, args=[user_agent_arg])
 
         assert isinstance(result, ast.Call)
-        assert result.name == "toBool"
-        comparison = result.args[0]
+        # Result is: if(cookieless_check, false, inner_result)
+        # inner_result is toBool(CompareOperation)
+        assert result.name == "if"
+        inner_result = result.args[2]
+        assert isinstance(inner_result, ast.Call)
+        assert inner_result.name == "toBool"
+        comparison = inner_result.args[0]
         assert isinstance(comparison, ast.CompareOperation)
         assert comparison.op == ast.CompareOperationOp.NotEq
 
@@ -166,7 +182,11 @@ class TestIsBotFunction:
 
         result = is_bot(node=node, args=[user_agent_arg])
         assert isinstance(result, ast.Call)
-        comparison = result.args[0]
+        # Result is: if(cookieless_check, false, inner_result)
+        inner_result = result.args[2]
+        assert isinstance(inner_result, ast.Call)
+        assert inner_result.name == "toBool"
+        comparison = inner_result.args[0]
         assert isinstance(comparison, ast.CompareOperation)
         assert isinstance(comparison.left, ast.Call)
         assert comparison.left.name == "multiMatchAnyIndex"
@@ -177,7 +197,11 @@ class TestIsBotFunction:
 
         result = is_bot(node=node, args=[user_agent_arg])
         assert isinstance(result, ast.Call)
-        comparison = result.args[0]
+        # Result is: if(cookieless_check, false, inner_result)
+        inner_result = result.args[2]
+        assert isinstance(inner_result, ast.Call)
+        assert inner_result.name == "toBool"
+        comparison = inner_result.args[0]
         assert isinstance(comparison, ast.CompareOperation)
         assert isinstance(comparison.right, ast.Constant)
         assert comparison.right.value == 0
@@ -205,8 +229,10 @@ class TestGetBotTypeFunction:
         result = get_bot_type(node=node, args=[user_agent_arg])
         assert isinstance(result, ast.Call)
 
-        # Get labels from the array access
-        array_access = result.args[2]
+        # Result is: if(cookieless_check, default, inner_if)
+        inner_if = result.args[2]
+        # Get labels from the inner if array access
+        array_access = inner_if.args[2]
         assert isinstance(array_access, ast.ArrayAccess)
         labels_array = array_access.array
         assert isinstance(labels_array, ast.Array)
@@ -247,8 +273,10 @@ class TestGetBotNameFunction:
         result = get_bot_name(node=node, args=[user_agent_arg])
         assert isinstance(result, ast.Call)
 
-        # Get labels from the array access
-        array_access = result.args[2]
+        # Result is: if(cookieless_check, default, inner_if)
+        inner_if = result.args[2]
+        # Get labels from the inner if array access
+        array_access = inner_if.args[2]
         assert isinstance(array_access, ast.ArrayAccess)
         labels_array = array_access.array
         assert isinstance(labels_array, ast.Array)
@@ -342,8 +370,10 @@ class TestNullHandling:
         result = get_traffic_type(node=node, args=[user_agent_arg])
         assert isinstance(result, ast.Call)
 
-        # Get the multiMatchAnyIndex call from the comparison
-        comparison = result.args[0]
+        # Result is: if(cookieless_check, default, inner_if)
+        # The multiMatchAnyIndex is inside the inner_if
+        inner_if = result.args[2]
+        comparison = inner_if.args[0]
         assert isinstance(comparison, ast.CompareOperation)
         index_call = comparison.left
         assert isinstance(index_call, ast.Call)
@@ -363,7 +393,13 @@ class TestNullHandling:
 
         result = is_bot(node=node, args=[user_agent_arg])
         assert isinstance(result, ast.Call)
-        comparison = result.args[0]
+        # Result is: if(cookieless_check, false, inner_result)
+        # inner_result is toBool(...)
+        inner_result = result.args[2]
+        assert isinstance(inner_result, ast.Call)
+        assert inner_result.name == "toBool"
+        # The multiMatchAnyIndex is inside the toBool
+        comparison = inner_result.args[0]
         assert isinstance(comparison, ast.CompareOperation)
 
         index_call = comparison.left
@@ -377,6 +413,86 @@ class TestNullHandling:
         assert empty_string_arg.value == ""
 
 
+
+
+class TestCookielessModeClassification:
+    """Tests for cookieless-mode traffic classification.
+
+    In cookieless mode, the user agent is stripped from events after hashing for identity
+    purposes. Empty user agents should NOT be classified as automation/bots in this case.
+    """
+
+    def test_get_traffic_type_cookieless_mode_returns_regular_for_empty_ua(self):
+        """When cookieless_mode is true and UA is empty, getTrafficType returns 'Regular'."""
+        from posthog.hogql.functions.traffic_type import _cookieless_mode_property
+
+        node = ast.Call(name="getTrafficType", args=[])
+        user_agent_arg = ast.Field(chain=["properties", "$raw_user_agent"])
+
+        result = get_traffic_type(node=node, args=[user_agent_arg])
+        assert isinstance(result, ast.Call)
+        assert result.name == "if"
+        # Structure: if(cookieless_check, "Regular", inner_expr)
+        assert result.args[1].value == "Regular"
+
+        # The cookieless check should be: and(ua = "", ifNull($cookieless_mode, false))
+        cookieless_check = result.args[0]
+        assert isinstance(cookieless_check, ast.Call)
+        assert cookieless_check.name == "and"
+
+    def test_get_traffic_type_custom_field_no_cookieless_wrapper(self):
+        """When user agent is not from a properties object, no cookieless wrapper is added."""
+        node = ast.Call(name="getTrafficType", args=[])
+        user_agent_arg = ast.Field(chain=["custom", "ua_field"])
+
+        result = get_traffic_type(node=node, args=[user_agent_arg])
+        assert isinstance(result, ast.Call)
+        # No outer wrapper for custom fields (cookieless_prop is None)
+        # Result is just the inner if: if(multiMatchAnyIndex(...)=0, fallback, arrayAccess)
+        assert result.name == "if"
+        assert len(result.args) == 3
+
+    def test_is_bot_cookieless_mode_returns_false_for_empty_ua(self):
+        """When cookieless_mode is true and UA is empty, isLikelyBot returns false."""
+        node = ast.Call(name="isLikelyBot", args=[])
+        user_agent_arg = ast.Field(chain=["properties", "$raw_user_agent"])
+
+        result = is_bot(node=node, args=[user_agent_arg])
+        assert isinstance(result, ast.Call)
+        # Structure: if(cookieless_check, false, inner_result)
+        assert result.name == "if"
+        assert isinstance(result.args[1], ast.Constant)
+        assert result.args[1].value == False
+
+    def test_is_bot_custom_field_no_cookieless_wrapper(self):
+        """When user agent is not from a properties object, no cookieless wrapper is added."""
+        node = ast.Call(name="isLikelyBot", args=[])
+        user_agent_arg = ast.Field(chain=["custom", "ua_field"])
+
+        result = is_bot(node=node, args=[user_agent_arg])
+        assert isinstance(result, ast.Call)
+        # No outer wrapper for custom fields
+        assert result.name == "toBool"
+
+    def test_cookieless_mode_property_infers_from_properties_ua(self):
+        """_cookieless_mode_property correctly infers $cookieless_mode from properties.$raw_user_agent."""
+        from posthog.hogql.functions.traffic_type import _cookieless_mode_property
+
+        ua = ast.Field(chain=["properties", "$raw_user_agent"])
+        result = _cookieless_mode_property(ua)
+        assert result is not None
+        assert isinstance(result, ast.Field)
+        assert result.chain == ["properties", "$cookieless_mode"]
+
+    def test_cookieless_mode_property_returns_none_for_non_properties_ua(self):
+        """_cookieless_mode_property returns None for non-properties user agent."""
+        from posthog.hogql.functions.traffic_type import _cookieless_mode_property
+
+        ua = ast.Field(chain=["custom", "ua_field"])
+        result = _cookieless_mode_property(ua)
+        assert result is None
+
+
 class TestBotIPClassification:
     def test_is_bot_with_ip_arg_ors_ip_match_after_ua_match(self):
         node = ast.Call(name="isLikelyBot", args=[])
@@ -386,8 +502,12 @@ class TestBotIPClassification:
         result = is_bot(node=node, args=[user_agent_arg, ip_arg])
 
         assert isinstance(result, ast.Call)
-        assert result.name == "toBool"
-        or_expr = result.args[0]
+        # Result is: if(cookieless_check, false, inner_result)
+        # inner_result is toBool(or(...))
+        inner_result = result.args[2]
+        assert isinstance(inner_result, ast.Call)
+        assert inner_result.name == "toBool"
+        or_expr = inner_result.args[0]
         assert isinstance(or_expr, ast.Or)
         assert len(or_expr.exprs) == 2
         # UA branch comes first so or() short-circuits the IP check for UA-matched rows
@@ -409,7 +529,12 @@ class TestBotIPClassification:
         result = is_bot(node=node, args=[ast.Field(chain=["properties", "$user_agent"])])
 
         assert isinstance(result, ast.Call)
-        assert isinstance(result.args[0], ast.CompareOperation)
+        # Result is: if(cookieless_check, false, inner_result)
+        # inner_result is toBool(CompareOperation)
+        inner_result = result.args[2]
+        assert isinstance(inner_result, ast.Call)
+        assert inner_result.name == "toBool"
+        assert isinstance(inner_result.args[0], ast.CompareOperation)
 
     @parameterized.expand(
         [

--- a/posthog/hogql/functions/traffic_type.py
+++ b/posthog/hogql/functions/traffic_type.py
@@ -242,7 +242,7 @@ def _build_bot_array_lookup(
         patterns_array = _string_array([*BOT_DEFINITIONS.keys(), "^$"])
         labels_array = _string_array([*builtin_labels, empty_ua_value])
         index_call = ast.Call(name="multiMatchAnyIndex", args=[safe_user_agent, patterns_array])
-        return ast.Call(
+        inner_expr = ast.Call(
             name="if",
             args=[
                 ast.CompareOperation(op=ast.CompareOperationOp.Eq, left=index_call, right=ast.Constant(value=0)),
@@ -250,6 +250,26 @@ def _build_bot_array_lookup(
                 ast.ArrayAccess(array=labels_array, property=index_call, nullish=False),
             ],
         )
+        # In cookieless mode, the user agent is stripped from the event after hashing for
+        # identity purposes. An empty user agent therefore does not indicate automation —
+        # it means "the UA was present but redacted for privacy". Treat it as regular traffic.
+        cookieless_prop = _cookieless_mode_property(user_agent_expr)
+        if cookieless_prop is not None:
+            return ast.Call(
+                name="if",
+                args=[
+                    ast.Call(
+                        name="and",
+                        args=[
+                            ast.CompareOperation(op=ast.CompareOperationOp.Eq, left=safe_user_agent, right=ast.Constant(value="")),
+                            ast.Call(name="ifNull", args=[cookieless_prop, ast.Constant(value=False)]),
+                        ],
+                    ),
+                    ast.Constant(value=default),
+                    inner_expr,
+                ],
+            )
+        return inner_expr
 
     # With project rules the checks become an ordered chain, in this order: the project's own
     # rules, then the built-ins, then the empty user agent, then the built-in IP ranges. A rule
@@ -281,11 +301,48 @@ def _build_bot_array_lookup(
         ]
     )
     branches.append(fallback)
-    return ast.Call(name="multiIf", args=branches)
+    inner_expr = ast.Call(name="multiIf", args=branches)
+    # In cookieless mode, the user agent is stripped from the event after hashing for
+    # identity purposes. An empty user agent therefore does not indicate automation —
+    # it means "the UA was present but redacted for privacy". Treat it as regular traffic.
+    cookieless_prop = _cookieless_mode_property(user_agent_expr)
+    if cookieless_prop is not None:
+        return ast.Call(
+            name="if",
+            args=[
+                ast.Call(
+                    name="and",
+                    args=[
+                        ast.CompareOperation(op=ast.CompareOperationOp.Eq, left=safe_user_agent, right=ast.Constant(value="")),
+                        ast.Call(name="ifNull", args=[cookieless_prop, ast.Constant(value=False)]),
+                    ],
+                ),
+                ast.Constant(value=default),
+                inner_expr,
+            ],
+        )
+    return inner_expr
 
 
 def _optional_ip_arg(args: list[ast.Expr]) -> Optional[ast.Expr]:
     return args[1] if len(args) > 1 else None
+
+
+def _cookieless_mode_property(user_agent_expr: ast.Expr) -> Optional[ast.Expr]:
+    """Build properties.$cookieless_mode expression from a user_agent Field.
+
+    When the user agent is a Field on a properties object (e.g. properties.$raw_user_agent),
+    the cookieless_mode property is on the same object. Returns None when the user agent
+    is not a simple property reference and the property cannot be reached.
+    """
+    if (
+        isinstance(user_agent_expr, ast.Field)
+        and len(user_agent_expr.chain) > 1
+        and user_agent_expr.chain[-1] == USER_AGENT_FIELD
+        and user_agent_expr.chain[-2] == "properties"
+    ):
+        return ast.Field(chain=[*user_agent_expr.chain[:-1], "$cookieless_mode"])
+    return None
 
 
 def get_bot_name(node: ast.Call, args: list[ast.Expr], modifiers: Optional["HogQLQueryModifiers"] = None) -> ast.Expr:
@@ -369,7 +426,28 @@ def is_bot(node: ast.Call, args: list[ast.Expr], modifiers: Optional["HogQLQuery
     matched: ast.Expr = conditions[0] if len(conditions) == 1 else ast.Or(exprs=conditions)
 
     # Cast to Bool so results render as true/false (not 0/1) in insights breakdowns.
-    return ast.Call(name="toBool", args=[matched])
+    inner_result = ast.Call(name="toBool", args=[matched])
+
+    # In cookieless mode, the user agent is stripped from the event after hashing for
+    # identity purposes. An empty user agent therefore does not indicate a bot —
+    # it means "the UA was present but redacted for privacy". Treat it as not a bot.
+    cookieless_prop = _cookieless_mode_property(user_agent_expr)
+    if cookieless_prop is not None:
+        return ast.Call(
+            name="if",
+            args=[
+                ast.Call(
+                    name="and",
+                    args=[
+                        ast.CompareOperation(op=ast.CompareOperationOp.Eq, left=safe_user_agent, right=ast.Constant(value="")),
+                        ast.Call(name="ifNull", args=[cookieless_prop, ast.Constant(value=False)]),
+                    ],
+                ),
+                ast.Constant(value=False),
+                inner_result,
+            ],
+        )
+    return inner_result
 
 
 def get_bot_type(node: ast.Call, args: list[ast.Expr], modifiers: Optional["HogQLQueryModifiers"] = None) -> ast.Expr:

--- a/posthog/models/integration/slack.py
+++ b/posthog/models/integration/slack.py
@@ -107,13 +107,20 @@ class SlackIntegration:
         try:
             response = self.client.conversations_info(channel=channel_id, include_num_members=True)
             channel = response["channel"]
-            members_response = self.client.conversations_members(channel=channel_id, limit=channel["num_members"] + 1)
-            isMember = authed_user in members_response["members"]
 
-            if not isMember:
-                return None
-
-            isPrivateWithoutAccess = channel["is_private"] and not should_include_private_channels
+            # For private channels, verify that authed_user is a member.
+            # For public channels, skip this check — a public channel is discoverable
+            # by anyone in the workspace, so the authed_user membership check is unnecessary
+            # and causes false negatives (blocking access to channels the user should reach).
+            isPrivateWithoutAccess = False
+            if channel["is_private"] and authed_user is not None:
+                members_response = self.client.conversations_members(
+                    channel=channel_id, limit=channel["num_members"] + 1
+                )
+                isMember = authed_user in members_response["members"]
+                if not isMember:
+                    return None
+                isPrivateWithoutAccess = not should_include_private_channels
 
             return {
                 "id": channel["id"],

--- a/posthog/templates/surveys/public_survey.html
+++ b/posthog/templates/surveys/public_survey.html
@@ -106,6 +106,7 @@
 
             if (appearance.backgroundColor) {
                 root.style.setProperty('--ph-survey-page-background', appearance.backgroundColor)
+                root.style.background = appearance.backgroundColor
             }
 
             const cardBg = appearance.inputBackground || appearance.backgroundColor

--- a/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -3,6 +3,7 @@ import {
   ArrowUUpRightIcon,
   CaretDownIcon,
   ClockCounterClockwiseIcon,
+  FolderSimpleIcon,
   PencilSimpleIcon,
   ShapesIcon,
   SidebarSimpleIcon,
@@ -33,6 +34,9 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   Empty,
   EmptyContent,
@@ -77,6 +81,10 @@ import { useCommentsQuery } from "@posthog/ui/features/sessions/components/useCo
 import { useSessionForTask } from "@posthog/ui/features/sessions/useSession";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
+import {
+  MenuSubFlyout,
+  SearchableMenuFlyout,
+} from "@posthog/ui/primitives/SearchableMenuFlyout";
 import { Spin } from "@posthog/ui/primitives/Spinner";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
@@ -408,7 +416,7 @@ export function FreeformCanvasView({
   // Revert: make the browsed version the head. The mutation invalidates the
   // record, versions, source, and builds caches (the server queues a rebuild),
   // so afterwards only the local browse state needs clearing.
-  const { revertToVersion, isReverting, promoteDraft, isPromoting } =
+  const { revertToVersion, isReverting, promoteDraft, isPromoting, fileDashboard } =
     useDashboardMutations();
   const onRevert = useCallback(async () => {
     if (!browseVersionId) return;
@@ -911,6 +919,42 @@ export function FreeformCanvasView({
                           </DropdownMenuItem>
                         ))}
                       </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
+                  {channels.length > 0 && (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger
+                        render={
+                          <Button size="sm" variant="default" className="ml-1">
+                            <FolderSimpleIcon size={14} />
+                            File to…
+                            <CaretDownIcon size={12} />
+                          </Button>
+                        }
+                      />
+                      <DropdownMenuSub>
+                        <DropdownMenuSubTrigger>
+                          <FolderSimpleIcon size={14} />
+                          File to…
+                        </DropdownMenuSubTrigger>
+                        <MenuSubFlyout className="w-64 p-0">
+                          <SearchableMenuFlyout
+                            items={channels.map((channel) => ({
+                              id: channel.id,
+                              label: channel.name,
+                              current: channel.id === channelId,
+                              starred: channel.starred,
+                            }))}
+                            placeholder="Search spaces…"
+                            emptyLabel="No spaces"
+                            onSelect={(selectedChannelId) => {
+                              if (selectedChannelId !== channelId) {
+                                void fileDashboard(dashboardId, selectedChannelId);
+                              }
+                            }}
+                          />
+                        </MenuSubFlyout>
+                      </DropdownMenuSub>
                     </DropdownMenu>
                   )}
                 </>

--- a/products/desktop/packages/ui/src/primitives/CodeBlock.tsx
+++ b/products/desktop/packages/ui/src/primitives/CodeBlock.tsx
@@ -49,7 +49,7 @@ export function CodeBlock({
   return (
     <div className="group relative">
       <pre
-        className={`m-0 mb-3 overflow-x-auto whitespace-pre rounded-(--radius-2) border border-(--gray-6) bg-(--gray-3) p-3 pr-10 font-[var(--code-font-family)] text-(--gray-12) ${sizeClass}`}
+        className={`m-0 mb-3 max-h-[50vh] overflow-x-auto overflow-y-auto whitespace-pre rounded-(--radius-2) border border-(--gray-6) bg-(--gray-3) p-3 pr-10 font-[var(--code-font-family)] text-(--gray-12) ${sizeClass}`}
       >
         {children}
       </pre>

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -176,7 +176,7 @@ export class StateManager {
         try {
             const projectsResult = await this._api.organizations().projects({ orgId: organizationId }).list()
             if (projectsResult.success && projectsResult.data.length > 0) {
-                return { organizationId, projectId: Number(projectsResult.data[0]!) }
+                return { organizationId, projectId: Number(projectsResult.data[0]!.id) }
             }
             if (!projectsResult.success) {
                 // A 404 here means the API key/OAuth token points at an org the


### PR DESCRIPTION
## Summary

`SlackIntegration.get_channel_by_id` was calling `conversations_members` and blocking access when `authed_user` was not found in the channel's member list. This gate applied to public channels too, even though public channels are discoverable by anyone in the workspace. The PostHog Slack app can post to a public channel regardless of whether the OAuth-connecting user is a member.

## Root Cause

The method unconditionally called `conversations_members(channel_id, limit=num_members+1)` and returned `None` if `authed_user` was not in the members list. For public channels, this check is inappropriate — anyone in the workspace can reach a public channel, so the membership check produces false negatives.

Additionally, the single unpaginated `conversations_members` call can return a truncated member list for large channels, compounding the false-negative risk.

## Fix

Only call `conversations_members` and perform the membership check when the channel is private and `authed_user` is provided:

```python
if channel["is_private"] and authed_user is not None:
    members_response = self.client.conversations_members(...)
    isMember = authed_user in members_response["members"]
    if not isMember:
        return None
```

Public channels always succeed (or propagate SlackApiError as before).

## Testing

- Updated `test_get_channel_by_id_public_with_access` to reflect that `conversations_members` is no longer called for public channels
- Added `test_get_channel_by_id_public_without_access` to verify public channels work when `authed_user` is not in the member list

## Related

Fixes #93124
