### PR TITLE
chore(mcp): remove heatmaps flag gate

### DIFF
--- a/products/signals/skills/signals-scout-session-replay/SKILL.md
+++ b/products/signals/skills/signals-scout-session-replay/SKILL.md
@@ -295,7 +295,7 @@ Direct calls (read-only):
 - `query-session-recordings-list` — resolve `$session_id`s to watchable recordings (pass `session_ids` + a matching `date_from`); order by `console_error_count` or `activity_score` when shortlisting.
 - `session-recording-get` — one recording's metadata for a finding's example links.
 - `session-recording-summaries-list` / `session-recording-summary-get` — stored AI summaries (list filters: `session_ids`, `has_exceptions`, `outcome`; get returns segment-level detail). A 404 just means no summary exists — never trigger generation.
-- `heatmaps-list` / `heatmaps-events` — spatial corroboration for a cluster. Feature-gated: skip silently if absent.
+- `heatmaps-list` / `heatmaps-events` — spatial corroboration for a cluster. Use them when the tools are available; skip only when they are absent.
 - `vision-scanners-list` / `vision-scanners-observations-list` / `vision-observations-list` / `vision-quota-retrieve` — scanner config, observation health, and quota. Feature-gated and often absent even where replay vision is in use — lead with `$recording_observed` SQL; these are the optional mechanism-confirmation layer.
 - `advanced-activity-logs-list` (`scopes: ["Team"]` + `start_date`/`end_date`) — dating recording-config changes against capture cliffs.
 - `read-data-schema` — confirm `$rageclick` / `$dead_click` / replay SDK properties exist before aggregating. Inbox & reviewer routing (mechanics in `authoring-scouts` → `references/report-contract.md`):

--- a/products/signals/skills/signals-scout-session-replay/SKILL.md
+++ b/products/signals/skills/signals-scout-session-replay/SKILL.md
@@ -295,7 +295,7 @@ Direct calls (read-only):
 - `query-session-recordings-list` — resolve `$session_id`s to watchable recordings (pass `session_ids` + a matching `date_from`); order by `console_error_count` or `activity_score` when shortlisting.
 - `session-recording-get` — one recording's metadata for a finding's example links.
 - `session-recording-summaries-list` / `session-recording-summary-get` — stored AI summaries (list filters: `session_ids`, `has_exceptions`, `outcome`; get returns segment-level detail). A 404 just means no summary exists — never trigger generation.
-- `heatmaps-list` / `heatmaps-events` — spatial corroboration for a cluster. Use them when the tools are available; skip only when they are absent.
+- `heatmaps-list` / `heatmaps-events` — spatial corroboration for a cluster.
 - `vision-scanners-list` / `vision-scanners-observations-list` / `vision-observations-list` / `vision-quota-retrieve` — scanner config, observation health, and quota. Feature-gated and often absent even where replay vision is in use — lead with `$recording_observed` SQL; these are the optional mechanism-confirmation layer.
 - `advanced-activity-logs-list` (`scopes: ["Team"]` + `start_date`/`end_date`) — dating recording-config changes against capture cliffs.
 - `read-data-schema` — confirm `$rageclick` / `$dead_click` / replay SDK properties exist before aggregating. Inbox & reviewer routing (mechanics in `authoring-scouts` → `references/report-contract.md`):

--- a/products/web_analytics/mcp/tools.yaml
+++ b/products/web_analytics/mcp/tools.yaml
@@ -27,7 +27,6 @@ tools:
             JSON array of the spots you want to inspect (the `pointer_relative_x` / `pointer_y` values from
             `heatmaps-list`), plus the same page/date filters. Returns the underlying per-session interactions so you
             can open the session recordings that produced a hotspot.
-        feature_flag: heatmaps-mcp
     heatmaps-list:
         operation: heatmaps_list
         enabled: true
@@ -56,7 +55,6 @@ tools:
             distinct coordinates, so the default page plus the `fold` summary is usually enough for analysis — raise
             `limit` or page with `offset` only if you need more, and check `has_more` to know when the list is
             truncated.
