### PR TITLE
fix(node): reuse one HTTP/2 session per origin

### DIFF
--- a/nodejs/src/cdp/services/messaging/push-notification.service.ts
+++ b/nodejs/src/cdp/services/messaging/push-notification.service.ts
@@ -69,6 +69,8 @@ const pushNotificationRescheduledCounter = new Counter({
 // keyed by the auth key id so the whole fleet reuses one token per key rather than minting one per send.
 const APNS_JWT_CACHE_PREFIX = '@posthog/apns-provider-jwt/'
 const APNS_JWT_TTL_SECONDS = 45 * 60
+// Apple asks providers to reuse a connection for hours to days and to ping it after an hour idle.
+const APNS_IDLE_TIMEOUT_MS = 60 * 60 * 1000
 
 // One entry per signing key, so the ceiling is the number of APNs integrations routed through this pod.
 // Pruned on write rather than on a timer.
@@ -509,6 +511,7 @@ export class PushNotificationService {
             body: JSON.stringify(apnsPayload),
             // APNs requires HTTP/2
             allowH2: true,
+            http2IdleTimeoutMs: APNS_IDLE_TIMEOUT_MS,
         }
 
         if (params.timeoutMs !== undefined) {

--- a/nodejs/src/common/utils/request-http2.test.ts
+++ b/nodejs/src/common/utils/request-http2.test.ts
@@ -166,7 +166,7 @@ describe('secure HTTP/2 requests', () => {
         await tlsIdentity?.cleanup()
     })
 
-    it('negotiates, reuses, runs concurrently, defaults, and falls back through a CONNECT proxy', async () => {
+    it('negotiates, multiplexes concurrent requests on one session, defaults, and falls back through a CONNECT proxy', async () => {
         const http2Authority = `origin.test:${serverPort(http2Origin)}`
         const http2Url = `https://${http2Authority}`
         const bufferedResponse = await requestModule.fetch(`${http2Url}/buffered`, { allowH2: true, timeoutMs: 2000 })
@@ -201,8 +201,8 @@ describe('secure HTTP/2 requests', () => {
 
         expect(http2OriginProtocols).toEqual(['2.0', '2.0', '2.0', '2.0', '1.1'])
         expect(http1OriginProtocols).toEqual(['1.1'])
-        expect(http2SessionCount).toBe(2)
-        expect(proxyAuthorities).toEqual([http2Authority, http2Authority, http2Authority, http1Authority])
+        expect(http2SessionCount).toBe(1)
+        expect(proxyAuthorities).toEqual([http2Authority, http2Authority, http1Authority])
     }, 10000)
 
     it('closes an idle HTTP/2 session after the keep-alive timeout but not one with a slow response in flight', async () => {

--- a/nodejs/src/common/utils/request-http2.test.ts
+++ b/nodejs/src/common/utils/request-http2.test.ts
@@ -1,3 +1,4 @@
+import dnsPromises from 'dns/promises'
 import http from 'node:http'
 import http2 from 'node:http2'
 import https from 'node:https'
@@ -7,82 +8,145 @@ import tls from 'node:tls'
 import { TestTlsIdentity, createTestTlsIdentity } from '~/tests/helpers/tls'
 
 type RequestModule = typeof import('./request')
+type AnyServer = http.Server | http2.Http2SecureServer | https.Server
 
 const proxyEnvironmentNames = ['HTTPS_PROXY', 'HTTP_PROXY', 'https_proxy', 'http_proxy'] as const
+const ORIGIN_HOST = 'origin.test'
+const keepAliveTimeoutMs = 1000
 
-function serverPort(server: http.Server | http2.Http2SecureServer | https.Server): number {
+function serverPort(server: AnyServer): number {
     return (server.address() as AddressInfo).port
 }
 
-function listen(server: http.Server | http2.Http2SecureServer | https.Server): Promise<void> {
+function listen(server: AnyServer): Promise<void> {
     return new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
 }
 
-function close(server: http.Server | http2.Http2SecureServer | https.Server): Promise<void> {
+function close(server: AnyServer): Promise<void> {
     if (!server.listening) {
         return Promise.resolve()
     }
     return new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
 }
 
-describe('secure HTTP/2 requests', () => {
+async function waitFor(condition: () => boolean, timeoutMs: number): Promise<void> {
+    const deadline = Date.now() + timeoutMs
+    while (!condition()) {
+        if (Date.now() > deadline) {
+            throw new Error('condition not met in time')
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25))
+    }
+}
+
+/** An HTTP/2 origin that counts sessions and streams, pings its client, and can hold responses. */
+class Http2Origin {
+    public readonly server: http2.Http2SecureServer
+    public readonly sessions: Array<{ session: http2.ServerHttp2Session; streams: number; open: boolean }> = []
+    public readonly served = new Map<string, number>()
+    public inFlight = 0
+    public maxInFlight = 0
+    private readonly pending: Array<() => void> = []
+    private readonly pings = new Set<NodeJS.Timeout>()
+
+    constructor(
+        identity: TestTlsIdentity,
+        private readonly respond: (url: string, finish: () => void, origin: Http2Origin) => void,
+        settings: http2.Settings = {}
+    ) {
+        this.server = http2.createSecureServer({
+            allowHTTP1: true,
+            cert: identity.certificate,
+            key: identity.privateKey,
+            settings,
+        })
+        this.server.on('session', (session) => {
+            const entry = { session, streams: 0, open: true }
+            this.sessions.push(entry)
+            session.on('stream', () => entry.streams++)
+            const ping = setInterval(() => session.ping(() => {}), 100)
+            this.pings.add(ping)
+            session.once('close', () => {
+                entry.open = false
+                clearInterval(ping)
+                this.pings.delete(ping)
+            })
+        })
+        this.server.on('request', (request, response) => {
+            const url = request.url ?? ''
+            this.served.set(url, (this.served.get(url) ?? 0) + 1)
+            this.inFlight++
+            this.maxInFlight = Math.max(this.maxInFlight, this.inFlight)
+            const finish = (): void => {
+                this.inFlight--
+                response.writeHead(200, { 'content-type': 'text/plain', 'x-http-version': request.httpVersion })
+                response.end(url)
+            }
+            this.respond(url, finish, this)
+        })
+    }
+
+    public get openSessions(): number {
+        return this.sessions.filter((entry) => entry.open).length
+    }
+
+    public holdUntil(count: number, finish: () => void): void {
+        this.pending.push(finish)
+        if (this.pending.length === count) {
+            this.pending.splice(0).forEach((release) => release())
+        }
+    }
+
+    public async stop(): Promise<void> {
+        for (const ping of this.pings) {
+            clearInterval(ping)
+        }
+        for (const entry of this.sessions) {
+            entry.session.destroy()
+        }
+        await close(this.server)
+    }
+}
+
+describe.each([['CONNECT proxy'], ['direct connection']])('secure HTTP/2 requests over a %s', (mode) => {
+    const viaProxy = mode === 'CONNECT proxy'
     let requestModule: RequestModule
-    let http2Origin: http2.Http2SecureServer
+    let identity: TestTlsIdentity
+    let origin: Http2Origin
     let http1Origin: https.Server
     let connectProxy: http.Server
     let tlsConnectSpy: jest.SpyInstance
-    let tlsIdentity: TestTlsIdentity | undefined
+    let lookupSpy: jest.SpyInstance | undefined
     const originalExternalRequestConnections = process.env.EXTERNAL_REQUEST_CONNECTIONS
     const originalKeepAliveTimeout = process.env.EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS
-    const keepAliveTimeoutMs = 1000
     const originalProxyEnvironment = Object.fromEntries(
         proxyEnvironmentNames.map((name) => [name, process.env[name]])
     ) as Record<(typeof proxyEnvironmentNames)[number], string | undefined>
-    let http2SessionCount = 0
-    const http2OriginProtocols: string[] = []
     const http1OriginProtocols: string[] = []
     const proxyAuthorities: string[] = []
     const openSockets = new Set<net.Socket>()
-    const openHttp2Sessions = new Set<http2.ServerHttp2Session>()
-    const pendingConcurrentResponses: Array<() => void> = []
+    const extraOrigins: Http2Origin[] = []
+
+    const originUrl = (target: Http2Origin): string => `https://${ORIGIN_HOST}:${serverPort(target.server)}`
+
+    const fetchText = async (url: string, options: { http2IdleTimeoutMs?: number } = {}): Promise<string> => {
+        const response = await requestModule.fetchStreamed(url, { allowH2: true, timeoutMs: 5000, ...options })
+        return (await response.read(100)).bytes.toString()
+    }
 
     beforeAll(async () => {
-        const generatedTlsIdentity = await createTestTlsIdentity('origin.test')
-        tlsIdentity = generatedTlsIdentity
-
-        http2Origin = http2.createSecureServer({
-            allowHTTP1: true,
-            cert: generatedTlsIdentity.certificate,
-            key: generatedTlsIdentity.privateKey,
-        })
-        http2Origin.on('request', (request, response) => {
-            http2OriginProtocols.push(request.httpVersion)
-            const finishResponse = (): void => {
-                response.writeHead(200, { 'content-type': 'text/plain' })
-                response.end(request.url)
-            }
-            if (request.url === '/slow') {
-                setTimeout(finishResponse, keepAliveTimeoutMs * 1.5)
+        identity = await createTestTlsIdentity(ORIGIN_HOST)
+        origin = new Http2Origin(identity, (url, finish) => {
+            if (url === '/slow') {
+                setTimeout(finish, keepAliveTimeoutMs * 1.5)
                 return
             }
-            if (request.url?.startsWith('/concurrent-')) {
-                pendingConcurrentResponses.push(finishResponse)
-                if (pendingConcurrentResponses.length === 2) {
-                    pendingConcurrentResponses.splice(0).forEach((finish) => finish())
-                }
-                return
-            }
-            finishResponse()
+            finish()
         })
-        http2Origin.on('session', (session) => {
-            http2SessionCount += 1
-            openHttp2Sessions.add(session)
-            session.once('close', () => openHttp2Sessions.delete(session))
-        })
-        await listen(http2Origin)
+        await listen(origin.server)
 
         http1Origin = https.createServer(
-            { cert: generatedTlsIdentity.certificate, key: generatedTlsIdentity.privateKey },
+            { cert: identity.certificate, key: identity.privateKey },
             (request, response) => {
                 http1OriginProtocols.push(request.httpVersion)
                 response.writeHead(200, { 'content-type': 'text/plain' })
@@ -118,16 +182,23 @@ describe('secure HTTP/2 requests', () => {
         tlsConnectSpy = jest
             .spyOn(tls, 'connect')
             .mockImplementation(((options: tls.ConnectionOptions, callback?: () => void) =>
-                connectWithSystemTrust(
-                    { ...options, ca: generatedTlsIdentity.certificate },
-                    callback
-                )) as typeof tls.connect)
-        process.env.HTTPS_PROXY = `http://127.0.0.1:${serverPort(connectProxy)}`
-        process.env.EXTERNAL_REQUEST_CONNECTIONS = '2'
+                connectWithSystemTrust({ ...options, ca: identity.certificate }, callback)) as typeof tls.connect)
+        for (const name of proxyEnvironmentNames) {
+            delete process.env[name]
+        }
+        if (viaProxy) {
+            process.env.HTTPS_PROXY = `http://127.0.0.1:${serverPort(connectProxy)}`
+        } else {
+            const realLookup = dnsPromises.lookup
+            lookupSpy = jest
+                .spyOn(dnsPromises, 'lookup')
+                .mockImplementation(((hostname: string, options: unknown) =>
+                    hostname === ORIGIN_HOST
+                        ? Promise.resolve([{ address: '127.0.0.1', family: 4 }])
+                        : (realLookup as (h: string, o: unknown) => Promise<unknown>)(hostname, options)) as never)
+        }
+        process.env.EXTERNAL_REQUEST_CONNECTIONS = '4'
         process.env.EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS = String(keepAliveTimeoutMs)
-        delete process.env.HTTP_PROXY
-        delete process.env.https_proxy
-        delete process.env.http_proxy
 
         jest.resetModules()
         requestModule = require('./request') as RequestModule
@@ -153,76 +224,102 @@ describe('secure HTTP/2 requests', () => {
             process.env.EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS = originalKeepAliveTimeout
         }
         tlsConnectSpy.mockRestore()
+        lookupSpy?.mockRestore()
 
-        for (const session of openHttp2Sessions) {
-            session.destroy()
-        }
         for (const socket of openSockets) {
             socket.destroy()
         }
         http1Origin.closeAllConnections()
         connectProxy.closeAllConnections()
-        await Promise.all([close(http2Origin), close(http1Origin), close(connectProxy)])
-        await tlsIdentity?.cleanup()
+        await Promise.all([
+            origin.stop(),
+            ...extraOrigins.map((extra) => extra.stop()),
+            close(http1Origin),
+            close(connectProxy),
+        ])
+        await identity.cleanup()
     })
 
-    it('negotiates, multiplexes concurrent requests on one session, defaults, and falls back through a CONNECT proxy', async () => {
-        const http2Authority = `origin.test:${serverPort(http2Origin)}`
-        const http2Url = `https://${http2Authority}`
-        const bufferedResponse = await requestModule.fetch(`${http2Url}/buffered`, { allowH2: true, timeoutMs: 2000 })
+    const startOrigin = async (
+        respond: (url: string, finish: () => void, target: Http2Origin) => void,
+        settings: http2.Settings = {}
+    ): Promise<Http2Origin> => {
+        const extra = new Http2Origin(identity, respond, settings)
+        extraOrigins.push(extra)
+        await listen(extra.server)
+        return extra
+    }
+
+    it('negotiates, multiplexes, defaults to HTTP/1.1, and falls back to an HTTP/1.1 origin', async () => {
+        const url = originUrl(origin)
+        const bufferedResponse = await requestModule.fetch(`${url}/buffered`, { allowH2: true, timeoutMs: 2000 })
         expect(await bufferedResponse.text()).toBe('/buffered')
+        expect(await fetchText(`${url}/streamed`)).toBe('/streamed')
 
-        const streamedResponse = await requestModule.fetchStreamed(`${http2Url}/streamed`, {
-            allowH2: true,
-            timeoutMs: 2000,
-        })
-        expect((await streamedResponse.read(100)).bytes.toString()).toBe('/streamed')
-
-        const concurrentBodies = await Promise.all(
-            ['/concurrent-a', '/concurrent-b'].map(async (path) => {
-                const response = await requestModule.fetchStreamed(`${http2Url}${path}`, {
-                    allowH2: true,
-                    timeoutMs: 2000,
-                })
-                return (await response.read(100)).bytes.toString()
-            })
+        const concurrent = await Promise.all(
+            ['/concurrent-a', '/concurrent-b'].map((path) => fetchText(`${url}${path}`))
         )
-        expect(concurrentBodies).toEqual(['/concurrent-a', '/concurrent-b'])
+        expect(concurrent).toEqual(['/concurrent-a', '/concurrent-b'])
 
-        const defaultResponse = await requestModule.fetchStreamed(`${http2Url}/default`, { timeoutMs: 2000 })
+        const defaultResponse = await requestModule.fetchStreamed(`${url}/default`, { timeoutMs: 2000 })
+        expect(defaultResponse.headers['x-http-version']).toBe('1.1')
         expect((await defaultResponse.read(100)).bytes.toString()).toBe('/default')
 
-        const http1Authority = `origin.test:${serverPort(http1Origin)}`
-        const fallbackResponse = await requestModule.fetchStreamed(`https://${http1Authority}/fallback`, {
-            allowH2: true,
-            timeoutMs: 2000,
-        })
-        expect((await fallbackResponse.read(100)).bytes.toString()).toBe('/fallback')
+        const fallbackUrl = `https://${ORIGIN_HOST}:${serverPort(http1Origin)}/fallback`
+        expect(await fetchText(fallbackUrl)).toBe('/fallback')
 
-        expect(http2OriginProtocols).toEqual(['2.0', '2.0', '2.0', '2.0', '1.1'])
+        expect(origin.sessions.map((entry) => entry.streams)).toEqual([4])
         expect(http1OriginProtocols).toEqual(['1.1'])
-        expect(http2SessionCount).toBe(1)
-        expect(proxyAuthorities).toEqual([http2Authority, http2Authority, http1Authority])
+        if (viaProxy) {
+            const http2Authority = `${ORIGIN_HOST}:${serverPort(origin.server)}`
+            expect(proxyAuthorities).toEqual([
+                http2Authority,
+                http2Authority,
+                `${ORIGIN_HOST}:${serverPort(http1Origin)}`,
+            ])
+        }
     }, 10000)
 
-    it('closes an idle HTTP/2 session after the keep-alive timeout but not one with a slow response in flight', async () => {
-        const http2Url = `https://origin.test:${serverPort(http2Origin)}`
-        const slowResponse = await requestModule.fetchStreamed(`${http2Url}/slow`, {
-            allowH2: true,
-            timeoutMs: keepAliveTimeoutMs * 5,
-        })
-        expect((await slowResponse.read(100)).bytes.toString()).toBe('/slow')
-        const sessionsBeforeIdle = http2SessionCount
+    it('carries a burst to a cold origin on one session', async () => {
+        const cold = await startOrigin((url, finish, target) => target.holdUntil(6, finish))
+        const paths = Array.from({ length: 6 }, (_, index) => `/burst-${index}`)
 
-        await new Promise((resolve) => setTimeout(resolve, keepAliveTimeoutMs * 2.5))
-        expect(openHttp2Sessions.size).toBe(0)
+        const bodies = await Promise.all(paths.map((path) => fetchText(`${originUrl(cold)}${path}`)))
 
-        const response = await requestModule.fetchStreamed(`${http2Url}/after-idle`, {
-            allowH2: true,
-            timeoutMs: 2000,
-        })
-        expect((await response.read(100)).bytes.toString()).toBe('/after-idle')
-        expect(http2SessionCount).toBe(sessionsBeforeIdle + 1)
-        expect(openHttp2Sessions.size).toBe(1)
+        expect(bodies).toEqual(paths)
+        expect(cold.sessions.map((entry) => entry.streams)).toEqual([6])
+    }, 10000)
+
+    it('stays within the stream limit the origin advertises', async () => {
+        const limited = await startOrigin((url, finish) => setTimeout(finish, 100), { maxConcurrentStreams: 3 })
+        const paths = Array.from({ length: 8 }, (_, index) => `/limited-${index}`)
+
+        const bodies = await Promise.all(paths.map((path) => fetchText(`${originUrl(limited)}${path}`)))
+
+        expect(bodies).toEqual(paths)
+        expect(limited.maxInFlight).toBe(3)
+        expect([...limited.served.values()]).toEqual(paths.map(() => 1))
+        expect(limited.sessions).toHaveLength(1)
+    }, 10000)
+
+    it('closes an idle session after the keep-alive timeout despite pings, but not one with a slow response in flight', async () => {
+        const url = originUrl(origin)
+        expect(await fetchText(`${url}/slow`)).toBe('/slow')
+        const sessionsBefore = origin.sessions.length
+
+        await waitFor(() => origin.openSessions === 0, keepAliveTimeoutMs * 3)
+
+        expect(await fetchText(`${url}/after-idle`)).toBe('/after-idle')
+        expect(origin.sessions).toHaveLength(sessionsBefore + 1)
+        expect(origin.openSessions).toBe(1)
     }, 15000)
+
+    it('keeps a session open for the idle timeout a caller asks for', async () => {
+        const patient = await startOrigin((url, finish) => finish())
+
+        expect(await fetchText(`${originUrl(patient)}/patient`, { http2IdleTimeoutMs: 60_000 })).toBe('/patient')
+        await new Promise((resolve) => setTimeout(resolve, keepAliveTimeoutMs * 2))
+
+        expect(patient.openSessions).toBe(1)
+    }, 10000)
 })

--- a/nodejs/src/common/utils/request-http2.test.ts
+++ b/nodejs/src/common/utils/request-http2.test.ts
@@ -318,7 +318,7 @@ describe.each([['CONNECT proxy'], ['direct connection']])('secure HTTP/2 request
         const patient = await startOrigin((url, finish) => finish())
 
         expect(await fetchText(`${originUrl(patient)}/patient`, { http2IdleTimeoutMs: 60_000 })).toBe('/patient')
-        await new Promise((resolve) => setTimeout(resolve, keepAliveTimeoutMs * 2))
+        await new Promise((resolve) => setTimeout(resolve, keepAliveTimeoutMs * 1.5))
 
         expect(patient.openSessions).toBe(1)
     }, 10000)

--- a/nodejs/src/common/utils/request-http2.test.ts
+++ b/nodejs/src/common/utils/request-http2.test.ts
@@ -33,6 +33,8 @@ describe('secure HTTP/2 requests', () => {
     let tlsConnectSpy: jest.SpyInstance
     let tlsIdentity: TestTlsIdentity | undefined
     const originalExternalRequestConnections = process.env.EXTERNAL_REQUEST_CONNECTIONS
+    const originalKeepAliveTimeout = process.env.EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS
+    const keepAliveTimeoutMs = 1000
     const originalProxyEnvironment = Object.fromEntries(
         proxyEnvironmentNames.map((name) => [name, process.env[name]])
     ) as Record<(typeof proxyEnvironmentNames)[number], string | undefined>
@@ -58,6 +60,10 @@ describe('secure HTTP/2 requests', () => {
             const finishResponse = (): void => {
                 response.writeHead(200, { 'content-type': 'text/plain' })
                 response.end(request.url)
+            }
+            if (request.url === '/slow') {
+                setTimeout(finishResponse, keepAliveTimeoutMs * 1.5)
+                return
             }
             if (request.url?.startsWith('/concurrent-')) {
                 pendingConcurrentResponses.push(finishResponse)
@@ -118,6 +124,7 @@ describe('secure HTTP/2 requests', () => {
                 )) as typeof tls.connect)
         process.env.HTTPS_PROXY = `http://127.0.0.1:${serverPort(connectProxy)}`
         process.env.EXTERNAL_REQUEST_CONNECTIONS = '2'
+        process.env.EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS = String(keepAliveTimeoutMs)
         delete process.env.HTTP_PROXY
         delete process.env.https_proxy
         delete process.env.http_proxy
@@ -139,6 +146,11 @@ describe('secure HTTP/2 requests', () => {
             delete process.env.EXTERNAL_REQUEST_CONNECTIONS
         } else {
             process.env.EXTERNAL_REQUEST_CONNECTIONS = originalExternalRequestConnections
+        }
+        if (originalKeepAliveTimeout === undefined) {
+            delete process.env.EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS
+        } else {
+            process.env.EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS = originalKeepAliveTimeout
         }
         tlsConnectSpy.mockRestore()
 
@@ -192,4 +204,25 @@ describe('secure HTTP/2 requests', () => {
         expect(http2SessionCount).toBe(2)
         expect(proxyAuthorities).toEqual([http2Authority, http2Authority, http2Authority, http1Authority])
     }, 10000)
+
+    it('closes an idle HTTP/2 session after the keep-alive timeout but not one with a slow response in flight', async () => {
+        const http2Url = `https://origin.test:${serverPort(http2Origin)}`
+        const slowResponse = await requestModule.fetchStreamed(`${http2Url}/slow`, {
+            allowH2: true,
+            timeoutMs: keepAliveTimeoutMs * 5,
+        })
+        expect((await slowResponse.read(100)).bytes.toString()).toBe('/slow')
+        const sessionsBeforeIdle = http2SessionCount
+
+        await new Promise((resolve) => setTimeout(resolve, keepAliveTimeoutMs * 2.5))
+        expect(openHttp2Sessions.size).toBe(0)
+
+        const response = await requestModule.fetchStreamed(`${http2Url}/after-idle`, {
+            allowH2: true,
+            timeoutMs: 2000,
+        })
+        expect((await response.read(100)).bytes.toString()).toBe('/after-idle')
+        expect(http2SessionCount).toBe(sessionsBeforeIdle + 1)
+        expect(openHttp2Sessions.size).toBe(1)
+    }, 15000)
 })

--- a/nodejs/src/common/utils/request.ts
+++ b/nodejs/src/common/utils/request.ts
@@ -2,16 +2,20 @@ import { LookupAddress } from 'dns'
 import dns from 'dns/promises'
 import * as ipaddr from 'ipaddr.js'
 import net from 'node:net'
+import tls from 'node:tls'
 import { Counter, Gauge } from 'prom-client'
 // eslint-disable-next-line no-restricted-imports
 import {
     Agent,
+    Client,
     Dispatcher,
     type HeadersInit,
+    Pool,
     ProxyAgent,
     RequestInfo,
     RequestInit,
     Response,
+    errors,
     request,
     fetch as undiciFetch,
 } from 'undici'
@@ -42,6 +46,11 @@ const unsafeRequestCounter = new Counter({
 const inflightExternalRequests = new Gauge({
     name: 'cdp_http_inflight_requests',
     help: 'Number of currently inflight external HTTP requests (undici). Use as HPA scaling metric for cdp-cyclotron-worker.',
+})
+
+const idleHttp2SessionsClosed = new Counter({
+    name: 'node_request_http2_idle_sessions_closed',
+    help: 'HTTP/2 sessions this process closed because the keep-alive timeout passed with no request in flight',
 })
 
 // NOTE: This isn't exactly fetch - it's meant to be very close but limited to only options we actually want to expose
@@ -266,6 +275,55 @@ class InsecureAgent extends Agent {
     }
 }
 
+/**
+ * undici retires an idle HTTP/1.1 socket after the keep-alive timeout, but leaves an idle HTTP/2 session
+ * open until the origin closes it. undici 8 fixes this (nodejs/undici#5406); this gives the same idle
+ * lifetime to a session on undici 7. Without it, a caller that fetches from many origins holds one open
+ * socket per origin it ever reached.
+ */
+function makeIdleReapingPoolFactory(idleTimeoutMs: number): (origin: string | URL, options: object) => Pool {
+    return (origin, options) =>
+        new Pool(origin, {
+            ...(options as Pool.Options),
+            factory: (clientOrigin, clientOptions) =>
+                makeIdleReapingClient(clientOrigin, clientOptions as Client.Options, idleTimeoutMs),
+        })
+}
+
+function makeIdleReapingClient(origin: URL, options: Client.Options, idleTimeoutMs: number): Client {
+    const connect = options.connect
+    if (typeof connect !== 'function') {
+        return new Client(origin, options)
+    }
+    const client: Client = new Client(origin, {
+        ...options,
+        connect: (connectOptions, callback) =>
+            connect(connectOptions, (...result) => {
+                const socket = result[1]
+                if (socket instanceof tls.TLSSocket && socket.alpnProtocol === 'h2') {
+                    closeSocketWhenIdle(client, socket, idleTimeoutMs)
+                }
+                callback(...result)
+            }),
+    })
+    return client
+}
+
+function closeSocketWhenIdle(client: Client, socket: tls.TLSSocket, idleTimeoutMs: number): void {
+    socket.setTimeout(idleTimeoutMs)
+    socket.on('timeout', () => {
+        // A stream that waits on a slow origin sends no bytes, so socket inactivity alone is not idleness.
+        const { running, pending, size } = client.stats
+        if (running > 0 || pending > 0 || size > 0) {
+            socket.setTimeout(idleTimeoutMs)
+            return
+        }
+        idleHttp2SessionsClosed.inc()
+        // The informational code keeps undici from failing a request queued on this client, so the client reconnects for the next one.
+        socket.destroy(new errors.InformationalError('socket idle timeout'))
+    })
+}
+
 // When a proxy URL is available, external requests go through a CONNECT tunnel.
 // The proxy handles SSRF blocking (private IP rejection) at the network level,
 // so we skip the DNS lookup (httpStaticLookup) which would be redundant.
@@ -273,19 +331,24 @@ function makeSecureDispatcher({ allowH2 }: { allowH2: boolean }): Dispatcher {
     const proxyUrl =
         process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.https_proxy || process.env.http_proxy
 
+    const keepAliveTimeoutMs = Number(requestConfig.EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS)
+    const idleReaping = allowH2 ? { factory: makeIdleReapingPoolFactory(keepAliveTimeoutMs) } : {}
+
     if (proxyUrl) {
         return new ProxyAgent({
             uri: proxyUrl,
-            keepAliveTimeout: requestConfig.EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS,
+            keepAliveTimeout: keepAliveTimeoutMs,
             connections: requestConfig.EXTERNAL_REQUEST_CONNECTIONS,
             allowH2,
             requestTls: { allowH2 },
+            ...idleReaping,
         })
     }
     return new Agent({
-        keepAliveTimeout: Number(requestConfig.EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS),
+        keepAliveTimeout: keepAliveTimeoutMs,
         connections: requestConfig.EXTERNAL_REQUEST_CONNECTIONS,
         allowH2,
+        ...idleReaping,
         connect: {
             lookup: httpStaticLookup,
             timeout: requestConfig.EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS,

--- a/nodejs/src/common/utils/request.ts
+++ b/nodejs/src/common/utils/request.ts
@@ -276,21 +276,32 @@ class InsecureAgent extends Agent {
 }
 
 /**
- * undici retires an idle HTTP/1.1 socket after the keep-alive timeout, but leaves an idle HTTP/2 session
- * open until the origin closes it. undici 8 fixes this (nodejs/undici#5406); this gives the same idle
- * lifetime to a session on undici 7. Without it, a caller that fetches from many origins holds one open
- * socket per origin it ever reached.
+ * Node's HTTP/2 client multiplexes up to this many streams on one session. undici's own default for its
+ * initial peer setting is the same value.
  */
-function makeIdleReapingPoolFactory(idleTimeoutMs: number): (origin: string | URL, options: object) => Pool {
+const HTTP2_STREAMS_PER_SESSION = 100
+
+/**
+ * undici 7 gives an HTTP/2 client the same defaults as an HTTP/1.1 client, which costs one session per
+ * origin twice over. Its `pipelining` default of 1 marks the client busy after one in-flight request, so a
+ * pool opens a new connection for every concurrent request instead of a new stream. It also retires an
+ * idle HTTP/1.1 socket after the keep-alive timeout but leaves an idle HTTP/2 session open until the origin
+ * closes it (nodejs/undici#5406 fixes the latter in undici 8). A caller that fetches from many origins
+ * would otherwise hold one open socket per concurrent request per origin it ever reached.
+ *
+ * Both fixes wait for ALPN, so a fallback HTTP/1.1 connection keeps its defaults. HTTP/1.1 pipelining
+ * would be unsafe against arbitrary origins.
+ */
+function makeHttp2SessionPoolFactory(idleTimeoutMs: number): (origin: string | URL, options: object) => Pool {
     return (origin, options) =>
         new Pool(origin, {
             ...(options as Pool.Options),
             factory: (clientOrigin, clientOptions) =>
-                makeIdleReapingClient(clientOrigin, clientOptions as Client.Options, idleTimeoutMs),
+                makeHttp2SessionClient(clientOrigin, clientOptions as Client.Options, idleTimeoutMs),
         })
 }
 
-function makeIdleReapingClient(origin: URL, options: Client.Options, idleTimeoutMs: number): Client {
+function makeHttp2SessionClient(origin: URL, options: Client.Options, idleTimeoutMs: number): Client {
     const connect = options.connect
     if (typeof connect !== 'function') {
         return new Client(origin, options)
@@ -301,6 +312,7 @@ function makeIdleReapingClient(origin: URL, options: Client.Options, idleTimeout
             connect(connectOptions, (...result) => {
                 const socket = result[1]
                 if (socket instanceof tls.TLSSocket && socket.alpnProtocol === 'h2') {
+                    client.pipelining = HTTP2_STREAMS_PER_SESSION
                     closeSocketWhenIdle(client, socket, idleTimeoutMs)
                 }
                 callback(...result)
@@ -332,7 +344,7 @@ function makeSecureDispatcher({ allowH2 }: { allowH2: boolean }): Dispatcher {
         process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.https_proxy || process.env.http_proxy
 
     const keepAliveTimeoutMs = Number(requestConfig.EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS)
-    const idleReaping = allowH2 ? { factory: makeIdleReapingPoolFactory(keepAliveTimeoutMs) } : {}
+    const http2Sessions = allowH2 ? { factory: makeHttp2SessionPoolFactory(keepAliveTimeoutMs) } : {}
 
     if (proxyUrl) {
         return new ProxyAgent({
@@ -341,14 +353,14 @@ function makeSecureDispatcher({ allowH2 }: { allowH2: boolean }): Dispatcher {
             connections: requestConfig.EXTERNAL_REQUEST_CONNECTIONS,
             allowH2,
             requestTls: { allowH2 },
-            ...idleReaping,
+            ...http2Sessions,
         })
     }
     return new Agent({
         keepAliveTimeout: keepAliveTimeoutMs,
         connections: requestConfig.EXTERNAL_REQUEST_CONNECTIONS,
         allowH2,
-        ...idleReaping,
+        ...http2Sessions,
         connect: {
             lookup: httpStaticLookup,
             timeout: requestConfig.EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS,

--- a/nodejs/src/common/utils/request.ts
+++ b/nodejs/src/common/utils/request.ts
@@ -1,6 +1,8 @@
 import { LookupAddress } from 'dns'
 import dns from 'dns/promises'
 import * as ipaddr from 'ipaddr.js'
+import { EventEmitter } from 'node:events'
+import type { ClientHttp2Session } from 'node:http2'
 import net from 'node:net'
 import tls from 'node:tls'
 import { Counter, Gauge } from 'prom-client'
@@ -19,6 +21,7 @@ import {
     request,
     fetch as undiciFetch,
 } from 'undici'
+import { kHTTP2Session } from 'undici/lib/core/symbols'
 import { URL } from 'url'
 
 import { getExternalRequestConfig } from '~/common/config'
@@ -60,6 +63,8 @@ export type FetchOptions = {
     body?: string | Buffer
     timeoutMs?: number
     allowH2?: boolean
+    /** How long an idle HTTP/2 session to an origin stays open. Defaults to the keep-alive timeout. */
+    http2IdleTimeoutMs?: number
 }
 
 export type FetchResponse = {
@@ -276,75 +281,186 @@ class InsecureAgent extends Agent {
 }
 
 /**
- * Node's HTTP/2 client multiplexes up to this many streams on one session. undici's own default for its
- * initial peer setting is the same value.
+ * Streams one HTTP/2 session carries at most. Node's own default limit is the same, so an origin that
+ * advertises more gets a second session past this point instead of a larger first one.
  */
 const HTTP2_STREAMS_PER_SESSION = 100
 
 /**
- * undici 7 gives an HTTP/2 client the same defaults as an HTTP/1.1 client, which costs one session per
- * origin twice over. Its `pipelining` default of 1 marks the client busy after one in-flight request, so a
- * pool opens a new connection for every concurrent request instead of a new stream. It also retires an
- * idle HTTP/1.1 socket after the keep-alive timeout but leaves an idle HTTP/2 session open until the origin
- * closes it (nodejs/undici#5406 fixes the latter in undici 8). A caller that fetches from many origins
- * would otherwise hold one open socket per concurrent request per origin it ever reached.
+ * One origin's connections on the HTTP/2 dispatcher.
  *
- * Both fixes wait for ALPN, so a fallback HTTP/1.1 connection keeps its defaults. HTTP/1.1 pipelining
- * would be unsafe against arbitrary origins.
+ * undici 7 opens a new connection for every request that arrives while the first one is still
+ * negotiating, and its HTTP/2 client neither multiplexes past one stream by default nor stops at the
+ * origin's advertised stream limit. This holds every request on the first connection until ALPN and
+ * the origin's SETTINGS frame have answered both questions, then sets the client's stream budget from
+ * the answer. Requests beyond that budget go to an ordinary pool, so an HTTP/1.1 origin still gets
+ * parallel connections and an HTTP/2 origin busy with non-idempotent requests still gets more sessions.
  */
-function makeHttp2SessionPoolFactory(idleTimeoutMs: number): (origin: string | URL, options: object) => Pool {
-    return (origin, options) =>
-        new Pool(origin, {
-            ...(options as Pool.Options),
-            factory: (clientOrigin, clientOptions) =>
-                makeHttp2SessionClient(clientOrigin, clientOptions as Client.Options, idleTimeoutMs),
-        })
-}
+class Http2OriginDispatcher extends Dispatcher {
+    private readonly first: Pool
+    private overflow: Pool | undefined
+    private budgetKnown = false
 
-function makeHttp2SessionClient(origin: URL, options: Client.Options, idleTimeoutMs: number): Client {
-    const connect = options.connect
-    if (typeof connect !== 'function') {
-        return new Client(origin, options)
+    constructor(
+        private readonly origin: string | URL,
+        private readonly options: Pool.Options,
+        private readonly idleTimeoutMs: number
+    ) {
+        super()
+        this.first = this.makePool(1, true)
     }
-    const client: Client = new Client(origin, {
-        ...options,
-        connect: (connectOptions, callback) =>
-            connect(connectOptions, (...result) => {
-                const socket = result[1]
-                if (socket instanceof tls.TLSSocket && socket.alpnProtocol === 'h2') {
-                    client.pipelining = HTTP2_STREAMS_PER_SESSION
-                    closeSocketWhenIdle(client, socket, idleTimeoutMs)
-                }
-                callback(...result)
-            }),
-    })
-    return client
-}
 
-function closeSocketWhenIdle(client: Client, socket: tls.TLSSocket, idleTimeoutMs: number): void {
-    socket.setTimeout(idleTimeoutMs)
-    socket.on('timeout', () => {
-        // A stream that waits on a slow origin sends no bytes, so socket inactivity alone is not idleness.
-        const { running, pending, size } = client.stats
-        if (running > 0 || pending > 0 || size > 0) {
-            socket.setTimeout(idleTimeoutMs)
+    public override dispatch(options: Dispatcher.DispatchOptions, handler: Dispatcher.DispatchHandler): boolean {
+        const connections = this.options.connections ?? 0
+        if (!this.budgetKnown || this.first.stats.free > 0 || connections === 1) {
+            return this.first.dispatch(options, handler)
+        }
+        this.overflow ??= this.makePool(connections > 1 ? connections - 1 : undefined, false)
+        return this.overflow.dispatch(options, handler)
+    }
+
+    public override close(): Promise<void>
+    public override close(callback: () => void): void
+    public override close(callback?: () => void): Promise<void> | void {
+        return settle(
+            this.pools().map((pool) => pool.close()),
+            callback
+        )
+    }
+
+    public override destroy(): Promise<void>
+    public override destroy(error: Error | null): Promise<void>
+    public override destroy(callback: () => void): void
+    public override destroy(error: Error | null, callback: () => void): void
+    public override destroy(
+        errorOrCallback?: Error | null | (() => void),
+        callback?: () => void
+    ): Promise<void> | void {
+        const error = errorOrCallback instanceof Error ? errorOrCallback : null
+        const done = typeof errorOrCallback === 'function' ? errorOrCallback : callback
+        return settle(
+            this.pools().map((pool) => pool.destroy(error)),
+            done
+        )
+    }
+
+    private pools(): Pool[] {
+        return this.overflow ? [this.first, this.overflow] : [this.first]
+    }
+
+    private makePool(connections: number | undefined, gate: boolean): Pool {
+        const pool = new Pool(this.origin, {
+            ...this.options,
+            connections,
+            factory: (clientOrigin, clientOptions) =>
+                this.makeClient(clientOrigin, clientOptions as Client.Options, gate),
+        })
+        const source: EventEmitter = pool
+        for (const event of ['connect', 'disconnect', 'connectionError', 'drain']) {
+            source.on(event, (...args: unknown[]) => EventEmitter.prototype.emit.call(this, event, ...args))
+        }
+        return pool
+    }
+
+    private makeClient(origin: URL, options: Client.Options, gate: boolean): Client {
+        const connect = options.connect
+        if (typeof connect !== 'function') {
+            throw new Error('undici must hand the client factory a connector function')
+        }
+        const client: Client = new Client(origin, {
+            ...options,
+            connect: (connectOptions, callback) => {
+                if (gate) {
+                    this.budgetKnown = false
+                }
+                connect(connectOptions, (error, socket) => {
+                    if (error !== null || socket === null) {
+                        callback(error ?? new Error('connector returned no socket'), null)
+                        return
+                    }
+                    callback(null, socket)
+                    this.onConnected(client, socket, gate)
+                })
+            },
+        })
+        return client
+    }
+
+    /** undici attaches the session to the socket before the connector callback returns, so this runs after it. */
+    private onConnected(client: Client, socket: net.Socket | tls.TLSSocket, gate: boolean): void {
+        const session = (socket as unknown as { [kHTTP2Session]?: ClientHttp2Session })[kHTTP2Session]
+        client.pipelining = 1
+        if (!session) {
+            if (gate) {
+                this.budgetKnown = true
+            }
             return
         }
-        idleHttp2SessionsClosed.inc()
-        // The informational code keeps undici from failing a request queued on this client, so the client reconnects for the next one.
-        socket.destroy(new errors.InformationalError('socket idle timeout'))
-    })
+        session.on('remoteSettings', (settings) => {
+            const advertised = settings.maxConcurrentStreams ?? HTTP2_STREAMS_PER_SESSION
+            client.pipelining = Math.max(1, Math.min(advertised, HTTP2_STREAMS_PER_SESSION))
+            if (gate) {
+                this.budgetKnown = true
+            }
+        })
+        closeSocketWhenIdle(client, socket, this.idleTimeoutMs)
+    }
+}
+
+function settle(pending: Promise<unknown>[], callback?: () => void): Promise<void> | void {
+    const done = Promise.all(pending).then(() => undefined)
+    if (!callback) {
+        return done
+    }
+    done.then(callback, callback)
+}
+
+/**
+ * undici retires an idle HTTP/1.1 socket after the keep-alive timeout but leaves an idle HTTP/2 session
+ * open until the origin closes it. The clock here is the client's own request accounting rather than
+ * socket activity, because undici pings the session every minute and an origin may ping too, and either
+ * would reset a socket inactivity timer.
+ */
+function closeSocketWhenIdle(client: Client, socket: net.Socket | tls.TLSSocket, idleTimeoutMs: number): void {
+    const tickMs = Math.max(1, Math.ceil(idleTimeoutMs / 4))
+    let idleSinceMs: number | undefined
+    let timer: NodeJS.Timeout
+    const tick = (): void => {
+        if (socket.destroyed) {
+            return
+        }
+        const { running, pending, size } = client.stats
+        if (running > 0 || pending > 0 || size > 0) {
+            idleSinceMs = undefined
+        } else if (idleSinceMs === undefined) {
+            idleSinceMs = Date.now()
+        } else if (Date.now() - idleSinceMs >= idleTimeoutMs) {
+            idleHttp2SessionsClosed.inc()
+            // The informational code keeps undici from failing a request queued on this client, so the client reconnects for the next one.
+            socket.destroy(new errors.InformationalError('socket idle timeout'))
+            return
+        }
+        timer = setTimeout(tick, tickMs).unref()
+    }
+    timer = setTimeout(tick, tickMs).unref()
+    socket.once('close', () => clearTimeout(timer))
 }
 
 // When a proxy URL is available, external requests go through a CONNECT tunnel.
 // The proxy handles SSRF blocking (private IP rejection) at the network level,
 // so we skip the DNS lookup (httpStaticLookup) which would be redundant.
-function makeSecureDispatcher({ allowH2 }: { allowH2: boolean }): Dispatcher {
+function makeSecureDispatcher({ http2IdleTimeoutMs }: { http2IdleTimeoutMs?: number }): Dispatcher {
     const proxyUrl =
         process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.https_proxy || process.env.http_proxy
 
     const keepAliveTimeoutMs = Number(requestConfig.EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS)
-    const http2Sessions = allowH2 ? { factory: makeHttp2SessionPoolFactory(keepAliveTimeoutMs) } : {}
+    const allowH2 = http2IdleTimeoutMs !== undefined
+    const http2Sessions = allowH2
+        ? {
+              factory: (origin: string | URL, options: object) =>
+                  new Http2OriginDispatcher(origin, options as Pool.Options, http2IdleTimeoutMs),
+          }
+        : {}
 
     if (proxyUrl) {
         return new ProxyAgent({
@@ -368,9 +484,22 @@ function makeSecureDispatcher({ allowH2 }: { allowH2: boolean }): Dispatcher {
     })
 }
 
-const sharedSecureAgent = makeSecureDispatcher({ allowH2: false })
-const sharedSecureH2Agent = makeSecureDispatcher({ allowH2: true })
+const sharedSecureAgent = makeSecureDispatcher({})
 const sharedInsecureAgent = new InsecureAgent()
+const sharedSecureH2Agents = new Map<number, Dispatcher>()
+
+function secureDispatcher(options: { allowH2?: boolean; http2IdleTimeoutMs?: number }): Dispatcher {
+    if (!options.allowH2) {
+        return sharedSecureAgent
+    }
+    const idleTimeoutMs = options.http2IdleTimeoutMs ?? Number(requestConfig.EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS)
+    let dispatcher = sharedSecureH2Agents.get(idleTimeoutMs)
+    if (!dispatcher) {
+        dispatcher = makeSecureDispatcher({ http2IdleTimeoutMs: idleTimeoutMs })
+        sharedSecureH2Agents.set(idleTimeoutMs, dispatcher)
+    }
+    return dispatcher
+}
 
 function destroyBody(body: Dispatcher.ResponseData['body']): void {
     try {
@@ -483,8 +612,12 @@ export async function fetch(url: string, options: FetchOptions = {}): Promise<Fe
     validateHostnameIPLiteral(parsed.hostname, !isProdEnv())
     inflightExternalRequests.inc()
     try {
-        const dispatcher = options.allowH2 ? sharedSecureH2Agent : sharedSecureAgent
-        return await _fetch(url, options, dispatcher, requestConfig.EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS)
+        return await _fetch(
+            url,
+            options,
+            secureDispatcher(options),
+            requestConfig.EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS
+        )
     } finally {
         inflightExternalRequests.dec()
     }
@@ -494,6 +627,8 @@ export type StreamedFetchOptions = {
     headers?: HeadersInit
     timeoutMs: number
     allowH2?: boolean
+    /** How long an idle HTTP/2 session to an origin stays open. Defaults to the keep-alive timeout. */
+    http2IdleTimeoutMs?: number
 }
 
 export type StreamedResponse = {
@@ -597,7 +732,7 @@ export async function fetchStreamed(url: string, options: StreamedFetchOptions):
         result = await request(parsed.toString(), {
             method: 'GET',
             headers: options.headers,
-            dispatcher: options.allowH2 ? sharedSecureH2Agent : sharedSecureAgent,
+            dispatcher: secureDispatcher(options),
             signal: AbortSignal.timeout(options.timeoutMs),
             responseHeaders: 'raw',
         })

--- a/nodejs/src/common/utils/undici-internals.d.ts
+++ b/nodejs/src/common/utils/undici-internals.d.ts
@@ -1,0 +1,3 @@
+declare module 'undici/lib/core/symbols' {
+    export const kHTTP2Session: unique symbol
+}


### PR DESCRIPTION
## Problem

A caller of the shared secure HTTP/2 dispatcher gets one TLS connection per concurrent request to an origin, and every one of them stays open for as long as the process lives. Three undici 7 behaviors cause this, and a version bump is not available to us:

- A request that arrives while the first connection to an origin is still negotiating opens another connection. Measured: six concurrent requests to a cold origin opened six sessions.
- Client `pipelining` defaults to 1 for every protocol, so a warm HTTP/2 session takes one stream and the pool opens a connection for each further concurrent request.
- Raising `pipelining` alone is unsafe: undici does not track the origin's advertised `SETTINGS_MAX_CONCURRENT_STREAMS`. Measured against an origin advertising 10 streams: 20 of 30 requests failed and 10 were delivered twice.
- An idle HTTP/1.1 socket closes after the keep-alive timeout, but an idle HTTP/2 session stays open until the origin closes it.

The AI research image fetch lane ([#95947](https://github.com/PostHog/posthog/pull/95947)) fetches from thousands of customer origins per pod, often several images from one origin at once. The APNs push service is the other caller.

## Changes

- A burst of concurrent requests to one origin now shares one HTTP/2 session, cold or warm, up to the stream limit the origin advertises. An origin that advertises three streams sees at most three in flight and every request exactly once.
- An idle HTTP/2 session now closes once the caller's idle timeout passes with nothing queued or running on it, whether or not either side sends PING frames.
- Callers can set `http2IdleTimeoutMs`. The image lane keeps the keep-alive default. APNs asks for an hour, because Apple's guidance is to reuse a connection for hours to days.
- HTTP/1.1 origins are unchanged: parallel connections, no pipelining. Non-idempotent requests on HTTP/2 still fan out to more sessions, because undici serializes them per session.
- Mechanism: the HTTP/2 agent routes each origin through `Http2OriginDispatcher`. It holds every request on the first connection until ALPN and the origin's SETTINGS frame have arrived, sets the client's `pipelining` to the advertised limit capped at 100, and sends requests beyond that to an ordinary pool. The idle clock polls the client's own request accounting. The origin's SETTINGS come from the session undici attaches to the socket, read through undici's internal symbol table, which its package pins.
- A new counter, `node_request_http2_idle_sessions_closed`, counts sessions closed this way.

> [!NOTE]
> This reads one undici internal, the `kHTTP2Session` symbol, to reach the Node session and its `remoteSettings` event. undici's `package.json` has no `exports` field, so the import is stable for the pinned 7.24.8. The declaration lives in `undici-internals.d.ts`; an undici upgrade that moves it fails the build, not production.

## How did you test this code?

- Rewrote the HTTP/2 integration test to run its cases over both a CONNECT proxy and a direct connection. The direct path had no coverage before.
- Cold burst: six concurrent requests to a fresh origin land as six streams on one session. Fails on master with six sessions.
- Stream limit: eight concurrent requests to an origin advertising three streams all succeed, at most three in flight, each served once. Fails on master.
- Idle close: every test origin pings its client every 100 ms, and the session still closes after the timeout. A response slower than the timeout survives, and the next request reconnects on a new session. Fails on master.
- Caller idle timeout: a request with `http2IdleTimeoutMs` of a minute keeps its session past the default timeout.
- The existing multiplexing case now expects all four requests on one session and two CONNECT tunnels instead of three.
- Ran the three request utility suites. The push notification suite does not load in this checkout because `@posthog/hogvm` is not built here; its change is one added field.
- Not run: a production proxy, or an origin that lowers its stream limit mid-session.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1), driven by Robbie. Skills invoked: `/writing-pr-descriptions`, `/qa-team`, `/writing-tests`. The first two commits shipped a socket inactivity reaper and a fixed `pipelining` of 100; a six-agent QA review found the fixed value lets a session overflow the origin's stream limit, that the value stuck across an HTTP/1.1 reconnect, and that PING frames reset the socket timer. The third commit replaces both with the per-origin dispatcher. undici 8 fixes the stream limit upstream but was ruled out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

