### PR TITLE
feat(signals): tell inbox report runs to keep the report state honest

### DIFF
--- a/products/signals/frontend/inbox/inboxTaskKickoffLogic.test.ts
+++ b/products/signals/frontend/inbox/inboxTaskKickoffLogic.test.ts
@@ -1,5 +1,5 @@
 import { makeReport } from './__mocks__/inboxMocks'
-import { buildDiscussReportPrompt } from './inboxTaskKickoffLogic'
+import { buildCreatePrReportPrompt, buildDiscussReportPrompt } from './inboxTaskKickoffLogic'
 import { SignalReportStatus } from './types'
 
 describe('buildDiscussReportPrompt', () => {
@@ -15,6 +15,7 @@ describe('buildDiscussReportPrompt', () => {
             )
             expect(prompt).toContain('carry the action out')
             expect(prompt).toContain(url)
+            expect(prompt).toContain('inbox-reports-set-state')
         }
     )
 
@@ -33,6 +34,8 @@ describe('buildDiscussReportPrompt', () => {
         const prompt = buildDiscussReportPrompt(makeReport({ status }), url, 'Carry out the recommendation')
         expect(prompt).toContain('Answer this question')
         expect(prompt).not.toContain('carry the action out')
+        // An answer-only run changes nothing about the report, so it is never told to touch the state.
+        expect(prompt).not.toContain('inbox-reports-set-state')
     })
 
     it.each([
@@ -58,5 +61,23 @@ describe('buildDiscussReportPrompt', () => {
         const prompt = buildDiscussReportPrompt(report, url, 'Carry out the recommendation')
         expect(prompt).toContain('Answer this question')
         expect(prompt).not.toContain('carry the action out')
+    })
+})
+
+describe('buildCreatePrReportPrompt', () => {
+    it('tells the agent how to leave the report state', () => {
+        const prompt = buildCreatePrReportPrompt(makeReport({ status: SignalReportStatus.READY }))
+        expect(prompt).toContain('open a PR')
+        expect(prompt).toContain('inbox-reports-set-state')
+        expect(prompt).toContain('fixed_outside_posthog')
+        expect(prompt).toContain('suppressed')
+        // Resolving through the state API closes the report's open PR, so the run must not report
+        // the PR it just opened as a resolution.
+        expect(prompt).toContain('Do NOT set the state to resolved because you opened a PR')
+    })
+
+    it('keeps the user feedback after the state instructions', () => {
+        const prompt = buildCreatePrReportPrompt(makeReport({ status: SignalReportStatus.READY }), 'check the retries')
+        expect(prompt.indexOf('inbox-reports-set-state')).toBeLessThan(prompt.indexOf('check the retries'))
     })
 })

--- a/products/signals/frontend/inbox/inboxTaskKickoffLogic.test.ts
+++ b/products/signals/frontend/inbox/inboxTaskKickoffLogic.test.ts
@@ -2,82 +2,100 @@ import { makeReport } from './__mocks__/inboxMocks'
 import { buildCreatePrReportPrompt, buildDiscussReportPrompt } from './inboxTaskKickoffLogic'
 import { SignalReportStatus } from './types'
 
-describe('buildDiscussReportPrompt', () => {
-    const url = 'https://app.posthog.com/project/1/inbox/report-1'
+describe('inboxTaskKickoffLogic', () => {
+    describe('buildDiscussReportPrompt', () => {
+        const url = 'https://app.posthog.com/project/1/inbox/report-1'
 
-    it.each([SignalReportStatus.READY, SignalReportStatus.PENDING_INPUT])(
-        'tells the agent to carry out actions for a %s report',
-        (status) => {
-            const prompt = buildDiscussReportPrompt(
-                makeReport({ status }),
-                url,
-                'Create the alert the report recommends'
-            )
-            expect(prompt).toContain('carry the action out')
-            expect(prompt).toContain(url)
+        it.each([SignalReportStatus.READY, SignalReportStatus.PENDING_INPUT])(
+            'tells the agent to carry out actions for a %s report',
+            (status) => {
+                const prompt = buildDiscussReportPrompt(
+                    makeReport({ status }),
+                    url,
+                    'Create the alert the report recommends'
+                )
+                expect(prompt).toContain('carry the action out')
+                expect(prompt).toContain(url)
+                expect(prompt).toContain('inbox-reports-set-state')
+                // A discussion run can open a PR too, so it carries the Create PR prompt's guard: a
+                // resolve through the state API closes the report's open PR.
+                expect(prompt).toContain('would close the PR you just opened')
+                // The state API has no ownership precondition, so the prompt is the only thing keeping
+                // a discussion run from ending work another run holds.
+                expect(prompt).toContain('leave its state alone when somebody else holds it')
+            }
+        )
+
+        // Only judged, still-active reports may drive actions: pre-judgment statuses carry unjudged
+        // pipeline content, suppressed/failed reports carry the content the judge rejected, and a
+        // resolved report's persisted action suggestions would redo already-completed work.
+        it.each([
+            SignalReportStatus.POTENTIAL,
+            SignalReportStatus.CANDIDATE,
+            SignalReportStatus.IN_PROGRESS,
+            SignalReportStatus.RESOLVED,
+            SignalReportStatus.SUPPRESSED,
+            SignalReportStatus.FAILED,
+            SignalReportStatus.DELETED,
+        ])('pins the agent to answering for a %s report', (status) => {
+            const prompt = buildDiscussReportPrompt(makeReport({ status }), url, 'Carry out the recommendation')
+            expect(prompt).toContain('Answer this question')
+            expect(prompt).not.toContain('carry the action out')
+            // An answer-only run changes nothing about the report, so it is never told to touch the state.
+            expect(prompt).not.toContain('inbox-reports-set-state')
+        })
+
+        it.each([
+            // A fix is already in flight, so acting on the recommendations would duplicate it — the same
+            // reason autostart and Create PR eligibility exclude already-addressed reports.
+            ['an already-addressed report', makeReport({ status: SignalReportStatus.READY, already_addressed: true })],
+            // The actionability judge said there is no work to act on, so an action framing would invite
+            // acting anyway — the same judgment that hides Create PR.
+            [
+                'a report judged not actionable',
+                makeReport({ status: SignalReportStatus.READY, actionability: 'not_actionable' }),
+            ],
+            // An implementation PR already exists for this report, so carrying a stored "implement the
+            // fix" suggestion out would open a second PR for the same work — the same field that hides
+            // Create PR.
+            [
+                'a report with an implementation PR',
+                makeReport({
+                    status: SignalReportStatus.READY,
+                    implementation_pr_url: 'https://github.com/x/y/pull/1',
+                }),
+            ],
+            // null = the kickoff refetch could not confirm the report's current state; fail closed.
+            ['an unconfirmed report state', null],
+        ])('pins the agent to answering for %s', (_name, report) => {
+            const prompt = buildDiscussReportPrompt(report, url, 'Carry out the recommendation')
+            expect(prompt).toContain('Answer this question')
+            expect(prompt).not.toContain('carry the action out')
+        })
+    })
+
+    describe('buildCreatePrReportPrompt', () => {
+        it('tells the agent how to leave the report state', () => {
+            const prompt = buildCreatePrReportPrompt(makeReport({ status: SignalReportStatus.READY }))
+            expect(prompt).toContain('open a PR')
             expect(prompt).toContain('inbox-reports-set-state')
-        }
-    )
+            expect(prompt).toContain('fixed_outside_posthog')
+            expect(prompt).toContain('suppressed')
+            // Suppressing leaves the claim standing, so the run has to drop it itself.
+            expect(prompt).toContain('then release your claim')
+            // The claim is taken once, at task creation, so a rerun starts unclaimed.
+            expect(prompt).toContain('claim it again first')
+            // Resolving through the state API closes the report's open PR, so the run must not report
+            // the PR it just opened as a resolution.
+            expect(prompt).toContain('Do NOT set the state to resolved because you opened a PR')
+        })
 
-    // Only judged, still-active reports may drive actions: pre-judgment statuses carry unjudged
-    // pipeline content, suppressed/failed reports carry the content the judge rejected, and a
-    // resolved report's persisted action suggestions would redo already-completed work.
-    it.each([
-        SignalReportStatus.POTENTIAL,
-        SignalReportStatus.CANDIDATE,
-        SignalReportStatus.IN_PROGRESS,
-        SignalReportStatus.RESOLVED,
-        SignalReportStatus.SUPPRESSED,
-        SignalReportStatus.FAILED,
-        SignalReportStatus.DELETED,
-    ])('pins the agent to answering for a %s report', (status) => {
-        const prompt = buildDiscussReportPrompt(makeReport({ status }), url, 'Carry out the recommendation')
-        expect(prompt).toContain('Answer this question')
-        expect(prompt).not.toContain('carry the action out')
-        // An answer-only run changes nothing about the report, so it is never told to touch the state.
-        expect(prompt).not.toContain('inbox-reports-set-state')
-    })
-
-    it.each([
-        // A fix is already in flight, so acting on the recommendations would duplicate it — the same
-        // reason autostart and Create PR eligibility exclude already-addressed reports.
-        ['an already-addressed report', makeReport({ status: SignalReportStatus.READY, already_addressed: true })],
-        // The actionability judge said there is no work to act on, so an action framing would invite
-        // acting anyway — the same judgment that hides Create PR.
-        [
-            'a report judged not actionable',
-            makeReport({ status: SignalReportStatus.READY, actionability: 'not_actionable' }),
-        ],
-        // An implementation PR already exists for this report, so carrying a stored "implement the
-        // fix" suggestion out would open a second PR for the same work — the same field that hides
-        // Create PR.
-        [
-            'a report with an implementation PR',
-            makeReport({ status: SignalReportStatus.READY, implementation_pr_url: 'https://github.com/x/y/pull/1' }),
-        ],
-        // null = the kickoff refetch could not confirm the report's current state; fail closed.
-        ['an unconfirmed report state', null],
-    ])('pins the agent to answering for %s', (_name, report) => {
-        const prompt = buildDiscussReportPrompt(report, url, 'Carry out the recommendation')
-        expect(prompt).toContain('Answer this question')
-        expect(prompt).not.toContain('carry the action out')
-    })
-})
-
-describe('buildCreatePrReportPrompt', () => {
-    it('tells the agent how to leave the report state', () => {
-        const prompt = buildCreatePrReportPrompt(makeReport({ status: SignalReportStatus.READY }))
-        expect(prompt).toContain('open a PR')
-        expect(prompt).toContain('inbox-reports-set-state')
-        expect(prompt).toContain('fixed_outside_posthog')
-        expect(prompt).toContain('suppressed')
-        // Resolving through the state API closes the report's open PR, so the run must not report
-        // the PR it just opened as a resolution.
-        expect(prompt).toContain('Do NOT set the state to resolved because you opened a PR')
-    })
-
-    it('keeps the user feedback after the state instructions', () => {
-        const prompt = buildCreatePrReportPrompt(makeReport({ status: SignalReportStatus.READY }), 'check the retries')
-        expect(prompt.indexOf('inbox-reports-set-state')).toBeLessThan(prompt.indexOf('check the retries'))
+        it('keeps the user feedback after the state instructions', () => {
+            const prompt = buildCreatePrReportPrompt(
+                makeReport({ status: SignalReportStatus.READY }),
+                'check the retries'
+            )
+            expect(prompt.indexOf('inbox-reports-set-state')).toBeLessThan(prompt.indexOf('check the retries'))
+        })
     })
 })

--- a/products/signals/frontend/inbox/inboxTaskKickoffLogic.ts
+++ b/products/signals/frontend/inbox/inboxTaskKickoffLogic.ts
@@ -60,10 +60,15 @@ const CREATE_PR_RUNTIME: ClaudeRuntimeSelection = {
 // closes the report's open PR (`close_pr_when_report_dismissed`), which is why opening a PR must
 // not be reported as a resolution. Without this the report stays claimed and unresolved after a
 // run that found nothing to do, and the next reader cannot tell it from work still in flight.
+// The claim needs the same care from both ends: it is taken once, when the task is created, so a
+// rerun of a task that released it starts unclaimed, and suppressing a report leaves the claim
+// standing (only `claim_report` clears an actor), which would show a finished run as still working
+// if the report is ever restored.
 const REPORT_STATE_INSTRUCTIONS = `Keep the report's own state honest while you work, with the inbox MCP tools (\`inbox-reports-set-state\`, \`inbox-reports-claim\`):
-- Opening the PR is enough by itself. This run already holds the report, the PR is linked to it for you, and merging the PR resolves it. Do NOT set the state to resolved because you opened a PR: that closes the PR you just opened.
+- Read the report before you start. This run took the report when its task was created, but a rerun of a run that released it starts unclaimed: claim it again first, so the work you are about to do is visible to everyone else.
+- Opening the PR is enough by itself. The PR is linked to the report for you, and merging it resolves the report. Do NOT set the state to resolved because you opened a PR: that closes the PR you just opened.
 - If the work is finished without a PR, set the state to resolved with the reason that fits (\`fixed_outside_posthog\`, \`pr_merged\`, or \`already_fixed\`) and a short note that says what you did.
-- If the report holds no work to do, set the state to suppressed with the reason that says why (\`report_unclear\`, \`analysis_wrong\`, \`wrong_repo\` with \`corrected_repository\`, \`wontfix_intentional\`, \`wontfix_irrelevant\`, or \`other\`) and a short note.
+- If the report holds no work to do, set the state to suppressed with the reason that says why (\`report_unclear\`, \`analysis_wrong\`, \`wrong_repo\` with \`corrected_repository\`, \`wontfix_intentional\`, \`wontfix_irrelevant\`, or \`other\`) and a short note, then release your claim: suppressing does not release it for you.
 - If you stop for any other reason, release your claim on the report, so it does not look like work is still in flight.`
 
 export function buildCreatePrReportPrompt(report: SignalReport, feedback?: string): string {
@@ -121,10 +126,13 @@ export function buildDiscussReportPrompt(report: SignalReport | null, reportUrl:
     // ("create the alert the report recommends"); "answer this question" would pin the agent to
     // replying instead of acting.
     // State hygiene rides along with the action framing only: a run that just answers a question
-    // has changed nothing about the report, and a discussion task never claims it, so the only
-    // endings worth recording are an action that finishes the report or an exchange that shows it
-    // holds no work.
-    return `A user sent this about the PostHog Inbox report at ${reportUrl}. If it is a question, answer it; if it asks for action, carry the action out and summarize what you did:\n\n${question.trim()}\n\nIf you carry an action out that finishes what the report asked for, record it on the report with the inbox MCP tools (\`inbox-reports-set-state\`): set the state to resolved with the reason \`fixed_outside_posthog\` and a short note that says what you did. If the exchange shows the report holds no work to do, set the state to suppressed with the reason that says why and a short note. Answering a question changes nothing about the report, so leave its state alone.`
+    // has changed nothing about the report, so the only endings worth recording are an action that
+    // finishes the report or an exchange that shows it holds no work. A discussion run may open a
+    // PR of its own, so it needs the same do-not-resolve-on-an-open-PR rule the Create PR prompt
+    // carries. It also never claims the report (`record_report_task` claims for `implementation`
+    // only) and the state API has no ownership precondition, so it is told to keep its hands off a
+    // report somebody else is working — the check a discussion run can actually make.
+    return `A user sent this about the PostHog Inbox report at ${reportUrl}. If it is a question, answer it; if it asks for action, carry the action out and summarize what you did:\n\n${question.trim()}\n\nIf you carry an action out that finishes what the report asked for, record it on the report with the inbox MCP tools (\`inbox-reports-set-state\`): set the state to resolved with the reason \`fixed_outside_posthog\` and a short note that says what you did. Opening a pull request does not finish it — the PR is linked to the report and merging it resolves the report, so setting the state to resolved would close the PR you just opened. If the exchange shows the report holds no work to do, set the state to suppressed with the reason that says why and a short note. Before either, read the report again and leave its state alone when somebody else holds it or an implementation PR is already open on it: that work is not yours to end. Answering a question changes nothing about the report, so leave its state alone.`
 }
 
 // The per-report cap 429 carries code `signal_report_task_cap` with its message under `error`

--- a/products/signals/frontend/inbox/inboxTaskKickoffLogic.ts
+++ b/products/signals/frontend/inbox/inboxTaskKickoffLogic.ts
@@ -53,10 +53,23 @@ const CREATE_PR_RUNTIME: ClaudeRuntimeSelection = {
     reasoning_effort: ReasoningEffortEnumApi.High,
 }
 
-function buildCreatePrReportPrompt(report: SignalReport, feedback?: string): string {
+// The report's state is part of what a run owes the reader, and only the two ends of the happy
+// path are automatic: creating an implementation task claims the report server-side
+// (`record_implementation_task`), and a merged PR resolves it (`_apply_pr_report_state`). Every
+// other ending needs the agent, so spell the endings out. Resolving through the state API also
+// closes the report's open PR (`close_pr_when_report_dismissed`), which is why opening a PR must
+// not be reported as a resolution. Without this the report stays claimed and unresolved after a
+// run that found nothing to do, and the next reader cannot tell it from work still in flight.
+const REPORT_STATE_INSTRUCTIONS = `Keep the report's own state honest while you work, with the inbox MCP tools (\`inbox-reports-set-state\`, \`inbox-reports-claim\`):
+- Opening the PR is enough by itself. This run already holds the report, the PR is linked to it for you, and merging the PR resolves it. Do NOT set the state to resolved because you opened a PR: that closes the PR you just opened.
+- If the work is finished without a PR, set the state to resolved with the reason that fits (\`fixed_outside_posthog\`, \`pr_merged\`, or \`already_fixed\`) and a short note that says what you did.
+- If the report holds no work to do, set the state to suppressed with the reason that says why (\`report_unclear\`, \`analysis_wrong\`, \`wrong_repo\` with \`corrected_repository\`, \`wontfix_intentional\`, \`wontfix_irrelevant\`, or \`other\`) and a short note.
+- If you stop for any other reason, release your claim on the report, so it does not look like work is still in flight.`
+
+export function buildCreatePrReportPrompt(report: SignalReport, feedback?: string): string {
     const base = `Act on PostHog Inbox report "${report.title ?? report.id}" (id ${report.id}). Investigate the root cause using the report's contributing findings, implement the fix, and open a PR.${
         report.summary ? `\n\nReport summary:\n${report.summary}` : ''
-    }`
+    }\n\n${REPORT_STATE_INSTRUCTIONS}`
     const trimmed = feedback?.trim()
     if (!trimmed) {
         return base
@@ -107,7 +120,11 @@ export function buildDiscussReportPrompt(report: SignalReport | null, reportUrl:
     // Framed as question-or-action because a report's suggested prompts include next-step requests
     // ("create the alert the report recommends"); "answer this question" would pin the agent to
     // replying instead of acting.
-    return `A user sent this about the PostHog Inbox report at ${reportUrl}. If it is a question, answer it; if it asks for action, carry the action out and summarize what you did:\n\n${question.trim()}`
+    // State hygiene rides along with the action framing only: a run that just answers a question
+    // has changed nothing about the report, and a discussion task never claims it, so the only
+    // endings worth recording are an action that finishes the report or an exchange that shows it
+    // holds no work.
+    return `A user sent this about the PostHog Inbox report at ${reportUrl}. If it is a question, answer it; if it asks for action, carry the action out and summarize what you did:\n\n${question.trim()}\n\nIf you carry an action out that finishes what the report asked for, record it on the report with the inbox MCP tools (\`inbox-reports-set-state\`): set the state to resolved with the reason \`fixed_outside_posthog\` and a short note that says what you did. If the exchange shows the report holds no work to do, set the state to suppressed with the reason that says why and a short note. Answering a question changes nothing about the report, so leave its state alone.`
 }
 
 // The per-report cap 429 carries code `signal_report_task_cap` with its message under `error`


### PR DESCRIPTION
## Problem

Someone presses **Create PR** or **Ask AI** on a web inbox report, the run does its work — and the report itself never moves. The two kickoff prompts in `products/signals/frontend/inbox/inboxTaskKickoffLogic.ts` describe the job (investigate, fix, open a PR / answer or act) and say nothing about the report's own state, so only the two ends of the happy path are handled at all: creating an implementation task claims the report server-side (`record_implementation_task`), and a merged PR resolves it (`_apply_pr_report_state`).

Every other ending is invisible. A run that decides there is nothing to implement, or that fixes the problem without a pull request, leaves the report sitting claimed and unresolved — indistinguishable in the inbox from work still in flight.

## Changes

Both prompts now carry the endings the platform cannot infer for itself, so a reader opening the inbox afterwards sees what actually happened:

- **Create PR**: resolve with a matching reason (`fixed_outside_posthog`, `pr_merged`, `already_fixed`) when the work landed without a PR; suppress with a dismissal reason (`report_unclear`, `analysis_wrong`, `wrong_repo`, `wontfix_*`, `other`) plus a note when the report holds no work; release the claim on any other stop. The reason codes are the ones the state API already documents, so they render as labelled chips instead of raw codes.
- The prompt explicitly says **not** to resolve on opening a PR. A resolve through the state API closes the report's open pull request (`close_pr_when_report_dismissed`), and a merge resolves the report on its own — so "I opened a PR, therefore resolved" would close the PR it just opened.
- **Ask AI**: the same guidance, but only in the action-capable framing. An answer-only run changed nothing about the report, and a discussion task never claims it, so it is told to leave the state alone.

Prompt copy only — no API, permission, or UI change. Both kickoff paths run with `run_source: signal_report`, which already grants full MCP scopes, so `inbox-reports-set-state` and `inbox-reports-claim` are reachable from these runs today.

Desktop has its own Create PR prompt (`products/desktop/packages/core/src/inbox/reportActions.ts`) with the same gap; left for a follow-up rather than widening this diff.

## How did you test this code?

Automated only — no manual run of an inbox task was performed.

- Extended `products/signals/frontend/inbox/inboxTaskKickoffLogic.test.ts` and ran it (15 passed). New coverage: the Create PR prompt carries the state guidance and the "don't resolve because you opened a PR" guard, user feedback still lands after that guidance, and the answer-only Ask AI framing carries no state instruction — none of which any existing test pinned.
- `oxfmt` and `oxlint` clean on the touched directory. `tsgo --noEmit` reports nothing on either changed file (that run also surfaces pre-existing unrelated errors in this sandbox, mostly unbuilt workspace packages).
- No duplicate: `gh pr list --state open --search` over inbox/report/prompt keywords found no open PR covering this.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a Slack thread that started as a question: whether these runs are told to tidy the report as they work. They are not, which is what this PR fixes. No repo skills were invoked.

The shape came from reading the signals backend rather than guessing: claim-on-start and resolve-on-merge are already automatic, so the prompt only covers what is left, and the resolve-closes-the-PR side effect is why the guard is worded as a prohibition. Scoped to the web inbox prompts, matching where the question was aimed.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1788768305908769)*
