### PR TITLE
feat(visual-review): shrink thumbnails and zoom snapshots

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -9041,13 +9041,13 @@ snapshots:
     scenes-app-visual-review-flakiness--unstable--light:
         hash: v1.k794b7964.b7ed7d1fd134416708818961f5d8c2c4ac1cfaa6d9337fc9798015cff0ff446c.ArB6eVT85c9Vwx5S4ZE5MvBPfo9KZ3VKqWYLUNLInMs
     scenes-app-visual-review-run--ready-to-finalize--dark:
-        hash: v1.k794b7964.f3a36b59f01f60089f80ec544c60c8c396a032af9f233293c2b7a8ef0551ac9d.sbAIU7T7p95O1GkL_UFuwnwKz7-fT7_NgeFLdTGW5rY
+        hash: v1.k794b7964.879549ba86b942a0497ef5b08bb0172ac58c62fe8da41a21584c82bea231db20.lG7LsOxr5tzXDBwFMJwt3c7IgoQuIH6h8qlUZnPNJVw
     scenes-app-visual-review-run--ready-to-finalize--light:
-        hash: v1.k794b7964.6d062d9079ba453f7727b285ee1898c4f14a18ea79e01d06a01940bd692e6509.TTJPqPDwloovibr-rtDoMoOLManmx7Mhy6BLlrHyfwA
+        hash: v1.k794b7964.0d8d3ddc1d9df90c6cd478955c3cdf9d8558b5c815cda8b0229df186ca9631b6.6Y2TI_P5yWT2O5LWBnfmoteb9CA1FxlTBMRi4F8L1tQ
     scenes-app-visual-review-run--tracking-only-master-run--dark:
-        hash: v1.k794b7964.2c95aa21c766c205eda18d90cdd9bf28c990a83c7ad37cac3561b5763b6c5b34.hsM-4UaeCtNfxMeRPzUnFY8oFzYqkwd3aql3bQOaJ7A
+        hash: v1.k794b7964.16fda1278ef2eb5cec07ca3903959e2701d2ff01e37c20a9b4e5cd013a765dd0.TQ9RJbHXN6hccxpL_rOIK0ylVS9s8KVzCjNgCZWqi6w
     scenes-app-visual-review-run--tracking-only-master-run--light:
-        hash: v1.k794b7964.82f2750059b1ef9ab2adb777da603d4d0985b7213235780f24377be11e601a5e.BdVEZ3jDXINsbZgssAvaGfjq_qmGcGOqm2AhdvSYmXg
+        hash: v1.k794b7964.0b4be0f88182eb58f126babc0e5ac2b7298d059c931fd6783eae41a51d02dd1b.juEjllaWH8Fvc3b0lQlS5q-BPokNkac-bVjJ5QZChIs
     scenes-app-web-analytics--web-analytics-dashboard--dark:
         hash: v1.k794b7964.55266a5db3b8220c100018a05bff0a022eb0a3c8d4bd48bfbd27d3b985a27be4.UEzOfjKha_a43TKv4CCrKtQGZ3RcjDK2G2CO8qWbsVA
     scenes-app-web-analytics--web-analytics-dashboard--light:

--- a/frontend/src/lib/components/VisualImageDiffViewer/VisualImageDiffViewer.test.tsx
+++ b/frontend/src/lib/components/VisualImageDiffViewer/VisualImageDiffViewer.test.tsx
@@ -1,0 +1,34 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { VisualImageDiffViewer } from './VisualImageDiffViewer'
+
+describe('VisualImageDiffViewer', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    it.each<[string, string, string]>([
+        ['before image', 'View before snapshot full screen', '/before.png'],
+        ['after image', 'View after snapshot full screen', '/after.png'],
+    ])('opens the clicked %s in a full-screen modal', async (_imageName, accessibleName, expectedUrl) => {
+        const user = userEvent.setup()
+
+        render(
+            <VisualImageDiffViewer
+                baselineUrl="/before.png"
+                currentUrl="/after.png"
+                diffUrl={null}
+                diffPercentage={1}
+                result="changed"
+            />
+        )
+
+        await user.click(screen.getByLabelText(accessibleName))
+
+        const zoomedImage = document.querySelector('[data-attr="visual-review-zoomed-image"] img')
+        expect(zoomedImage).toHaveAttribute('src', expectedUrl)
+    })
+})

