### PR TITLE
fix(hobby): cap retention on the replay snapshot topic

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -632,7 +632,8 @@ services:
                     clickhouse_person_distinct_id \
                     clickhouse_app_metrics2 \
                     log_entries \
-                    clickhouse_tophog"
+                    clickhouse_tophog \
+                    session_recording_snapshot_item_events"
                 for topic in $$TOPICS; do
                     if rpk topic create "$$topic" --brokers kafka:9092 -p 1 -r 1 2>&1; then
                         echo "Topic $$topic created successfully"
@@ -645,6 +646,15 @@ services:
                         fi
                     fi
                 done
+                # The replay snapshot topic is a transport buffer a healthy consumer drains within
+                # seconds. Bound it so a stalled ingestion-sessionreplay can't grow it until the
+                # disk fills and takes the broker — and everything on it — down.
+                if rpk topic alter-config session_recording_snapshot_item_events --brokers kafka:9092 \
+                    --set retention.ms=86400000 --set retention.bytes=53687091200; then
+                    echo "Applied retention caps to session_recording_snapshot_item_events"
+                else
+                    echo "Failed to apply retention caps to session_recording_snapshot_item_events"
+                fi
                 echo "Final topic list:"
                 rpk topic list --brokers kafka:9092
                 echo "Topics ready"


### PR DESCRIPTION
## Problem

Hobby creates Kafka topics with no retention configuration, so any consumer outage turns a transport topic into a disk-filling backlog. Concretely: a stalled `ingestion-sessionreplay` let `session_recording_snapshot_item_events` grow to ~860 GB on a hobby deployment, filled the Docker volume, and crashed Redpanda, ZooKeeper, and ClickHouse together — a full outage caused by one lagging consumer.

The snapshot topic is a pure transport buffer: a healthy consumer drains it within seconds, so retention beyond a day only preserves data for an outage that has already lost the recordings' usefulness.

## Changes

- `kafka-init`: pre-create `session_recording_snapshot_item_events` and set `retention.ms=24h`, `retention.bytes=50 GB` on it. The `alter-config` runs on every init, so existing installs pick it up on their next `up`.

The numbers are a proposal — happy to change them; the point is that the topic is bounded at all.

## How did you test this code?

`docker compose config` on the patched file. Similar caps (100 GB / 24 h), applied with `rpk topic alter-config` during recovery on the affected deployment, have held the topic bounded since; the init-time application here has not been run through a fresh `kafka-init`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the session recording snapshot events topic to local Kafka environments.
  - Configured the topic with 24-hour retention and a 50 GiB storage limit.
  - Added status logging for the topic configuration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->