### PR TITLE
fix(error-tracking): strip release remote credentials from events

### DIFF
--- a/rust/cymbal/src/core/types/frames/releases.rs
+++ b/rust/cymbal/src/core/types/frames/releases.rs
@@ -129,7 +129,7 @@ impl ReleaseRecord {
             project: self.project.clone(),
             version: self.version.clone(),
             timestamp: self.created_at,
-            metadata: self.metadata.clone(),
+            metadata: self.metadata.as_ref().map(sanitize_metadata_for_event),
         }
     }
 
@@ -161,6 +161,36 @@ fn truncate_chars(value: &mut String, max_chars: usize) {
     if let Some((byte_index, _)) = value.char_indices().nth(max_chars) {
         value.truncate(byte_index);
     }
+}
+
+fn sanitize_metadata_for_event(metadata: &Value) -> Value {
+    let mut sanitized = metadata.clone();
+    if let Some(Value::String(remote_url)) = sanitized.pointer_mut("/git/remote_url") {
+        *remote_url = sanitize_remote_url(remote_url);
+    }
+    sanitized
+}
+
+fn sanitize_remote_url(url: &str) -> String {
+    let sanitized_end = url.find(['?', '#']).unwrap_or(url.len());
+    let Some(scheme_end) = url[..sanitized_end].find("://") else {
+        return url[..sanitized_end].to_string();
+    };
+    let authority_start = scheme_end + 3;
+    let authority_end = url[authority_start..sanitized_end]
+        .find('/')
+        .map_or(sanitized_end, |index| authority_start + index);
+    let authority = &url[authority_start..authority_end];
+    let Some(credentials_end) = authority.rfind('@') else {
+        return url[..sanitized_end].to_string();
+    };
+
+    format!(
+        "{}{}{}",
+        &url[..authority_start],
+        &authority[credentials_end + 1..],
+        &url[authority_end..sanitized_end]
+    )
 }
 
 /// Reconstruct the release `hash_id` the CLI wrote for a mobile build, from the app metadata the
@@ -293,6 +323,40 @@ mod tests {
             version: "1.0".to_string(),
             project: "com.app".to_string(),
             metadata,
+        }
+    }
+
+    #[test]
+    fn event_remote_urls_drop_credentials_query_and_fragment() {
+        let cases = [
+            (
+                "https://user:password@github.com/example/repo.git?token=query#access_token=fragment",
+                "https://github.com/example/repo.git",
+            ),
+            (
+                "https://github.com/example/repo.git#access_token=fragment",
+                "https://github.com/example/repo.git",
+            ),
+            (
+                "https://github.com/example/repo.git",
+                "https://github.com/example/repo.git",
+            ),
+            (
+                "git@github.com:example/repo.git",
+                "git@github.com:example/repo.git",
+            ),
+            (
+                "git@github.com:example/repo.git?token=query#access_token=fragment",
+                "git@github.com:example/repo.git",
+            ),
+        ];
+
+        for (remote_url, expected) in cases {
+            let info = serde_json::to_value(
+                record(Some(json!({"git": {"remote_url": remote_url}}))).to_info(),
+            )
+            .unwrap();
+            assert_eq!(info["metadata"]["git"]["remote_url"], expected);
         }
     }
 

--- a/rust/cymbal/src/modes/processing/types/exception_event.rs
+++ b/rust/cymbal/src/modes/processing/types/exception_event.rs
@@ -826,7 +826,7 @@ mod tests {
     }
 
     #[test]
-    fn exception_release_emitted_only_when_a_release_resolves() {
+    fn exception_release_is_sanitized_and_emitted_only_when_a_release_resolves() {
         let issue = Issue {
             id: Uuid::now_v7(),
             team_id: 42,
@@ -836,7 +836,13 @@ mod tests {
             description: None,
             created_at: chrono::Utc::now(),
         };
-        let record = release_record("hash-abc");
+        let mut record = release_record("hash-abc");
+        record.metadata = Some(serde_json::json!({
+            "git": {
+                "commit_id": "abc123",
+                "remote_url": "https://x-access-token:secret@github.com/example/repo.git?token=query-secret#access_token=fragment-secret"
+            }
+        }));
         let expected = serde_json::to_value(record.to_info()).unwrap();
 
         // A resolved release surfaces as `$exception_release` on both the grouping-rule projection
@@ -845,10 +851,21 @@ mod tests {
         resolved.state.metadata.release = Some(record.to_info());
         let grouping = resolved.grouping_rule_properties();
         assert_eq!(grouping["$exception_release"], expected);
+        assert_eq!(
+            grouping["$exception_release"]["metadata"]["git"],
+            serde_json::json!({
+                "commit_id": "abc123",
+                "remote_url": "https://github.com/example/repo.git"
+            })
+        );
         let fingerprinted =
             resolved.into_fingerprinted(SelectedFingerprint::manual("fp".to_string()));
         let wire = serde_json::to_value(fingerprinted.processed_properties(&issue)).unwrap();
         assert_eq!(wire["$exception_release"], expected);
+        assert_eq!(
+            wire["$exception_release"]["metadata"]["git"]["remote_url"],
+            "https://github.com/example/repo.git"
+        );
 
         // No release resolved: the property is omitted.
         let mut resolved = resolved_event();


### PR DESCRIPTION
## Problem

Users with affected releases can have embedded Git credentials copied into each exception event.

Cymbal copies release metadata into `$exception_release`. #95807 prevents new CLI uploads from storing credentials, but existing release metadata can still contain them.

## Changes

- Cymbal removes URL user information, query parameters, and fragments from `metadata.git.remote_url` before attaching release metadata to exception events.
- Clean repository URLs and SCP-style SSH remotes remain unchanged.
- Other Git metadata remains available. Stored release rows and release API responses do not change.
- Nothing looks different in the UI.

## How did you test this code?

- Focused Cymbal tests cover user information, query parameters, fragments, SCP-style SSH remotes, and both event projection paths.
- `cargo fmt --all -- --check`
- `cargo clippy -p cymbal --lib --tests -- -D warnings`
- Not run: `hogli ci:preflight` requires a `.git` directory that the Cockpit Jujutsu workspace does not provide.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This change does not alter a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented this change with local Rust tooling and GitHub CLI. The session used `/writing-tests`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `/pr`.

The regression fixtures use invented repository URLs and tokens.
