### PR TITLE
fix(data-warehouse): stop an account filter reading as a broken connection

### DIFF
--- a/products/data_warehouse/frontend/shared/components/forms/InputWithSuggestionsDropdown.test.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/InputWithSuggestionsDropdown.test.tsx
@@ -1,0 +1,42 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { initKeaTests } from '~/test/init'
+
+import { InputWithSuggestionsDropdown } from './InputWithSuggestionsDropdown'
+
+describe('InputWithSuggestionsDropdown', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    afterEach(cleanup)
+
+    const openPicker = (suggestions: string[]): void => {
+        render(
+            <InputWithSuggestionsDropdown
+                value=""
+                onChange={() => {}}
+                suggestions={suggestions}
+                data-attr="account"
+                emptyMessage="Nothing is available."
+                noMatchMessage={() => 'Nothing matches your filter.'}
+            />
+        )
+        fireEvent.focus(document.querySelector('[data-attr="account"]')!)
+    }
+
+    // Callers that filter server-side hand back an empty `suggestions` list while a search term is
+    // active, and the "nothing is available" wording there reads as a broken connection rather than
+    // a filter that matched nothing.
+    it('reports a filter that matched nothing rather than an empty source list', () => {
+        openPicker([])
+        expect(screen.getByText('Nothing is available.')).toBeInTheDocument()
+
+        fireEvent.change(screen.getByPlaceholderText('Filter suggestions…'), { target: { value: 'abc' } })
+
+        expect(screen.getByText('Nothing matches your filter.')).toBeInTheDocument()
+        expect(screen.queryByText('Nothing is available.')).not.toBeInTheDocument()
+    })
+})

