### PR TITLE
feat(warehouse-sources): promote the Calendly source to GA

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/calendly/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/calendly/source.py
@@ -92,7 +92,7 @@ class CalendlySource(
             name=SchemaExternalDataSourceType.CALENDLY,
             category=DataWarehouseSourceCategory.PRODUCTIVITY,
             label="Calendly",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.GA,
             caption="""Enter your Calendly personal access token to pull your Calendly data into the PostHog Data warehouse.
 
 You can create a personal access token in Calendly under **Integrations → API & Webhooks**. A personal access token requires a paid Calendly plan.""",


### PR DESCRIPTION
## Problem

People browsing the data warehouse source catalog see Calendly tagged "Alpha", which reads as a warning that the connector is unproven. It no longer is: it has been live for over three months with a clean import record, so the label understates how ready it is and discourages teams from connecting it.

## Changes

- Calendly now shows as generally available in the source picker instead of carrying the "Alpha" tag. Nothing else about connecting or syncing the source changes.
- `releaseStatus` on the Calendly `SourceConfig` moves from `ReleaseStatus.ALPHA` to `ReleaseStatus.GA`. That is the whole diff — one line.

Gating was deliberately left alone. Calendly has no `unreleasedSource` flag and no `featureFlag`, so there is nothing to remove; the source was already visible and connectable to everyone. The webhook hog function template keeps `status="alpha"`, which is the convention every warehouse-source webhook template follows, including GA sources like GitHub and Customer.io.

Promotion criteria, measured over the last 7 days:

- Live for 3.1 months, clearing the "100+ teams or 3+ months" bar on time-in-market.
- Import error rate of 0.0%, against a threshold of 2.5%.

## How did you test this code?

No tests were run for this change. It swaps one enum member in a config declaration, changes no behavior, schema, or sync logic, and no test asserts Calendly's release status.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The posthog.com Calendly doc does not state a release stage.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code (Opus 5). Skills invoked: `/implementing-warehouse-sources` for the release-status conventions, `/writing-pr-descriptions` for this body.

The scope was deliberately held to the status field. The skill's release-status section describes `unreleasedSource` and `featureFlag` as the gating mechanisms and `releaseStatus` as a soft label, so with neither gate present on this source there was nothing to unwind alongside the promotion. The webhook template's `status` field belongs to the hog function template system rather than to the source's release stage, which a check across the other webhook-capable GA sources confirmed.

No duplicate: searched open PRs for "Calendly", "releaseStatus", "promote", and "general availability", and listed the data warehouse maintainer's open PRs in full. Nothing addresses this promotion. Every Calendly PR in the repo's history is already merged.

Public artifact: the diff, commit message, and this description contain nothing beyond what is already in this repository. The two metrics quoted above came from the task request.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
