### PR TITLE
fix(hobby): generate the oidc signing key at install and upgrade

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -158,10 +158,14 @@ else
     # Django's SECRET_KEY (the compose file falls back to POSTHOG_SECRET when unset, for
     # installs whose .env predates this variable).
     BROWSERLESS_SECRET=$(openssl rand -hex 32)
+    # RS256 signing key for the OAuth/OIDC provider (toolbar authentication, API-scoped tokens).
+    # Stored on one line with literal "\n" separators, which settings turn back into newlines.
+    OIDC_RSA_PRIVATE_KEY=$(openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 2>/dev/null | awk 'NR > 1 { printf "\\n" } { printf "%s", $0 }')
     cat > .env <<EOF
 POSTHOG_SECRET=$POSTHOG_SECRET
 ENCRYPTION_SALT_KEYS=$ENCRYPTION_SALT_KEYS
 BROWSERLESS_SECRET=$BROWSERLESS_SECRET
+OIDC_RSA_PRIVATE_KEY="$OIDC_RSA_PRIVATE_KEY"
 DOMAIN=$DOMAIN
 TLS_BLOCK=$TLS_BLOCK
 REGISTRY_URL=$REGISTRY_URL

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -139,6 +139,14 @@ else
     fi
 fi
 
+# Installs that predate the OAuth/OIDC signing key need one for toolbar authentication and
+# API-scoped tokens. Same one-line, "\n"-separated format bin/deploy-hobby writes.
+if ! grep -q "^OIDC_RSA_PRIVATE_KEY=" .env; then
+    OIDC_RSA_PRIVATE_KEY=$(openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 2>/dev/null | awk 'NR > 1 { printf "\\n" } { printf "%s", $0 }')
+    printf 'OIDC_RSA_PRIVATE_KEY="%s"\n' "$OIDC_RSA_PRIVATE_KEY" >> .env
+    echo "Added missing OIDC_RSA_PRIVATE_KEY to .env file"
+fi
+
 # PostHog's AI features (the Max assistant, SQL/regex assist) run on your own LLM provider key.
 # If none is configured yet, offer to add one. Existing keys are never touched — we only append
 # when the key is absent, so this is safe to run on every upgrade.

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -119,6 +119,9 @@ services:
             # (native port 9000, user "default", empty password).
             CLICKHOUSE_LOGS_CLUSTER_HOST: 'clickhouse'
             CLICKHOUSE_LOGS_CLUSTER_SECURE: 'false'
+            # RS256 key for the OAuth/OIDC provider (toolbar authentication, API-scoped
+            # tokens); written to .env by bin/deploy-hobby and bin/upgrade-hobby.
+            OIDC_RSA_PRIVATE_KEY: ${OIDC_RSA_PRIVATE_KEY:-}
             # AI provider keys for PostHog's AI features. Blank unless set in .env.
             ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
             OPENAI_API_KEY: ${OPENAI_API_KEY:-}
@@ -182,6 +185,9 @@ services:
             # (native port 9000, user "default", empty password).
             CLICKHOUSE_LOGS_CLUSTER_HOST: 'clickhouse'
             CLICKHOUSE_LOGS_CLUSTER_SECURE: 'false'
+            # RS256 key for the OAuth/OIDC provider (toolbar authentication, API-scoped
+            # tokens); written to .env by bin/deploy-hobby and bin/upgrade-hobby.
+            OIDC_RSA_PRIVATE_KEY: ${OIDC_RSA_PRIVATE_KEY:-}
             # AI provider keys for PostHog's AI features. Blank unless set in .env.
             ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
             OPENAI_API_KEY: ${OPENAI_API_KEY:-}
@@ -482,6 +488,9 @@ services:
             # Workload.LOGS.
             CLICKHOUSE_LOGS_CLUSTER_HOST: 'clickhouse'
             CLICKHOUSE_LOGS_CLUSTER_SECURE: 'false'
+            # RS256 key for the OAuth/OIDC provider (toolbar authentication, API-scoped
+            # tokens); written to .env by bin/deploy-hobby and bin/upgrade-hobby.
+            OIDC_RSA_PRIVATE_KEY: ${OIDC_RSA_PRIVATE_KEY:-}
             # AI provider keys for PostHog's AI features. Blank unless set in .env.
             ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
             OPENAI_API_KEY: ${OPENAI_API_KEY:-}


### PR DESCRIPTION
## Problem

Toolbar and heatmap authentication on hobby 500s ("Oops! Things went south") at `/toolbar_oauth/authorize/`: the OAuth provider signs RS256 tokens, and `posthog/api/oauth/toolbar_service.py` raises `You must set OIDC_RSA_PRIVATE_KEY to use RSA algorithm`. `bin/deploy-hobby` generates every other secret but never this one, so it is empty on every hobby install (the `TEST` branch in `settings/web.py` only generates an ephemeral key for the test suite).

## Changes

- `bin/deploy-hobby`: generate a 2048-bit RSA key on fresh installs and write it to `.env` as one double-quoted line with literal `\n` separators — the format `settings/web.py` already decodes.
- `bin/upgrade-hobby`: backfill a missing key on existing installs, next to the `ENCRYPTION_SALT_KEYS` backfill.
- `docker-compose.hobby.yml`: pass `OIDC_RSA_PRIVATE_KEY` to `web`, `worker`, and `temporal-django-worker` (empty when unset, so installs that bypass the scripts behave as today).

## How did you test this code?

- The exact generation command and `.env` line, round-tripped two ways through `docker compose config`: (a) compose reading `.env` directly, (b) after `set -a; . ./.env` as `bin/upgrade-hobby` does. Both yield a key that `openssl pkey -check` accepts after the `\n` decoding in settings; sourcing the line under `set -e` is clean.
- `bash -n` on both scripts.
- A key generated the same way has been running on a hobby deployment since July: toolbar authentication works and `get_or_create_toolbar_oauth_application` returns an RS256 app.
- Not run through a complete fresh `deploy-hobby` / `upgrade-hobby` execution.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.
