### PR TITLE
chore(readme): point the contributors badge at the GitHub contributors graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img alt="posthoglogo" src="https://user-images.githubusercontent.com/65415371/205059737-c8a4f836-4889-4654-902e-f302b187b6a0.png">
 </p>
 <p align="center">
-  <a href='https://posthog.com/contributors'><img alt="GitHub contributors" src="https://img.shields.io/github/contributors/posthog/posthog"/></a>
+  <a href='https://github.com/PostHog/posthog/graphs/contributors'><img alt="GitHub contributors" src="https://img.shields.io/github/contributors/posthog/posthog"/></a>
   <a href='http://makeapullrequest.com'><img alt='PRs Welcome' src='https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=shields'/></a>
   <img alt="Docker Pulls" src="https://img.shields.io/docker/pulls/posthog/posthog"/>
   <a href="https://github.com/PostHog/posthog/commits/master"><img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/posthog/posthog"/> </a>


### PR DESCRIPTION
## Problem

- Anyone who clicks the "GitHub contributors" badge at the top of the README lands on a 404 at posthog.com/contributors.
- That page was fed by the retired [contributions-bot](https://github.com/PostHog/contributions-bot) and no longer exists.

## Changes

- The badge now links to the GitHub contributors graph, which is the same count the badge already shows.
- No code changes, README only.

## How did you test this code?

- `curl -sL -o /dev/null -w "%{http_code}" https://posthog.com/contributors` returns 404.
- The new target, https://github.com/PostHog/posthog/graphs/contributors, returns 200.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

Authored with Claude Code while investigating a support ticket about missing contributor merch codes. Companion docs change: PostHog/posthog.com#19992. Skills invoked: `writing-pr-descriptions`.
