### PR TITLE
fix(github): say what to check when a repository is not accessible

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
@@ -361,6 +361,12 @@ def _should_stop_desc(
     return any(_is_older_than_cutoff(item.get(incremental_field), cutoff) for item in data if item)
 
 
+# GitHub answers 404 both for a repository that doesn't exist and for one the token can't see, so
+# the reason can't tell the two apart. The source layer matches this text to append the next step
+# once for the whole batch instead of repeating it per repository.
+REPOSITORY_NOT_ACCESSIBLE_REASON = "not found or not accessible"
+
+
 def validate_credentials(
     personal_access_token: str, repository: str, api_version: str = GITHUB_DEFAULT_API_VERSION
 ) -> tuple[bool, str | None]:
@@ -392,7 +398,7 @@ def validate_credentials(
             return False, "Invalid personal access token"
 
         if response.status_code == 404:
-            return False, f"Repository '{repository}' not found or not accessible"
+            return False, f"Repository '{repository}' {REPOSITORY_NOT_ACCESSIBLE_REASON}"
 
         try:
             body = response.json()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/source.py
@@ -50,6 +50,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.generated_
 from products.warehouse_sources.backend.temporal.data_imports.sources.github.github import (
     _ORG_PERMISSION_REASON,
     ORG_SCOPED_ENDPOINTS,
+    REPOSITORY_NOT_ACCESSIBLE_REASON,
     GithubEgressIdentity,
     GithubResumeConfig,
     check_org_endpoint_permission,
@@ -131,6 +132,17 @@ GITHUB_WEBHOOK_EVENT_CHECKLIST: str = "\n".join(
 # template lands `body[eventType]` as the row and these nest the object under a different key
 # (`alert` for the code-scanning/Dependabot/secret-scanning alerts, `forkee` for forks), so each
 # needs its own reshaping branch before its webhook rows would match what the poll path writes.
+
+
+_REPOSITORY_ACCESS_GUIDANCE = "Check the spelling and that your token has read access."
+
+
+def _join_validation_failures(failures: list[str]) -> str:
+    """Join the per-repository failures, with one next step for the whole list rather than one each."""
+    joined = "; ".join(failures)
+    if any(REPOSITORY_NOT_ACCESSIBLE_REASON in failure for failure in failures):
+        return f"{joined}. {_REPOSITORY_ACCESS_GUIDANCE}"
+    return joined
 
 
 @SourceRegistry.register
@@ -645,9 +657,9 @@ If automatic creation failed with a permissions error, the fix depends on how yo
                 # A 401 is token-level — probing further repos yields the same answer.
                 if message == "Invalid personal access token":
                     return False, message
-                failures.append(message or f"Repository '{repository}' not found or not accessible")
+                failures.append(message or f"Repository '{repository}' {REPOSITORY_NOT_ACCESSIBLE_REASON}")
             if failures:
-                return False, "; ".join(failures)
+                return False, _join_validation_failures(failures)
             return True, None
         except Exception as e:
             # `_get_access_token` and the OAuth mixin raise deterministic config/credential errors

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_source_class.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_source_class.py
@@ -642,6 +642,36 @@ class TestGithubSource:
 
         assert valid is False
         assert message is not None and "a/missing" in message
+        assert message.count("read access") == 1
+
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.github.source.validate_github_credentials"
+    )
+    def test_validate_credentials_states_the_next_step_once_for_several_repos(self, mock_validate):
+        # Guards against the next step moving back into the per-repo reason, where N inaccessible
+        # repos would read as the same sentence N times.
+        mock_validate.side_effect = [
+            (False, "Repository 'a/one' not found or not accessible"),
+            (False, "Repository 'a/two' not found or not accessible"),
+        ]
+
+        valid, message = self.source.validate_credentials(_pat_config(repositories=["a/one", "a/two"]), self.team_id)
+
+        assert valid is False
+        assert message is not None
+        assert "a/one" in message and "a/two" in message
+        assert message.count("read access") == 1
+
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.github.source.validate_github_credentials"
+    )
+    def test_validate_credentials_omits_repo_guidance_for_other_failures(self, mock_validate):
+        mock_validate.side_effect = [(False, "Validation failed")]
+
+        valid, message = self.source.validate_credentials(_pat_config(repositories=["a/one"]), self.team_id)
+
+        assert valid is False
+        assert message == "Validation failed"
 
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.github.source.validate_github_credentials"


### PR DESCRIPTION
## Problem

A customer connecting a GitHub source is told a repository is "not found or not accessible" and gets no next step. The two causes need different actions — a typo in the identifier, or a token that cannot read the repository — and the message points at neither.

GitHub answers 404 for both, so the reason genuinely cannot tell them apart. It can still name the two things to check.

Adding the next step to the per-repository reason would make the multi-repository case worse. The source validates up to 20 repositories and joins their failures, so two inaccessible repositories already repeat "not found or not accessible" twice. Repeating a next step alongside it doubles the noise.

## Changes

- The wizard now closes a repository-access failure with one sentence: check the spelling, and check that the token has read access.
- A batch of inaccessible repositories states that sentence once, after the list, rather than once per repository.
- A failure that is not about repository access, such as a rejected token or a GitHub validation error, reads exactly as before.
- The rest is mechanical: the 404 reason text moves into a named constant so the source layer can match it.

The next step sits at the join rather than in the reason because that is the only place that knows how many repositories failed.

## How did you test this code?

Added two cases to `test_github_source_class.py`:

- Two inaccessible repositories produce one next step, not two. This catches the next step drifting back into the per-repository reason.
- A non-access failure keeps its own message, with no repository guidance appended.

Also tightened the existing aggregation test to assert the next step appears once.

Ran `github/tests/test_github_source_class.py` and `github/tests/test_github_validate_credentials.py` (103 passed).

Not run: `test_github_webhook_template.py` and the other database-backed tests in the directory. They fail at setup in this sandbox because no Postgres is running, and they do not touch this path.

No manual testing — this sandbox has no dev stack running.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No API, setting, or documented flow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code (Opus 5) while triaging a day of failed source-creation attempts in the new-source wizard. Most messages in that set were already clear and actionable; this one named the problem but dead-ended, and its multi-repository form repeated itself.

Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`.

No duplicate: searched open PRs for the message text, the `github` scope, and the source module path, and listed every open PR by the area's maintainer. Nothing touches this path.

Public artifact: the triage input was customer-entered repository identifiers. None of it reaches this diff — the test repositories are invented placeholders.

The first attempt put the next step directly in the 404 reason. That was reverted once the joined multi-repository message showed the guidance repeating per entry.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
