### PR TITLE
fix(shopify): classify token-endpoint 5xx as retryable noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/source.py
@@ -122,6 +122,10 @@ class ShopifySource(ResumableSource[ShopifySourceConfig, ShopifyResumeConfig]):
             "Shopify: rate limit exceeded",
             "Shopify: internal error",
             "Shopify: connection broken while reading response",
+            # `_get_shopify_access_token` raises this once its own tenacity retries (same 5-attempt
+            # budget) are exhausted for a 429/5xx from the OAuth token endpoint — the same
+            # self-recovering contract as the GraphQL messages above.
+            "Failed to retrieve Shopify access token:",
         }
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_non_retryable_errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_non_retryable_errors.py
@@ -70,6 +70,8 @@ def test_transient_http_errors_stay_retryable(status_code, reason):
         "Shopify: internal error from request 500 Internal Server Error",
         'Shopify: internal errors in payload [{"message": "internal error", "extensions": {"code": "internal_server_error"}}]',
         "Shopify: connection broken while reading response: Connection broken: IncompleteRead(0 bytes read)",
+        "Failed to retrieve Shopify access token: 500 Internal Server Error",
+        "Failed to retrieve Shopify access token: 429 Too Many Requests",
     ],
 )
 def test_exhausted_internal_retries_are_classified_as_retryable(error_message):


### PR DESCRIPTION
## Problem

A transient Shopify outage on the OAuth token endpoint gets reported to error tracking as a bug, even though the import recovers on its own. [This issue](https://us.posthog.com/project/2/error_tracking/01a075de-89ea-7b83-ae2e-7635d596b0d7) fired for a `500 Internal Server Error` while minting an access token.

`_get_shopify_access_token` already retries a 429/5xx from the token endpoint (5 attempts, exponential backoff) before re-raising as `ShopifyRetryableError`. Temporal then retries the whole activity, so the failure is self-recovering. The GraphQL path has an equivalent retry loop, and its messages are listed in `get_retryable_errors` so they log as a warning instead of reaching error tracking - the token-endpoint message was missing from that list.

## Changes

- Add the token-endpoint's exhausted-retry message to `ShopifySource.get_retryable_errors`, so it is logged as a warning and left for Temporal's activity retry, same as the existing GraphQL-path entries.
- Mechanical: extend the existing retryable-error test with two cases for this message (500 and 429).

## How did you test this code?

Added 2 parameterized cases to `test_exhausted_internal_retries_are_classified_as_retryable` covering a 500 and a 429 from the token endpoint - guards against this message being reported to error tracking again. Ran the full `test_non_retryable_errors.py` file locally: 15 passed.

No duplicate: searched open PRs for "ShopifyRetryableError", "shopify access token", and "shopify" (`gh pr list --state open --search ...`) plus every open PR from the account this automation runs under. Found #95585 (deprecates a Shopify API version) and #88212 (widens `shop_not_permitted` guidance) - neither touches `get_retryable_errors` or this code path.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal error-classification change, no user-facing behavior or docs to update.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via the PostHog error tracking MCP tool (`query-error-tracking-issue`) to pull the issue's stack trace and confirm it originates in `shopify.py`'s `_get_shopify_access_token`. Invoked `/writing-tests` before extending the test file, and `/writing-pr-descriptions` before drafting this body.