### PR TITLE
chore(flags): remove fully rolled out flag gates

### DIFF
--- a/.agents/skills/visualizing-change-over-time/SKILL.md
+++ b/.agents/skills/visualizing-change-over-time/SKILL.md
@@ -90,10 +90,8 @@ There are **two** ways to render a slope graph; which you reach for depends on t
   the two slope points (the last segment is dashed when it's the current,
   still-accumulating period). Set it via `trendsFilter.display: "SlopeGraph"`
   (trends-only).
-  - In the **product insight editor**, the picker entry is gated behind
-    `FEATURE_FLAGS.SLOPE_GRAPH_INSIGHT` (`slope-graph-insight`).
-  - Via the **API / `posthog:insight-create` MCP tool** it works without the flag —
-    pass a `TrendsQuery` with `trendsFilter.display: "SlopeGraph"`. To frame a clean
-    before → after, choose the date range and `interval` so the first bucket is your
-    baseline and the last is "now" (e.g. monthly buckets starting from the baseline
-    month).
+  - The **product insight editor** includes the slope graph picker entry.
+  - Via the **API / `posthog:insight-create` MCP tool**, pass a `TrendsQuery` with
+    `trendsFilter.display: "SlopeGraph"`. To frame a clean before-and-after, choose
+    the date range and `interval` so the first bucket is your baseline and the last is
+    "now" (e.g. monthly buckets starting from the baseline month).

--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -29,10 +29,7 @@ from posthog.api.forbid_destroy_model import ForbidDestroyModel
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.cloud_utils import is_cloud
-from posthog.constants import (
-    SUBSCRIPTION_AI_PROMPT_FEATURE_FLAG_KEY,
-    SUBSCRIPTION_AI_SUMMARY_PROMPT_GUIDE_FEATURE_FLAG_KEY,
-)
+from posthog.constants import SUBSCRIPTION_AI_PROMPT_FEATURE_FLAG_KEY
 from posthog.dataclasses import frozen
 from posthog.event_usage import get_request_analytics_properties, groups
 from posthog.exceptions import QuotaLimitExceeded
@@ -656,15 +653,9 @@ class SubscriptionSerializer(serializers.ModelSerializer):
                 {"delivery_config": ["post_all_insights_in_main_message is only supported for Slack subscriptions."]}
             )
 
-        # Only gate non-empty writes to `summary_prompt_guide`. Clearing (empty string)
-        # and field-absent PATCHes always pass through so users aren't stuck with a value
-        # they can no longer edit if the flag flips off after they set one.
         prompt_guide = attrs.get("summary_prompt_guide")
-        if prompt_guide:
-            if len(prompt_guide) > 500:
-                raise ValidationError({"summary_prompt_guide": ["AI summary context must be 500 characters or fewer."]})
-            if not self._prompt_guide_feature_enabled():
-                raise exceptions.PermissionDenied("Setting AI summary context is not enabled for this organization.")
+        if prompt_guide and len(prompt_guide) > 500:
+            raise ValidationError({"summary_prompt_guide": ["AI summary context must be 500 characters or fewer."]})
 
         if attrs.get("summary_enabled"):
             organization = self.context["get_organization"]()
@@ -756,33 +747,6 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         except Exception:
             # Telemetry must never poison the validation path.
             pass
-
-    def _evaluate_feature_flag(self, flag_key: str) -> bool:
-        """Evaluate a feature flag for the caller's organization.
-
-        Scoped by organization (not user) so gates are stable across a team's
-        members. `only_evaluate_locally=False` so we respect server-side cohort
-        / property conditions — these checks aren't on a hot path.
-        (`_ai_create_gate_reason` is intentionally person-scoped instead — it
-        backs a per-user early-access opt-in — so don't unify the two.)
-        """
-        request = self.context.get("request")
-        if not request or not getattr(request, "user", None) or not getattr(request.user, "distinct_id", None):
-            return False
-        organization = self.context["get_organization"]()
-        org_id = str(organization.id) if organization else ""
-        return bool(
-            posthoganalytics.feature_enabled(
-                flag_key,
-                str(request.user.distinct_id),
-                groups={"organization": org_id},
-                group_properties={"organization": {"id": org_id}},
-                only_evaluate_locally=False,
-            )
-        )
-
-    def _prompt_guide_feature_enabled(self) -> bool:
-        return self._evaluate_feature_flag(SUBSCRIPTION_AI_SUMMARY_PROMPT_GUIDE_FEATURE_FLAG_KEY)
 
     def _validate_dashboard_export_subscription(self, attrs):
         dashboard = attrs.get("dashboard") or (self.instance.dashboard if self.instance else None)

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -1017,79 +1017,37 @@ class TestSubscriptionTemporal(APILicensedTest):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["title"] == "Updated title"
 
-    def test_can_set_prompt_guide_when_feature_flag_enabled(self):
+    def test_can_create_subscription_with_prompt_guide(self):
         self.organization.is_ai_data_processing_approved = True
         self.organization.save()
 
