### PR TITLE
fix(geoip): count lookup misses as a metric instead of error logs

### DIFF
--- a/posthog/geoip.py
+++ b/posthog/geoip.py
@@ -158,11 +158,18 @@ def _lookup_location(ip_address: str) -> CachedLocation:
 
     The database is opened once at import and never written, so the mapping from address to location
     cannot change under a running process — a deploy shipping a new database restarts it. Frozen, so a
-    cached entry can't be mutated through one caller and observed by the next. lru_cache doesn't store
-    exceptions, so a failed lookup is retried rather than pinned for the life of the process.
+    cached entry can't be mutated through one caller and observed by the next. A public address the
+    database does not cover is memoized as an empty location, so a repeat request for it does not pay
+    the lookup again. Other failures raise, and lru_cache doesn't store exceptions, so those are retried
+    rather than pinned for the life of the process.
     """
     assert geoip is not None  # caller checks; keeps the cached path free of the None branch
-    city = geoip.city(ip_address)
+    try:
+        city = geoip.city(ip_address)
+    except AddressNotFoundError:
+        # A public address missing from the database is a coverage gap, not an operational error.
+        GEOIP_LOOKUP_FAILURES.labels(reason="not_found").inc()
+        return CachedLocation(latitude=None, longitude=None, country_code=None)
     latitude = city.get("latitude")
     longitude = city.get("longitude")
     country_code = city.get("country_code")
@@ -180,6 +187,7 @@ def get_geoip_location(ip_address: Optional[str]) -> GeoLocation:
     try:
         location = _lookup_location(ip_address)
     except Exception:
+        GEOIP_LOOKUP_FAILURES.labels(reason="lookup_error").inc()
         logger.exception("geoIP location error")
         return {}
     out: GeoLocation = {}

--- a/posthog/geoip.py
+++ b/posthog/geoip.py
@@ -56,11 +56,17 @@ type IPClassification = Literal[
     "link_local",
     "reserved",
     "unspecified",
+    "multicast",
+    "shared",
+    "site_local",
 ]
 
 _NON_PUBLIC_IP_CATEGORIES: frozenset[IPClassification] = frozenset(
-    {"private", "loopback", "link_local", "reserved", "unspecified"}
+    {"private", "loopback", "link_local", "reserved", "unspecified", "multicast", "shared", "site_local"}
 )
+
+# RFC 6598 shared address space, which Python reports as neither private nor reserved.
+_SHARED_ADDRESS_SPACE = ipaddress.IPv4Network("100.64.0.0/10")
 
 
 def _classify_ip(ip_address: str) -> IPClassification:
@@ -83,6 +89,15 @@ def _classify_ip(ip_address: str) -> IPClassification:
         return "reserved"
     if parsed.is_private:
         return "private"
+    # Python's private and reserved predicates miss these three, and none of them can have a location:
+    # multicast is never a unicast source, RFC 6598 shared space sits behind a carrier or cloud NAT, and
+    # RFC 3879 deprecated IPv6 site-local.
+    if parsed.is_multicast:
+        return "multicast"
+    if parsed in _SHARED_ADDRESS_SPACE:
+        return "shared"
+    if isinstance(parsed, ipaddress.IPv6Address) and parsed.is_site_local:
+        return "site_local"
     return "public"
 
 

--- a/posthog/geoip.py
+++ b/posthog/geoip.py
@@ -6,6 +6,8 @@ from typing import Optional, TypedDict
 from django.contrib.gis.geoip2 import GeoIP2
 
 import structlog
+from geoip2.errors import AddressNotFoundError
+from prometheus_client import Counter
 
 from posthog.exceptions_capture import capture_exception
 
@@ -38,6 +40,39 @@ GEOIP_KEY_MAPPING = {"city": "city_name"}
 # of active client addresses is worth holding onto. Each entry is a few hundred bytes.
 GEOIP_LOCATION_CACHE_SIZE = 4096
 
+# Only genuine lookup failures increment this counter. Non-public ranges have no location by definition,
+# so skipping them keeps the counter low-volume and actionable.
+GEOIP_LOOKUP_FAILURES = Counter(
+    "geoip_lookup_failures_total",
+    "GeoIP city lookups that returned no location, by failure reason.",
+    labelnames=["reason"],
+)
+
+_NON_PUBLIC_IP_CATEGORIES = frozenset({"private", "loopback", "link_local", "reserved", "unspecified"})
+
+
+def _classify_ip(ip_address: str) -> str:
+    """Classify an address before a GeoIP lookup.
+
+    The order is significant because Python also reports loopback, link-local, reserved, and
+    unspecified addresses as private.
+    """
+    try:
+        parsed = ipaddress.ip_address(ip_address)
+    except ValueError:
+        return "invalid"
+    if parsed.is_unspecified:
+        return "unspecified"
+    if parsed.is_loopback:
+        return "loopback"
+    if parsed.is_link_local:
+        return "link_local"
+    if parsed.is_reserved:
+        return "reserved"
+    if parsed.is_private:
+        return "private"
+    return "public"
+
 
 def get_geoip_properties(ip_address: Optional[str]) -> dict[str, str]:
     """
