### PR TITLE
fix(experiments): respect configured credible interval level

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/HowToReadTooltip.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/HowToReadTooltip.tsx
@@ -10,10 +10,12 @@ import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { ExperimentStatsMethod } from '~/types'
 
 import { experimentLogic } from '../../experimentLogic'
+import { getExperimentIntervalLevelPercentage } from '../shared/utils'
 
 export function HowToReadTooltip(): JSX.Element {
-    const { statsMethod } = useValues(experimentLogic)
+    const { experiment, statsMethod } = useValues(experimentLogic)
     const { isDarkModeOn } = useValues(themeLogic)
+    const intervalLevel = getExperimentIntervalLevelPercentage(experiment, statsMethod)
 
     return (
         <>
@@ -64,8 +66,8 @@ export function HowToReadTooltip(): JSX.Element {
                         <p className="mb-3">
                             The bars show{' '}
                             {statsMethod === ExperimentStatsMethod.Bayesian
-                                ? '95% credible intervals'
-                                : '95% confidence intervals'}
+                                ? `${intervalLevel} credible intervals`
+                                : `${intervalLevel} confidence intervals`}
                             . When an interval doesn't cross the 0% line, the result is significant.
                         </p>
                         <img

--- a/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
@@ -34,7 +34,7 @@ import {
     formatIntervalPercent,
     formatMetricValue,
     formatPValue,
-    getIntervalLabel,
+    getExperimentIntervalTitle,
     isBayesianResult,
     isFrequentistResult,
 } from '../shared/utils'
@@ -167,9 +167,7 @@ export function ResultDetails({
         },
         {
             key: 'interval',
-            title: result.variant_results?.[0]
-                ? `${getIntervalLabel(result.variant_results[0])} (95%)`
-                : 'Confidence interval (95%)',
+            title: getExperimentIntervalTitle(result.variant_results?.[0], experiment),
             tooltip:
                 "The range that likely contains the true effect. When it doesn't cross 0%, the result is significant.",
             render: (_, item: ExperimentVariantResult & { key: string }) => {

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.test.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.test.ts
@@ -220,6 +220,11 @@ describe('getExperimentIntervalLevelPercentage', () => {
             expected: '95%',
         },
         {
+            label: 'Bayesian derived endpoint bounds',
+            stats_config: { method: ExperimentStatsMethod.Bayesian, bayesian: { ci_level: 0.9999999999999999 } },
+            expected: '95%',
+        },
+        {
             label: 'Bayesian null config',
             stats_config: {
                 method: ExperimentStatsMethod.Bayesian,

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.test.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.test.ts
@@ -6,6 +6,7 @@ import {
     ExperimentStatsMethod,
     FunnelConversionWindowTimeUnit,
 } from '~/types'
+import type { Experiment } from '~/types'
 
 import {
     type ExperimentVariantResult,
@@ -187,12 +188,83 @@ describe('getChanceToWin', () => {
 
 describe('getExperimentIntervalLevelPercentage', () => {
     it.each([
-        [{ method: ExperimentStatsMethod.Bayesian, bayesian: { ci_level: 0.9 } }, '90%'],
-        [{ method: ExperimentStatsMethod.Bayesian }, '95%'],
-        [{ method: ExperimentStatsMethod.Bayesian, bayesian: { ci_level: 0.99 } }, '99%'],
-        [{ method: ExperimentStatsMethod.Frequentist, frequentist: { alpha: 0.1 } }, '90%'],
-        [{ method: ExperimentStatsMethod.Frequentist }, '95%'],
-    ])('formats the configured interval level for %p', (stats_config, expected) => {
+        {
+            label: 'Bayesian 90%',
+            stats_config: { method: ExperimentStatsMethod.Bayesian, bayesian: { ci_level: 0.9 } },
+            expected: '90%',
+        },
+        { label: 'Bayesian default', stats_config: { method: ExperimentStatsMethod.Bayesian }, expected: '95%' },
+        {
+            label: 'Bayesian 99%',
+            stats_config: { method: ExperimentStatsMethod.Bayesian, bayesian: { ci_level: 0.99 } },
+            expected: '99%',
+        },
+        {
+            label: 'Bayesian fractional',
+            stats_config: { method: ExperimentStatsMethod.Bayesian, bayesian: { ci_level: 0.925 } },
+            expected: '92.5%',
+        },
+        {
+            label: 'Bayesian zero endpoint',
+            stats_config: { method: ExperimentStatsMethod.Bayesian, bayesian: { ci_level: 0 } },
+            expected: '95%',
+        },
+        {
+            label: 'Bayesian one endpoint',
+            stats_config: { method: ExperimentStatsMethod.Bayesian, bayesian: { ci_level: 1 } },
+            expected: '95%',
+        },
+        {
+            label: 'Bayesian above range',
+            stats_config: { method: ExperimentStatsMethod.Bayesian, bayesian: { ci_level: 1.5 } },
+            expected: '95%',
+        },
+        {
+            label: 'Bayesian null config',
+            stats_config: {
+                method: ExperimentStatsMethod.Bayesian,
+                bayesian: null,
+            } as unknown as Experiment['stats_config'],
+            expected: '95%',
+        },
+        {
+            label: 'Bayesian array config',
+            stats_config: {
+                method: ExperimentStatsMethod.Bayesian,
+                bayesian: [],
+            } as unknown as Experiment['stats_config'],
+            expected: '95%',
+        },
+        {
+            label: 'Frequentist 90%',
+            stats_config: { method: ExperimentStatsMethod.Frequentist, frequentist: { alpha: 0.1 } },
+            expected: '90%',
+        },
+        { label: 'Frequentist default', stats_config: { method: ExperimentStatsMethod.Frequentist }, expected: '95%' },
+        {
+            label: 'Frequentist fractional',
+            stats_config: { method: ExperimentStatsMethod.Frequentist, frequentist: { alpha: 0.075 } },
+            expected: '92.5%',
+        },
+        {
+            label: 'Frequentist zero endpoint',
+            stats_config: { method: ExperimentStatsMethod.Frequentist, frequentist: { alpha: 0 } },
+            expected: '95%',
+        },
+        {
+            label: 'Frequentist one endpoint',
+            stats_config: { method: ExperimentStatsMethod.Frequentist, frequentist: { alpha: 1 } },
+            expected: '95%',
+        },
+        {
+            label: 'Frequentist array config',
+            stats_config: {
+                method: ExperimentStatsMethod.Frequentist,
+                frequentist: [],
+            } as unknown as Experiment['stats_config'],
+            expected: '95%',
+        },
+    ])('formats the configured interval level for $label', ({ stats_config, expected }) => {
         expect(getExperimentIntervalLevelPercentage({ stats_config })).toBe(expected)
     })
 })

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.test.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.test.ts
@@ -1,6 +1,11 @@
 import type { ExperimentFunnelsQuery, ExperimentMetric, ExperimentTrendsQuery } from '~/queries/schema/schema-general'
 import { ExperimentMetricType, NodeKind } from '~/queries/schema/schema-general'
-import { ExperimentMetricGoal, ExperimentMetricMathType, FunnelConversionWindowTimeUnit } from '~/types'
+import {
+    ExperimentMetricGoal,
+    ExperimentMetricMathType,
+    ExperimentStatsMethod,
+    FunnelConversionWindowTimeUnit,
+} from '~/types'
 
 import {
     type ExperimentVariantResult,
@@ -10,6 +15,8 @@ import {
     formatTickValue,
     getChanceToWin,
     getDefaultMetricTitle,
+    getExperimentIntervalLevelPercentage,
+    getExperimentIntervalTitle,
     getMetricColors,
     getMetricTag,
     isProportionMetric,
@@ -175,6 +182,39 @@ describe('getChanceToWin', () => {
         const result = createFrequentistResult()
         expect(getChanceToWin(result, ExperimentMetricGoal.Increase)).toBeUndefined()
         expect(getChanceToWin(result, ExperimentMetricGoal.Decrease)).toBeUndefined()
+    })
+})
+
+describe('getExperimentIntervalLevelPercentage', () => {
+    it.each([
+        [{ method: ExperimentStatsMethod.Bayesian, bayesian: { ci_level: 0.9 } }, '90%'],
+        [{ method: ExperimentStatsMethod.Bayesian }, '95%'],
+        [{ method: ExperimentStatsMethod.Bayesian, bayesian: { ci_level: 0.99 } }, '99%'],
+        [{ method: ExperimentStatsMethod.Frequentist, frequentist: { alpha: 0.1 } }, '90%'],
+        [{ method: ExperimentStatsMethod.Frequentist }, '95%'],
+    ])('formats the configured interval level for %p', (stats_config, expected) => {
+        expect(getExperimentIntervalLevelPercentage({ stats_config })).toBe(expected)
+    })
+})
+
+describe('getExperimentIntervalTitle', () => {
+    it('uses the configured Bayesian ci_level in the credible interval title', () => {
+        const result: ExperimentVariantResult = {
+            key: 'test',
+            sum: 100,
+            number_of_samples: 100,
+            sum_squares: 100,
+            significant: true,
+            method: 'bayesian',
+            credible_interval: [0.05, 0.15],
+            chance_to_win: 0.75,
+        }
+
+        expect(
+            getExperimentIntervalTitle(result, {
+                stats_config: { method: ExperimentStatsMethod.Bayesian, bayesian: { ci_level: 0.9 } },
+            })
+        ).toBe('Credible interval (90%)')
     })
 })
 

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
@@ -234,6 +234,17 @@ function normalizeOpenIntervalValue(value: unknown, fallback: number): number {
     return Number.isFinite(numericValue) && numericValue > 0 && numericValue < 1 ? numericValue : fallback
 }
 
+function hasStrictBayesianIntervalBounds(intervalLevel: number): boolean {
+    const lowerBound = (1 - intervalLevel) / 2
+    const upperBound = 1 - lowerBound
+    return lowerBound > 0 && lowerBound < upperBound && upperBound < 1
+}
+
+function normalizeBayesianCiLevel(value: unknown): number {
+    const intervalLevel = normalizeOpenIntervalValue(value, DEFAULT_BAYESIAN_CI_LEVEL)
+    return hasStrictBayesianIntervalBounds(intervalLevel) ? intervalLevel : DEFAULT_BAYESIAN_CI_LEVEL
+}
+
 function getExperimentStatsMethod(experiment: Pick<Experiment, 'stats_config'>): ExperimentStatsMethod {
     return getStatsConfig(experiment).method === ExperimentStatsMethod.Frequentist
         ? ExperimentStatsMethod.Frequentist
@@ -253,7 +264,7 @@ export function getExperimentIntervalLevel(
         return 1 - normalizeOpenIntervalValue(frequentistConfig.alpha, DEFAULT_FREQUENTIST_ALPHA)
     }
     const bayesianConfig = getNestedStatsConfig(experiment, 'bayesian')
-    return normalizeOpenIntervalValue(bayesianConfig.ci_level, DEFAULT_BAYESIAN_CI_LEVEL)
+    return normalizeBayesianCiLevel(bayesianConfig.ci_level)
 }
 
 export function getExperimentIntervalLevelPercentage(

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
@@ -21,7 +21,8 @@ import {
     isExperimentRatioMetric,
     isExperimentRetentionMetric,
 } from '~/queries/schema/schema-general'
-import { ExperimentMetricGoal } from '~/types'
+import { ExperimentMetricGoal, ExperimentStatsMethod } from '~/types'
+import type { Experiment } from '~/types'
 
 export type ExperimentVariantResult = ExperimentVariantResultFrequentist | ExperimentVariantResultBayesian
 
@@ -210,6 +211,37 @@ export function getVariantInterval(result: ExperimentVariantResult): [number, nu
 
 export function getIntervalLabel(result: ExperimentVariantResult): string {
     return isBayesianResult(result) ? 'Credible interval' : 'Confidence interval'
+}
+
+export function getExperimentIntervalLevel(
+    experiment: Pick<Experiment, 'stats_config'>,
+    statsMethod: ExperimentStatsMethod = experiment.stats_config?.method || ExperimentStatsMethod.Bayesian
+): number {
+    if (statsMethod === ExperimentStatsMethod.Frequentist) {
+        return 1 - (experiment.stats_config?.frequentist?.alpha ?? 0.05)
+    }
+    return experiment.stats_config?.bayesian?.ci_level ?? 0.95
+}
+
+export function getExperimentIntervalLevelPercentage(
+    experiment: Pick<Experiment, 'stats_config'>,
+    statsMethod?: ExperimentStatsMethod
+): string {
+    return `${(getExperimentIntervalLevel(experiment, statsMethod) * 100).toFixed(0)}%`
+}
+
+export function getExperimentIntervalTitle(
+    result: ExperimentVariantResult | undefined,
+    experiment: Pick<Experiment, 'stats_config'>
+): string {
+    const statsMethod =
+        result?.method === ExperimentStatsMethod.Frequentist
+            ? ExperimentStatsMethod.Frequentist
+            : result?.method === ExperimentStatsMethod.Bayesian
+              ? ExperimentStatsMethod.Bayesian
+              : undefined
+    const intervalLevel = getExperimentIntervalLevelPercentage(experiment, statsMethod)
+    return result ? `${getIntervalLabel(result)} (${intervalLevel})` : `Confidence interval (${intervalLevel})`
 }
 
 export function getIntervalBounds(result: ExperimentVariantResult): [number, number] {

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
@@ -213,21 +213,54 @@ export function getIntervalLabel(result: ExperimentVariantResult): string {
     return isBayesianResult(result) ? 'Credible interval' : 'Confidence interval'
 }
 
+const DEFAULT_BAYESIAN_CI_LEVEL = 0.95
+const DEFAULT_FREQUENTIST_ALPHA = 0.05
+
+function isStatsConfigRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function getStatsConfig(experiment: Pick<Experiment, 'stats_config'>): Record<string, unknown> {
+    return isStatsConfigRecord(experiment.stats_config) ? experiment.stats_config : {}
+}
+
+function getNestedStatsConfig(experiment: Pick<Experiment, 'stats_config'>, key: string): Record<string, unknown> {
+    const nestedConfig = getStatsConfig(experiment)[key]
+    return isStatsConfigRecord(nestedConfig) ? nestedConfig : {}
+}
+
+function normalizeOpenIntervalValue(value: unknown, fallback: number): number {
+    const numericValue = typeof value === 'number' || typeof value === 'string' ? Number(value) : Number.NaN
+    return Number.isFinite(numericValue) && numericValue > 0 && numericValue < 1 ? numericValue : fallback
+}
+
+function getExperimentStatsMethod(experiment: Pick<Experiment, 'stats_config'>): ExperimentStatsMethod {
+    return getStatsConfig(experiment).method === ExperimentStatsMethod.Frequentist
+        ? ExperimentStatsMethod.Frequentist
+        : ExperimentStatsMethod.Bayesian
+}
+
+function formatIntervalLevelPercentage(intervalLevel: number): string {
+    return `${Number((intervalLevel * 100).toFixed(10))}%`
+}
+
 export function getExperimentIntervalLevel(
     experiment: Pick<Experiment, 'stats_config'>,
-    statsMethod: ExperimentStatsMethod = experiment.stats_config?.method || ExperimentStatsMethod.Bayesian
+    statsMethod: ExperimentStatsMethod = getExperimentStatsMethod(experiment)
 ): number {
     if (statsMethod === ExperimentStatsMethod.Frequentist) {
-        return 1 - (experiment.stats_config?.frequentist?.alpha ?? 0.05)
+        const frequentistConfig = getNestedStatsConfig(experiment, 'frequentist')
+        return 1 - normalizeOpenIntervalValue(frequentistConfig.alpha, DEFAULT_FREQUENTIST_ALPHA)
     }
-    return experiment.stats_config?.bayesian?.ci_level ?? 0.95
+    const bayesianConfig = getNestedStatsConfig(experiment, 'bayesian')
+    return normalizeOpenIntervalValue(bayesianConfig.ci_level, DEFAULT_BAYESIAN_CI_LEVEL)
 }
 
 export function getExperimentIntervalLevelPercentage(
     experiment: Pick<Experiment, 'stats_config'>,
     statsMethod?: ExperimentStatsMethod
 ): string {
-    return `${(getExperimentIntervalLevel(experiment, statsMethod) * 100).toFixed(0)}%`
+    return formatIntervalLevelPercentage(getExperimentIntervalLevel(experiment, statsMethod))
 }
 
 export function getExperimentIntervalTitle(

--- a/products/experiments/backend/hogql_queries/experiment_funnels_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_funnels_query_runner.py
@@ -31,6 +31,7 @@ from products.experiments.backend.hogql_queries.funnels_statistics_v2 import (
     calculate_credible_intervals_v2,
     calculate_probabilities_v2,
 )
+from products.experiments.backend.hogql_queries.utils import get_bayesian_interval_bounds
 from products.experiments.backend.models.experiment import Experiment
 from products.product_analytics.backend.facade.queries import FunnelsQueryRunner
 
@@ -81,7 +82,10 @@ class ExperimentFunnelsQueryRunner(QueryRunner):
             control_variant, test_variants = self._get_variants_with_base_stats(funnels_result)
             probabilities = calculate_probabilities_v2(control_variant, test_variants)
             significance_code, loss = are_results_significant_v2(control_variant, test_variants, probabilities)
-            credible_intervals = calculate_credible_intervals_v2([control_variant, *test_variants])
+            lower_bound, upper_bound = get_bayesian_interval_bounds(self.experiment.stats_config)
+            credible_intervals = calculate_credible_intervals_v2(
+                [control_variant, *test_variants], lower_bound=lower_bound, upper_bound=upper_bound
+            )
         except Exception as e:
             raise ValueError(f"Error calculating experiment funnel results: {str(e)}") from e
 

--- a/products/experiments/backend/hogql_queries/experiment_funnels_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_funnels_query_runner.py
@@ -31,7 +31,7 @@ from products.experiments.backend.hogql_queries.funnels_statistics_v2 import (
     calculate_credible_intervals_v2,
     calculate_probabilities_v2,
 )
-from products.experiments.backend.hogql_queries.utils import get_bayesian_interval_bounds
+from products.experiments.backend.hogql_queries.utils import get_bayesian_ci_level, get_bayesian_interval_bounds
 from products.experiments.backend.models.experiment import Experiment
 from products.product_analytics.backend.facade.queries import FunnelsQueryRunner
 
@@ -224,6 +224,11 @@ class ExperimentFunnelsQueryRunner(QueryRunner):
         if last_refresh is None:
             return None
         return last_refresh + timedelta(hours=24)
+
+    def get_cache_payload(self) -> dict:
+        payload = super().get_cache_payload()
+        payload["bayesian_ci_level"] = get_bayesian_ci_level(self.experiment.stats_config)
+        return payload
 
     def _is_stale(self, last_refresh: Optional[datetime], lazy: bool = False) -> bool:
         if not last_refresh:

--- a/products/experiments/backend/hogql_queries/experiment_trends_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_trends_query_runner.py
@@ -49,6 +49,7 @@ from products.experiments.backend.hogql_queries.trends_statistics_v2_count impor
     calculate_probabilities_v2_count,
 )
 from products.experiments.backend.hogql_queries.types import ExperimentMetricType
+from products.experiments.backend.hogql_queries.utils import get_bayesian_interval_bounds
 from products.experiments.backend.models.experiment import Experiment
 
 
@@ -290,19 +291,24 @@ class ExperimentTrendsQueryRunner(QueryRunner):
 
         # Statistical analysis
         control_variant, test_variants = self._get_variants_with_base_stats(count_result, exposure_result)
+        lower_bound, upper_bound = get_bayesian_interval_bounds(self.experiment.stats_config)
         match self._get_metric_type():
             case ExperimentMetricType.CONTINUOUS:
                 probabilities = calculate_probabilities_v2_continuous(control_variant, test_variants)
                 significance_code, p_value = are_results_significant_v2_continuous(
                     control_variant, test_variants, probabilities
                 )
-                credible_intervals = calculate_credible_intervals_v2_continuous([control_variant, *test_variants])
+                credible_intervals = calculate_credible_intervals_v2_continuous(
+                    [control_variant, *test_variants], lower_bound=lower_bound, upper_bound=upper_bound
+                )
             case ExperimentMetricType.COUNT:
                 probabilities = calculate_probabilities_v2_count(control_variant, test_variants)
                 significance_code, p_value = are_results_significant_v2_count(
                     control_variant, test_variants, probabilities
                 )
-                credible_intervals = calculate_credible_intervals_v2_count([control_variant, *test_variants])
+                credible_intervals = calculate_credible_intervals_v2_count(
+                    [control_variant, *test_variants], lower_bound=lower_bound, upper_bound=upper_bound
+                )
             case _:
                 raise ValueError(f"Unsupported metric type: {self._get_metric_type()}")
 

--- a/products/experiments/backend/hogql_queries/experiment_trends_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_trends_query_runner.py
@@ -49,7 +49,7 @@ from products.experiments.backend.hogql_queries.trends_statistics_v2_count impor
     calculate_probabilities_v2_count,
 )
 from products.experiments.backend.hogql_queries.types import ExperimentMetricType
-from products.experiments.backend.hogql_queries.utils import get_bayesian_interval_bounds
+from products.experiments.backend.hogql_queries.utils import get_bayesian_ci_level, get_bayesian_interval_bounds
 from products.experiments.backend.models.experiment import Experiment
 
 
@@ -420,6 +420,11 @@ class ExperimentTrendsQueryRunner(QueryRunner):
         if last_refresh is None:
             return None
         return last_refresh + timedelta(hours=24)
+
+    def get_cache_payload(self) -> dict:
+        payload = super().get_cache_payload()
+        payload["bayesian_ci_level"] = get_bayesian_ci_level(self.experiment.stats_config)
+        return payload
 
     def _is_stale(self, last_refresh: Optional[datetime], lazy: bool = False) -> bool:
         if not last_refresh:

--- a/products/experiments/backend/hogql_queries/funnels_statistics_v2.py
+++ b/products/experiments/backend/hogql_queries/funnels_statistics_v2.py
@@ -199,32 +199,38 @@ def are_results_significant_v2(
     return ExperimentSignificanceCode.LOW_WIN_PROBABILITY, 1.0
 
 
-def calculate_credible_intervals_v2(variants: list[ExperimentVariantFunnelsBaseStats]) -> dict[str, list[float]]:
+def calculate_credible_intervals_v2(
+    variants: list[ExperimentVariantFunnelsBaseStats], lower_bound: float = 0.025, upper_bound: float = 0.975
+) -> dict[str, list[float]]:
     """
     Calculate Bayesian credible intervals for conversion rates of each variant.
 
-    This function computes the 95% credible intervals for the true conversion rate
+    This function computes credible intervals for the true conversion rate
     of each variant using a Beta model. The interval represents the range where we
-    believe the true conversion rate lies with 95% probability.
+    believe the true conversion rate lies with the configured probability.
 
     Parameters:
     -----------
     variants : list[ExperimentVariantFunnelsBaseStats]
         List of all variants (including control), each containing success_count and failure_count
+    lower_bound : float, optional (default=0.025)
+        Lower percentile for the credible interval
+    upper_bound : float, optional (default=0.975)
+        Upper percentile for the credible interval
 
     Returns:
     --------
     dict[str, list[float]]
         Dictionary mapping variant keys to [lower, upper] credible intervals, where:
-        - lower is the 2.5th percentile of the Beta posterior distribution
-        - upper is the 97.5th percentile of the Beta posterior distribution
+        - lower is the lower percentile of the Beta posterior distribution
+        - upper is the upper percentile of the Beta posterior distribution
         - intervals represent conversion rates between 0 and 1
 
     Notes:
     ------
     - Uses Beta distribution as conjugate prior for binomial data
     - Uses Beta(1,1) as minimally informative prior (uniform over [0,1])
-    - Computes 95% credible intervals (2.5th to 97.5th percentiles)
+    - Computes credible intervals from the supplied percentiles
     - Intervals become narrower with more data (larger success_count + failure_count)
     - Returns empty dict if any calculations fail
 
@@ -246,8 +252,7 @@ def calculate_credible_intervals_v2(variants: list[ExperimentVariantFunnelsBaseS
         alpha = ALPHA_PRIOR + variant.success_count
         beta = BETA_PRIOR + variant.failure_count
 
-        # Calculate 95% credible interval
-        lower, upper = stats.beta.ppf([0.025, 0.975], alpha, beta)
+        lower, upper = stats.beta.ppf([lower_bound, upper_bound], alpha, beta)
 
         intervals[variant.key] = [float(lower), float(upper)]
 

--- a/products/experiments/backend/hogql_queries/test/test_stats_config.py
+++ b/products/experiments/backend/hogql_queries/test/test_stats_config.py
@@ -1,3 +1,4 @@
+import math
 from typing import cast
 
 from posthog.test.base import APIBaseTest
@@ -23,6 +24,7 @@ from products.experiments.backend.hogql_queries.trends_statistics_v2_continuous 
 )
 from products.experiments.backend.hogql_queries.trends_statistics_v2_count import calculate_credible_intervals_v2_count
 from products.experiments.backend.hogql_queries.utils import (
+    get_bayesian_ci_level,
     get_bayesian_experiment_result,
     get_bayesian_interval_bounds,
     get_frequentist_experiment_result,
@@ -229,6 +231,83 @@ class TestStatsConfig(APIBaseTest):
 
         self.assertGreater(count_width_99, count_width_90, "99% count CI should be wider than 90% CI")
         self.assertGreater(continuous_width_99, continuous_width_90, "99% continuous CI should be wider than 90% CI")
+
+    @parameterized.expand(
+        [
+            ("ninety", {"bayesian": {"ci_level": 0.90}}, 0.90),
+            ("fractional", {"bayesian": {"ci_level": 0.925}}, 0.925),
+            ("ninety_nine", {"bayesian": {"ci_level": 0.99}}, 0.99),
+            ("numeric_string", {"bayesian": {"ci_level": "0.925"}}, 0.925),
+        ]
+    )
+    def test_bayesian_ci_level_accepts_valid_open_interval_values(self, _name, stats_config, expected) -> None:
+        self.assertAlmostEqual(get_bayesian_ci_level(stats_config), expected)
+
+    @parameterized.expand(
+        [
+            ("zero", {"bayesian": {"ci_level": 0}}),
+            ("one", {"bayesian": {"ci_level": 1}}),
+            ("below_range", {"bayesian": {"ci_level": -0.1}}),
+            ("above_range", {"bayesian": {"ci_level": 1.5}}),
+            ("none", {"bayesian": {"ci_level": None}}),
+            ("nan", {"bayesian": {"ci_level": math.nan}}),
+            ("infinity", {"bayesian": {"ci_level": math.inf}}),
+            ("negative_infinity", {"bayesian": {"ci_level": -math.inf}}),
+            ("not_a_number", {"bayesian": {"ci_level": "not-a-number"}}),
+            ("bayesian_none", {"bayesian": None}),
+            ("bayesian_list", {"bayesian": []}),
+            ("bayesian_string", {"bayesian": "bad"}),
+            ("bayesian_int", {"bayesian": 123}),
+            ("root_list", []),
+        ]
+    )
+    def test_bayesian_ci_level_invalid_values_use_default(self, _name, stats_config) -> None:
+        self.assertEqual(get_bayesian_ci_level(stats_config), 0.95)
+
+    def test_bayesian_interval_bounds_use_fractional_ci_level(self) -> None:
+        lower, upper = get_bayesian_interval_bounds({"bayesian": {"ci_level": 0.925}})
+
+        self.assertAlmostEqual(lower, 0.0375)
+        self.assertAlmostEqual(upper, 0.9625)
+
+    @parameterized.expand(
+        [
+            ("zero", {"bayesian": {"ci_level": 0}}),
+            ("one", {"bayesian": {"ci_level": 1}}),
+            ("above_range", {"bayesian": {"ci_level": 1.5}}),
+            ("malformed_bayesian", {"bayesian": []}),
+        ]
+    )
+    def test_bayesian_interval_bounds_invalid_values_use_default(self, _name, stats_config) -> None:
+        lower, upper = get_bayesian_interval_bounds(stats_config)
+
+        self.assertAlmostEqual(lower, 0.025)
+        self.assertAlmostEqual(upper, 0.975)
+
+    @parameterized.expand(
+        [
+            ("bayesian_none", {"bayesian": None}),
+            ("bayesian_list", {"bayesian": []}),
+            ("bayesian_string", {"bayesian": "bad"}),
+            ("bayesian_int", {"bayesian": 123}),
+        ]
+    )
+    def test_bayesian_malformed_nested_config_falls_back_to_defaults(self, _name, stats_config) -> None:
+        metric = self.create_mean_metric()
+        control = self.create_variant("control", sum_val=100.0, sum_squares=10500.0, samples=1000)
+        test = self.create_variant("test", sum_val=120.0, sum_squares=14500.0, samples=1000)
+
+        result = get_bayesian_experiment_result(
+            metric=metric,
+            control_variant=control,
+            test_variants=[test],
+            stats_config=stats_config,
+        )
+
+        assert result.variant_results is not None
+        variant = cast(ExperimentVariantResultBayesian, result.variant_results[0])
+        assert variant.credible_interval is not None
+        self.assertEqual(len(variant.credible_interval), 2)
 
     def test_numeric_validation_alpha_out_of_range_uses_default(self) -> None:
         metric = self.create_mean_metric()

--- a/products/experiments/backend/hogql_queries/test/test_stats_config.py
+++ b/products/experiments/backend/hogql_queries/test/test_stats_config.py
@@ -7,17 +7,23 @@ from parameterized import parameterized
 
 from posthog.schema import (
     EventsNode,
+    ExperimentFunnelsQuery,
     ExperimentMeanMetric,
     ExperimentMetricMathType,
     ExperimentQuery,
     ExperimentStatsBase,
+    ExperimentTrendsQuery,
     ExperimentVariantFunnelsBaseStats,
     ExperimentVariantResultBayesian,
     ExperimentVariantResultFrequentist,
     ExperimentVariantTrendsBaseStats,
+    FunnelsQuery,
+    TrendsQuery,
 )
 
+from products.experiments.backend.hogql_queries.experiment_funnels_query_runner import ExperimentFunnelsQueryRunner
 from products.experiments.backend.hogql_queries.experiment_query_runner import ExperimentQueryRunner
+from products.experiments.backend.hogql_queries.experiment_trends_query_runner import ExperimentTrendsQueryRunner
 from products.experiments.backend.hogql_queries.funnels_statistics_v2 import calculate_credible_intervals_v2
 from products.experiments.backend.hogql_queries.trends_statistics_v2_continuous import (
     calculate_credible_intervals_v2_continuous,
@@ -55,6 +61,31 @@ class TestStatsConfig(APIBaseTest):
             sum=sum_val,
             sum_squares=sum_squares,
             number_of_samples=samples,
+        )
+
+    def create_feature_flag(self, key: str = "test-flag") -> FeatureFlag:
+        return FeatureFlag.objects.create(
+            name=f"Test flag: {key}",
+            key=key,
+            team=self.team,
+            filters={
+                "groups": [{"properties": [], "rollout_percentage": None}],
+                "multivariate": {
+                    "variants": [
+                        {"key": "control", "name": "Control", "rollout_percentage": 50},
+                        {"key": "test", "name": "Test", "rollout_percentage": 50},
+                    ]
+                },
+            },
+            created_by=self.user,
+        )
+
+    def create_experiment(self, stats_config: dict | None = None) -> Experiment:
+        return Experiment.objects.create(
+            name="test-experiment",
+            team=self.team,
+            feature_flag=self.create_feature_flag(),
+            stats_config=stats_config,
         )
 
     @parameterized.expand(
@@ -253,6 +284,7 @@ class TestStatsConfig(APIBaseTest):
             ("nan", {"bayesian": {"ci_level": math.nan}}),
             ("infinity", {"bayesian": {"ci_level": math.inf}}),
             ("negative_infinity", {"bayesian": {"ci_level": -math.inf}}),
+            ("derived_upper_endpoint", {"bayesian": {"ci_level": 0.9999999999999999}}),
             ("not_a_number", {"bayesian": {"ci_level": "not-a-number"}}),
             ("bayesian_none", {"bayesian": None}),
             ("bayesian_list", {"bayesian": []}),
@@ -275,6 +307,7 @@ class TestStatsConfig(APIBaseTest):
             ("zero", {"bayesian": {"ci_level": 0}}),
             ("one", {"bayesian": {"ci_level": 1}}),
             ("above_range", {"bayesian": {"ci_level": 1.5}}),
+            ("derived_upper_endpoint", {"bayesian": {"ci_level": 0.9999999999999999}}),
             ("malformed_bayesian", {"bayesian": []}),
         ]
     )
@@ -283,6 +316,41 @@ class TestStatsConfig(APIBaseTest):
 
         self.assertAlmostEqual(lower, 0.025)
         self.assertAlmostEqual(upper, 0.975)
+
+    def test_legacy_funnels_cache_payload_includes_bayesian_ci_level(self) -> None:
+        experiment = self.create_experiment({"bayesian": {"ci_level": 0.9}})
+        query = ExperimentFunnelsQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentFunnelsQuery",
+            funnels_query=FunnelsQuery(series=[EventsNode(event="$pageview"), EventsNode(event="purchase")]),
+        )
+
+        payload_90 = ExperimentFunnelsQueryRunner(query=query, team=self.team).get_cache_payload()
+        experiment.stats_config = {"bayesian": {"ci_level": 0.99}}
+        experiment.save(update_fields=["stats_config"])
+        payload_99 = ExperimentFunnelsQueryRunner(query=query, team=self.team).get_cache_payload()
+
+        self.assertEqual(payload_90["bayesian_ci_level"], 0.9)
+        self.assertEqual(payload_99["bayesian_ci_level"], 0.99)
+        self.assertEqual(payload_90 | {"bayesian_ci_level": 0.99}, payload_99)
+
+    def test_legacy_trends_cache_payload_includes_bayesian_ci_level(self) -> None:
+        experiment = self.create_experiment({"bayesian": {"ci_level": 0.9}})
+        query = ExperimentTrendsQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentTrendsQuery",
+            count_query=TrendsQuery(series=[EventsNode(event="$pageview")]),
+            exposure_query=None,
+        )
+
+        payload_90 = ExperimentTrendsQueryRunner(query=query, team=self.team).get_cache_payload()
+        experiment.stats_config = {"bayesian": {"ci_level": 0.99}}
+        experiment.save(update_fields=["stats_config"])
+        payload_99 = ExperimentTrendsQueryRunner(query=query, team=self.team).get_cache_payload()
+
+        self.assertEqual(payload_90["bayesian_ci_level"], 0.9)
+        self.assertEqual(payload_99["bayesian_ci_level"], 0.99)
+        self.assertEqual(payload_90 | {"bayesian_ci_level": 0.99}, payload_99)
 
     @parameterized.expand(
         [

--- a/products/experiments/backend/hogql_queries/test/test_stats_config.py
+++ b/products/experiments/backend/hogql_queries/test/test_stats_config.py
@@ -10,13 +10,21 @@ from posthog.schema import (
     ExperimentMetricMathType,
     ExperimentQuery,
     ExperimentStatsBase,
+    ExperimentVariantFunnelsBaseStats,
     ExperimentVariantResultBayesian,
     ExperimentVariantResultFrequentist,
+    ExperimentVariantTrendsBaseStats,
 )
 
 from products.experiments.backend.hogql_queries.experiment_query_runner import ExperimentQueryRunner
+from products.experiments.backend.hogql_queries.funnels_statistics_v2 import calculate_credible_intervals_v2
+from products.experiments.backend.hogql_queries.trends_statistics_v2_continuous import (
+    calculate_credible_intervals_v2_continuous,
+)
+from products.experiments.backend.hogql_queries.trends_statistics_v2_count import calculate_credible_intervals_v2_count
 from products.experiments.backend.hogql_queries.utils import (
     get_bayesian_experiment_result,
+    get_bayesian_interval_bounds,
     get_frequentist_experiment_result,
     split_baseline_and_test_variants,
 )
@@ -180,6 +188,47 @@ class TestStatsConfig(APIBaseTest):
         width_99 = variant_99.credible_interval[1] - variant_99.credible_interval[0]
 
         self.assertGreater(width_99, width_90, "99% CI should be wider than 90% CI")
+
+    def test_legacy_funnel_ci_level_actually_affects_interval_width(self) -> None:
+        variants = [
+            ExperimentVariantFunnelsBaseStats(key="control", success_count=100, failure_count=900),
+            ExperimentVariantFunnelsBaseStats(key="test", success_count=150, failure_count=850),
+        ]
+        lower_90, upper_90 = get_bayesian_interval_bounds({"bayesian": {"ci_level": 0.90}})
+        lower_99, upper_99 = get_bayesian_interval_bounds({"bayesian": {"ci_level": 0.99}})
+
+        result_90 = calculate_credible_intervals_v2(variants, lower_bound=lower_90, upper_bound=upper_90)
+        result_99 = calculate_credible_intervals_v2(variants, lower_bound=lower_99, upper_bound=upper_99)
+
+        width_90 = result_90["test"][1] - result_90["test"][0]
+        width_99 = result_99["test"][1] - result_99["test"][0]
+
+        self.assertGreater(width_99, width_90, "99% CI should be wider than 90% CI")
+
+    def test_legacy_trends_ci_level_actually_affects_interval_width(self) -> None:
+        variants = [
+            ExperimentVariantTrendsBaseStats(key="control", count=100, exposure=1, absolute_exposure=1000),
+            ExperimentVariantTrendsBaseStats(key="test", count=150, exposure=1, absolute_exposure=1000),
+        ]
+        lower_90, upper_90 = get_bayesian_interval_bounds({"bayesian": {"ci_level": 0.90}})
+        lower_99, upper_99 = get_bayesian_interval_bounds({"bayesian": {"ci_level": 0.99}})
+
+        count_result_90 = calculate_credible_intervals_v2_count(variants, lower_bound=lower_90, upper_bound=upper_90)
+        count_result_99 = calculate_credible_intervals_v2_count(variants, lower_bound=lower_99, upper_bound=upper_99)
+        continuous_result_90 = calculate_credible_intervals_v2_continuous(
+            variants, lower_bound=lower_90, upper_bound=upper_90
+        )
+        continuous_result_99 = calculate_credible_intervals_v2_continuous(
+            variants, lower_bound=lower_99, upper_bound=upper_99
+        )
+
+        count_width_90 = count_result_90["test"][1] - count_result_90["test"][0]
+        count_width_99 = count_result_99["test"][1] - count_result_99["test"][0]
+        continuous_width_90 = continuous_result_90["test"][1] - continuous_result_90["test"][0]
+        continuous_width_99 = continuous_result_99["test"][1] - continuous_result_99["test"][0]
+
+        self.assertGreater(count_width_99, count_width_90, "99% count CI should be wider than 90% CI")
+        self.assertGreater(continuous_width_99, continuous_width_90, "99% continuous CI should be wider than 90% CI")
 
     def test_numeric_validation_alpha_out_of_range_uses_default(self) -> None:
         metric = self.create_mean_metric()

--- a/products/experiments/backend/hogql_queries/utils.py
+++ b/products/experiments/backend/hogql_queries/utils.py
@@ -108,6 +108,16 @@ def _validate_numeric_range(value: Any, min_val: float, max_val: float, default:
         return default
 
 
+def get_bayesian_ci_level(stats_config: dict | None = None) -> float:
+    bayesian_config = stats_config.get("bayesian", {}) if stats_config else {}
+    return _validate_numeric_range(bayesian_config.get("ci_level", 0.95), 0.0, 1.0, 0.95)
+
+
+def get_bayesian_interval_bounds(stats_config: dict | None = None) -> tuple[float, float]:
+    tail_probability = (1 - get_bayesian_ci_level(stats_config)) / 2
+    return tail_probability, 1 - tail_probability
+
+
 def sanitize_non_finite(value: Any) -> Any:
     """Replace non-finite floats (inf/-inf/nan) with None, recursively.
 
@@ -616,7 +626,7 @@ def get_bayesian_experiment_result(
     resolved_cuped_config = cuped_config or get_cuped_config(stats_config, metric)
 
     config = BayesianConfig(
-        ci_level=_validate_numeric_range(bayesian_config.get("ci_level", 0.95), 0.0, 1.0, 0.95),
+        ci_level=get_bayesian_ci_level(stats_config),
         difference_type=_parse_enum_config(
             bayesian_config.get("difference_type", "RELATIVE"), DifferenceType, DifferenceType.RELATIVE
         ),

--- a/products/experiments/backend/hogql_queries/utils.py
+++ b/products/experiments/backend/hogql_queries/utils.py
@@ -1,4 +1,5 @@
 import math
+from collections.abc import Mapping
 from enum import Enum
 from typing import Any, Optional, TypeVar
 
@@ -49,6 +50,7 @@ from products.experiments.stats.shared.statistics import (
 logger = structlog.get_logger(__name__)
 
 V = TypeVar("V", ExperimentVariantTrendsBaseStats, ExperimentVariantFunnelsBaseStats, ExperimentStatsBase)
+DEFAULT_BAYESIAN_CI_LEVEL = 0.95
 
 
 def get_experiment_query_debug(
@@ -108,12 +110,33 @@ def _validate_numeric_range(value: Any, min_val: float, max_val: float, default:
         return default
 
 
-def get_bayesian_ci_level(stats_config: dict | None = None) -> float:
-    bayesian_config = stats_config.get("bayesian", {}) if stats_config else {}
-    return _validate_numeric_range(bayesian_config.get("ci_level", 0.95), 0.0, 1.0, 0.95)
+def _coerce_mapping(value: object | None) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
 
 
-def get_bayesian_interval_bounds(stats_config: dict | None = None) -> tuple[float, float]:
+def _get_bayesian_config(stats_config: Mapping[str, Any] | None = None) -> Mapping[str, Any]:
+    return _coerce_mapping(_coerce_mapping(stats_config).get("bayesian"))
+
+
+def _validate_open_numeric_range(value: Any, min_val: float, max_val: float, default: float) -> float:
+    try:
+        float_value = float(value)
+    except (TypeError, ValueError):
+        return default
+
+    if math.isfinite(float_value) and min_val < float_value < max_val:
+        return float_value
+    return default
+
+
+def get_bayesian_ci_level(stats_config: Mapping[str, Any] | None = None) -> float:
+    bayesian_config = _get_bayesian_config(stats_config)
+    return _validate_open_numeric_range(
+        bayesian_config.get("ci_level", DEFAULT_BAYESIAN_CI_LEVEL), 0.0, 1.0, DEFAULT_BAYESIAN_CI_LEVEL
+    )
+
+
+def get_bayesian_interval_bounds(stats_config: Mapping[str, Any] | None = None) -> tuple[float, float]:
     tail_probability = (1 - get_bayesian_ci_level(stats_config)) / 2
     return tail_probability, 1 - tail_probability
 
@@ -622,8 +645,9 @@ def get_bayesian_experiment_result(
     """
     Get experiment results using the new Bayesian method with the new format
     """
-    bayesian_config = stats_config.get("bayesian", {}) if stats_config else {}
-    resolved_cuped_config = cuped_config or get_cuped_config(stats_config, metric)
+    bayesian_config = _get_bayesian_config(stats_config)
+    stats_config_for_cuped = stats_config if isinstance(stats_config, dict) else None
+    resolved_cuped_config = cuped_config or get_cuped_config(stats_config_for_cuped, metric)
 
     config = BayesianConfig(
         ci_level=get_bayesian_ci_level(stats_config),

--- a/products/experiments/backend/hogql_queries/utils.py
+++ b/products/experiments/backend/hogql_queries/utils.py
@@ -129,16 +129,26 @@ def _validate_open_numeric_range(value: Any, min_val: float, max_val: float, def
     return default
 
 
+def _get_interval_bounds_for_level(ci_level: float) -> tuple[float, float]:
+    tail_probability = (1 - ci_level) / 2
+    return tail_probability, 1 - tail_probability
+
+
+def _has_strict_interval_bounds(ci_level: float) -> bool:
+    lower_bound, upper_bound = _get_interval_bounds_for_level(ci_level)
+    return 0.0 < lower_bound < upper_bound < 1.0
+
+
 def get_bayesian_ci_level(stats_config: Mapping[str, Any] | None = None) -> float:
     bayesian_config = _get_bayesian_config(stats_config)
-    return _validate_open_numeric_range(
+    ci_level = _validate_open_numeric_range(
         bayesian_config.get("ci_level", DEFAULT_BAYESIAN_CI_LEVEL), 0.0, 1.0, DEFAULT_BAYESIAN_CI_LEVEL
     )
+    return ci_level if _has_strict_interval_bounds(ci_level) else DEFAULT_BAYESIAN_CI_LEVEL
 
 
 def get_bayesian_interval_bounds(stats_config: Mapping[str, Any] | None = None) -> tuple[float, float]:
-    tail_probability = (1 - get_bayesian_ci_level(stats_config)) / 2
-    return tail_probability, 1 - tail_probability
+    return _get_interval_bounds_for_level(get_bayesian_ci_level(stats_config))
 
 
 def sanitize_non_finite(value: Any) -> Any:

--- a/products/experiments/frontend/legacy/components/LegacySummaryTable.tsx
+++ b/products/experiments/frontend/legacy/components/LegacySummaryTable.tsx
@@ -9,8 +9,15 @@ import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
 
 import { ExperimentFunnelsQuery, ExperimentTrendsQuery, isExperimentTrendsQuery } from '~/queries/schema/schema-general'
+import { getExperimentIntervalLevelPercentage } from '~/scenes/experiments/MetricsView/shared/utils'
 import { getViewRecordingFiltersLegacy } from '~/scenes/experiments/utils'
-import { FilterLogicalOperator, InsightType, RecordingUniversalFilters, TrendExperimentVariant } from '~/types'
+import {
+    ExperimentStatsMethod,
+    FilterLogicalOperator,
+    InsightType,
+    RecordingUniversalFilters,
+    TrendExperimentVariant,
+} from '~/types'
 
 import {
     legacyCalculateDelta,
@@ -58,6 +65,7 @@ export function LegacySummaryTable({
     )
 
     const winningVariant = legacyGetHighestProbabilityVariant(result)
+    const intervalLevel = getExperimentIntervalLevelPercentage(experiment, ExperimentStatsMethod.Bayesian)
 
     const columns: LemonTableColumns<any> = [
         {
@@ -171,8 +179,10 @@ export function LegacySummaryTable({
             key: 'credibleInterval',
             title: (
                 <div className="inline-flex items-center deprecated-space-x-1">
-                    <div className="">Credible interval (95%)</div>
-                    <Tooltip title="A credible interval estimates the percentage change in the mean, indicating with 95% probability how much higher or lower the test variant's mean is compared to the control.">
+                    <div className="">Credible interval ({intervalLevel})</div>
+                    <Tooltip
+                        title={`A credible interval estimates the percentage change in the mean, indicating with ${intervalLevel} probability how much higher or lower the test variant's mean is compared to the control.`}
+                    >
                         <IconInfo className="text-secondary text-base" />
                     </Tooltip>
                 </div>
@@ -248,8 +258,10 @@ export function LegacySummaryTable({
             key: 'credibleInterval',
             title: (
                 <div className="inline-flex items-center deprecated-space-x-1">
-                    <div className="">Credible interval (95%)</div>
-                    <Tooltip title="A credible interval estimates the percentage change in the conversion rate, indicating with 95% probability how much higher or lower the test variant's conversion rate is compared to the control.">
+                    <div className="">Credible interval ({intervalLevel})</div>
+                    <Tooltip
+                        title={`A credible interval estimates the percentage change in the conversion rate, indicating with ${intervalLevel} probability how much higher or lower the test variant's conversion rate is compared to the control.`}
+                    >
                         <IconInfo className="text-secondary text-base" />
                     </Tooltip>
                 </div>

--- a/products/experiments/frontend/legacy/metricsView/LegacyMetricsView.tsx
+++ b/products/experiments/frontend/legacy/metricsView/LegacyMetricsView.tsx
@@ -6,6 +6,8 @@ import { LemonDivider, Tooltip } from '@posthog/lemon-ui'
 import { IconAreaChart } from 'lib/lemon-ui/icons'
 
 import { ExperimentFunnelsQuery, ExperimentTrendsQuery } from '~/queries/schema/schema-general'
+import { getExperimentIntervalLevelPercentage } from '~/scenes/experiments/MetricsView/shared/utils'
+import { ExperimentStatsMethod } from '~/types'
 
 import {
     legacyCredibleIntervalForVariant,
@@ -72,6 +74,7 @@ export function LegacyMetricsView({ isSecondary }: { isSecondary?: boolean }): J
     const chartBound = maxAbsValue + padding
 
     const commonTickValues = legacyGetNiceTickValues(chartBound)
+    const intervalLevel = getExperimentIntervalLevelPercentage(experiment, ExperimentStatsMethod.Bayesian)
 
     return (
         <div className="mb-4 -mt-2">
@@ -101,9 +104,9 @@ export function LegacyMetricsView({ isSecondary }: { isSecondary?: boolean }): J
                                             <p className="mb-4">
                                                 Each bar shows how a variant is performing compared to the control (the
                                                 gray bar) for this metric, using a{' '}
-                                                <strong>95% credible interval.</strong> That means there's a 95% chance
-                                                the true difference for that variant falls within this range. The
-                                                vertical "0%" line is your baseline:
+                                                <strong>{intervalLevel} credible interval.</strong> That means there's a{' '}
+                                                {intervalLevel} chance the true difference for that variant falls within
+                                                this range. The vertical "0%" line is your baseline:
                                             </p>
                                             <ul className="mb-4 list-disc pl-4">
                                                 <li>


### PR DESCRIPTION
## Problem

Experimenters could configure an interval level while some labels and legacy interval calculations still behaved like the default 95%.

#62236 reports this as a stale 95% label. The inconsistency also affected legacy funnel and trend calculations.

Newer experiment results already respected `stats_config.bayesian.ci_level`. Legacy funnel and trend paths still used default Bayesian bounds.

Invalid endpoint values, malformed config, and cached legacy results could also leave labels and intervals out of sync.

Closes #62236

## Changes

- Interval labels now normalize Bayesian `ci_level` and frequentist `alpha` before display.
- Fractional levels like 92.5% remain visible instead of rounding to whole percentages.
- Bayesian interval helpers now accept only usable levels with strict in-range quantile bounds.
- Invalid or malformed Bayesian config falls back to 95% instead of raising.
- Legacy funnel and trend calculations now use normalized Bayesian percentiles.
- Legacy funnel and trend cache payloads now include the normalized Bayesian interval level.
- No screenshots: this is a text-only display and calculation fix.
- PR #92541 fixes recalculation invalidation when `stats_config` changes. This PR fixes labels, calculated intervals, and legacy cache keys.

## How did you test this code?

- Jest coverage checks fractional labels, invalid fallbacks, and derived-endpoint fallbacks.
- Backend coverage checks open-interval validation, malformed config fallbacks, derived-endpoint fallbacks, and legacy cache keys.
- `.codex/with-flox pnpm --filter=@posthog/frontend exec jest frontend/src/scenes/experiments/MetricsView/shared/utils.test.ts --runInBand` passed.
- `.codex/with-flox env DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog CLICKHOUSE_HOST=localhost REDIS_URL=redis://localhost:6379/0 TEST=1 pytest products/experiments/backend/hogql_queries/test/test_stats_config.py --reuse-db` passed.
- `.codex/with-flox ruff format --check products/experiments/backend/hogql_queries/utils.py products/experiments/backend/hogql_queries/experiment_funnels_query_runner.py products/experiments/backend/hogql_queries/experiment_trends_query_runner.py products/experiments/backend/hogql_queries/test/test_stats_config.py` passed.
- `.codex/with-flox ruff check products/experiments/backend/hogql_queries/utils.py products/experiments/backend/hogql_queries/experiment_funnels_query_runner.py products/experiments/backend/hogql_queries/experiment_trends_query_runner.py products/experiments/backend/hogql_queries/test/test_stats_config.py` passed.
- `.codex/with-flox pnpm --filter=@posthog/frontend format:check` passed.
- `.codex/with-flox pnpm --filter=@posthog/frontend lint` passed with zero errors.
- `.codex/with-flox pnpm --filter=@posthog/frontend exec tsgo --checkers 1 --noEmit` passed.
- `git diff --check` passed.
- `.codex/with-flox ./bin/hogli ci:preflight --strict` passed with zero failures.
- `.codex/with-flox uv run --no-sync mypy --cache-fine-grained .` passed.
- Not completed locally: the full `pnpm turbo run backend:test --filter=@posthog/products-experiments` suite was not rerun. Earlier host-side pytest could not resolve Docker service hostname `objectstorage`, while the local object storage container was healthy.
- GitHub Actions are waiting for fork workflow approval.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This fixes existing interval labels and calculations.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Agent and tools: Codex CLI with GPT-5, shell, Git, GitHub CLI, Flox, and hogli.

Skills invoked: `/writing-pr-descriptions`, `/running-ci-preflight`, `/writing-ui-components`, `/writing-tests`, `/writing-user-facing-copy`, and `/writing-code-comments`.

Duplicate check: #62236 is open, and searches for #62236, `ci_level`, credible interval wording, and changed helper names found no competing PR. PR #62286 was a closed unmerged UI-label attempt. PR #92541 covers recalculation fingerprinting, not legacy credible interval bounds.

Public artifact check: The committed tests use synthetic aggregate values only. No private session material, customer data, internal links, secrets, or local evidence files are included.