--- a/frontend/src/lib/components/VisualImageDiffViewer/VisualImageDiffViewer.tsx
+++ b/frontend/src/lib/components/VisualImageDiffViewer/VisualImageDiffViewer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { LemonSegmentedButton, LemonSlider, LemonSwitch, LemonTag, type LemonTagType } from '@posthog/lemon-ui'
 
+import { LemonModal } from 'lib/lemon-ui/LemonModal'
 import { cn } from 'lib/utils/css-classes'
 
 export type VisualDiffResult = 'changed' | 'new' | 'removed' | 'unchanged'
@@ -102,6 +103,7 @@ interface ImagePanelProps {
     highlightedOverlayIndex?: number | null
     /** Fires on hover so a parent panel can sync. */
     onOverlayHover?: (index: number | null) => void
+    onClick?: () => void
 }
 
 function ImagePanel({
@@ -115,37 +117,54 @@ function ImagePanel({
     overlayHeight,
     highlightedOverlayIndex,
     onOverlayHover,
+    onClick,
 }: ImagePanelProps): JSX.Element {
     const hasOverlay = !!url && !!overlayBoxes && overlayBoxes.length > 0 && !!overlayWidth && !!overlayHeight
+    const image = url ? (
+        // `block` on the inline-block wrapper kills the implicit
+        // baseline-descender gap that nudges the SVG overlay a few
+        // pixels below the image's actual bottom edge.
+        <div className="relative inline-block max-w-full leading-none">
+            <img
+                src={url}
+                alt={label}
+                loading="lazy"
+                decoding="async"
+                className={cn('block h-auto bg-black/5', imgClassName || 'max-w-full')}
+                // eslint-disable-next-line react/forbid-dom-props
+                style={imgStyle}
+            />
+            {hasOverlay && (
+                <BboxOverlay
+                    boxes={overlayBoxes!}
+                    width={overlayWidth!}
+                    height={overlayHeight!}
+                    highlightedIndex={highlightedOverlayIndex ?? null}
+                    onHover={onOverlayHover}
+                />
+            )}
+        </div>
+    ) : null
+
     return (
         <div className="overflow-hidden rounded-lg border bg-bg-light inline-block max-w-full">
             <div className="px-2 py-1 text-[11px] font-semibold uppercase tracking-wide border-b bg-bg-3000">
                 {label}
             </div>
-            {url ? (
-                // `block` on the inline-block wrapper kills the implicit
-                // baseline-descender gap that nudges the SVG overlay a few
-                // pixels below the image's actual bottom edge.
-                <div className="relative inline-block max-w-full leading-none">
-                    <img
-                        src={url}
-                        alt={label}
-                        loading="lazy"
-                        decoding="async"
-                        className={cn('block h-auto bg-black/5', imgClassName || 'max-w-full')}
-                        // eslint-disable-next-line react/forbid-dom-props
-                        style={imgStyle}
-                    />
-                    {hasOverlay && (
-                        <BboxOverlay
-                            boxes={overlayBoxes!}
-                            width={overlayWidth!}
-                            height={overlayHeight!}
-                            highlightedIndex={highlightedOverlayIndex ?? null}
-                            onHover={onOverlayHover}
-                        />
-                    )}
-                </div>
+            {image ? (
+                onClick ? (
+                    <button
+                        type="button"
+                        onClick={onClick}
+                        aria-label={`View ${label.toLowerCase()} snapshot full screen`}
+                        data-attr="visual-review-zoom-image"
+                        className="block max-w-full cursor-zoom-in border-0 bg-transparent p-0 text-left"
+                    >
+                        {image}
+                    </button>
+                ) : (
+                    image
+                )
             ) : (
                 <EmptyImageState title={emptyTitle} />
             )}
@@ -364,6 +383,7 @@ export function VisualImageDiffViewer({
     const [blendPercentage, setBlendPercentage] = useState(50)
     const [showDiffOverlay, setShowDiffOverlay] = useState(false)
     const [diffOverlayOpacity, setDiffOverlayOpacity] = useState(55)
+    const [zoomedImage, setZoomedImage] = useState<{ url: string; label: string } | null>(null)
     const [flicker, setFlicker] = useState(false)
     const [flickerCurrentVisible, setFlickerCurrentVisible] = useState(false)
     const [draggingSplit, setDraggingSplit] = useState(false)
@@ -477,6 +497,11 @@ export function VisualImageDiffViewer({
                         emptyTitle="Before snapshot missing"
                         imgClassName={pixelatedClass}
                         imgStyle={pixelatedStyle}
+                        onClick={
+                            baselineUrl
+                                ? () => setZoomedImage({ url: baselineUrl, label: 'Before snapshot' })
+                                : undefined
+                        }
                     />
                     <ImagePanel
                         url={currentUrl}
@@ -484,6 +509,9 @@ export function VisualImageDiffViewer({
                         emptyTitle="After snapshot missing"
                         imgClassName={pixelatedClass}
                         imgStyle={pixelatedStyle}
+                        onClick={
+                            currentUrl ? () => setZoomedImage({ url: currentUrl, label: 'After snapshot' }) : undefined
+                        }
                         overlayBoxes={overlaySafeOnAfter ? overlayBoxesIfShown : undefined}
                         overlayWidth={overlayCoordWidth}
                         overlayHeight={overlayCoordHeight}
@@ -724,95 +752,112 @@ export function VisualImageDiffViewer({
     }
 
     return (
-        <section className={cn('overflow-hidden rounded-xl border bg-surface-primary shadow-sm', className)}>
-            <div className="border-b bg-gradient-to-r from-bg-light via-bg-light to-bg-light/70 p-3">
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                    <div className="flex flex-wrap items-center gap-2">
-                        <LemonTag type={RESULT_TAG_TYPES[result]}>{RESULT_LABELS[result]}</LemonTag>
-                        {diffLabel && <LemonTag type="muted">{diffLabel}</LemonTag>}
-                        {hasOverlayBoxes && (
-                            <LemonSwitch
-                                checked={showClusters}
-                                onChange={setShowClusters}
-                                size="xsmall"
-                                label="Clusters"
-                                bordered
+        <>
+            <section className={cn('overflow-hidden rounded-xl border bg-surface-primary shadow-sm', className)}>
+                <div className="border-b bg-gradient-to-r from-bg-light via-bg-light to-bg-light/70 p-3">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                        <div className="flex flex-wrap items-center gap-2">
+                            <LemonTag type={RESULT_TAG_TYPES[result]}>{RESULT_LABELS[result]}</LemonTag>
+                            {diffLabel && <LemonTag type="muted">{diffLabel}</LemonTag>}
+                            {hasOverlayBoxes && (
+                                <LemonSwitch
+                                    checked={showClusters}
+                                    onChange={setShowClusters}
+                                    size="xsmall"
+                                    label="Clusters"
+                                    bordered
+                                />
+                            )}
+                            {isSmallImage && (
+                                <LemonTag type="highlight" className="font-bold">
+                                    Enlarged 2x for review
+                                </LemonTag>
+                            )}
+                        </div>
+                        {supportsComparison && (
+                            <LemonSegmentedButton
+                                size="small"
+                                value={mode}
+                                onChange={(newMode) => setMode(newMode)}
+                                options={comparisonModes}
                             />
                         )}
-                        {isSmallImage && (
-                            <LemonTag type="highlight" className="font-bold">
-                                Enlarged 2x for review
-                            </LemonTag>
-                        )}
                     </div>
-                    {supportsComparison && (
-                        <LemonSegmentedButton
-                            size="small"
-                            value={mode}
-                            onChange={(newMode) => setMode(newMode)}
-                            options={comparisonModes}
-                        />
-                    )}
-                </div>
 
-                {supportsComparison && mode !== 'sideBySide' && mode !== 'diff' && (
-                    <div className="mt-3 flex flex-wrap items-center gap-4 rounded-lg border bg-surface-primary px-3 py-2">
-                        {mode === 'split' && hasBothImages && (
-                            <LemonSwitch checked={flicker} onChange={setFlicker} size="small" label="Flicker" />
-                        )}
-                        {mode === 'blend' && (
-                            <div className="flex min-w-60 flex-1 items-center gap-3">
-                                <span className="text-xs text-muted-foreground whitespace-nowrap">Before → After</span>
-                                <LemonSlider
-                                    min={0}
-                                    max={100}
-                                    step={1}
-                                    value={blendPercentage}
-                                    onChange={setBlendPercentage}
-                                    className="m-0 w-full"
-                                />
-                                <span className="text-xs tabular-nums text-muted-foreground w-10 text-right">
-                                    {blendPercentage}%
-                                </span>
-                            </div>
-                        )}
-                        {hasDiffImage && (
-                            <>
-                                <LemonSwitch
-                                    checked={showDiffOverlay}
-                                    onChange={setShowDiffOverlay}
-                                    size="small"
-                                    label="Diff overlay"
-                                />
-                                <div
-                                    className={cn(
-                                        'flex min-w-60 flex-1 items-center gap-3 transition-opacity',
-                                        showDiffOverlay ? 'opacity-100' : 'opacity-40 pointer-events-none'
-                                    )}
-                                    aria-hidden={!showDiffOverlay}
-                                >
+                    {supportsComparison && mode !== 'sideBySide' && mode !== 'diff' && (
+                        <div className="mt-3 flex flex-wrap items-center gap-4 rounded-lg border bg-surface-primary px-3 py-2">
+                            {mode === 'split' && hasBothImages && (
+                                <LemonSwitch checked={flicker} onChange={setFlicker} size="small" label="Flicker" />
+                            )}
+                            {mode === 'blend' && (
+                                <div className="flex min-w-60 flex-1 items-center gap-3">
                                     <span className="text-xs text-muted-foreground whitespace-nowrap">
-                                        Overlay opacity
+                                        Before → After
                                     </span>
                                     <LemonSlider
                                         min={0}
                                         max={100}
                                         step={1}
-                                        value={diffOverlayOpacity}
-                                        onChange={setDiffOverlayOpacity}
+                                        value={blendPercentage}
+                                        onChange={setBlendPercentage}
                                         className="m-0 w-full"
                                     />
                                     <span className="text-xs tabular-nums text-muted-foreground w-10 text-right">
-                                        {diffOverlayOpacity}%
+                                        {blendPercentage}%
                                     </span>
                                 </div>
-                            </>
-                        )}
-                    </div>
-                )}
-            </div>
+                            )}
+                            {hasDiffImage && (
+                                <>
+                                    <LemonSwitch
+                                        checked={showDiffOverlay}
+                                        onChange={setShowDiffOverlay}
+                                        size="small"
+                                        label="Diff overlay"
+                                    />
+                                    <div
+                                        className={cn(
+                                            'flex min-w-60 flex-1 items-center gap-3 transition-opacity',
+                                            showDiffOverlay ? 'opacity-100' : 'opacity-40 pointer-events-none'
+                                        )}
+                                        aria-hidden={!showDiffOverlay}
+                                    >
+                                        <span className="text-xs text-muted-foreground whitespace-nowrap">
+                                            Overlay opacity
+                                        </span>
+                                        <LemonSlider
+                                            min={0}
+                                            max={100}
+                                            step={1}
+                                            value={diffOverlayOpacity}
+                                            onChange={setDiffOverlayOpacity}
+                                            className="m-0 w-full"
+                                        />
+                                        <span className="text-xs tabular-nums text-muted-foreground w-10 text-right">
+                                            {diffOverlayOpacity}%
+                                        </span>
+                                    </div>
+                                </>
+                            )}
+                        </div>
+                    )}
+                </div>
 
-            {supportsComparison ? renderComparisonBody() : renderSingleImageBody()}
-        </section>
+                {supportsComparison ? renderComparisonBody() : renderSingleImageBody()}
+            </section>
+            <LemonModal
+                isOpen={!!zoomedImage}
+                onClose={() => setZoomedImage(null)}
+                fullScreen
+                simple
+                data-attr="visual-review-zoomed-image"
+            >
+                <div className="flex h-full min-h-0 items-center justify-center bg-bg-3000 p-4">
+                    {zoomedImage && (
+                        <img src={zoomedImage.url} alt={zoomedImage.label} className="h-full w-full object-contain" />
+                    )}
+                </div>
+            </LemonModal>
+        </>
     )
 }

--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -96,13 +96,13 @@ function SnapshotThumbnail({
                     </span>
                 </>
             )}
-            <div className="w-[125px] h-[86px] rounded-sm overflow-hidden bg-bg-3000 relative">
+            <div className="w-[84px] h-[58px] rounded-sm overflow-hidden bg-bg-3000 relative">
                 {imgSrc ? (
                     <img
                         src={imgSrc}
                         alt=""
-                        width={125}
-                        height={86}
+                        width={84}
+                        height={58}
                         loading="lazy"
                         decoding="async"
                         className={`w-full h-full object-contain ${isQuarantined ? 'grayscale opacity-40' : ''}`}
@@ -119,7 +119,7 @@ function SnapshotThumbnail({
                     </span>
                 )}
             </div>
-            <div className="flex items-center gap-1 max-w-[130px] w-full">
+            <div className="flex items-center gap-1 max-w-[87px] w-full">
                 {hasDiff ? (
                     <SnapshotChangeBadge snapshot={snapshot} size="small" />
                 ) : (


### PR DESCRIPTION
🤖 Robot update

## Problem

Visual review thumbnails take space away from the story under review. Before and after images also need a clearer full-screen view.

## Changes

- Review thumbnails now use about 67% of their previous width and height.
- Clicking Before or After opens that image in a full-screen viewer.
- The viewer preserves the image aspect ratio while filling the available screen.
- The shared image viewer owns the zoom state and modal.
- A parameterized UI test covers both image paths.
- Screenshots were not captured because the Storybook browser route did not render in this environment.

## How did you test this code?

- `pnpm --filter=@posthog/frontend exec jest frontend/src/lib/components/VisualImageDiffViewer/VisualImageDiffViewer.test.tsx --runInBand`
- `pnpm storybook -- --ci --smoke-test`
- `pnpm --filter=@posthog/frontend fix`
- `pnpm exec oxlint frontend/src/lib/components/VisualImageDiffViewer/VisualImageDiffViewer.tsx frontend/src/lib/components/VisualImageDiffViewer/VisualImageDiffViewer.test.tsx products/visual_review/frontend/scenes/VisualReviewRunScene.tsx`
- `VIRTUAL_ENV=\"$PWD/.venv\" bin/hogli ci:preflight --fix`
- `pnpm --filter=@posthog/frontend typescript:check` did not pass because unrelated Quill export and module resolution errors remain in other products.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- No open pull request matched this change.
- The test covers the new zoom behavior. Thumbnail sizing is static styling.
- Skills invoked: `/writing-ui-components`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/running-ci-preflight`, and `/writing-pr-descriptions`.
- No private customer or internal material was used.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*