### PR TITLE
fix(mcp): validate org fetch before committing session

### DIFF
--- a/services/mcp/src/tools/organizations/setActive.ts
+++ b/services/mcp/src/tools/organizations/setActive.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod'
 
+import { wrapError } from '@/lib/errors'
 import { buildActiveEnvironmentContextPrompt } from '@/lib/instructions'
 import { OrganizationSetActiveSchema } from '@/schema/tool-inputs'
 import type { CachedOrg, CachedProject, CachedUser, Context, ToolBase } from '@/tools/types'
@@ -15,16 +16,25 @@ export const setActiveHandler: ToolBase<typeof schema, Result>['handler'] = asyn
     params: Params
 ) => {
     const { orgId } = params
-    await context.cache.set('orgId', orgId)
 
-    // Fetch fresh org data and cache it
-    let org: CachedOrg | undefined
+    // Validate before committing the session: only switch to an organization the
+    // user can actually access. Previously orgId was cached before the fetch, so
+    // a bad id (or an org the session can't reach) silently "succeeded" and every
+    // later org-scoped call failed with an opaque error instead. Mirrors the fix
+    // already applied to switch-project (`tools/projects/setActive.ts`).
     const orgResult = await context.api.organizations().get({ orgId })
-    if (orgResult.success) {
-        org = orgResult.data
-        await context.cache.set(`cachedOrg:${orgId}` as const, org)
-        await context.cache.set(`cachedOrgFetchedAt:${orgId}` as const, Date.now())
+    if (!orgResult.success) {
+        throw wrapError(
+            `Could not switch to organization ${orgId}: it was not found or you don't have access to it. ` +
+                'Use `organizations-get` to list the organizations available to you and retry with a valid id.',
+            orgResult.error
+        )
     }
+
+    const org: CachedOrg = orgResult.data
+    await context.cache.set('orgId', orgId)
+    await context.cache.set(`cachedOrg:${orgId}` as const, org)
+    await context.cache.set(`cachedOrgFetchedAt:${orgId}` as const, Date.now())
 
     // Read cached user and project for full metadata block
     const distinctId = (await context.cache.get('distinctId')) ?? 'unknown'

--- a/services/mcp/tests/unit/switch-organization.test.ts
+++ b/services/mcp/tests/unit/switch-organization.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import setActiveOrganizationTool from '@/tools/organizations/setActive'
+import type { Context } from '@/tools/types'
+
+function createMockContext(overrides: { organizationGet: ReturnType<typeof vi.fn> }): {
+    context: Context
+    cache: Map<string, unknown>
+} {
+    const cache = new Map<string, unknown>()
+    const context = {
+        api: {
+            publicBaseUrl: 'https://us.posthog.com',
+            organizations: () => ({ get: overrides.organizationGet }),
+        },
+        cache: {
+            get: async (key: string) => cache.get(key),
+            set: async (key: string, value: unknown) => {
+                cache.set(key, value)
+            },
+        },
+        stateManager: {
+            getOrFetchIntegrationKinds: vi.fn().mockResolvedValue(undefined),
+        },
+        env: {},
+        sessionManager: {},
+        getDistinctId: async () => 'test-distinct-id',
+        trackEvent: async () => {},
+    } as unknown as Context
+    return { context, cache }
+}
+
+describe('switch-organization', () => {
+    const tool = setActiveOrganizationTool()
+
+    it('does not commit the session and preserves the error cause when the organization is unreachable', async () => {
+        const apiError = new Error('404')
+        const organizationGet = vi.fn().mockResolvedValue({ success: false, error: apiError })
+        const { context, cache } = createMockContext({ organizationGet })
+
+        let caught: (Error & { cause?: unknown }) | undefined
+        try {
+            await tool.handler(context, { orgId: 'org-999' })
+        } catch (e) {
+            caught = e as Error & { cause?: unknown }
+        }
+
+        expect(caught?.message).toMatch(/Could not switch to organization org-999.*organizations-get/s)
+        expect(caught?.cause).toBe(apiError)
+        // A failed switch must not strand the session on an unreachable organization.
+        expect(cache.get('orgId')).toBeUndefined()
+    })
+
+    it('commits the session and caches the organization when the fetch succeeds', async () => {
+        const organizationGet = vi.fn().mockResolvedValue({
+            success: true,
+            data: { id: 'org-123', name: 'My org' },
+        })
+        const { context, cache } = createMockContext({ organizationGet })
+
+        const result = await tool.handler(context, { orgId: 'org-123' })
+
+        expect(result.content[0]!.text).toContain('Switched to organization org-123')
+        expect(cache.get('orgId')).toBe('org-123')
+        expect(cache.get('cachedOrg:org-123')).toEqual({ id: 'org-123', name: 'My org' })
+    })
+})


### PR DESCRIPTION
## Problem

An agent calling `switch-organization` with an organization id it cannot access is told the switch succeeded. The handler wrote `orgId` to the session cache and returned a success message before (and independent of) fetching the organization, so a failed fetch was silently ignored. Every later org-scoped call then failed with an opaque 403/404 that never mentioned the switch, and the stale `orgId` persisted in the token-keyed cache for its full 7-day TTL.

`switch-project` had the identical shape and was already fixed in #71976 — the fix was never mirrored onto `switch-organization`.

Closes #78629

## Changes

- `switch-organization` now fetches the organization first; only on success does it commit `orgId` and the cached org to the session.
- On a failed fetch, it throws a descriptive error (naming `organizations-get` as the recovery path) instead of reporting success. The original API error is preserved as `cause`, matching `switch-project`'s pattern for keeping recoverable not-found/no-access failures out of exception tracking.
- No change to the success-path response shape or to `switch-project`.

## How did you test this code?

- Added `services/mcp/tests/unit/switch-organization.test.ts`, mirroring the existing `switch-project.test.ts` pattern: one case asserting a failed fetch does not commit `orgId` and preserves the error `cause`, one case asserting a successful fetch commits `orgId` and the cached org. Both pass (`npx vitest run tests/unit/switch-organization.test.ts tests/unit/switch-project.test.ts` — 6/6 passed, including the 4 pre-existing `switch-project` cases, confirming no regression there).
- `npx tsgo --noEmit` in `services/mcp`: no errors introduced by this change (confirmed identical pre-existing error count with and without the diff, via `git stash`/`stash pop`; all pre-existing errors are unrelated `@posthog/quill` UI-app build artifacts, not touching `tools/organizations` or `tools/projects`).
- `oxlint --quiet` and `oxfmt --check` on both changed files: clean.
- Did not manually exercise this against a live PostHog org/session — no live environment set up for this change; relying on the unit tests above plus the direct mirror of the already-shipped `switch-project` fix.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

Found via an isolated multi-repo scan for well-defined, unclaimed backend bugs. Root-caused by diffing `organizations/setActive.ts` against the already-fixed `projects/setActive.ts`, which shares the exact same fetch-then-cache shape and already documents the failure mode in its own comments. The fix, tests, lint/format, and typecheck were all done and verified in this session before opening this PR.

**Autonomy:** Human-driven (agent-assisted)