-        with patch("ee.api.subscription.posthoganalytics.feature_enabled", return_value=True):
-            response = self._create_subscription(summary_enabled=True, summary_prompt_guide="focus on revenue trends")
+        response = self._create_subscription(summary_enabled=True, summary_prompt_guide="focus on revenue trends")
 
         assert response.status_code == status.HTTP_201_CREATED
         assert response.json()["summary_prompt_guide"] == "focus on revenue trends"
 
     @parameterized.expand(
         [
-            # (case_name, flag_value_during_patch, payload, expected_status, expected_fragment_or_stored_value)
-            (
-                "reject_non_empty_patch",
-                False,
-                {"summary_prompt_guide": "changed"},
-                status.HTTP_403_FORBIDDEN,
-                "AI summary context",
-            ),
-            ("allow_clear_via_empty_string", False, {"summary_prompt_guide": ""}, status.HTTP_200_OK, ""),
-            ("allow_unrelated_patch", False, {"title": "Updated title"}, status.HTTP_200_OK, "original"),
-            (
-                "allow_non_empty_patch_when_flag_on",
-                True,
-                {"summary_prompt_guide": "changed"},
-                status.HTTP_200_OK,
-                "changed",
-            ),
-            (
-                "deny_on_feature_flag_eval_error",
-                None,
-                {"summary_prompt_guide": "changed"},
-                status.HTTP_403_FORBIDDEN,
-                "AI summary context",
-            ),
+            ("allow_non_empty_patch", {"summary_prompt_guide": "changed"}, status.HTTP_200_OK, "changed"),
+            ("allow_clear_via_empty_string", {"summary_prompt_guide": ""}, status.HTTP_200_OK, ""),
+            ("allow_unrelated_patch", {"title": "Updated title"}, status.HTTP_200_OK, "original"),
         ]
     )
     def test_prompt_guide_patch_behaviour(
-        self, case_name: str, flag_value: Optional[bool], payload: dict, expected_status: int, expected_body_fragment
+        self, case_name: str, payload: dict, expected_status: int, expected_body_fragment
     ):
         self.organization.is_ai_data_processing_approved = True
         self.organization.save()
-        with patch("ee.api.subscription.posthoganalytics.feature_enabled", return_value=True):
-            create_response = self._create_subscription(summary_enabled=True, summary_prompt_guide="original")
+        create_response = self._create_subscription(summary_enabled=True, summary_prompt_guide="original")
         subscription_id = create_response.json()["id"]
 
-        with patch("ee.api.subscription.posthoganalytics.feature_enabled", return_value=flag_value):
-            response = self.client.patch(
-                f"/api/projects/{self.team.id}/subscriptions/{subscription_id}",
-                payload,
-            )
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/subscriptions/{subscription_id}",
+            payload,
+        )
 
         assert response.status_code == expected_status, response.content
-        if expected_status == status.HTTP_403_FORBIDDEN:
-            assert expected_body_fragment in response.json()["detail"]
-        else:
-            # Read-back the stored `summary_prompt_guide` on the updated subscription.
-            if "summary_prompt_guide" in payload:
-                assert response.json()["summary_prompt_guide"] == (expected_body_fragment or "")
-            else:
-                # Unrelated PATCH — original stored value must survive untouched.
-                assert response.json()["summary_prompt_guide"] == expected_body_fragment
-
-    def test_cannot_create_subscription_with_prompt_guide_when_feature_flag_disabled(self):
-        self.organization.is_ai_data_processing_approved = True
-        self.organization.save()
-
-        with patch("ee.api.subscription.posthoganalytics.feature_enabled", return_value=False):
-            response = self._create_subscription(summary_enabled=True, summary_prompt_guide="focus on revenue trends")
-
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert "AI summary context" in response.json()["detail"]
+        assert response.json()["summary_prompt_guide"] == expected_body_fragment
 
     def _seed_active_summary_subscriptions(self, count: int) -> list[Subscription]:
         # Build raw rows so we can place an org over its tier cap to exercise

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1653,9 +1653,9 @@ snapshots:
     components-playerinspector-itemevent--error-event--light:
         hash: v1.k794b7964.afc6d2764d5be460d97666b066a1847e968c03bc25cdc93eb635aaf6236987fa.-GKL8sP-_D1ax1EsxNNwJK2oIUbdkGDklb7oubwwAbY
     components-playerinspector-itemevent--group-identify-event--dark:
-        hash: v1.k794b7964.140df5ff37fb935b3a0a0ae33031a7d287425d54b40b77cb89a8306e48858605.QxqSKMdYAAMlmHDQQecETx4DqQiv9EVwA8id-UmHxy8
+        hash: v1.k794b7964.020ccc26c80412355b7d52f754cbd191020eb918ce8e36afdc2e8ea313312cda.t7ZM7PhR_DL27Ra1vqmUvl7sPEOPtt6mgQzxTc05HB8
     components-playerinspector-itemevent--group-identify-event--light:
-        hash: v1.k794b7964.39f5f4a7b28d6941c48876b5d8159f400498aa7e600719e6a110a1ee536edbf5.8Drzy2rFGSypzVl_OrI5VNsGL8JlnrhQzD2WAu92f-o
+        hash: v1.k794b7964.75ef27daa7cec23c3d71381abd88a8d2c1c83e17e0ba92a2e0aff561f8a49634.CQNcRuWq4BraNA00QNNYyGMzdFrkc-lh6HnVQUKIUuo
     components-playerinspector-itemevent--page-view-with-current-url--dark:
         hash: v1.k794b7964.147d0bb47e01b52332e72f27fea7fd5d660f40bcbc26bcd5fffda3d9cd0ce23d.8nsNQNgi7Kao46k1_6IRkXOc7rMx52X8NtMHfo4rxfc
     components-playerinspector-itemevent--page-view-with-current-url--light:
@@ -1669,13 +1669,13 @@ snapshots:
     components-playerinspector-itemevent--sentry-error-event--light:
         hash: v1.k794b7964.60a92c99eb051b1a5f1f6729c10319927cbd562a24c8133674bbd7d467aec2c3.n-bkiQTdF14SSeupLiEOXbFMmrWsSam5OVOUflYsugY
     components-playerinspector-itemevent--web-vitals-event--dark:
-        hash: v1.k794b7964.c7010a17087a5d938010755a647e04d0950b272490f72652e39952e9f43c8ee7.V8sVtA7GO9RV46TXBX4MJPAjicCqlNF-vrsNyGXHeV8
+        hash: v1.k794b7964.6730f7f77fe652e6f40eb29a49affb3362ef101ba9ba68a321a244bec0490128.Ka3oOzDGWmhPFlfeIIFpA-S6J387GOEzY6IPmk3LaZY
     components-playerinspector-itemevent--web-vitals-event--light:
