### PR TITLE
chore(warehouse_sources): promote Brevo to GA

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/brevo/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/brevo/source.py
@@ -68,7 +68,7 @@ class BrevoSource(ResumableSource[BrevoSourceConfig, BrevoResumeConfig]):
             category=DataWarehouseSourceCategory.MARKETING___EMAIL,
             keywords=["sendinblue"],
             label="Brevo",
-            releaseStatus=ReleaseStatus.BETA,
+            releaseStatus=ReleaseStatus.GA,
             caption="""Enter your Brevo API key to automatically pull your Brevo (formerly Sendinblue) data into the PostHog Data warehouse.
 
 You can create an API key in your [Brevo account settings](https://app.brevo.com/settings/keys/api).""",


### PR DESCRIPTION
## Problem

Anyone browsing the data warehouse source catalog sees Brevo labelled **Beta**, which reads as "not ready for production yet". It is ready — the connector has been live for over three months with a clean import record, so the label is now understating it and gives teams a reason to hesitate before connecting.

## Changes

- Brevo now shows as **GA** in the new-source wizard and on its docs page, instead of Beta.
- Mechanical: one field on `BrevoSource.get_source_config` — `releaseStatus` goes from `ReleaseStatus.BETA` to `ReleaseStatus.GA`.

Brevo carries no `unreleasedSource` flag and no `featureFlag` gate, so nothing else had to be unwound. It was already visible and connectable to everyone; only the label changes.

The promotion bar it clears:

- Adoption maturity: live 3.1 months (bar is 100+ teams **or** 3 months).
- Import error rate over the last 7 days: 0.0% (bar is under 2.5%).

## How did you test this code?

No new tests. `releaseStatus` is a declared label with no branching on it, so a test asserting the new value would only restate the diff.

No automated tests were run for this change, and no manual testing was done — the connector's request, schema, and sync paths are untouched, so the existing Brevo suites cover the same ground they did before. CI reports the results.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The posthog.com Brevo doc renders its release status from the `public_source_configs` API, so it picks the change up automatically.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Tooling: Claude Code (Opus 5), via the `gh` CLI and repo file tools. Skills invoked: `/implementing-warehouse-sources` (for the release-status conventions and the `ReleaseStatus` enum rule), `/writing-pr-descriptions`.

Decisions along the way:

- Followed the enum convention rather than dropping `releaseStatus` entirely. Omitting the field also means GA, but the explicit `ReleaseStatus.GA` matches what every other GA source in the tree does.
- Left gating alone. The skill only calls for removing `unreleasedSource` / `featureFlag` when they are present, and Brevo has neither.

No duplicate: searched open PRs for "brevo", "releaseStatus", and "promote", and listed the maintainer's open PRs. The nearest match, [#95842](https://github.com/PostHog/posthog/pull/95842), promotes ActiveCampaign and Mailjet and touches neither Brevo file. Nothing else addresses this.

Public artifact: the diff is one enum value. The adoption and error-rate figures quoted above are this connector's own aggregate health metrics, not customer data, and no session material reached the branch.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