@@ -52,14 +87,25 @@ def get_geoip_properties(ip_address: Optional[str]) -> dict[str, str]:
         $geoip_postal_code
         $geoip_time_zone
     """
-    if not ip_address or not geoip or ip_address == "127.0.0.1" or ip_address.startswith("192.168."):
-        # Local addresses would otherwise throw "The address 127.0.0.1 is not in the database." below
+    if not ip_address or not geoip:
+        return {}
+
+    category = _classify_ip(ip_address)
+    if category in _NON_PUBLIC_IP_CATEGORIES:
+        return {}
+    if category == "invalid":
+        GEOIP_LOOKUP_FAILURES.labels(reason="invalid").inc()
         return {}
 
     try:
         geoip_properties = geoip.city(ip_address)
-    except Exception as e:
-        logger.exception(f"geoIP computation error: {e}")
+    except AddressNotFoundError:
+        # A public address missing from the database is a coverage gap, not an operational error.
+        GEOIP_LOOKUP_FAILURES.labels(reason="not_found").inc()
+        return {}
+    except Exception:
+        GEOIP_LOOKUP_FAILURES.labels(reason="lookup_error").inc()
+        logger.exception("geoIP computation error")
         return {}
 
     properties: dict[str, str] = {}
@@ -81,13 +127,7 @@ def _is_non_public_ip(ip_address: str) -> bool:
     """True for addresses geoip can't usefully locate — private/reserved ranges (incl. IPv6) and
     malformed input. Without this, RFC1918 (10/8, 172.16/12), loopback (::1), link-local, etc. would
     fall through to geoip.city() and raise "not in the database" on every such request."""
-    try:
-        parsed = ipaddress.ip_address(ip_address)
-    except ValueError:
-        return True
-    return (
-        parsed.is_private or parsed.is_loopback or parsed.is_link_local or parsed.is_reserved or parsed.is_unspecified
-    )
+    return _classify_ip(ip_address) != "public"
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/posthog/geoip.py
+++ b/posthog/geoip.py
@@ -1,7 +1,7 @@
 import ipaddress
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Optional, TypedDict
+from typing import Literal, Optional, TypedDict
 
 from django.contrib.gis.geoip2 import GeoIP2
 
@@ -48,10 +48,22 @@ GEOIP_LOOKUP_FAILURES = Counter(
     labelnames=["reason"],
 )
 
-_NON_PUBLIC_IP_CATEGORIES = frozenset({"private", "loopback", "link_local", "reserved", "unspecified"})
+type IPClassification = Literal[
+    "public",
+    "invalid",
+    "private",
+    "loopback",
+    "link_local",
+    "reserved",
+    "unspecified",
+]
+
+_NON_PUBLIC_IP_CATEGORIES: frozenset[IPClassification] = frozenset(
+    {"private", "loopback", "link_local", "reserved", "unspecified"}
+)
 
 
-def _classify_ip(ip_address: str) -> str:
+def _classify_ip(ip_address: str) -> IPClassification:
     """Classify an address before a GeoIP lookup.
 
     The order is significant because Python also reports loopback, link-local, reserved, and

--- a/posthog/helpers/tests/test_geoip.py
+++ b/posthog/helpers/tests/test_geoip.py
@@ -58,6 +58,9 @@ def _total_failure_count() -> float:
         pytest.param("169.254.42.42", id="link_local"),
         pytest.param("240.0.0.42", id="reserved"),
         pytest.param("0.0.0.0", id="unspecified"),
