### PR TITLE
fix(clickhouse-cloud): say what to do when the API key is rejected

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse_cloud/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse_cloud/source.py
@@ -127,7 +127,10 @@ Generate an API key from your [ClickHouse Cloud console](https://console.clickho
         if validate_clickhouse_cloud_credentials(config.key_id, config.key_secret):
             return True, None
 
-        return False, "Invalid ClickHouse Cloud API key ID or secret"
+        return False, (
+            "Your ClickHouse Cloud API key was rejected. Check the key ID and secret, or create a new key "
+            "in your ClickHouse Cloud console, then reconnect."
+        )
 
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[ClickhouseCloudResumeConfig]:
         return ResumableSourceManager[ClickhouseCloudResumeConfig](inputs, ClickhouseCloudResumeConfig)


### PR DESCRIPTION
## Problem

A customer whose ClickHouse Cloud key fails validation in the new-source wizard reads "Invalid ClickHouse Cloud API key ID or secret" and has nowhere to go. The message names the two fields but never says to create a new key, or where the key lives.

The same source already words its other credential failures the way the rest of the warehouse sources do: what went wrong, then the action to take. The rejection path is the one that does not.

## Changes

- The wizard now tells the customer to check the key ID and secret, or create a new key in their ClickHouse Cloud console, then reconnect.
- The message follows the two-sentence shape the source's permission error and the sibling API sources already use, so the same class of problem reads the same way everywhere.

One string. No behavior change: the same condition still fails validation, and nothing else reads this text.

## How did you test this code?

Ran the `validate_credentials` tests in `clickhouse_cloud/tests/test_clickhouse_cloud_source.py` (2 passed). They assert the boolean and that a message is present, which is the contract this keeps.

No new test. The change is copy only, and asserting an exact user-facing sentence would only pin the wording that the next copy edit is meant to change.

No manual testing — this sandbox has no dev stack running.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No API, setting, or documented flow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code (Opus 5) while triaging a day of failed source-creation attempts in the new-source wizard. Most messages in that set were already clear and actionable; this one identified the problem but dead-ended.

Skills invoked: `/writing-pr-descriptions`, `/writing-user-facing-copy`.

No duplicate: searched open PRs for the message text, the `clickhouse-cloud` scope, and the source module path, and listed every open PR by the area's maintainer. Nothing touches this string.

Public artifact: the triage input was customer-entered credentials and account values. None of it reaches this diff — no fixtures or examples were added.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