-        hash: v1.k794b7964.f6eecbe85fedd1c71f63c301b70f28e9a2d2291e70bc7587bb2e3cb4de64db4c.s1Qr84WeSsLBSWJ5OQl15QkQ9qIMCjr1L70pxgqHzzI
+        hash: v1.k794b7964.dd484c80a262f0aea0ac71dbaa1a374d041f923514347987144f228e8c141c2b.ztm3Ntf_Lhi0e9eWrTi8uLQWoeNKME685csT8aV2xhI
     components-playerinspector-itemevent--web-vitals-event-with-unusable-values--dark:
-        hash: v1.k794b7964.a0a2c7917255169a045b428aedfabaaf585549938336fa3ef6b3ea43ba75f890.jEMfcnfMMDUB1vNcE2GLiXrIBVnUjT81wg24-XNLJkM
+        hash: v1.k794b7964.a2741710445511ea067fec2074596bb6a2e73640a619b311e0f916de6058beca.86dHY2W-HTx3iC5W9_2x6sKnk7UQgfdkwf2Rmu9VeHk
     components-playerinspector-itemevent--web-vitals-event-with-unusable-values--light:
-        hash: v1.k794b7964.977488d5c87c3666827d8e7247a7ad4ef0db4d9c18537a5b1fccf46827ff9012.pxOweNjiGiwl8ADJsqty3CIvXkMKose2gO3FiRpaz7A
+        hash: v1.k794b7964.e3e39536bdc9827f1de938b0a7ffa6b221a50e24cc6f99cad77aa14a1fd4f476.TNjr3W4qfbNPCBSIqyi3M5TBagFFII8jWVMn02dNJew
     components-playerinspector-itemexperimentvariant--default--dark:
         hash: v1.k794b7964.16972cbc7f6e7bf8b96068c9870985988263ded5d21d1417f67313d47cd46534.fRpxzpthpTvisi_q793m1PcRBjqfU_QQ8E_rFmg8djs
     components-playerinspector-itemexperimentvariant--default--light:
@@ -9049,17 +9049,13 @@ snapshots:
     scenes-app-visual-review-run--tracking-only-master-run--light:
         hash: v1.k794b7964.0b4be0f88182eb58f126babc0e5ac2b7298d059c931fd6783eae41a51d02dd1b.juEjllaWH8Fvc3b0lQlS5q-BPokNkac-bVjJ5QZChIs
     scenes-app-web-analytics--web-analytics-dashboard--dark:
-        hash: v1.k794b7964.55266a5db3b8220c100018a05bff0a022eb0a3c8d4bd48bfbd27d3b985a27be4.UEzOfjKha_a43TKv4CCrKtQGZ3RcjDK2G2CO8qWbsVA
+        hash: v1.k794b7964.f5d4eaeb2f42c57efd97afcf9dc348dbcefa2c36bad5688f29819353cac123b2.gW-lCFWYrmybLwy9wI9Siw-PdWs1-t4OXPSUEJpp-fM
     scenes-app-web-analytics--web-analytics-dashboard--light:
-        hash: v1.k794b7964.7cea7646d314bd81dedfa7fc1e29eba42c72dc973aba774014d8ecebcedb62c0.cIQ6AdNJbkfSYICiSYEXd8M0IsX3s00kYfCAX7_r8nI
+        hash: v1.k794b7964.603164be14a9a6d3dc71c94324bb514d725ba78200b931fd4467df981607bfff.CU_Z2epZB6iEEU3SmSTTk7sr-Fk0plMFoAUDBQZEccM
     scenes-app-web-analytics--web-analytics-dashboard-loading--dark:
-        hash: v1.k794b7964.7cd9b8f9d3911be6d3ff11574a99ea342e3fbf65a9dd3c5a74ce17a08c996f84.yW3thSwEzhSxzXB1NLtSPaYzBKVAAkGUDkQomEolJ1Q
+        hash: v1.k794b7964.99c592ebf6459e3bd3181a503ace0baefff13f073dbeb8abdf3239aa35add35f.MQn5H6WaVRxG3d6OpSseGS9dt0lpQbdK2bt1JQKq5Yo
     scenes-app-web-analytics--web-analytics-dashboard-loading--light:
-        hash: v1.k794b7964.b28bba9bb3455f55c526d7cb16a1a9f200173ccaf1f7787c8b8ec18048269442.Vt_vOHjevuaVijh1bPLyHxHRkiFWkrEFEgxQ70Fxhec
-    scenes-app-web-analytics--web-analytics-dashboard-metric-cards--dark:
-        hash: v1.k794b7964.f5d4eaeb2f42c57efd97afcf9dc348dbcefa2c36bad5688f29819353cac123b2.JwwyQkgUVHtueVujBNjb9dk0bU7bSk35qyORxjPStR4
-    scenes-app-web-analytics--web-analytics-dashboard-metric-cards--light:
-        hash: v1.k794b7964.603164be14a9a6d3dc71c94324bb514d725ba78200b931fd4467df981607bfff.WVd9qLxalzFHpOgWUZhKbg9drkuvRYSMGgh0n29luZI
+        hash: v1.k794b7964.6258be5657c96ca59930d83fbf5862f493916e1d9f84c5ce21f8bc014f72b807.6ng36a5wZsONFiJPIicn29HBQlzisgbatipqJZVRCa4
     scenes-app-web-analytics-achievements--daily-only-arm--dark:
         hash: v1.k794b7964.8f024a521e113d8101749768f8d4f49d8dcac1365f43d9b2038c6df0021bac6a.BYx467NAatau4dzb13PnZCTODi-yUho-Vhm_JdtCY9w
     scenes-app-web-analytics-achievements--daily-only-arm--light:

