### PR TITLE
feat(warehouse-sources): promote Recharge and Gorgias to GA

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gorgias/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gorgias/source.py
@@ -128,7 +128,7 @@ Create an API key in your Gorgias account under **Settings → REST API**. Use t
 This source authenticates with HTTP Basic Auth (email + API key) and requires read access to the endpoints you want to sync (tickets, messages, customers, users, satisfaction surveys, tags, views, teams, macros).""",
             iconPath="/static/services/gorgias.png",
             docsUrl="https://posthog.com/docs/cdp/sources/gorgias",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.GA,
             fields=cast(
                 list[FieldType],
                 [

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/recharge/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/recharge/source.py
@@ -70,7 +70,7 @@ Some resources (such as Payment methods) are only available on Recharge Pro or C
 """,
             iconPath="/static/services/recharge.png",
             docsUrl="https://posthog.com/docs/cdp/sources/recharge",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.GA,
             fields=cast(
                 list[FieldType],
                 [


### PR DESCRIPTION
## Problem

People connecting Recharge or Gorgias see an "Alpha" label on the connector, which signals the source is new and lightly tested. Both have been live for over three months and now run clean, so the label understates how ready they are.

Neither source is gated by a feature flag or `unreleasedSource`, so this only changes the label.

- Recharge: live 3.1 months, 0.0% import error rate over the last 7 days.
- Gorgias: live 3.1 months, 0.0% import error rate over the last 7 days.

The bar for GA is 100+ teams or 3+ months live, plus an import error rate under 2.5%. Both clear it on the time-in-production route.

## Changes

- The new-source wizard shows Recharge and Gorgias without an "Alpha" badge.
- Each source sets `releaseStatus=ReleaseStatus.GA` in `get_source_config`, replacing `ReleaseStatus.ALPHA`. That is the whole diff: one line per source, and no gating, schema, or sync logic moves.

No screenshot: the change removes a badge the frontend renders from `releaseStatus`, and the connector tile is otherwise identical.

## How did you test this code?

- `ruff check` and `ruff format --check` pass on both changed files.
- No test asserts the release status of either source, so nothing needed updating. Confirmed by searching both sources' test directories and the shared source tests.
- Not run: the warehouse source suites. A single enum member swap on a declarative config field has no runtime behavior for them to cover, and CI runs them anyway.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The posthog.com docs for both sources do not state a release stage.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Opus 5 through PostHog Desktop, from a task listing the two sources and their current metrics.
- Skills invoked: `/implementing-warehouse-sources` for where `releaseStatus` lives and the enum convention, `/writing-pr-descriptions` for this body.
- Checked for duplicates first: searched open PRs for each source name, "releaseStatus", and "promote", and listed every open PR authored by Gilbert09. Nothing open touches the release status of either source.
- Decision: 33 sources already spell out `ReleaseStatus.GA` rather than omitting the field, so these follow that convention instead of dropping the line.
- Public artifact: the diff and this description contain only source names, release status, and the metrics the task supplied. No customer or session material.
