### PR TITLE
fix(mcp-store): connect to validated IPs for upstream MCP calls

### DIFF
--- a/products/mcp_store/backend/pinned_transport.py
+++ b/products/mcp_store/backend/pinned_transport.py
@@ -1,0 +1,70 @@
+"""Connect-time SSRF validation and DNS pinning for MCP store upstream fetches.
+
+This is the httpx counterpart of ``posthog.security.pinned_requests`` (the
+requests-based pinning used by Teams webhook delivery, CIMD and
+business_knowledge): ``check_mcp_url_policy`` alone leaves a TOCTOU window,
+because the hostname is resolved once for validation (dnspython) and again when
+``httpx`` opens the connection (getaddrinfo), so a rebinding DNS record passes
+validation and still connects internally.
+
+``ValidatingPinnedTransport`` closes that window with a single resolution at
+connect time: each outgoing request is resolved, validated, and its URL is
+rewritten to the validated IP so httpx never re-resolves via getaddrinfo.
+Validation runs per request — the initial request and every same-origin
+redirect retry — so a redirect hop cannot cross into unvalidated address space.
+
+Operator-configured internal endpoints (``MCP_STORE_INTERNAL_ALLOWED_URLS_BY_TEAM``)
+are exempt: they point at internal services by design, so their addresses are
+trusted and the connection resolves normally.
+"""
+
+import urllib.parse as urlparse
+
+import httpx
+
+from posthog.security.pinned_requests import SSRFBlockedError, select_pinned_ip
+from posthog.security.url_validation import validate_url_and_pin_ips
+
+from .url_policy import is_internal_mcp_url
+
+
+class ValidatingPinnedTransport(httpx.HTTPTransport):
+    """httpx transport that validates every request URL and pins the connection.
+
+    ``handle_request`` runs for every request sent through the client, so each
+    hop gets a fresh resolution + validation and the TCP connection goes to the
+    exact IP that was validated. Raises ``SSRFBlockedError`` (fail closed) when a
+    URL does not pass validation.
+    """
+
+    def __init__(self, url: str, team_id: int | None) -> None:
+        super().__init__()
+        self._allow_internal = is_internal_mcp_url(url, team_id)
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        if self._allow_internal:
+            # Operator-configured internal endpoint: trusted by policy, connect
+            # directly like the requests-side machinery trusts its allowlists.
+            return super().handle_request(request)
+
+        verdict = validate_url_and_pin_ips(str(request.url))
+        if not verdict.allowed:
+            raise SSRFBlockedError(verdict.reason or "URL blocked by SSRF protection")
+
+        pinned_ip = select_pinned_ip(verdict.pinned_ips)
+        if pinned_ip is None:
+            # No IPs to pin (e.g. the dev-mode SSRF bypass) — same pass-through
+            # posture as PinnedIPAdapter with an empty pin map.
+            return super().handle_request(request)
+
+        # Rewrite the URL to the validated IP so httpx connects to it directly
+        # (no second getaddrinfo lookup), while the Host header and TLS SNI /
+        # certificate verification keep using the original hostname.
+        original_netloc = request.url.netloc.decode("ascii")
+        original_host = urlparse.urlparse(f"//{original_netloc}").hostname or ""
+        request.headers["Host"] = original_netloc
+        request.url = request.url.copy_with(host=str(pinned_ip))
+        if original_host:
+            # httpcore honors this extension for SNI and certificate checks.
+            request.extensions["sni_hostname"] = original_host
+        return super().handle_request(request)

--- a/products/mcp_store/backend/proxy.py
+++ b/products/mcp_store/backend/proxy.py
@@ -11,6 +11,7 @@ import httpx
 import structlog
 
 from posthog.api.streaming import sse_streaming_response
+from posthog.security.pinned_requests import SSRFBlockedError
 from posthog.security.url_validation import is_url_allowed
 from posthog.settings import SERVER_GATEWAY_INTERFACE
 
@@ -18,6 +19,7 @@ from ee.hogai.utils.asgi import SyncIterableToAsync
 
 from .models import MCPAuditEvent, MCPGatewayServer, MCPServerInstallation, MCPServerInstallationTool
 from .oauth import TokenRefreshError, is_token_expiring, refresh_installation_token
