### PR TITLE
fix(data-warehouse): say when a source's API was temporarily unavailable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
@@ -195,6 +195,10 @@ TRANSIENT_EGRESS_MESSAGE = (
     "clears on its own; the next sync runs on schedule."
 )
 
+TRANSIENT_VENDOR_UNAVAILABLE_MESSAGE = (
+    "Your source's API was temporarily unavailable, so this sync couldn't finish. The next sync runs on schedule."
+)
+
 # A retryable failure that outlives its retries keeps whatever the driver said, so `latest_error`
 # ends up holding raw connection text — a psycopg "connection to server at <host>, port <port>
 # failed: ..." line, a pymysql `(2013, ...)` tuple, a urllib3 connection-pool dump. None of it
@@ -225,6 +229,14 @@ Transient_Error_Messages: dict[str, str] = {
     "Tunnel connection failed: 502": TRANSIENT_EGRESS_MESSAGE,
     "Tunnel connection failed: 503": TRANSIENT_EGRESS_MESSAGE,
     "Tunnel connection failed: 504": TRANSIENT_EGRESS_MESSAGE,
+    # A vendor API that was down or overloaded, in the wording `requests.raise_for_status()` builds:
+    # "<status> Server Error: <reason> for url: <url>". REST sources retry these in their transport
+    # and again through Temporal, so reaching here means the outage outlasted both and the stored
+    # text is a bare status plus the vendor URL. Only the gateway statuses are mapped: a 500 can be
+    # one request the vendor mishandles every time, which is not an outage that clears on its own.
+    "502 Server Error": TRANSIENT_VENDOR_UNAVAILABLE_MESSAGE,
+    "503 Server Error": TRANSIENT_VENDOR_UNAVAILABLE_MESSAGE,
+    "504 Server Error": TRANSIENT_VENDOR_UNAVAILABLE_MESSAGE,
 }
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/test_external_data_job_activities.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/test_external_data_job_activities.py
@@ -21,6 +21,7 @@ from products.warehouse_sources.backend.temporal.data_imports.external_data_job 
     TRANSIENT_EGRESS_MESSAGE,
     TRANSIENT_POOLER_MESSAGE,
     TRANSIENT_SOURCE_CONNECTION_MESSAGE,
+    TRANSIENT_VENDOR_UNAVAILABLE_MESSAGE,
     UNEXPECTED_ERROR_MESSAGE,
     UpdateExternalDataJobStatusInputs,
     _customer_facing_error,
@@ -297,6 +298,13 @@ def test_read_only_transaction_disables_the_schema_only_when_the_source_raised_i
             ExternalDataSourceType.SALESFORCE,
             "ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 502 Bad gateway'))",
             TRANSIENT_EGRESS_MESSAGE,
+        ),
+        # A REST source whose vendor stayed unavailable for longer than both retry layers.
+        (
+            "vendor_service_unavailable",
+            ExternalDataSourceType.APPLESEARCHADS,
+            "503 Server Error: Service Temporarily Unavailable for url: https://api.example.com/v1/things",
+            TRANSIENT_VENDOR_UNAVAILABLE_MESSAGE,
         ),
     ]
 )


### PR DESCRIPTION
## Problem

When a vendor API stays down long enough, the sync error a customer reads is a raw HTTP status followed by the vendor's URL. It says nothing about what happened or what to do, and it reads like a defect in their setup.

- REST sources retry a gateway error in their transport, then again through Temporal.
- An outage that outlives both layers stores whatever `raise_for_status()` built.
- Several sources hit this daily, across a handful of teams each.

## Changes

- The sync error panel now says the source's API was temporarily unavailable and that the next sync runs on schedule.
- Only the gateway statuses map: a plain 500 can be one request the vendor mishandles every run, which no waiting fixes.
- The mapping sits in the transient table, so it rewrites the stored message only. The failure stays retryable and the schema stays enabled.
- A source that already classifies its own 5xx keeps its own message, because the non-retryable map is matched first.

## How did you test this code?

- Ran the finalization activity tests locally against the dev stack: `pytest products/warehouse_sources/backend/temporal/data_imports/tests/test_external_data_job_activities.py`.
- The new case covers a REST vendor outage reaching finalization, which the existing cases did not: they all carry database driver or proxy wording.
- The test asserts the schema is not disabled, so a future move of this entry into the non-retryable map fails here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triage of a day of warehouse sync failures found this class among the raw messages customers were left with. The alternative was a per-source mapping, but the wording comes from the shared HTTP transport and the same text reaches every REST source, so the shared transient table is where it belongs.

Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`.

No duplicate: `gh pr list --state open --search` for the message shape, the status codes and the module found nothing covering this path.

Public artifact: the test uses an invented URL on a reserved domain. No customer value appears in the diff or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
