### PR TITLE
fix(hobby): bind the minio ports to localhost

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -370,9 +370,12 @@ services:
         logging: *default-logging
         volumes:
             - objectstorage:/data
+        # web/worker/plugins reach MinIO as objectstorage:19000 over the compose network and
+        # the root credentials above are fixed, so keep the API and console off public
+        # interfaces — same as the seaweedfs ports below.
         ports:
-            - '19000:19000'
-            - '19001:19001'
+            - '127.0.0.1:19000:19000'
+            - '127.0.0.1:19001:19001'
 
     seaweedfs:
         extends:


### PR DESCRIPTION
## Problem

A default hobby install publishes MinIO's S3 API (`19000`) and web console (`19001`) on every interface, with the root credentials fixed in the compose file (`object_storage_root_user` / `object_storage_root_password`). Anyone who can reach the host on those ports can log into the console and read or write everything in object storage — exports, batch-export files, data-warehouse files.

Nothing outside the stack needs them: `web`, `worker`, `plugins`, and `bin/migrate-storage-hobby` all reach MinIO as `objectstorage:19000` over the compose network.

## Changes

- Bind `19000` and `19001` to `127.0.0.1`, matching how the `seaweedfs` ports directly below are already published. Host-local tooling keeps working; the ports just stop being reachable from outside the machine.

Compose-only change.

## How did you test this code?

Running with exactly this binding on a hobby deployment since July — object storage for `web`/`worker`/`plugins`, CSV exports, and the MinIO→SeaweedFS migration script all unaffected. `docker compose config` validates the patched file.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.