--- a/frontend/src/lib/components/AllowTrainingCallout/AllowTrainingCallout.tsx
+++ b/frontend/src/lib/components/AllowTrainingCallout/AllowTrainingCallout.tsx
@@ -4,7 +4,6 @@ import { LemonBanner } from '@posthog/lemon-ui'
 
 import { useRestrictedArea } from 'lib/components/RestrictedArea'
 import { OrganizationMembershipLevel } from 'lib/constants'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { preflightLogic } from 'lib/logic/preflightLogic'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { urls } from 'scenes/urls'
@@ -19,12 +18,10 @@ export function AllowTrainingCallout({
     const { currentOrganization, currentOrganizationLoading } = useValues(organizationLogic)
     const { updateOrganization } = useActions(organizationLogic)
     const { isHobby } = useValues(preflightLogic)
-    const isFlagEnabled = useFeatureFlag('AI_TRAINING')
     const restrictionReason = useRestrictedArea({ minimumAccessLevel: OrganizationMembershipLevel.Admin })
 
     if (
         isHobby ||
-        !isFlagEnabled ||
         restrictionReason ||
         currentOrganization?.is_ai_training_opted_in !== false ||
         currentOrganization.is_hipaa ||

--- a/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
+++ b/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
@@ -93,22 +93,18 @@ export function ChartFilter(): JSX.Element {
                         />
                     ),
                 },
-                ...(featureFlags[FEATURE_FLAGS.SLOPE_GRAPH_INSIGHT]
-                    ? [
-                          {
-                              value: ChartDisplayType.SlopeGraph,
-                              icon: <IconTrends />,
-                              label: 'Slope graph',
-                              disabledReason: trendsOnlyDisabledReason,
-                              labelInMenu: (
-                                  <ChartFilterOptionLabel
-                                      label="Slope graph"
-                                      description="Change from the start to the end of the range, one line per series."
-                                  />
-                              ),
-                          },
-                      ]
-                    : []),
+                {
+                    value: ChartDisplayType.SlopeGraph,
+                    icon: <IconTrends />,
+                    label: 'Slope graph',
+                    disabledReason: trendsOnlyDisabledReason,
+                    labelInMenu: (
+                        <ChartFilterOptionLabel
+                            label="Slope graph"
+                            description="Change from the start to the end of the range, one line per series."
+                        />
+                    ),
+                },
             ],
         },
         {

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -185,7 +185,6 @@ export const FEATURE_FLAGS = {
     ACCESS_CONTROL_RESOLUTION_PREVIEW: 'access-control-resolution-preview', // owner: @a-lider #team-platform-features, gates the access resolution preview settings section and its banner
     AI_OBSERVABILITY_INSTRUMENTATION_CHECKLIST: 'ai-observability-instrumentation-checklist', // owner: #team-ai-observability, gates the instrumentation checklist card and empty states
     AI_OBSERVABILITY_SELF_DRIVING: 'ai-observability-daily-digest-scout', // owner: #team-ai-observability, gates the AI observability Self-driving tab
-    AI_TRAINING: 'ai-training', // owner: @nicowaltz #team-replay #ai-research, gates the AI training opt-out UI and API enforcement
     AUDIT_LOGS_ACCESS: 'audit-logs-access', // owner: #team-platform-features, used to control access to audit logs
     BATCH_EXPORT_ALERTS: 'batch-export-alerts', // owner: #team-batch-exports
     BATCH_EXPORT_EARLIEST_BACKFILL: 'batch-export-earliest-backfill', // owner: #team-batch-exports, allow backfilling from beginning of time
@@ -235,7 +234,6 @@ export const FEATURE_FLAGS = {
     SETTINGS_SESSIONS_V2_JOIN: 'settings-sessions-v2-join', // owner: @robbie-c #team-web-analytics
     SETTINGS_WEB_ANALYTICS_PRE_AGGREGATED_TABLES: 'web-analytics-pre-aggregated-tables', // owner: @lricoy #team-web-analytics
     SIGNALS_PR_REFUNDS: 'signals-pr-refunds', // owner: #team-self-driving, gates the inbox PR refund flow (also checked server-side)
-    SLOPE_GRAPH_INSIGHT: 'slope-graph-insight', // owner: @pauldambra #team-product-analytics
     STARTUP_PROGRAM_INTENT: 'startup-program-intent', // owner: @pawel-cebula #team-billing
     SURVEYS_ACTIONS: 'surveys-actions', // owner: #team-surveys
     SURVEYS_ADAPTIVE_LIMITS: 'surveys-adaptive-limits', // owner: #team-surveys
@@ -461,7 +459,6 @@ export const FEATURE_FLAGS = {
     PRODUCT_TOURS: 'product-tours-2025', // owner: @adboio #team-surveys
     PRODUCT_TOURS_LOCALIZATION: 'product-tours-localization', // owner: @adboio #team-surveys
     PROJECT_SECRET_API_KEYS: 'project-secret-api-keys', // owner: #team-platform-features
-    PROMOTED_EVENT_PROPERTIES_EDIT: 'promoted-event-properties-edit', // owner: @pauldambra #team-product-analytics, gates the primary-property picker on the event definition edit page (flag slug kept as `promoted-event-properties-edit` to avoid migrating teams that already toggled it on)
     PROPERTY_ACCESS_CONTROL: 'property-access-control', // owner: @reecejones #team-platform-features
     PULSE: 'pulse', // owner: #team-analytics-platform
     QUICK_START_PULSE_INDICATOR: 'quick-start-pulse-indicator', // owner: @fercgomes #team-growth multivariate=control,test
@@ -502,7 +499,6 @@ export const FEATURE_FLAGS = {
     SSO_SETTINGS_REDESIGN: 'sso-settings-redesign', // owner: @reecejones #team-platform-features
     STREAMLIT_APPS: 'streamlit-apps', // owner: @sakce
     SUBSCRIPTION_AI_PROMPT: 'ai-subscriptions', // owner: #team-analytics-platform, gates AI prompt-based subscriptions
-    SUBSCRIPTION_AI_SUMMARY_PROMPT_GUIDE: 'subscription-ai-summary-prompt-guide', // owner: #team-analytics-platform, gates the per-subscription prompt guide textarea
     SUBSCRIPTION_CREATION_WIZARD: 'subscription-creation-wizard', // owner: #team-analytics-platform, experiment=control,test
     SUBSCRIPTION_SLACK_GALLERY: 'subscription-slack-gallery', // owner: #team-analytics-platform, enables gallery delivery after the worker rollout completes
     SURVEY_HEADLINE_SUMMARY: 'survey-headline-summary', // owner: @adboio #team-surveys
@@ -550,7 +546,6 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_LIVE_MAP: 'web-analytics-live-map', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_LIVE_PERSON_DRILLDOWN: 'web-analytics-live-person-drilldown', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_MARKETING: 'marketing-analytics', // owner: @jabahamondes #team-web-analytics
-    WEB_ANALYTICS_METRIC_CARDS: 'web-analytics-metric-cards', // owner: #team-web-analytics
     WEB_ANALYTICS_OPEN_URL: 'web-analytics-open-url', // owner: @lricoy #team-web-analytics
     WEB_ANALYTICS_PAGE_PERFORMANCE: 'web-analytics-page-performance', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_PRECOMPUTE_TOGGLE: 'web-analytics-precompute-toggle', // owner: @lricoy #team-web-analytics

--- a/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
+++ b/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
@@ -7,7 +7,6 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { capitalizeFirstLetter } from 'lib/utils/strings'
 
-import { OverviewGrid } from '~/queries/nodes/OverviewGrid/OverviewGrid'
 import { OverviewMetricCardGrid, OverviewMetricCardItem } from '~/queries/nodes/OverviewGrid/OverviewMetricCardGrid'
 import { AnyResponseType, WebOverviewQuery, WebOverviewQueryResponse } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
@@ -67,22 +66,8 @@ export function WebOverview(props: {
             warningLink: showWarning ? 'https://posthog.com/docs/advanced/proxy' : undefined,
         })) || []
 
-    if (featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_METRIC_CARDS]) {
-        return (
-            <OverviewMetricCardGrid
-                items={overviewItems}
-                loading={responseLoading}
-                numSkeletons={numSkeletons}
-                samplingRate={samplingRate}
-                preComputeStrategy={preComputeStrategy}
-                onDisablePrecompute={props.context.onDisableWebAnalyticsPrecompute}
-                labelFromKey={labelFromKey}
-            />
-        )
-    }
-
     return (
-        <OverviewGrid
+        <OverviewMetricCardGrid
             items={overviewItems}
             loading={responseLoading}
             numSkeletons={numSkeletons}

--- a/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
@@ -313,34 +313,32 @@ export function DefinitionEdit(rawProps: DefinitionLogicProps): JSX.Element {
                             })()}
 
                         {!isProperty && !hasTaxonomyPrimaryProperty(editDefinition.name) && (
-                            <FlaggedFeature flag={FEATURE_FLAGS.PROMOTED_EVENT_PROPERTIES_EDIT}>
-                                <div className="ph-ignore-input">
-                                    <LemonField
-                                        name="primary_property"
-                                        label={
-                                            <LemonLabel info="When set, PostHog surfaces like the session replay inspector show this property's value alongside the event. Choose the single property that best summarizes each occurrence of the event.">
-                                                Primary property
-                                            </LemonLabel>
-                                        }
-                                        data-attr="definition-primary-property"
-                                    >
-                                        {({ value, onChange }) => (
-                                            <TaxonomicPopover<string>
-                                                allowClear
-                                                data-attr="definition-primary-property-picker"
-                                                groupType={TaxonomicFilterGroupType.EventProperties}
-                                                eventNames={[editDefinition.name]}
-                                                value={value ?? null}
-                                                onChange={(changedValue) =>
-                                                    onChange(typeof changedValue === 'string' ? changedValue : null)
-                                                }
-                                                placeholder="Select a primary property"
-                                                selectingKeyOnly
-                                            />
-                                        )}
-                                    </LemonField>
-                                </div>
-                            </FlaggedFeature>
+                            <div className="ph-ignore-input">
+                                <LemonField
+                                    name="primary_property"
+                                    label={
+                                        <LemonLabel info="When set, PostHog surfaces like the session replay inspector show this property's value alongside the event. Choose the single property that best summarizes each occurrence of the event.">
+                                            Primary property
+                                        </LemonLabel>
+                                    }
+                                    data-attr="definition-primary-property"
+                                >
+                                    {({ value, onChange }) => (
+                                        <TaxonomicPopover<string>
+                                            allowClear
+                                            data-attr="definition-primary-property-picker"
+                                            groupType={TaxonomicFilterGroupType.EventProperties}
+                                            eventNames={[editDefinition.name]}
+                                            value={value ?? null}
+                                            onChange={(changedValue) =>
+                                                onChange(typeof changedValue === 'string' ? changedValue : null)
+                                            }
+                                            placeholder="Select a primary property"
+                                            selectingKeyOnly
+                                        />
+                                    )}
+                                </LemonField>
+                            </div>
                         )}
                     </div>
                 )}

