### PR TITLE
fix(temporal): let a single worker service every task queue on hobby

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -109,6 +109,10 @@ services:
             BROWSERLESS_TOKEN: ${BROWSERLESS_SECRET:-$POSTHOG_SECRET}
             HEATMAP_BROWSERLESS_URL: 'http://browserless:3000'
             HEATMAP_BROWSERLESS_TOKEN: ${BROWSERLESS_SECRET:-$POSTHOG_SECRET}
+            # Hobby runs a single temporal-django-worker. Collapse every Temporal task queue
+            # onto the one it polls, so workflows started on other queues (exports, Max AI,
+            # replay, batch exports, data warehouse) run instead of never being picked up.
+            TEMPORAL_USE_SINGLE_TASK_QUEUE: 'true'
             # Point Django at the Rust feature-flags container; the setting
             # otherwise defaults to localhost:3001.
             FEATURE_FLAGS_SERVICE_URL: 'http://feature-flags:3001'
@@ -172,6 +176,10 @@ services:
             DEPLOYMENT: 'hobby'
             PERSONHOG_ADDR: 'personhog-router:50052'
             PERSONHOG_ENABLED: 'true'
+            # Hobby runs a single temporal-django-worker. Collapse every Temporal task queue
+            # onto the one it polls, so workflows started on other queues (exports, Max AI,
+            # replay, batch exports, data warehouse) run instead of never being picked up.
+            TEMPORAL_USE_SINGLE_TASK_QUEUE: 'true'
             # Point Django at the Rust feature-flags container; the setting
             # otherwise defaults to localhost:3001.
             FEATURE_FLAGS_SERVICE_URL: 'http://feature-flags:3001'
@@ -470,6 +478,10 @@ services:
             BROWSERLESS_TOKEN: ${BROWSERLESS_SECRET:-$POSTHOG_SECRET}
             HEATMAP_BROWSERLESS_URL: 'http://browserless:3000'
             HEATMAP_BROWSERLESS_TOKEN: ${BROWSERLESS_SECRET:-$POSTHOG_SECRET}
+            # Hobby runs a single temporal-django-worker. Collapse every Temporal task queue
+            # onto the one it polls, so workflows started on other queues (exports, Max AI,
+            # replay, batch exports, data warehouse) run instead of never being picked up.
+            TEMPORAL_USE_SINGLE_TASK_QUEUE: 'true'
             # Point Django at the Rust feature-flags container; the setting
             # otherwise defaults to localhost:3001.
             FEATURE_FLAGS_SERVICE_URL: 'http://feature-flags:3001'

--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -550,7 +550,7 @@ def workflows_include_data_import_syncs(workflows: collections.abc.Iterable[type
     return any(wf in DATA_SYNC_WORKFLOWS for wf in workflows)
 
 
-if settings.DEBUG:
+if settings.DEBUG or settings.TEMPORAL_USE_SINGLE_TASK_QUEUE:
     TASK_QUEUE_METRIC_PREFIXES = {}
 else:
     TASK_QUEUE_METRIC_PREFIXES = {

--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -211,13 +211,21 @@ CLICKHOUSE_MAX_BLOCK_SIZE_OVERRIDES: dict[int, int] = dict(
 # Temporal has a limitation where a worker can only listen to a single queue.
 # To avoid running multiple workers, when running locally (DEBUG=True), we use a single queue for all tasks.
 # In production (DEBUG=False), we use separate queues for each worker type.
+# Self-hosted stacks that run one temporal-django-worker (hobby) opt into the same collapse with
+# TEMPORAL_USE_SINGLE_TASK_QUEUE, so every workflow is scheduled on the queue that worker polls
+# instead of on queues nothing services.
+TEMPORAL_USE_SINGLE_TASK_QUEUE: bool = get_from_env("TEMPORAL_USE_SINGLE_TASK_QUEUE", False, type_cast=str_to_bool)
+default_task_queue = os.getenv("TEMPORAL_TASK_QUEUE", "general-purpose-task-queue")
+
+
 def _set_temporal_task_queue(task_queue: str) -> str:
     if DEBUG:
         return "development-task-queue"
+    if TEMPORAL_USE_SINGLE_TASK_QUEUE:
+        return default_task_queue
     return task_queue
 
 
-default_task_queue = os.getenv("TEMPORAL_TASK_QUEUE", "general-purpose-task-queue")
 TEMPORAL_TASK_QUEUE: str = _set_temporal_task_queue(default_task_queue)
 DATA_WAREHOUSE_TASK_QUEUE = _set_temporal_task_queue("data-warehouse-task-queue")
 DATA_WAREHOUSE_CDP_PRODUCER_TASK_QUEUE = _set_temporal_task_queue("data-warehouse-cdp-producer-task-queue")


### PR DESCRIPTION
## Problem

On hobby, any feature that runs as a Temporal workflow on a queue other than `general-purpose-task-queue` silently does nothing. CSV/tabular export (`analytics-platform-task-queue`) creates an `ExportedAsset` whose content never arrives, replay exports (`session-replay-task-queue`) stall, and Max AI (`max-ai-task-queue`) sits on "pending" — even though `bin/deploy-hobby` now prompts for an Anthropic key to "enable PostHog AI". Hobby runs one `temporal-django-worker`, `start_temporal_worker --task-queue` takes exactly one queue, and nothing polls the rest.

Dev already solves this: with `DEBUG=True`, `_set_temporal_task_queue` collapses every queue name onto one, and `start_temporal_worker` aggregates specs per name (`defaultdict(set)`) precisely so one worker registers everything.

## Changes

- `posthog/settings/temporal.py`: new `TEMPORAL_USE_SINGLE_TASK_QUEUE` (default off) applies the same collapse outside `DEBUG`, onto `TEMPORAL_TASK_QUEUE`.
- `start_temporal_worker`: skip the per-queue metric prefixes when collapsed, as `DEBUG` already does.
- `docker-compose.hobby.yml`: set it on `web`, `worker`, and `temporal-django-worker`, so schedulers and the worker agree on queue names.

Net effect: the existing hobby worker services every queue — exports, Max AI, replay, batch exports, data warehouse — with no extra containers. The alternative, one `temporal-django-worker-*` per queue, costs roughly 1 GB RAM per worker on machines the hobby docs size at 4 GB. Cloud and any deployment not setting the variable are unchanged.

## How did you test this code?

`py_compile` and `docker compose config` on the patched files. Not run end-to-end in this exact form: on a live hobby deployment the queue gap was confirmed (export workflows scheduled on `analytics-platform-task-queue`, `content=NULL` forever) and fixed with per-queue sibling workers; the collapse itself is the `DEBUG` code path every dev stack runs. A maintainer sanity check that nothing registered on those queues assumes a dedicated worker would be welcome.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.
