### PR TITLE
fix(logs): start a series-bands baseline at sustained traffic, not the first row

### DIFF
--- a/products/logs/backend/presentation/views/anomalies_api.py
+++ b/products/logs/backend/presentation/views/anomalies_api.py
@@ -282,7 +282,11 @@ class LogsSeriesBandSeriesSerializer(serializers.Serializer):
         )
     )
     history_start = serializers.DateTimeField(
-        help_text="Earliest bucket with data inside the fetched lookback.",
+        help_text=(
+            "Start of sustained traffic inside the fetched lookback: the first bucket followed by a week with "
+            "enough non-empty buckets. A stray earlier row does not move it. The window start when no traffic "
+            "is sustained yet."
+        ),
     )
     band_ready_at = serializers.DateTimeField(
         allow_null=True,

--- a/products/logs/backend/series_bands.py
+++ b/products/logs/backend/series_bands.py
@@ -38,7 +38,8 @@ MAX_WINDOW_START_AGE_DAYS = VOLUME_BUCKETS_TTL_DAYS - MAX_WINDOW_DAYS
 BASELINE_WEEKS = 5
 # Below this many full prior weeks the band rests on too little history to draw.
 MIN_BASELINE_WEEKS_FOR_BAND = 2
-SECONDS_PER_WEEK = 7 * 24 * 3600
+SECONDS_PER_DAY = 24 * 3600
+SECONDS_PER_WEEK = 7 * SECONDS_PER_DAY
 
 MAX_SERIES = int(os.environ.get("LOGS_SERIES_BANDS_MAX_SERIES", "100"))
 # Display grains a caller may pick. Every rung divides an hour so slots stay
@@ -46,9 +47,9 @@ MAX_SERIES = int(os.environ.get("LOGS_SERIES_BANDS_MAX_SERIES", "100"))
 INTERVAL_LADDER_MINUTES = (5, 15, 30, 60)
 MAX_BUCKETS_PER_SERIES = int(os.environ.get("LOGS_SERIES_BANDS_MAX_BUCKETS_PER_SERIES", "500"))
 # A series' lifetime starts at the first slot followed by sustained traffic: at
-# least this fraction of the week's slots after it are non-empty. A stray row
-# weeks before the real start would otherwise date the lifetime and turn every
-# empty week between them into a baseline of zeros.
+# least this fraction of the slots after it are non-empty, over the day and over
+# the week. A stray row before the real start would otherwise date the lifetime
+# and turn every empty week between them into a baseline of zeros.
 ALIVE_SLOT_FRACTION = float(os.environ.get("LOGS_SERIES_BANDS_ALIVE_SLOT_FRACTION", "0.2"))
 # Widening keeps the envelope from reading as a hairline on quiet series: the
 # fraction scales both edges, the floor lifts the upper edge by a per-hour
@@ -152,10 +153,11 @@ def fetch_series_slot_rows(
     # week, so a series without sustained traffic is dated from the window start
     # and reports as learning with band_ready_at ahead of the window.
     alive_slots = max(1, math.ceil(ALIVE_SLOT_FRACTION * SECONDS_PER_WEEK / (interval_minutes * 60)))
-    # Sustained traffic also has to start straight away. A stray row a few days
-    # ahead of a dense stretch fits inside the same week-long run, so the run
-    # cannot open on a gap wider than the mean spacing its own slots allow.
-    alive_gap_seconds = SECONDS_PER_WEEK // max(1, alive_slots - 1)
+    # The week's count alone reads a few stray rows a few days ahead of a dense
+    # stretch as its start, because the stretch supplies the count. Holding the
+    # same fraction over the day after the slot leaves only slots that carry
+    # traffic of their own.
+    alive_day_slots = max(1, math.ceil(ALIVE_SLOT_FRACTION * SECONDS_PER_DAY / (interval_minutes * 60)))
     # The series cap ranks over the whole 42d, not the display window: a series
     # that went silent this week has zero window volume, and ranking on the
     # window alone would drop exactly the series a silence should surface. The
@@ -195,7 +197,7 @@ def fetch_series_slot_rows(
                 arrayFirst(
                     i -> i + {alive_slots} - 1 <= length(slot_times)
                         AND slot_times[i + {alive_slots} - 1] - slot_times[i] < {week_seconds}
-                        AND slot_times[i + 1] - slot_times[i] <= {alive_gap_seconds},
+                        AND slot_times[i + {alive_day_slots} - 1] - slot_times[i] < {day_seconds},
                     arrayEnumerate(slot_times)
                 ) AS alive_index,
                 if(alive_index = 0, {window_start}, toDateTime(slot_times[alive_index])) AS lifetime_start
@@ -231,7 +233,8 @@ def fetch_series_slot_rows(
             "baseline_seconds": ast.Constant(value=BASELINE_WEEKS * SECONDS_PER_WEEK),
             "week_seconds": ast.Constant(value=SECONDS_PER_WEEK),
             "alive_slots": ast.Constant(value=alive_slots),
-            "alive_gap_seconds": ast.Constant(value=alive_gap_seconds),
+            "alive_day_slots": ast.Constant(value=alive_day_slots),
+            "day_seconds": ast.Constant(value=SECONDS_PER_DAY),
             "max_series_plus_probe": ast.Constant(value=MAX_SERIES + 1),
             "row_limit": ast.Constant(value=MAX_SELECT_RETURNED_ROWS),
         },

--- a/products/logs/backend/series_bands.py
+++ b/products/logs/backend/series_bands.py
@@ -117,7 +117,12 @@ class _SlotRow:
     baseline_samples: int
     baseline_min: int
     baseline_max: int
+
+
+@frozen
+class _SeriesRows:
     lifetime_start: dt.datetime
+    slots: list[_SlotRow]
 
 
 def floor_to_interval(value: dt.datetime, interval_minutes: int) -> dt.datetime:
@@ -131,7 +136,7 @@ def fetch_series_slot_rows(
     window_start: dt.datetime,
     window_end: dt.datetime,
     interval_minutes: int,
-) -> dict[_SeriesKey, list[_SlotRow]]:
+) -> dict[_SeriesKey, _SeriesRows]:
     """One ClickHouse pass: interval rollup over the window plus baseline, folded
     by time-of-week onto the display window's slots, plus each series' lifetime
     start.
@@ -139,23 +144,19 @@ def fetch_series_slot_rows(
     Rows are sparse — a (series, slot) with no observed and no baseline data has
     no row. Missing baseline weeks are reconstructed in Python from
     baseline_samples vs the weeks the series existed. Baseline samples only
-    count slots at or after the lifetime start, so a stray row before it never
-    reaches the envelope."""
+    count slots at or after the lifetime start."""
     tag_queries(product=Product.LOGS, feature=Feature.QUERY, source="logs_series_bands", team_id=str(team.id))
 
     baseline_start = window_start - dt.timedelta(weeks=BASELINE_WEEKS)
+    # arrayFirst yields index 0 when no run of alive_slots slots fits inside a
+    # week, so a series without sustained traffic is dated from the window start
+    # and reports as learning with band_ready_at ahead of the window.
     alive_slots = max(1, math.ceil(ALIVE_SLOT_FRACTION * SECONDS_PER_WEEK / (interval_minutes * 60)))
     # The series cap ranks over the whole 42d, not the display window: a series
     # that went silent this week has zero window volume, and ranking on the
     # window alone would drop exactly the series a silence should surface. The
     # subquery fetches one series past the cap so the caller can tell a full
     # response from a truncated one.
-    #
-    # The lifetime start is the first non-empty slot with at least alive_slots
-    # non-empty slots inside the week that starts at it. Over the sorted slot
-    # times that is the first index i where slot i + alive_slots - 1 still sits
-    # inside a week of slot i. arrayFirst yields 0 when no index qualifies, and
-    # slot_times[0] is 0, which the caller reads as no lifetime start.
     query = parse_select(
         """
         WITH slots AS (
@@ -192,7 +193,7 @@ def fetch_series_slot_rows(
                         AND slot_times[i + {alive_slots} - 1] - slot_times[i] < {week_seconds},
                     arrayEnumerate(slot_times)
                 ) AS alive_index,
-                slot_times[alive_index] AS lifetime_start
+                if(alive_index = 0, {window_start}, toDateTime(slot_times[alive_index])) AS lifetime_start
             FROM slots
             GROUP BY namespace, environment, severity_text
         )
@@ -204,9 +205,9 @@ def fetch_series_slot_rows(
                 (toUnixTimestamp(slots.slot) - toUnixTimestamp({window_start}) + {baseline_seconds}) % {week_seconds}
             ) AS target_time,
             sumIf(slots.slot_count, slots.slot >= {window_start}) AS observed,
-            countIf(slots.slot < {window_start} AND toUnixTimestamp(slots.slot) >= lifetimes.lifetime_start) AS baseline_samples,
-            minIf(slots.slot_count, slots.slot < {window_start} AND toUnixTimestamp(slots.slot) >= lifetimes.lifetime_start) AS baseline_min,
-            maxIf(slots.slot_count, slots.slot < {window_start} AND toUnixTimestamp(slots.slot) >= lifetimes.lifetime_start) AS baseline_max,
+            countIf(slots.slot < {window_start} AND slots.slot >= lifetimes.lifetime_start) AS baseline_samples,
+            minIf(slots.slot_count, slots.slot < {window_start} AND slots.slot >= lifetimes.lifetime_start) AS baseline_min,
+            maxIf(slots.slot_count, slots.slot < {window_start} AND slots.slot >= lifetimes.lifetime_start) AS baseline_max,
             lifetimes.lifetime_start AS lifetime_start
         FROM slots
         INNER JOIN lifetimes
@@ -246,23 +247,19 @@ def fetch_series_slot_rows(
     if len(response.results) >= MAX_SELECT_RETURNED_ROWS:
         raise SeriesBandsFetchTruncated(f"series bands fetch returned {len(response.results)} rows, at the row limit")
 
-    rows: dict[_SeriesKey, list[_SlotRow]] = {}
+    rows: dict[_SeriesKey, _SeriesRows] = {}
     for row in response.results:
         key = _SeriesKey(namespace=row[0], environment=row[1], severity=row[2])
-        lifetime_start_ts = int(row[8])
-        # A series with no sustained traffic yet is dated from the window start,
-        # so it reports as learning with band_ready_at ahead of the window.
-        lifetime_start = (
-            dt.datetime.fromtimestamp(lifetime_start_ts, tz=dt.UTC) if lifetime_start_ts > 0 else window_start
-        )
-        rows.setdefault(key, []).append(
+        series = rows.get(key)
+        if series is None:
+            series = rows[key] = _SeriesRows(lifetime_start=ensure_utc(row[8]), slots=[])
+        series.slots.append(
             _SlotRow(
                 target_time=ensure_utc(row[3]),
                 observed=int(row[4]),
                 baseline_samples=int(row[5]),
                 baseline_min=int(row[6]),
                 baseline_max=int(row[7]),
-                lifetime_start=lifetime_start,
             )
         )
     return rows
@@ -271,11 +268,10 @@ def fetch_series_slot_rows(
 def _baseline_weeks_available(later: dt.datetime, lifetime_start: dt.datetime) -> int:
     """Whole weeks of series lifetime before `later`, capped at the baseline depth.
 
-    The lifetime starts at the first slot followed by sustained traffic, not at
-    the first row. Against the window start this is the series' maturity;
-    against one display slot it is how many of that slot's weekly samples carry
-    information. A week whose sample slot predates the lifetime says nothing; a
-    week inside the lifetime with no row was a real zero.
+    Against the window start this is the series' maturity; against one display
+    slot it is how many of that slot's weekly samples carry information. A week
+    whose sample slot predates the lifetime says nothing; a week inside the
+    lifetime with no row was a real zero.
     """
     weeks = int((later - lifetime_start).total_seconds()) // SECONDS_PER_WEEK
     return min(BASELINE_WEEKS, max(0, weeks))
@@ -300,13 +296,13 @@ def _band_gate(
 
 def _build_series(
     key: _SeriesKey,
-    slot_rows: list[_SlotRow],
+    series_rows: _SeriesRows,
     window_start: dt.datetime,
     window_end: dt.datetime,
     interval_minutes: int,
 ) -> BandSeries:
-    by_time = {row.target_time: row for row in slot_rows}
-    lifetime_start = min(row.lifetime_start for row in slot_rows)
+    by_time = {row.target_time: row for row in series_rows.slots}
+    lifetime_start = series_rows.lifetime_start
     baseline_weeks, band_ready_at = _band_gate(window_start, window_end, lifetime_start)
     banded = band_ready_at is None
     floor = BAND_FLOOR_PER_HOUR * interval_minutes / 60

--- a/products/logs/backend/series_bands.py
+++ b/products/logs/backend/series_bands.py
@@ -152,6 +152,10 @@ def fetch_series_slot_rows(
     # week, so a series without sustained traffic is dated from the window start
     # and reports as learning with band_ready_at ahead of the window.
     alive_slots = max(1, math.ceil(ALIVE_SLOT_FRACTION * SECONDS_PER_WEEK / (interval_minutes * 60)))
+    # Sustained traffic also has to start straight away. A stray row a few days
+    # ahead of a dense stretch fits inside the same week-long run, so the run
+    # cannot open on a gap wider than the mean spacing its own slots allow.
+    alive_gap_seconds = SECONDS_PER_WEEK // max(1, alive_slots - 1)
     # The series cap ranks over the whole 42d, not the display window: a series
     # that went silent this week has zero window volume, and ranking on the
     # window alone would drop exactly the series a silence should surface. The
@@ -190,7 +194,8 @@ def fetch_series_slot_rows(
                 arraySort(groupArray(toUnixTimestamp(slot))) AS slot_times,
                 arrayFirst(
                     i -> i + {alive_slots} - 1 <= length(slot_times)
-                        AND slot_times[i + {alive_slots} - 1] - slot_times[i] < {week_seconds},
+                        AND slot_times[i + {alive_slots} - 1] - slot_times[i] < {week_seconds}
+                        AND slot_times[i + 1] - slot_times[i] <= {alive_gap_seconds},
                     arrayEnumerate(slot_times)
                 ) AS alive_index,
                 if(alive_index = 0, {window_start}, toDateTime(slot_times[alive_index])) AS lifetime_start
@@ -226,6 +231,7 @@ def fetch_series_slot_rows(
             "baseline_seconds": ast.Constant(value=BASELINE_WEEKS * SECONDS_PER_WEEK),
             "week_seconds": ast.Constant(value=SECONDS_PER_WEEK),
             "alive_slots": ast.Constant(value=alive_slots),
+            "alive_gap_seconds": ast.Constant(value=alive_gap_seconds),
             "max_series_plus_probe": ast.Constant(value=MAX_SERIES + 1),
             "row_limit": ast.Constant(value=MAX_SELECT_RETURNED_ROWS),
         },

--- a/products/logs/backend/series_bands.py
+++ b/products/logs/backend/series_bands.py
@@ -10,6 +10,7 @@ gating, widening) where the arithmetic is cheap and unit-testable.
 """
 
 import os
+import math
 import datetime as dt
 from zoneinfo import ZoneInfo
 
@@ -44,6 +45,11 @@ MAX_SERIES = int(os.environ.get("LOGS_SERIES_BANDS_MAX_SERIES", "100"))
 # aligned with the weekly fold, and 5 is the bucket size of logs_volume_buckets.
 INTERVAL_LADDER_MINUTES = (5, 15, 30, 60)
 MAX_BUCKETS_PER_SERIES = int(os.environ.get("LOGS_SERIES_BANDS_MAX_BUCKETS_PER_SERIES", "500"))
+# A series' lifetime starts at the first slot followed by sustained traffic: at
+# least this fraction of the week's slots after it are non-empty. A stray row
+# weeks before the real start would otherwise date the lifetime and turn every
+# empty week between them into a baseline of zeros.
+ALIVE_SLOT_FRACTION = float(os.environ.get("LOGS_SERIES_BANDS_ALIVE_SLOT_FRACTION", "0.2"))
 # Widening keeps the envelope from reading as a hairline on quiet series: the
 # fraction scales both edges, the floor lifts the upper edge by a per-hour
 # count so a band exists even where every baseline week saw the same value.
@@ -111,7 +117,7 @@ class _SlotRow:
     baseline_samples: int
     baseline_min: int
     baseline_max: int
-    earliest_slot: dt.datetime
+    lifetime_start: dt.datetime
 
 
 def floor_to_interval(value: dt.datetime, interval_minutes: int) -> dt.datetime:
@@ -127,34 +133,32 @@ def fetch_series_slot_rows(
     interval_minutes: int,
 ) -> dict[_SeriesKey, list[_SlotRow]]:
     """One ClickHouse pass: interval rollup over the window plus baseline, folded
-    by time-of-week onto the display window's slots.
+    by time-of-week onto the display window's slots, plus each series' lifetime
+    start.
 
     Rows are sparse — a (series, slot) with no observed and no baseline data has
     no row. Missing baseline weeks are reconstructed in Python from
-    baseline_samples vs the weeks the series existed."""
+    baseline_samples vs the weeks the series existed. Baseline samples only
+    count slots at or after the lifetime start, so a stray row before it never
+    reaches the envelope."""
     tag_queries(product=Product.LOGS, feature=Feature.QUERY, source="logs_series_bands", team_id=str(team.id))
 
     baseline_start = window_start - dt.timedelta(weeks=BASELINE_WEEKS)
+    alive_slots = max(1, math.ceil(ALIVE_SLOT_FRACTION * SECONDS_PER_WEEK / (interval_minutes * 60)))
     # The series cap ranks over the whole 42d, not the display window: a series
     # that went silent this week has zero window volume, and ranking on the
     # window alone would drop exactly the series a silence should surface. The
     # subquery fetches one series past the cap so the caller can tell a full
     # response from a truncated one.
+    #
+    # The lifetime start is the first non-empty slot with at least alive_slots
+    # non-empty slots inside the week that starts at it. Over the sorted slot
+    # times that is the first index i where slot i + alive_slots - 1 still sits
+    # inside a week of slot i. arrayFirst yields 0 when no index qualifies, and
+    # slot_times[0] is 0, which the caller reads as no lifetime start.
     query = parse_select(
         """
-        SELECT
-            namespace,
-            environment,
-            severity_text,
-            {window_start} + toIntervalSecond(
-                (toUnixTimestamp(slot) - toUnixTimestamp({window_start}) + {baseline_seconds}) % {week_seconds}
-            ) AS target_time,
-            sumIf(slot_count, slot >= {window_start}) AS observed,
-            countIf(slot < {window_start}) AS baseline_samples,
-            minIf(slot_count, slot < {window_start}) AS baseline_min,
-            maxIf(slot_count, slot < {window_start}) AS baseline_max,
-            min(slot) AS earliest_slot
-        FROM (
+        WITH slots AS (
             SELECT
                 namespace,
                 environment,
@@ -176,8 +180,40 @@ def fetch_series_slot_rows(
                     LIMIT {max_series_plus_probe}
                 )
             GROUP BY namespace, environment, severity_text, slot
+        ),
+        lifetimes AS (
+            SELECT
+                namespace,
+                environment,
+                severity_text,
+                arraySort(groupArray(toUnixTimestamp(slot))) AS slot_times,
+                arrayFirst(
+                    i -> i + {alive_slots} - 1 <= length(slot_times)
+                        AND slot_times[i + {alive_slots} - 1] - slot_times[i] < {week_seconds},
+                    arrayEnumerate(slot_times)
+                ) AS alive_index,
+                slot_times[alive_index] AS lifetime_start
+            FROM slots
+            GROUP BY namespace, environment, severity_text
         )
-        GROUP BY namespace, environment, severity_text, target_time
+        SELECT
+            slots.namespace AS namespace,
+            slots.environment AS environment,
+            slots.severity_text AS severity_text,
+            {window_start} + toIntervalSecond(
+                (toUnixTimestamp(slots.slot) - toUnixTimestamp({window_start}) + {baseline_seconds}) % {week_seconds}
+            ) AS target_time,
+            sumIf(slots.slot_count, slots.slot >= {window_start}) AS observed,
+            countIf(slots.slot < {window_start} AND toUnixTimestamp(slots.slot) >= lifetimes.lifetime_start) AS baseline_samples,
+            minIf(slots.slot_count, slots.slot < {window_start} AND toUnixTimestamp(slots.slot) >= lifetimes.lifetime_start) AS baseline_min,
+            maxIf(slots.slot_count, slots.slot < {window_start} AND toUnixTimestamp(slots.slot) >= lifetimes.lifetime_start) AS baseline_max,
+            lifetimes.lifetime_start AS lifetime_start
+        FROM slots
+        INNER JOIN lifetimes
+            ON slots.namespace = lifetimes.namespace
+            AND slots.environment = lifetimes.environment
+            AND slots.severity_text = lifetimes.severity_text
+        GROUP BY namespace, environment, severity_text, target_time, lifetime_start
         LIMIT {row_limit}
         """,
         placeholders={
@@ -188,6 +224,7 @@ def fetch_series_slot_rows(
             "interval": ast.Call(name="toIntervalMinute", args=[ast.Constant(value=interval_minutes)]),
             "baseline_seconds": ast.Constant(value=BASELINE_WEEKS * SECONDS_PER_WEEK),
             "week_seconds": ast.Constant(value=SECONDS_PER_WEEK),
+            "alive_slots": ast.Constant(value=alive_slots),
             "max_series_plus_probe": ast.Constant(value=MAX_SERIES + 1),
             "row_limit": ast.Constant(value=MAX_SELECT_RETURNED_ROWS),
         },
@@ -212,6 +249,12 @@ def fetch_series_slot_rows(
     rows: dict[_SeriesKey, list[_SlotRow]] = {}
     for row in response.results:
         key = _SeriesKey(namespace=row[0], environment=row[1], severity=row[2])
+        lifetime_start_ts = int(row[8])
+        # A series with no sustained traffic yet is dated from the window start,
+        # so it reports as learning with band_ready_at ahead of the window.
+        lifetime_start = (
+            dt.datetime.fromtimestamp(lifetime_start_ts, tz=dt.UTC) if lifetime_start_ts > 0 else window_start
+        )
         rows.setdefault(key, []).append(
             _SlotRow(
                 target_time=ensure_utc(row[3]),
@@ -219,37 +262,39 @@ def fetch_series_slot_rows(
                 baseline_samples=int(row[5]),
                 baseline_min=int(row[6]),
                 baseline_max=int(row[7]),
-                earliest_slot=ensure_utc(row[8]),
+                lifetime_start=lifetime_start,
             )
         )
     return rows
 
 
-def _baseline_weeks_available(later: dt.datetime, earliest_slot: dt.datetime) -> int:
+def _baseline_weeks_available(later: dt.datetime, lifetime_start: dt.datetime) -> int:
     """Whole weeks of series lifetime before `later`, capped at the baseline depth.
 
-    Against the window start this is the series' maturity; against one display
-    slot it is how many of that slot's weekly samples carry information. A week
-    whose sample slot predates the series says nothing; a week inside the
-    lifetime with no row was a real zero.
+    The lifetime starts at the first slot followed by sustained traffic, not at
+    the first row. Against the window start this is the series' maturity;
+    against one display slot it is how many of that slot's weekly samples carry
+    information. A week whose sample slot predates the lifetime says nothing; a
+    week inside the lifetime with no row was a real zero.
     """
-    weeks = int((later - earliest_slot).total_seconds()) // SECONDS_PER_WEEK
+    weeks = int((later - lifetime_start).total_seconds()) // SECONDS_PER_WEEK
     return min(BASELINE_WEEKS, max(0, weeks))
 
 
 def _band_gate(
-    window_start: dt.datetime, window_end: dt.datetime, earliest_slot: dt.datetime
+    window_start: dt.datetime, window_end: dt.datetime, lifetime_start: dt.datetime
 ) -> tuple[int, dt.datetime | None]:
     """Baseline depth at the window start, and when a shallow series gains its band.
 
-    The gate reads history before window_start, so a live window must travel a
-    whole window length past the history threshold before a band is drawn. One
-    rule returns both, so the countdown cannot drift off the gate it counts to.
+    The gate reads sustained history before window_start, so a live window must
+    travel a whole window length past the lifetime threshold before a band is
+    drawn. One rule returns both, so the countdown cannot drift off the gate it
+    counts to.
     """
-    baseline_weeks = _baseline_weeks_available(window_start, earliest_slot)
+    baseline_weeks = _baseline_weeks_available(window_start, lifetime_start)
     if baseline_weeks >= MIN_BASELINE_WEEKS_FOR_BAND:
         return baseline_weeks, None
-    threshold = earliest_slot + dt.timedelta(weeks=MIN_BASELINE_WEEKS_FOR_BAND)
+    threshold = lifetime_start + dt.timedelta(weeks=MIN_BASELINE_WEEKS_FOR_BAND)
     return baseline_weeks, threshold + (window_end - window_start)
 
 
@@ -261,8 +306,8 @@ def _build_series(
     interval_minutes: int,
 ) -> BandSeries:
     by_time = {row.target_time: row for row in slot_rows}
-    earliest_slot = min(row.earliest_slot for row in slot_rows)
-    baseline_weeks, band_ready_at = _band_gate(window_start, window_end, earliest_slot)
+    lifetime_start = min(row.lifetime_start for row in slot_rows)
+    baseline_weeks, band_ready_at = _band_gate(window_start, window_end, lifetime_start)
     banded = band_ready_at is None
     floor = BAND_FLOOR_PER_HOUR * interval_minutes / 60
 
@@ -279,7 +324,7 @@ def _build_series(
         if banded:
             # Every slot sits at or after window_start, so a banded series has at
             # least MIN_BASELINE_WEEKS_FOR_BAND samples to expect at every slot.
-            expected = _baseline_weeks_available(slot, earliest_slot)
+            expected = _baseline_weeks_available(slot, lifetime_start)
             samples = row.baseline_samples if row else 0
             # A lifetime week with no row at this slot was a real zero, so any
             # missing sample drags the envelope floor to zero.
@@ -296,7 +341,7 @@ def _build_series(
         severity=key.severity,
         total_count=total_count,
         baseline_weeks=baseline_weeks,
-        history_start=earliest_slot,
+        history_start=lifetime_start,
         band_ready_at=band_ready_at,
         buckets=buckets,
     )

--- a/products/logs/backend/test/test_series_bands.py
+++ b/products/logs/backend/test/test_series_bands.py
@@ -27,6 +27,9 @@ WINDOW_START = WINDOW_END - dt.timedelta(days=7)
 BASELINE_START = WINDOW_START - dt.timedelta(weeks=5)
 # A display slot a few days into the window, so its weekly samples spread across it.
 SLOT = WINDOW_START + dt.timedelta(days=3, hours=4)
+# Two days of rows clear the sustained-traffic threshold at every grain on the
+# ladder, so a series' lifetime starts at the first of them.
+ALIVE_HOURS = 48
 
 
 class TestSeriesBands(ClickhouseTestMixin, BaseTest):
@@ -39,6 +42,20 @@ class TestSeriesBands(ClickhouseTestMixin, BaseTest):
                 for team_id, ts, service, ns, env, sev, count in rows
             ],
         )
+
+    def _slots(
+        self,
+        service: str,
+        start: dt.datetime,
+        hours: int,
+        count: int,
+        key: tuple[str, str, str] = ("ns", "prod", "error"),
+        interval_minutes: int = 60,
+    ) -> list[tuple]:
+        step = dt.timedelta(minutes=interval_minutes)
+        return [
+            (self.team.pk, start + slot * step, service, *key, count) for slot in range(hours * 60 // interval_minutes)
+        ]
 
     @parameterized.expand(
         [
@@ -55,10 +72,15 @@ class TestSeriesBands(ClickhouseTestMixin, BaseTest):
         service = f"svc-banded-{interval_minutes}"
         window_start = WINDOW_END - dt.timedelta(days=window_days)
         step = dt.timedelta(minutes=interval_minutes)
-        rows = [
-            # Anchors the series' lifetime at the full 5-week baseline.
-            (self.team.pk, window_start - dt.timedelta(weeks=5), service, "ns", "prod", "error", 1),
-        ]
+        # Starts the series' lifetime a full 5-week baseline back. The run closes as
+        # the baseline opens, so it folds onto later slots than the ones asserted here.
+        rows = self._slots(
+            service,
+            window_start - dt.timedelta(weeks=5, days=2),
+            ALIVE_HOURS,
+            1,
+            interval_minutes=interval_minutes,
+        )
         for week, value in enumerate([10, 20, 30, 40, 50], start=1):
             rows.append((self.team.pk, SLOT - dt.timedelta(weeks=week), service, "ns", "prod", "error", value))
         # Partial rows within one display bucket, including a repeated 5-minute key.
@@ -101,24 +123,80 @@ class TestSeriesBands(ClickhouseTestMixin, BaseTest):
         assert quiet.lower == 0
         assert quiet.upper == quiet_upper
 
-    def test_learning_series_carries_no_band(self):
+    @parameterized.expand(
+        [
+            # A stray row two weeks before the sustained start does not date the lifetime.
+            ("stray_then_sustained", WINDOW_START - dt.timedelta(weeks=3), WINDOW_START - dt.timedelta(weeks=1), 1),
+            # Traffic that starts mid-week dates the lifetime at that slot, not a week boundary.
+            ("mid_week_start", None, WINDOW_START - dt.timedelta(weeks=2, days=-3, hours=-5), 1),
+            # No sustained traffic at all dates the lifetime at the window start.
+            ("never_sustained", WINDOW_START - dt.timedelta(weeks=1), None, 0),
+        ]
+    )
+    def test_learning_series_dates_history_from_sustained_traffic(
+        self,
+        _name: str,
+        stray_at: dt.datetime | None,
+        sustained_from: dt.datetime | None,
+        baseline_weeks: int,
+    ) -> None:
         service = "svc-learning"
-        self._insert(
-            [
-                (self.team.pk, WINDOW_START - dt.timedelta(weeks=1), service, "", "", "info", 10),
-                (self.team.pk, SLOT, service, "", "", "info", 12),
-            ]
-        )
+        key = ("", "", "info")
+        rows = [(self.team.pk, SLOT, service, *key, 12)]
+        if stray_at is not None:
+            rows.append((self.team.pk, stray_at, service, *key, 10))
+        if sustained_from is not None:
+            rows += self._slots(service, sustained_from, ALIVE_HOURS, 1, key)
+        self._insert(rows)
 
         result = run_series_bands(self.team, service, window_start=WINDOW_START, window_end=WINDOW_END)
 
         assert len(result.series) == 1
         series = result.series[0]
-        assert series.baseline_weeks == 1
-        assert series.history_start == WINDOW_START - dt.timedelta(weeks=1)
-        assert series.band_ready_at == WINDOW_END + dt.timedelta(weeks=1)
+        history_start = sustained_from if sustained_from is not None else WINDOW_START
+        assert series.history_start == history_start
+        assert series.baseline_weeks == baseline_weeks
+        assert series.band_ready_at == history_start + dt.timedelta(weeks=2, days=7)
         assert all(bucket.lower is None and bucket.upper is None for bucket in series.buckets)
         assert series.total_count == 12
+
+    def test_band_after_stray_row_comes_from_sustained_traffic(self):
+        service = "svc-stray"
+        sustained_from = WINDOW_START - dt.timedelta(weeks=3)
+        rows = [(self.team.pk, sustained_from - dt.timedelta(weeks=2), service, "ns", "prod", "error", 1)]
+        rows += self._slots(service, sustained_from, 4 * 7 * 24, 9)
+        self._insert(rows)
+
+        result = run_series_bands(self.team, service, window_start=WINDOW_START, window_end=WINDOW_END)
+
+        series = result.series[0]
+        assert series.history_start == sustained_from
+        assert series.baseline_weeks == 3
+        assert series.band_ready_at is None
+        # The stray row folds onto the window's first slot; the band there still
+        # comes from the three sustained weeks of 9, not the stray 1.
+        first = series.buckets[0]
+        assert first.time == WINDOW_START
+        assert first.lower == pytest.approx(8.1)
+        assert first.upper == pytest.approx(11.9)
+        assert all(
+            bucket.observed == 9
+            and bucket.lower is not None
+            and bucket.upper is not None
+            and bucket.lower <= bucket.observed <= bucket.upper
+            for bucket in series.buckets
+        )
+
+    def test_silent_window_marks_below_the_band(self):
+        service = "svc-silent"
+        self._insert(self._slots(service, BASELINE_START, 5 * 7 * 24, 9))
+
+        result = run_series_bands(self.team, service, window_start=WINDOW_START, window_end=WINDOW_END)
+
+        series = result.series[0]
+        assert series.baseline_weeks == 5
+        assert series.total_count == 0
+        assert all(bucket.observed == 0 and bucket.lower == pytest.approx(8.1) for bucket in series.buckets)
 
     def test_band_ready_at_is_when_the_gate_opens(self):
         earliest = WINDOW_START - dt.timedelta(weeks=1)
@@ -131,7 +209,7 @@ class TestSeriesBands(ClickhouseTestMixin, BaseTest):
 
     def test_missing_baseline_week_drags_floor_to_zero(self):
         service = "svc-gappy"
-        rows = [(self.team.pk, BASELINE_START, service, "ns", "prod", "warn", 1)]
+        rows = self._slots(service, BASELINE_START, ALIVE_HOURS, 1, ("ns", "prod", "warn"))
         for week, value in enumerate([100, 110, 120], start=1):
             rows.append((self.team.pk, SLOT - dt.timedelta(weeks=week), service, "ns", "prod", "warn", value))
         self._insert(rows)

--- a/products/logs/backend/test/test_series_bands.py
+++ b/products/logs/backend/test/test_series_bands.py
@@ -27,6 +27,8 @@ WINDOW_START = WINDOW_END - dt.timedelta(days=7)
 BASELINE_START = WINDOW_START - dt.timedelta(weeks=5)
 # A display slot a few days into the window, so its weekly samples spread across it.
 SLOT = WINDOW_START + dt.timedelta(days=3, hours=4)
+# Close enough to a sustained start five days later to share one week-long run.
+NEARBY_STRAY = WINDOW_START - dt.timedelta(weeks=1, days=5)
 # Two days of rows clear the sustained-traffic threshold at every grain on the
 # ladder, so a series' lifetime starts at the first of them.
 ALIVE_HOURS = 48
@@ -123,33 +125,33 @@ class TestSeriesBands(ClickhouseTestMixin, BaseTest):
     @parameterized.expand(
         [
             # A stray row two weeks before the sustained start does not date the lifetime.
-            ("stray_then_sustained", WINDOW_START - dt.timedelta(weeks=3), WINDOW_START - dt.timedelta(weeks=1), 1),
-            # A stray row five days before the sustained start shares one week-long
-            # run with it, and still does not date the lifetime.
+            ("stray_then_sustained", (WINDOW_START - dt.timedelta(weeks=3),), WINDOW_START - dt.timedelta(weeks=1), 1),
+            # A stray row that shares a week-long run with the sustained start does not either.
+            ("nearby_stray", (NEARBY_STRAY,), WINDOW_START - dt.timedelta(weeks=1), 1),
+            # Nor does a pair of stray rows an hour apart, which carries no day of traffic.
             (
-                "nearby_stray_then_sustained",
-                WINDOW_START - dt.timedelta(weeks=1, days=5),
+                "stray_pair",
+                (NEARBY_STRAY, NEARBY_STRAY + dt.timedelta(hours=1)),
                 WINDOW_START - dt.timedelta(weeks=1),
                 1,
             ),
             # Traffic that starts mid-week dates the lifetime at that slot, not a week boundary.
-            ("mid_week_start", None, WINDOW_START - dt.timedelta(days=10, hours=19), 1),
+            ("mid_week_start", (), WINDOW_START - dt.timedelta(days=10, hours=19), 1),
             # No sustained traffic at all dates the lifetime at the window start.
-            ("never_sustained", WINDOW_START - dt.timedelta(weeks=1), None, 0),
+            ("never_sustained", (WINDOW_START - dt.timedelta(weeks=1),), None, 0),
         ]
     )
     def test_learning_series_dates_history_from_sustained_traffic(
         self,
         _name: str,
-        stray_at: dt.datetime | None,
+        strays: tuple[dt.datetime, ...],
         sustained_from: dt.datetime | None,
         baseline_weeks: int,
     ) -> None:
         service = "svc-learning"
         key = ("", "", "info")
         rows = [(self.team.pk, SLOT, service, *key, 12)]
-        if stray_at is not None:
-            rows.append((self.team.pk, stray_at, service, *key, 10))
+        rows += [(self.team.pk, stray, service, *key, 10) for stray in strays]
         if sustained_from is not None:
             rows += self._slots(service, sustained_from, ALIVE_HOURS, 1, key)
         self._insert(rows)

--- a/products/logs/backend/test/test_series_bands.py
+++ b/products/logs/backend/test/test_series_bands.py
@@ -72,25 +72,22 @@ class TestSeriesBands(ClickhouseTestMixin, BaseTest):
         service = f"svc-banded-{interval_minutes}"
         window_start = WINDOW_END - dt.timedelta(days=window_days)
         step = dt.timedelta(minutes=interval_minutes)
-        # Starts the series' lifetime a full 5-week baseline back. The run closes as
-        # the baseline opens, so it folds onto later slots than the ones asserted here.
+        # This window's own display slot, far enough in that the run below folds clear of it.
+        slot = window_start + dt.timedelta(days=3, hours=4)
+        # Starts the series' lifetime at the full 5-week baseline.
         rows = self._slots(
-            service,
-            window_start - dt.timedelta(weeks=5, days=2),
-            ALIVE_HOURS,
-            1,
-            interval_minutes=interval_minutes,
+            service, window_start - dt.timedelta(weeks=5), ALIVE_HOURS, 1, interval_minutes=interval_minutes
         )
         for week, value in enumerate([10, 20, 30, 40, 50], start=1):
-            rows.append((self.team.pk, SLOT - dt.timedelta(weeks=week), service, "ns", "prod", "error", value))
+            rows.append((self.team.pk, slot - dt.timedelta(weeks=week), service, "ns", "prod", "error", value))
         # Partial rows within one display bucket, including a repeated 5-minute key.
-        rows.append((self.team.pk, SLOT, service, "ns", "prod", "error", 5))
-        rows.append((self.team.pk, SLOT, service, "ns", "prod", "error", 5))
-        rows.append((self.team.pk, SLOT + dt.timedelta(minutes=5), service, "ns", "prod", "error", 15))
+        rows.append((self.team.pk, slot, service, "ns", "prod", "error", 5))
+        rows.append((self.team.pk, slot, service, "ns", "prod", "error", 5))
+        rows.append((self.team.pk, slot + dt.timedelta(minutes=5), service, "ns", "prod", "error", 15))
         # Excluded: future bucket, other service, other team.
         rows.append((self.team.pk, NOW + dt.timedelta(hours=2), service, "ns", "prod", "error", 999))
-        rows.append((self.team.pk, SLOT, "svc-other", "ns", "prod", "error", 999))
-        rows.append((self.team.pk + 1, SLOT, service, "ns", "prod", "error", 999))
+        rows.append((self.team.pk, slot, "svc-other", "ns", "prod", "error", 999))
+        rows.append((self.team.pk + 1, slot, service, "ns", "prod", "error", 999))
         self._insert(rows)
 
         result = run_series_bands(
@@ -113,12 +110,12 @@ class TestSeriesBands(ClickhouseTestMixin, BaseTest):
         by_time = {bucket.time: bucket for bucket in series.buckets}
         # Band folds the five weekly samples 10..50 into a 10% widened envelope,
         # then lifts the upper edge by the per-hour floor scaled to the grain.
-        banded = by_time[SLOT]
+        banded = by_time[slot]
         assert banded.observed == 25
         assert banded.lower == pytest.approx(9.0)
         assert banded.upper == pytest.approx(banded_upper)
 
-        quiet = by_time[SLOT + step]
+        quiet = by_time[slot + step]
         assert quiet.observed == 0
         assert quiet.lower == 0
         assert quiet.upper == quiet_upper

--- a/products/logs/backend/test/test_series_bands.py
+++ b/products/logs/backend/test/test_series_bands.py
@@ -127,6 +127,14 @@ class TestSeriesBands(ClickhouseTestMixin, BaseTest):
         [
             # A stray row two weeks before the sustained start does not date the lifetime.
             ("stray_then_sustained", WINDOW_START - dt.timedelta(weeks=3), WINDOW_START - dt.timedelta(weeks=1), 1),
+            # A stray row five days before the sustained start shares one week-long
+            # run with it, and still does not date the lifetime.
+            (
+                "nearby_stray_then_sustained",
+                WINDOW_START - dt.timedelta(weeks=1, days=5),
+                WINDOW_START - dt.timedelta(weeks=1),
+                1,
+            ),
             # Traffic that starts mid-week dates the lifetime at that slot, not a week boundary.
             ("mid_week_start", None, WINDOW_START - dt.timedelta(days=10, hours=19), 1),
             # No sustained traffic at all dates the lifetime at the window start.

--- a/products/logs/backend/test/test_series_bands.py
+++ b/products/logs/backend/test/test_series_bands.py
@@ -128,7 +128,7 @@ class TestSeriesBands(ClickhouseTestMixin, BaseTest):
             # A stray row two weeks before the sustained start does not date the lifetime.
             ("stray_then_sustained", WINDOW_START - dt.timedelta(weeks=3), WINDOW_START - dt.timedelta(weeks=1), 1),
             # Traffic that starts mid-week dates the lifetime at that slot, not a week boundary.
-            ("mid_week_start", None, WINDOW_START - dt.timedelta(weeks=2, days=-3, hours=-5), 1),
+            ("mid_week_start", None, WINDOW_START - dt.timedelta(days=10, hours=19), 1),
             # No sustained traffic at all dates the lifetime at the window start.
             ("never_sustained", WINDOW_START - dt.timedelta(weeks=1), None, 0),
         ]

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -1312,7 +1312,7 @@ export interface LogsSeriesBandSeriesApi {
     total_count: number
     /** Full weeks of history behind the band, 0 to 5. Below 2 the series is still learning and its buckets carry no band. */
     baseline_weeks: number
-    /** Earliest bucket with data inside the fetched lookback. */
+    /** Start of sustained traffic inside the fetched lookback: the first bucket followed by a week with enough non-empty buckets. A stray earlier row does not move it. The window start when no traffic is sustained yet. */
     history_start: string
     /**
      * When this series gains its band, so a learning series can count down to it. Null once the band is drawn.

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -49813,7 +49813,7 @@ export namespace Schemas {
       total_count: number;
       /** Full weeks of history behind the band, 0 to 5. Below 2 the series is still learning and its buckets carry no band. */
       baseline_weeks: number;
-      /** Earliest bucket with data inside the fetched lookback. */
+      /** Start of sustained traffic inside the fetched lookback: the first bucket followed by a week with enough non-empty buckets. A stray earlier row does not move it. The window start when no traffic is sustained yet. */
       history_start: string;
       /**
          * When this series gains its band, so a learning series can count down to it. Null once the band is drawn.


### PR DESCRIPTION
## Problem

- A user who opens the Anomalies tab for a young service sees every bucket marked as an anomaly, even where the volume is flat.
- A series shaped like `0 0 0 1 0 0 0 0 0 0 9 9 9 9 9 9` marks every 9, because one stray log record two weeks before the real start dates the series' lifetime.
- The maturity gate then passes on that stray row, and every empty week between the stray and the real start becomes a baseline of zeros.
- The band is `[0, floor]`, 0 to 2 at the hourly grain, and every real bucket sits above it.

## Changes

- A series now counts as alive from the first slot followed by sustained traffic. The band, the maturity gate, and `history_start` all read from that slot.
- Sustained means 20 percent of the slots after it are non-empty, over the day after it and over the week after it. At the hourly grain that is 5 slots and 34 slots. Both scales are needed, because the week's count alone reads a stray row ahead of a dense stretch as the start.
- A young service reports as learning with `band_ready_at` two weeks after the sustained start, and the band it then gets comes from real traffic, so flat 9s sit inside it.
- Baseline samples only count slots at or after the sustained start, so a stray earlier row never reaches the envelope. Weeks after the sustained start with no rows stay real zeros, so a genuine silence still marks below the band.
- A series with no sustained traffic yet is dated from the window start, so it reports as learning with `band_ready_at` ahead of the window.
- The fraction is an env tunable, `LOGS_SERIES_BANDS_ALIVE_SLOT_FRACTION`, next to the other series-bands tunables, so ops can change it without a deploy.
- The sustained start is computed inside the same ClickHouse query as the rollup, in a `lifetimes` CTE over the per-slot subquery. HogQL accepted `arrayFirst` with a lambda over `arrayEnumerate` and array-index arithmetic on the sorted slot times, so no Python fallback and no second query was needed. A `min()`-style aggregate on the outer query was rejected because the outer query groups by target slot, and a per-series value belongs on a per-series join.
- Mechanical: the `history_start` help text describes the new rule, and the generated types under `products/logs/frontend/generated/` and `services/mcp/` carry it.

> [!NOTE]
> This changes what a user of the Anomalies tab sees, but no in-app notice ships with it. The tab is behind the `logs-anomalies` feature flag, the old behavior was plainly broken, and the existing learning tag already shows the new `history_start` date, so the screen explains itself.

## How did you test this code?

Extended `products/logs/backend/test/test_series_bands.py`. These tests insert into `logs_volume_buckets` and run the rendered SQL on ClickHouse.

- `test_learning_series_dates_history_from_sustained_traffic`, five parameterized cases. A stray row weeks before the sustained start, one five days before it, and a pair an hour apart all leave the lifetime at the sustained start.
- The same test covers traffic that starts mid-week, which dates the lifetime at that slot, and a series with no sustained traffic, which is dated from the window start. Each stray case fails without the rule it covers.
- `test_band_after_stray_row_comes_from_sustained_traffic`: a stray row two weeks before three weeks of flat 9s. The band is built from the 9s and the stray never lowers it. Fails on master with the lower edge at 0.9 instead of 8.1.
- `test_silent_window_marks_below_the_band`: a series alive for five weeks that goes silent for the whole window still marks every bucket below the band. Guards the zero-fill rule after the sustained start.
- The banded tests now seed two days of rows at their display grain instead of a single anchor row, which is what a lifetime needs under the new rule.

Not run: the frontend Jest suite for the Anomalies tab, which mocks this endpoint and reads no field that changed shape.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The endpoint is experimental and behind a feature flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code, with a human directing the fix and the rule it implements.
- Skills invoked: /writing-clickhouse-queries, /writing-tests, /writing-code-comments, /writing-dataclasses, /improving-drf-endpoints, /announcing-behavior-changes, /writing-pr-descriptions.
- Duplicate check: `gh pr list --state open --search "series bands"` found #95897, #95910, and #95911, which change other parts of the same endpoint. None touches the lifetime start.
- Decisions: the lifetime start went into a HogQL CTE on the first try, so the Python fallback the brief allowed was not needed. The baseline aggregates were also filtered to the lifetime, which the brief did not name, because a stray sample at the same weekly slot would otherwise mask a real zero.
- Review follow-ups: the day scale joined the rule after review found a stray pair could still open the lifetime under the week's count alone.
- Public artifact: the fixtures are invented shapes. No customer data or internal service names appear in the diff or this description.