+from .pinned_transport import ValidatingPinnedTransport
 from .policy import GatewayCaller, PolicyContext
 from .url_policy import check_mcp_url_policy, trust_environment_proxy
 
@@ -532,9 +534,14 @@ def proxy_mcp_request(
     if mcp_session_id:
         headers["Mcp-Session-Id"] = mcp_session_id
 
+    # The transport validates each request URL and pins the connection to the
+    # validated IP at connect time, closing the DNS-rebinding window between
+    # check_mcp_url_policy above and this connection (the same guarantee
+    # PinnedIPAdapter gives the requests-based callers).
     client = httpx.Client(
         timeout=UPSTREAM_TIMEOUT,
         trust_env=trust_environment_proxy(installation.url, installation.team_id),
+        transport=ValidatingPinnedTransport(installation.url, installation.team_id),
     )
     try:
         upstream_response, upstream_url = send_mcp_request_with_same_origin_redirect(
@@ -544,6 +551,14 @@ def proxy_mcp_request(
             content=body,
             headers=headers,
             stream=True,
+        )
+    except SSRFBlockedError as exc:
+        client.close()
+        logger.warning("SSRF: blocked proxy request at connect time", url=installation.url, reason=str(exc))
+        return HttpResponse(
+            json.dumps({"error": f"URL not allowed: {exc}"}),
+            content_type="application/json",
+            status=400,
         )
     except httpx.ConnectError:
         client.close()

--- a/products/mcp_store/backend/test/test_pinned_transport.py
+++ b/products/mcp_store/backend/test/test_pinned_transport.py
@@ -1,0 +1,180 @@
+import json
+import socket
+import ipaddress
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from posthog.security.url_validation import PinnedUrlVerdict
+
+from products.mcp_store.backend import pinned_transport as pt
+
+
+def _verdict(allowed: bool, reason: str | None = None, ips: set[str] | None = None) -> PinnedUrlVerdict:
+    return PinnedUrlVerdict(
+        allowed=allowed, reason=reason, pinned_ips={ipaddress.ip_address(ip) for ip in (ips or set())}
+    )
+
+
+class TestValidatingPinnedTransport:
+    def test_blocked_url_raises_before_any_connection(self):
+        # A URL whose resolution fails SSRF validation must never reach the
+        # socket layer — no connection, no credential leaves the process.
+        transport = pt.ValidatingPinnedTransport.__new__(pt.ValidatingPinnedTransport)
+        transport._allow_internal = False
+        request = httpx.Request("POST", "http://rebind.attacker.test/mcp", content=b"{}")
+
+        with (
+            patch.object(
+                pt, "validate_url_and_pin_ips", return_value=_verdict(False, "Local/Loopback host not allowed")
+            ),
+            patch.object(httpx.HTTPTransport, "handle_request") as super_handle,
+        ):
+            with pytest.raises(pt.SSRFBlockedError, match="Loopback"):
+                transport.handle_request(request)
+        super_handle.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "ip,expected_netloc",
+        [
+            ("93.184.216.34", "93.184.216.34:8443"),
+            ("2001:db8::1", "[2001:db8::1]:8443"),
+        ],
+    )
+    def test_rewrites_url_to_pinned_ip_and_preserves_host_header(self, ip, expected_netloc):
+        # The connection goes to the validated IP (no second getaddrinfo) while
+        # the Host header and TLS SNI keep the original hostname.
+        transport = pt.ValidatingPinnedTransport.__new__(pt.ValidatingPinnedTransport)
+        transport._allow_internal = False
+        request = httpx.Request("POST", "https://mcp.example.org:8443/path?q=1", content=b"{}")
+
+        with (
+            patch.object(pt, "validate_url_and_pin_ips", return_value=_verdict(True, ips={ip})),
+            patch.object(httpx.HTTPTransport, "handle_request", return_value=MagicMock()),
+        ):
+            transport.handle_request(request)
+
+        assert str(request.url) == f"https://{expected_netloc}/path?q=1"
+        assert request.headers["Host"] == "mcp.example.org:8443"
+        assert request.extensions["sni_hostname"] == "mcp.example.org"
+
+    def test_no_pins_passes_through_untouched(self):
+        # Empty pin set means pinning was intentionally skipped (dev SSRF
+        # bypass); the request must connect normally, not fail closed.
+        transport = pt.ValidatingPinnedTransport.__new__(pt.ValidatingPinnedTransport)
+        transport._allow_internal = False
+        request = httpx.Request("POST", "https://mcp.example.org/mcp", content=b"{}")
+
+        with (
+            patch.object(pt, "validate_url_and_pin_ips", return_value=_verdict(True)),
+            patch.object(httpx.HTTPTransport, "handle_request", return_value=MagicMock()) as super_handle,
+        ):
+            transport.handle_request(request)
+
+        super_handle.assert_called_once()
+        assert str(request.url) == "https://mcp.example.org/mcp"
+        assert "Host" not in request.headers
+        assert "sni_hostname" not in request.extensions
+
+    def test_internal_allowlisted_endpoints_skip_validation(self):
+        # Operator-configured internal URLs (MCP_STORE_INTERNAL_ALLOWED_URLS_BY_TEAM)
+        # are trusted by policy and must keep resolving normally.
+        transport = pt.ValidatingPinnedTransport.__new__(pt.ValidatingPinnedTransport)
+        transport._allow_internal = True
+        request = httpx.Request("POST", "http://internal.service:8000/mcp", content=b"{}")
+
+        with (
+            patch.object(pt, "validate_url_and_pin_ips") as validate,
+            patch.object(httpx.HTTPTransport, "handle_request", return_value=MagicMock()) as super_handle,
+        ):
+            transport.handle_request(request)
+
+        validate.assert_not_called()
+        super_handle.assert_called_once()
+        assert str(request.url) == "http://internal.service:8000/mcp"
+
+    def test_each_request_is_revalidated(self):
+        # handle_request runs per hop, so a redirect retry hits validation again
+        # with the redirect URL — no cached "already validated" state exists.
+        transport = pt.ValidatingPinnedTransport.__new__(pt.ValidatingPinnedTransport)
+        transport._allow_internal = False
+
+        with (
+            patch.object(
+                pt, "validate_url_and_pin_ips", return_value=_verdict(True, ips={"93.184.216.34"})
+            ) as validate,
+            patch.object(httpx.HTTPTransport, "handle_request", return_value=MagicMock()),
+        ):
+            transport.handle_request(httpx.Request("POST", "http://rebind.attacker.test/mcp", content=b"{}"))
+            transport.handle_request(httpx.Request("POST", "http://rebind.attacker.test/mcp/", content=b"{}"))
+
+        assert validate.call_count == 2
+
+
+class TestPinnedConnection:
+    def test_connection_uses_validated_ip_not_dns(self):
+        """End-to-end rebinding check over a real socket.
+
+        Validation resolves the host to the loopback server; DNS (getaddrinfo) is
+        poisoned to a dead address. The fetch only succeeds if the connection
+        uses the validated IP instead of re-resolving — the DNS-rebinding window
+        this transport exists to close.
+        """
+        received: dict[str, str] = {}
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                received["host"] = self.headers.get("Host", "")
+                received["authorization"] = self.headers.get("Authorization", "")
+                body = self.rfile.read(int(self.headers.get("Content-Length", 0))).decode()
+                received["body"] = body
+                out = json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"tools": []}}).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(out)))
+                self.end_headers()
+                self.wfile.write(out)
+
+            def log_message(self, *args):
+                pass
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        port = server.server_address[1]
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+
+        transport = pt.ValidatingPinnedTransport.__new__(pt.ValidatingPinnedTransport)
+        transport._allow_internal = False
+
+        original_getaddrinfo = socket.getaddrinfo
+
+        def rebound_getaddrinfo(host, *args, **kwargs):
+            if host == "rebind.attacker.test":
+                # Where an unpatched httpx stack would connect (the rebind).
+                return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.2", port))]
+            return original_getaddrinfo(host, *args, **kwargs)
+
+        try:
+            with (
+                patch.object(
+                    pt,
+                    "validate_url_and_pin_ips",
+                    return_value=_verdict(True, ips={"127.0.0.1"}),
+                ),
+                patch("socket.getaddrinfo", side_effect=rebound_getaddrinfo),
+            ):
+                with httpx.Client(transport=transport, trust_env=False) as client:
+                    response = client.post(
+                        f"http://rebind.attacker.test:{port}/mcp",
+                        content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "ping"}).encode(),
+                        headers={"Authorization": "Bearer sk-test-upstream"},
+                    )
+            assert response.status_code == 200
+            assert json.loads(response.text)["result"] == {"tools": []}
+            assert received["host"] == f"rebind.attacker.test:{port}"
+            assert received["authorization"] == "Bearer sk-test-upstream"
+        finally:
+            server.shutdown()

