### PR TITLE
fix(data-warehouse): pause schedule when discovery disables a schema

### DIFF
--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -1496,9 +1496,13 @@ def sync_old_schemas_with_new_schemas(
                 s.soft_delete()
                 deleted_schemas.append(schema)
             else:
-                s.should_sync = False
-                s.status = ExternalDataSchema.Status.COMPLETED
-                s.save()
+                # update_should_sync (not a plain save) so a schema this branch disables also
+                # gets its Temporal schedule paused — otherwise the schedule keeps firing and
+                # every tick creates a job that fails against a table discovery no longer offers.
+                updated = update_should_sync(schema_id=str(s.id), team_id=team_id, should_sync=False)
+                if updated is not None:
+                    updated.status = ExternalDataSchema.Status.COMPLETED
+                    updated.save(update_fields=["status", "updated_at"])
 
     return SchemaSyncResult(created=actually_created, deleted=deleted_schemas)
 

--- a/products/warehouse_sources/backend/tests/test_schema_discovery_reconcile.py
+++ b/products/warehouse_sources/backend/tests/test_schema_discovery_reconcile.py
@@ -155,17 +155,24 @@ class TestSchemaDiscoveryReconcile(BaseTest):
             team_id=self.team.pk, source_id=source.pk, name="leads", should_sync=True
         )
 
-        sync_result = sync_old_schemas_with_new_schemas(
-            {"contacts": None},
-            source_id=str(source.pk),
-            team_id=self.team.pk,
-        )
+        with (
+            patch("products.data_warehouse.backend.facade.api.external_data_workflow_exists", return_value=True),
+            patch("products.data_warehouse.backend.facade.api.pause_external_data_schedule") as mock_pause,
+        ):
+            sync_result = sync_old_schemas_with_new_schemas(
+                {"contacts": None},
+                source_id=str(source.pk),
+                team_id=self.team.pk,
+            )
 
         enabled_unsynced.refresh_from_db()
         assert sync_result.deleted == []
         assert enabled_unsynced.deleted is False
         assert enabled_unsynced.should_sync is False
         assert enabled_unsynced.status == ExternalDataSchema.Status.COMPLETED
+        # Regression: this branch used to flip should_sync with a plain save(), leaving the
+        # Temporal schedule running so it kept firing against a table discovery no longer offers.
+        mock_pause.assert_called_once_with(str(enabled_unsynced.id))
 
 
 class TestSchemaNameMatchesAutoSyncPatterns(SimpleTestCase):


### PR DESCRIPTION
## Problem

When schema discovery stops reporting a table someone had enabled, the schema gets disabled but its Temporal schedule keeps firing. Every tick creates a new `ExternalDataJob` that fails against a table the source no longer offers — forever, with no path back to a clean state.

Closes #91765

## Changes

- `sync_old_schemas_with_new_schemas`'s disable branch (the one that keeps a user-enabled schema visible instead of soft-deleting it) now goes through `update_should_sync` instead of a plain `save()`. That routes it through the existing schedule-pause logic every other disable path already uses.
- The `status = COMPLETED` write stays a separate, explicit step right after, so this doesn't change what a disabled schema looks like — only whether its schedule actually stops.
- Mechanical: no other call site or behavior changes.

## How did you test this code?

Extended the existing `test_dropped_user_enabled_schema_is_disabled_not_deleted_before_first_sync` test (it already sets up exactly this scenario) with mocks for `external_data_workflow_exists` and `pause_external_data_schedule`, then asserted the pause is called with the disabled schema's id. This follows the same facade-mocking convention (`_SCHEDULE_FN`) already used elsewhere in the same test file. It catches the exact regression: if the disable branch goes back to a plain `save()`, this assertion fails.

Ran `ruff check` and `ruff format --check` on both changed files — clean.

Could not run this against a live Postgres/Django test database in this sandbox — no Docker available, and the PostgreSQL installer was blocked by network policy (403 from the download host). CI will need to be the first real run of this test; flagging that here rather than claiming a local pass that didn't happen.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — this is internal reconciliation behavior with no documented workflow change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code at the direction of the PR author, working from the issue's own root-cause analysis and suggested fix (route the disable branch through `update_should_sync`). The `.agents/skills/writing-tests/SKILL.md` gate was applied by hand: extended the nearest existing test rather than adding a new one, and mocked only the Temporal facade boundary. Decision: kept the `status = COMPLETED` write as a second explicit save rather than folding it into `update_should_sync`, to avoid changing that shared function's behavior for its other callers.
