### PR TITLE
feat(tasks): run analysis fully in the background

### DIFF
--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskAnalysisButton.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskAnalysisButton.tsx
@@ -6,10 +6,8 @@ import {
 } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { toastError } from "@posthog/ui/features/notifications/errorDetails";
-import { toast } from "@posthog/ui/primitives/toast";
 import type { ReactElement } from "react";
 import { useAuthenticatedMutation } from "../../../hooks/useAuthenticatedMutation";
-import { navigateToTaskDetail } from "../../../router/navigationBridge";
 import { track } from "../../../shell/analytics";
 import { useFeatureFlag } from "../../feature-flags/useFeatureFlag";
 
@@ -39,12 +37,6 @@ export function useTaskAnalysis(task: Task): TaskAnalysisControls {
           run_id: runId ?? "",
           created: result.created,
         });
-        toast.success(
-          result.created
-            ? "Analyzing this run. The report will appear on the analysis task."
-            : "An analysis for this run already exists. Opening it.",
-        );
-        navigateToTaskDetail(result.analysis_task_id);
       },
       onError: (error) => {
         toastError("Could not analyze this run", error);

--- a/products/tasks/backend/logic/services/task_analysis.py
+++ b/products/tasks/backend/logic/services/task_analysis.py
@@ -268,6 +268,10 @@ def create_task_analysis(*, team: Team, user_id: int, target_task: Task, target_
                 pending_user_message=prompt,
                 extra_run_state=extra_run_state,
                 inactivity_timeout_seconds=TASK_ANALYSIS_INACTIVITY_TIMEOUT_SECONDS,
+                # The analysis runs fully in the background: the internal flag keeps it out of
+                # the default task list, search, and agent task tools while direct access by
+                # id still works.
+                internal=True,
             )
     except IntegrityError:
         claimed = find_existing_analysis_task(team_id=team.id, target_run_id=str(target_run.id))

--- a/products/tasks/backend/logic/services/task_analysis.py
+++ b/products/tasks/backend/logic/services/task_analysis.py
@@ -268,9 +268,6 @@ def create_task_analysis(*, team: Team, user_id: int, target_task: Task, target_
                 pending_user_message=prompt,
                 extra_run_state=extra_run_state,
                 inactivity_timeout_seconds=TASK_ANALYSIS_INACTIVITY_TIMEOUT_SECONDS,
-                # The analysis runs fully in the background: the internal flag keeps it out of
-                # the default task list, search, and agent task tools while direct access by
-                # id still works.
                 internal=True,
             )
     except IntegrityError:

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -14160,6 +14160,7 @@ class TestTaskRunAnalyzeAPI(BaseTaskAPITest):
         self.assertTrue(body["created"])
         analysis_task = Task.objects.get(id=body["analysis_task_id"])
         self.assertEqual(analysis_task.origin_product, Task.OriginProduct.TASK_ANALYSIS)
+        self.assertTrue(analysis_task.internal)
         self.assertIn("analyzing-task-runs", analysis_task.description)
         run = analysis_task.latest_run
         assert run is not None


### PR DESCRIPTION
## Problem

When a person runs "Run analysis" on a task, the desktop app shows two success toasts and opens the analysis task in the editor. The analysis task also appears in the task list, so a background job shows up as a task row of its own. Nothing about the analysis should be visible: it should start and stay in the background.

## Changes

- Running an analysis now shows nothing on success. The success toasts and the jump to the analysis task are gone; the button's loading state and error toasts stay.
- Analysis tasks no longer appear in the default task list, task search, or the agent task tools. They are created with the internal flag, which hides them from those surfaces while direct access by id still works.

The desktop change is user-visible; the flag on task creation is the mechanical half.

## How did you test this code?

- Extended `test_analyze_creates_posthog_funded_analysis_task` to assert the analysis task carries the internal flag. It catches a revert that puts analysis tasks back in the default task list.
- Ran the analyze endpoint tests (`-k analyze`, 24 passed) and the desktop `ChannelItemRow` / `TaskHeaderActions` tests (48 passed). The typecheck for the desktop UI package passes.
- Not run: the full backend suite, and no manual run against a booted desktop app.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by an agent (Claude Code) in a PostHog Desktop cloud task; directed by the user's request in the desktop-cost-management channel.
- Skills invoked: /writing-tests, /writing-pr-descriptions.
- Decision: the internal flag is the same mechanism loop runs use to stay out of the default list; a filter in the desktop list queries was rejected because it would miss server surfaces (search, agent tools).
- No duplicate found: an open-PR search for run analysis background changes found nothing.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