-        feature_flag: heatmaps-mcp
     heatmaps-saved-create:
         operation: saved_create
         enabled: true
@@ -75,7 +73,6 @@ tools:
             wildcards are not allowed.
         exclude_params:
             - deleted
-        feature_flag: heatmaps-mcp
     heatmaps-saved-get:
         operation: saved_retrieve
         enabled: true
@@ -90,7 +87,6 @@ tools:
             Get a single saved heatmap by its `short_id`, including per-width render `status`. Poll this after
             `heatmaps-saved-create` until `status` is 'completed'; the rendered page is then viewable by the user in the
             PostHog UI.
-        feature_flag: heatmaps-mcp
     heatmaps-saved-list:
         operation: saved_list
         enabled: true
@@ -107,7 +103,6 @@ tools:
             type 'screenshot') renders the page so heatmap data can be overlaid on it. Filter by `type`, `status`,
             `created_by`, or a `search` substring on URL/name. The rendered page (screenshot with data overlaid) is
             viewable by the user in the PostHog UI.
-        feature_flag: heatmaps-mcp
     heatmaps-saved-regenerate:
         operation: saved_regenerate_create
         enabled: true
@@ -122,7 +117,6 @@ tools:
             Re-run screenshot generation for a saved heatmap of type 'screenshot' by its `short_id`. Clears the existing
             renders and re-renders at every target width; `status` returns to 'processing'. Use when a page has changed
             or a render failed.
-        feature_flag: heatmaps-mcp
     heatmaps-saved-update:
         operation: saved_partial_update
         enabled: true
@@ -137,7 +131,6 @@ tools:
             Update a saved heatmap by its `short_id`. Send only the fields to change — rename via `name`, change
             `widths`, or soft-delete by setting `deleted: true` (deletion goes through this update, not a destroy call).
             Changing the `url` of a 'screenshot' heatmap triggers a fresh render.
