### PR TITLE
fix(data-warehouse): stop a repartition retry abandoning the table

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition_controller.py
@@ -830,6 +830,36 @@ class TestRepartitionActivity:
         pending = schema.repartition_pending
         assert pending is not None and pending["attempts"] == 1
 
+    def test_a_retry_inside_the_run_that_spent_the_cap_still_rewrites(self, team):
+        # The attempt is charged before the rewrite, so on the run that charges the last one the
+        # persisted count already reads the cap when that run's own Temporal retry re-reads it. Giving
+        # up there abandoned the table terminally on a heartbeat blip, before the retry ran the
+        # rewrite at all, although the cap counts the sync runs that failed and not the retries
+        # within one.
+        schema = _make_schema(team, {})
+        schema.set_repartition_pending(
+            {
+                "partition_mode": "md5",
+                "partition_count": 4,
+                "partition_keys": ["id"],
+                "trigger_reason": "t",
+                "attempts": MAX_REPARTITION_ATTEMPTS - 1,
+            }
+        )
+        inputs = self._inputs(team, schema)
+
+        def killed_mid_rewrite(**kwargs):
+            raise KeyboardInterrupt("worker killed")
+
+        with contextlib.suppress(BaseException):
+            self._run(inputs, AsyncMock(side_effect=killed_mid_rewrite))
+
+        rewrite = AsyncMock(return_value={"outcome": "completed", "row_count": 6, "partition_mode_after": "md5"})
+        capture = self._run(inputs, rewrite)
+
+        rewrite.assert_awaited_once()
+        assert "warehouse_repartition_failed" not in [c.args[0] for c in capture.call_args_list]
+
     def test_an_overlapping_attempt_charge_survives_another_attempts_refund(self, team):
         # Overlapping attempts must not erase each other's charge, or the cap never counts up and the
         # retry loop this change exists to stop comes back.

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
@@ -404,7 +404,7 @@ def _maybe_repartition_table(inputs: RepartitionActivityInputs, logger: Filterin
     # Never while a swap is staged: an interrupted swap may already have deleted live, leaving temp
     # the only intact copy, and `_give_up` clears the marker that points at it. A ready swap has to be
     # completed however many attempts it took to get here.
-    if swap is None and _exhausted_attempts(pending):
+    if swap is None and _exhausted_attempts(pending, inputs.job_id):
         _give_up(inputs, schema, pending, trigger_reason, logger)
         return
 
@@ -700,8 +700,21 @@ def _handle_budget_exceeded(
     return _handle_failure(inputs, schema, pending, trigger_reason, error, claim_token, logger, charged_attempts)
 
 
-def _exhausted_attempts(pending: dict[str, Any] | None) -> bool:
-    return pending is not None and int(pending.get("attempts", 0)) >= MAX_REPARTITION_ATTEMPTS
+def _exhausted_attempts(pending: dict[str, Any] | None, job_id: str) -> bool:
+    """Whether earlier sync runs already spent the whole retry cap on this rewrite.
+
+    Discounts a charge this run made itself. An attempt is charged before the rewrite (see
+    `_charge_attempt`), and Temporal retries the activity inside one sync, so on the run that charges
+    the last attempt the persisted count already reads the cap when that run's own retry re-reads it.
+    Giving up there abandons the table before the retry runs the rewrite at all, because the cap
+    counts the sync runs that failed and not the retries within one.
+    """
+    if pending is None:
+        return False
+    attempts = int(pending.get("attempts", 0))
+    if pending.get("charged_job_id") == job_id:
+        attempts -= 1
+    return attempts >= MAX_REPARTITION_ATTEMPTS
 
 
 def _give_up(


### PR DESCRIPTION
## Problem

- A large warehouse table stops repartitioning for good the first time its final sync run is retried, so it keeps syncing on the layout that made it fail.
- The retry cap counts sync runs, not the Temporal retries inside one run, and an attempt is charged before the rewrite starts.
- On the run that charges the third attempt, the stored count already reads the cap, so that run's own retry reads the cap as spent.
- The retry then abandons the rewrite instead of running it. It clears the pending target, engages the daily cooldown, and reports `RepartitionAttemptsExhausted` with `final=true`.
- A heartbeat timeout is enough to trigger this, and that is the ordinary reason Temporal retries this activity.

## Changes

- A table now keeps its rewrite when the run holding its last attempt is retried, so a heartbeat blip on the final chance no longer abandons it.
- The cap check discounts a charge the current run made itself, by matching the stored `charged_job_id` against this run's job id.
- The give-up at the cap is unchanged for a retry that fails cleanly, because the failure path counts the charge itself, and for a later sync run, which sees a charge from another job.
- Nothing in the UI changes.

## How did you test this code?

- New test `test_a_retry_inside_the_run_that_spent_the_cap_still_rewrites`: it fails when the cap check ignores the current run's charge, which is the defect fixed here. Its sibling `test_retries_inside_one_sync_run_burn_a_single_attempt` starts from zero attempts, so no existing case reaches the cap inside one run.
- Ran the cap check over its inputs directly in this sandbox: no marker, a count under the cap, a count at the cap, a charge from another job, and a charge from this job. Only the last one is newly exempt.
- Not run: `test_repartition_controller.py` itself. Its session setup needs ClickHouse, which this sandbox has no server for. The file collects, and CI runs it.
- No manual or production verification was performed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The README already describes the cap as consecutive failed sync runs, which is what this restores.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Written by Claude Opus 5 in a PostHog cloud task, triaging a day of `warehouse_repartition_failed` events. The terminal one was an `RepartitionAttemptsExhausted` give-up, and reading the charge and give-up bookkeeping found the retry that never rewrites.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- No duplicate: no open PR touches the attempt cap. [#95861](https://github.com/PostHog/posthog/pull/95861) fixes the other failure mode from the same day, budget-exceeded rewrites that cannot converge, by holding imports while a checkpoint is live. It leaves the give-up path alone, and the two diffs do not overlap.
- Public artifact: the diff carries no material from the agent session. The test uses the fixture helpers already in the file and invented ids.
