### PR TITLE
feat(warehouse_sources): promote the Notion source to GA

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/notion/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/notion/source.py
@@ -82,7 +82,7 @@ class NotionSource(ResumableSource[NotionSourceConfig, NotionResumeConfig]):
             name=SchemaExternalDataSourceType.NOTION,
             category=DataWarehouseSourceCategory.PRODUCTIVITY,
             label="Notion",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.GA,
             caption="""Enter your Notion internal integration token to pull your Notion data into the PostHog Data warehouse.
 
 Create an internal integration at [notion.so/my-integrations](https://www.notion.so/my-integrations) and copy its token (starts with `ntn_` or `secret_`).


### PR DESCRIPTION
## Problem

- Anyone picking Notion in the data warehouse source wizard sees an "Alpha" label, which reads as new and lightly tested.
- The connector no longer fits that label. It has been live for more than three months, and its imports report no errors over the last seven days, which clears our bar for general availability.

## Changes

- The Notion source now shows as GA in the source wizard and in the public source config API. The alpha label is gone.
- `releaseStatus` on `NotionSource.get_source_config` moves from `ReleaseStatus.ALPHA` to `ReleaseStatus.GA`. That one line is the whole diff.
- The source has no `featureFlag` and no `unreleasedSource` flag, so there is no gating to remove alongside the stage change. Gating stays untouched.
- No connector behavior, schema, or sync logic changes.

## How did you test this code?

- Ran the Notion source and transport tests (`sources/notion/tests/`) and the registry invariants that read every source config (`test_source_categories.py`, `test_source_versions.py`). Both pass. No test asserted the alpha status, so nothing needed updating.
- Not run: any sync against a live Notion account, and the wider warehouse_sources suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. The user-facing Notion doc lives in the posthog.com repo and does not state a release stage.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by an agent (PostHog Desktop) as a release-status promotion.
- Skills invoked: `/implementing-warehouse-sources`, `/writing-pr-descriptions`.
- No duplicate: searched open PRs for the source name, `releaseStatus`, and promotion terms, and listed the maintainer's own open PRs. The only other open Notion PR is [#92737](https://github.com/PostHog/posthog/pull/92737), which adds a `database_rows` stream and does not touch release status.
- Public artifact: the promotion criteria are stated qualitatively here. No customer names or usage figures are in the diff or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