--- a/products/data_warehouse/frontend/shared/components/forms/InputWithSuggestionsDropdown.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/InputWithSuggestionsDropdown.tsx
@@ -40,7 +40,7 @@ export interface InputWithSuggestionsDropdownProps {
     /** Notified as the popover search term changes, for sources that load suggestions server-side
      *  (e.g. a large repository list). Client-side filtering of the current suggestions still applies. */
     onSearchChange?: (term: string) => void
-    /** Text shown when `suggestions` is empty after loading. */
+    /** Text shown when `suggestions` is empty after loading and no search term is filtering them. */
     emptyMessage?: string
     /** Text shown when the search term filters out every suggestion. Receives the current term. */
     noMatchMessage?: (term: string) => string
@@ -117,7 +117,7 @@ export function InputWithSuggestionsDropdown({
                         <p className="m-0 px-2 py-1 text-xs text-secondary flex items-center gap-1">
                             <Spinner /> {loadingMessage}
                         </p>
-                    ) : suggestions.length === 0 ? (
+                    ) : suggestions.length === 0 && !searchTerm.trim() ? (
                         <p className="m-0 px-2 py-1 text-xs text-secondary">{emptyMessage}</p>
                     ) : filtered.length === 0 ? (
                         <p className="m-0 px-2 py-1 text-xs text-secondary">{noMatchMessage(searchTerm)}</p>

--- a/products/data_warehouse/frontend/shared/components/forms/IntegrationAccountSelector.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/IntegrationAccountSelector.tsx
@@ -436,7 +436,7 @@ function IntegrationAccountFieldWithDropdown({
     placeholder,
     caption,
 }: IntegrationAccountSelectorProps & { integrationId: number }): JSX.Element {
-    const { accounts, accountsLoading, accountsLoaded, accountsError } = useValues(
+    const { accounts, accountsLoading, accountsLoaded, accountsError, search } = useValues(
         integrationAccountsLogic({ id: integrationId, sourceType })
     )
     const { loadAccounts, setSearch } = useActions(integrationAccountsLogic({ id: integrationId, sourceType }))
@@ -444,6 +444,11 @@ function IntegrationAccountFieldWithDropdown({
     useEffect(() => {
         loadAccounts()
     }, [loadAccounts])
+
+    // The list is filtered server-side, so while a search term is active `accounts` holds the
+    // matches rather than everything the connection can reach. Every "we found nothing" hint below
+    // is about the connection, so hold them back until the list is unfiltered.
+    const filtering = !!search.trim()
 
     const suggestions = useMemo<InputSuggestion[]>(() => {
         const sorted = [...accounts].sort((a, b) => Number(b.is_primary) - Number(a.is_primary))
@@ -475,7 +480,11 @@ function IntegrationAccountFieldWithDropdown({
             {({ value, onChange }) => {
                 const accountValues = accounts.map((account) => account.value)
                 const savedValueMissing =
-                    !!value && !accountsLoading && accounts.length > 0 && !accountValues.includes(String(value))
+                    !!value &&
+                    !accountsLoading &&
+                    !filtering &&
+                    accounts.length > 0 &&
+                    !accountValues.includes(String(value))
                 return (
                     <div className="flex flex-col gap-2">
                         <InputWithSuggestionsDropdown
@@ -488,6 +497,9 @@ function IntegrationAccountFieldWithDropdown({
                             onSearchChange={setSearch}
                             searchPlaceholder="Filter accounts…"
                             emptyMessage="No accounts accessible by this integration."
+                            noMatchMessage={() =>
+                                'No accounts match your filter. Clear it to see every account this connection can reach.'
+                            }
                             loadingMessage="Loading accounts…"
                         />
                         {accountsError && (
@@ -495,12 +507,17 @@ function IntegrationAccountFieldWithDropdown({
                                 {accountsError} <ReconnectLink integrationKind={integrationKind} />
                             </p>
                         )}
-                        {accountsLoaded && !accountsLoading && !accountsError && accounts.length === 0 && (
-                            <p className="m-0 text-xs text-warning">
-                                No accounts to show. If you know the {fieldLabel}, enter it above and save. You can also{' '}
-                                <ReconnectLink integrationKind={integrationKind} /> to grant access to more accounts.
-                            </p>
-                        )}
+                        {accountsLoaded &&
+                            !accountsLoading &&
+                            !accountsError &&
+                            !filtering &&
+                            accounts.length === 0 && (
+                                <p className="m-0 text-xs text-warning">
+                                    No accounts to show. If you know the {fieldLabel}, enter it above and save. You can
+                                    also <ReconnectLink integrationKind={integrationKind} /> to grant access to more
+                                    accounts.
+                                </p>
+                            )}
                         {savedValueMissing && (
                             <p className="m-0 text-xs text-warning">
                                 The currently saved {fieldLabel} <code>{value}</code> isn't in the accessible list for


### PR DESCRIPTION
## Problem

Someone connecting an ad platform in the data warehouse source wizard types their account ID into the account picker's filter, sees "No accounts accessible by this integration", and concludes the connection is broken. Session scans of the new-source flow caught a user going on to disconnect a working integration after this.

- The picker loads accounts server-side, so an unmatched filter term returns an empty list.
- The picker rendered the empty list as "no accounts accessible", the wording reserved for a connection that can reach nothing.
- A second warning under the field told the user to reconnect the integration to grant access to more accounts.

## Changes

- The picker now says "No accounts match your filter. Clear it to see every account this connection can reach." when a filter term is active.
- The "reconnect to grant access to more accounts" warning stays hidden while a filter is active. It only appears when the unfiltered list is genuinely empty.
- The "your saved account isn't in the accessible list" warning stays hidden while a filter is active, for the same reason.
- `InputWithSuggestionsDropdown` prefers its no-match message over its empty message whenever a search term is set. Its `emptyMessage` doc comment says so.

Nothing looks different when no filter is active, so the screenshots would be identical.

## How did you test this code?

- New test in `InputWithSuggestionsDropdown.test.tsx`: an empty suggestion list shows the empty message, and shows the no-match message once a filter term is typed. It catches a return to the old branch order, which is the bug this PR fixes. Confirmed it fails against the pre-fix ternary.
- Not run: the repo-wide typecheck passes over the touched files, but fails elsewhere in this sandbox because the nested quill workspace is not built.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code from a review of Replay Vision session summaries of the data-warehouse new-source onboarding flow. The summaries stayed out of the diff and this description: the friction is described generically and no organisation name, account value, or host from them appears anywhere in the PR.

Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

No duplicate: searched open PRs for the account picker, the wizard, and `InputWithSuggestionsDropdown`. [#91610](https://github.com/PostHog/posthog/pull/91610) touches the same component but only renames a kea action, so it does not address this.
