### PR TITLE
fix(data-warehouse): find Sources in Cmd+K when searching "warehouse"

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2021,9 +2021,9 @@ snapshots:
     components-search--product-recents-and-starred--light:
         hash: v1.k794b7964.f2c75682469c037327f94f22550286ed866d4883e03ef7c66a3f234a31b1017b.1gKkr-42m5_F8qJMq6ahElSjOFRERpPTay3A0__UOo0
     components-search--searching--dark:
-        hash: v1.k794b7964.3ce8ecf4192605f50f2ab332c2f6f370e79080ef1dd9628746b59ec59043e1b0.8RSulgjoFeYFhPE9GqdfAZ5eNfm4qVUy88-C8XemASA
+        hash: v1.k794b7964.0e06879e25784ab8baf33a0c5dcafa9594d1214c529ed1a0d4edcc64de71e848.acBWuTFeGQNg4HWk4KP4fxvj_nIIy1sGj8-j-9Y95U8
     components-search--searching--light:
-        hash: v1.k794b7964.e3c66e67f7bca4e981758e7f1a2be7684796dc64559e557530218938905849a9.2QaIxMkDumTR2GyoyM2avUDc7FJyKeYlpCBa2dzTEmk
+        hash: v1.k794b7964.4f003a1303f6d43e7fd41113fa84ad2325e1f06dec63b86fd11eec318101b20b.YAJd9pl9u_wr88-1YZClQ651pgzCpVutniyzKfNsqfI
     components-sentencelist--full-sentence--dark:
         hash: v1.k794b7964.7e8e5dd2e09d246cc3668f362f2391fe67618bd1143aa393832297f5dc30e558.yptEWKc5RAUY613Fwd5cQ0VIinMvpdoI6cuKgagAGxk
     components-sentencelist--full-sentence--light:

--- a/frontend/src/lib/components/Search/searchLogic.tsx
+++ b/frontend/src/lib/components/Search/searchLogic.tsx
@@ -972,6 +972,11 @@ export const searchLogic = kea<searchLogicType>([
                     Pipeline: ['data pipelines', 'data pipeline'],
                 }
 
+                // Synonyms people search for that don't appear in the item name.
+                const pathSearchKeywords: Record<string, string[]> = {
+                    Sources: ['data warehouse', 'warehouse', 'connectors', 'import data'],
+                }
+
                 const items = filteredMetadata.map((item) => ({
                     id: `data-management-${item.path}`,
                     name: item.path,
@@ -981,7 +986,10 @@ export const searchLogic = kea<searchLogicType>([
                     href: item.href || PLACEHOLDER_HREF,
                     itemType: item.iconType || item.type || null,
                     tags: item.tags,
-                    searchKeywords: item.category ? categorySearchKeywords[item.category] : undefined,
+                    searchKeywords: [
+                        ...(item.category ? (categorySearchKeywords[item.category] ?? []) : []),
+                        ...(pathSearchKeywords[item.path] ?? []),
+                    ],
                     lastViewedAt: item.sceneKey ? (sceneLogViewsByRef[item.sceneKey] ?? null) : null,
                     disabledReason: getProductAccessDisabledReason(item),
                     record: {


### PR DESCRIPTION
## Problem

A customer opened the Cmd+K command menu and searched for "warehouse" to find where they connect data warehouse sources. Nothing came up, which is confusing.

The menu item is called "Sources", and its search only matched an item's name, category, and category-level keywords. The word "warehouse" appears nowhere on it, so the search returned no result.

## Changes

- Searching "warehouse" (also "connectors" or "import data") in the Cmd+K menu now surfaces the "Sources" item.
- Mechanical: added a per-item keyword map for Data management items in the search logic, mirroring the existing per-product keyword map used for Tools. Item keywords merge with the existing category keywords.

## How did you test this code?

The agent could not exercise the live Cmd+K menu in a running app. Verified the fuzzy matcher pairs the new keywords with the item: `filterSearchItems` (Fuse.js) already matches on `searchKeywords`, so "warehouse" now resolves to Sources. No new automated test added for a small keyword change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8) at the direction of the assignee, who reported the customer confusion. Invoked the `/writing-tests` and `/writing-pr-descriptions` skills. A regression test was drafted and then dropped at the driver's request as too heavy for a one-line keyword change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
