### PR TITLE
chore(warehouse_sources): promote ActiveCampaign and Mailjet to GA

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/active_campaign/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/active_campaign/source.py
@@ -52,7 +52,7 @@ class ActiveCampaignSource(ResumableSource[ActiveCampaignSourceConfig, ActiveCam
             name=SchemaExternalDataSourceType.ACTIVE_CAMPAIGN,
             category=DataWarehouseSourceCategory.MARKETING___EMAIL,
             label="ActiveCampaign",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.GA,
             caption="""Enter your ActiveCampaign API URL and key to sync your CRM and marketing data into the PostHog Data warehouse.
 
 You can find both in your ActiveCampaign account under **Settings > Developer**. The API key is account-wide and grants read access to every endpoint listed below.""",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mailjet/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mailjet/source.py
@@ -72,7 +72,7 @@ class MailJetSource(
             name=SchemaExternalDataSourceType.MAILJET,
             category=DataWarehouseSourceCategory.MARKETING___EMAIL,
             label="Mailjet",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.GA,
             caption="""Enter your Mailjet API key and secret key to pull your Mailjet data into the PostHog Data warehouse.
 
 You can find your API key and secret key in your [Mailjet API key management page](https://app.mailjet.com/account/apikeys).


### PR DESCRIPTION
## Problem

Anyone browsing the data warehouse source catalog sees an "alpha" label on ActiveCampaign and Mailjet, which reads as a warning not to rely on them. Both have been live over three months and import cleanly, so the label understates how stable they are.

Each source qualifies against the promotion bar (7-day window):

| Source | Live for | Teams | Import error rate | Bar |
| --- | --- | --- | --- | --- |
| ActiveCampaign | 3.1 months | 18 | 0.2% | 100+ teams or 3 months live, error rate under 2.5% |
| Mailjet | 3.1 months | 4 | 0.0% | 100+ teams or 3 months live, error rate under 2.5% |

## Changes

- The catalog no longer marks ActiveCampaign or Mailjet as alpha, so a user picking a source sees them as generally available.
- Each source's `releaseStatus` moves from `ReleaseStatus.ALPHA` to `ReleaseStatus.GA`, which is what `/api/public_source_configs/` surfaces.
- No gating changes. Neither source carries an `unreleasedSource` flag or a `featureFlag`, so there was nothing to remove.
- Mailjet's webhook hog function template keeps its own `status="alpha"`. That is a separate template lifecycle field, and GA sources such as Stripe carry the same value.

No connector behavior, schema, or sync logic changes.

## How did you test this code?

`ruff check` passes on both edited files. No test asserts a release status for either source, so no test needed updating.

Not run: the warehouse source suites, because this is a two-line metadata change with no behavioral surface. CI covers them.

Nothing a person sees is visual beyond the catalog badge dropping, so no screenshots.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The docs pages for both sources do not state a release stage.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code (PostHog Desktop). Skills invoked: `/implementing-warehouse-sources` for the release status conventions, `/writing-pr-descriptions` for this body.

No duplicate: searched open PRs for each source name, "releaseStatus", and "promote", and listed every open PR from the warehouse sources maintainer. Nothing addresses either promotion. The one Mailjet hit ([#95125](https://github.com/PostHog/posthog/pull/95125)) is a webhook sync backfill fix.

Public artifact: the diff and this description carry only source metadata and the aggregate adoption figures that justify the promotion. No customer data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
