### PR TITLE
fix(inngest): read the webhooks table from the v1 inventory only

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/inngest/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/inngest/settings.py
@@ -4,11 +4,10 @@ from typing import Literal, Optional
 from products.warehouse_sources.backend.types import IncrementalField, IncrementalFieldType
 
 # Vendor API versions. Inngest serves its REST API under URL-path-versioned prefixes
-# (`/v1/...`, `/v2/...`) and the per-environment signing key authenticates both. Most resources
-# live under a single version — the events walk and cancellations are v1-only, while environments
-# and the key inventories are v2-only — so their paths are fixed regardless of a source's pin.
-# Webhooks is served under both, so a source's pin selects which inventory it reads (see
-# `version_paths` below). New sources default to v2.
+# (`/v1/...`, `/v2/...`) and the per-environment signing key authenticates both. Every resource
+# this source reads lives under a single version — the events walk, cancellations and webhooks are
+# v1-only, while environments and the key inventories are v2-only — so their paths are fixed
+# regardless of a source's pin. New sources default to v2.
 INNGEST_API_VERSION_V1 = "v1"
 INNGEST_API_VERSION_V2 = "v2"
 INNGEST_SUPPORTED_VERSIONS = (INNGEST_API_VERSION_V1, INNGEST_API_VERSION_V2)
@@ -124,14 +123,6 @@ INNGEST_ENDPOINTS: dict[str, InngestEndpointConfig] = {
         primary_keys=["id"],
         pagination="none",
         redacted_fields=("url",),
-        # Webhooks is the one resource this source reads that Inngest serves under both versions.
-        # A v2-pinned source reads the v2 inventory (cursor envelope) to stay consistent with its
-        # other v2-native reads; v1 pins keep the original `/v1/webhooks` list path. The v2
-        # envelope could not be curl-verified without credentials, but `_get_v2_list_rows`
-        # degrades to a single page when the response carries no `page` object.
-        version_paths={
-            INNGEST_API_VERSION_V2: InngestVersionPath(path="/v2/webhooks", pagination="v2_cursor"),
-        },
     ),
     "event_keys": InngestEndpointConfig(
         name="event_keys",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/inngest/tests/test_inngest.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/inngest/tests/test_inngest.py
@@ -302,31 +302,15 @@ class TestV1Lists:
 
 
 class TestVersionDispatch:
-    @parameterized.expand([("v1", "/v1/webhooks"), ("v2", "/v2/webhooks")])
-    def test_webhooks_endpoint_follows_the_source_pin(self, api_version: str, expected_path: str) -> None:
-        # Webhooks is served under both API versions; the source pin decides which inventory a
-        # source reads. A v1 pin must stay on the original path (existing syncs byte-for-byte), a
-        # v2 pin must move to the v2 inventory. The url field is capability-bearing and dropped on
-        # either version.
-        seen_urls: list[str] = []
-
-        def fake_fetch(session: Any, url: str, headers: dict, logger: Any, params: dict | None = None) -> Any:
-            seen_urls.append(url)
-            return {
-                "data": [{"id": "wh1", "name": "intake", "url": "https://inn.gs/secret"}],
-                "page": {"hasMore": False},
-            }
-
-        rows, _ = _run_rows("webhooks", fake_fetch, api_version=api_version)
-        assert seen_urls[0] == f"https://api.inngest.com{expected_path}"
-        assert rows == [{"id": "wh1", "name": "intake"}]
-
     @parameterized.expand(
         [
-            # Cancellations only exist in v1 and the envs inventory only in v2, so a pin on the
-            # other version must not relocate them off their only compatible home (a 404 otherwise).
+            # Cancellations and the webhooks inventory only exist in v1 and the envs inventory only
+            # in v2, so a pin on the other version must not relocate them off their only compatible
+            # home (a 404 otherwise).
             ("cancellations", "v2", "/v1/cancellations"),
             ("environments", "v1", "/v2/envs"),
+            ("webhooks", "v2", "/v1/webhooks"),
+            ("webhooks", "v1", "/v1/webhooks"),
         ]
     )
     def test_version_locked_endpoint_ignores_the_pin(self, endpoint: str, api_version: str, expected_path: str) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/inngest/tests/test_inngest_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/inngest/tests/test_inngest_source.py
@@ -134,7 +134,7 @@ class TestInngestSource:
         self, _name: str, pin: Optional[str], expected: str
     ) -> None:
         # A pinned source must sync under its own version, not the default — dropping the resolve
-        # would silently read version-mobile tables (webhooks) from the wrong API version.
+        # would leave every source reading the default version's paths.
         config = InngestSourceConfig(signing_key="signkey-prod-test")
         inputs = _source_inputs("webhooks")
         inputs.api_version = pin


### PR DESCRIPTION
## Problem

Anyone syncing the Inngest `webhooks` table gets no rows: every run of that table fails, and the sync error is a bare 404 with an API URL in it.

- Inngest serves the webhooks inventory under `/v1/webhooks` only.
- The endpoint config also declared a `/v2/webhooks` variant, which was never verified against the API.
- New sources default to the v2 pin, so they route the table to a path Inngest answers with 404.

## Changes

- The `webhooks` table now syncs on every source, whichever API version the source is pinned to.
- The endpoint is version-locked to its v1 path, next to the other single-version resources.
- The dispatch test drops the v2 case and covers webhooks under both pins, so a future pin cannot move the table off its only working path.
- Comment edits in the endpoint catalog are mechanical.

Nothing user-visible changes beyond the table syncing again; there is no UI in this diff.

## How did you test this code?

- Ran the source's unit tests locally: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/inngest/tests/`.
- The new dispatch cases catch a pin that relocates webhooks off `/v1/webhooks`, which the removed test asserted the opposite of.
- Not run: any live call against the Inngest API, since this sandbox has no credentials.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triage of a day of warehouse sync failures surfaced this class: a small number of teams, every job on the table failing with the same 404. Reading the endpoint catalog showed the v2 variant carried a comment saying the v2 envelope could not be verified, and the canonical description for the table points at the v1 API docs, so the fix is to drop the unverified variant rather than to map the 404 to friendlier copy.

Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/writing-code-comments`.

No duplicate: `gh pr list --state open --search` for the source name, the table name and the error shape found nothing covering this path.

Public artifact: nothing here comes from a non-public source. The API paths and the 404 are the vendor's own, and no customer value appears in the diff or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
