### PR TITLE
fix(mysql): catch a scheme-less URL pasted into the host field

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -444,7 +444,9 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
         # A pasted URL or connection string in the host field otherwise fails DNS resolution with a
         # misleading "check the spelling" message that echoes the raw value back (which can embed
         # credentials). Catch it early with an actionable message that never reflects the input.
-        if "://" in config.host:
+        # A scheme-less paste ("db.example.com/mydb", "user:secret@db.example.com") has no "://",
+        # so match the path and userinfo separators — neither is legal in a hostname anyway.
+        if "/" in config.host or "@" in config.host:
             return False, _HOST_IS_URL_ERROR
 
         valid_host, host_errors = self.is_database_host_valid(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -2487,6 +2487,9 @@ class TestMySQLSourceValidateCredentials:
         [
             "https://db.example.com/",
             "mysql://root:secret@db.example.com:3306/mydb",
+            # No scheme, so the guard has to match on the path and userinfo separators instead.
+            "db.example.com/mydb",
+            "root:secret@db.example.com",
         ],
     )
     def test_url_in_host_field_rejected_without_echoing_input(self, source, mocker, host):


### PR DESCRIPTION
## Problem

A customer who pastes something like `db.example.com/mydb` into the MySQL host field gets told the host could not be resolved, with their own pasted value quoted back at them. That points them at spelling when the real problem is that the field wants a bare hostname.

The source already guards against this, but it only matches on `://`. A paste that carries a path or userinfo without a scheme walks straight past it into DNS resolution.

Echoing the value back is the worse half. `user:secret@db.example.com` has no scheme either, so a pasted password reaches the resolution error message. The guard was added to stop exactly that.

## Changes

- The host field now rejects a value containing `/` or `@` up front, and returns the existing "enter just the hostname" guidance instead of a resolution error.
- The wizard no longer reflects a pasted host value in that case, so a password inside a connection string stays out of the message.
- No new user-facing copy. This reuses the message the scheme case already returns.
- Neither separator is legal in a hostname, so the wider match cannot reject a host that would otherwise have worked.

Scoped to the MySQL source. The Postgres, ClickHouse, and PlanetScale sources have the same `://`-only guard, left alone here so this stays reviewable.

## How did you test this code?

Extended the existing `test_url_in_host_field_rejected_without_echoing_input` case with two scheme-less hosts: one with a path, one with userinfo. Both previously fell through the guard to `is_database_host_valid`, which the test stubs to fail if it is reached.

Ran the `validate_credentials` tests in `mysql/tests/test_mysql.py` (13 passed). Not run: the rest of the MySQL suite, or anything needing a live database.

No manual testing — this sandbox has no dev stack running.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The host field's caption already tells the customer to enter a bare hostname.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code (Opus 5) while triaging a day of failed source-creation attempts in the new-source wizard. Most of the messages in that set were already clear and actionable and needed no change; this one was a real gap, because the message a customer saw described the wrong problem.

Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`.

No duplicate: searched open PRs for the message text, `fix(mysql)`, and the source module path, and listed every open PR by the area's maintainer. Nothing covers this guard.

Public artifact: the triage input was customer-entered form values. None of it reaches this diff — the two new test hosts are invented, and the code comment uses `db.example.com`.

Considered widening the guard to a hostname regex instead of two separators. Rejected it: a regex would also have to accept every valid label shape, and would reject hosts today's guard lets through, which is a behavior change beyond the failure being fixed.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
