### PR TITLE
fix(hobby): let caddy trust x-forwarded-* from private-range proxies

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -17,6 +17,12 @@ services:
             CADDYFILE: |
                 {
                 ${CADDY_TLS_BLOCK:-}
+                # Honour X-Forwarded-* from a reverse proxy in front of Caddy (nginx or a cloud
+                # LB on the same host or VPC). Without this Caddy overwrites X-Forwarded-Proto
+                # with http, Django sees an insecure request, and SAML responses are rejected.
+                servers {
+                    trusted_proxies static private_ranges
+                }
                 }
                 ${CADDY_HOST:-http://localhost:8000} {
                     @replay-capture {


### PR DESCRIPTION
## Problem

Running hobby behind another reverse proxy that terminates TLS (nginx, Cloudflare → nginx, a cloud load balancer) breaks anything that needs the request scheme. The visible symptom is SAML login failing with `invalid_response` ("The response was received at http://… instead of https://…").

Cause: Caddy's global block has no `trusted_proxies`, so it overwrites the upstream `X-Forwarded-Proto: https` with `http`. Django's `SECURE_PROXY_SSL_HEADER` then sees `http`, `request.is_secure()` is false, and python3-saml rejects the assertion's `Destination`.

## Changes

- Add `servers { trusted_proxies static private_ranges }` to the Caddyfile global block in `docker-compose.base.yml`, so `X-Forwarded-*` from a proxy on a private address (same host, Docker network, VPC) is passed through.

Requests arriving directly at Caddy from public addresses are unaffected — Caddy still sets the headers itself. Compose-only change (the Caddyfile lives in the `CADDYFILE` literal).

## How did you test this code?

Hit and fixed on a hobby deployment behind nginx + Cloudflare. Before: the `AssertionConsumerServiceURL` in the generated `SAMLRequest` was `http://…` and login failed. After adding this block: `https://…`, SAML login works, and it has been running since July. `docker compose config` validates the patched file.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.