--- a/products/mcp_store/backend/test/test_proxy.py
+++ b/products/mcp_store/backend/test/test_proxy.py
@@ -14,6 +14,7 @@ from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models import Organization, Team, User
+from posthog.security.pinned_requests import SSRFBlockedError
 
 from products.mcp_store.backend.models import (
     MCPAuditEvent,
@@ -334,6 +335,12 @@ class TestMCPProxyEndpoint(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         [
             ("connect_error", httpx.ConnectError("Connection refused"), 502, "Upstream MCP server unreachable"),
             ("timeout", httpx.TimeoutException("Timed out"), 502, "Upstream MCP server timed out"),
+            (
+                "ssrf_blocked_at_connect",
+                SSRFBlockedError("Disallowed target IP: 127.0.0.1"),
+                400,
+                "URL not allowed: Disallowed target IP: 127.0.0.1",
+            ),
         ]
     )
     @patch("products.mcp_store.backend.proxy.httpx.Client")

--- a/products/mcp_store/backend/tools.py
+++ b/products/mcp_store/backend/tools.py
@@ -13,8 +13,11 @@ from django.utils import timezone
 import httpx
 import structlog
 
+from posthog.security.pinned_requests import SSRFBlockedError
+
 from .models import MCPServerInstallation, MCPServerInstallationTool
 from .oauth import TokenRefreshError, is_token_expiring, refresh_installation_token
+from .pinned_transport import ValidatingPinnedTransport
 from .policy import SYNC_DEFAULT_APPROVAL_STATE
 from .proxy import build_upstream_auth_headers, validated_same_origin_redirect_url
 from .url_policy import check_mcp_url_policy, trust_environment_proxy
@@ -91,9 +94,14 @@ def fetch_upstream_tools(installation: MCPServerInstallation) -> list[dict[str, 
     }
 
     try:
+        # The transport validates each request URL and pins the connection to the
+        # validated IP at connect time — check_mcp_url_policy above cannot carry
+        # its resolution across to this connection, so pinning closes the
+        # DNS-rebinding window between validate and connect.
         with httpx.Client(
             timeout=HANDSHAKE_TIMEOUT,
             trust_env=trust_environment_proxy(installation.url, installation.team_id),
+            transport=ValidatingPinnedTransport(installation.url, installation.team_id),
         ) as client:
             session_id, upstream_url = _mcp_initialize(client, installation.url, base_headers)
             session_headers = dict(base_headers)
@@ -108,6 +116,8 @@ def fetch_upstream_tools(installation: MCPServerInstallation) -> list[dict[str, 
                 # here are purely janitorial and must not mask real errors above.
                 if session_id:
                     _mcp_terminate_session(client, upstream_url, session_headers)
+    except SSRFBlockedError as exc:
+        raise ToolsFetchError(f"URL not allowed: {exc}") from exc
     except httpx.ConnectError as exc:
         raise ToolsFetchError("Upstream MCP server unreachable") from exc
     except httpx.TimeoutException as exc:
@@ -143,9 +153,12 @@ def call_upstream_tool(
     }
 
     try:
+        # Same connect-time validation + pinning as fetch_upstream_tools — the
+        # two paths share the SSRF guard, auth headers and redirect handling.
         with httpx.Client(
             timeout=CALL_TIMEOUT,
             trust_env=trust_environment_proxy(installation.url, installation.team_id),
+            transport=ValidatingPinnedTransport(installation.url, installation.team_id),
         ) as client:
             session_id, upstream_url = _mcp_initialize(client, installation.url, base_headers)
             session_headers = dict(base_headers)
@@ -158,6 +171,8 @@ def call_upstream_tool(
             finally:
                 if session_id:
                     _mcp_terminate_session(client, upstream_url, session_headers)
+    except SSRFBlockedError as exc:
+        raise ToolCallError(f"URL not allowed: {exc}") from exc
     except httpx.ConnectError as exc:
         raise ToolCallError("Upstream MCP server unreachable") from exc
     except httpx.TimeoutException as exc:


### PR DESCRIPTION
## Problem

- Adding an MCP server means the store fetches from a member-supplied URL. Before connecting, `check_mcp_url_policy` validates the URL and resolves the hostname — then the connection itself is opened by a plain `httpx.Client`, which resolves the hostname a second time.
- Two resolutions of the same attacker-controlled hostname is a DNS-rebinding window. A DNS record can answer the validator with a public IP and answer the actual connect with `127.0.0.1`, a cluster-internal address, or a cloud metadata IP.
- When that happens, the proxy POSTs the org's upstream credential to the internal host and streams the response back. From a pre-fix repro of this chain, the internal listener captured:

  ```
  [internal] Authorization header captured: Bearer sk-live-ORG-MCP-SECRET-4f1a
  ```

- The repo already documents this exact requirement in `posthog/security/pinned_requests.py`: `validate_url_and_pin_ips` alone leaves a TOCTOU window, and callers that open a connection afterwards must use the returned IPs via `PinnedIPAdapter` instead of re-resolving DNS. Teams webhook delivery, CIMD, and business_knowledge do this. The MCP store (proxy.py, and the same shape twice in tools.py) did not.

## Changes

- New `ValidatingPinnedTransport` in `products/mcp_store/backend/pinned_transport.py`: an `httpx.HTTPTransport` subclass that runs the repo's own `validate_url_and_pin_ips` at connect time, for every request through the client, and rewrites the connection to the validated IP so httpcore never re-resolves the hostname.
  - Blocked URLs raise before any socket exists; `SSRFBlockedError` maps to a 400 `{"error": "URL not allowed: …"}` in the proxy and `ToolsFetchError`/`ToolCallError` in tools, matching the existing error surface.
  - The `Host` header keeps the original netloc and `sni_hostname` keeps TLS verification on the original hostname.
  - Redirects are never auto-followed; each same-origin redirect retry goes through the transport again, so every hop gets a fresh resolve-validate-pin.
  - The validated IP set is fed through the existing `select_pinned_ip` (the same chooser the requests-side machinery uses). An empty pin set (dev-mode SSRF bypass) passes through untouched, and the operator's internal allowlist is honored, both matching `PinnedIPAdapter`'s posture.
- Wired into all three call sites: `proxy_mcp_request`, `fetch_upstream_tools`, `call_upstream_tool`. The transport is passed where the `httpx.Client` is constructed, so existing tests' patch targets and timeout-kwarg assertions stay intact. The `check_mcp_url_policy` preflights are kept as fast-fail defense in depth.
- No signature changes; callers in `presentation/views.py`, `presentation/agent_views.py`, and gateway tasks are unaffected.

## How did you test this code?

- New `test_pinned_transport.py`, mirroring the conventions of `posthog/security/test/test_pinned_requests.py`: boundary patches of `validate_url_and_pin_ips`, host-rewrite/`Host`/SNI assertions for both IPv4 and IPv6, and a live-socket test asserting the connection lands on the pinned IP.
- New `ssrf_blocked_at_connect` row in `test_proxy.py`'s parameterized error-mapping test.
- A stdlib harness exercising both directions of the fix: the original rebind (validator sees public, connect resolves internal) no longer reaches the internal service and no credential leaves the process; a resolution that only turns internal at connect time is refused with 400; and a benign allowed fetch still succeeds end-to-end while DNS for it is poisoned to a dead address, proving the connection uses the pinned IP.
- `ruff check` and `ruff format` pass on the touched files at the repo-pinned version.
- Not run locally: the full pytest suite (local checkout has no dev deps installed). Deferred to CI on this branch.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This is an internal hardening change with no user-facing behavior change for allowed URLs.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Found during an authorized security review of the MCP store's outbound request path; this PR ships only the fix. The key decision was pinning at connect time inside an `httpx.HTTPTransport` rather than pre-resolving at the call sites, so validation cannot be raced by a second resolution, and every redirect hop is covered without new per-call-site state.
