### PR TITLE
fix(heatmaps): Add loading + other fixes to heatmaps

### DIFF
--- a/frontend/src/lib/components/heatmaps/HeatMapsSettings.tsx
+++ b/frontend/src/lib/components/heatmaps/HeatMapsSettings.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react'
 
 import { IconInfo } from '@posthog/icons'
 
-import { HEATMAP_COLOR_PALETTE_OPTIONS } from 'lib/components/heatmaps/heatmapDataLogic'
+import { HEATMAP_COLOR_PALETTE_OPTIONS, HEATMAP_TYPE_OPTIONS } from 'lib/components/heatmaps/heatmapDataLogic'
 import { HeatmapFilters, HeatmapFixedPositionMode } from 'lib/components/heatmaps/types'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
@@ -106,28 +106,7 @@ export const HeatmapsSettings = ({
                     <LemonSelect
                         onChange={(e) => patchHeatmapFilters?.({ type: e })}
                         value={heatmapFilters?.type ?? undefined}
-                        options={[
-                            {
-                                value: 'click',
-                                label: 'Clicks',
-                            },
-                            {
-                                value: 'rageclick',
-                                label: 'Rageclicks',
-                            },
-                            {
-                                value: 'deadclick',
-                                label: 'Dead clicks',
-                            },
-                            {
-                                value: 'mousemove',
-                                label: 'Mouse moves',
-                            },
-                            {
-                                value: 'scrolldepth',
-                                label: 'Scroll depth',
-                            },
-                        ]}
+                        options={HEATMAP_TYPE_OPTIONS}
                         size="small"
                     />
 

--- a/frontend/src/lib/components/heatmaps/HeatmapCanvas.tsx
+++ b/frontend/src/lib/components/heatmaps/HeatmapCanvas.tsx
@@ -2,16 +2,14 @@ import heatmapsJs, { Heatmap as HeatmapJS } from 'heatmap.js'
 import { useActions, useValues } from 'kea'
 import { MutableRefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { HEATMAP_LOADING_DEBOUNCE_MS, heatmapDataLogic } from 'lib/components/heatmaps/heatmapDataLogic'
+import { heatmapDataLogic } from 'lib/components/heatmaps/heatmapDataLogic'
 import { HeatmapAreaPoint } from 'lib/components/heatmaps/types'
 import { useShiftKeyPressed } from 'lib/components/heatmaps/useShiftKeyPressed'
-import { useDebouncedValue } from 'lib/hooks/useDebouncedValue'
-import { Spinner } from 'lib/lemon-ui/Spinner'
 import { cn } from 'lib/utils/css-classes'
-import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
 import { pluralize } from 'lib/utils/strings'
 
 import { HeatmapEventsPanel } from './HeatmapEventsPanel'
+import { HeatmapLoadingInfo } from './HeatmapLoadingInfo'
 import { ScrollDepthCanvas } from './ScrollDepthCanvas'
 import { MousePosition, useMousePosition } from './useMousePosition'
 import { useScrollSync } from './useScrollSync'
@@ -36,35 +34,8 @@ function heatmapValueAt(
     try {
         return heatmapJs?.getValueAt(position)
     } catch {
-        // heatmap.js throws reading its canvas if it was created while the container had
-        // zero height (IndexSizeError in Chromium, raw NS_ERROR_FAILURE in Firefox);
-        // this runs on every mouse move, so swallow rather than crash the scene
         return undefined
     }
-}
-
-function HeatmapLoadingInfo({
-    context,
-    exportToken,
-}: {
-    context: 'in-app' | 'toolbar'
-    exportToken?: string
-}): JSX.Element | null {
-    const { rawHeatmapLoading } = useValues(heatmapDataLogic({ context, exportToken }))
-    const loading = useDebouncedValue(rawHeatmapLoading, HEATMAP_LOADING_DEBOUNCE_MS)
-
-    if (!loading || context === 'toolbar' || exportToken || inStorybook() || inStorybookTestRunner()) {
-        return null
-    }
-
-    return (
-        <div className="absolute inset-0 z-20 flex items-start justify-center pointer-events-none">
-            <div className={cn(INFO_BOX_CLASSES, 'flex items-center gap-2 mt-8 px-3 py-2')}>
-                <Spinner />
-                Loading heatmap data
-            </div>
-        </div>
-    )
 }
 
 function HeatmapMouseInfo({

--- a/frontend/src/lib/components/heatmaps/HeatmapCanvas.tsx
+++ b/frontend/src/lib/components/heatmaps/HeatmapCanvas.tsx
@@ -2,14 +2,18 @@ import heatmapsJs, { Heatmap as HeatmapJS } from 'heatmap.js'
 import { useActions, useValues } from 'kea'
 import { MutableRefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { heatmapDataLogic } from 'lib/components/heatmaps/heatmapDataLogic'
+import { HEATMAP_LOADING_DEBOUNCE_MS, heatmapDataLogic } from 'lib/components/heatmaps/heatmapDataLogic'
 import { HeatmapAreaPoint } from 'lib/components/heatmaps/types'
 import { useShiftKeyPressed } from 'lib/components/heatmaps/useShiftKeyPressed'
+import { useDebouncedValue } from 'lib/hooks/useDebouncedValue'
+import { Spinner } from 'lib/lemon-ui/Spinner'
 import { cn } from 'lib/utils/css-classes'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+import { pluralize } from 'lib/utils/strings'
 
 import { HeatmapEventsPanel } from './HeatmapEventsPanel'
 import { ScrollDepthCanvas } from './ScrollDepthCanvas'
-import { useMousePosition } from './useMousePosition'
+import { MousePosition, useMousePosition } from './useMousePosition'
 import { useScrollSync } from './useScrollSync'
 
 // Radius in pixels to search for nearby heatmap elements when clicking
@@ -21,6 +25,46 @@ const TOOLTIP_FLIP_THRESHOLD_PX = 160
 const HEATMAP_CONFIG = {
     minOpacity: 0,
     maxOpacity: 0.8,
+}
+
+const INFO_BOX_CLASSES = 'border rounded bg-surface-primary shadow-md font-semibold'
+
+function heatmapValueAt(
+    heatmapJs: HeatmapJS<'value', 'x', 'y'> | undefined,
+    position: MousePosition
+): number | undefined {
+    try {
+        return heatmapJs?.getValueAt(position)
+    } catch {
+        // heatmap.js throws reading its canvas if it was created while the container had
+        // zero height (IndexSizeError in Chromium, raw NS_ERROR_FAILURE in Firefox);
+        // this runs on every mouse move, so swallow rather than crash the scene
+        return undefined
+    }
+}
+
+function HeatmapLoadingInfo({
+    context,
+    exportToken,
+}: {
+    context: 'in-app' | 'toolbar'
+    exportToken?: string
+}): JSX.Element | null {
+    const { rawHeatmapLoading } = useValues(heatmapDataLogic({ context, exportToken }))
+    const loading = useDebouncedValue(rawHeatmapLoading, HEATMAP_LOADING_DEBOUNCE_MS)
+
+    if (!loading || context === 'toolbar' || exportToken || inStorybook() || inStorybookTestRunner()) {
+        return null
+    }
+
+    return (
+        <div className="absolute inset-0 z-20 flex items-start justify-center pointer-events-none">
+            <div className={cn(INFO_BOX_CLASSES, 'flex items-center gap-2 mt-8 px-3 py-2')}>
+                <Spinner />
+                Loading heatmap data
+            </div>
+        </div>
+    )
 }
 
 function HeatmapMouseInfo({
@@ -35,21 +79,11 @@ function HeatmapMouseInfo({
     onHasValue?: (hasValue: boolean) => void
 }): JSX.Element | null {
     const shiftPressed = useShiftKeyPressed()
-    const { heatmapTooltipLabel, rawHeatmapLoading, heatmapTooltipSuppressed } = useValues(
-        heatmapDataLogic({ context })
-    )
+    const { heatmapTooltipNoun, rawHeatmapLoading, heatmapTooltipSuppressed } = useValues(heatmapDataLogic({ context }))
 
     const containerMousePosition = useMousePosition(containerRef?.current)
     const viewportMousePosition = useMousePosition()
-    let value: number | undefined
-    try {
-        value = heatmapJsRef.current?.getValueAt(containerMousePosition)
-    } catch {
-        // heatmap.js throws reading its canvas if it was created while the container had
-        // zero height (IndexSizeError in Chromium, raw NS_ERROR_FAILURE in Firefox);
-        // this runs on every mouse move, so swallow rather than crash the scene
-        value = undefined
-    }
+    const value = containerMousePosition ? heatmapValueAt(heatmapJsRef.current, containerMousePosition) : undefined
 
     const hasValue = !!(containerMousePosition && (value || shiftPressed)) && !heatmapTooltipSuppressed
 
@@ -57,7 +91,7 @@ function HeatmapMouseInfo({
         onHasValue?.(hasValue)
     }, [hasValue, onHasValue])
 
-    if (!hasValue) {
+    if (!hasValue || !viewportMousePosition) {
         return null
     }
 
@@ -73,8 +107,8 @@ function HeatmapMouseInfo({
                 right: flipLeft ? window.innerWidth - viewportMousePosition.x + TOOLTIP_OFFSET_PX : undefined,
             }}
         >
-            <div className="border rounded bg-surface-primary shadow-md p-2 whitespace-nowrap font-semibold">
-                {rawHeatmapLoading ? 'Loading…' : `${value ?? 0} ${heatmapTooltipLabel}`}
+            <div className={cn(INFO_BOX_CLASSES, 'p-2 whitespace-nowrap')}>
+                {rawHeatmapLoading ? 'Loading…' : pluralize(value ?? 0, heatmapTooltipNoun)}
             </div>
         </div>
     )
@@ -219,12 +253,15 @@ export function HeatmapCanvas({
 
     if (heatmapFilters.type === 'scrolldepth') {
         return (
-            <ScrollDepthCanvas
-                key={`scrolldepth-${heatmapFilters.type}-${exportToken ? 'export' : `${widthOverride ?? windowWidth}x${windowHeight}`}`}
-                positioning={positioning}
-                context={context}
-                exportToken={exportToken}
-            />
+            <>
+                <ScrollDepthCanvas
+                    key={`scrolldepth-${heatmapFilters.type}-${exportToken ? 'export' : `${widthOverride ?? windowWidth}x${windowHeight}`}`}
+                    positioning={positioning}
+                    context={context}
+                    exportToken={exportToken}
+                />
+                <HeatmapLoadingInfo context={context} exportToken={exportToken} />
+            </>
         )
     }
 
@@ -283,6 +320,7 @@ export function HeatmapCanvas({
                 onHasValue={setHasValueUnderMouse}
             />
             <HeatmapEventsPanel context={context} exportToken={exportToken} />
+            <HeatmapLoadingInfo context={context} exportToken={exportToken} />
         </div>
     )
 }

--- a/frontend/src/lib/components/heatmaps/HeatmapLoadingInfo.tsx
+++ b/frontend/src/lib/components/heatmaps/HeatmapLoadingInfo.tsx
@@ -1,0 +1,30 @@
+import { useValues } from 'kea'
+
+import { HEATMAP_LOADING_DEBOUNCE_MS, heatmapDataLogic } from 'lib/components/heatmaps/heatmapDataLogic'
+import { useDebouncedValue } from 'lib/hooks/useDebouncedValue'
+import { Spinner } from 'lib/lemon-ui/Spinner'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+
+export function HeatmapLoadingInfo({
+    context,
+    exportToken,
+}: {
+    context: 'in-app' | 'toolbar'
+    exportToken?: string
+}): JSX.Element | null {
+    const { rawHeatmapLoading } = useValues(heatmapDataLogic({ context, exportToken }))
+    const loading = useDebouncedValue(rawHeatmapLoading, HEATMAP_LOADING_DEBOUNCE_MS)
+
+    if (!loading || context === 'toolbar' || exportToken || inStorybook() || inStorybookTestRunner()) {
+        return null
+    }
+
+    return (
+        <div className="absolute inset-0 z-20 flex items-start justify-center pointer-events-none">
+            <div className="flex items-center gap-2 mt-8 px-3 py-2 border rounded bg-surface-primary shadow-md font-semibold">
+                <Spinner />
+                Loading heatmap data
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/lib/components/heatmaps/ScrollDepthCanvas.tsx
+++ b/frontend/src/lib/components/heatmaps/ScrollDepthCanvas.tsx
@@ -89,7 +89,7 @@ function ScrollDepthMouseInfo({
 }): JSX.Element | null {
     const { heatmapElements, rawHeatmapLoading } = useValues(heatmapDataLogic({ context, exportToken }))
 
-    const { y: mouseY } = useMousePosition()
+    const mouseY = useMousePosition()?.y
 
     if (!mouseY) {
         return null

--- a/frontend/src/lib/components/heatmaps/ScrollDepthCanvas.tsx
+++ b/frontend/src/lib/components/heatmaps/ScrollDepthCanvas.tsx
@@ -91,7 +91,7 @@ function ScrollDepthMouseInfo({
 
     const mouseY = useMousePosition()?.y
 
-    if (!mouseY) {
+    if (mouseY === undefined) {
         return null
     }
 

--- a/frontend/src/lib/components/heatmaps/heatmapDataLogic.ts
+++ b/frontend/src/lib/components/heatmaps/heatmapDataLogic.ts
@@ -13,6 +13,7 @@ import {
     HeatmapFixedPositionMode,
     HeatmapJsData,
     HeatmapJsDataPoint,
+    HeatmapKind,
 } from 'lib/components/heatmaps/types'
 import {
     DEFAULT_HEATMAP_FILTERS,
@@ -37,6 +38,20 @@ const UNBOUNDED_HEATMAP_LIMIT = 0
 // Limit canvas height to prevent browser freezing with heatmap.js
 // Large canvases (e.g., 24000px) cause heatmap.js to block the main thread
 export const MAX_HEATMAP_HEIGHT = 8000
+
+export const HEATMAP_LOADING_DEBOUNCE_MS = 200
+
+export const HEATMAP_TYPES: Record<HeatmapKind, { label: string; noun: string }> = {
+    click: { label: 'Clicks', noun: 'click' },
+    rageclick: { label: 'Rageclicks', noun: 'rageclick' },
+    deadclick: { label: 'Dead clicks', noun: 'dead click' },
+    mousemove: { label: 'Mouse moves', noun: 'mouse move' },
+    scrolldepth: { label: 'Scroll depth', noun: 'scroll depth' },
+}
+
+export const HEATMAP_TYPE_OPTIONS: LemonSelectOption<HeatmapKind>[] = (Object.keys(HEATMAP_TYPES) as HeatmapKind[]).map(
+    (value) => ({ value, label: HEATMAP_TYPES[value].label })
+)
 
 export const HEATMAP_COLOR_PALETTE_OPTIONS: LemonSelectOption<string>[] = [
     { value: 'default', label: 'Default (multicolor)' },
@@ -163,7 +178,7 @@ export interface heatmapDataLogicValues {
     heatmapFilters: HeatmapFilters
     heatmapFixedPositionMode: HeatmapFixedPositionMode
     heatmapJsData: HeatmapJsData
-    heatmapTooltipLabel: string
+    heatmapTooltipNoun: string
     heatmapTooltipSuppressed: boolean
     heightOverride: number
     href: string | null
@@ -307,7 +322,7 @@ export interface heatmapDataLogicMeta {
             min: number
         }
         widthOverride: (windowWidthOverride: number | null) => number
-        heatmapTooltipLabel: (heatmapFilters: HeatmapFilters) => string
+        heatmapTooltipNoun: (heatmapFilters: HeatmapFilters) => string
         heatmapEmpty: (rawHeatmap: HeatmapResponseType | null, rawHeatmapLoading: boolean) => boolean
         maxYFromEvents: (heatmapElements: HeatmapElement[]) => number
         heightOverride: (maxYFromEvents: number, windowHeight: number) => number
@@ -604,13 +619,13 @@ export const heatmapDataLogic = kea<heatmapDataLogicType>([
             (windowWidthOverride: number | null): number => windowWidthOverride ?? DEFAULT_HEATMAP_WIDTH,
         ],
 
-        heatmapTooltipLabel: [
+        heatmapTooltipNoun: [
             (s) => [s.heatmapFilters],
             (heatmapFilters: HeatmapFilters) => {
                 if (heatmapFilters.aggregation === 'unique_visitors') {
-                    return 'visitors'
+                    return 'visitor'
                 }
-                return heatmapFilters.type + 's'
+                return HEATMAP_TYPES[heatmapFilters.type ?? 'click'].noun
             },
         ],
 

--- a/frontend/src/lib/components/heatmaps/heatmapDataLogic.ts
+++ b/frontend/src/lib/components/heatmaps/heatmapDataLogic.ts
@@ -625,7 +625,7 @@ export const heatmapDataLogic = kea<heatmapDataLogicType>([
                 if (heatmapFilters.aggregation === 'unique_visitors') {
                     return 'visitor'
                 }
-                return HEATMAP_TYPES[heatmapFilters.type ?? 'click'].noun
+                return (HEATMAP_TYPES[heatmapFilters.type ?? 'click'] ?? HEATMAP_TYPES.click).noun
             },
         ],
 

--- a/frontend/src/lib/components/heatmaps/types.ts
+++ b/frontend/src/lib/components/heatmaps/types.ts
@@ -17,7 +17,7 @@ export type HeatmapEventFilter = {
     properties?: Record<string, any>[]
 }
 
-export type HeatmapKind = 'click' | 'rageclick' | 'mousemove' | 'scrolldepth'
+export type HeatmapKind = 'click' | 'rageclick' | 'deadclick' | 'mousemove' | 'scrolldepth'
 
 export type HeatmapRequestType = {
     type: HeatmapKind
@@ -32,7 +32,7 @@ export type HeatmapRequestType = {
 
 export type HeatmapFilters = {
     enabled: boolean
-    type?: string
+    type?: HeatmapKind
     viewportAccuracy?: number
     aggregation?: HeatmapRequestType['aggregation']
 }

--- a/frontend/src/lib/components/heatmaps/useMousePosition.test.ts
+++ b/frontend/src/lib/components/heatmaps/useMousePosition.test.ts
@@ -1,0 +1,48 @@
+import { fireEvent, renderHook } from '@testing-library/react'
+
+import { useMousePosition } from './useMousePosition'
+
+const CONTAINER_LEFT = 100
+const CONTAINER_TOP = 50
+const CONTAINER_WIDTH = 200
+const CONTAINER_HEIGHT = 300
+
+function createContainer(): HTMLElement {
+    const element = document.createElement('div')
+    element.getBoundingClientRect = () =>
+        ({
+            left: CONTAINER_LEFT,
+            top: CONTAINER_TOP,
+            width: CONTAINER_WIDTH,
+            height: CONTAINER_HEIGHT,
+        }) as DOMRect
+    return element
+}
+
+describe('useMousePosition', () => {
+    test.each<[string, number, number]>([
+        ['left of', 90, 100],
+        ['above', 150, 40],
+        ['right of', 310, 100],
+        ['below', 150, 360],
+    ])('clears the container position once the pointer is %s the container', (_, clientX, clientY) => {
+        const container = createContainer()
+        const { result } = renderHook(() => useMousePosition(container))
+
+        fireEvent.mouseMove(window, { clientX: 150, clientY: 100 })
+        expect(result.current).toEqual({ x: 50, y: 50 })
+
+        fireEvent.mouseMove(window, { clientX, clientY })
+        expect(result.current).toBeNull()
+    })
+
+    it('reports viewport positions when no container is given', () => {
+        const { result } = renderHook(() => useMousePosition())
+
+        expect(result.current).toBeNull()
+
+        fireEvent.mouseMove(window, { clientX: 150, clientY: 100 })
+
+        expect(result.current).toEqual({ x: 150, y: 100 })
+    })
+})

--- a/frontend/src/lib/components/heatmaps/useMousePosition.ts
+++ b/frontend/src/lib/components/heatmaps/useMousePosition.ts
@@ -1,24 +1,28 @@
 import { useEffect, useState } from 'react'
 
+export type MousePosition = { x: number; y: number }
+
+function positionIn(e: MouseEvent, container?: HTMLElement | null): MousePosition | null {
+    if (!container) {
+        return { x: e.clientX, y: e.clientY }
+    }
+    const rect = container.getBoundingClientRect()
+    const x = e.clientX - rect.left
+    const y = e.clientY - rect.top
+    return x >= 0 && y >= 0 && x <= rect.width && y <= rect.height ? { x, y } : null
+}
+
 /**
  * Hook to get the current mouse position relative to the window.
  * Optionally takes a container element.
  * if one is provided, the position will be relative to the container.
  */
-export const useMousePosition = (container?: HTMLElement | null): { x: number; y: number } => {
-    const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 })
+export function useMousePosition(container?: HTMLElement | null): MousePosition | null {
+    const [mousePosition, setMousePosition] = useState<MousePosition | null>(null)
 
     useEffect(() => {
         const onMove = (e: MouseEvent): void => {
-            const rect = container ? container.getBoundingClientRect() : { left: 0, top: 0 }
-            const newX = e.clientX - rect.left
-            const newY = e.clientY - rect.top
-            const inBounds = newX >= 0 && newY >= 0
-
-            setMousePosition((prev) => {
-                const hasChanged = newX !== prev.x || newY !== prev.y
-                return inBounds && hasChanged ? { x: newX, y: newY } : prev
-            })
+            setMousePosition(positionIn(e, container))
         }
 
         window.addEventListener('mousemove', onMove, { passive: true })

--- a/frontend/src/toolbar/elements/ScrollDepth.tsx
+++ b/frontend/src/toolbar/elements/ScrollDepth.tsx
@@ -13,7 +13,7 @@ function ScrollDepthMouseInfo(): JSX.Element | null {
     const { heatmapElements, rawHeatmapLoading } = useValues(heatmapToolbarMenuLogic)
 
     const shiftPressed = useShiftKeyPressed()
-    const { y: mouseY } = useMousePosition()
+    const mouseY = useMousePosition()?.y
 
     if (!mouseY) {
         return null

--- a/frontend/src/toolbar/elements/ScrollDepth.tsx
+++ b/frontend/src/toolbar/elements/ScrollDepth.tsx
@@ -15,7 +15,7 @@ function ScrollDepthMouseInfo(): JSX.Element | null {
     const shiftPressed = useShiftKeyPressed()
     const mouseY = useMousePosition()?.y
 
-    if (!mouseY) {
+    if (mouseY === undefined) {
         return null
     }
 

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -343,7 +343,6 @@ export interface heatmapToolbarMenuLogicValues {
     heatmapElements: HeatmapElement[] // heatmapDataLogic
     heatmapFilters: HeatmapFilters // heatmapDataLogic
     heatmapFixedPositionMode: HeatmapFixedPositionMode // heatmapDataLogic
-    heatmapTooltipLabel: string // heatmapDataLogic
     rawHeatmapLoading: boolean // heatmapDataLogic
     viewportRange: {
         max: number
@@ -668,7 +667,6 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                 'viewportRange',
                 'heatmapFilters',
                 'heatmapElements',
-                'heatmapTooltipLabel',
                 'dateRange',
             ],
         ],

--- a/products/web_analytics/frontend/heatmaps/components/FilterPanel.tsx
+++ b/products/web_analytics/frontend/heatmaps/components/FilterPanel.tsx
@@ -1,17 +1,18 @@
 import { useActions, useValues } from 'kea'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { IconFilter, IconGear, IconLaptop, IconPhone, IconTabletLandscape, IconTabletPortrait } from '@posthog/icons'
 import { LemonBadge, LemonBanner, LemonButton, LemonSegmentedButton, LemonSelect } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
-import { heatmapDataLogic } from 'lib/components/heatmaps/heatmapDataLogic'
+import { HEATMAP_LOADING_DEBOUNCE_MS, heatmapDataLogic } from 'lib/components/heatmaps/heatmapDataLogic'
 import { HeatmapsSettings } from 'lib/components/heatmaps/HeatMapsSettings'
 import { SectionSetting } from 'lib/components/heatmaps/HeatMapsSettings'
 import { HeatmapEventFilter } from 'lib/components/heatmaps/types'
 import { heatmapDateOptions } from 'lib/components/IframedToolbarBrowser/utils'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { useDebouncedValue } from 'lib/hooks/useDebouncedValue'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LoadingBar } from 'lib/lemon-ui/LoadingBar'
 import { Popover } from 'lib/lemon-ui/Popover'
@@ -36,20 +37,6 @@ const propertyFiltersToCohortIds = (filters: AnyPropertyFilter[]): number[] =>
         .filter((f): f is CohortPropertyFilter => f.type === PropertyFilterType.Cohort)
         .map((f) => f.value)
         .filter((v): v is number => typeof v === 'number')
-
-const useDebounceLoading = (loading: boolean, delay = 200): boolean => {
-    const [debouncedLoading, setDebouncedLoading] = useState(false)
-
-    useEffect(() => {
-        const timer = setTimeout(() => {
-            setDebouncedLoading(loading)
-        }, delay)
-
-        return () => clearTimeout(timer)
-    }, [loading, delay])
-
-    return debouncedLoading
-}
 
 export function ViewportChooser({ lockedWidth }: { lockedWidth?: number }): JSX.Element {
     const { widthOverride } = useValues(heatmapDataLogic({ context: 'in-app' }))
@@ -152,13 +139,13 @@ export function FilterPanel({
     const eventFilterEnabled = useFeatureFlag('HEATMAPS_EVENT_FILTER')
     const eventFilterCount = commonFilters?.events?.length ?? 0
 
-    const debouncedLoading = useDebounceLoading(rawHeatmapLoading ?? false)
+    const debouncedLoading = useDebouncedValue(rawHeatmapLoading, HEATMAP_LOADING_DEBOUNCE_MS)
 
     // KLUDGE: the loading bar flaps in visual regression tests,
     // for some reason our wait for loading to finish can't see it
     // this is ugly but better than stopping taking visual snapshots of it
     return (
-        <>
+        <div className="relative">
             {debouncedLoading && !inStorybook() && !inStorybookTestRunner() && (
                 <LoadingBar
                     wrapperClassName="absolute top-0 left-0 w-full overflow-hidden rounded-none my-0"
@@ -328,6 +315,6 @@ export function FilterPanel({
                     settings. A high value can hide data on pages with less traffic.
                 </LemonBanner>
             ) : null}
-        </>
+        </div>
     )
 }


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem
The heatmap gives no sign it's loading when you change a filter, and its tooltip keeps showing a count after the cursor has left the canvas.

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Added a loading chip while heatmap data loads, cleared the tooltip once the cursor leaves the canvas, and fixed the counts to read "1 dead click" instead of "1 deadclicks".

<!-- For each change a person can notice, say what they will now see or do differently, not only the code path that does it. Mark the rest as mechanical so a reviewer knows nothing user-visible is hiding in it. -->

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally tested
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - No duplicate: when this PR fixes something believed to be live on master, no open PR already fixes it. A broken master attracts parallel agents, so search before opening — `gh pr list --state open --search "<keywords>" --limit 20`, which lists drafts too, and most agent PRs start as drafts. Say here which PR you found and why this one is still needed, or that the search found nothing.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the palette and role mapping.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
