### PR TITLE
fix(settings): parse OPT_OUT_CAPTURE as a boolean

### DIFF
--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -2102,7 +2102,7 @@ def redirect_to_site(request):
     if toolbar_flags_key:
         params["toolbarFlagsKey"] = toolbar_flags_key
 
-    if not settings.TEST and not os.environ.get("OPT_OUT_CAPTURE"):
+    if not settings.TEST and not settings.OPT_OUT_CAPTURE:
         params["instrument"] = True
         params["userEmail"] = request.user.email
         params["distinctId"] = request.user.distinct_id

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -97,7 +97,7 @@ class PostHogConfig(AppConfig):
         if settings.E2E_TESTING:
             posthoganalytics.api_key = "phc_ex7Mnvi4DqeB6xSQoXU1UVPzAmUIpiciRKQQXGGTYQO"  # ty: ignore[invalid-assignment]
             posthoganalytics.personal_api_key = None
-        elif settings.TEST or os.environ.get("OPT_OUT_CAPTURE", False):
+        elif settings.TEST or settings.OPT_OUT_CAPTURE:
             posthoganalytics.disabled = True  # ty: ignore[invalid-assignment]
         elif settings.DEBUG:
             # In dev, analytics is by default turned to self-capture, i.e. data going into this very instance of PostHog


### PR DESCRIPTION
## Problem

`OPT_OUT_CAPTURE` can't be turned off. `posthog/apps.py` checks `os.environ.get("OPT_OUT_CAPTURE", False)`, so any non-empty value — including the literal `false` that `docker-compose.hobby.yml` passes by default (`${OPT_OUT_CAPTURE:-false}`) — disables the `posthoganalytics` client. Every hobby `web` therefore runs with backend telemetry off regardless of what the operator set, and `posthog/api/user.py` makes the same string check when deciding whether to instrument the toolbar.

`settings.OPT_OUT_CAPTURE` (`settings/base_variables.py`) already parses the variable with `str_to_bool` and is what preflight reports, so the two currently disagree.

## Changes

- `posthog/apps.py` and `posthog/api/user.py` read `settings.OPT_OUT_CAPTURE` instead of the raw environment string.

Behaviour change worth stating plainly: hobby installs that keep the default `false` start sending PostHog's own product analytics, which is the documented default. `OPT_OUT_CAPTURE=1`/`true` keeps working exactly as before.

## How did you test this code?

`python -m py_compile` on both files. Not exercised at runtime — the change swaps a raw env read for the existing, already-parsed setting; CI covers the preflight and user endpoints.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.
