### PR TITLE
perf(taxonomy): search small projects through their own index

### DIFF
--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -45,6 +45,7 @@ from posthog.models.activity_logging.activity_log import Detail, dict_changes_be
 from posthog.models.user import User
 from posthog.models.utils import UUIDT
 from posthog.settings import EE_AVAILABLE
+from posthog.taxonomy.definition_search import search_plan
 from posthog.taxonomy.taxonomy import CORE_EVENTS, STALE_EVENT_DAYS
 from posthog.utils import get_safe_cache, relative_date_parse
 
@@ -379,17 +380,6 @@ class EventDefinitionViewSet(
         # Allows this endpoint to return lists of event definitions, actions, or both.
         event_type = EventDefinitionType(self.request.GET.get("event_type", EventDefinitionType.EVENT))
 
-        search = self.request.GET.get("search", None)
-        search_query, search_kwargs = term_search_filter_sql(self.search_fields, search)
-
-        params = {"project_id": self.project_id, "is_posthog_event": "$%", **search_kwargs}
-        order_expressions = self._ordering_params_from_request()
-        has_explicit_ordering = "ordering" in self.request.GET
-        has_search_terms = bool(search and search.strip())
-
-        if has_search_terms and not has_explicit_ordering:
-            order_expressions = [("length(name)", "ASC"), *order_expressions]
-
         event_definition_object_manager: Manager
         if EE_AVAILABLE:
             from ee.models.event_definition import EnterpriseEventDefinition
@@ -397,6 +387,24 @@ class EventDefinitionViewSet(
             event_definition_object_manager = EnterpriseEventDefinition.objects
         else:
             event_definition_object_manager = EventDefinition.objects
+
+        search = self.request.GET.get("search", None)
+        has_search_terms = bool(search and search.strip())
+        plan = (
+            search_plan("posthog_eventdefinition", self.project_id, event_definition_object_manager.db)
+            if has_search_terms
+            else None
+        )
+        search_query, search_kwargs = term_search_filter_sql(
+            self.search_fields, search, avoid_trigram_index=plan == "project_scan"
+        )
+
+        params = {"project_id": self.project_id, "is_posthog_event": "$%", **search_kwargs}
+        order_expressions = self._ordering_params_from_request()
+        has_explicit_ordering = "ordering" in self.request.GET
+
+        if has_search_terms and not has_explicit_ordering:
+            order_expressions = [("length(name)", "ASC"), *order_expressions]
 
         exclude_hidden = self.request.GET.get("exclude_hidden", "false").lower() == "true"
         if exclude_hidden and EE_AVAILABLE:

--- a/posthog/filters.py
+++ b/posthog/filters.py
@@ -75,7 +75,16 @@ def term_search_filter_sql(
     search_fields: list[str],
     search_terms: Optional[str] = "",
     search_extra: Optional[str] = "",
+    avoid_trigram_index: bool = False,
 ) -> tuple[str, dict]:
+    """Builds the `?search=` predicate: every space-separated term must match one of the fields.
+
+    `field ILIKE pattern` lets the planner answer from a trigram GIN index on the field. Where that
+    index is global and the query is already scoped to one tenant, the planner still often reads the
+    posting lists for the whole index. `avoid_trigram_index` emits the equivalent
+    `lower(field) LIKE lower(pattern)`, which no trigram index on `field` can serve, so the planner
+    has to start from the tenant-scoped index instead.
+    """
     if not search_fields or not search_terms:
         return "", {}
 
@@ -87,7 +96,10 @@ def term_search_filter_sql(
         search_filter_query = []
         for idx, search_field in enumerate(search_fields):
             index = term_idx * len(search_fields) + idx
-            search_filter_query.append(f"{search_field} ilike %(search_{index})s")
+            if avoid_trigram_index:
+                search_filter_query.append(f"lower({search_field}) like lower(%(search_{index})s)")
+            else:
+                search_filter_query.append(f"{search_field} ilike %(search_{index})s")
             kwargs[f"search_{index}"] = f"%{search_term}%"
         term_filter.append(f"({' OR '.join(search_filter_query)})")
 

--- a/posthog/taxonomy/definition_search.py
+++ b/posthog/taxonomy/definition_search.py
@@ -1,9 +1,10 @@
 from typing import Literal
 
-from django.core.cache import cache
 from django.db import connections
 
 from opentelemetry import trace
+
+from posthog.utils import get_safe_cache, safe_cache_set
 
 DefinitionTable = Literal["posthog_eventdefinition", "posthog_propertydefinition"]
 SearchPlan = Literal["project_scan", "trigram"]
@@ -32,7 +33,8 @@ def search_plan(table: DefinitionTable, project_id: int, db_alias: str) -> Searc
 
 def _cached_search_plan(table: DefinitionTable, project_id: int, db_alias: str) -> SearchPlan:
     cache_key = f"taxonomy_search_plan:{table}:{project_id}"
-    cached = cache.get(cache_key)
+    # A cache outage must only cost the count query, never the search itself.
+    cached = get_safe_cache(cache_key)
     if cached is not None:
         return cached
 
@@ -44,5 +46,5 @@ def _cached_search_plan(table: DefinitionTable, project_id: int, db_alias: str) 
         definition_count = cursor.fetchone()[0]
 
     plan: SearchPlan = "trigram" if definition_count > PROJECT_SCAN_MAX_DEFINITIONS else "project_scan"
-    cache.set(cache_key, plan, SEARCH_PLAN_CACHE_SECONDS)
+    safe_cache_set(cache_key, plan, SEARCH_PLAN_CACHE_SECONDS)
     return plan

--- a/posthog/taxonomy/definition_search.py
+++ b/posthog/taxonomy/definition_search.py
@@ -1,0 +1,48 @@
+from typing import Literal
+
+from django.core.cache import cache
+from django.db import connections
+
+from opentelemetry import trace
+
+DefinitionTable = Literal["posthog_eventdefinition", "posthog_propertydefinition"]
+SearchPlan = Literal["project_scan", "trigram"]
+
+# Above this many definitions, walking the project's rows costs more than the global trigram index.
+# Measured on production: at ~140k rows the project scan still wins by 40x; at ~600k rows the two
+# are level for short terms; the largest projects have millions of rows and must keep the index.
+PROJECT_SCAN_MAX_DEFINITIONS = 50_000
+
+# A project rarely crosses the threshold, and a stale answer only costs query time, never results.
+SEARCH_PLAN_CACHE_SECONDS = 24 * 60 * 60
+
+
+def search_plan(table: DefinitionTable, project_id: int, db_alias: str) -> SearchPlan:
+    """Picks how a `?search=` on a definitions table should reach the project's rows.
+
+    Postgres cannot scope the trigram GIN index on `name` to one project, so for the common small
+    project it reads posting lists for every project before intersecting. Small projects are
+    faster to scan through their own unique index and filter in place; only the few huge projects
+    are better off with the trigram index. The count is bounded so it stays cheap for those.
+    """
+    plan = _cached_search_plan(table, project_id, db_alias)
+    trace.get_current_span().set_attribute("taxonomy_search_plan", plan)
+    return plan
+
+
+def _cached_search_plan(table: DefinitionTable, project_id: int, db_alias: str) -> SearchPlan:
+    cache_key = f"taxonomy_search_plan:{table}:{project_id}"
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    with connections[db_alias].cursor() as cursor:
+        cursor.execute(
+            f"SELECT count(*) FROM (SELECT 1 FROM {table} WHERE COALESCE(project_id, team_id) = %(project_id)s LIMIT %(limit)s) bounded",
+            {"project_id": project_id, "limit": PROJECT_SCAN_MAX_DEFINITIONS + 1},
+        )
+        definition_count = cursor.fetchone()[0]
+
+    plan: SearchPlan = "trigram" if definition_count > PROJECT_SCAN_MAX_DEFINITIONS else "project_scan"
+    cache.set(cache_key, plan, SEARCH_PLAN_CACHE_SECONDS)
+    return plan

--- a/posthog/taxonomy/property_definition_api.py
+++ b/posthog/taxonomy/property_definition_api.py
@@ -26,6 +26,7 @@ from posthog.models import EventProperty, PropertyDefinition, User
 from posthog.models.activity_logging.activity_log import Detail, log_activity
 from posthog.models.utils import UUIDT
 from posthog.settings import EE_AVAILABLE
+from posthog.taxonomy.definition_search import search_plan
 from posthog.taxonomy.taxonomy import (
     CORE_FILTER_DEFINITIONS_BY_GROUP,
     PROPERTY_NAME_ALIASES,
@@ -678,8 +679,11 @@ class PropertyDefinitionViewSet(
             span.set_attribute("limit", limit or 0)
             span.set_attribute("offset", offset or 0)
 
+            plan = search_plan("posthog_propertydefinition", self.project_id, read_db_alias()) if search else None
             search_extra = add_name_alias_to_search_query(search, prop_type)
-            search_query, search_kwargs = term_search_filter_sql(self.search_fields, search, search_extra)
+            search_query, search_kwargs = term_search_filter_sql(
+                self.search_fields, search, search_extra, avoid_trigram_index=plan == "project_scan"
+            )
 
             query_context = (
                 QueryContext(

--- a/posthog/taxonomy/test/test_definition_search.py
+++ b/posthog/taxonomy/test/test_definition_search.py
@@ -39,6 +39,11 @@ class TestSearchPlan(BaseTest):
         with self.assertNumQueries(1):
             search_plan("posthog_eventdefinition", self.team.pk + 1, DEFAULT_DB_ALIAS)
 
+    @parameterized.expand([("cache_read_fails", "get"), ("cache_write_fails", "set")])
+    def test_plan_survives_a_cache_outage(self, _name: str, failing_method: str) -> None:
+        with patch.object(cache, failing_method, side_effect=ConnectionError("redis down")):
+            assert search_plan("posthog_eventdefinition", self.team.pk, DEFAULT_DB_ALIAS) == "project_scan"
+
 
 class TestDefinitionEndpointsUseSearchPlan(APIBaseTest):
     def setUp(self) -> None:

--- a/posthog/taxonomy/test/test_definition_search.py
+++ b/posthog/taxonomy/test/test_definition_search.py
@@ -1,0 +1,70 @@
+from posthog.test.base import APIBaseTest, BaseTest
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.db import DEFAULT_DB_ALIAS, connection
+from django.test.utils import CaptureQueriesContext
+
+from parameterized import parameterized
+
+from posthog.models import EventDefinition, PropertyDefinition
+from posthog.taxonomy import definition_search
+from posthog.taxonomy.definition_search import search_plan
+
+
+class TestSearchPlan(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        cache.clear()
+        for name in ("a", "b", "c"):
+            EventDefinition.objects.create(team=self.team, name=name)
+
+    @parameterized.expand(
+        [
+            ("small_project_scans_its_own_rows", 3, "project_scan"),
+            ("huge_project_keeps_the_trigram_index", 2, "trigram"),
+        ]
+    )
+    def test_plan_follows_the_definition_count(self, _name: str, max_definitions: int, expected: str) -> None:
+        with patch.object(definition_search, "PROJECT_SCAN_MAX_DEFINITIONS", max_definitions):
+            assert search_plan("posthog_eventdefinition", self.team.pk, DEFAULT_DB_ALIAS) == expected
+
+    def test_plan_is_cached_per_table_and_project(self) -> None:
+        search_plan("posthog_eventdefinition", self.team.pk, DEFAULT_DB_ALIAS)
+
+        with self.assertNumQueries(0):
+            assert search_plan("posthog_eventdefinition", self.team.pk, DEFAULT_DB_ALIAS) == "project_scan"
+        with self.assertNumQueries(1):
+            search_plan("posthog_propertydefinition", self.team.pk, DEFAULT_DB_ALIAS)
+        with self.assertNumQueries(1):
+            search_plan("posthog_eventdefinition", self.team.pk + 1, DEFAULT_DB_ALIAS)
+
+
+class TestDefinitionEndpointsUseSearchPlan(APIBaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        cache.clear()
+        EventDefinition.objects.create(team=self.team, name="foo")
+        PropertyDefinition.objects.create(team=self.team, name="foo")
+
+    @parameterized.expand(
+        [
+            ("event_definitions_small_project", "event_definitions", 1, "lower(name) like lower("),
+            ("event_definitions_huge_project", "event_definitions", 0, "name ilike "),
+            ("property_definitions_small_project", "property_definitions", 1, "lower(name) like lower("),
+            ("property_definitions_huge_project", "property_definitions", 0, "name ilike "),
+        ]
+    )
+    def test_search_predicate_follows_the_plan(
+        self, _name: str, endpoint: str, max_definitions: int, expected_predicate: str
+    ) -> None:
+        with (
+            patch.object(definition_search, "PROJECT_SCAN_MAX_DEFINITIONS", max_definitions),
+            CaptureQueriesContext(connection) as queries,
+        ):
+            response = self.client.get(f"/api/projects/{self.team.pk}/{endpoint}/?search=foo")
+
+        assert response.status_code == 200
+        search_queries = [q["sql"] for q in queries.captured_queries if "%foo%" in q["sql"]]
+        assert search_queries, "no search query was captured"
+        assert all(expected_predicate in sql for sql in search_queries), search_queries

--- a/posthog/test/test_filters.py
+++ b/posthog/test/test_filters.py
@@ -1,0 +1,23 @@
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.filters import term_search_filter_sql
+
+
+class TestTermSearchFilterSql(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("trigram_index", False, "AND (((name ilike %(search_0)s OR alias ilike %(search_1)s)) )"),
+            (
+                "project_scan",
+                True,
+                "AND (((lower(name) like lower(%(search_0)s) OR lower(alias) like lower(%(search_1)s))) )",
+            ),
+        ]
+    )
+    def test_predicate_form_follows_index_choice(self, _name: str, avoid_trigram_index: bool, expected: str) -> None:
+        sql, params = term_search_filter_sql(["name", "alias"], "Foo", avoid_trigram_index=avoid_trigram_index)
+
+        assert sql == expected
+        assert params == {"search_0": "%Foo%", "search_1": "%Foo%"}

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -1699,7 +1699,7 @@ def get_daterange(
     return time_range
 
 
-def get_safe_cache(cache_key: str):
+def get_safe_cache(cache_key: str) -> Any:
     try:
         cached_result = cache.get(cache_key)  # cache.get is safe in most cases
         return cached_result


### PR DESCRIPTION
## Problem

Typing in the taxonomic filter takes seconds to return events and properties, even in a project with a few thousand definitions. In APM, the events tab had a p95 of 13.6 s, and the event and person property tabs a p95 of about 7.5 s.

- The event and property definition lists search names with `ILIKE`.
- Postgres answers that from the trigram index on `name`, which covers every project at once.
- For a longer search term, the planner reads the trigram posting lists for the whole table, then intersects them with the project's rows.
- That cost does not depend on the size of the project. A small project pays for the whole table.
- Scanning only the project's own rows through the project-scoped index takes tens of milliseconds for most projects.

### Measurements

All timings are `EXPLAIN (ANALYZE, BUFFERS)` on the production read replica, warm cache, one run each. The test project has about 5.7k event definitions and 89k property definitions.

The plan the planner picks today depends on the search term, not on the project size:

| Query (test project) | Plan the planner picks | Time |
| --- | --- | --- |
| events, `%page%` | project-scoped index | 42 ms |
| events, `%session recording%` | global trigram index | 3,485 ms |
| events, `%billing_product_activated%` | global trigram index | 585 ms |
| properties, `%current url%` | global trigram index | 2,826 ms |

The paginator count runs the same predicate, so each request pays this twice.

The same queries with the predicate written as `lower(name) LIKE lower(pattern)`, which the trigram index cannot serve:

| Query | `ILIKE` (today) | `lower LIKE` | Change |
| --- | --- | --- | --- |
| test project, events, `session recording` | 3,485 ms | 9 ms | about 380x faster |
| test project, properties, `current url` | 2,826 ms | 39 ms | about 70x faster |
| 143k-row project, events, `session recording` | 3,309 ms | 78 ms | about 40x faster |
| 580k-row project, events, `page` | 521 ms | 445 ms | about equal |
| 26M-row project (the largest), events, `page` | 14,040 ms | not run, would scan 26M rows | much worse |

The project scan costs about one page per row. The trigram path costs roughly 15k to 25k pages per trigram in the term. The two are level somewhere around a few hundred thousand rows. Almost every project sits far below that, so the rewrite must apply to small projects and stay off the largest ones.

## Changes

- Searching events and properties in the taxonomic filter returns in tens of milliseconds instead of seconds for most projects. Results, order, and wildcards do not change.
- The two endpoints now choose how to reach the rows before they search:
  - A project with at most 50,000 definitions in the table uses `lower(name) LIKE lower(pattern)`. No trigram index can serve that form, so the planner starts from the project-scoped index.
  - A larger project keeps `ILIKE`, because a few very large projects are faster on the trigram index.
- The decision comes from a bounded count (`LIMIT 50001`) on the project-scoped index, cached for 24 hours per table and project. A stale answer only changes query time, never results.
- A cache outage does not break search. The plan lookup uses the safe cache helpers, so a Redis failure costs one count query per request instead of a 5xx.
- The chosen plan is recorded on the current trace span as `taxonomy_search_plan`, so the effect is visible per request in APM.
- Mechanical: `term_search_filter_sql` gains an `avoid_trigram_index` flag that switches the predicate form. Existing callers keep the default. `get_safe_cache` gains a return type annotation.

> [!NOTE]
> The 50,000 threshold is deliberately conservative. The measurements above show the project scan still wins by about 40x at 143k rows, and the two forms are level for short terms at about 580k rows. The trigram index stays in use for the projects that need it.

## How did you test this code?

- `posthog/test/test_filters.py`: the predicate switches form with the flag and keeps identical parameters. Catches a change that alters the SQL shape or drops the wildcards.
- `posthog/taxonomy/test/test_definition_search.py`:
  - the plan follows the definition count against the threshold, and is cached per table and project (one count query, then none). Catches a cache key that mixes tables or projects.
  - the plan still comes back when the cache read or the cache write raises. Catches a return to the plain `cache.get` and `cache.set` calls.
  - both endpoints emit the predicate form the plan asks for. Catches a refactor that stops passing the plan into either viewset, which every result-based test would miss.
- Ran the existing `posthog/api/test/test_event_definition.py`, `posthog/api/test/test_property_definition.py` and their `ee/` counterparts on a devbox against Postgres.
- Ran the branch in a dev stack and searched the taxonomic filter with a scripted browser. Every search returned exactly the seeded rows. The recording below shows the events tab, the event properties tab, and the person properties tab. The response times in it go through an ssh tunnel, so they say nothing about production speed.
- Not checked: production latency after deploy. The `taxonomy_search_plan` span attribute and the per-endpoint APM p95s are the follow-up check.

![Searching events, event properties and person properties in the taxonomic filter on this branch](https://raw.githubusercontent.com/PostHog/pr-assets/fce232b809ffea1e2b48c4de0b5c957dd081adc7/2026/09/3a253d3e-7373-4e7c-acda-69a06937ade7.gif)

[Same recording as mp4](https://raw.githubusercontent.com/PostHog/pr-assets/e786408359e7087784d3790d49b58b2e3970bc64/2026/09/827bf9b4-d51e-4d40-b138-b0d40dd8dd77.mp4)

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No API surface or documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools: Claude Code (PostHog Desktop task), PostHog MCP for the APM trace, `hogli metabase:query` for `EXPLAIN ANALYZE` against the read replica, `hogli devbox` for the database-backed tests.
- Skills invoked: `/modifying-taxonomic-filter`, `/improving-drf-endpoints`, `/writing-tests`, `/writing-pr-descriptions`, `/pr-shepherd` (with `qa-swarm`, `review-triage`, `ci-shepherd`).
- Decisions: started from an APM trace of a slow taxonomic filter open. A prior analysis blamed the global trigram index; `EXPLAIN ANALYZE` on both plan forms confirmed it and set the threshold. The first design applied the project-scan form unconditionally; the size check was added after measuring the largest projects, where the trigram index is the faster path. The count is cached at the reviewer's request, so the check adds no per-request cost after the first hit. The safe cache helpers came from a bot review finding.
- Related open PRs, neither a duplicate: #90647 fixes the unfiltered list and states `?search=` is unaffected. #95646 adds a project-scoped trigram index for the SQL editor's suggestion lookup. If that index lands, the `ILIKE` form here can use it too; this change needs no migration and stands on its own.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
