### PR TITLE
chore(desktop): remove spend analysis flag gate

### DIFF
--- a/products/desktop/packages/shared/src/feature-flag-keys.json
+++ b/products/desktop/packages/shared/src/feature-flag-keys.json
@@ -31,7 +31,6 @@
   "SAVED_SEARCHES_RAIL_FLAG": "posthog-desktop-saved-searches-rail",
   "SELF_DRIVING_SETUP_TASK_FLAG": "posthog-code-self-driving-setup-task",
   "SIGNALS_PR_REFUNDS_FLAG": "signals-pr-refunds",
-  "SPEND_ANALYSIS_FLAG": "posthog-code-spend-analysis",
   "SPOKEN_NARRATION_FLAG": "posthog-code-spoken-narration",
   "TASK_ANALYSIS_FLAG": "posthog-code-task-analysis",
   "TASK_COST_VISIBLE_FLAG": "posthog-code-task-cost-visible",

--- a/products/desktop/packages/shared/src/flags.ts
+++ b/products/desktop/packages/shared/src/flags.ts
@@ -3,7 +3,6 @@ import featureFlagKeys from "./feature-flag-keys.json" with { type: "json" };
 export const BILLING_FLAG = featureFlagKeys.BILLING_FLAG;
 export const CLOUD_COMPUTE_BILLING_FLAG =
   featureFlagKeys.CLOUD_COMPUTE_BILLING_FLAG;
-export const SPEND_ANALYSIS_FLAG = featureFlagKeys.SPEND_ANALYSIS_FLAG;
 export const EXPERIMENT_SUGGESTIONS_FLAG =
   featureFlagKeys.EXPERIMENT_SUGGESTIONS_FLAG;
 /** Autoresearch (metric-optimization loop). Staff-gated while it bakes. */

--- a/products/desktop/packages/ui/src/features/billing/useSpendTotals.ts
+++ b/products/desktop/packages/ui/src/features/billing/useSpendTotals.ts
@@ -12,7 +12,6 @@ import {
 } from "@posthog/core/billing/spendLimits";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
-import { useSpendAnalysisEnabled } from "@posthog/ui/features/usage/useSpendAnalysisEnabled";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
@@ -57,14 +56,13 @@ function fetchSpendWindow(
  */
 export function useSpendTotals(): SpendSnapshot | null {
   const client = useOptionalAuthenticatedClient();
-  const enabled = useSpendAnalysisEnabled();
   const query = useQuery({
     queryKey: SPEND_TOTALS_QUERY_KEY,
     queryFn: () => {
       if (!client) throw new Error("Not authenticated");
       return fetchSpendWindow(client);
     },
-    enabled: client !== null && enabled,
+    enabled: client !== null,
     refetchInterval: POLL_INTERVAL_MS,
     staleTime: 60_000,
     retry: false,

--- a/products/desktop/packages/ui/src/features/command/CommandMenu.tsx
+++ b/products/desktop/packages/ui/src/features/command/CommandMenu.tsx
@@ -83,7 +83,6 @@ import {
 } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
-import { useSpendAnalysisEnabled } from "@posthog/ui/features/usage/useSpendAnalysisEnabled";
 import { useWorkspaces } from "@posthog/ui/features/workspace/useWorkspace";
 import { LoopIcon } from "@posthog/ui/primitives/LoopIcon";
 import {
@@ -233,7 +232,6 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
   );
   const loopsEnabled = useFeatureFlag(LOOPS_FLAG);
   const inboxAvailable = useInboxAvailable();
-  const spendAnalysisEnabled = useSpendAnalysisEnabled();
   const { channels } = useChannels({ enabled: bluebirdEnabled });
   const { theme, setTheme } = useThemeStore();
   const toggleLeftSidebar = useSidebarStore((state) => state.toggle);
@@ -431,21 +429,14 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
             },
           ]
         : []),
-      // Gated like every other cost-management entry point: without spend
-      // analysis the settings page is hidden and redirects to General, so the
-      // command would not do what its label says.
-      ...(spendAnalysisEnabled
-        ? [
-            {
-              id: "cost-management",
-              label: "Cost management",
-              keywords: "cost spend limits budget savings recommendations",
-              icon: <Gauge size={12} className="text-gray-11" />,
-              action: "open-cost-management" as CommandMenuAction,
-              onRun: () => openSettingsDialog("cost-management"),
-            },
-          ]
-        : []),
+      {
+        id: "cost-management",
+        label: "Cost management",
+        keywords: "cost spend limits budget savings recommendations",
+        icon: <Gauge size={12} className="text-gray-11" />,
+        action: "open-cost-management" as CommandMenuAction,
+        onRun: () => openSettingsDialog("cost-management"),
+      },
       {
         id: "plan-usage",
         label: "Plan & usage",
@@ -653,7 +644,6 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
     openFilePicker,
     loopsEnabled,
     inboxAvailable,
-    spendAnalysisEnabled,
     bluebirdEnabled,
     spacesLayout,
   ]);

