### PR TITLE
chore(replay): remove toolbar heatmap area filter flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -520,7 +520,6 @@ export const FEATURE_FLAGS = {
     TAXONOMIC_FILTER_DEFAULT_PINS: 'taxonomic-filter-default-pins', // owner: @pauldambra #team-product-analytics, seeds $current_url/email default pinned filters
     TAXONOMIC_FILTER_MENU_REBUILD: 'taxonomic-filter-menu-rebuild', // owner: @adamleith, opt-in to the rebuilt TaxonomicFilter — headless filter panel + new popover menu (column / preview-pane)
     TEXT_CARD_WORD_ART: 'text-card-word-art', // owner: @jonmcwest, gates the word art insert button in dashboard text cards
-    TOOLBAR_HEATMAP_AREA_FILTER: 'toolbar-heatmap-area-filter', // owner: @pauldambra #team-replay, gates the target button that filters the toolbar heatmap/clickmap to a chosen page area
     TRACING: 'tracing', // owner: #team-apm (@jonmcwest, @frankh)
     TRACING_FACET_RAIL: 'tracing-facet-rail', // owner: #team-apm — gates the facet rail (faceted filter sidebar) in tracing
     TRACING_LATENCY_HEATMAP: 'tracing-latency-heatmap', // owner: #team-apm — gates the latency-over-time heatmap chart in tracing

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -1237,9 +1237,6 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
             toolbarPosthogJS.capture('toolbar mode triggered', { mode: 'heatmap', enabled: false })
         },
 
-        // the feature flag gates only the menu button; the whole selection machine stays
-        // dormant because startAreaSelection is that button's only caller — a second caller
-        // would silently un-gate the feature
         startAreaSelection: () => {
             // product tours' picker also listens for document clicks; two armed pickers
             // would both consume the same page click

--- a/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
+++ b/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
@@ -17,7 +17,7 @@ import { elementsLogic } from '~/toolbar/elements/elementsLogic'
 import { heatmapToolbarMenuLogic } from '~/toolbar/elements/heatmapToolbarMenuLogic'
 import { currentPageLogic } from '~/toolbar/stats/currentPageLogic'
 import { heatmapCaptureLogic } from '~/toolbar/stats/heatmapCaptureLogic'
-import { toolbarPosthogJS, useToolbarFeatureFlag } from '~/toolbar/toolbarPosthogJS'
+import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
 import { urls } from '~/toolbar/urls'
 import { joinWithUiHost } from '~/toolbar/utils'
 
@@ -83,7 +83,6 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
     const { wildcardHref, autoWildcardEnabled, wildcardHrefTooSpecific, wildcardHrefEndsWithSlash } =
         useValues(currentPageLogic)
     const { setWildcardHref, autoWildcardHref, setAutoWildcardEnabled } = useActions(currentPageLogic)
-    const areaFilterFlagEnabled = useToolbarFeatureFlag('toolbar-heatmap-area-filter')
 
     const { captureResultLoading, isAuthenticated, captureProgress } = useValues(heatmapCaptureLogic)
     const { saveToPostHog } = useActions(heatmapCaptureLogic)
@@ -192,27 +191,25 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
                         }}
                         dateOptions={heatmapDateOptions}
                     />
-                    {areaFilterFlagEnabled ? (
-                        <LemonButton
-                            size="small"
-                            type="secondary"
-                            icon={<IconTarget />}
-                            active={areaSelectionActive}
-                            data-attr="heatmap-area-filter-toggle"
-                            onClick={() => (areaSelectionActive ? cancelAreaSelection() : startAreaSelection())}
-                            tooltip={
-                                <>
-                                    Filter the heatmap and clickmap to one part of the page, e.g. the nav or the main
-                                    content. Click this, then hover the page and click an area. Press <kbd>↑</kbd> to
-                                    grow the selection to a bigger container, <kbd>↓</kbd> to shrink it, and{' '}
-                                    <kbd>Esc</kbd> to cancel. Heatmap points on fixed or sticky elements are only
-                                    included when the chosen area is itself fixed or sticky.
-                                </>
-                            }
-                        >
-                            {areaSelectionActive ? 'Click an area of the page…' : 'Filter to area'}
-                        </LemonButton>
-                    ) : null}
+                    <LemonButton
+                        size="small"
+                        type="secondary"
+                        icon={<IconTarget />}
+                        active={areaSelectionActive}
+                        data-attr="heatmap-area-filter-toggle"
+                        onClick={() => (areaSelectionActive ? cancelAreaSelection() : startAreaSelection())}
+                        tooltip={
+                            <>
+                                Filter the heatmap and clickmap to one part of the page, e.g. the nav or the main
+                                content. Click this, then hover the page and click an area. Press <kbd>↑</kbd> to grow
+                                the selection to a bigger container, <kbd>↓</kbd> to shrink it, and <kbd>Esc</kbd> to
+                                cancel. Heatmap points on fixed or sticky elements are only included when the chosen
+                                area is itself fixed or sticky.
+                            </>
+                        }
+                    >
+                        {areaSelectionActive ? 'Click an area of the page…' : 'Filter to area'}
+                    </LemonButton>
                 </div>
                 {heatmapAreaFilter && !areaSelectionActive ? (
                     <div className="flex flex-row items-center gap-2 py-2 border-b">


### PR DESCRIPTION
## Problem

The toolbar heatmap area filter is fully rolled out. The `toolbar-heatmap-area-filter` feature flag still hides the "Filter to area" button behind a flag check.

## Changes

- The "Filter to area" button in the heatmap toolbar now always shows. Previously it only appeared for users with the `toolbar-heatmap-area-filter` flag on.
- Mechanical: removed the flag constant and the flag check in `HeatmapToolbarMenu`.

## How did you test this code?

TypeScript check shows no errors in the changed files. oxlint is clean. Ran the toolbar jest suites (`heatmapCaptureLogic`, `heatmapToolbarMenuLogic`, `currentPageLogic`) - all pass. I did not run the full CI matrix; the draft PR will run it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This change was directed by a human and is attributable to pauldambra.

Agent: pi coding assistant. Skills invoked: `writing-pr-descriptions`.

The work removed a fully rolled out feature flag for the toolbar heatmap area filter. No customer, ticket, or internal material appears in this PR.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
