### PR TITLE
fix(data-warehouse): say when a pasted connection string can't be read

### DIFF
--- a/products/data_warehouse/frontend/shared/components/forms/SourceForm.test.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SourceForm.test.tsx
@@ -1,4 +1,13 @@
-import { SourceConfig, SourceFieldSelectConfig, SourceFieldSwitchGroupConfig } from '~/queries/schema/schema-general'
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+
+import {
+    SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldSelectConfig,
+    SourceFieldSwitchGroupConfig,
+} from '~/queries/schema/schema-general'
 
 import { sourceFieldToElement } from './SourceForm'
 
@@ -47,7 +56,29 @@ const switchGroupState = (storedGroupValue: any, formValue?: any): { checked: bo
     return { checked: toggle.props.checked, childrenVisible: !!children.find((child: any) => child?.props?.name) }
 }
 
+const CONNECTION_STRING_FIELD: SourceFieldInputConfig = {
+    type: 'text',
+    name: 'connection_string',
+    label: 'Connection string (optional)',
+    required: false,
+    placeholder: 'postgresql://user:password@localhost:5432/database',
+    secret: true,
+}
+
+const POSTGRES_CONFIG = { name: 'Postgres', fields: [] } as unknown as SourceConfig
+
+// Renders the connection string field at a given value and reports whether it tells the user the
+// string didn't parse.
+const connectionStringWarns = (value: string): boolean => {
+    const element = sourceFieldToElement(CONNECTION_STRING_FIELD, POSTGRES_CONFIG)
+    const lemonField = element.props.children.find((child: any) => child?.props?.name === 'connection_string')
+    render(lemonField.props.children({ value, onChange: jest.fn() }))
+    return screen.queryByText(/Couldn't read that connection string/) !== null
+}
+
 describe('sourceFieldToElement', () => {
+    afterEach(cleanup)
+
     it('renders a select field caption as field help text', () => {
         const element = sourceFieldToElement(SELECT_FIELD, SOURCE_CONFIG)
         expect(element.props.help).toBeTruthy()
@@ -56,6 +87,18 @@ describe('sourceFieldToElement', () => {
     it('omits help when a select field has no caption', () => {
         const element = sourceFieldToElement({ ...SELECT_FIELD, caption: undefined }, SOURCE_CONFIG)
         expect(element.props.help).toBeUndefined()
+    })
+
+    // A string the parser rejects used to prefill nothing and say nothing, so the user only found
+    // out at the next step, as required-field errors on Host, Port, Database, User and Password.
+    it.each([
+        ['stays quiet for a string it can read', 'postgresql://alice:s3cret@db.example.com:5432/analytics', false],
+        ['warns when the database is missing', 'postgresql://alice:s3cret@db.example.com:5432', true],
+        ['warns when the scheme belongs to another source', 'mysql://alice:s3cret@db.example.com:3306/analytics', true],
+        ['stays quiet while the value is still half typed', 'postgresq', false],
+        ['stays quiet when the field is empty', '', false],
+    ])('%s', (_name, value, expected) => {
+        expect(connectionStringWarns(value)).toBe(expected)
     })
 
     // job_inputs cross an encrypted field that stringifies booleans, so the form prefills `enabled`

--- a/products/data_warehouse/frontend/shared/components/forms/SourceForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SourceForm.tsx
@@ -161,35 +161,59 @@ export const sourceFieldToElement = (
         return (
             <React.Fragment key={field.name}>
                 <LemonField name={field.name} label={field.label}>
-                    {({ onChange }) => (
-                        <LemonInput
-                            key={field.name}
-                            className="ph-connection-string"
-                            data-attr={field.name}
-                            placeholder={field.placeholder}
-                            type="text"
-                            onChange={(updatedConnectionString) => {
-                                onChange(updatedConnectionString)
-                                const { isValid, fields } = parseConnectionStringForSource(
-                                    sourceConfig.name,
-                                    updatedConnectionString
-                                )
+                    {({ value, onChange }) => {
+                        const typed = String(value ?? '')
+                        // A half-typed string parses as garbage, so only report a failure once the
+                        // value carries a scheme and reads as a whole connection string.
+                        const looksLikeConnectionString = typed.includes('://')
+                        const unparsed =
+                            looksLikeConnectionString &&
+                            !parseConnectionStringForSource(sourceConfig.name, typed).isValid
+                        return (
+                            <>
+                                <LemonInput
+                                    key={field.name}
+                                    className="ph-connection-string"
+                                    data-attr={field.name}
+                                    placeholder={field.placeholder}
+                                    type="text"
+                                    onChange={(updatedConnectionString) => {
+                                        onChange(updatedConnectionString)
+                                        const { isValid, fields } = parseConnectionStringForSource(
+                                            sourceConfig.name,
+                                            updatedConnectionString
+                                        )
 
-                                if (isValid) {
-                                    for (const { path, value } of fields) {
-                                        if (setSourceConnectionDetailsValue) {
-                                            setSourceConnectionDetailsValue(['payload', ...path], value)
-                                        } else {
-                                            sourceWizardLogic.actions.setSourceConnectionDetailsValue(
-                                                ['payload', ...path],
-                                                value
-                                            )
+                                        if (isValid) {
+                                            for (const { path, value } of fields) {
+                                                if (setSourceConnectionDetailsValue) {
+                                                    setSourceConnectionDetailsValue(['payload', ...path], value)
+                                                } else {
+                                                    sourceWizardLogic.actions.setSourceConnectionDetailsValue(
+                                                        ['payload', ...path],
+                                                        value
+                                                    )
+                                                }
+                                            }
                                         }
-                                    }
-                                }
-                            }}
-                        />
-                    )}
+                                    }}
+                                />
+                                {unparsed && (
+                                    <p className="m-0 mt-1 text-xs text-warning">
+                                        Couldn't read that connection string, so the fields below are still empty.{' '}
+                                        {field.placeholder ? (
+                                            <>
+                                                Check it looks like <code>{field.placeholder}</code>, or fill them in
+                                                yourself.
+                                            </>
+                                        ) : (
+                                            'Fill them in yourself instead.'
+                                        )}
+                                    </p>
+                                )}
+                            </>
+                        )
+                    }}
                 </LemonField>
                 <LemonDivider />
             </React.Fragment>


### PR DESCRIPTION
## Problem

Someone setting up a SQL source in the data warehouse wizard pastes a connection string, gets no feedback, and then hits required-field errors on Host, Port, Database, User and Password at the next step. Session scans of the new-source flow caught users cycling through this several times before giving up on a source.

- The connection string field prefills those five fields when it can parse what you paste.
- When the parser rejects the string, the field did nothing and said nothing. The failure only surfaced one step later, as five errors that name none of its cause.
- The parser rejects a string that is missing the user, host or database, and one written for a different source's scheme.

## Changes

- The field now warns "Couldn't read that connection string, so the fields below are still empty", followed by the format the source expects, taken from the field's own placeholder.
- The warning waits until the value contains `://`, so it does not fire on every keystroke while someone types the scheme.
- A string the parser accepts still prefills the fields below and shows nothing, as before.

Visual change: one line of warning text under the connection string field, in the same style as the other in-form warnings. No screenshot was captured, because this sandbox cannot build the nested quill workspace that the app's styles import.

## How did you test this code?

- Five cases added to `SourceForm.test.tsx`, covering a readable string, a string missing the database, another source's scheme, a half-typed value and an empty field. They catch the silent-failure path this PR fixes, which no existing test covered. Extended the existing `sourceFieldToElement` block rather than adding a file.
- Not run: the repo-wide typecheck passes over the touched files, but fails elsewhere in this sandbox because the nested quill workspace is not built.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code from a review of Replay Vision session summaries of the data-warehouse new-source onboarding flow. The summaries stayed out of the diff and this description: the friction is described generically, and the connection strings in the new tests are invented against `example.com` rather than taken from any session.

Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

No duplicate: searched open PRs for the connection string field, `SourceForm`, and field prefilling. [#90777](https://github.com/PostHog/posthog/pull/90777) touches the same file but covers masking saved credentials in update mode, where this field does not render.
