### PR TITLE
fix(hobby): finish wiring the feature-flags service

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -112,6 +112,9 @@ services:
             # Point Django at the Rust feature-flags container; the setting
             # otherwise defaults to localhost:3001.
             FEATURE_FLAGS_SERVICE_URL: 'http://feature-flags:3001'
+            # Must match INTERNAL_REQUEST_TOKEN on the feature-flags service; flag test
+            # evaluation otherwise fails with "Internal request token not configured".
+            INTERNAL_REQUEST_TOKEN: ${INTERNAL_REQUEST_TOKEN:-$POSTHOG_SECRET}
             # The logs product uses a dedicated ClickHouse cluster config (separate
             # from CLICKHOUSE_HOST) whose host defaults to localhost and whose SECURE
             # defaults to true outside DEBUG. Point it at the stack's ClickHouse over
@@ -175,6 +178,9 @@ services:
             # Point Django at the Rust feature-flags container; the setting
             # otherwise defaults to localhost:3001.
             FEATURE_FLAGS_SERVICE_URL: 'http://feature-flags:3001'
+            # Must match INTERNAL_REQUEST_TOKEN on the feature-flags service; flag test
+            # evaluation otherwise fails with "Internal request token not configured".
+            INTERNAL_REQUEST_TOKEN: ${INTERNAL_REQUEST_TOKEN:-$POSTHOG_SECRET}
             # The logs product uses a dedicated ClickHouse cluster config (separate
             # from CLICKHOUSE_HOST) whose host defaults to localhost and whose SECURE
             # defaults to true outside DEBUG. Point it at the stack's ClickHouse over
@@ -473,6 +479,9 @@ services:
             # Point Django at the Rust feature-flags container; the setting
             # otherwise defaults to localhost:3001.
             FEATURE_FLAGS_SERVICE_URL: 'http://feature-flags:3001'
+            # Must match INTERNAL_REQUEST_TOKEN on the feature-flags service; flag test
+            # evaluation otherwise fails with "Internal request token not configured".
+            INTERNAL_REQUEST_TOKEN: ${INTERNAL_REQUEST_TOKEN:-$POSTHOG_SECRET}
             # The logs product uses a dedicated ClickHouse cluster config (separate
             # from CLICKHOUSE_HOST) whose host defaults to localhost and whose SECURE
             # defaults to true outside DEBUG. Point it at the stack's ClickHouse over
@@ -572,6 +581,16 @@ services:
             file: docker-compose.base.yml
             service: feature-flags
         logging: *default-logging
+        environment:
+            # HyperCache's S3 tier. With no endpoint the AWS SDK dials real S3 on every Redis
+            # miss and waits out its retries (~4s) before falling back to Postgres, which pushes
+            # /flags past REQUEST_TIMEOUT_MS. Use the stack's object store, like web and worker.
+            OBJECT_STORAGE_ENDPOINT: http://objectstorage:19000
+            AWS_ACCESS_KEY_ID: 'object_storage_root_user'
+            AWS_SECRET_ACCESS_KEY: 'object_storage_root_password'
+            # Shared secret for authenticated Django → flags calls (flag test evaluation);
+            # must match INTERNAL_REQUEST_TOKEN on web and worker.
+            INTERNAL_REQUEST_TOKEN: ${INTERNAL_REQUEST_TOKEN:-$POSTHOG_SECRET}
         depends_on:
             - db
             - redis7


### PR DESCRIPTION
## Problem

Two things on the hobby `feature-flags` service were never wired up:

1. **`/flags` takes ~4 s on every Redis miss and 503s under load.** The service's HyperCache reads Redis → S3 → Postgres. With `OBJECT_STORAGE_ENDPOINT` empty, the AWS SDK dials real S3, waits out its retries, then falls back to Postgres — pushing requests past `REQUEST_TIMEOUT_MS` (4500 ms). `canonical_log_line` shows `duration_ms ~4160` with every sub-stage at 0 ms and `flags_cache_source: fallback`. Every other S3-using hobby service (`web`, `worker`, `plugins`, `cymbal`) already gets an endpoint.
2. **Flag "Test evaluation" fails with "Internal request token not configured".** Django (`settings.INTERNAL_REQUEST_TOKEN`, default `""`) and the flags service must share `INTERNAL_REQUEST_TOKEN`; hobby sets it on neither (dev compose sets `dev-internal-token`).

## Changes

- `feature-flags`: point the S3 tier at the stack's object store with the credentials `web`/`worker` use, so a miss resolves locally in milliseconds instead of timing out against AWS.
- `feature-flags`, `web`, `worker`, `temporal-django-worker`: `INTERNAL_REQUEST_TOKEN: ${INTERNAL_REQUEST_TOKEN:-$POSTHOG_SECRET}`, following the `INTERNAL_API_SECRET` fallback `recording-api` already uses. A dedicated secret can be generated in `bin/deploy-hobby` later if preferred.

Compose-only change.

## How did you test this code?

Both applied on a hobby deployment: `/flags` went from ~4.2 s (503s under load) to ~8 ms, and flag test evaluation works with the shared token. `docker compose config` validates the patched file.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.