--- a/frontend/src/scenes/data-management/definition/DefinitionView.stories.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.stories.tsx
@@ -40,7 +40,6 @@ const meta: Meta = {
         viewMode: 'story',
         mockDate: '2026-04-30',
         pageUrl: urls.eventDefinition(MOCK_EVENT_DEFINITION.id),
-        featureFlags: ['promoted-event-properties-edit'],
         // The full DefinitionView mounts EventDefinitionProperties / EventDefinitionInsights / a
         // matching-events table — those keep their loaders spinning because we don't mock every
         // downstream endpoint. The metadata row (Status + Primary property) is what this story

--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -420,11 +420,7 @@ export function DefinitionView(rawProps: DefinitionLogicProps): JSX.Element {
                     </div>
                 )}
 
-                {isEvent && (
-                    <FlaggedFeature flag={FEATURE_FLAGS.PROMOTED_EVENT_PROPERTIES_EDIT}>
-                        <PrimaryPropertyDetail definition={definition as EventDefinition} />
-                    </FlaggedFeature>
-                )}
+                {isEvent && <PrimaryPropertyDetail definition={definition as EventDefinition} />}
             </div>
 
             <SceneDivider />

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemEvent.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemEvent.tsx
@@ -14,11 +14,9 @@ import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { SimpleKeyValueList } from 'lib/components/SimpleKeyValueList'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TitledSnack } from 'lib/components/TitledSnack'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ceilMsToClosestSecond } from 'lib/utils/durations'
 import { autoCaptureEventToDescription } from 'lib/utils/events'
 import { getPrimaryPropertyForEvent } from 'lib/utils/events'
