### PR TITLE
fix(desktop): render MCP apps reliably in chat

### DIFF
--- a/products/desktop/docs/ARCHITECTURE.md
+++ b/products/desktop/docs/ARCHITECTURE.md
@@ -253,6 +253,18 @@ MCP Apps render tool-provided HTML UIs inside sandboxed iframes.
 
 The core service manages MCP server connections, caches resources, and proxies UI calls. `useAppBridge` handles `@modelcontextprotocol/ext-apps` host communication, tRPC routing, theme, display mode, and dimensions.
 
+A tool can select an app in its registration metadata or in one call result.
+A result-level `_meta.ui.resourceUri` takes precedence, which lets one tool show different interfaces for different calls.
+Desktop preserves complete successful `CallToolResult` values across Claude, Codex, and Pi so the app receives `structuredContent`, `_meta`, and content blocks.
+Pi still throws when a result has `isError`, so Pi failure semantics remain unchanged.
+
+Desktop runs executable app HTML only when the resource uses a `ui://` URI and the exact `text/html;profile=mcp-app` MIME type.
+The app can read other resource URI schemes through the same MCP server.
+Desktop does not fetch those resource URIs directly.
+
+Result and cancellation events include the tool call ID.
+The host uses this ID so concurrent calls to the same tool cannot send data to each other's app.
+
 ## References
 
 - [AGENTS.md](../AGENTS.md)

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/mapping.test.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/mapping.test.ts
@@ -6,6 +6,22 @@ import {
 } from "./mapping";
 import { APP_SERVER_NOTIFICATIONS } from "./protocol";
 
+const COMPLETE_MCP_RESULT = {
+  content: [
+    { type: "text", text: "42 rows" },
+    {
+      type: "resource",
+      resource: {
+        uri: "ui://posthog/query-result",
+        mimeType: "text/html",
+        text: "interactive result",
+      },
+    },
+  ],
+  structuredContent: { columns: ["count"], rows: [[42]] },
+  _meta: { ui: { resourceUri: "ui://posthog/query-result" } },
+};
+
 describe("mapAppServerNotification", () => {
   it("maps an agent message delta to an ACP agent_message_chunk", () => {
     const result = mapAppServerNotification(
@@ -686,6 +702,45 @@ describe("mapHistoryItem", () => {
     });
   });
 
+  it("replays a completed MCP call with its full raw result", () => {
+    expect(
+      mapHistoryItem("s-1", {
+        type: "mcpToolCall",
+        id: "m1",
+        server: "posthog",
+        tool: "query",
+        status: "completed",
+        arguments: { sql: "SELECT 1" },
+        result: COMPLETE_MCP_RESULT,
+      }),
+    ).toEqual([
+      {
+        sessionId: "s-1",
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: "m1",
+          title: "posthog/query",
+          kind: "other",
+          status: "completed",
+          rawInput: { sql: "SELECT 1" },
+          rawOutput: COMPLETE_MCP_RESULT,
+          content: [
+            {
+              type: "content",
+              content: { type: "text", text: "42 rows" },
+            },
+          ],
+          _meta: {
+            posthog: {
+              toolName: "mcp__posthog__query",
+              mcp: { server: "posthog", tool: "query" },
+            },
+          },
+        },
+      },
+    ]);
+  });
+
   it("does not replay ephemeral reasoning items", () => {
     expect(mapHistoryItem("s-1", { type: "reasoning", id: "r1" })).toEqual([]);
   });
@@ -719,7 +774,7 @@ describe("mcpToolCall result rendering", () => {
           tool: "query",
           status: "completed",
           arguments: { sql: "SELECT 1" },
-          result: { content: [{ type: "text", text: "42 rows" }] },
+          result: COMPLETE_MCP_RESULT,
         },
       }),
     ).toEqual({
@@ -731,6 +786,7 @@ describe("mcpToolCall result rendering", () => {
         content: [
           { type: "content", content: { type: "text", text: "42 rows" } },
         ],
+        rawOutput: COMPLETE_MCP_RESULT,
       },
     });
   });

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/mapping.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/mapping.ts
@@ -177,6 +177,11 @@ export function parseUnifiedDiff(diff: string): {
   return { oldText: oldLines.join("\n"), newText: newLines.join("\n") };
 }
 
+type AppServerMcpResult = {
+  content?: unknown;
+  [key: string]: unknown;
+};
+
 export type AppServerItem = {
   type?: string;
   id?: string;
@@ -192,7 +197,7 @@ export type AppServerItem = {
   arguments?: unknown;
   aggregatedOutput?: string | null;
   changes?: Array<{ path?: string; diff?: string; kind?: unknown }>;
-  result?: { content?: unknown } | null;
+  result?: AppServerMcpResult | null;
   error?: { message?: string } | null;
   // Present on message/reasoning items replayed from thread history.
   text?: string;
@@ -320,6 +325,9 @@ export function mapHistoryItem(
                   }
                 : {}),
             ...(content ? { content } : {}),
+            ...(item.type === "mcpToolCall" && item.result != null
+              ? { rawOutput: item.result }
+              : {}),
           },
         },
       ];
@@ -555,6 +563,9 @@ function mapItem(
       toolCallId: item.id,
       status: mapStatus(item.status),
       ...(content ? { content } : {}),
+      ...(item.type === "mcpToolCall" && item.result != null
+        ? { rawOutput: item.result }
+        : {}),
     },
   };
 }

