### PR TITLE
fix(hobby): pass PERSONHOG_ADDR to temporal-django-worker

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -485,6 +485,9 @@ services:
             # AI provider keys for PostHog's AI features. Blank unless set in .env.
             ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
             OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+            # Same as web and worker: Temporal activities that resolve group types go
+            # through personhog too.
+            PERSONHOG_ADDR: 'personhog-router:50052'
         depends_on:
             - db
             - redis7


### PR DESCRIPTION
## Problem

`PERSONHOG_ADDR` is set on `web`, `worker`, and `ingestion-general` in the hobby compose file but not on `temporal-django-worker`, so Temporal activities that resolve group types (Max AI tool-building, for one) call `require_personhog_client()` without a client. The fallback now degrades gracefully instead of crashing, but the worker still silently loses group-type data it should have.

## Changes

- `docker-compose.hobby.yml`: the same `PERSONHOG_ADDR: personhog-router:50052` on `temporal-django-worker`.

Compose-only change.

## How did you test this code?

`docker compose config` on the patched file. On a hobby deployment, adding this variable is what turned `get_group_types_for_project` from a `RuntimeError` into a working call (verified in July, before the fallback caught it).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.