@@ -231,17 +229,14 @@ export function ItemEventMenu({ item }: ItemEventProps): JSX.Element {
 }
 
 function SingleEventDetail({ item }: ItemEventProps): JSX.Element {
-    const { featureFlags } = useValues(featureFlagLogic)
-    const canPinPrimaryProperty = !!featureFlags[FEATURE_FLAGS.PROMOTED_EVENT_PROPERTIES_EDIT]
     const eventName = item.data.event
 
-    const primaryPropertyActions =
-        canPinPrimaryProperty && isString(eventName)
-            ? (key: string, isRowHovered: boolean): JSX.Element | null =>
-                  key in item.data.properties ? (
-                      <PinPrimaryPropertyButton eventName={eventName} propertyKey={key} isRowHovered={isRowHovered} />
-                  ) : null
-            : undefined
+    const primaryPropertyActions = isString(eventName)
+        ? (key: string, isRowHovered: boolean): JSX.Element | null =>
+              key in item.data.properties ? (
+                  <PinPrimaryPropertyButton eventName={eventName} propertyKey={key} isRowHovered={isRowHovered} />
+              ) : null
+        : undefined
 
     return item.data.fullyLoaded ? (
         <EventPropertyTabs

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -1876,7 +1876,6 @@ export const SETTINGS_MAP: SettingSection[] = [
                 id: 'organization-ai-training-opt-out',
                 title: 'Internal AI training',
                 component: <OrganizationAITrainingOptOut />,
-                flag: 'AI_TRAINING',
                 hideOn: [Realm.SelfHostedClickHouse, Realm.SelfHostedPostgres],
                 keywords: ['ai', 'training', 'opt-out', 'opt-in', 'model', 'max'],
                 searchDescription:

--- a/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.stories.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.stories.tsx
@@ -2,6 +2,7 @@ import { Meta } from '@storybook/react'
 import { useActions } from 'kea'
 import { useEffect } from 'react'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { App } from 'scenes/App'
 import { urls } from 'scenes/urls'
 

--- a/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.stories.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.stories.tsx
@@ -2,7 +2,6 @@ import { Meta } from '@storybook/react'
 import { useActions } from 'kea'
 import { useEffect } from 'react'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { App } from 'scenes/App'
 import { urls } from 'scenes/urls'
 
@@ -78,21 +77,6 @@ export function WebAnalyticsDashboard(): JSX.Element {
         setSourceTab(SourceTab.REFERRING_DOMAIN)
 
         // Set the device tab to browsers
-        setDeviceTab(DeviceTab.BROWSER)
-    }, [setDeviceTab, setSourceTab])
-
-    return <App />
-}
-
-WebAnalyticsDashboardMetricCards.parameters = {
-    ...meta.parameters,
-    featureFlags: [...((meta.parameters?.featureFlags as string[]) ?? []), FEATURE_FLAGS.WEB_ANALYTICS_METRIC_CARDS],
-}
-export function WebAnalyticsDashboardMetricCards(): JSX.Element {
-    const { setSourceTab, setDeviceTab } = useActions(webAnalyticsLogic)
-
-    useEffect(() => {
-        setSourceTab(SourceTab.REFERRING_DOMAIN)
         setDeviceTab(DeviceTab.BROWSER)
     }, [setDeviceTab, setSourceTab])
 

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -331,7 +331,6 @@ SURVEY_TARGETING_FLAG_PREFIX = "survey-targeting-"
 PRODUCT_TOUR_TARGETING_FLAG_PREFIX = "product-tour-targeting-"
 
 # Server-side evaluation via posthoganalytics; keep in sync with frontend FEATURE_FLAGS.
-SUBSCRIPTION_AI_SUMMARY_PROMPT_GUIDE_FEATURE_FLAG_KEY = "subscription-ai-summary-prompt-guide"
 SUBSCRIPTION_AI_PROMPT_FEATURE_FLAG_KEY = "ai-subscriptions"
 # Enable only after every subscriptions worker has deployed the gallery claim boundary. Older workers
 # share the v2 activity name and would otherwise send the legacy layout during a rolling deployment.

--- a/products/event_definitions/backend/models/event_definition.py
+++ b/products/event_definitions/backend/models/event_definition.py
@@ -42,7 +42,6 @@ class EventDefinition(UUIDTModel):
     )
 
     # DB column kept as `promoted_property` to avoid a Postgres column rename.
-    # Safe because the feature is flag-gated (`promoted-event-properties-edit`) and minimally used.
     primary_property = models.CharField(max_length=400, null=True, blank=True, db_column="promoted_property")
 
     class Meta:

--- a/products/exports/backend/temporal/subscriptions/snapshot_activities.py
+++ b/products/exports/backend/temporal/subscriptions/snapshot_activities.py
@@ -1,13 +1,11 @@
 import uuid
 from typing import Any
 
-import posthoganalytics
 import temporalio.activity
 from asgiref.sync import sync_to_async
 from prometheus_client import Counter
 from structlog import get_logger
 
-from posthog.constants import SUBSCRIPTION_AI_SUMMARY_PROMPT_GUIDE_FEATURE_FLAG_KEY
 from posthog.ph_client import ph_scoped_capture
 from posthog.security.llm_prompt_sanitization import PROMPT_GUIDE_MAX_LEN, sanitize_user_text
 from posthog.storage import object_storage
@@ -266,34 +264,6 @@ def _load_core_memory_text(subscription: Subscription) -> str:
     return memory.formatted_text
 
 
-def _prompt_guide_feature_enabled_for_subscription(subscription: Subscription) -> bool:
-    """Gate the *read* side of `summary_prompt_guide` on the same flag as writes.
-
-    Writes are gated in `ee/api/subscription.py`, but without this read-side check
-    a value stored while the flag was on would keep steering the LLM after the
-    flag flipped off. Flipping the flag off must stop the guide from taking effect
-    on the next delivery, not just stop new writes. Evaluated per subscription —
-    anchored on the creator's distinct_id so the gate tracks whoever set it, with
-    the subscription's team organization as group context.
-
-    Subscriptions without a creator (or whose creator has no distinct_id) default
-    to disallowed — same fail-closed stance as the serializer gate.
-    """
-    creator = subscription.created_by
-    if not creator or not creator.distinct_id:
-        return False
-    org_id = str(subscription.team.organization_id) if subscription.team_id else ""
-    return bool(
-        posthoganalytics.feature_enabled(
-            SUBSCRIPTION_AI_SUMMARY_PROMPT_GUIDE_FEATURE_FLAG_KEY,
-            str(creator.distinct_id),
-            groups={"organization": org_id},
-            group_properties={"organization": {"id": org_id}},
-            only_evaluate_locally=False,
-        )
-    )
-
-
 def _capture_summary_generated_event(
     subscription: Subscription,
     *,
@@ -533,14 +503,11 @@ async def _run_snapshot_subscription_insights(inputs: SnapshotInsightsInputs) ->
     summary_text: str | None = None
     try:
         temporalio.activity.heartbeat("generating LLM summary")
-        # Gate the read side on the same flag as writes so stored guides stop steering
-        # the LLM as soon as the flag flips off — not only the next time someone edits.
-        if subscription.summary_prompt_guide and await database_sync_to_async(
-            _prompt_guide_feature_enabled_for_subscription, thread_sensitive=False
-        )(subscription):
-            prompt_guide = sanitize_user_text(subscription.summary_prompt_guide, PROMPT_GUIDE_MAX_LEN)
-        else:
-            prompt_guide = ""
+        prompt_guide = (
+            sanitize_user_text(subscription.summary_prompt_guide, PROMPT_GUIDE_MAX_LEN)
+            if subscription.summary_prompt_guide
+            else ""
+        )
         core_memory_text = await database_sync_to_async(_load_core_memory_text, thread_sensitive=False)(subscription)
         content_snapshots = [
             s

--- a/products/exports/backend/temporal/subscriptions/test_snapshot_ai_consent.py
+++ b/products/exports/backend/temporal/subscriptions/test_snapshot_ai_consent.py
@@ -224,55 +224,7 @@ async def test_skips_summary_when_summary_not_enabled(team, user):
     assert result.summary_skipped_over_budget is False
 
 
-async def test_stored_prompt_guide_is_ignored_when_prompt_guide_flag_is_off(team, user, monkeypatch):
-    # Stored `summary_prompt_guide` set while the flag was on must stop steering the LLM the
-    # moment the flag flips off, not only on the next edit — otherwise ungating on the frontend
-    # leaves users with no way to stop a value from taking effect.
-    subscription = await _create_subscription(team, user)
-    await sync_to_async(Subscription.objects.filter(pk=subscription.pk).update)(
-        summary_prompt_guide="secret ops context"
-    )
-    await _set_ai_consent(subscription, approved=True)
-    delivery = await _create_delivery(
-        subscription,
-        {
-            "insights": [
-                {
-                    "id": subscription.insight_id,
-                    "name": "Pageviews",
-                    "query_results": {"result": [{"label": "Pageviews", "data": [1, 2, 3]}]},
-                }
-            ]
-        },
-    )
-
-    seen_prompt_guides: list[str] = []
-
-    def fake_generate(previous_states, current_states, *, prompt_guide: str = "", **kwargs):
-        seen_prompt_guides.append(prompt_guide)
-        return "- Pageviews is trending up"
-
-    monkeypatch.setattr(
-        "products.exports.backend.temporal.subscriptions.snapshot_activities.generate_change_summary",
-        fake_generate,
-    )
-    monkeypatch.setattr(
-        "products.exports.backend.temporal.subscriptions.snapshot_activities.posthoganalytics.feature_enabled",
-        lambda *a, **kw: False,
-    )
-
-    await _run(
-        SnapshotInsightsInputs(
-            subscription_id=subscription.id,
-            team_id=subscription.team_id,
-            delivery_id=str(delivery.id),
-        )
-    )
-
-    assert seen_prompt_guides == [""]
-
-
-async def test_stored_prompt_guide_flows_when_prompt_guide_flag_is_on(team, user, monkeypatch):
+async def test_stored_prompt_guide_flows_into_summary(team, user, monkeypatch):
     subscription = await _create_subscription(team, user)
     await sync_to_async(Subscription.objects.filter(pk=subscription.pk).update)(summary_prompt_guide="focus on revenue")
     await _set_ai_consent(subscription, approved=True)
@@ -299,11 +251,6 @@ async def test_stored_prompt_guide_flows_when_prompt_guide_flag_is_on(team, user
         "products.exports.backend.temporal.subscriptions.snapshot_activities.generate_change_summary",
         fake_generate,
     )
-    monkeypatch.setattr(
-        "products.exports.backend.temporal.subscriptions.snapshot_activities.posthoganalytics.feature_enabled",
-        lambda *a, **kw: True,
-    )
-
     await _run(
         SnapshotInsightsInputs(
             subscription_id=subscription.id,

--- a/products/product_analytics/frontend/insights/trends/TrendsSlopeChart/TrendsSlopeChart.stories.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsSlopeChart/TrendsSlopeChart.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { InsightVizStory } from 'scenes/insights/__mocks__/createInsightVizStory'
 
 import __trendsSlopeGraph from '~/mocks/fixtures/api/projects/team_id/insights/trendsSlopeGraph.json'
@@ -15,7 +14,6 @@ const meta: Meta = {
     parameters: {
         layout: 'centered',
         mockDate: '2022-04-01',
-        featureFlags: [FEATURE_FLAGS.SLOPE_GRAPH_INSIGHT],
         testOptions: {
             snapshotBrowsers: ['chromium'],
             waitForSelector: '[data-attr=trends-slope-graph] canvas',

--- a/products/product_analytics/skills/choosing-trend-or-slope-view/SKILL.md
+++ b/products/product_analytics/skills/choosing-trend-or-slope-view/SKILL.md
@@ -64,14 +64,13 @@ are the points you want compared (the slope uses the first and last interval).
 ## Important limits
 
 - **Two surfaces, one computation.** Both the inline slope (Max's `query-trends`
-  result card) and the saved-insight slope (`ChartDisplayType.SlopeGraph`, behind the
-  `slope-graph-insight` feature flag) show the same thing: the first interval's value
-  vs the last interval's value, at the chosen group-by interval. The grouping defines
-  the slope — group by month to compare the first vs last month, by day for the first
-  vs last day. Use the inline view for a quick before→after on a result you're already
-  looking at; reach for the saved display to persist it on a dashboard where the flag
-  is enabled. A still-accumulating final period is shown as-is with a dashed connector,
-  the same affordance the line chart uses for an incomplete tail.
+  result card) and the saved-insight slope (`ChartDisplayType.SlopeGraph`) show the
+  same thing: the first interval's value vs the last interval's value, at the chosen
+  group-by interval. The grouping defines the slope - group by month to compare the
+  first vs last month, by day for the first vs last day. Use the inline view for a
+  quick before-and-after on a result you're already looking at; use the saved display
+  to persist it on a dashboard. A still-accumulating final period is shown as-is with
+  a dashed connector, the same affordance the line chart uses for an incomplete tail.
 - For period-over-period on a single series (this month vs last), a line with
   `compareFilter: { "compare": true }` overlays the two periods; a slope is the
   better fit when comparing the endpoints of **many** series at once.

--- a/products/subscriptions/frontend/components/Subscriptions/views/EditSubscription.tsx
+++ b/products/subscriptions/frontend/components/Subscriptions/views/EditSubscription.tsx
@@ -7,12 +7,10 @@ import { LemonInput, LemonTextArea, Link } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
-import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { UsageLimitPaywall } from 'lib/components/PayGateMini/UsageLimitPaywall'
 import { TZLabel } from 'lib/components/TZLabel'
 import { UserActivityIndicator } from 'lib/components/UserActivityIndicator/UserActivityIndicator'
 import { usersLemonSelectOptions } from 'lib/components/UserSelectItem'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useIntegrationManagementRestriction } from 'lib/integrations/integrationPermissions'
@@ -839,18 +837,16 @@ function EditSubscriptionForm({
                                         )}
 
                                     {subscription.summary_enabled && (
-                                        <FlaggedFeature flag={FEATURE_FLAGS.SUBSCRIPTION_AI_SUMMARY_PROMPT_GUIDE}>
-                                            <LemonField
-                                                name="summary_prompt_guide"
-                                                label="Context for the AI summary"
-                                                showOptional
-                                            >
-                                                <LemonTextArea
-                                                    placeholder="e.g. This is a daily revenue health check - focus on revenue drop-off and churn signals"
-                                                    maxLength={500}
-                                                />
-                                            </LemonField>
-                                        </FlaggedFeature>
+                                        <LemonField
+                                            name="summary_prompt_guide"
+                                            label="Context for the AI summary"
+                                            showOptional
+                                        >
+                                            <LemonTextArea
+                                                placeholder="e.g. This is a daily revenue health check - focus on revenue drop-off and churn signals"
+                                                maxLength={500}
+                                            />
+                                        </LemonField>
                                     )}
                                 </>
                             )}


### PR DESCRIPTION
Robot: This draft removes five fully rolled out feature gates from the product surfaces they control.

## Problem

People should not depend on remote flag checks for features already available to everyone.

## Changes

- The slope graph picker is always available in the insight editor.
- Web analytics uses the metric card layout by default.
- AI training settings, promoted event properties, and subscription prompt context no longer use these gates.
- The subscription API and delivery worker keep prompt context behavior consistent without a flag.
- Mechanical cleanup removes constants, stories, imports, and obsolete tests.
- No screenshot is included because the layout and copy stay unchanged.

## How did you test this code?

- Passed targeted subscription API tests for prompt context creation and updates.
- Passed the stored prompt context snapshot activity test.
- Passed Ruff checks and formatting checks for changed Python files.
- Frontend formatting and lint fixes passed.
- Not run: the full frontend TypeScript check timed out twice in this sandbox.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The change updates internal skill guidance where it referenced the removed gate.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The flag inventory used the current user's project flags, then kept boolean flags with empty targeting and 100% rollout. Skills invoked: `/cleaning-up-stale-feature-flags`, `/writing-ui-components`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, and `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
