### PR TITLE
feat(ai-research): fetch images over HTTP/2

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/IMPLEMENTATION_NOTES.md
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/IMPLEMENTATION_NOTES.md
@@ -22,7 +22,7 @@ The fetcher follows configuration redirects only inside the source registrable d
 
 The shared streamed-request helper preserves repeated response field lines. Policy evaluation therefore sees every opt-out field in received order.
 
-Image and configuration requests opt into HTTP/2 on the shared secure dispatcher. One TLS session then carries every concurrent and sequential request to an origin, which saves a handshake on both sides. An origin that offers only HTTP/1.1 gets HTTP/1.1 with no change in behavior.
+Image and configuration requests opt into HTTP/2 on the shared secure dispatcher. Requests to an origin reuse its session instead of opening a new TLS connection each time, which saves a handshake on both sides. The dispatcher decides how many sessions an origin gets and when an idle one closes. An origin that offers only HTTP/1.1 gets HTTP/1.1 with no change in behavior.
 
 Production requests use Smokescreen. The Rust admission policy also refuses every IP literal, including a public IP literal.
 

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/IMPLEMENTATION_NOTES.md
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/IMPLEMENTATION_NOTES.md
@@ -22,6 +22,8 @@ The fetcher follows configuration redirects only inside the source registrable d
 
 The shared streamed-request helper preserves repeated response field lines. Policy evaluation therefore sees every opt-out field in received order.
 
+Image and configuration requests opt into HTTP/2 on the shared secure dispatcher. One TLS session then carries every concurrent and sequential request to an origin, which saves a handshake on both sides. An origin that offers only HTTP/1.1 gets HTTP/1.1 with no change in behavior.
+
 Production requests use Smokescreen. The Rust admission policy also refuses every IP literal, including a public IP literal.
 
 Web Bot Auth uses the shared PostHog key directory. The directory response has a 60-second public cache lifetime.

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/configuration-policy.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/configuration-policy.test.ts
@@ -420,6 +420,7 @@ describe('HttpConfigurationFetcher', () => {
             ['https://example.com/robots.txt'],
             ['https://cdn.example.com/robots'],
         ])
+        expect(fetchStreamedMock.mock.calls.map(([, options]) => options.allowH2)).toEqual([true, true])
     })
 
     it('does not follow a configuration redirect to another registrable domain', async () => {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/configuration-policy.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/configuration-policy.ts
@@ -110,6 +110,7 @@ export class HttpConfigurationFetcher {
         try {
             response = await fetchStreamed(target.toString(), {
                 timeoutMs: Math.max(1, deadlineMs - Date.now()),
+                allowH2: true,
                 headers: {
                     'user-agent': USER_AGENT,
                     accept: file === 'robots' ? 'text/plain,*/*;q=0.1' : 'application/json,*/*;q=0.1',

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.test.ts
@@ -56,7 +56,7 @@ describe('HttpImageFetcher', () => {
     })
     afterEach(() => jest.restoreAllMocks())
 
-    it('negotiates HTTP/2 so one TLS session serves every request to an origin', async () => {
+    it('opts every image request into HTTP/2', async () => {
         fetchStreamedMock.mockResolvedValue(image(PNG, 'image/png'))
 
         await fetcher().fetch('https://cdn.example.com/a.png', OPTIONS)

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.test.ts
@@ -56,6 +56,17 @@ describe('HttpImageFetcher', () => {
     })
     afterEach(() => jest.restoreAllMocks())
 
+    it('negotiates HTTP/2 so one TLS session serves every request to an origin', async () => {
+        fetchStreamedMock.mockResolvedValue(image(PNG, 'image/png'))
+
+        await fetcher().fetch('https://cdn.example.com/a.png', OPTIONS)
+
+        expect(fetchStreamedMock).toHaveBeenCalledWith(
+            'https://cdn.example.com/a.png',
+            expect.objectContaining({ allowH2: true })
+        )
+    })
+
     it('identifies every request as PostHogImageFetcherBot', async () => {
         fetchStreamedMock.mockResolvedValue(image(PNG, 'image/png'))
 

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.ts
@@ -233,7 +233,7 @@ export class HttpImageFetcher implements ImageFetcher {
             headers['if-modified-since'] = previousCache.lastModified
         }
         try {
-            const response = await fetchStreamed(url, { headers, timeoutMs })
+            const response = await fetchStreamed(url, { headers, timeoutMs, allowH2: true })
             const status = response.status
             requestOutcome = ImageFetchRequestMetrics.outcomeForHttpStatus(status)
             const cache = cacheMetadata(requestTimeMs, Date.now(), response.headerLines)


### PR DESCRIPTION
## Problem

Every image the AI research image fetch lane requests from a customer's origin costs a full TLS handshake, on our side and on theirs. The lane follows up with a second handshake to the same origin for its `robots.txt` and TDMRep checks.

[#90344](https://github.com/PostHog/posthog/pull/90344) added HTTP/2 to the shared secure request helper and left the fetch lane on HTTP/1.1 as a follow-up. This is that follow-up.

## Changes

- The image hop and the configuration fetcher now opt into HTTP/2 on the shared secure dispatcher.
- Requests to an origin reuse its HTTP/2 session instead of opening a new TLS connection each time. How many sessions an origin gets, and when an idle one closes, is decided in the shared dispatcher by [#95957](https://github.com/PostHog/posthog/pull/95957).
- An origin that offers only HTTP/1.1 gets HTTP/1.1 with no change in behavior.
- Redirect handling, SSRF checks, CONNECT proxy routing, and the per-domain scheduler are unchanged. The per-domain concurrency limit now bounds streams rather than connections.
- The implementation notes gain one paragraph on the transport. Mechanical.

> [!NOTE]
> undici 7 does not retire an idle HTTP/2 session on the keep-alive timeout the way it does an HTTP/1.1 socket. [#95957](https://github.com/PostHog/posthog/pull/95957) fixes that in the shared helper and should land before or with this PR.

## How did you test this code?

- Extended the existing image fetcher and configuration policy unit tests to assert the HTTP/2 opt-in reaches the shared helper. Both fail against the previous code because the option is absent.
- Ran both suites with the change applied.
- Not run: a live origin. The negotiation, session reuse, and fallback behavior are covered by the shared helper's integration test from #90344, which this PR does not change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The lane's implementation notes are updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1), driven by Robbie. Skills invoked: `/writing-pr-descriptions`. No open PR already makes this change; the search for the lane's HTTP/2 follow-up found only the merged transport PR. Tests were written first and run red before the source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



