### PR TITLE
fix(data-warehouse): stop a resumed repartition re-reading copied rows

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any
 import pyarrow as pa
 import deltalake as deltalake
 import pyarrow.compute as pc
+import pyarrow.dataset as pads
 import deltalake.exceptions
 from structlog.types import FilteringBoundLogger
 
@@ -854,6 +855,54 @@ def select_coarsen_target(
     return None, "unsupported_mode"
 
 
+def _rows_per_source_file(old_delta: deltalake.DeltaTable) -> dict[str, int]:
+    """Row count per data file, keyed by file name, read from the Delta log (metadata only)."""
+    actions = old_delta.get_add_actions(flatten=True)
+    names = actions.schema.names
+    if "path" not in names or "num_records" not in names:
+        return {}
+    paths = actions.column("path").to_pylist()
+    counts = actions.column("num_records").to_pylist()
+    return {path.rsplit("/", 1)[-1]: count or 0 for path, count in zip(paths, counts) if path}
+
+
+def _drop_copied_source_files(
+    old_delta: deltalake.DeltaTable, dataset: pads.Dataset, skip_rows: int
+) -> tuple[pads.Dataset, int]:
+    """Trim the source files a resumed rewrite already copied, returning the rows left to skip.
+
+    The scan hands batches over one file at a time in the order `get_fragments` lists them, so the
+    `skip_rows` prefix temp already holds is exactly the leading whole files whose row counts sum
+    under it, plus part of the file that straddles the boundary. Dropping those files costs one
+    Delta-log read; discarding their rows batch by batch costs a full decode of every one of them, on
+    the same activity budget as the rows the attempt still has to write. So on a table that needs
+    several budgets the prefix grows until re-reading it fills a budget on its own, and an attempt that
+    appends nothing is what the controller counts against its give-up cap.
+
+    Only whole files are dropped, so the boundary file is still skipped row by row.
+    """
+    if not isinstance(dataset, pads.FileSystemDataset):
+        return dataset, skip_rows
+
+    per_file = _rows_per_source_file(old_delta)
+    fragments = list(dataset.get_fragments())
+    copied = 0
+    boundary = 0
+    for fragment in fragments:
+        rows = per_file.get(fragment.path.rsplit("/", 1)[-1])
+        if rows is None:
+            rows = fragment.count_rows()
+        if copied + rows > skip_rows:
+            break
+        copied += rows
+        boundary += 1
+
+    if boundary == 0:
+        return dataset, skip_rows
+    trimmed = pads.FileSystemDataset(fragments[boundary:], dataset.schema, dataset.format, dataset.filesystem)
+    return trimmed, skip_rows - copied
+
+
 def _read_next_batch(reader: pa.RecordBatchReader) -> pa.RecordBatch | None:
     try:
         return reader.read_next_batch()
@@ -902,9 +951,11 @@ async def _rewrite_into_temp(
     `total_rows` is the source row count, used only to report progress as a percentage and an ETA.
 
     `skip_rows` resumes a prior attempt that ran out of budget: temp already holds a scan-ordered
-    prefix of `skip_rows` rows, so this call reads-and-discards that many source rows (the source is
-    immutable during the rewrite, so the scan order is stable) and appends only the remainder. The
-    rewrite writes in `append` mode, so resuming builds on the existing temp rather than replacing it.
+    prefix of `skip_rows` rows, so this call skips that many source rows (the source is immutable
+    during the rewrite, so the scan order is stable) and appends only the remainder. Whole source files
+    inside the prefix are dropped from the scan on their recorded row counts, so only the file that
+    straddles the boundary is read-and-discarded. The rewrite writes in `append` mode, so resuming
+    builds on the existing temp rather than replacing it.
     """
     await logger.ainfo(
         f"repartition: rewrite starting target_scheme={_format_scheme(target)} total_rows={total_rows} "
@@ -916,6 +967,12 @@ async def _rewrite_into_temp(
     )
 
     dataset = await asyncio.to_thread(old_delta.to_pyarrow_dataset)
+    if skip_rows:
+        dataset, skip_rows = await asyncio.to_thread(_drop_copied_source_files, old_delta, dataset, skip_rows)
+        await logger.ainfo(
+            f"repartition: resume dropped the source files already copied, {skip_rows} rows left to skip",
+            rows_to_skip=skip_rows,
+        )
     reader = await asyncio.to_thread(
         lambda: dataset.scanner(
             batch_size=batch_size,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition.py
@@ -809,6 +809,67 @@ class TestRewriteIntoTemp:
         assert final.num_rows == len(rows)
         assert set(final.column("id").to_pylist()) == set(range(len(rows)))
 
+    def test_resume_does_not_re_read_the_source_files_it_already_copied(self, tmp_path):
+        # The prefix temp already holds is charged to the resumed attempt's own budget when it is
+        # skipped row by row, so on a table that needs several budgets the re-read grows until it fills
+        # a budget on its own and the attempt appends nothing — which is what the controller counts
+        # against its give-up cap before abandoning the table. One row per month means one source file
+        # per row, so a copied prefix is a whole number of files and the scan must never open them.
+        rows = [(i, datetime.datetime(2024, 1, 1) + datetime.timedelta(days=40 * i)) for i in range(6)]
+        live = _write_month_partitioned(str(tmp_path / "live"), rows)
+        temp_uri = str(tmp_path / "tmp")
+        target = RepartitionTarget(
+            partition_keys=["created_at"], trigger_reason="t", partition_mode="datetime", partition_format="day"
+        )
+
+        clock = Mock(side_effect=itertools.chain([0.0] * 8, itertools.repeat(100.0)))
+        with (
+            patch.object(repartition_module, "time", Mock(monotonic=clock)),
+            patch.object(repartition_module, "REWRITE_BUFFER_MAX_ROWS", 1),
+        ):
+            with pytest.raises(RepartitionBudgetExceededError):
+                asyncio.run(
+                    _rewrite_into_temp(
+                        old_delta=live,
+                        temp_uri=temp_uri,
+                        storage_options={},
+                        target=target,
+                        batch_size=1,
+                        logger=logger,
+                        deadline=50.0,
+                    )
+                )
+        copied = deltalake.DeltaTable(temp_uri).to_pyarrow_table().num_rows
+        assert 0 < copied < len(rows)
+
+        reads = 0
+        read_batch = repartition_module._read_next_batch
+
+        def counting_read(reader):
+            nonlocal reads
+            reads += 1
+            return read_batch(reader)
+
+        with patch.object(repartition_module, "_read_next_batch", counting_read):
+            rows_written, _ = asyncio.run(
+                _rewrite_into_temp(
+                    old_delta=live,
+                    temp_uri=temp_uri,
+                    storage_options={},
+                    target=target,
+                    batch_size=1,
+                    logger=logger,
+                    skip_rows=copied,
+                )
+            )
+
+        # One read per uncopied file, plus the read that exhausts the scan.
+        assert reads == (len(rows) - copied) + 1
+        assert rows_written == len(rows) - copied
+        final = deltalake.DeltaTable(temp_uri).to_pyarrow_table()
+        assert final.num_rows == len(rows)
+        assert set(final.column("id").to_pylist()) == set(range(len(rows)))
+
     def test_a_finished_rewrite_beats_the_deadline(self, tmp_path):
         # One source file, one batch, so the reader is exhausted on the second loop iteration. The
         # clock is over the deadline by then: a rewrite that has already copied every row must still


### PR DESCRIPTION
## Problem

A data warehouse table too large to repartition in one run stops converging and is abandoned un-repartitioned, so it keeps syncing on the layout that was already too big for the merge.

- The rewrite streams the live table into a temp table. When it runs out of the activity's budget it checkpoints, and the next sync resumes.
- The resume reads and discards every source row temp already holds, to line the scan back up. That decode is charged to the same budget as the rows the attempt still has to write.
- The re-read grows with each budget, so the attempt eventually appends nothing before the deadline.
- An attempt that appends nothing is what the controller counts against its cap of three, so the table is dropped and the daily cooldown is stamped.

Yesterday's `warehouse_repartition_failed` events show this on tables of hundreds of millions of rows, across five source types, half of them terminal.

## Changes

- A large table now keeps converging across syncs instead of stalling: the resumed rewrite starts appending straight away rather than decoding the copied prefix again.
- The resume drops the already-copied source files from the scan. Only the file that straddles the boundary is still skipped row by row, so it lands on the same row as before.
- File row counts come from the Delta log, so choosing the files costs one metadata read and reads no data.
- Nothing else changes. Sync semantics, partition sizing and the retry cap are untouched, and there is no user-facing copy or UI in this diff.

## How did you test this code?

- Added `test_resume_does_not_re_read_the_source_files_it_already_copied`. It resumes a rewrite over a copied prefix and asserts the scan opens only the uncopied files. Reverting the fix fails it, because the old path reads every source file. The nearest existing test, `test_resume_from_a_prefix_completes_the_table_exactly_once`, covers the resulting rows and not the work done to produce them.
- Ran the repartition unit, controller and activity suites locally, plus `mypy` over the changed module.
- Not run: the end-to-end data import suite, and no manual sync against a real source.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. `products/warehouse_sources/backend/temporal/data_imports/README.md` describes the checkpoint and resume, and both still work the way it says.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code from a triage of yesterday's `warehouse_repartition_failed` events. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The other failure mode in that triage, `RepartitionAttemptsExhausted` on the coarsening trigger, is the controller's designed give-up after three runs that were hard-killed before they could record any outcome. No separate change was opened for it. This one shortens the run that recovers from such a kill, because the recovering run no longer re-streams the whole table.

The first design considered making the give-up cap forgive a hard-killed attempt that still advanced its checkpoint. It was dropped: the cost of the resume is the root cause, and the cap is doing what it was written to do.

No duplicate: `gh pr list --state open` searched for the error types, the sample message shape, and the repartition path, and the maintainer's own open PRs were listed. #95006 removes the auto-coarsen rollout flag and #92380 changes the corrupt-table revive; neither touches the resume.

Public artifact: the failure sample that prompted this carries customer table names, bucket paths, schema ids and team ids. None of it reaches the diff or this description, and the test fixture is invented.

