### PR TITLE
feat(notebooks): slice editor responsiveness by notebook size

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/notebookAnalytics.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookAnalytics.test.ts
@@ -1,9 +1,14 @@
 import { AccessControlLevel, UserType } from '~/types'
 
 import { NotebookType } from '../types'
-import { NotebookOpenedProperties, buildNotebookOpenedEvent } from './notebookAnalytics'
+import {
+    NOTEBOOK_SIZE_PROPERTY_KEYS,
+    NotebookOpenedProperties,
+    buildNotebookOpenedEvent,
+    buildNotebookSizeProperties,
+} from './notebookAnalytics'
 
-describe('buildNotebookOpenedEvent', () => {
+describe('notebookAnalytics', () => {
     const user = { uuid: 'user-1' } as UserType
 
     const notebook = (overrides: Partial<NotebookType> = {}): NotebookType =>
@@ -15,44 +20,76 @@ describe('buildNotebookOpenedEvent', () => {
             ...overrides,
         }) as NotebookType
 
-    it.each([
-        [
-            'the creator opening directly (counts top-level nodes)',
-            {},
-            false,
-            {
-                short_id: 'abc123',
-                is_creator: true,
-                user_access_level: AccessControlLevel.Editor,
-                access_source: 'direct',
-                node_count: 3,
-            },
-        ],
-        [
-            'a viewer of another user’s notebook via shared link',
-            { created_by: { uuid: 'other' } as UserType },
-            true,
-            { is_creator: false, access_source: 'shared_link' },
-        ],
-        [
-            'a notebook with no content and no creator',
-            { content: null, created_by: null },
-            false,
-            { is_creator: false, node_count: 0 },
-        ],
-    ] as [string, Partial<NotebookType>, boolean, Partial<NotebookOpenedProperties>][])(
-        'builds the event for %s',
-        (_label, overrides, isShared, expected) => {
-            expect(buildNotebookOpenedEvent(notebook(overrides), user, isShared)).toMatchObject(expected)
-        }
-    )
+    describe('buildNotebookOpenedEvent', () => {
+        it.each([
+            [
+                'the creator opening directly (counts top-level nodes)',
+                {},
+                false,
+                {
+                    short_id: 'abc123',
+                    is_creator: true,
+                    user_access_level: AccessControlLevel.Editor,
+                    access_source: 'direct',
+                    node_count: 3,
+                },
+            ],
+            [
+                'a viewer of another user’s notebook via shared link',
+                { created_by: { uuid: 'other' } as UserType },
+                true,
+                { is_creator: false, access_source: 'shared_link' },
+            ],
+            [
+                'a notebook with no content and no creator',
+                { content: null, created_by: null },
+                false,
+                { is_creator: false, node_count: 0 },
+            ],
+        ] as [string, Partial<NotebookType>, boolean, Partial<NotebookOpenedProperties>][])(
+            'builds the event for %s',
+            (_label, overrides, isShared, expected) => {
+                expect(buildNotebookOpenedEvent(notebook(overrides), user, isShared)).toMatchObject(expected)
+            }
+        )
 
-    it.each([
-        ['scratchpad', 'scratchpad'],
-        ['template', 'template-onboarding'],
-        ['no notebook loaded', undefined],
-    ])('does not emit for %s', (_label, shortId) => {
-        const nb = shortId === undefined ? null : notebook({ short_id: shortId })
-        expect(buildNotebookOpenedEvent(nb, user, false)).toBeNull()
+        it.each([
+            ['scratchpad', 'scratchpad'],
+            ['template', 'template-onboarding'],
+            ['no notebook loaded', undefined],
+        ])('does not emit for %s', (_label, shortId) => {
+            const nb = shortId === undefined ? null : notebook({ short_id: shortId })
+            expect(buildNotebookOpenedEvent(nb, user, false)).toBeNull()
+        })
+    })
+
+    describe('buildNotebookSizeProperties', () => {
+        const sizes = { cellCount: 6, codeCellCount: 2, charLength: 480 }
+
+        it('maps the size dimensions for a real notebook', () => {
+            expect(buildNotebookSizeProperties(notebook(), false, sizes)).toEqual({
+                notebook_short_id: 'abc123',
+                notebook_cell_count: 6,
+                notebook_code_cell_count: 2,
+                notebook_char_length: 480,
+            })
+        })
+
+        it.each([
+            ['no notebook loaded', null, false],
+            ['scratchpad', 'scratchpad', false],
+            ['template', 'template-onboarding', false],
+            ['an anonymous shared view', 'abc123', true],
+        ])('returns null for %s so its size never registers', (_label, shortId, isShared) => {
+            const nb = shortId === null ? null : notebook({ short_id: shortId })
+            expect(buildNotebookSizeProperties(nb, isShared, sizes)).toBeNull()
+        })
+
+        // Guards the pollution risk: the keys we register must match the keys `beforeUnmount`
+        // unregisters. If the two drift, a size property leaks onto events on other pages.
+        it('emits exactly the keys listed for unregister', () => {
+            const properties = buildNotebookSizeProperties(notebook(), false, sizes)
+            expect(Object.keys(properties ?? {}).sort()).toEqual([...NOTEBOOK_SIZE_PROPERTY_KEYS].sort())
+        })
     })
 })

--- a/frontend/src/scenes/notebooks/Notebook/notebookAnalytics.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookAnalytics.ts
@@ -32,3 +32,48 @@ export function buildNotebookOpenedEvent(
         node_count: notebook.content?.content?.length ?? 0,
     }
 }
+
+// Analytics contract — frozen wire strings. Do not rename: breakdowns of `react_framerate` and
+// `$web_vitals` by notebook size depend on these exact keys.
+export const NOTEBOOK_SIZE_PROPERTY_KEYS = [
+    'notebook_short_id',
+    'notebook_cell_count',
+    'notebook_code_cell_count',
+    'notebook_char_length',
+] as const
+
+export type NotebookSizeProperties = {
+    notebook_short_id: string
+    notebook_cell_count: number
+    notebook_code_cell_count: number
+    notebook_char_length: number
+}
+
+/**
+ * Builds the notebook-size super-properties, or `null` when the notebook is not a real persisted
+ * notebook (scratchpad / template) or is an anonymous shared view. Registering these while a
+ * notebook is open lets the existing `react_framerate` and `$web_vitals` events be sliced by
+ * notebook size, so we can tell whether responsiveness degrades as a notebook grows.
+ */
+export function buildNotebookSizeProperties(
+    notebook: NotebookType | null,
+    isShared: boolean,
+    sizes: { cellCount: number; codeCellCount: number; charLength: number }
+): NotebookSizeProperties | null {
+    const shortId = notebook?.short_id
+    if (
+        !notebook ||
+        !shortId ||
+        shortId === SCRATCHPAD_NOTEBOOK.short_id ||
+        shortId.startsWith('template-') ||
+        isShared
+    ) {
+        return null
+    }
+    return {
+        notebook_short_id: shortId,
+        notebook_cell_count: sizes.cellCount,
+        notebook_code_cell_count: sizes.codeCellCount,
+        notebook_char_length: sizes.charLength,
+    }
+}

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -31,6 +31,7 @@ import {
     tryApplyTextChanges,
 } from 'lib/components/MarkdownNotebook/collaboration'
 import type { TextChange } from 'lib/components/MarkdownNotebook/collaboration'
+import { parseMarkdownNotebook } from 'lib/components/MarkdownNotebook/markdown'
 import type { MarkdownNotebookCaretPosition, RemoteNotebookCaret } from 'lib/components/MarkdownNotebook/remoteCarets'
 import type { NotebookCollaborationConflict } from 'lib/components/MarkdownNotebook/types'
 import { JSONContent } from 'lib/components/RichContentEditor/types'
@@ -103,7 +104,7 @@ import {
     notebookArtifactContentToMarkdown,
 } from './markdownNotebookV2'
 import { NOTEBOOKS_VERSION, migrate } from './migrations/migrate'
-import { buildNotebookOpenedEvent } from './notebookAnalytics'
+import { NOTEBOOK_SIZE_PROPERTY_KEYS, buildNotebookOpenedEvent, buildNotebookSizeProperties } from './notebookAnalytics'
 import { shouldWarnBeforeLeavingNotebook } from './notebookBeforeUnload'
 import { notebookKernelInfoLogic } from './notebookKernelInfoLogic'
 import type { NotebookKernelInfo } from './notebookKernelInfoLogic'
@@ -349,6 +350,7 @@ export interface notebookLogicValues {
     nodeLogics: Record<string, BuiltLogic<notebookNodeLogicType>>
     nodeLogicsWithChildren: BuiltLogic<notebookNodeLogicType>[]
     notebook: NotebookType | null
+    notebookBlockCount: number
     notebookLoading: boolean
     notebookMissing: boolean
     notebookPresenceParticipants: NotebookPresenceParticipant[]
@@ -426,6 +428,9 @@ export interface notebookLogicActions {
         value: true
     }
     copyMarkdown: () => {
+        value: true
+    }
+    registerNotebookSizeProperties: () => {
         value: true
     }
     disconnectMarkdownUpdateStream: () => {
@@ -689,6 +694,7 @@ export interface notebookLogicMeta {
         sqlV2NodeSummaries: (content: JSONContent) => SqlV2NodeSummary[]
         frameNodeSummaries: (content: JSONContent) => NotebookFrameNodeSummary[]
         dependencyGraph: (content: JSONContent) => NotebookDependencyGraph
+        notebookBlockCount: (markdownEditorMarkdown: string) => number
         pythonNodeIndices: (content: JSONContent) => Map<string, number>
         sqlNodeIndices: (content: JSONContent) => Map<string, number>
         duckSqlNodeIndices: (content: JSONContent) => Map<string, number>
@@ -815,6 +821,8 @@ export const notebookLogic = kea<notebookLogicType>([
         exportJSON: true,
         downloadMarkdown: true,
         copyMarkdown: true,
+        /** Refresh the notebook-size super-properties so size-correlated telemetry stays current. */
+        registerNotebookSizeProperties: true,
         registerNodeLogic: (nodeId: string, nodeLogic: BuiltLogic<notebookNodeLogicType>) => ({ nodeId, nodeLogic }),
         unregisterNodeLogic: (nodeId: string) => ({ nodeId }),
         setEditable: (editable: boolean) => ({ editable }),
@@ -1442,6 +1450,12 @@ export const notebookLogic = kea<notebookLogicType>([
         sqlV2NodeSummaries: [(s) => [s.content], (content: JSONContent) => collectSqlV2Nodes(content)],
         frameNodeSummaries: [(s) => [s.content], (content: JSONContent) => collectNotebookFrameNodes(content)],
         dependencyGraph: [(s) => [s.content], (content: JSONContent) => buildNotebookDependencyGraph(content)],
+        // Total block count (all cell types), memoized on the markdown so it re-parses only when the
+        // document text changes. Read on the debounced content-change path, not per keystroke.
+        notebookBlockCount: [
+            (s) => [s.markdownEditorMarkdown],
+            (markdownEditorMarkdown: string): number => parseMarkdownNotebook(markdownEditorMarkdown).nodes.length,
+        ],
 
         pythonNodeIndices: [
             (s) => [s.content],
@@ -2030,6 +2044,7 @@ export const notebookLogic = kea<notebookLogicType>([
                     short_id: values.notebook?.short_id,
                     is_markdown: isMarkdownNotebookContent(values.content),
                 })
+                actions.registerNotebookSizeProperties()
             }
 
             if (!values.isLocalOnly && values.localContent && values.content && !values.notebookLoading) {
@@ -2097,6 +2112,7 @@ export const notebookLogic = kea<notebookLogicType>([
                     posthog.capture('notebook opened', openedEvent)
                 }
             }
+            actions.registerNotebookSizeProperties()
         },
         loadNotebookFailure: () => {
             actions.processPendingMarkdownStreamEvents()
@@ -2119,6 +2135,19 @@ export const notebookLogic = kea<notebookLogicType>([
         },
         copyMarkdown: async () => {
             await copyToClipboard(getMarkdownNotebookMarkdown(values.content), 'markdown')
+        },
+
+        registerNotebookSizeProperties: () => {
+            // Register size as super-properties so the existing `react_framerate` and `$web_vitals`
+            // events fired while this notebook is open carry it. `beforeUnmount` unregisters them.
+            const sizeProperties = buildNotebookSizeProperties(values.notebook, values.isShared, {
+                cellCount: values.notebookBlockCount,
+                codeCellCount: values.dependencyGraph.nodes.length,
+                charLength: values.markdownEditorMarkdown.length,
+            })
+            if (sizeProperties) {
+                posthog.register(sizeProperties)
+            }
         },
 
         setEditingNodeEditing: ({ nodeId, editing }) => {
@@ -2218,6 +2247,11 @@ export const notebookLogic = kea<notebookLogicType>([
     }),
 
     beforeUnmount(() => {
+        // Clear the size super-properties so they don't leak onto events on other pages.
+        for (const key of NOTEBOOK_SIZE_PROPERTY_KEYS) {
+            posthog.unregister(key)
+        }
+
         const hashParams = router.values.currentLocation.hashParams
         delete hashParams['🦔']
         router.actions.replace(


### PR DESCRIPTION
## Problem

People report the notebook editor feels slow, and believe it gets worse once a notebook grows past 5-6 cells. Existing telemetry already measures notebook-page responsiveness per client: `$web_vitals` INP and `react_framerate` both carry `$pathname`, and both carry the person and organization, so p50/p90/p99 already slice per user and per org. What they do not carry is the notebook's size, so the "worse with more cells" hypothesis cannot be tested from current data.

## Changes

- Notebook-page events (`react_framerate`, `$web_vitals`) now carry the open notebook's size, so responsiveness can break down by cell count for the first time. Nothing on screen changes.
- `notebookLogic` registers four super-properties while a notebook is open: `notebook_short_id`, `notebook_cell_count`, `notebook_code_cell_count`, `notebook_char_length`.
- Registration runs when the notebook loads and refreshes on each debounced content change, so the count tracks edits.
- `beforeUnmount` unregisters the four keys, so the size never rides on events on other pages.
- The properties do not register for scratchpad, template, or anonymous shared views.
- `buildNotebookSizeProperties` is a pure helper; a new memoized `notebookBlockCount` selector parses the markdown once per document change to count total blocks. `notebook_code_cell_count` reuses the existing `dependencyGraph` selector. This is deliberately a data-only change with no editor hot-path timing, so it stays cheap.

> [!NOTE]
> When a notebook is open in both the scene and the side panel at once, the two mounts share the super-properties (last-writer-wins), and closing one unregisters while the other stays open. The scene mount is the INP-relevant one, so this edge case does not affect the main measurement.

## How did you test this code?

- Extended `notebookAnalytics.test.ts` with `buildNotebookSizeProperties` cases: the mapped output, the four null-guards (no notebook, scratchpad, template, shared view), and a key-drift guard asserting the registered keys equal the `NOTEBOOK_SIZE_PROPERTY_KEYS` list that `beforeUnmount` unregisters. The drift guard catches the leak regression: if the two lists diverge, a size property escapes onto events on other pages.
- Ran the suite locally (`notebookAnalytics.test.ts`, 12 pass), `typescript:check`, and Oxlint/Oxfmt.
- Not run: the full frontend suite and any browser test; the register/unregister lifecycle is exercised only through the pure helper, not a mounted-logic test.

After data lands, these breakdowns become possible and return nothing today: `$web_vitals` INP p90/p99 by `notebook_code_cell_count`, and `react_framerate` `long_frame_count` by the same bucket.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5). The user asked whether notebook responsiveness was already measurable per client and, if not, to add it. Investigation used the PostHog MCP `execute-sql` tool against project 2 to confirm existing per-client and per-org data, then scoped the new work to the missing size dimension.
- Skills invoked: `/writing-kea-logics`, `/writing-tests`, `/writing-pr-descriptions`.
- Decision: registered size as super-properties on existing events rather than adding a dedicated commit-latency event, which keeps the change data-only and off the editor hot path. A follow-up commit-timing event stays available if the size breakdown confirms latency climbs with cell count.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