-        feature_flag: heatmaps-mcp
     saved-capture-create:
         operation: saved_capture_create
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -5481,8 +5481,7 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        },
-        "feature_flag": "heatmaps-mcp"
+        }
     },
     "heatmaps-list": {
         "description": "Aggregated heatmap interactions captured on a page. Filter by `url_exact` (one page) or `url_pattern` (regex across pages), a date window (`date_from`/`date_to`, data is retained 90 days), and optionally a viewport range (`viewport_width_min`/`viewport_width_max`, CSS px) to isolate a device class. Set `type` to 'click' (default), 'rageclick', 'mousemove', or 'scrolldepth'. For clicks each result is a point — `pointer_relative_x` (0..1 across the viewport), `pointer_y` (absolute pixels down the page), and a `count`; 'scrolldepth' returns reach buckets instead. For the click types the response also includes a `fold` summary — `pct_below_fold` (share of non-fixed interactions that landed below the user's initial viewport, i.e. required scrolling), `below_fold_count`, `total_count`, and the `median_viewport_height` (the typical fold line in CSS px) — so a high `pct_below_fold` flags engaged content sitting off the first screen. `rageclick` hotspots and shallow scroll depth are the strongest signals that something on the page is confusing or buried. Heatmaps only know coordinates, not what was clicked — cross-reference autocapture events on the same URL to name the elements, and use `heatmaps-events` to jump to the sessions behind a hotspot. Click results are returned hottest-first and capped at `limit` (default 500); busy pages have thousands of distinct coordinates, so the default page plus the `fold` summary is usually enough for analysis — raise `limit` or page with `offset` only if you need more, and check `has_more` to know when the list is truncated.",
@@ -5496,8 +5495,7 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        },
-        "feature_flag": "heatmaps-mcp"
+        }
     },
     "heatmaps-saved-create": {
         "description": "Create a saved heatmap for a page URL. For type 'screenshot' (the default) this enqueues a headless render of the page at each target width — poll `heatmaps-saved-get` until `status` is 'completed'; the rendered page (with data overlaid) is then viewable by the user in the PostHog UI. Provide `widths` (CSS px, 100-3000) to control which viewports are rendered, or omit it for sensible defaults. The URL must be exact — wildcards are not allowed.",
@@ -5511,8 +5509,7 @@
             "idempotentHint": false,
             "openWorldHint": true,
             "readOnlyHint": false
-        },
-        "feature_flag": "heatmaps-mcp"
+        }
     },
     "heatmaps-saved-get": {
         "description": "Get a single saved heatmap by its `short_id`, including per-width render `status`. Poll this after `heatmaps-saved-create` until `status` is 'completed'; the rendered page is then viewable by the user in the PostHog UI.",
@@ -5526,8 +5523,7 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        },
-        "feature_flag": "heatmaps-mcp"
+        }
     },
     "heatmaps-saved-list": {
         "description": "List saved heatmaps for the project. A saved heatmap pins a page URL plus a set of viewport widths and (for type 'screenshot') renders the page so heatmap data can be overlaid on it. Filter by `type`, `status`, `created_by`, or a `search` substring on URL/name. The rendered page (screenshot with data overlaid) is viewable by the user in the PostHog UI.",
@@ -5541,8 +5537,7 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        },
-        "feature_flag": "heatmaps-mcp"
+        }
     },
     "heatmaps-saved-regenerate": {
         "description": "Re-run screenshot generation for a saved heatmap of type 'screenshot' by its `short_id`. Clears the existing renders and re-renders at every target width; `status` returns to 'processing'. Use when a page has changed or a render failed.",
@@ -5556,8 +5551,7 @@
             "idempotentHint": false,
             "openWorldHint": true,
             "readOnlyHint": false
-        },
-        "feature_flag": "heatmaps-mcp"
+        }
     },
     "heatmaps-saved-update": {
         "description": "Update a saved heatmap by its `short_id`. Send only the fields to change — rename via `name`, change `widths`, or soft-delete by setting `deleted: true` (deletion goes through this update, not a destroy call). Changing the `url` of a 'screenshot' heatmap triggers a fresh render.",
@@ -5571,8 +5565,7 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false
-        },
-        "feature_flag": "heatmaps-mcp"
+        }
     },
     "inbox-report-artefacts-create": {
         "description": "Append an artefact to a signal report so it reads as a living document. Everything is append-only. Log types accumulate — `code_reference` (a contiguous span of source lines, at most 20: file_path, start_line, end_line, contents, relevance_note; a single line is just start_line == end_line), `commit` (one commit that has already been pushed to a remote branch: repository, branch, commit_sha, message — usually recorded automatically when you push via git_signed_commit. Only create one yourself for a commit pushed to a remote by other means; never record a commit that is not on a remote branch — an unpushed or local-only commit is always a mistake), `task_run` (associates a tasks.Task with the report — this IS the task↔report association: content.task_id defaults to your own task, product/type label the run and default to tasks/agent_run, and re-associating an already-linked task is idempotent, returning the existing entry), `note` (free-form: note). Status types are latest-wins — appending a new version supersedes the previous one as the report's canonical status: `priority_judgment` (explanation, priority P0–P4), `actionability_judgment` (explanation, actionability, already_addressed), `safety_judgment` (choice), `repo_selection` (repository, reason), `suggested_reviewers` (a list of {github_login}). Status judgments are consequential, not advisory: the canonical priority/actionability steer what humans and agents pick up next, and PostHog's automation uses them when deciding which reports to act on. `content` is a JSON object matching the chosen type and is validated against its schema. Writes are attributed to your task automatically. Returns the created artefact including its id.",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -5678,8 +5678,7 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        },
