### PR TITLE
feat(hobby): add the capture-ai service so /i/v0/ai works

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -503,6 +503,14 @@ services:
             service: capture
         logging: *default-logging
 
+    capture-ai:
+        build:
+            context: ./posthog/rust
+        extends:
+            file: docker-compose.base.yml
+            service: capture-ai
+        logging: *default-logging
+
     capture-logs:
         build:
             context: ./posthog/rust


### PR DESCRIPTION
## Problem

`/i/v0/ai` returns 502 on hobby. The Caddyfile routes it to `capture-ai:3000`, `docker-compose.base.yml` defines the service, `kafka-init` pre-creates `events_plugin_ingestion_ai`, and `ingestion-general` (combined mode) already consumes that topic — only `docker-compose.hobby.yml` never adds the service, so the endpoint has nothing behind it.

## Changes

- Add `capture-ai` to the hobby compose file, mirroring the existing `capture-logs` block.

Compose-only change. `$ai_*` events sent through the regular `/e/` endpoint are unaffected (capture already routes them to the AI topic); this only makes the dedicated endpoint work.

## How did you test this code?

`docker compose config` only. Not exercised end-to-end — opened as a draft so someone with an AI-SDK setup can confirm a request to `/i/v0/ai` lands in `ai_events`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.
