### PR TITLE
fix(aio): tighten the line reference instruction

### DIFF
--- a/products/ai_observability/backend/summarization/prompts/system_detailed.djt
+++ b/products/ai_observability/backend/summarization/prompts/system_detailed.djt
@@ -14,7 +14,7 @@ IMPORTANT GUIDELINES:
 - Provide 5-10 bullet points covering the main aspects of what happened.
 - Include interesting notes highlighting notable aspects that a human user responsible for the system might want to know.
 - Line references go in the line_refs field - DO NOT include them in the text field.
-- Line references format: Pick ONE most relevant line reference per bullet/note in format "L45". Do not use ranges or multiple references.
+- Line references format: exactly one reference per bullet/note, like "L45". Write "L28", never "L28-L31" or "L28, L34". If a bullet covers several lines, pick the most important one.
 - Focus on what was accomplished, any issues encountered, and key details.
 - Strong emotions, either positive or negative, expressed by a user are always interesting.
 - Keep the summary concise but comprehensive.

--- a/products/ai_observability/backend/summarization/prompts/system_minimal.djt
+++ b/products/ai_observability/backend/summarization/prompts/system_minimal.djt
@@ -14,7 +14,7 @@ IMPORTANT GUIDELINES:
 - Include 0-2 interesting notes ONLY if they are critical (errors, failures, strong user emotions, or unusual patterns).
 - Focus on key actions, outcomes, tool calls, errors, or notable outputs.
 - Line references go in the line_refs field - DO NOT include them in the text field.
-- Line references format: Pick ONE most relevant line reference per bullet/note in format "L45". Do not use ranges or multiple references.
+- Line references format: exactly one reference per bullet/note, like "L45". Write "L28", never "L28-L31" or "L28, L34". If a bullet covers several lines, pick the most important one.
 - Be concise - skip minor details and focus on what matters most.
 - If there are errors or tool calls, prioritize those.
 - Strong emotions, either positive or negative, expressed by a user are always interesting.


### PR DESCRIPTION
## Problem

A summary bullet is meant to name one line, so a reader can jump to it. Bullets now often name a span or a list instead, like `L28-L31` or `L28, L34`.

The instruction against that is weak in two specific ways:

- It states a prohibition with no counter-example, and models follow demonstrations more reliably than prohibitions.
- It offers no alternative for a bullet that genuinely covers several lines, so a model with a multi-line bullet has no sanctioned option.

Nothing renders these references today, so nothing is visibly broken. The Clusters UI drops the field, and the interactive Summary tab runs a different model and generates on demand. This is a first iteration to find out whether the instruction is the cause before changing any code.

Origin: [Slack thread](https://posthog.slack.com/archives/C0BLK2ZEUSH/p1788710995817449).

## Changes

- The instruction now names the two wrong forms and says which line to pick when a bullet covers several.
- Nothing else changes. Prompt text only, in both the minimal and detailed system prompts.

Length stays roughly flat on purpose. The line sits fifth in an eleven-item list that the model skims, and batch summarization runs at minimal reasoning effort, so extra words would likely hurt rather than help.

The counter-example stays out of the `STRUCTURED OUTPUT` block, since a model copies from examples.

## How did you test this code?

Not testable in CI, and not manually tested. The effect is a rate in stored `$ai_trace_summary` output.

Reading it needs several days compared against the pre-change trend rather than the day before, because the rate was already moving on its own. The summary event records no model, so the summarization model configuration has to stay fixed during that window for the reading to mean anything.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). This began as an investigation into an automated report that these references broke UI navigation. Tracing the consumers showed no surface reads them, so the reported impact did not hold.

Two larger changes were built and then dropped. Normalizing `line_refs` in the pydantic schema discarded a line the model had supplied, to satisfy a rule no consumer needs. Validating the `model` request param fixed a real gap, an unchecked string reaching the provider, but no caller has passed a non-default model, so it was cut rather than bundled here. What survives is the cheapest hypothesis, testable with one prompt line.

Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-pr-descriptions`.

Public artifact: the work drew on an internal Slack report and internal query results. Neither appears here. This description carries no metrics, quotes, or customer data, and the diff touches only repository code.