--- a/products/desktop/packages/ui/src/features/cost-management/CostManagementSettings.tsx
+++ b/products/desktop/packages/ui/src/features/cost-management/CostManagementSettings.tsx
@@ -1,12 +1,4 @@
-import { Gauge } from "@phosphor-icons/react";
 import { leanSkillById } from "@posthog/core/billing/leanSkills";
-import {
-  Empty,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from "@posthog/quill";
 import { ANALYTICS_EVENTS, formatModelId } from "@posthog/shared";
 import { CostManagementView } from "@posthog/ui/features/cost-management/CostManagementView";
 import { CustomImageBuildDialog } from "@posthog/ui/features/cost-management/CustomImageBuildDialog";
@@ -20,13 +12,11 @@ import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { skillErrorDescription } from "@posthog/ui/features/skills/skillErrors";
 import { useInstallMarketplaceSkill } from "@posthog/ui/features/skills/useMarketplace";
 import { useDeleteSkill } from "@posthog/ui/features/skills/useSkillMutations";
-import { useSpendAnalysisEnabled } from "@posthog/ui/features/usage/useSpendAnalysisEnabled";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { useState } from "react";
 
 export function CostManagementSettings() {
-  const spendAnalysisEnabled = useSpendAnalysisEnabled();
   const setLastUsedModel = useSettingsStore((state) => state.setLastUsedModel);
   const setSte100Enabled = useSettingsStore((state) => state.setSte100Enabled);
   const markDone = useSettingsStore((state) => state.markCostChecklistDone);
@@ -53,24 +43,6 @@ export function CostManagementSettings() {
       return next;
     });
   const openSkill = openSkillId === null ? null : leanSkillById(openSkillId);
-
-  if (!spendAnalysisEnabled) {
-    return (
-      <Empty className="mx-auto max-w-md py-16">
-        <EmptyHeader>
-          <EmptyMedia variant="icon">
-            <Gauge size={24} />
-          </EmptyMedia>
-          <EmptyTitle>Cost management isn't available</EmptyTitle>
-          <EmptyDescription>
-            Spend reporting isn't enabled for your account yet, so there is
-            nothing to set limits against.
-          </EmptyDescription>
-        </EmptyHeader>
-      </Empty>
-    );
-  }
-
   const switchDefaultModel = (toModelId: string) => {
     const previous = useSettingsStore.getState().lastUsedModel;
     setLastUsedModel(toModelId);

--- a/products/desktop/packages/ui/src/features/settings/components/SettingsPanel.tsx
+++ b/products/desktop/packages/ui/src/features/settings/components/SettingsPanel.tsx
@@ -24,12 +24,10 @@ import {
   Wrench,
 } from "@phosphor-icons/react";
 import { Input, MenuLabel } from "@posthog/quill";
-import { BILLING_FLAG } from "@posthog/shared";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { UserAvatar } from "@posthog/ui/features/auth/UserAvatar";
 import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
-import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useQuickAskAvailable } from "@posthog/ui/features/quick-ask/useQuickAskAvailable";
 import { SettingsPageContent } from "@posthog/ui/features/settings/components/SettingsPageContent";
 import { closeSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
@@ -147,12 +145,10 @@ export function SettingsPanel({
   );
   const client = useOptionalAuthenticatedClient();
   const { data: user } = useCurrentUser({ client });
-  const billingEnabled = useFeatureFlag(BILLING_FLAG);
   const { localWorkspaces } = useHostCapabilities();
   const quickAskAvailable = useQuickAskAvailable();
 
   const hiddenCategories = getHiddenSettingsCategories({
-    billingEnabled,
     localWorkspaces,
     quickAskAvailable,
   });

--- a/products/desktop/packages/ui/src/features/settings/components/SettingsPanel.tsx
+++ b/products/desktop/packages/ui/src/features/settings/components/SettingsPanel.tsx
@@ -44,7 +44,6 @@ import {
   type SettingsCategory,
 } from "@posthog/ui/features/settings/types";
 import { ProjectSwitcher } from "@posthog/ui/features/sidebar/components/ProjectSwitcher";
-import { useSpendAnalysisEnabled } from "@posthog/ui/features/usage/useSpendAnalysisEnabled";
 import * as nav from "@posthog/ui/router/navigationBridge";
 import { useHostCapabilities } from "@posthog/ui/shell/useHostCapabilities";
 import { type ReactNode, useState } from "react";
@@ -152,10 +151,8 @@ export function SettingsPanel({
   const { localWorkspaces } = useHostCapabilities();
   const quickAskAvailable = useQuickAskAvailable();
 
-  const spendAnalysisEnabled = useSpendAnalysisEnabled();
   const hiddenCategories = getHiddenSettingsCategories({
     billingEnabled,
-    spendAnalysisEnabled,
     localWorkspaces,
     quickAskAvailable,
   });

--- a/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.stories.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.stories.tsx
@@ -98,5 +98,5 @@ export const OrganizationLimitReached: Story = {
 };
 
 export const Loading: Story = {
-  args: { usage: null, usageLoading: true }
+  args: { usage: null, usageLoading: true },
 };

--- a/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.stories.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.stories.tsx
@@ -45,7 +45,6 @@ const meta: Meta<typeof PlanUsageContent> = {
   args: {
     billingEnabled: true,
     cloudComputeEnabled: true,
-    spendAnalysisEnabled: true,
     billingUrl: "https://app.posthog.com/organization/billing",
     usage,
     usageLoading: false,
@@ -60,20 +59,17 @@ export const WithComponentBreakdown: Story = {};
 export const CloudComputeDisabled: Story = {
   args: {
     cloudComputeEnabled: false,
-    spendAnalysisEnabled: false,
   },
 };
 
 export const BreakdownAwaitingData: Story = {
   args: {
-    spendAnalysisEnabled: false,
     usage: { ...usage, ai_credits: { ...usage.ai_credits, breakdown: null } },
   },
 };
 
 export const ExplicitZeroUsage: Story = {
   args: {
-    spendAnalysisEnabled: false,
     usage: {
       ...usage,
       ai_credits: {
@@ -93,7 +89,6 @@ export const ExplicitZeroUsage: Story = {
 
 export const OrganizationLimitReached: Story = {
   args: {
-    spendAnalysisEnabled: false,
     usage: {
       ...usage,
       ai_credits: { ...usage.ai_credits, exhausted: true, used_usd: 70 },
@@ -103,5 +98,5 @@ export const OrganizationLimitReached: Story = {
 };
 
 export const Loading: Story = {
-  args: { usage: null, usageLoading: true, spendAnalysisEnabled: false },
+  args: { usage: null, usageLoading: true }
 };

--- a/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
@@ -213,9 +213,7 @@ export function PlanUsageContent({
         </SettingsSubsection>
       )}
 
-      <PersonalSpendDisclosure>
-        {personalSpendAnalysis}
-      </PersonalSpendDisclosure>
+      <PersonalSpendDisclosure>{personalSpendAnalysis}</PersonalSpendDisclosure>
     </Flex>
   );
 }

--- a/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
@@ -2,7 +2,6 @@ import {
   ArrowSquareOut,
   CaretDown,
   CaretUp,
-  CreditCard,
   WarningCircle,
 } from "@phosphor-icons/react";
 import {
@@ -14,13 +13,6 @@ import {
   isCodeUsageFreeTier,
 } from "@posthog/core/billing/usageDisplay";
 import type { UsageOutput } from "@posthog/core/usage/schemas";
-import {
-  Empty,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from "@posthog/quill";
 import { BILLING_FLAG, CLOUD_COMPUTE_BILLING_FLAG } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
@@ -29,7 +21,6 @@ import { useUsage } from "@posthog/ui/features/billing/useUsage";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { SettingsSubsection } from "@posthog/ui/features/settings/components/SettingsSubsection";
 import { SpendAnalysisSection } from "@posthog/ui/features/usage/components/SpendAnalysisSection";
-import { useSpendAnalysisEnabled } from "@posthog/ui/features/usage/useSpendAnalysisEnabled";
 import { useTrackUsageViewed } from "@posthog/ui/features/usage/useTrackUsageViewed";
 import { track } from "@posthog/ui/shell/analytics";
 import { getBillingUrl } from "@posthog/ui/utils/urls";
@@ -39,7 +30,6 @@ import { type ReactNode, useEffect, useState } from "react";
 export function PlanUsageSettings() {
   const billingEnabled = useFeatureFlag(BILLING_FLAG);
   const cloudComputeEnabled = useFeatureFlag(CLOUD_COMPUTE_BILLING_FLAG);
-  const spendAnalysisEnabled = useSpendAnalysisEnabled();
   const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
   const billingUrl = getBillingUrl(cloudRegion);
 
@@ -66,7 +56,6 @@ export function PlanUsageSettings() {
     <PlanUsageContent
       billingEnabled={billingEnabled}
       cloudComputeEnabled={cloudComputeEnabled}
-      spendAnalysisEnabled={spendAnalysisEnabled}
       billingUrl={billingUrl}
       usage={usage}
       usageLoading={usageLoading}
@@ -78,7 +67,6 @@ export function PlanUsageSettings() {
 interface PlanUsageContentProps {
   billingEnabled: boolean;
   cloudComputeEnabled: boolean;
-  spendAnalysisEnabled: boolean;
   billingUrl: string | null | undefined;
   usage: UsageOutput | null | undefined;
   usageLoading: boolean;
@@ -88,7 +76,6 @@ interface PlanUsageContentProps {
 export function PlanUsageContent({
   billingEnabled,
   cloudComputeEnabled,
-  spendAnalysisEnabled,
   billingUrl,
   usage,
   usageLoading,
@@ -104,22 +91,6 @@ export function PlanUsageContent({
   const openBilling = () => {
     if (billingUrl) window.open(billingUrl, "_blank", "noopener,noreferrer");
   };
-
-  if (!billingEnabled && !spendAnalysisEnabled) {
-    return (
-      <Empty className="mx-auto max-w-md py-16">
-        <EmptyHeader>
-          <EmptyMedia variant="icon">
-            <CreditCard size={24} />
-          </EmptyMedia>
-          <EmptyTitle>Plan & usage isn't available</EmptyTitle>
-          <EmptyDescription>
-            Billing and usage reporting aren't enabled for your account yet.
-          </EmptyDescription>
-        </EmptyHeader>
-      </Empty>
-    );
-  }
 
   return (
     <Flex direction="column" gap="8">
@@ -242,11 +213,9 @@ export function PlanUsageContent({
         </SettingsSubsection>
       )}
 
-      {spendAnalysisEnabled && (
-        <PersonalSpendDisclosure>
-          {personalSpendAnalysis}
-        </PersonalSpendDisclosure>
-      )}
+      <PersonalSpendDisclosure>
+        {personalSpendAnalysis}
+      </PersonalSpendDisclosure>
     </Flex>
   );
 }

--- a/products/desktop/packages/ui/src/features/settings/settingsVisibility.test.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsVisibility.test.ts
@@ -7,39 +7,15 @@ describe("getHiddenSettingsCategories", () => {
       name: "shows all categories when every capability is available",
       input: {
         billingEnabled: true,
-        spendAnalysisEnabled: true,
         localWorkspaces: true,
         quickAskAvailable: true,
       },
       expected: [],
     },
     {
-      name: "hides plan and usage without billing or spend analysis",
-      input: {
-        billingEnabled: false,
-        spendAnalysisEnabled: false,
-        localWorkspaces: true,
-        quickAskAvailable: true,
-      },
-      expected: ["plan-usage", "cost-management"],
-    },
-    {
-      // Every limit and recommendation on the page is measured against
-      // personal spend, so without it the page has nothing to show.
-      name: "hides cost management without spend analysis",
-      input: {
-        billingEnabled: true,
-        spendAnalysisEnabled: false,
-        localWorkspaces: true,
-        quickAskAvailable: true,
-      },
-      expected: ["cost-management"],
-    },
-    {
       name: "hides host-specific categories without local workspaces",
       input: {
         billingEnabled: true,
-        spendAnalysisEnabled: true,
         localWorkspaces: false,
         quickAskAvailable: true,
       },
@@ -52,7 +28,6 @@ describe("getHiddenSettingsCategories", () => {
       name: "hides quick-ask when the panel is unavailable",
       input: {
         billingEnabled: true,
-        spendAnalysisEnabled: true,
         localWorkspaces: true,
       },
       expected: ["quick-ask"],

--- a/products/desktop/packages/ui/src/features/settings/settingsVisibility.test.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsVisibility.test.ts
@@ -6,7 +6,6 @@ describe("getHiddenSettingsCategories", () => {
     {
       name: "shows all categories when every capability is available",
       input: {
-        billingEnabled: true,
         localWorkspaces: true,
         quickAskAvailable: true,
       },
@@ -15,7 +14,6 @@ describe("getHiddenSettingsCategories", () => {
     {
       name: "hides host-specific categories without local workspaces",
       input: {
-        billingEnabled: true,
         localWorkspaces: false,
         quickAskAvailable: true,
       },
@@ -27,7 +25,6 @@ describe("getHiddenSettingsCategories", () => {
       // packaged desktop without the prototype gate).
       name: "hides quick-ask when the panel is unavailable",
       input: {
-        billingEnabled: true,
         localWorkspaces: true,
       },
       expected: ["quick-ask"],

--- a/products/desktop/packages/ui/src/features/settings/settingsVisibility.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsVisibility.ts
@@ -12,7 +12,6 @@ const LOCAL_ONLY_CATEGORIES: ReadonlySet<SettingsCategory> = new Set([
 ]);
 
 interface SettingsVisibility {
-  billingEnabled: boolean;
   localWorkspaces: boolean;
   /**
    * The quick-ask panel exists on this host and build. Off (web, and packaged
@@ -23,7 +22,6 @@ interface SettingsVisibility {
 }
 
 export function getHiddenSettingsCategories({
-  billingEnabled,
   localWorkspaces,
   quickAskAvailable = false,
 }: SettingsVisibility): ReadonlySet<SettingsCategory> {

--- a/products/desktop/packages/ui/src/features/settings/settingsVisibility.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsVisibility.ts
@@ -13,7 +13,6 @@ const LOCAL_ONLY_CATEGORIES: ReadonlySet<SettingsCategory> = new Set([
 
 interface SettingsVisibility {
   billingEnabled: boolean;
-  spendAnalysisEnabled: boolean;
   localWorkspaces: boolean;
   /**
    * The quick-ask panel exists on this host and build. Off (web, and packaged
@@ -25,7 +24,6 @@ interface SettingsVisibility {
 
 export function getHiddenSettingsCategories({
   billingEnabled,
-  spendAnalysisEnabled,
   localWorkspaces,
   quickAskAvailable = false,
 }: SettingsVisibility): ReadonlySet<SettingsCategory> {
@@ -33,12 +31,6 @@ export function getHiddenSettingsCategories({
   // direct navigation to one, so a deep link can't reach them either.
   const hiddenCategories = new Set<SettingsCategory>();
 
-  if (!billingEnabled && !spendAnalysisEnabled) {
-    hiddenCategories.add("plan-usage");
-  }
-  if (!spendAnalysisEnabled) {
-    hiddenCategories.add("cost-management");
-  }
   if (!localWorkspaces) {
     for (const category of LOCAL_ONLY_CATEGORIES) {
       hiddenCategories.add(category);

--- a/products/desktop/packages/ui/src/features/usage/useSpendAnalysis.ts
+++ b/products/desktop/packages/ui/src/features/usage/useSpendAnalysis.ts
@@ -4,6 +4,7 @@ import {
   windowToDateFrom,
 } from "@posthog/core/billing/spendAnalysisFormat";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
 import { logger } from "@posthog/ui/shell/logger";
 import { useQuery } from "@tanstack/react-query";
 
@@ -46,6 +47,7 @@ export function useSpendAnalysis({
     },
     enabled: client !== null,
     staleTime: SPEND_ANALYSIS_STALE_TIME_MS,
+    meta: AUTH_SCOPED_QUERY_META,
   });
 
   return {

--- a/products/desktop/packages/ui/src/features/usage/useSpendAnalysisEnabled.ts
+++ b/products/desktop/packages/ui/src/features/usage/useSpendAnalysisEnabled.ts
@@ -1,6 +1,3 @@
-import { SPEND_ANALYSIS_FLAG } from "@posthog/shared";
-import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
-
 export function useSpendAnalysisEnabled(): boolean {
-  return useFeatureFlag(SPEND_ANALYSIS_FLAG) || import.meta.env.DEV;
+  return true;
 }

--- a/products/desktop/packages/ui/src/features/usage/useSpendAnalysisEnabled.ts
+++ b/products/desktop/packages/ui/src/features/usage/useSpendAnalysisEnabled.ts
@@ -1,3 +1,0 @@
-export function useSpendAnalysisEnabled(): boolean {
-  return true;
-}


### PR DESCRIPTION
Robot: PostHog Desktop now shows spend analysis without a remote rollout check or a permanent true hook.

## Problem

Desktop users should not depend on a flag that already serves everyone.

## Changes

- Spend analysis runs without a feature flag hook.
- Settings, cost management, the command menu, plan usage, and spend totals use the enabled paths directly.
- The unused shared flag key, lookup, hook, and fallback states are removed.
- Settings stories and visibility tests now match the always-available behavior.
- No screenshot is included because the existing layout stays unchanged.

## How did you test this code?

- Passed the Desktop UI test suite: 535 files and 4,367 tests.
- The shared package build passed during the earlier Desktop validation run.
- Not run: the full Desktop typecheck timed out in the sandbox.
- Biome format and lint processes ran out of memory in the sandbox.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This is the second layer in a stack. Skills invoked: `/posthog-desktop`, `/writing-ui-components`, `/writing-tests`, and `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
