### PR TITLE
fix(whop): stop retrying a request Whop rejects as invalid

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/whop/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/whop/source.py
@@ -145,6 +145,15 @@ class WhopSource(
                 "Your Whop API key does not have permission to read this resource. Grant the missing read "
                 "permission in your Whop dashboard and reconnect."
             ),
+            # Whop answers `code=bad_request` when it refuses the list query this source builds for a
+            # table. The query is derived from the endpoint catalog and the connected company, so every
+            # run reissues the identical request and re-fails. Whop reports a missing permission as 403
+            # and an overload as 429/5xx, so a 400 is never a transient blip. Without this the schema
+            # keeps its schedule and burns a job on every run while showing the raw HTTP error.
+            "400 Client Error: Bad Request for url: https://api.whop.com": (
+                "Whop rejected the request for this table, so it can't sync. Turn off syncing for this "
+                "table, then re-enable the sync."
+            ),
         }
 
     def get_canonical_descriptions(self) -> CanonicalDescriptions:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/whop/tests/test_whop_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/whop/tests/test_whop_source.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 from posthog.schema import ReleaseStatus
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import error_message_matches
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.whop import WhopSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.whop.settings import (
     ALL_WEBHOOK_EVENTS,
@@ -47,6 +48,21 @@ class TestWhopSource:
         # Endpoints paged newest-first re-yield watermark boundary rows, which append would
         # duplicate; only a merge on `id` dedupes them.
         assert schema.supports_append is (endpoint in INCREMENTAL_ENDPOINTS and endpoint not in MERGE_ONLY_ENDPOINTS)
+
+    @pytest.mark.parametrize(
+        "observed_error,non_retryable",
+        [
+            (
+                "400 Client Error: Bad Request for url: https://api.whop.com/api/v1/payments"
+                "?first=100&company_id=biz_example | api error: code=bad_request",
+                True,
+            ),
+            ("429 Client Error: Too Many Requests for url: https://api.whop.com/api/v1/payments", False),
+            ("503 Server Error: Service Unavailable for url: https://api.whop.com/api/v1/payments", False),
+        ],
+    )
+    def test_a_rejected_request_stops_the_sync_and_an_overload_does_not(self, observed_error, non_retryable):
+        assert error_message_matches(observed_error, self.source.get_non_retryable_errors()) is non_retryable
 
     def test_canonical_descriptions_only_describe_real_schemas(self):
         # A key that doesn't match a schema name is silently ignored, so the descriptions would


### PR DESCRIPTION
## Problem

A customer syncing a Whop table that Whop rejects sees a bare HTTP status and the full request URL in the sync error panel, with no next step.

- The list query is rebuilt from the endpoint catalog and the connected company, so every scheduled run reissues the identical request and fails the same way.
- Nothing pauses the table, so the source keeps burning a job on each run and the error rate stays inflated.
- The source already maps a rejected API key and a missing read permission to a friendly message. A rejected request has no mapping.

## Changes

- The sync error panel now says Whop rejected the request for the table, and to turn syncing off for that table then re-enable the sync.
- A rejected request now pauses the schema instead of retrying on the next schedule.
- The mapping is scoped to the Whop host, so a rate limit or a Whop outage still retries.
- Mechanical: one parameterized case set in the existing Whop source tests.

The alternative was to keep the failure retryable and only rewrite the stored message. That leaves the schema failing forever on a request that can never succeed, which is what makes this class large in the first place.

## How did you test this code?

- Added three cases to `test_whop_source.py`. They catch a rescope of the new key that would let a rejected request retry again, and a key broad enough to swallow a rate limit or a Whop outage. No existing test covered Whop error classification.
- Ran the Whop source test file locally with pytest.
- Not run: the wider data imports suites and any live Whop call. No manual verification against Whop's API was possible from this sandbox.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing setup step or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Written by Claude Code while triaging the previous day's data warehouse sync failure classes.
- Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- No duplicate: `gh pr list --state open --search "whop"` returned nothing, and the maintainer's open PRs hold no Whop change. PR #87534 applies the same shape to a different source, which is where the approach comes from.
- Public artifact: the diff carries no material from the agent session. The company id in the test string is invented, and no customer error text was copied into the code, the tests, or this description.
- Whop's own reason for rejecting the request is not knowable from our side, so the message points at the only action a customer can take. The full error still reaches error tracking for debugging.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