--- a/products/desktop/packages/agent/src/pi/conversation/translatePiMessage.test.ts
+++ b/products/desktop/packages/agent/src/pi/conversation/translatePiMessage.test.ts
@@ -197,19 +197,81 @@ describe("createPiMessageTranslator", () => {
   it("adds canonical metadata to a bridged MCP tool result", () => {
     const translator = createPiMessageTranslator();
     const content: ToolResultMessage["content"] = [
-      { type: "text", text: "ok" },
+      { type: "text", text: "visible result" },
     ];
+    const mcpResult = {
+      content: [
+        {
+          type: "resource",
+          resource: {
+            uri: "ui://posthog/actions",
+            mimeType: "text/html",
+            text: "full resource",
+          },
+        },
+      ],
+      structuredContent: { actions: [{ id: 1 }] },
+      _meta: { ui: { resourceUri: "ui://posthog/actions" } },
+    };
+    const details = {
+      posthog: {
+        mcp: { server: "posthog-code-tools", tool: "show_actions" },
+        mcpResult,
+      },
+    };
 
     expect(
       translator.translateToolExecutionEnd(
         "action-1",
         "mcp_posthog_code_tools_show_actions",
+        { content, details },
+        false,
+        false,
+        12,
+      ),
+    ).toEqual([
+      {
+        type: "tool_call_updated",
+        timestamp: 12,
+        toolCall: {
+          id: "action-1",
+          status: "completed",
+          rawOutput: mcpResult,
+          details,
+          content: [
+            {
+              type: "content",
+              content: { type: "text", text: "visible result" },
+            },
+          ],
+          _meta: {
+            posthog: {
+              toolName: "mcp__posthog-code-tools__show_actions",
+              mcp: {
+                server: "posthog-code-tools",
+                tool: "show_actions",
+              },
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it("falls back to bridged content for legacy MCP details", () => {
+    const translator = createPiMessageTranslator();
+    const content: ToolResultMessage["content"] = [
+      { type: "text", text: "legacy result" },
+    ];
+
+    expect(
+      translator.translateToolExecutionEnd(
+        "action-legacy",
+        "mcp_posthog_query",
         {
           content,
           details: {
-            posthog: {
-              mcp: { server: "posthog-code-tools", tool: "show_actions" },
-            },
+            posthog: { mcp: { server: "posthog", tool: "query" } },
           },
         },
         false,
@@ -218,15 +280,12 @@ describe("createPiMessageTranslator", () => {
       ),
     ).toMatchObject([
       {
-        type: "tool_call_updated",
         toolCall: {
+          rawOutput: content,
           _meta: {
             posthog: {
-              toolName: "mcp__posthog-code-tools__show_actions",
-              mcp: {
-                server: "posthog-code-tools",
-                tool: "show_actions",
-              },
+              toolName: "mcp__posthog__query",
+              mcp: { server: "posthog", tool: "query" },
             },
           },
         },

--- a/products/desktop/packages/agent/src/pi/conversation/translatePiMessage.ts
+++ b/products/desktop/packages/agent/src/pi/conversation/translatePiMessage.ts
@@ -48,6 +48,7 @@ interface PiToolExecutionResult {
 const mcpToolDetailsSchema = z.object({
   posthog: z.object({
     mcp: z.object({ server: z.string().min(1), tool: z.string().min(1) }),
+    mcpResult: z.unknown().optional(),
   }),
 });
 
@@ -230,20 +231,23 @@ export function createPiMessageTranslator(): PiMessageTranslator {
     status: AgentToolCallStatus,
     timestamp: number,
   ): AgentConversationEvent[] {
+    const mcpDetails = mcpToolDetailsSchema.safeParse(result.details);
+    const mcpResult = mcpDetails.success
+      ? mcpDetails.data.posthog.mcpResult
+      : undefined;
     const toolCall: Extract<
       AgentConversationEvent,
       { type: "tool_call_updated" }
     >["toolCall"] & { _meta?: ReturnType<typeof posthogToolMeta> } = {
       id: toolCallId,
       status,
-      rawOutput: result.content,
+      rawOutput: mcpResult ?? result.content,
     };
 
     if (result.details !== undefined) {
       toolCall.details = result.details;
     }
 
-    const mcpDetails = mcpToolDetailsSchema.safeParse(result.details);
     if (mcpDetails.success) {
       const mcp = mcpDetails.data.posthog.mcp;
       toolCall._meta = posthogToolMeta({ toolName: mcpToolKey(mcp), mcp });

--- a/products/desktop/packages/core/src/mcp-apps/mcp-apps.test.ts
+++ b/products/desktop/packages/core/src/mcp-apps/mcp-apps.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { McpAppsService } from "./mcp-apps";
 import {
+  LEGACY_RESOURCE_URI_META_KEY,
   McpAppsServiceEvent,
   type McpResourceUiMeta,
   type McpServerConnectionConfig,
@@ -128,28 +129,50 @@ const REVIEW_PERMISSIONS = { clipboardWrite: {} };
 
 const UI_META = { ui: { csp: REVIEW_CSP, permissions: REVIEW_PERMISSIONS } };
 
+type TestTool = {
+  name: string;
+  _meta?: Record<string, unknown>;
+};
+
+const DEFAULT_TOOLS: TestTool[] = [
+  {
+    name: "loops-review",
+    _meta: { ui: { resourceUri: REVIEW_URI } },
+  },
+  { name: "loops-list" },
+];
+
 // metaOn picks whether this client advertises `_meta.ui` on resources/list or
 // on the read response.
-function makeClient(metaOn: "list" | "read" = "list") {
+function makeClient(
+  metaOn: "list" | "read" = "list",
+  tools: TestTool[] = DEFAULT_TOOLS,
+) {
   return {
     close: vi.fn(async () => {}),
-    listTools: vi.fn(async () => ({
-      tools: [
-        {
-          name: "loops-review",
-          _meta: { ui: { resourceUri: REVIEW_URI } },
-        },
-        { name: "loops-list" },
-      ],
-    })),
-    listResources: vi.fn(async () => ({
-      resources: [
-        {
-          uri: REVIEW_URI,
-          ...(metaOn === "list" ? { _meta: UI_META } : {}),
-        } as { uri: string; _meta?: McpResourceUiMeta["_meta"] },
-      ],
-    })),
+    listTools: vi.fn(
+      async (_params?: {
+        cursor?: string;
+      }): Promise<{ tools: TestTool[]; nextCursor?: string }> => ({ tools }),
+    ),
+    listResources: vi.fn(
+      async (_params?: {
+        cursor?: string;
+      }): Promise<{
+        resources: Array<{
+          uri: string;
+          _meta?: McpResourceUiMeta["_meta"];
+        }>;
+        nextCursor?: string;
+      }> => ({
+        resources: [
+          {
+            uri: REVIEW_URI,
+            ...(metaOn === "list" ? { _meta: UI_META } : {}),
+          },
+        ],
+      }),
+    ),
     readResource: vi.fn(async ({ uri }: { uri: string }) => ({
       contents: [
         {
@@ -164,6 +187,9 @@ function makeClient(metaOn: "list" | "read" = "list") {
           _meta?: McpResourceUiMeta["_meta"];
         },
       ],
+    })),
+    callTool: vi.fn(async ({ name }: { name: string }) => ({
+      content: [{ type: "text", text: name }],
     })),
   };
 }
@@ -201,6 +227,33 @@ describe("McpAppsService lazy discovery", () => {
       service.hasUiForTool("mcp__posthog__loops-review"),
     ).resolves.toBe(true);
     expect(client.listTools).toHaveBeenCalledTimes(1);
+  });
+
+  it("discovers on first getToolDefinition when no session ran discovery", async () => {
+    service.setServerConfigs([config("posthog")]);
+    const client = connectClient(service);
+
+    await expect(
+      service.getToolDefinition("mcp__posthog__loops-list"),
+    ).resolves.toMatchObject({ name: "loops-list" });
+    expect(client.listTools).toHaveBeenCalledTimes(1);
+  });
+
+  it("discovers a UI from legacy flat tool metadata", async () => {
+    service.setServerConfigs([config("posthog")]);
+    connectClient(
+      service,
+      makeClient("list", [
+        {
+          name: "legacy-review",
+          _meta: { [LEGACY_RESOURCE_URI_META_KEY]: REVIEW_URI },
+        },
+      ]),
+    );
+
+    await expect(
+      service.hasUiForTool("mcp__posthog__legacy-review"),
+    ).resolves.toBe(true);
   });
 
   it("emits DiscoveryComplete after a lazy discovery", async () => {
@@ -338,15 +391,29 @@ describe("McpAppsService lazy discovery", () => {
     await expect(
       service.hasUiForTool("mcp__posthog__loops-list"),
     ).resolves.toBe(false);
+    await expect(
+      service.getToolDefinition("mcp__posthog__loops-list"),
+    ).resolves.toMatchObject({ name: "loops-list" });
     expect(client.listTools).toHaveBeenCalledTimes(1);
   });
 
-  it("re-lists on handleDiscovery even when already discovered", async () => {
+  it("replaces the server's tool state when discovery runs again", async () => {
     service.setServerConfigs([config("posthog")]);
     const client = connectClient(service);
 
     await service.hasUiForTool("mcp__posthog__loops-review");
+    client.listTools.mockResolvedValueOnce({ tools: [] });
     await service.handleDiscovery(["posthog"]);
+
+    await expect(
+      service.hasUiForTool("mcp__posthog__loops-review"),
+    ).resolves.toBe(false);
+    await expect(
+      service.getToolDefinition("mcp__posthog__loops-review"),
+    ).resolves.toBeNull();
+    await expect(
+      service.getToolDefinition("mcp__posthog__loops-list"),
+    ).resolves.toBeNull();
     expect(client.listTools).toHaveBeenCalledTimes(2);
   });
 
@@ -357,9 +424,58 @@ describe("McpAppsService lazy discovery", () => {
     await service.hasUiForTool("mcp__posthog__loops-review");
     await service.disconnectServer("posthog");
     await expect(
+      service.getToolDefinition("mcp__posthog__loops-review"),
+    ).resolves.toMatchObject({ name: "loops-review" });
+    await expect(
       service.hasUiForTool("mcp__posthog__loops-review"),
     ).resolves.toBe(true);
     expect(client.listTools).toHaveBeenCalledTimes(2);
+  });
+
+  it("follows pagination for tool and resource discovery", async () => {
+    service.setServerConfigs([config("posthog")]);
+    const client = makeClient();
+    client.listTools
+      .mockResolvedValueOnce({ tools: [], nextCursor: "tools-page-2" })
+      .mockResolvedValueOnce({ tools: DEFAULT_TOOLS });
+    client.listResources
+      .mockResolvedValueOnce({ resources: [], nextCursor: "resources-page-2" })
+      .mockResolvedValueOnce({
+        resources: [{ uri: REVIEW_URI, _meta: UI_META }],
+      });
+    connectClient(service, client);
+
+    await service.handleDiscovery(["posthog"]);
+
+    await expect(
+      service.getToolDefinition("mcp__posthog__loops-list"),
+    ).resolves.toMatchObject({ name: "loops-list" });
+    const resource = await service.getUiResourceForTool(
+      "mcp__posthog__loops-review",
+    );
+    expect(resource?.csp).toEqual(REVIEW_CSP);
+    expect(client.listTools).toHaveBeenNthCalledWith(2, {
+      cursor: "tools-page-2",
+    });
+    expect(client.listResources).toHaveBeenNthCalledWith(2, {
+      cursor: "resources-page-2",
+    });
+  });
+
+  it("stops discovery when a server never ends pagination", async () => {
+    service.setServerConfigs([config("posthog")]);
+    const client = makeClient();
+    client.listTools.mockResolvedValue({ tools: [], nextCursor: "again" });
+    client.listResources.mockResolvedValue({
+      resources: [],
+      nextCursor: "again",
+    });
+    connectClient(service, client);
+
+    await service.handleDiscovery(["posthog"]);
+
+    expect(client.listTools).toHaveBeenCalledTimes(100);
+    expect(client.listResources).toHaveBeenCalledTimes(100);
   });
 
   it("resolves lazily-discovered UI resources for a tool", async () => {
@@ -371,6 +487,27 @@ describe("McpAppsService lazy discovery", () => {
     );
     expect(resource?.uri).toBe(REVIEW_URI);
     expect(resource?.html).toBe("<html></html>");
+  });
+
+  it("does not register executable HTML from a non-ui resource URI", async () => {
+    service.setServerConfigs([config("posthog")]);
+    const client = connectClient(
+      service,
+      makeClient("list", [
+        {
+          name: "unsafe-review",
+          _meta: { ui: { resourceUri: "https://example.test/app.html" } },
+        },
+      ]),
+    );
+
+    await expect(
+      service.hasUiForTool("mcp__posthog__unsafe-review"),
+    ).resolves.toBe(false);
+    await expect(
+      service.getUiResourceForTool("mcp__posthog__unsafe-review"),
+    ).resolves.toBeNull();
+    expect(client.readResource).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -490,9 +627,109 @@ describe("McpAppsService lazy discovery", () => {
     await service.getUiResourceByUri("staging", REVIEW_URI);
     await service.disconnectServer("posthog");
 
+    await expect(
+      service.getToolDefinition("mcp__staging__loops-review"),
+    ).resolves.toMatchObject({ name: "loops-review" });
     await service.getUiResourceByUri("staging", REVIEW_URI);
     expect(stagingClient.readResource).toHaveBeenCalledTimes(1);
     await service.getUiResourceByUri("posthog", REVIEW_URI);
     expect(posthogClient.readResource).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("McpAppsService executable resource validation", () => {
+  let service: McpAppsService;
+
+  beforeEach(() => {
+    service = makeService();
+    service.setServerConfigs([config("posthog")]);
+  });
+
+  it("requires the exact MCP App HTML MIME type", async () => {
+    const client = makeClient();
+    client.readResource.mockResolvedValueOnce({
+      contents: [
+        {
+          uri: REVIEW_URI,
+          mimeType: "text/html",
+          text: "<html></html>",
+        },
+      ],
+    });
+    connectClient(service, client);
+
+    await expect(
+      service.getUiResourceByUri("posthog", REVIEW_URI),
+    ).resolves.toBeNull();
+  });
+
+  it("rejects MCP App HTML over the HTML size limit", async () => {
+    const client = makeClient();
+    client.readResource.mockResolvedValueOnce({
+      contents: [
+        {
+          uri: REVIEW_URI,
+          mimeType: UI_MIME_TYPE,
+          text: "x".repeat(5 * 1024 * 1024 + 1),
+        },
+      ],
+    });
+    connectClient(service, client);
+
+    await expect(
+      service.getUiResourceByUri("posthog", REVIEW_URI),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("McpAppsService app proxies", () => {
+  let service: McpAppsService;
+
+  beforeEach(() => {
+    service = makeService();
+    service.setServerConfigs([config("posthog")]);
+  });
+
+  it("rejects UI-less model-only tools and allows default visibility", async () => {
+    const client = connectClient(
+      service,
+      makeClient("list", [
+        {
+          name: "model-only",
+          _meta: { ui: { visibility: ["model"] } },
+        },
+        { name: "default-visible" },
+      ]),
+    );
+
+    await expect(
+      service.proxyToolCall("posthog", "model-only"),
+    ).rejects.toThrow('Tool "model-only" is not accessible to apps');
+    await expect(
+      service.proxyToolCall("posthog", "default-visible"),
+    ).resolves.toEqual({
+      content: [{ type: "text", text: "default-visible" }],
+    });
+    await expect(
+      service.proxyToolCall("posthog", "unlisted-tool"),
+    ).rejects.toThrow('Tool "unlisted-tool" is not available to apps');
+    expect(client.callTool).toHaveBeenCalledExactlyOnceWith({
+      name: "default-visible",
+      arguments: undefined,
+    });
+  });
+
+  it("reads arbitrary URI schemes through the same MCP server", async () => {
+    const client = makeClient();
+    const uri = "data://documents/report.json";
+    client.readResource.mockResolvedValueOnce({
+      contents: [{ uri, mimeType: "application/json", text: "{}" }],
+    });
+    connectClient(service, client);
+
+    await expect(service.proxyResourceRead("posthog", uri)).resolves.toEqual({
+      contents: [{ uri, mimeType: "application/json", text: "{}" }],
+    });
+    expect(client.readResource).toHaveBeenCalledExactlyOnceWith({ uri });
   });
 });

--- a/products/desktop/packages/core/src/mcp-apps/mcp-apps.ts
+++ b/products/desktop/packages/core/src/mcp-apps/mcp-apps.ts
@@ -25,10 +25,10 @@ import {
   type McpResourceUiMeta,
   type McpServerConnectionConfig,
   type McpToolUiAssociation,
-  type McpToolUiMeta,
+  type McpToolUiVisibility,
   type McpUiResource,
-  POSTHOG_EXEC_TOOL_KEY,
   resolveResultResourceUri,
+  resolveToolRegistrationMetadata,
 } from "./schemas";
 
 function summarizeResult(result: unknown): Record<string, unknown> {
@@ -52,6 +52,7 @@ function summarizeResult(result: unknown): Record<string, unknown> {
 
 const UI_MIME_TYPE = "text/html;profile=mcp-app";
 const MAX_HTML_SIZE = 5 * 1024 * 1024; // 5MB
+const MAX_DISCOVERY_PAGES = 100;
 const DISCOVERY_FAILURE_BACKOFF_MS = 60_000;
 
 interface ServerConnection {
@@ -68,6 +69,8 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
   private resourceCache = new Map<string, McpUiResource>();
   private toolAssociations = new Map<string, McpToolUiAssociation>();
   private toolDefinitions = new Map<string, Tool>();
+  private toolVisibilities = new Map<string, McpToolUiVisibility[]>();
+  private serverToolKeys = new Map<string, Set<string>>();
   private serverConfigs = new Map<string, McpServerConnectionConfig>();
   private configResolver?: (serverName: string) => Promise<void>;
   private pendingConnections = new Map<string, Promise<ServerConnection>>();
@@ -103,6 +106,20 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
         map.delete(key);
       }
     }
+  }
+
+  private clearServerDiscoveryData(serverName: string): void {
+    const toolKeys = this.serverToolKeys.get(serverName);
+    if (toolKeys) {
+      for (const toolKey of toolKeys) {
+        this.toolAssociations.delete(toolKey);
+        this.toolDefinitions.delete(toolKey);
+        this.toolVisibilities.delete(toolKey);
+      }
+    }
+    this.serverToolKeys.delete(serverName);
+    this.evictServerEntries(this.resourceCache, serverName);
+    this.evictServerEntries(this.resourceMetaCache, serverName);
   }
 
   /**
@@ -176,18 +193,60 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
     } satisfies McpAppsDiscoveryCompleteEvent);
   }
 
+  private async listAllTools(
+    client: Client,
+    serverName: string,
+  ): Promise<Tool[]> {
+    const tools: Tool[] = [];
+    let cursor: string | undefined;
+
+    for (let page = 0; page < MAX_DISCOVERY_PAGES; page++) {
+      const result = await client.listTools(cursor ? { cursor } : undefined);
+      tools.push(...result.tools);
+      cursor = result.nextCursor;
+      if (!cursor) return tools;
+    }
+
+    this.log.warn("Tool discovery reached the page limit", {
+      serverName,
+      pageLimit: MAX_DISCOVERY_PAGES,
+    });
+    return tools;
+  }
+
+  private async listAllResources(
+    client: Client,
+    serverName: string,
+  ): Promise<McpResourceUiMeta[]> {
+    const resources: McpResourceUiMeta[] = [];
+    let cursor: string | undefined;
+
+    for (let page = 0; page < MAX_DISCOVERY_PAGES; page++) {
+      const result = await client.listResources(
+        cursor ? { cursor } : undefined,
+      );
+      resources.push(...(result.resources as McpResourceUiMeta[]));
+      cursor = result.nextCursor;
+      if (!cursor) return resources;
+    }
+
+    this.log.warn("Resource discovery reached the page limit", {
+      serverName,
+      pageLimit: MAX_DISCOVERY_PAGES,
+    });
+    return resources;
+  }
+
   /**
-   * Connect to a single server and call listTools() to discover which
-   * tools have _meta.ui fields. The connection is kept for later reuse
-   * (proxy calls, resource reads, lazy HTML fetches). Throws on connection
-   * or listTools failure — callers decide whether that is fatal.
+   * Connect to a single server and discover tool and resource metadata. The
+   * connection stays open for proxy calls, resource reads, and HTML fetches.
    */
   private async discoverServerUiTools(serverName: string): Promise<void> {
     const conn = await this.getOrCreateConnection(serverName);
 
-    const [toolsList, resourcesList] = await Promise.all([
-      conn.client.listTools(),
-      conn.client.listResources().catch((err) => {
+    const [tools, resources] = await Promise.all([
+      this.listAllTools(conn.client, serverName),
+      this.listAllResources(conn.client, serverName).catch((err) => {
         this.log.warn("listResources failed during discovery", {
           serverName,
           error: err instanceof Error ? err.message : String(err),
@@ -198,43 +257,51 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
 
     this.log.info("discoverServerUiTools: listed tools", {
       serverName,
-      toolNames: toolsList.tools.map((t) => t.name),
+      toolNames: tools.map((tool) => tool.name),
       hasExecTool:
         serverName === BUILTIN_POSTHOG_SERVER_NAME &&
-        toolsList.tools.some((t) => t.name === EXEC_TOOL_NAME),
-      resourceUris: resourcesList?.resources.map((r) => r.uri),
+        tools.some((tool) => tool.name === EXEC_TOOL_NAME),
+      resourceUris: resources?.map((resource) => resource.uri),
     });
 
-    for (const tool of toolsList.tools) {
-      if (
-        serverName === BUILTIN_POSTHOG_SERVER_NAME &&
-        tool.name === EXEC_TOOL_NAME
-      ) {
-        this.toolDefinitions.set(POSTHOG_EXEC_TOOL_KEY, tool);
+    this.clearServerDiscoveryData(serverName);
+    const serverToolKeys = new Set<string>();
+
+    for (const tool of tools) {
+      const toolKey = `mcp__${serverName}__${tool.name}`;
+      const { resourceUri, visibility } = resolveToolRegistrationMetadata(tool);
+
+      serverToolKeys.add(toolKey);
+      this.toolDefinitions.set(toolKey, tool);
+      this.toolVisibilities.set(toolKey, visibility);
+
+      if (!resourceUri) continue;
+      if (!resourceUri.startsWith("ui://")) {
+        this.log.warn("Ignoring MCP App tool with a non-ui resource URI", {
+          serverName,
+          toolName: tool.name,
+          resourceUri,
+        });
+        continue;
       }
 
-      const uiMeta = (tool as McpToolUiMeta)._meta?.ui;
-      if (!uiMeta?.resourceUri) continue;
-
-      const toolKey = `mcp__${serverName}__${tool.name}`;
       this.toolAssociations.set(toolKey, {
         toolKey,
         serverName,
         toolName: tool.name,
-        resourceUri: uiMeta.resourceUri,
-        visibility: uiMeta.visibility,
+        resourceUri,
+        visibility,
       });
-      this.toolDefinitions.set(toolKey, tool);
     }
+    this.serverToolKeys.set(serverName, serverToolKeys);
 
-    // Cache resource metadata (CSP, permissions) for use in fetchUiResource
-    if (resourcesList) {
-      for (const resource of resourcesList.resources) {
-        const meta = resource as McpResourceUiMeta;
-        if (meta._meta?.ui) {
+    // Cache resource metadata because some servers omit it from read responses.
+    if (resources) {
+      for (const resource of resources) {
+        if (resource._meta?.ui) {
           this.resourceMetaCache.set(
             this.resourceKey(serverName, resource.uri),
-            meta,
+            resource,
           );
         }
       }
@@ -452,6 +519,14 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
     serverName: string,
     resourceUri: string,
   ): Promise<McpUiResource | null> {
+    if (!resourceUri.startsWith("ui://")) {
+      this.log.warn("Rejecting executable MCP App resource with a non-ui URI", {
+        serverName,
+        resourceUri,
+      });
+      return null;
+    }
+
     const key = this.resourceKey(serverName, resourceUri);
     const cached = this.resourceCache.get(key);
     if (cached) {
@@ -593,7 +668,13 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
     return has;
   }
 
-  getToolDefinition(toolKey: string): Tool | null {
+  async getToolDefinition(toolKey: string): Promise<Tool | null> {
+    const existing = this.toolDefinitions.get(toolKey);
+    if (existing) return existing;
+
+    const mcp = parseMcpToolName(toolKey);
+    if (!mcp) return null;
+    await this.ensureServerDiscovered(mcp.server);
     return this.toolDefinitions.get(toolKey) ?? null;
   }
 
@@ -602,12 +683,17 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
     toolName: string,
     args?: Record<string, unknown>,
   ): Promise<unknown> {
-    // Validate visibility: reject if tool is model-only
+    await this.ensureServerDiscovered(serverName);
+
     const toolKey = `mcp__${serverName}__${toolName}`;
-    const association = this.toolAssociations.get(toolKey);
-    if (association?.visibility && !association.visibility.includes("app")) {
+    if (!this.toolDefinitions.has(toolKey)) {
+      throw new Error(`Tool "${toolName}" is not available to apps`);
+    }
+
+    const visibility = this.toolVisibilities.get(toolKey);
+    if (!visibility?.includes("app")) {
       throw new Error(
-        `Tool "${toolName}" is not accessible to apps (visibility: ${association.visibility.join(", ")})`,
+        `Tool "${toolName}" is not accessible to apps (visibility: ${visibility?.join(", ") ?? "unknown"})`,
       );
     }
 
@@ -621,11 +707,7 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
   }
 
   async proxyResourceRead(serverName: string, uri: string): Promise<unknown> {
-    // Only allow ui:// scheme reads
-    if (!uri.startsWith("ui://")) {
-      throw new Error(`Only ui:// URIs are allowed, got: ${uri}`);
-    }
-
+    // Arbitrary schemes stay confined to the app's captured MCP server.
     const conn = await this.getOrCreateConnection(serverName);
     const result = await conn.client.readResource({ uri });
     return result;
@@ -696,6 +778,8 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
     this.resourceMetaCache.clear();
     this.toolAssociations.clear();
     this.toolDefinitions.clear();
+    this.toolVisibilities.clear();
+    this.serverToolKeys.clear();
     this.pendingConnections.clear();
     this.pendingFetches.clear();
     this.discoveredServers.clear();
@@ -725,6 +809,7 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
     this.discoveredServers.delete(serverName);
     this.unavailableServers.delete(serverName);
     this.discoveryFailedAt.delete(serverName);
+    this.clearServerDiscoveryData(serverName);
 
     const conn = this.connections.get(serverName);
     if (!conn) return;
@@ -738,15 +823,6 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
       });
     }
     this.connections.delete(serverName);
-
-    for (const [key, assoc] of this.toolAssociations) {
-      if (assoc.serverName === serverName) {
-        this.toolAssociations.delete(key);
-      }
-    }
-
-    this.evictServerEntries(this.resourceCache, serverName);
-    this.evictServerEntries(this.resourceMetaCache, serverName);
   }
 
   async cleanup(): Promise<void> {
@@ -763,6 +839,8 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
     this.resourceMetaCache.clear();
     this.toolAssociations.clear();
     this.toolDefinitions.clear();
+    this.toolVisibilities.clear();
+    this.serverToolKeys.clear();
     this.serverConfigs.clear();
     this.pendingConnections.clear();
     this.pendingFetches.clear();

--- a/products/desktop/packages/core/src/mcp-apps/schemas.test.ts
+++ b/products/desktop/packages/core/src/mcp-apps/schemas.test.ts
@@ -3,7 +3,44 @@ import {
   LEGACY_RESOURCE_URI_META_KEY,
   POSTHOG_EXEC_TOOL_KEY,
   resolveResultResourceUri,
+  resolveToolRegistrationMetadata,
 } from "./schemas";
+
+describe("resolveToolRegistrationMetadata", () => {
+  it.each([
+    [
+      "modern nested metadata",
+      { _meta: { ui: { resourceUri: "ui://modern" } } },
+      "ui://modern",
+    ],
+    [
+      "legacy flat metadata",
+      { _meta: { [LEGACY_RESOURCE_URI_META_KEY]: "ui://legacy" } },
+      "ui://legacy",
+    ],
+  ])("reads %s", (_label, tool, expectedResourceUri) => {
+    expect(resolveToolRegistrationMetadata(tool).resourceUri).toBe(
+      expectedResourceUri,
+    );
+  });
+
+  it("prefers modern metadata and preserves declared visibility", () => {
+    expect(
+      resolveToolRegistrationMetadata({
+        _meta: {
+          ui: { resourceUri: "ui://modern", visibility: ["model"] },
+          [LEGACY_RESOURCE_URI_META_KEY]: "ui://legacy",
+        },
+      }),
+    ).toEqual({ resourceUri: "ui://modern", visibility: ["model"] });
+  });
+
+  it("defaults missing visibility to model and app access", () => {
+    expect(resolveToolRegistrationMetadata({ name: "default-tool" })).toEqual({
+      visibility: ["model", "app"],
+    });
+  });
+});
 
 describe("resolveResultResourceUri", () => {
   it("reads the modern nested _meta.ui.resourceUri", () => {

--- a/products/desktop/packages/core/src/mcp-apps/schemas.ts
+++ b/products/desktop/packages/core/src/mcp-apps/schemas.ts
@@ -46,14 +46,59 @@ export interface McpUiResource {
 
 export type McpToolUiVisibility = "model" | "app";
 
-/** Shape of the `_meta.ui` field on MCP tool definitions that have a UI. */
+export const LEGACY_RESOURCE_URI_META_KEY = "ui/resourceUri";
+
+/** Shape of UI metadata on MCP tool definitions. */
 export interface McpToolUiMeta {
   _meta?: {
     ui?: {
       resourceUri?: string;
       visibility?: McpToolUiVisibility[];
     };
+    [LEGACY_RESOURCE_URI_META_KEY]?: string;
   };
+}
+
+export interface McpToolRegistrationMetadata {
+  resourceUri?: string;
+  visibility: McpToolUiVisibility[];
+}
+
+const DEFAULT_TOOL_VISIBILITY: McpToolUiVisibility[] = ["model", "app"];
+
+/**
+ * Registration metadata supports both resource URI formats, while visibility
+ * defaults to both callers when the server omits it, as required by MCP Apps.
+ */
+export function resolveToolRegistrationMetadata(
+  tool: unknown,
+): McpToolRegistrationMetadata {
+  if (tool == null || typeof tool !== "object") {
+    return { visibility: [...DEFAULT_TOOL_VISIBILITY] };
+  }
+
+  const meta = (tool as McpToolUiMeta)._meta;
+  const modernResourceUri = meta?.ui?.resourceUri;
+  const legacyResourceUri = meta?.[LEGACY_RESOURCE_URI_META_KEY];
+  const resourceUri =
+    typeof modernResourceUri === "string" && modernResourceUri.length > 0
+      ? modernResourceUri
+      : typeof legacyResourceUri === "string" && legacyResourceUri.length > 0
+        ? legacyResourceUri
+        : undefined;
+
+  const declaredVisibility = meta?.ui?.visibility;
+  const visibility =
+    declaredVisibility === undefined
+      ? [...DEFAULT_TOOL_VISIBILITY]
+      : Array.isArray(declaredVisibility)
+        ? declaredVisibility.filter(
+            (value): value is McpToolUiVisibility =>
+              value === "model" || value === "app",
+          )
+        : [];
+
+  return { resourceUri, visibility };
 }
 
 /** Shape of MCP resource definitions that carry `_meta.ui` CSP/permissions. */
@@ -80,15 +125,6 @@ export interface McpResourceUiMeta {
 export const BUILTIN_POSTHOG_SERVER_NAME = "posthog";
 export const EXEC_TOOL_NAME = "exec";
 export const POSTHOG_EXEC_TOOL_KEY = `mcp__${BUILTIN_POSTHOG_SERVER_NAME}__${EXEC_TOOL_NAME}`;
-
-/**
- * Legacy flat `_meta` key for a UI resource URI on a tool-call response. Mirrors
- * `RESOURCE_URI_META_KEY` from `@modelcontextprotocol/ext-apps`. The modern form
- * is the nested `_meta.ui.resourceUri`; servers may emit either (PostHog emits
- * both). Hardcoded rather than imported so this module stays free of the
- * ext-apps server entrypoint.
- */
-export const LEGACY_RESOURCE_URI_META_KEY = "ui/resourceUri";
 
 /**
  * Resolve a UI resource URI from a tool-call response, preferring the modern

--- a/products/desktop/packages/harness/src/extensions/mcp/proxy-tool.test.ts
+++ b/products/desktop/packages/harness/src/extensions/mcp/proxy-tool.test.ts
@@ -20,6 +20,8 @@ const ECHO_TOOL = {
   },
   handler: (args: Record<string, unknown>) => ({
     content: [{ type: "text", text: `echo: ${String(args.text)}` }],
+    structuredContent: { echoed: args.text },
+    _meta: { ui: { resourceUri: "ui://demo/echo" } },
   }),
 };
 
@@ -290,11 +292,31 @@ describe("mcp proxy tool", () => {
     });
     await manager.startServer("demo", "/workspace");
 
-    const result = await text(tool, {
-      tool: "mcp_demo_echo",
-      args: '{"text":"hi"}',
+    const result = await tool.execute(
+      "id-1",
+      {
+        tool: "mcp_demo_echo",
+        args: '{"text":"hi"}',
+      } as never,
+      undefined,
+      undefined as never,
+      undefined as never,
+    );
+    expect(result.content).toEqual([{ type: "text", text: "echo: hi" }]);
+    expect(result.details).toEqual({
+      kind: "call",
+      server: "demo",
+      tool: "echo",
+      piName: "mcp_demo_echo",
+      posthog: {
+        mcp: { server: "demo", tool: "echo" },
+        mcpResult: {
+          content: [{ type: "text", text: "echo: hi" }],
+          structuredContent: { echoed: "hi" },
+          _meta: { ui: { resourceUri: "ui://demo/echo" } },
+        },
+      },
     });
-    expect(result).toBe("echo: hi");
     await mock.close();
   });
 

--- a/products/desktop/packages/harness/src/extensions/mcp/proxy-tool.ts
+++ b/products/desktop/packages/harness/src/extensions/mcp/proxy-tool.ts
@@ -22,6 +22,7 @@ import type { ManagedServer, ServerManager } from "./server-manager";
 import {
   type BridgedContent,
   invokeTool,
+  type McpToolDetails,
   type SearchableTool,
   type ToolBridge,
 } from "./tool-bridge";
@@ -57,7 +58,12 @@ export type McpProxyDetails =
   | { kind: "error"; message: string }
   | { kind: "search"; query: string; hits: Hit[] }
   | { kind: "connect"; server: string; toolCount: number }
-  | { kind: "call"; server: string; tool: string; piName: string };
+  | ({
+      kind: "call";
+      server: string;
+      tool: string;
+      piName: string;
+    } & Partial<McpToolDetails>);
 
 function normalize(s: string): string {
   return s.toLowerCase().replace(/[-_]/g, " ");
@@ -328,7 +334,7 @@ async function callOrConnect(
 
   manager.touch(owner);
   const timeoutMs = manager.getRequestTimeoutMs(owner);
-  const { content } = await invokeTool(
+  const { content, mcpResult } = await invokeTool(
     client,
     owner,
     meta.mcpName,
@@ -338,7 +344,16 @@ async function callOrConnect(
   );
   return {
     content,
-    details: { kind: "call", server: owner, tool: meta.mcpName, piName: name },
+    details: {
+      kind: "call",
+      server: owner,
+      tool: meta.mcpName,
+      piName: name,
+      posthog: {
+        mcp: { server: owner, tool: meta.mcpName },
+        ...(mcpResult !== undefined ? { mcpResult } : {}),
+      },
+    },
   };
 }
 

--- a/products/desktop/packages/harness/src/extensions/mcp/tool-bridge.test.ts
+++ b/products/desktop/packages/harness/src/extensions/mcp/tool-bridge.test.ts
@@ -29,7 +29,10 @@ interface RegisteredTool {
     toolCallId: string,
     params: unknown,
     signal?: AbortSignal,
-  ) => Promise<{ content: Array<{ type: string; text?: string }> }>;
+  ) => Promise<{
+    content: Array<{ type: string; text?: string }>;
+    details?: unknown;
+  }>;
 }
 
 function fakeHost(initialActive: string[] = ["read", "bash"]) {
@@ -219,6 +222,38 @@ describe("ToolBridge", () => {
     expect(getActive()).toContain("read");
   });
 
+  it("does not register or expose app-only tools to model search", async () => {
+    const { host, registered, getActive } = fakeHost();
+    const bridge = new ToolBridge(settings, host);
+
+    await bridge.refreshTools(
+      "demo",
+      fakeClient({
+        tools: [
+          {
+            name: "model-tool",
+            description: "Visible to the model",
+            inputSchema: {},
+            _meta: { ui: { visibility: ["model", "app"] } },
+          },
+          {
+            name: "app-only-tool",
+            description: "Visible only to the app",
+            inputSchema: {},
+            _meta: { ui: { visibility: ["app"] } },
+          },
+        ],
+      }),
+    );
+
+    expect(registered.has("mcp_demo_model_tool")).toBe(true);
+    expect(registered.has("mcp_demo_app_only_tool")).toBe(false);
+    expect(getActive()).not.toContain("mcp_demo_app_only_tool");
+    expect(bridge.getSearchableTools().map((tool) => tool.piName)).toEqual([
+      "mcp_demo_model_tool",
+    ]);
+  });
+
   it("appends annotation hints to descriptions", async () => {
     const { host, registered } = fakeHost();
     const bridge = new ToolBridge(settings, host);
@@ -405,14 +440,33 @@ describe("ToolBridge", () => {
       expect(text).toContain("row 0");
       expect(text).not.toContain("row 4999");
       expect(text).toContain("Output truncated");
+      expect(result?.details).toMatchObject({
+        posthog: {
+          mcp: { server: "demo", tool: "dump" },
+          mcpResult: { content: [{ type: "text", text: bigOutput }] },
+        },
+      });
     });
 
     it("forwards arguments and converts result content", async () => {
       const { host, registered } = fakeHost();
       const bridge = new ToolBridge(settings, host);
-      const onCall = vi.fn().mockReturnValue({
-        content: [{ type: "text", text: "hi jonathan" }],
-      });
+      const mcpResult = {
+        content: [
+          { type: "text", text: "hi jonathan" },
+          {
+            type: "resource",
+            resource: {
+              uri: "ui://demo/result",
+              mimeType: "text/html",
+              text: "resource body",
+            },
+          },
+        ],
+        structuredContent: { resultCount: 1 },
+        _meta: { ui: { resourceUri: "ui://demo/result" } },
+      };
+      const onCall = vi.fn().mockReturnValue(mcpResult);
       await bridge.refreshTools(
         "demo",
         fakeClient({ tools: [{ name: "echo", inputSchema: {} }], onCall }),
@@ -424,10 +478,16 @@ describe("ToolBridge", () => {
         name: "echo",
         arguments: { text: "hi" },
       });
-      expect(result).toMatchObject({
-        content: [{ type: "text", text: "hi jonathan" }],
+      expect(result).toEqual({
+        content: [
+          { type: "text", text: "hi jonathan" },
+          { type: "text", text: "resource body" },
+        ],
         details: {
-          posthog: { mcp: { server: "demo", tool: "echo" } },
+          posthog: {
+            mcp: { server: "demo", tool: "echo" },
+            mcpResult,
+          },
         },
       });
     });

--- a/products/desktop/packages/harness/src/extensions/mcp/tool-bridge.ts
+++ b/products/desktop/packages/harness/src/extensions/mcp/tool-bridge.ts
@@ -19,6 +19,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
+  type CallToolResult,
   CallToolResultSchema,
   ListToolsResultSchema,
 } from "@modelcontextprotocol/sdk/types.js";
@@ -111,6 +112,7 @@ export interface McpToolDefinition {
   name: string;
   description?: string;
   inputSchema: Record<string, unknown>;
+  _meta?: Record<string, unknown>;
   annotations?: {
     readOnlyHint?: boolean;
     destructiveHint?: boolean;
@@ -148,6 +150,15 @@ export async function listAllTools(
   return tools;
 }
 
+function isVisibleToModel(tool: McpToolDefinition): boolean {
+  const ui = tool._meta?.ui;
+  if (!ui || typeof ui !== "object") return true;
+
+  const visibility = (ui as { visibility?: unknown }).visibility;
+  if (visibility === undefined) return true;
+  return Array.isArray(visibility) && visibility.includes("model");
+}
+
 function buildDescription(tool: McpToolDefinition): string {
   let description = tool.description ?? `MCP tool: ${tool.name}`;
   const ann = tool.annotations;
@@ -179,6 +190,13 @@ export interface SearchableTool extends ToolMeta {
   piName: string;
   /** Whether this tool is currently in the model's active tool set. */
   active: boolean;
+}
+
+export interface McpToolDetails {
+  posthog: {
+    mcp: { server: string; tool: string };
+    mcpResult?: CallToolResult;
+  };
 }
 
 /**
@@ -220,9 +238,15 @@ export async function invokeTool(
   args: Record<string, unknown>,
   timeoutMs: number,
   signal?: AbortSignal,
-): Promise<{ content: BridgedContent[] }> {
+): Promise<{
+  content: BridgedContent[];
+  mcpResult: CallToolResult | undefined;
+}> {
   if (signal?.aborted) {
-    return { content: [{ type: "text", text: "Cancelled" }] };
+    return {
+      content: [{ type: "text", text: "Cancelled" }],
+      mcpResult: undefined,
+    };
   }
   try {
     const result = await client.request(
@@ -244,7 +268,7 @@ export async function invokeTool(
       throw new McpError(text || "Tool reported an error", serverName, "tool");
     }
 
-    return { content };
+    return { content, mcpResult: result };
   } catch (err) {
     if (err instanceof McpError) throw err;
     throw new McpError(
@@ -387,6 +411,7 @@ export class ToolBridge {
       );
     }
 
+    const modelVisibleTools = tools.filter(isVisibleToModel);
     const previous = this.serverToolNames.get(serverName) ?? new Set<string>();
     const current = new Set<string>();
     // First MCP tool name to claim each pi name, so a collision report shows
@@ -397,7 +422,7 @@ export class ToolBridge {
     const directConfig = serverConfig?.directTools ?? true;
     const directNames = new Set<string>();
 
-    for (const tool of tools) {
+    for (const tool of modelVisibleTools) {
       const piName = buildToolName(
         this.settings.toolPrefix,
         serverName,
@@ -467,7 +492,7 @@ export class ToolBridge {
         ...(serverConfig.description !== undefined
           ? { description: serverConfig.description }
           : {}),
-        tools: tools.map((tool) => ({
+        tools: modelVisibleTools.map((tool) => ({
           name: buildToolName(this.settings.toolPrefix, serverName, tool.name),
           mcpName: tool.name,
           description: buildDescription(tool),
@@ -541,7 +566,7 @@ export class ToolBridge {
 
       async execute(_toolCallId, params, signal) {
         onToolUsed?.(serverName);
-        const { content } = await invokeTool(
+        const { content, mcpResult } = await invokeTool(
           client,
           serverName,
           tool.name,
@@ -552,7 +577,10 @@ export class ToolBridge {
         return {
           content,
           details: {
-            posthog: { mcp: { server: serverName, tool: tool.name } },
+            posthog: {
+              mcp: { server: serverName, tool: tool.name },
+              ...(mcpResult !== undefined ? { mcpResult } : {}),
+            },
           },
         };
       },

--- a/products/desktop/packages/shared/src/mcp-sandbox-proxy.test.ts
+++ b/products/desktop/packages/shared/src/mcp-sandbox-proxy.test.ts
@@ -14,6 +14,27 @@ describe("sandboxProxyHtml", () => {
     expect(sandboxProxyHtml).toContain("ui/notifications/sandbox-proxy-ready");
   });
 
+  it("retries readiness on a bounded schedule until resource-ready", () => {
+    const retrySchedule = sandboxProxyHtml.match(
+      /var readyRetryDelays = \[([^\]]+)\]/,
+    );
+    const retryDelays = retrySchedule?.[1]
+      .split(",")
+      .map((delay) => Number(delay.trim()));
+
+    expect(retryDelays).toEqual([50, 150, 500, 1000, 2000, 4000]);
+    expect(sandboxProxyHtml).toContain("readyRetryDelays.forEach");
+    expect(sandboxProxyHtml).toContain("if (sent) return;");
+
+    const resourceReadyHandler = sandboxProxyHtml.indexOf(
+      'data.method === "ui/notifications/sandbox-resource-ready"',
+    );
+    expect(resourceReadyHandler).toBeGreaterThan(-1);
+    expect(
+      sandboxProxyHtml.indexOf("sent = true", resourceReadyHandler),
+    ).toBeGreaterThan(resourceReadyHandler);
+  });
+
   it("listens for sandbox-resource-ready message", () => {
     expect(sandboxProxyHtml).toContain(
       "ui/notifications/sandbox-resource-ready",

--- a/products/desktop/packages/shared/src/mcp-sandbox-proxy.ts
+++ b/products/desktop/packages/shared/src/mcp-sandbox-proxy.ts
@@ -168,8 +168,8 @@ export const sandboxProxyHtml: string = `<!DOCTYPE html>
       });
 
       // Notify host that proxy is ready to receive HTML.
-      // Retry a few times because the host's useEffect listener may not be
-      // registered yet when src= loads faster than React's effect cycle.
+      // Retry for several seconds because the host listener may register after
+      // the iframe loads during a slow render or process handoff.
       var readyMsg = {
         jsonrpc: "2.0",
         method: "ui/notifications/sandbox-proxy-ready",
@@ -183,9 +183,11 @@ export const sandboxProxyHtml: string = `<!DOCTYPE html>
       }
 
       // The host removes its listener on first receipt, so retries are harmless
+      var readyRetryDelays = [50, 150, 500, 1000, 2000, 4000];
       sendReady();
-      setTimeout(sendReady, 50);
-      setTimeout(sendReady, 150);
+      readyRetryDelays.forEach(function (delay) {
+        setTimeout(sendReady, delay);
+      });
     };
 
     // Fire and forget, similar to IIFE

--- a/products/desktop/packages/ui/src/features/mcp-apps/components/McpAppHost.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-apps/components/McpAppHost.tsx
@@ -1,20 +1,19 @@
-import type { McpUiDisplayMode } from "@modelcontextprotocol/ext-apps/app-bridge";
+import type {
+  AppBridge,
+  McpUiDisplayMode,
+} from "@modelcontextprotocol/ext-apps/app-bridge";
 import type {
   CallToolResult,
   ReadResourceResult,
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
 import { ArrowsIn, ArrowsOut, Plugs, X } from "@phosphor-icons/react";
-import {
-  POSTHOG_EXEC_TOOL_KEY,
-  resolveResultResourceUri,
-} from "@posthog/core/mcp-apps/schemas";
 import { useService } from "@posthog/di/react";
 import { useHostTRPC } from "@posthog/host-router/react";
+import { Button, Text } from "@posthog/quill";
 import type { ToolViewProps } from "@posthog/ui/features/sessions/components/session-update/toolCallUtils";
 import { logger } from "@posthog/ui/shell/logger";
 import { useThemeStore } from "@posthog/ui/shell/themeStore";
-import { Box, Flex, IconButton, Text } from "@radix-ui/themes";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useSubscription } from "@trpc/tanstack-react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -24,7 +23,10 @@ import {
   MCP_SANDBOX_PROXY_URL,
   type McpSandboxProxyUrlProvider,
 } from "../identifiers";
-import { toCallToolResult } from "../utils/mcp-app-host-utils";
+import {
+  isMcpAppEventForToolCall,
+  sendToolResultOnce,
+} from "../utils/mcp-app-host-utils";
 
 const log = logger.scope("mcp-app-host");
 
@@ -32,6 +34,7 @@ interface McpAppHostProps extends ToolViewProps {
   mcpToolName: string;
   serverName: string;
   toolName: string;
+  resourceUri?: string;
 }
 
 export function McpAppHost({
@@ -39,6 +42,7 @@ export function McpAppHost({
   mcpToolName,
   serverName,
   toolName,
+  resourceUri,
 }: McpAppHostProps) {
   const trpc = useHostTRPC();
   const getSandboxProxyUrl = useService<McpSandboxProxyUrlProvider>(
@@ -49,23 +53,18 @@ export function McpAppHost({
     [getSandboxProxyUrl],
   );
   const containerRef = useRef<HTMLDivElement>(null);
-  const [_phase, setPhase] = useState<Phase>("loading");
+  const [, setPhase] = useState<Phase>("loading");
   const [displayMode, setDisplayMode] = useState<McpUiDisplayMode>("inline");
   const [iframeHeight, setIframeHeight] = useState(300);
   const [containerWidth, setContainerWidth] = useState(640);
   const [iframeEl, setIframeEl] = useState<HTMLIFrameElement | null>(null);
   const isDarkMode = useThemeStore((s) => s.isDarkMode);
 
-  const isExec = mcpToolName === POSTHOG_EXEC_TOOL_KEY;
-  const execResourceUri = isExec
-    ? resolveResultResourceUri(toolCall.rawOutput)
-    : undefined;
-
   const { data: uiResource, isLoading: resourceLoading } = useQuery(
-    isExec
+    resourceUri
       ? trpc.mcpApps.getUiResourceByUri.queryOptions(
-          { serverName, resourceUri: execResourceUri ?? "" },
-          { staleTime: Number.POSITIVE_INFINITY, enabled: !!execResourceUri },
+          { serverName, resourceUri },
+          { staleTime: Number.POSITIVE_INFINITY },
         )
       : trpc.mcpApps.getUiResource.queryOptions(
           { toolKey: mcpToolName },
@@ -83,7 +82,7 @@ export function McpAppHost({
   useEffect(() => {
     log.info("McpAppHost render", {
       mcpToolName,
-      isExec,
+      selectedResourceUri: resourceUri,
       toolCallId: toolCall.toolCallId,
       status: toolCall.status,
       resourceLoading,
@@ -92,7 +91,7 @@ export function McpAppHost({
     });
   }, [
     mcpToolName,
-    isExec,
+    resourceUri,
     toolCall.toolCallId,
     toolCall.status,
     resourceLoading,
@@ -108,6 +107,36 @@ export function McpAppHost({
   );
   const openLinkMut = useMutation(trpc.mcpApps.openLink.mutationOptions());
 
+  const deliveredResultsRef = useRef(new WeakMap<object, Set<string>>());
+  const deliverResult = useCallback(
+    (bridge: AppBridge, rawOutput: unknown) => {
+      if (
+        sendToolResultOnce(
+          deliveredResultsRef.current,
+          bridge,
+          toolCall.toolCallId,
+          rawOutput,
+        )
+      ) {
+        log.info("Sending tool result to app", {
+          mcpToolName,
+          toolCallId: toolCall.toolCallId,
+        });
+      }
+    },
+    [mcpToolName, toolCall.toolCallId],
+  );
+  const replayCompletedResult = useCallback(
+    (bridge: AppBridge) => {
+      if (toolCall.status !== "completed" && toolCall.status !== "failed") {
+        return;
+      }
+      if (toolCall.rawOutput == null) return;
+      deliverResult(bridge, toolCall.rawOutput);
+    },
+    [deliverResult, toolCall.rawOutput, toolCall.status],
+  );
+
   const { sendWhenReady } = useAppBridge({
     iframeEl,
     uiResource: uiResource,
@@ -121,6 +150,7 @@ export function McpAppHost({
     onPhaseChange: setPhase,
     onSizeChange: setIframeHeight,
     onDisplayModeChange: setDisplayMode,
+    onBridgeInitialized: replayCompletedResult,
     proxyToolCall: proxyToolCallMut.mutateAsync as (args: {
       serverName: string;
       toolName: string;
@@ -133,71 +163,33 @@ export function McpAppHost({
     openLink: openLinkMut.mutateAsync,
   });
 
-  const sentResultForCallRef = useRef<string | null>(null);
-  const sendResultOnce = useCallback(
-    (raw: unknown) => {
-      if (sentResultForCallRef.current === toolCall.toolCallId) return;
-      sentResultForCallRef.current = toolCall.toolCallId;
-      const toolResult = toCallToolResult(raw);
-      log.info("Sending tool result to app", { mcpToolName, toolResult });
-      sendWhenReady((bridge) => bridge.sendToolResult(toolResult));
-    },
-    [toolCall.toolCallId, sendWhenReady, mcpToolName],
-  );
-
-  // Forward tool results from subscriptions
   useSubscription(
     trpc.mcpApps.onToolResult.subscriptionOptions(
       { toolKey: mcpToolName },
       {
         onData: (event) => {
-          if (isExec) {
-            if (event.toolCallId !== toolCall.toolCallId) return;
-            sendResultOnce(event.result);
-            return;
-          }
-          const toolResult = toCallToolResult(event.result);
-          log.info("Sending tool result to app", {
-            mcpToolName,
-            toolResult,
-          });
-
-          sendWhenReady((bridge) => bridge.sendToolResult(toolResult));
+          if (!isMcpAppEventForToolCall(event, toolCall.toolCallId)) return;
+          sendWhenReady((bridge) => deliverResult(bridge, event.result));
         },
       },
     ),
   );
 
   useEffect(() => {
-    if (!isExec) return;
     if (toolCall.status !== "completed" && toolCall.status !== "failed") return;
-    if (toolCall.rawOutput == null) {
-      log.info("exec replay skipped: no rawOutput on toolCall", {
-        toolCallId: toolCall.toolCallId,
-        status: toolCall.status,
-      });
-      return;
-    }
-    log.info("exec replay: sending result from toolCall prop", {
-      toolCallId: toolCall.toolCallId,
-    });
-    sendResultOnce(toolCall.rawOutput);
-  }, [
-    isExec,
-    toolCall.status,
-    toolCall.rawOutput,
-    toolCall.toolCallId,
-    sendResultOnce,
-  ]);
+    if (toolCall.rawOutput == null) return;
+    sendWhenReady((bridge) => deliverResult(bridge, toolCall.rawOutput));
+  }, [deliverResult, sendWhenReady, toolCall.rawOutput, toolCall.status]);
 
-  // Forward tool cancellations from subscriptions
   useSubscription(
     trpc.mcpApps.onToolCancelled.subscriptionOptions(
       { toolKey: mcpToolName },
       {
-        onData: () => {
+        onData: (event) => {
+          if (!isMcpAppEventForToolCall(event, toolCall.toolCallId)) return;
           log.info("Received tool cancellation from subscription", {
             mcpToolName,
+            toolCallId: toolCall.toolCallId,
           });
           sendWhenReady((bridge) => bridge.sendToolCancelled({}));
         },
@@ -237,6 +229,7 @@ export function McpAppHost({
 
   const iframeElement = (
     <iframe
+      key={`${uiResource.serverName}\n${uiResource.uri}`}
       ref={setIframeEl}
       src={sandboxProxyUrl}
       // allow-same-origin would resolve this frame to the host's own origin.
@@ -250,13 +243,12 @@ export function McpAppHost({
   );
 
   const fullscreenToggle = (
-    <Flex justify="end" className="py-0.5">
-      <IconButton
-        size="1"
-        variant="ghost"
-        color="gray"
-        onClick={(e) => {
-          e.stopPropagation();
+    <div className="flex justify-end py-0.5">
+      <Button
+        size="icon-xs"
+        variant="default"
+        onClick={(event) => {
+          event.stopPropagation();
           const newMode = displayMode === "inline" ? "fullscreen" : "inline";
           setDisplayMode(newMode);
         }}
@@ -264,13 +256,9 @@ export function McpAppHost({
           displayMode === "inline" ? "Expand to fullscreen" : "Exit fullscreen"
         }
       >
-        {displayMode === "inline" ? (
-          <ArrowsOut size={12} />
-        ) : (
-          <ArrowsIn size={12} />
-        )}
-      </IconButton>
-    </Flex>
+        {displayMode === "inline" ? <ArrowsOut /> : <ArrowsIn />}
+      </Button>
+    </div>
   );
 
   if (displayMode === "fullscreen") {
@@ -281,38 +269,28 @@ export function McpAppHost({
           {fullscreenToggle}
 
           {createPortal(
-            <Box
-              className="pointer-events-auto absolute inset-0 flex flex-col bg-gray-1"
-              style={{
-                transition: "opacity 150ms ease",
-              }}
-            >
-              <Flex
-                align="center"
-                justify="between"
-                className="border-gray-6 border-b px-4 py-2"
-              >
-                <Flex align="center" gap="2">
+            <div className="pointer-events-auto absolute inset-0 flex flex-col bg-gray-1 transition-opacity duration-150">
+              <div className="flex items-center justify-between border-gray-6 border-b px-4 py-2">
+                <div className="flex items-center gap-2">
                   <Plugs size={14} className="text-gray-11" />
-                  <Text className="text-gray-11 text-sm">
+                  <Text render={<span />} size="sm" className="text-gray-11">
                     {serverName} - {toolName}
                   </Text>
-                </Flex>
-                <IconButton
-                  size="1"
-                  variant="ghost"
-                  color="gray"
+                </div>
+                <Button
+                  size="icon-xs"
+                  variant="default"
                   onClick={() => {
                     setDisplayMode("inline");
                   }}
                   title="Exit fullscreen (Escape)"
                 >
-                  <X size={14} />
-                </IconButton>
-              </Flex>
+                  <X />
+                </Button>
+              </div>
 
-              <Box className="flex-1 overflow-hidden p-4">{iframeElement}</Box>
-            </Box>,
+              <div className="flex-1 overflow-hidden p-4">{iframeElement}</div>
+            </div>,
             portalTarget,
           )}
         </>
@@ -321,14 +299,14 @@ export function McpAppHost({
   }
 
   return (
-    <Box>
+    <div>
       {fullscreenToggle}
-      <Box
+      <div
         ref={containerRef}
         className="overflow-hidden rounded-lg border border-gray-6"
       >
         {iframeElement}
-      </Box>
-    </Box>
+      </div>
+    </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/mcp-apps/components/McpToolBlock.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-apps/components/McpToolBlock.tsx
@@ -1,11 +1,10 @@
-import {
-  POSTHOG_EXEC_TOOL_KEY,
-  resolveResultResourceUri,
-} from "@posthog/core/mcp-apps/schemas";
 import { useServiceOptional } from "@posthog/di/react";
 import { useHostTRPC } from "@posthog/host-router/react";
 import { McpToolView } from "@posthog/ui/features/mcp-apps/components/McpToolView";
-import { parseMcpToolKey } from "@posthog/ui/features/mcp-apps/utils/mcp-app-host-utils";
+import {
+  resolveMcpToolPair,
+  selectMcpAppResource,
+} from "@posthog/ui/features/mcp-apps/utils/mcp-app-host-utils";
 import type { ToolViewProps } from "@posthog/ui/features/sessions/components/session-update/toolCallUtils";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -21,12 +20,10 @@ interface McpToolBlockProps extends ToolViewProps {
 
 export function McpToolBlock(props: McpToolBlockProps) {
   const { mcpToolName, toolCall } = props;
-  const { serverName, toolName } = parseMcpToolKey(mcpToolName);
-
-  const isExec = mcpToolName === POSTHOG_EXEC_TOOL_KEY;
-  const execResourceUri = isExec
-    ? resolveResultResourceUri(toolCall.rawOutput)
-    : undefined;
+  const { serverName, toolName } = resolveMcpToolPair(
+    toolCall._meta,
+    mcpToolName,
+  );
 
   const mcpAppsDisabled = useSettingsStore((s) => s.mcpAppsDisabledServers);
   const isDisabledForServer = mcpAppsDisabled.includes(serverName);
@@ -42,29 +39,37 @@ export function McpToolBlock(props: McpToolBlockProps) {
       { toolKey: mcpToolName },
       {
         staleTime: Infinity,
-        enabled: !isDisabledForServer && !isExec,
+        enabled:
+          !isDisabledForServer &&
+          selectMcpAppResource(toolCall.rawOutput, false) === null,
       },
     ),
   );
 
-  const hasUi = isExec ? !!execResourceUri : hasUiByTool;
+  const resourceSelection = selectMcpAppResource(
+    toolCall.rawOutput,
+    hasUiByTool,
+  );
 
   useSubscription(
     trpc.mcpApps.onDiscoveryComplete.subscriptionOptions(undefined, {
       enabled: !isDisabledForServer,
       onData: (_event) => {
-        if (isExec) {
+        void queryClient.invalidateQueries(
+          trpc.mcpApps.getToolDefinition.pathFilter(),
+        );
+        if (resourceSelection?.source === "result") {
           void queryClient.invalidateQueries(
             trpc.mcpApps.getUiResourceByUri.pathFilter(),
           );
-          return;
+        } else {
+          void queryClient.invalidateQueries(
+            trpc.mcpApps.hasUiForTool.pathFilter(),
+          );
+          void queryClient.invalidateQueries(
+            trpc.mcpApps.getUiResource.pathFilter(),
+          );
         }
-        void queryClient.invalidateQueries(
-          trpc.mcpApps.hasUiForTool.pathFilter(),
-        );
-        void queryClient.invalidateQueries(
-          trpc.mcpApps.getUiResource.pathFilter(),
-        );
       },
     }),
   );
@@ -72,8 +77,17 @@ export function McpToolBlock(props: McpToolBlockProps) {
   return (
     <>
       <McpToolView {...props} />
-      {hasUi && !isDisabledForServer && McpAppHost && (
-        <McpAppHost {...props} serverName={serverName} toolName={toolName} />
+      {resourceSelection && !isDisabledForServer && McpAppHost && (
+        <McpAppHost
+          {...props}
+          serverName={serverName}
+          toolName={toolName}
+          resourceUri={
+            resourceSelection.source === "result"
+              ? resourceSelection.resourceUri
+              : undefined
+          }
+        />
       )}
     </>
   );

--- a/products/desktop/packages/ui/src/features/mcp-apps/hooks/useAppBridge.ts
+++ b/products/desktop/packages/ui/src/features/mcp-apps/hooks/useAppBridge.ts
@@ -21,7 +21,6 @@ import type { ToolCall } from "../../sessions/types";
 import {
   computeContainerDimensions,
   INLINE_MAX_HEIGHT,
-  toCallToolResult,
 } from "../utils/mcp-app-host-utils";
 import { buildHostStyles } from "../utils/mcp-app-theme";
 
@@ -47,6 +46,7 @@ interface UseAppBridgeArgs {
   onPhaseChange: (phase: Phase) => void;
   onSizeChange: (height: number) => void;
   onDisplayModeChange: (mode: McpUiDisplayMode) => void;
+  onBridgeInitialized: (bridge: AppBridge) => void;
   proxyToolCall: (args: {
     serverName: string;
     toolName: string;
@@ -160,6 +160,7 @@ export function useAppBridge(args: UseAppBridgeArgs): UseAppBridgeReturn {
     const iframe = iframeEl;
     const resource = uiResource;
     let cleanedUp = false;
+    let effectBridge: AppBridge | null = null;
 
     const onProxyReady = async (event: MessageEvent) => {
       if (event.source !== iframe.contentWindow) return;
@@ -180,6 +181,7 @@ export function useAppBridge(args: UseAppBridgeArgs): UseAppBridgeReturn {
         const bridge = new AppBridge(null, HOST_INFO, HOST_CAPABILITIES, {
           hostContext,
         });
+        effectBridge = bridge;
 
         // We are NOT listening to every single event coming from the bridge
         // but this can always very easily be extended to listen to more events if needed
@@ -259,6 +261,8 @@ export function useAppBridge(args: UseAppBridgeArgs): UseAppBridgeReturn {
         };
 
         bridge.oninitialized = () => {
+          if (cleanedUp) return;
+
           log.debug("App initialized, phase -> initialized", {
             serverName: latestRef.current.serverName,
           });
@@ -283,20 +287,7 @@ export function useAppBridge(args: UseAppBridgeArgs): UseAppBridgeReturn {
             });
           }
 
-          // If the tool already completed (e.g. component remounted after
-          // scrolling back into the virtualized list), send the result now
-          // since the subscription event was missed.
-          if (
-            tc.rawOutput &&
-            (tc.status === "completed" || tc.status === "failed")
-          ) {
-            const toolResult = toCallToolResult(tc.rawOutput);
-            log.debug("Sending existing tool result to app (remount)", {
-              serverName: latestRef.current.serverName,
-              toolResult,
-            });
-            bridge.sendToolResult(toolResult);
-          }
+          latestRef.current.onBridgeInitialized(bridge);
 
           // Flush pending
           log.debug("Flushing pending messages", {
@@ -314,8 +305,9 @@ export function useAppBridge(args: UseAppBridgeArgs): UseAppBridgeReturn {
           iframe.contentWindow as Window,
         );
         await bridge.connect(transport);
-        bridgeRef.current = bridge;
+        if (cleanedUp) return;
 
+        bridgeRef.current = bridge;
         await bridge.sendSandboxResourceReady({
           html: applyCspToHtml(resource.html, resource.csp),
           csp: resource.csp,
@@ -329,10 +321,9 @@ export function useAppBridge(args: UseAppBridgeArgs): UseAppBridgeReturn {
           latestRef.current.onPhaseChange("resource-sent");
         }
       } catch (err) {
+        if (cleanedUp) return;
         log.error("Failed to initialize AppBridge", err);
-        if (!cleanedUp) {
-          latestRef.current.onPhaseChange("error");
-        }
+        latestRef.current.onPhaseChange("error");
       }
     };
 
@@ -342,13 +333,12 @@ export function useAppBridge(args: UseAppBridgeArgs): UseAppBridgeReturn {
       cleanedUp = true;
       window.removeEventListener("message", onProxyReady);
 
-      if (bridgeRef.current) {
-        const b = bridgeRef.current;
-        b.teardownResource({}).catch(() => {});
-        b.close().catch(() => {});
-      }
+      effectBridge?.teardownResource({}).catch(() => {});
+      effectBridge?.close().catch(() => {});
 
-      bridgeRef.current = null;
+      if (bridgeRef.current === effectBridge) {
+        bridgeRef.current = null;
+      }
       initializedRef.current = false;
       prevContextRef.current = null;
       pendingRef.current = [];

--- a/products/desktop/packages/ui/src/features/mcp-apps/identifiers.ts
+++ b/products/desktop/packages/ui/src/features/mcp-apps/identifiers.ts
@@ -6,6 +6,7 @@ export type McpAppHostComponent = ComponentType<
     mcpToolName: string;
     serverName: string;
     toolName: string;
+    resourceUri?: string;
   }
 >;
 

--- a/products/desktop/packages/ui/src/features/mcp-apps/utils/mcp-app-host-utils.test.ts
+++ b/products/desktop/packages/ui/src/features/mcp-apps/utils/mcp-app-host-utils.test.ts
@@ -1,11 +1,105 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   computeContainerDimensions,
   FULLSCREEN_HEADER_HEIGHT,
   FULLSCREEN_PADDING,
   INLINE_MAX_HEIGHT,
+  isMcpAppEventForToolCall,
+  resolveMcpToolPair,
+  selectMcpAppResource,
+  sendToolResultOnce,
   toCallToolResult,
 } from "./mcp-app-host-utils";
+
+function resultWithResourceUri(resourceUri: string): unknown {
+  return { _meta: { ui: { resourceUri } } };
+}
+
+describe("resolveMcpToolPair", () => {
+  it("uses structured metadata when the server name contains separators", () => {
+    expect(
+      resolveMcpToolPair(
+        {
+          posthog: {
+            toolName: "mcp__legal__server__query",
+            mcp: { server: "legal__server", tool: "query" },
+          },
+        },
+        "mcp__legal__server__query",
+      ),
+    ).toEqual({ serverName: "legal__server", toolName: "query" });
+  });
+
+  it("falls back to the tool key when metadata is absent", () => {
+    expect(resolveMcpToolPair(undefined, "mcp__posthog__query")).toEqual({
+      serverName: "posthog",
+      toolName: "query",
+    });
+  });
+});
+
+describe("selectMcpAppResource", () => {
+  it.each([
+    {
+      name: "uses a result resource without a registered UI",
+      rawOutput: resultWithResourceUri("ui://server/result"),
+      hasRegistrationUi: false,
+      expected: { source: "result", resourceUri: "ui://server/result" },
+    },
+    {
+      name: "uses a result resource instead of the registered UI",
+      rawOutput: resultWithResourceUri("ui://server/result"),
+      hasRegistrationUi: true,
+      expected: { source: "result", resourceUri: "ui://server/result" },
+    },
+    {
+      name: "falls back to the registered UI without a result resource",
+      rawOutput: { content: [] },
+      hasRegistrationUi: true,
+      expected: { source: "registration" },
+    },
+    {
+      name: "falls back to registration for a non-UI result URI",
+      rawOutput: resultWithResourceUri("https://example.com/app"),
+      hasRegistrationUi: true,
+      expected: { source: "registration" },
+    },
+  ])("$name", ({ rawOutput, hasRegistrationUi, expected }) => {
+    expect(selectMcpAppResource(rawOutput, hasRegistrationUi)).toEqual(
+      expected,
+    );
+  });
+});
+
+describe("MCP app event delivery", () => {
+  it.each([
+    ["matching", "call-1", true],
+    ["different", "call-2", false],
+  ])("identifies a %s tool call", (_name, eventToolCallId, expected) => {
+    expect(
+      isMcpAppEventForToolCall({ toolCallId: eventToolCallId }, "call-1"),
+    ).toBe(expected);
+  });
+
+  it("delivers a result once per bridge and tool call", () => {
+    const deliveredResults = new WeakMap<object, Set<string>>();
+    const firstBridge = { sendToolResult: vi.fn() };
+    const remountedBridge = { sendToolResult: vi.fn() };
+
+    expect(
+      sendToolResultOnce(deliveredResults, firstBridge, "call-1", "result"),
+    ).toBe(true);
+    expect(
+      sendToolResultOnce(deliveredResults, firstBridge, "call-1", "result"),
+    ).toBe(false);
+    expect(
+      sendToolResultOnce(deliveredResults, remountedBridge, "call-1", "result"),
+    ).toBe(true);
+
+    expect(firstBridge.sendToolResult).toHaveBeenCalledOnce();
+    expect(remountedBridge.sendToolResult).toHaveBeenCalledOnce();
+  });
+});
 
 describe("computeContainerDimensions", () => {
   it("returns inline dimensions with maxHeight", () => {

--- a/products/desktop/packages/ui/src/features/mcp-apps/utils/mcp-app-host-utils.ts
+++ b/products/desktop/packages/ui/src/features/mcp-apps/utils/mcp-app-host-utils.ts
@@ -1,12 +1,10 @@
-/**
- * Shared utilities for McpAppHost: container dimension calculations
- * for inline/fullscreen display modes.
- *
- * @see https://modelcontextprotocol.io/specification/2025-03-26/extensions/mcp-apps
- */
-
-import type { McpUiDisplayMode } from "@modelcontextprotocol/ext-apps/app-bridge";
+import type {
+  AppBridge,
+  McpUiDisplayMode,
+} from "@modelcontextprotocol/ext-apps/app-bridge";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { resolveResultResourceUri } from "@posthog/core/mcp-apps/schemas";
+import { readMcpToolDescriptor } from "@posthog/shared";
 
 export const INLINE_MAX_HEIGHT = 600;
 export const FULLSCREEN_HEADER_HEIGHT = 48;
@@ -18,6 +16,46 @@ export interface ContainerDimensions {
   maxHeight?: number;
 }
 
+export type McpAppResourceSelection =
+  | { source: "result"; resourceUri: string }
+  | { source: "registration" };
+
+export function selectMcpAppResource(
+  rawOutput: unknown,
+  hasRegistrationUi: boolean | undefined,
+): McpAppResourceSelection | null {
+  const resultResourceUri = resolveResultResourceUri(rawOutput);
+  if (resultResourceUri?.startsWith("ui://")) {
+    return { source: "result", resourceUri: resultResourceUri };
+  }
+  return hasRegistrationUi ? { source: "registration" } : null;
+}
+
+export function isMcpAppEventForToolCall(
+  event: { toolCallId: string },
+  toolCallId: string,
+): boolean {
+  return event.toolCallId === toolCallId;
+}
+
+export function sendToolResultOnce(
+  deliveredResults: WeakMap<object, Set<string>>,
+  bridge: Pick<AppBridge, "sendToolResult">,
+  toolCallId: string,
+  rawOutput: unknown,
+): boolean {
+  const deliveredToolCalls = deliveredResults.get(bridge);
+  if (deliveredToolCalls?.has(toolCallId)) return false;
+
+  if (deliveredToolCalls) {
+    deliveredToolCalls.add(toolCallId);
+  } else {
+    deliveredResults.set(bridge, new Set([toolCallId]));
+  }
+  bridge.sendToolResult(toCallToolResult(rawOutput));
+  return true;
+}
+
 export function parseMcpToolKey(mcpToolName: string): {
   serverName: string;
   toolName: string;
@@ -27,6 +65,16 @@ export function parseMcpToolKey(mcpToolName: string): {
     serverName: parts[1] ?? "",
     toolName: parts.slice(2).join("__"),
   };
+}
+
+export function resolveMcpToolPair(
+  meta: unknown,
+  mcpToolName: string,
+): { serverName: string; toolName: string } {
+  const descriptor = readMcpToolDescriptor(meta);
+  return descriptor
+    ? { serverName: descriptor.server, toolName: descriptor.tool }
+    : parseMcpToolKey(mcpToolName);
 }
 
 /**

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
@@ -35,6 +35,7 @@ const mockAcpClient = vi.hoisted(() => ({
             _meta?: { codeToolKind?: string };
           };
         }) => Promise<unknown>;
+        sessionUpdate: (params: unknown) => Promise<unknown>;
       }
     | undefined,
 }));
@@ -282,6 +283,18 @@ const baseSessionParams = {
   apiHost: "https://app.posthog.com",
   projectId: 1,
 };
+
+async function sendSessionUpdate(
+  update: Record<string, unknown>,
+): Promise<void> {
+  if (!mockAcpClient.current) {
+    throw new Error("Expected the ACP client to be initialized");
+  }
+  await mockAcpClient.current.sessionUpdate({
+    sessionId: "test-session-id",
+    update,
+  });
+}
 
 describe("AgentService", () => {
   let service: AgentService;
@@ -820,6 +833,72 @@ describe("AgentService", () => {
           reasoningEffort: "xhigh",
         }),
       );
+    });
+  });
+
+  describe("MCP tool lifecycle", () => {
+    const toolCallUpdate = {
+      sessionUpdate: "tool_call",
+      toolCallId: "tool-call-1",
+      title: "Query PostHog",
+      rawInput: { query: "select 1" },
+      _meta: {
+        posthog: {
+          toolName: "mcp__posthog__query",
+          mcp: { server: "posthog", tool: "query" },
+        },
+      },
+    };
+
+    it("forwards tool input from canonical PostHog metadata", async () => {
+      await service.startSession(baseSessionParams);
+
+      await sendSessionUpdate(toolCallUpdate);
+
+      expect(deps.mcpAppsService.notifyToolInput).toHaveBeenCalledWith(
+        "mcp__posthog__query",
+        "tool-call-1",
+        { query: "select 1" },
+      );
+    });
+
+    it("treats a completed historical tool call as terminal", async () => {
+      await service.startSession(baseSessionParams);
+
+      await sendSessionUpdate({
+        ...toolCallUpdate,
+        status: "completed",
+        rawOutput: { result: "historical" },
+      });
+
+      expect(deps.mcpAppsService.notifyToolResult).toHaveBeenCalledWith(
+        "mcp__posthog__query",
+        "tool-call-1",
+        { result: "historical" },
+        false,
+      );
+      expect(service.hasActiveSessions()).toBe(false);
+    });
+
+    it("uses the tracked tool key when completion metadata is absent", async () => {
+      await service.startSession(baseSessionParams);
+      await sendSessionUpdate(toolCallUpdate);
+      expect(service.hasActiveSessions()).toBe(true);
+
+      await sendSessionUpdate({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tool-call-1",
+        status: "completed",
+        rawOutput: { result: "ok" },
+      });
+
+      expect(deps.mcpAppsService.notifyToolResult).toHaveBeenCalledWith(
+        "mcp__posthog__query",
+        "tool-call-1",
+        { result: "ok" },
+        false,
+      );
+      expect(service.hasActiveSessions()).toBe(false);
     });
   });
 

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.ts
@@ -86,6 +86,7 @@ import {
   type ExecutionMode,
   isAuthError,
   type ModelAccess,
+  readMcpToolName,
   resolveCloudInitialPermissionMode,
   serializeError,
   TypedEventEmitter,
@@ -150,11 +151,6 @@ function isDevBuild(): boolean {
 
 /** Mark all content blocks as hidden so the renderer doesn't show a duplicate user message on retry */
 type MessageCallback = (message: unknown) => void;
-
-/** Shape of the `_meta.claudeCode` extension field on tool call updates. */
-interface ClaudeCodeToolMeta {
-  claudeCode?: { toolName?: string };
-}
 
 class NdJsonTap {
   private decoder = new TextDecoder();
@@ -2204,22 +2200,37 @@ For git operations while detached:
           return;
         }
 
-        const toolName = (update._meta as ClaudeCodeToolMeta | undefined)
-          ?.claudeCode?.toolName;
-        if (!toolName?.startsWith("mcp__")) return;
-
         const session = service.sessions.get(taskRunId);
+        const metadataToolName = readMcpToolName(update._meta);
         if (update.sessionUpdate === "tool_call") {
-          session?.inFlightMcpToolCalls.set(update.toolCallId, toolName);
+          if (!metadataToolName) return;
           service.mcpAppsService.notifyToolInput(
-            toolName,
+            metadataToolName,
             update.toolCallId,
             update.rawInput,
           );
+          if (update.status === "completed" || update.status === "failed") {
+            session?.inFlightMcpToolCalls.delete(update.toolCallId);
+            service.mcpAppsService.notifyToolResult(
+              metadataToolName,
+              update.toolCallId,
+              update.rawOutput,
+              update.status === "failed",
+            );
+          } else {
+            session?.inFlightMcpToolCalls.set(
+              update.toolCallId,
+              metadataToolName,
+            );
+          }
         } else if (
           update.status === "completed" ||
           update.status === "failed"
         ) {
+          const toolName =
+            metadataToolName ??
+            session?.inFlightMcpToolCalls.get(update.toolCallId);
+          if (!toolName) return;
           session?.inFlightMcpToolCalls.delete(update.toolCallId);
           service.mcpAppsService.notifyToolResult(
             toolName,


### PR DESCRIPTION
## Problem

MCP Apps can stay blank in Desktop chat when an agent runtime drops result metadata or the host routes a result to the wrong app instance.

Desktop also limits custom interfaces to tool registration metadata, so one tool cannot select a different onboarding interface for each call.

## Changes

- Desktop now renders a result-selected custom interface for any MCP tool call.
- Claude, Codex, and Pi keep complete successful MCP results for the app bridge.
- Concurrent calls use their tool call IDs, so results and cancellations reach only the matching app.
- Discovery reads all pages and supports current and legacy MCP App metadata.
- App-only tools stay out of Pi model context, while model-only tools stay unavailable to apps.
- Executable HTML still requires a `ui://` resource, the MCP App MIME type, and the sandbox.
- Host controls now use Quill with the same labels and placement.

Before:

```mermaid
flowchart LR
    A[Agent runtime] --> B[Reduced tool result]
    B --> C[Tool-level app]
    C --> D[Chat iframe]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phBlue;
    class B,C phGray;
    class D phYellow;
```

After:

```mermaid
flowchart LR
    A[Agent runtime] --> B[Complete tool result]
    B --> C[Result or tool app]
    C --> D[Per-call sandbox]
    D --> E[Chat thread]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phBlue;
    class B,C phGray;
    class D phRed;
    class E phYellow;
```

No screenshot is included. The app content comes from each MCP server, and the host controls keep their existing layout.

## How did you test this code?

- Scoped Vitest coverage checks result preservation, metadata compatibility, discovery pagination, visibility, lifecycle routing, and sandbox readiness.
- `pnpm typecheck` passed for the complete Desktop workspace.
- Biome passed on all changed files, and the host-boundary check found no new violations.
- A real Electron smoke test loaded `mcp-sandbox://proxy` and rendered an invented onboarding interface.
- The narrow smoke test rendered at 518 px with no horizontal overflow.
- `hogli ci:preflight --fix` could not run because the sandbox Python environment did not contain the hogli package.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/desktop/docs/ARCHITECTURE.md` now documents result-selected apps and the executable-resource boundary.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Desktop used Explore, Plan, and General subagents plus `agent-browser`.
- Skills: `/posthog-desktop`, `/implementing-mcp-ui-apps`, `/writing-ui-components`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/subagent-orchestration`, `/querying-posthog-data`, `/running-ci-preflight`, and `/writing-pr-descriptions`.
- The duplicate search found [#95512](https://github.com/PostHog/posthog/pull/95512). That PR repairs server payloads; this PR repairs Desktop transport and rendering.
- The committed fixtures are invented and contain no private source material.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*