### PR TITLE
feat(ingestion-consumer): count gap walks and clear stale confirmation lag

### DIFF
--- a/rust/common/kafka-consumer/src/partition_offset_ledger.rs
+++ b/rust/common/kafka-consumer/src/partition_offset_ledger.rs
@@ -8,6 +8,7 @@ use crate::types::Offset;
 struct Slot {
     complete: bool,
     charge: Charge,
+    delivered: bool,
 }
 
 /// A charge or completion the ledger's window cannot account for. The ledger
@@ -67,12 +68,13 @@ impl fmt::Display for LedgerError {
 
 impl std::error::Error for LedgerError {}
 
-/// A consumed contiguous prefix: its commit-ready frontier and the charge it
-/// covers.
+/// A consumed contiguous prefix: its commit-ready frontier, the charge it
+/// covers, and how many of its offsets Kafka never delivered.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TakenFrontier {
     pub offset: Offset,
     pub charge: Charge,
+    pub gap_offset_count: usize,
 }
 
 /// What a window holds: the offsets charged and not yet drained by
@@ -165,11 +167,13 @@ impl PartitionOffsetLedger {
                 self.slots.push_back(Slot {
                     complete: true,
                     charge: Charge::ZERO,
+                    delivered: false,
                 });
             }
             self.slots.push_back(Slot {
                 complete: false,
                 charge,
+                delivered: true,
             });
             total += charge;
             self.held_charge += charge;
@@ -224,22 +228,23 @@ impl PartitionOffsetLedger {
         (self.completed_prefix_len > 0).then(|| base_offset + self.completed_prefix_len)
     }
 
-    /// Take the frontier and the charge of everything below it, forgetting
-    /// that span. Kept separate from `complete` so that reading the frontier
-    /// has no side effects and only commit points consume it.
     pub fn take_frontier(&mut self) -> Option<TakenFrontier> {
         let frontier_offset = self.frontier()?;
-        let charge = self
-            .slots
-            .drain(..self.completed_prefix_len)
-            .map(|slot| slot.charge)
-            .sum();
+        let mut charge = Charge::ZERO;
+        let mut gap_offset_count = 0;
+        for slot in self.slots.drain(..self.completed_prefix_len) {
+            charge += slot.charge;
+            if !slot.delivered {
+                gap_offset_count += 1;
+            }
+        }
         self.held_charge -= charge;
         self.base_offset = Some(frontier_offset);
         self.completed_prefix_len = 0;
         Some(TakenFrontier {
             offset: frontier_offset,
             charge,
+            gap_offset_count,
         })
     }
 
