### PR TITLE
fix(warehouse_sources): say whether an Azure scope or a role is wrong

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/azure_cost_management/azure_cost_management.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/azure_cost_management/azure_cost_management.py
@@ -89,6 +89,11 @@ def normalize_scope(scope: str) -> str:
     trimmed = raw.strip("/")
     if not trimmed:
         raise ValueError("Azure Cost Management scope is required")
+    # Every Cost Management scope names a collection and an id (`subscriptions/<id>`,
+    # `providers/Microsoft.Billing/billingAccounts/<id>`). A single segment is usually a bare
+    # subscription id copied out of the portal, and it can only 404 once it reaches Azure.
+    if "/" not in trimmed:
+        raise ValueError("Azure Cost Management scope must be an ARM path such as subscriptions/<subscription id>")
     return trimmed
 
 
@@ -387,6 +392,26 @@ class AzureCostManagementClient:
             return response.json()
 
 
+def _scope_probe_failure_message(error: Exception) -> str:
+    """Name the one thing to fix. Azure denies a scope the service principal may not read (403)
+    separately from a scope it cannot find (400/404), and the two need opposite fixes."""
+    status = getattr(getattr(error, "response", None), "status_code", None)
+    if status == 403:
+        return (
+            "The service principal cannot read Cost Management on this scope. "
+            "Give it the Cost Management Reader role on the scope, then connect again."
+        )
+    if status in (400, 404):
+        return (
+            "Azure has no Cost Management scope at this path. Check it is an Azure Resource "
+            "Manager path such as subscriptions/<subscription id>, then connect again."
+        )
+    return (
+        "Could not read Azure Cost Management for that scope. Check the scope path and that the "
+        "service principal has the Cost Management Reader role on it."
+    )
+
+
 def validate_credentials(
     tenant_id: str, client_id: str, client_secret: str, scope: str, api_version: str
 ) -> tuple[bool, Optional[str]]:
@@ -405,11 +430,8 @@ def validate_credentials(
 
     try:
         client.request("GET", _endpoint_url(normalized_scope, "dimensions", api_version))
-    except Exception:
-        return (
-            False,
-            "Could not read Azure Cost Management for that scope. Check the scope path and that the service principal has the Cost Management Reader role on it.",
-        )
+    except Exception as error:
+        return False, _scope_probe_failure_message(error)
 
     return True, None
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/azure_cost_management/tests/test_azure_cost_management.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/azure_cost_management/tests/test_azure_cost_management.py
@@ -176,6 +176,8 @@ class TestNormalizeScope:
             ("query_delimiter", "subscriptions/abc/resources?api-version=2021-04-01"),
             ("fragment_delimiter", "subscriptions/abc/resources#"),
             ("backslash", "subscriptions\\abc"),
+            # A bare subscription id, without the collection segment Azure needs in front of it.
+            ("single_segment", "00000000-0000-0000-0000-000000000000"),
         ]
     )
     def test_rejects_non_path_scopes(self, _name: str, raw: str) -> None:
@@ -517,6 +519,16 @@ class TestValidateCredentials:
 
         assert valid is False
         assert message is not None and "Cost Management Reader" in message
+
+    @parameterized.expand([(400,), (404,)])
+    def test_unknown_scope_reports_the_path_not_the_role(self, status: int) -> None:
+        session = _FakeSession([_token_response(), _FakeResponse(status, reason="Not Found")])
+        with mock.patch(f"{TRANSPORT_MODULE}.make_tracked_session", return_value=session):
+            valid, message = validate_credentials("tenant", "client", "secret", "subscriptions/abc", "2025-03-01")
+
+        assert valid is False
+        assert message is not None and "Azure Resource Manager path" in message
+        assert "Cost Management Reader" not in message
 
 
 def _run_rows(


### PR DESCRIPTION
## Problem

- Someone connecting Microsoft Azure Cost Management gets the same error whether their scope path is wrong or their service principal lacks a role, so they retry the credentials that were never the problem.
- The connect-time probe reads the scope's dimension catalog. Any failure returned one message naming both the scope path and the Cost Management Reader role.
- A bare subscription id, the value the Azure portal offers to copy, is a valid-looking scope that Azure can never resolve. It reached Azure and came back as that same ambiguous message.

## Changes

- A person whose service principal lacks the role now reads only that, and the wording matches the message the same failure produces during a sync.
- A person whose scope path Azure cannot find now reads only that, with the shape of a working path.
- A single-segment scope is rejected in the form, before any request. Every Cost Management scope names a collection and an id, so one segment cannot work.
- Failures with no status keep the previous combined message.
- No sync behavior changes. The probe still runs one request against the same endpoint.

## How did you test this code?

- Added a `validate_credentials` case for the 400 and 404 responses. No existing test covered them, so a scope Azure could not find was indistinguishable from a missing role.
- Added a `normalize_scope` case for a single-segment scope.
- Not checked: a real Azure tenant. That needs an app registration and a billing scope this sandbox has no access to.
- `ruff check` and `ruff format` pass on the touched files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The setup docs already describe the scope format this message points at.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code (Opus 5) from Replay Vision session summaries of the data warehouse new-source onboarding flow. Sessions showed repeated failed attempts on this connector, with the same scope-and-role error each time. Skills invoked: `/writing-pr-descriptions`.

Decisions along the way:

- Splitting the message by response status beat adding a scope-format check alone, because a correctly shaped scope still fails when only the role is missing.
- The 403 wording copies the existing entry in `get_non_retryable_errors`, so the same problem reads the same way at connect time and at sync time.
- The single-segment guard sits in `normalize_scope`, next to the other scope rules, rather than in the source config, so both the probe and the sync path enforce it.
- `gh pr list --state open --search` over the connector, the scope wording, and the maintainer's open PRs found nothing covering this.
- Nothing in this diff comes from the session summaries. The strings are written from the connector's own field labels and the Azure roles named in its caption.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