-        "feature_flag": "heatmaps-mcp"
+        }
     },
     "heatmaps-list": {
         "description": "Aggregated heatmap interactions captured on a page. Filter by `url_exact` (one page) or `url_pattern` (regex across pages), a date window (`date_from`/`date_to`, data is retained 90 days), and optionally a viewport range (`viewport_width_min`/`viewport_width_max`, CSS px) to isolate a device class. Set `type` to 'click' (default), 'rageclick', 'mousemove', or 'scrolldepth'. For clicks each result is a point — `pointer_relative_x` (0..1 across the viewport), `pointer_y` (absolute pixels down the page), and a `count`; 'scrolldepth' returns reach buckets instead. For the click types the response also includes a `fold` summary — `pct_below_fold` (share of non-fixed interactions that landed below the user's initial viewport, i.e. required scrolling), `below_fold_count`, `total_count`, and the `median_viewport_height` (the typical fold line in CSS px) — so a high `pct_below_fold` flags engaged content sitting off the first screen. `rageclick` hotspots and shallow scroll depth are the strongest signals that something on the page is confusing or buried. Heatmaps only know coordinates, not what was clicked — cross-reference autocapture events on the same URL to name the elements, and use `heatmaps-events` to jump to the sessions behind a hotspot. Click results are returned hottest-first and capped at `limit` (default 500); busy pages have thousands of distinct coordinates, so the default page plus the `fold` summary is usually enough for analysis — raise `limit` or page with `offset` only if you need more, and check `has_more` to know when the list is truncated.",
@@ -5693,8 +5692,7 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        },
-        "feature_flag": "heatmaps-mcp"
+        }
     },
     "heatmaps-saved-create": {
         "description": "Create a saved heatmap for a page URL. For type 'screenshot' (the default) this enqueues a headless render of the page at each target width — poll `heatmaps-saved-get` until `status` is 'completed'; the rendered page (with data overlaid) is then viewable by the user in the PostHog UI. Provide `widths` (CSS px, 100-3000) to control which viewports are rendered, or omit it for sensible defaults. The URL must be exact — wildcards are not allowed.",
@@ -5708,8 +5706,7 @@
             "idempotentHint": false,
             "openWorldHint": true,
             "readOnlyHint": false
-        },
-        "feature_flag": "heatmaps-mcp"
+        }
     },
     "heatmaps-saved-get": {
         "description": "Get a single saved heatmap by its `short_id`, including per-width render `status`. Poll this after `heatmaps-saved-create` until `status` is 'completed'; the rendered page is then viewable by the user in the PostHog UI.",
@@ -5723,8 +5720,7 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        },
-        "feature_flag": "heatmaps-mcp"
+        }
     },
     "heatmaps-saved-list": {
         "description": "List saved heatmaps for the project. A saved heatmap pins a page URL plus a set of viewport widths and (for type 'screenshot') renders the page so heatmap data can be overlaid on it. Filter by `type`, `status`, `created_by`, or a `search` substring on URL/name. The rendered page (screenshot with data overlaid) is viewable by the user in the PostHog UI.",
@@ -5738,8 +5734,7 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        },
-        "feature_flag": "heatmaps-mcp"
+        }
     },
     "heatmaps-saved-regenerate": {
         "description": "Re-run screenshot generation for a saved heatmap of type 'screenshot' by its `short_id`. Clears the existing renders and re-renders at every target width; `status` returns to 'processing'. Use when a page has changed or a render failed.",
@@ -5753,8 +5748,7 @@
             "idempotentHint": false,
             "openWorldHint": true,
             "readOnlyHint": false
-        },
-        "feature_flag": "heatmaps-mcp"
+        }
     },
     "heatmaps-saved-update": {
         "description": "Update a saved heatmap by its `short_id`. Send only the fields to change — rename via `name`, change `widths`, or soft-delete by setting `deleted: true` (deletion goes through this update, not a destroy call). Changing the `url` of a 'screenshot' heatmap triggers a fresh render.",
@@ -5768,8 +5762,7 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false
-        },
-        "feature_flag": "heatmaps-mcp"
+        }
     },
     "inbox-report-artefacts-create": {
         "description": "Append an artefact to a signal report so it reads as a living document. Everything is append-only. Log types accumulate — `code_reference` (a contiguous span of source lines, at most 20: file_path, start_line, end_line, contents, relevance_note; a single line is just start_line == end_line), `commit` (one commit that has already been pushed to a remote branch: repository, branch, commit_sha, message — usually recorded automatically when you push via git_signed_commit. Only create one yourself for a commit pushed to a remote by other means; never record a commit that is not on a remote branch — an unpushed or local-only commit is always a mistake), `task_run` (associates a tasks.Task with the report — this IS the task↔report association: content.task_id defaults to your own task, product/type label the run and default to tasks/agent_run, and re-associating an already-linked task is idempotent, returning the existing entry), `note` (free-form: note). Status types are latest-wins — appending a new version supersedes the previous one as the report's canonical status: `priority_judgment` (explanation, priority P0–P4), `actionability_judgment` (explanation, actionability, already_addressed), `safety_judgment` (choice), `repo_selection` (repository, reason), `suggested_reviewers` (a list of {github_login}). Status judgments are consequential, not advisory: the canonical priority/actionability steer what humans and agents pick up next, and PostHog's automation uses them when deciding which reports to act on. `content` is a JSON object matching the chosen type and is validated against its schema. Writes are attributed to your task automatically. Returns the created artefact including its id.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/heatmaps-events.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/heatmaps-events.json
@@ -1,0 +1,104 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "aggregation": {
+            "default": "total_count",
+            "description": "How to aggregate counts: 'total_count' (every interaction, default) or 'unique_visitors' (distinct people).\n\n* `unique_visitors` - unique_visitors\n* `total_count` - total_count",
+            "enum": ["unique_visitors", "total_count"],
+            "type": "string"
+        },
+        "cohort_ids": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "JSON array of cohort IDs (e.g. '[123, 456]') to restrict results to people in those cohorts. Feature-flagged; ignored when the cohort filter is not enabled for the caller."
+        },
+        "date_from": {
+            "default": "-7d",
+            "description": "Start of the window. Relative (e.g. '-7d', '-30d', '-1mStart') or an absolute 'YYYY-MM-DD' date. Defaults to '-7d'. Heatmap data is retained for 90 days.",
+            "minLength": 1,
+            "type": "string"
+        },
+        "date_to": {
+            "description": "End of the window, inclusive. Relative or absolute 'YYYY-MM-DD'. Defaults to today.",
+            "minLength": 1,
+            "type": "string"
+        },
+        "events": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "JSON array of event filters (e.g. '[{\"id\": \"purchase\", \"properties\": []}]') to restrict results to sessions in which those events occurred. Each entry needs a string 'id' (the event name) and may carry a 'properties' array of property filters applied to that event, each of type 'event' or 'element'. Several entries are combined with AND: the session must contain a matching event for every entry. At most 10 entries, each with at most 20 property filters. Requires project-wide heatmap access, since the filter reads the project's events rather than one saved heatmap. Feature-flagged; ignored when the event filter is not enabled for the caller."
+        },
+        "filter_test_accounts": {
+            "anyOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "When true, exclude sessions from internal/test accounts using the project's test-account filters."
+        },
+        "hide_zero_coordinates": {
+            "default": true,
+            "description": "When true (default), drop interactions recorded at the (0, 0) origin, which are usually noise.",
+            "type": "boolean"
+        },
+        "limit": {
+            "default": 50,
+            "description": "Maximum interactions to return (1-100).",
+            "maximum": 100,
+            "minimum": 1,
+            "type": "number"
+        },
+        "offset": {
+            "default": 0,
+            "description": "Number of interactions to skip, for pagination.",
+            "minimum": 0,
+            "type": "number"
+        },
+        "points": {
+            "description": "JSON array of the heatmap coordinates to drill into, e.g. '[{\"x\": 0.5, \"y\": 100}]'. Each point needs 'x' (relative x, 0..1) and 'y' (absolute client-y pixels) matching values returned by the heatmaps list endpoint; an optional 'target_fixed' boolean matches fixed-position elements. Returns the individual session interactions behind those spots.",
+            "minLength": 1,
+            "type": "string"
+        },
+        "type": {
+            "default": "click",
+            "description": "The interaction type to return. One of: 'click' (default), 'rageclick', 'mousemove', or 'scrolldepth'. Scrolldepth returns scroll buckets instead of x/y coordinates.",
+            "minLength": 1,
+            "type": "string"
+        },
+        "url_exact": {
+            "description": "Match a single page by exact URL (trailing slash is ignored). Mutually exclusive with url_pattern.",
+            "minLength": 1,
+            "type": "string"
+        },
+        "url_pattern": {
+            "description": "Match pages by regex against the full current_url (anchored automatically). Use this to aggregate across query strings or path segments. Mutually exclusive with url_exact.",
+            "minLength": 1,
+            "type": "string"
+        },
+        "viewport_width_max": {
+            "description": "Only include interactions captured at a viewport at most this wide, in CSS pixels.",
+            "type": "number"
+        },
+        "viewport_width_min": {
+            "description": "Only include interactions captured at a viewport at least this wide, in CSS pixels. Use with viewport_width_max to isolate a device class (e.g. 360-768 for mobile).",
+            "type": "number"
+        }
+    },
+    "required": ["points"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/heatmaps-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/heatmaps-list.json
@@ -1,0 +1,99 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "aggregation": {
+            "default": "total_count",
+            "description": "How to aggregate counts: 'total_count' (every interaction, default) or 'unique_visitors' (distinct people).\n\n* `unique_visitors` - unique_visitors\n* `total_count` - total_count",
+            "enum": ["unique_visitors", "total_count"],
+            "type": "string"
+        },
+        "cohort_ids": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "JSON array of cohort IDs (e.g. '[123, 456]') to restrict results to people in those cohorts. Feature-flagged; ignored when the cohort filter is not enabled for the caller."
+        },
+        "date_from": {
+            "default": "-7d",
+            "description": "Start of the window. Relative (e.g. '-7d', '-30d', '-1mStart') or an absolute 'YYYY-MM-DD' date. Defaults to '-7d'. Heatmap data is retained for 90 days.",
+            "minLength": 1,
+            "type": "string"
+        },
+        "date_to": {
+            "description": "End of the window, inclusive. Relative or absolute 'YYYY-MM-DD'. Defaults to today.",
+            "minLength": 1,
+            "type": "string"
+        },
+        "events": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "JSON array of event filters (e.g. '[{\"id\": \"purchase\", \"properties\": []}]') to restrict results to sessions in which those events occurred. Each entry needs a string 'id' (the event name) and may carry a 'properties' array of property filters applied to that event, each of type 'event' or 'element'. Several entries are combined with AND: the session must contain a matching event for every entry. At most 10 entries, each with at most 20 property filters. Requires project-wide heatmap access, since the filter reads the project's events rather than one saved heatmap. Feature-flagged; ignored when the event filter is not enabled for the caller."
+        },
+        "filter_test_accounts": {
+            "anyOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "When true, exclude sessions from internal/test accounts using the project's test-account filters."
+        },
+        "hide_zero_coordinates": {
+            "default": true,
+            "description": "When true (default), drop interactions recorded at the (0, 0) origin, which are usually noise.",
+            "type": "boolean"
+        },
+        "limit": {
+            "default": 500,
+            "description": "Maximum number of coordinate points to return, ordered hottest-first by count. Defaults to 500. Pass 0 to fetch the full set (every coordinate) needed to render a complete heatmap overlay. Ignored for the 'scrolldepth' type, which always returns every bucket.",
+            "maximum": 1000000,
+            "minimum": 0,
+            "type": "number"
+        },
+        "offset": {
+            "default": 0,
+            "description": "Number of hottest-first points to skip, for paging through cooler coordinates. Ignored for the 'scrolldepth' type.",
+            "maximum": 1000000,
+            "minimum": 0,
+            "type": "number"
+        },
+        "type": {
+            "default": "click",
+            "description": "The interaction type to return. One of: 'click' (default), 'rageclick', 'mousemove', or 'scrolldepth'. Scrolldepth returns scroll buckets instead of x/y coordinates.",
+            "minLength": 1,
+            "type": "string"
+        },
+        "url_exact": {
+            "description": "Match a single page by exact URL (trailing slash is ignored). Mutually exclusive with url_pattern.",
+            "minLength": 1,
+            "type": "string"
+        },
+        "url_pattern": {
+            "description": "Match pages by regex against the full current_url (anchored automatically). Use this to aggregate across query strings or path segments. Mutually exclusive with url_exact.",
+            "minLength": 1,
+            "type": "string"
+        },
+        "viewport_width_max": {
+            "description": "Only include interactions captured at a viewport at most this wide, in CSS pixels.",
+            "type": "number"
+        },
+        "viewport_width_min": {
+            "description": "Only include interactions captured at a viewport at least this wide, in CSS pixels. Use with viewport_width_max to isolate a device class (e.g. 360-768 for mobile).",
+            "type": "number"
+        }
+    },
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/heatmaps-saved-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/heatmaps-saved-create.json
@@ -1,0 +1,66 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "block_consent_modals": {
+            "description": "When true, ask the headless browser to dismiss cookie/consent banners before capturing the screenshot. Off by default: the blocker can stall the render on some sites and time out. Only applies to 'screenshot' heatmaps.",
+            "type": "boolean"
+        },
+        "data_url": {
+            "anyOf": [
+                {
+                    "anyOf": [
+                        {
+                            "format": "uri",
+                            "maxLength": 2000,
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                {
+                    "maxLength": 0,
+                    "type": "string"
+                }
+            ],
+            "description": "URL whose heatmap data is overlaid on the screenshot. Defaults to 'url' when omitted."
+        },
+        "name": {
+            "anyOf": [
+                {
+                    "maxLength": 400,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Human-readable label for the saved heatmap."
+        },
+        "type": {
+            "default": "screenshot",
+            "description": "Render mode: 'screenshot' (renders the page headlessly, default), 'iframe', or 'recording'. Only 'screenshot' generates image bytes.\n\n* `screenshot` - Screenshot\n* `iframe` - Iframe\n* `recording` - Recording",
+            "enum": ["screenshot", "iframe", "recording"],
+            "type": "string"
+        },
+        "url": {
+            "description": "Exact page URL to render and overlay heatmap data on. Wildcards are not allowed.",
+            "format": "uri",
+            "maxLength": 2000,
+            "type": "string"
+        },
+        "widths": {
+            "description": "Viewport widths (px, 100-3000) to render the heatmap screenshot at — one render per width. Defaults to [320, 375, 425, 768, 1024, 1440, 1920] when omitted. At most 16 widths.",
+            "items": {
+                "maximum": 3000,
+                "minimum": 100,
+                "type": "number"
+            },
+            "maxItems": 16,
+            "type": "array"
+        }
+    },
+    "required": ["url"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/heatmaps-saved-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/heatmaps-saved-get.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "short_id": {
+            "type": "string"
+        }
+    },
+    "required": ["short_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/heatmaps-saved-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/heatmaps-saved-list.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "created_by": {
+            "description": "Filter by the creating user's ID.",
+            "type": "number"
+        },
+        "limit": {
+            "default": 100,
+            "description": "Maximum saved heatmaps to return.",
+            "type": "number"
+        },
+        "offset": {
+            "default": 0,
+            "description": "Number to skip, for pagination.",
+            "type": "number"
+        },
+        "order": {
+            "description": "Field to order by, e.g. '-updated_at' (default) or 'created_at'.",
+            "minLength": 1,
+            "type": "string"
+        },
+        "search": {
+            "description": "Case-insensitive substring match on URL or name.",
+            "minLength": 1,
+            "type": "string"
+        },
+        "status": {
+            "description": "Filter by generation status: 'processing', 'completed', or 'failed'.",
+            "minLength": 1,
+            "type": "string"
+        },
+        "type": {
+            "description": "Filter by render mode: 'screenshot', 'iframe', or 'recording'.",
+            "minLength": 1,
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/heatmaps-saved-regenerate.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/heatmaps-saved-regenerate.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "short_id": {
+            "type": "string"
+        }
+    },
+    "required": ["short_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/heatmaps-saved-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/heatmaps-saved-update.json
@@ -1,0 +1,72 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "block_consent_modals": {
+            "description": "When true, ask the headless browser to dismiss cookie/consent banners before capturing the screenshot. Off by default: the blocker can stall the render on some sites and time out. Only applies to 'screenshot' heatmaps.",
+            "type": "boolean"
+        },
+        "data_url": {
+            "anyOf": [
+                {
+                    "anyOf": [
+                        {
+                            "format": "uri",
+                            "maxLength": 2000,
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                {
+                    "maxLength": 0,
+                    "type": "string"
+                }
+            ],
+            "description": "URL whose heatmap data is overlaid on the screenshot. Defaults to 'url' when omitted."
+        },
+        "deleted": {
+            "description": "Set true to soft-delete the saved heatmap.",
+            "type": "boolean"
+        },
+        "name": {
+            "anyOf": [
+                {
+                    "maxLength": 400,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Human-readable label for the saved heatmap."
+        },
+        "short_id": {
+            "type": "string"
+        },
+        "type": {
+            "description": "Render mode: 'screenshot' (renders the page headlessly, default), 'iframe', or 'recording'. Only 'screenshot' generates image bytes.\n\n* `screenshot` - Screenshot\n* `iframe` - Iframe\n* `recording` - Recording",
+            "enum": ["screenshot", "iframe", "recording"],
+            "type": "string"
+        },
+        "url": {
+            "description": "Exact page URL to render and overlay heatmap data on. Wildcards are not allowed.",
+            "format": "uri",
+            "maxLength": 2000,
+            "type": "string"
+        },
+        "widths": {
+            "description": "Viewport widths (px, 100-3000) to render the heatmap screenshot at — one render per width. Defaults to [320, 375, 425, 768, 1024, 1440, 1920] when omitted. At most 16 widths.",
+            "items": {
+                "maximum": 3000,
+                "minimum": 100,
+                "type": "number"
+            },
+            "maxItems": 16,
+            "type": "array"
+        }
+    },
+    "required": ["short_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -920,7 +920,6 @@ describe('Tool Filtering - Feature Flags', () => {
                 'revamped-py-notebooks',
                 'tasks',
                 'dashboard-widgets',
-                'heatmaps-mcp',
                 'marketing-analytics-mcp',
                 'product-business-knowledge',
                 'field-notes',
@@ -945,7 +944,7 @@ describe('Tool Filtering - Feature Flags', () => {
                 'warehouse-multi-destination',
             ])
         )
-        expect(flags).toHaveLength(34)
+        expect(flags).toHaveLength(33)
     })
 
     it('every loops tool is gated on the loops flag', () => {


### PR DESCRIPTION
Robot: Heatmap MCP tools are available without a rollout flag.

## Problem

Agents should not lose access to tools that are already rolled out to everyone.

## Changes

- Heatmap MCP tools no longer use the `heatmaps-mcp` feature gate.
- Generated tool catalogs now match the YAML configuration.
- The required-flag test now reflects the current definitions.
- No screenshot is included because this changes tool availability, not a visual surface.

## How did you test this code?

- Regenerated the MCP tool catalogs.
- Passed MCP tool-name validation.
- Parsed both generated JSON catalogs successfully.
- Passed `tests/unit/tool-filtering.test.ts`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This is the top layer in a stack. Skills invoked: `/implementing-mcp-tools`, `/writing-tests`, and `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