@@ -286,6 +291,7 @@ mod tests {
         let taken = ledger.take_frontier().unwrap();
         assert_eq!(taken.offset, Offset(1));
         assert_eq!(taken.charge.events, 1);
+        assert_eq!(taken.gap_offset_count, 0);
         assert_eq!(ledger.held().offsets, 2);
         ledger.complete([Offset(1), Offset(2)]).unwrap();
         assert_eq!(ledger.frontier(), Some(Offset(3)));
@@ -379,6 +385,30 @@ mod tests {
         let taken = ledger.take_frontier().unwrap();
         assert_eq!(taken.offset, Offset(4));
         assert_eq!(taken.charge.events, 2);
+        assert_eq!(
+            taken.gap_offset_count, 2,
+            "offsets 1 and 2 were never delivered"
+        );
+    }
+
+    #[test]
+    fn a_take_counts_each_gap_offset_once() {
+        let mut ledger = PartitionOffsetLedger::new(1);
+        ledger.charge([charge(0), charge(2), charge(5)]).unwrap();
+        ledger.complete([Offset(0), Offset(2)]).unwrap();
+        // Filler is complete by construction, so the frontier runs up to the
+        // incomplete offset 5 over the three undelivered offsets 1, 3 and 4.
+        let taken = ledger.take_frontier().unwrap();
+        assert_eq!(taken.offset, Offset(5));
+        assert_eq!(taken.gap_offset_count, 3);
+        assert_eq!(ledger.held().offsets, 1);
+        ledger.complete([Offset(5)]).unwrap();
+        let taken = ledger.take_frontier().unwrap();
+        assert_eq!(taken.offset, Offset(6));
+        assert_eq!(
+            taken.gap_offset_count, 0,
+            "drained filler is not counted again"
+        );
     }
 
     #[test]

--- a/rust/common/kafka-consumer/src/topic_offset_ledger.rs
+++ b/rust/common/kafka-consumer/src/topic_offset_ledger.rs
@@ -19,6 +19,8 @@ const UNCOMMITTED_BYTES: &str = "kafka_consumer_ledger_uncommitted_bytes";
 const STALE_SLICES: &str = "kafka_consumer_ledger_stale_slices_total";
 /// Contract violations in the ledger's accounting; must stay at zero.
 const ERRORS: &str = "kafka_consumer_ledger_errors_total";
+/// Offsets a frontier commit walked over that Kafka never delivered.
+const GAP_OFFSETS: &str = "kafka_consumer_ledger_gap_offsets_total";
 
 /// A partition of a named topic, the key for everything the ledger tracks.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -197,14 +199,15 @@ impl TopicOffsetLedger {
     /// of its window. The drained offsets leave the window, so the gauges
     /// follow them down.
     pub fn take_frontier(&self, topic_partition: &TopicPartition) -> Option<Offset> {
-        let (offset, held) = {
+        let (taken, held) = {
             let mut partitions = self.partitions.lock().unwrap();
             let ledger = partitions.get_mut(topic_partition)?;
             let taken = ledger.take_frontier()?;
-            (taken.offset, ledger.held())
+            (taken, ledger.held())
         };
         publish_held(topic_partition, held);
-        Some(offset)
+        count_gap_offsets(topic_partition, taken.gap_offset_count);
+        Some(taken.offset)
     }
 
     /// What the partition's window still holds; nothing without a ledger.
@@ -269,6 +272,15 @@ fn publish_held(topic_partition: &TopicPartition, held: Held) {
         "partition" => partition
     )
     .set(held.charge.bytes as f64);
+}
+
+fn count_gap_offsets(topic_partition: &TopicPartition, gap_offset_count: usize) {
+    if gap_offset_count == 0 {
+        return;
+    }
+    let (topic, partition) = labels(topic_partition);
+    counter!(GAP_OFFSETS, "topic" => topic, "partition" => partition)
+        .increment(gap_offset_count as u64);
 }
 
 /// Count one charge or settlement the ledger rejected. A stale slice is

--- a/rust/ingestion-consumer/src/order_sentinel.rs
+++ b/rust/ingestion-consumer/src/order_sentinel.rs
@@ -304,7 +304,17 @@ impl CommitSentinel {
     pub fn forget_partitions<'a>(&self, revoked: impl IntoIterator<Item = (&'a str, i32)>) {
         let mut partitions = self.partitions.lock().unwrap();
         for (topic, partition) in revoked {
-            partitions.remove(&(topic.to_string(), partition));
+            let forgotten = partitions.remove(&(topic.to_string(), partition));
+            if forgotten.is_some_and(|state| state.attempted.is_some()) {
+                let topic: Arc<str> = Arc::from(topic);
+                let partition: Arc<str> = Arc::from(partition.to_string());
+                gauge!(
+                    "ingestion_consumer_commit_confirmation_lag",
+                    "topic" => topic,
+                    "partition" => partition,
+                )
+                .set(0.0);
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

Operators reading the offset ledger dashboard see two things that are not true now that the ledger frontier owns commits (#91766).

- A partition a pod no longer owns keeps showing a constant nonzero commit confirmation lag. The gauge is refreshed only from OffsetFetch results for assigned partitions. A partition revoked while a commit was still unconfirmed keeps its last value for the life of the process, and a pod that held it for one incremental assign dominates the per-partition max for days.
- Nothing records when a frontier commit steps past an offset Kafka never delivered. The ledger fills such an offset with pre-completed filler and the frontier walks over it. The commit sentinel compares a batch's first offset with the previous commit, so a gap inside a batch's span never reaches it.

## Changes

- The confirmation lag gauge drops to zero for a partition when the pod loses it. `CommitSentinel::forget_partitions` zeroes it for every revoked partition that had a commit attempted.
- A new counter, `kafka_consumer_ledger_gap_offsets_total` by topic and partition, counts undelivered offsets a frontier commit walked over. The topic ledger emits it when a take drains filler; a take without gaps emits nothing.
- Mechanical: the partition ledger marks filler slots as undelivered and `TakenFrontier` gains `gap_offset_count`.

## How did you test this code?

- `gap_filler_carries_no_charge_and_the_frontier_walks_over_it` now asserts the gap count.
- New `a_take_counts_each_gap_offset_once` catches a take that counts drained filler twice, or counts filler the frontier did not reach.
- The gauge reset has no unit test: the sentinel emits through the global metrics recorder, which the existing tests do not capture. Not verified in a running consumer.
- Ran clippy and the unit tests for common-kafka-consumer and ingestion-consumer inside flox.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Skills invoked: /writing-pr-descriptions. Both gaps surfaced while reviewing the first days of commit mode in production: a stale per-partition lag gauge on a pod that briefly held partitions during an incremental assign, and the sentinel gap counter reading zero once frontier commits replaced per-batch commits. Searched open ledger PRs; none covers either.