+        pytest.param("100.64.0.42", id="rfc6598_shared"),
+        pytest.param("224.0.0.42", id="multicast"),
+        pytest.param("fec0::42", id="ipv6_site_local"),
     ],
 )
 def test_geoip_skips_non_public_addresses_without_a_lookup(non_public_ip: str) -> None:

--- a/posthog/helpers/tests/test_geoip.py
+++ b/posthog/helpers/tests/test_geoip.py
@@ -1,20 +1,17 @@
-from typing import cast
-
 import pytest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
-from django.contrib.gis.geoip2 import GeoIP2, GeoIP2Exception
-from django.test import TestCase
+from django.contrib.gis.geoip2 import GeoIP2Exception
 
-from posthog.geoip import geoip, get_geoip_properties
+from geoip2.errors import AddressNotFoundError
+from prometheus_client import REGISTRY
+
+from posthog.geoip import get_geoip_properties
 
 australia_ip = "13.106.122.3"
 uk_ip = "31.28.64.3"
 us_ip_v6 = "2600:6c52:7a00:11c:1b6:b7b0:ea19:6365"
-localhost_ip = "127.0.0.1"
-local_network_ip = "192.168.97.2"
 mexico_ip = "187.188.10.252"
-australia_ip_2 = "13.106.122.3"
 
 
 @pytest.mark.parametrize(
@@ -36,32 +33,63 @@ def test_geoip_results(test_input, expected_country):
     assert len(properties) >= 5
 
 
-class TestGeoIPDBError(TestCase):
-    def setUp(self) -> None:
-        self.geoip_city_method = cast(GeoIP2, geoip).city
-        geoip.city = Mock(side_effect=GeoIP2Exception("GeoIP file not found"))  # type: ignore
-
-    def tearDown(self) -> None:
-        geoip.city = self.geoip_city_method  # type: ignore
-
-    def test_geoip_with_invalid_database_file_returns_successfully(self):
-        properties = get_geoip_properties(australia_ip)
-
-        self.assertEqual(properties, {})
+def _failure_count(reason: str) -> float:
+    return REGISTRY.get_sample_value("geoip_lookup_failures_total", {"reason": reason}) or 0.0
 
 
-class TestGeoIPError(TestCase):
-    def test_geoip_on_localhost_ip_returns_successfully(self):
-        properties = get_geoip_properties(localhost_ip)
+def _total_failure_count() -> float:
+    return sum(
+        sample.value
+        for metric in REGISTRY.collect()
+        if metric.name == "geoip_lookup_failures"
+        for sample in metric.samples
+        if sample.name == "geoip_lookup_failures_total"
+    )
 
-        self.assertEqual(properties, {})
 
-    def test_geoip_on_local_network_ip_returns_successfully(self):
-        properties = get_geoip_properties(local_network_ip)
+@pytest.mark.parametrize(
+    "non_public_ip",
+    [
+        pytest.param("127.0.0.1", id="ipv4_loopback"),
+        pytest.param("::1", id="ipv6_loopback"),
+        pytest.param("10.0.0.42", id="rfc1918_10"),
+        pytest.param("172.20.0.42", id="rfc1918_172"),
+        pytest.param("192.168.0.42", id="rfc1918_192"),
+        pytest.param("169.254.42.42", id="link_local"),
+        pytest.param("240.0.0.42", id="reserved"),
+        pytest.param("0.0.0.0", id="unspecified"),
+    ],
+)
+def test_geoip_skips_non_public_addresses_without_a_lookup(non_public_ip: str) -> None:
+    before = _total_failure_count()
+    with patch("posthog.geoip.geoip") as mock_geoip:
+        assert get_geoip_properties(non_public_ip) == {}
+    mock_geoip.city.assert_not_called()
+    assert _total_failure_count() == before
 
-        self.assertEqual(properties, {})
 
-    def test_geoip_on_invalid_ip_returns_successfully(self):
-        properties = get_geoip_properties(None)
+def test_geoip_on_invalid_ip_counts_an_invalid_failure() -> None:
+    with patch("posthog.geoip.geoip"):
+        before = _failure_count("invalid")
+        assert get_geoip_properties("not-an-ip-address") == {}
+    assert _failure_count("invalid") == before + 1
 
-        self.assertEqual(properties, {})
+
+@pytest.mark.parametrize(
+    "reason,exc",
+    [
+        ("lookup_error", GeoIP2Exception("GeoIP file not found")),
+        ("not_found", AddressNotFoundError("The address is not in the database.")),
+    ],
+)
+def test_failed_public_lookup_returns_empty_and_counts_reason(reason: str, exc: Exception) -> None:
+    mock_geoip = Mock()
+    mock_geoip.city.side_effect = exc
+    with patch("posthog.geoip.geoip", mock_geoip):
+        before = _failure_count(reason)
+        assert get_geoip_properties("8.8.8.8") == {}
+    assert _failure_count(reason) == before + 1
+
+
+def test_geoip_on_missing_ip_returns_successfully() -> None:
+    assert get_geoip_properties(None) == {}

--- a/posthog/test/test_geoip.py
+++ b/posthog/test/test_geoip.py
@@ -1,9 +1,15 @@
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from geoip2.errors import AddressNotFoundError
 from parameterized import parameterized
+from prometheus_client import REGISTRY
 
 from posthog.geoip import _lookup_location, get_geoip_location
+
+
+def _not_found_count() -> float:
+    return REGISTRY.get_sample_value("geoip_lookup_failures_total", {"reason": "not_found"}) or 0.0
 
 
 class TestGeoipLocation(BaseTest):
@@ -48,6 +54,21 @@ class TestGeoipLocation(BaseTest):
             get_geoip_location("8.8.8.8")
 
         mock_geoip.city.assert_called_once()
+
+    @patch("posthog.geoip.logger")
+    @patch("posthog.geoip.geoip")
+    def test_repeated_database_miss_counts_once_and_logs_no_error(self, mock_geoip, mock_logger):
+        # A public address the database doesn't cover is a coverage gap, so it must not reach the
+        # error log, and the negative result must be cached like a hit.
+        mock_geoip.city.side_effect = AddressNotFoundError("The address 8.8.8.8 is not in the database.")
+        before = _not_found_count()
+
+        for _ in range(3):
+            self.assertEqual(get_geoip_location("8.8.8.8"), {})
+
+        mock_geoip.city.assert_called_once()
+        mock_logger.exception.assert_not_called()
+        self.assertEqual(_not_found_count(), before + 1)
 
     @patch("posthog.geoip.geoip")
     def test_callers_cannot_corrupt_a_cached_entry(self, mock_geoip):


### PR DESCRIPTION
## Problem

Operators see expected GeoIP misses as errors when requests contain non-public addresses.

The property lookup only skips IPv4 localhost and one private range before querying MaxMind.

## Changes

- Operators no longer see expected GeoIP misses from non-public addresses as errors.
- A shared classifier skips private, loopback, link-local, reserved, and unspecified addresses before lookup.
- Genuine failures increment `geoip_lookup_failures_total` with `invalid`, `not_found`, or `lookup_error` reasons.
- `lookup_error` still emits an error log because it indicates an operational problem.

Before:

```mermaid
flowchart LR
    A{{Address}} --> B[Narrow string checks]
    B --> C[MaxMind lookup]
    C --> D[Expected miss logged as error]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B,C phBlue;
    class D phRed;
```

After:

```mermaid
flowchart LR
    A{{Address}} --> B[Classify address]
    B -->|Non-public| C[Skip lookup]
    B -->|Public| D[MaxMind lookup]
    D -->|Not found| E[Increment metric]
    D -->|Lookup error| F[Increment metric and log error]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B,D phBlue;
    class C,E phGray;
    class F phRed;
```

> [!NOTE]
> Alerts that match `geoIP computation error` for database misses will go quiet. Monitor `geoip_lookup_failures_total` instead.

## How did you test this code?

- `./bin/hogli test posthog/helpers/tests/test_geoip.py -k 'not geoip_results'` covers classification, skipped lookups, and failure reasons.
- `ruff check posthog/geoip.py posthog/helpers/tests/test_geoip.py`
- `uv run mypy --cache-fine-grained .`
- `./bin/hogli ci:preflight --fix`
- The full test file could not complete because this sandbox does not load the MaxMind database.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This changes internal logging and metrics only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Desktop used `gh`, Ruff, hogli, and mypy.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/instrumenting-first-party-metrics`, `/running-ci-preflight`, and `/writing-pr-descriptions`.
- The open PR search found no existing GeoIP PR that addresses this fix.
- Test fixtures use generic reserved addresses and contain no session-derived data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

from report https://us.posthog.com/project/2/inbox/01a06763-d37c-7b2c-9aad-cd233a6b08f5
