### PR TITLE
feat(usage-ingestion): route event usage through kafka

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -115,7 +115,7 @@ procs:
 
     ingestion:
         sandbox: true
-        shell: 'bin/wait-for-docker objectstorage && USAGE_INGESTION_REPORT_TEAMS="${USAGE_INGESTION_REPORT_TEAMS:-*}" PLUGIN_SERVER_MODE=ingestion-v2-combined HTTP_SERVER_PORT=6739 ./bin/posthog-node'
+        shell: 'bin/wait-for-docker objectstorage && USAGE_INGESTION_MODE="${USAGE_INGESTION_MODE:-kafka}" USAGE_INGESTION_REPORT_TEAMS="${USAGE_INGESTION_REPORT_TEAMS:-*}" PLUGIN_SERVER_MODE=ingestion-v2-combined HTTP_SERVER_PORT=6739 ./bin/posthog-node'
         capability: event_ingestion
         ready_pattern: 'All systems go'
         groups:

--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -137,9 +137,10 @@ export type CommonConfig = BaseServerConfig & {
     PERSONHOG_IDLE_CONNECTION_TIMEOUT_MS: number
     PERSONHOG_STATE_MONITOR_POLL_INTERVAL_MS: number
 
-    // Usage ingestion gRPC. One team list per deployment, because each reporting site is its
+    // Usage ingestion. One team list per deployment, because each reporting site is its
     // own service: '' reports nothing, '*' every team, '1,2' those teams. No percentage: it
     // would bill a fraction of a team.
+    USAGE_INGESTION_MODE: 'grpc' | 'kafka'
     USAGE_INGESTION_ADDR: string
     USAGE_INGESTION_TLS: boolean
     USAGE_INGESTION_TIMEOUT_MS: number
@@ -333,7 +334,8 @@ export function getDefaultCommonConfig(): CommonConfig {
         PERSONHOG_IDLE_CONNECTION_TIMEOUT_MS: 15 * 60 * 1000,
         PERSONHOG_STATE_MONITOR_POLL_INTERVAL_MS: 5_000,
 
-        // Usage ingestion gRPC
+        // Usage ingestion
+        USAGE_INGESTION_MODE: 'grpc',
         USAGE_INGESTION_ADDR: isDevEnv() ? 'localhost:7143' : '',
         USAGE_INGESTION_TLS: false,
         USAGE_INGESTION_TIMEOUT_MS: 5_000,

--- a/nodejs/src/common/config/kafka-topics.ts
+++ b/nodejs/src/common/config/kafka-topics.ts
@@ -19,6 +19,7 @@ export const KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW = `${prefix}events_plugin_in
 export const KAFKA_EVENTS_PLUGIN_INGESTION_AI = `${prefix}events_plugin_ingestion_ai${suffix}`
 export const KAFKA_EVENTS_PLUGIN_INGESTION_ASYNC = `${prefix}events_plugin_ingestion_async${suffix}`
 export const KAFKA_EVENTS_PLUGIN_INGESTION_HISTORICAL = `${prefix}events_plugin_ingestion_historical${suffix}`
+export const KAFKA_USAGE_INGESTION = `${prefix}usage_ingestion${suffix}`
 export const KAFKA_PLUGIN_LOG_ENTRIES = `${prefix}plugin_log_entries${suffix}`
 export const KAFKA_EVENTS_DEAD_LETTER_QUEUE = `${prefix}events_dead_letter_queue${suffix}`
 export const KAFKA_GROUPS = `${prefix}clickhouse_groups${suffix}`

--- a/nodejs/src/common/outputs/index.ts
+++ b/nodejs/src/common/outputs/index.ts
@@ -35,6 +35,9 @@ export type LogEntriesOutput = typeof LOG_ENTRIES_OUTPUT
 export const TOPHOG_OUTPUT = 'tophog' as const
 export type TophogOutput = typeof TOPHOG_OUTPUT
 
+export const USAGE_INGESTION_OUTPUT = 'usage_ingestion' as const
+export type UsageIngestionOutput = typeof USAGE_INGESTION_OUTPUT
+
 export const HOG_INVOCATION_RESULTS_OUTPUT = 'hog_invocation_results' as const
 export type HogInvocationResultsOutput = typeof HOG_INVOCATION_RESULTS_OUTPUT
 

--- a/nodejs/src/common/usage-ingestion/client.test.ts
+++ b/nodejs/src/common/usage-ingestion/client.test.ts
@@ -1,5 +1,11 @@
+import { fromBinary } from '@bufbuild/protobuf'
 import { Code, ConnectError } from '@connectrpc/connect'
 import { register } from 'prom-client'
+
+import { IngestBillingUsageRequestSchema } from '~/common/generated/usage-ingestion/usage_ingestion/v1/service_pb'
+import { USAGE_INGESTION_OUTPUT, UsageIngestionOutput } from '~/common/outputs'
+import { IngestionOutput } from '~/common/outputs/ingestion-output'
+import { IngestionOutputs } from '~/common/outputs/ingestion-outputs'
 
 import { UsageIngestionClient, UsageRecordInput } from './client'
 
@@ -77,6 +83,31 @@ describe('UsageIngestionClient', () => {
         await client.ingest([record(7)])
 
         expect(headers).toEqual([{ 'x-client-name': 'cdp' }])
+    })
+
+    it('queues protobuf requests through the usage ingestion output in Kafka mode', async () => {
+        const queueMessages = jest.fn().mockResolvedValue(undefined)
+        const output: IngestionOutput = {
+            produce: jest.fn(),
+            queueMessages,
+            checkHealth: jest.fn(),
+            checkTopicExists: jest.fn(),
+        }
+        const outputs = new IngestionOutputs<UsageIngestionOutput>({ [USAGE_INGESTION_OUTPUT]: output })
+        client = new UsageIngestionClient({ transport: 'kafka', outputs, producerId: 'ingestion' })
+
+        await client.ingest([record(7)])
+
+        expect(queueMessages).toHaveBeenCalledWith([{ value: expect.any(Buffer) }])
+        const payload = queueMessages.mock.calls[0][0][0].value as Buffer
+        expect(fromBinary(IngestBillingUsageRequestSchema, payload).records).toEqual([
+            expect.objectContaining({
+                recordId: 'record-7',
+                producerId: 'ingestion',
+                teamId: 7n,
+                quantity: 1n,
+            }),
+        ])
     })
 
     // A retryable code gets the whole budget before the chunk is written off, and a code the

--- a/nodejs/src/common/usage-ingestion/client.ts
+++ b/nodejs/src/common/usage-ingestion/client.ts
@@ -1,4 +1,4 @@
-import { create } from '@bufbuild/protobuf'
+import { create, toBinary } from '@bufbuild/protobuf'
 import { Client, Code, ConnectError, createClient } from '@connectrpc/connect'
 import { createGrpcTransport } from '@connectrpc/connect-node'
 import { Counter } from 'prom-client'
@@ -8,6 +8,8 @@ import {
     IngestBillingUsageRequestSchema,
     UsageIngestion,
 } from '~/common/generated/usage-ingestion/usage_ingestion/v1/service_pb'
+import { USAGE_INGESTION_OUTPUT, UsageIngestionOutput } from '~/common/outputs'
+import { IngestionOutputs } from '~/common/outputs/ingestion-outputs'
 import { logger } from '~/common/utils/logger'
 import { delay } from '~/common/utils/utils'
 
@@ -72,28 +74,36 @@ export interface UsageRecordInput {
     timestampMs: number
 }
 
-export interface UsageIngestionClientConfig {
-    addr: string
+interface UsageIngestionClientBaseConfig {
     producerId: string
-    timeoutMs?: number
     maxBatchSize?: number
-    useTls?: boolean
 }
 
+export type UsageIngestionClientConfig = UsageIngestionClientBaseConfig &
+    (
+        | { transport?: 'grpc'; addr: string; timeoutMs?: number; useTls?: boolean }
+        | { transport: 'kafka'; outputs: IngestionOutputs<UsageIngestionOutput> }
+    )
+
 export class UsageIngestionClient {
-    private readonly client: Client<typeof UsageIngestion>
+    private readonly client?: Client<typeof UsageIngestion>
+    private readonly outputs?: IngestionOutputs<UsageIngestionOutput>
     private readonly producerId: string
     private readonly maxBatchSize: number
 
     constructor(config: UsageIngestionClientConfig) {
-        const scheme = config.useTls ? 'https' : 'http'
-        this.client = createClient(
-            UsageIngestion,
-            createGrpcTransport({
-                baseUrl: `${scheme}://${config.addr}`,
-                defaultTimeoutMs: config.timeoutMs ?? 5_000,
-            })
-        )
+        if (config.transport === 'kafka') {
+            this.outputs = config.outputs
+        } else {
+            const scheme = config.useTls ? 'https' : 'http'
+            this.client = createClient(
+                UsageIngestion,
+                createGrpcTransport({
+                    baseUrl: `${scheme}://${config.addr}`,
+                    defaultTimeoutMs: config.timeoutMs ?? 5_000,
+                })
+            )
+        }
         this.producerId = config.producerId
         this.maxBatchSize = config.maxBatchSize ?? 500
     }
@@ -124,10 +134,35 @@ export class UsageIngestionClient {
             ),
         })
 
+        if (this.outputs) {
+            try {
+                await this.outputs.queueMessages(USAGE_INGESTION_OUTPUT, [
+                    { value: Buffer.from(toBinary(IngestBillingUsageRequestSchema, request)) },
+                ])
+                for (const record of chunk) {
+                    usageRecordsSentCounter.inc({ producer_id: this.producerId, usage_key: record.usageKey })
+                }
+            } catch (error) {
+                for (const record of chunk) {
+                    usageRecordsFailedCounter.inc({
+                        producer_id: this.producerId,
+                        usage_key: record.usageKey,
+                        error_code: 'kafka',
+                    })
+                }
+                logger.warn('⚠️', 'failed to queue usage records', {
+                    producerId: this.producerId,
+                    records: chunk.length,
+                    error: String(error),
+                })
+            }
+            return
+        }
+
         try {
             // The header names this producer in the service's own request metrics, which
             // otherwise aggregate every caller into one series.
-            const response = await this.client.ingestBillingUsage(request, {
+            const response = await this.client!.ingestBillingUsage(request, {
                 headers: { 'x-client-name': this.producerId },
             })
             const rejected = rejectedRecords(chunk, response.acceptedRecordIds)

--- a/nodejs/src/common/usage-ingestion/index.test.ts
+++ b/nodejs/src/common/usage-ingestion/index.test.ts
@@ -1,7 +1,20 @@
+import { USAGE_INGESTION_OUTPUT, UsageIngestionOutput } from '~/common/outputs'
+import { IngestionOutput } from '~/common/outputs/ingestion-output'
+import { IngestionOutputs } from '~/common/outputs/ingestion-outputs'
+
 import { createEventUsageBatchFactory } from './index'
 
 describe('createEventUsageBatchFactory', () => {
+    const outputs = new IngestionOutputs<UsageIngestionOutput>({
+        [USAGE_INGESTION_OUTPUT]: {
+            produce: jest.fn(),
+            queueMessages: jest.fn(),
+            checkHealth: jest.fn(),
+            checkTopicExists: jest.fn(),
+        } satisfies IngestionOutput,
+    })
     const config = {
+        USAGE_INGESTION_MODE: 'grpc' as const,
         USAGE_INGESTION_ADDR: 'localhost:7143',
         USAGE_INGESTION_TLS: false,
         USAGE_INGESTION_TIMEOUT_MS: 5_000,
@@ -19,5 +32,25 @@ describe('createEventUsageBatchFactory', () => {
         ['bills nothing for a team outside the list', { ...config, USAGE_INGESTION_REPORT_TEAMS: '4' }, false],
     ])('%s', (_name, usageConfig, billed) => {
         expect(createEventUsageBatchFactory(usageConfig, 'events')().accepts(2)).toBe(billed)
+    })
+
+    it('uses Kafka without a gRPC address when an ingestion output is provided', () => {
+        const kafkaConfig = { ...config, USAGE_INGESTION_MODE: 'kafka' as const, USAGE_INGESTION_ADDR: '' }
+
+        expect(createEventUsageBatchFactory(kafkaConfig, 'events', outputs)().accepts(2)).toBe(true)
+    })
+
+    it('rejects Kafka mode without the usage ingestion output', () => {
+        const kafkaConfig = { ...config, USAGE_INGESTION_MODE: 'kafka' as const }
+
+        expect(() => createEventUsageBatchFactory(kafkaConfig, 'events')).toThrow(
+            'USAGE_INGESTION_MODE=kafka requires the usage ingestion Kafka output'
+        )
+    })
+
+    it('keeps non-event reporters on gRPC when event ingestion uses Kafka', () => {
+        const kafkaConfig = { ...config, USAGE_INGESTION_MODE: 'kafka' as const }
+
+        expect(createEventUsageBatchFactory(kafkaConfig, 'exceptions')().accepts(2)).toBe(true)
     })
 })

--- a/nodejs/src/common/usage-ingestion/index.ts
+++ b/nodejs/src/common/usage-ingestion/index.ts
@@ -1,5 +1,7 @@
 import { CommonConfig } from '~/common/config'
 import { buildIntegerMatcher } from '~/common/config/config'
+import { UsageIngestionOutput } from '~/common/outputs'
+import { IngestionOutputs } from '~/common/outputs/ingestion-outputs'
 import { ValueMatcher } from '~/types'
 
 import { UsageIngestionClient } from './client'
@@ -7,6 +9,7 @@ import { UsageRecordBatch } from './usage-record-batch'
 
 export type UsageIngestionConfig = Pick<
     CommonConfig,
+    | 'USAGE_INGESTION_MODE'
     | 'USAGE_INGESTION_ADDR'
     | 'USAGE_INGESTION_TLS'
     | 'USAGE_INGESTION_TIMEOUT_MS'
@@ -43,9 +46,28 @@ export function usageReportTeamMatcher(config: UsageIngestionConfig): ValueMatch
 
 export function createUsageIngestionClient(
     config: UsageIngestionConfig,
-    site: UsageReportSite
+    site: UsageReportSite,
+    outputs?: IngestionOutputs<UsageIngestionOutput>
 ): UsageIngestionClient | null {
-    if (!config.USAGE_INGESTION_ADDR || !config.USAGE_INGESTION_REPORT_TEAMS) {
+    if (!config.USAGE_INGESTION_REPORT_TEAMS) {
+        return null
+    }
+    const eventPipelineSite = site === 'events' || site === 'ai_events'
+    if (config.USAGE_INGESTION_MODE === 'kafka' && eventPipelineSite) {
+        if (!outputs) {
+            throw new Error('USAGE_INGESTION_MODE=kafka requires the usage ingestion Kafka output')
+        }
+        return new UsageIngestionClient({
+            transport: 'kafka',
+            outputs,
+            producerId: PRODUCER_IDS[site],
+            maxBatchSize: config.USAGE_INGESTION_MAX_BATCH_SIZE,
+        })
+    }
+    if (config.USAGE_INGESTION_MODE !== 'grpc' && config.USAGE_INGESTION_MODE !== 'kafka') {
+        throw new Error(`Unknown USAGE_INGESTION_MODE: ${String(config.USAGE_INGESTION_MODE)}`)
+    }
+    if (!config.USAGE_INGESTION_ADDR) {
         return null
     }
     return new UsageIngestionClient({
@@ -68,9 +90,10 @@ export function createUsageIngestionClient(
  */
 export function createEventUsageBatchFactory(
     config: UsageIngestionConfig,
-    site: UsageReportSite
+    site: UsageReportSite,
+    outputs?: IngestionOutputs<UsageIngestionOutput>
 ): () => UsageRecordBatch {
-    const client = createUsageIngestionClient(config, site)
+    const client = createUsageIngestionClient(config, site, outputs)
     const isTeamEnabled = usageReportTeamMatcher(config)
     return () => new UsageRecordBatch(client, { unit: 'events', isTeamEnabled })
 }

--- a/nodejs/src/ingestion/config.ts
+++ b/nodejs/src/ingestion/config.ts
@@ -14,6 +14,7 @@ import {
     KAFKA_LOG_ENTRIES,
     KAFKA_PERSON,
     KAFKA_PERSON_DISTINCT_ID,
+    KAFKA_USAGE_INGESTION,
 } from '~/common/config/kafka-topics'
 import type { PostgresRouterConfig } from '~/common/utils/db/postgres'
 import { isDevEnv, isProdEnv } from '~/common/utils/env-utils'
@@ -521,6 +522,9 @@ export type IngestionOutputsConfig = {
 
     INGESTION_OUTPUT_TOPHOG_TOPIC: string
     INGESTION_OUTPUT_TOPHOG_PRODUCER: ProducerName
+
+    INGESTION_OUTPUT_USAGE_INGESTION_TOPIC: string
+    INGESTION_OUTPUT_USAGE_INGESTION_PRODUCER: ProducerName
 }
 
 export function getDefaultIngestionOutputsConfig(): IngestionOutputsConfig {
@@ -562,5 +566,7 @@ export function getDefaultIngestionOutputsConfig(): IngestionOutputsConfig {
         INGESTION_OUTPUT_LOG_ENTRIES_PRODUCER: INGESTION_DOWNSTREAM_PRODUCER,
         INGESTION_OUTPUT_TOPHOG_TOPIC: KAFKA_CLICKHOUSE_TOPHOG,
         INGESTION_OUTPUT_TOPHOG_PRODUCER: INGESTION_DOWNSTREAM_PRODUCER,
+        INGESTION_OUTPUT_USAGE_INGESTION_TOPIC: KAFKA_USAGE_INGESTION,
+        INGESTION_OUTPUT_USAGE_INGESTION_PRODUCER: INGESTION_DOWNSTREAM_PRODUCER,
     }
 }

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -14,6 +14,7 @@ import {
     IngestionWarningsOutput,
     OverflowOutput,
     TophogOutput,
+    UsageIngestionOutput,
 } from '~/common/outputs'
 import {
     AsyncOutput,
@@ -98,6 +99,7 @@ export interface IngestionConsumerDeps {
         | PersonMergeEventsOutput
         | AppMetricsOutput
         | TophogOutput
+        | UsageIngestionOutput
     >
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager
@@ -316,7 +318,7 @@ export class IngestionConsumer {
                 EXPERIMENT_EXPOSURE_DUPLICATION_TEAMS: this.config.EXPERIMENT_EXPOSURE_DUPLICATION_TEAMS,
             },
             concurrentBatches: this.config.INGESTION_WORKER_CONCURRENT_BATCHES,
-            createEventUsageBatch: createEventUsageBatchFactory(this.config, 'events'),
+            createEventUsageBatch: createEventUsageBatchFactory(this.config, 'events', outputs),
         }
         const joinedPipelineDeps: JoinedIngestionPipelineDeps = {
             personsStore: this.personsStore,

--- a/nodejs/src/ingestion/pipelines/ai/consumer.test.ts
+++ b/nodejs/src/ingestion/pipelines/ai/consumer.test.ts
@@ -30,6 +30,7 @@ describe('createAiConsumer', () => {
             SKIP_PERSONS_PROCESSING_BY_TOKEN_DISTINCT_ID: '',
             INGESTION_FORCE_OVERFLOW_BY_TOKEN_DISTINCT_ID: '',
             EVENT_SCHEMA_ENFORCEMENT_ENABLED: false,
+            USAGE_INGESTION_MODE: 'grpc',
             USAGE_INGESTION_ADDR: '',
             USAGE_INGESTION_TLS: false,
             USAGE_INGESTION_TIMEOUT_MS: 5000,

--- a/nodejs/src/ingestion/pipelines/ai/consumer.ts
+++ b/nodejs/src/ingestion/pipelines/ai/consumer.ts
@@ -9,6 +9,7 @@ import {
     IngestionWarningsOutput,
     OverflowOutput,
     TophogOutput,
+    UsageIngestionOutput,
 } from '~/common/outputs'
 import { IngestionOutputs } from '~/common/outputs/ingestion-outputs'
 import { KafkaProducerRegistry } from '~/common/outputs/kafka-producer-registry'
@@ -74,7 +75,14 @@ export type AiConsumerConfig = CommonIngestionConsumerConfig &
 /** Outputs the AI pipeline emits to. The same instance backs the hog transformer's
  * monitoring (app_metrics + log_entries), wired up server-side. */
 export type AiOutputs = IngestionOutputs<
-    EventOutput | AiEventOutput | IngestionWarningsOutput | DlqOutput | OverflowOutput | AppMetricsOutput | TophogOutput
+    | EventOutput
+    | AiEventOutput
+    | IngestionWarningsOutput
+    | DlqOutput
+    | OverflowOutput
+    | AppMetricsOutput
+    | TophogOutput
+    | UsageIngestionOutput
 >
 
 /**
@@ -170,8 +178,6 @@ export function createAiConsumer(config: AiConsumerConfig, sharedScope: AiShared
             `AI_BLOB_OFFLOAD_UPLOAD_MAX_CONCURRENCY must be a positive integer, got ${uploadMaxConcurrency}`
         )
     }
-    const createEventUsageBatch = createEventUsageBatchFactory(config, 'ai_events')
-
     const aiBlobOffloadConfig = {
         isTeamEnabled: buildIntegerMatcher(config.AI_BLOB_OFFLOAD_TEAMS, true),
         minBase64Length: config.AI_BLOB_OFFLOAD_MIN_BASE64_LENGTH,
@@ -207,7 +213,7 @@ export function createAiConsumer(config: AiConsumerConfig, sharedScope: AiShared
             topHog: container.topHog,
             aiBlobStore: container.aiBlobStore.store,
             aiBlobOffloadConfig,
-            createEventUsageBatch,
+            createEventUsageBatch: createEventUsageBatchFactory(config, 'ai_events', container.outputs),
         })
     )
 }

--- a/nodejs/src/ingestion/pipelines/ai/outputs/registry.ts
+++ b/nodejs/src/ingestion/pipelines/ai/outputs/registry.ts
@@ -7,6 +7,7 @@ import {
     LOG_ENTRIES_OUTPUT,
     OVERFLOW_OUTPUT,
     TOPHOG_OUTPUT,
+    USAGE_INGESTION_OUTPUT,
 } from '~/common/outputs'
 import { IngestionOutputsBuilder } from '~/common/outputs/ingestion-outputs-builder'
 
@@ -52,5 +53,9 @@ export function createOutputsRegistry() {
         .register(TOPHOG_OUTPUT, {
             topicKey: 'INGESTION_OUTPUT_TOPHOG_TOPIC',
             producerKey: 'INGESTION_OUTPUT_TOPHOG_PRODUCER',
+        })
+        .register(USAGE_INGESTION_OUTPUT, {
+            topicKey: 'INGESTION_OUTPUT_USAGE_INGESTION_TOPIC',
+            producerKey: 'INGESTION_OUTPUT_USAGE_INGESTION_PRODUCER',
         })
 }

--- a/nodejs/src/ingestion/pipelines/analytics/outputs/registry.ts
+++ b/nodejs/src/ingestion/pipelines/analytics/outputs/registry.ts
@@ -15,6 +15,7 @@ import {
     LOG_ENTRIES_OUTPUT,
     OVERFLOW_OUTPUT,
     TOPHOG_OUTPUT,
+    USAGE_INGESTION_OUTPUT,
 } from '~/common/outputs'
 import { IngestionOutputsBuilder } from '~/common/outputs/ingestion-outputs-builder'
 
@@ -74,6 +75,10 @@ export function createOutputsRegistry() {
             .register(TOPHOG_OUTPUT, {
                 topicKey: 'INGESTION_OUTPUT_TOPHOG_TOPIC',
                 producerKey: 'INGESTION_OUTPUT_TOPHOG_PRODUCER',
+            })
+            .register(USAGE_INGESTION_OUTPUT, {
+                topicKey: 'INGESTION_OUTPUT_USAGE_INGESTION_TOPIC',
+                producerKey: 'INGESTION_OUTPUT_USAGE_INGESTION_PRODUCER',
             })
     )
 }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/consumer.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/consumer.test.ts
@@ -84,6 +84,7 @@ describe('SessionRecordingIngester', () => {
             // reach unless a test opts in via overrides.
             SESSION_RECORDING_MAX_BATCH_AGE_MS: 60 * 60 * 1000,
             SESSION_RECORDING_MAX_BATCH_SIZE_KB: 1024 * 1024,
+            USAGE_INGESTION_MODE: 'grpc',
             USAGE_INGESTION_ADDR: '',
             USAGE_INGESTION_TLS: false,
             USAGE_INGESTION_TIMEOUT_MS: 5000,

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -423,7 +423,7 @@ export class IngestionApiServer implements NodeServer {
                 EXPERIMENT_EXPOSURE_DUPLICATION_TEAMS: this.config.EXPERIMENT_EXPOSURE_DUPLICATION_TEAMS,
             },
             concurrentBatches: this.config.INGESTION_WORKER_CONCURRENT_BATCHES,
-            createEventUsageBatch: createEventUsageBatchFactory(this.config, 'events'),
+            createEventUsageBatch: createEventUsageBatchFactory(this.config, 'events', ingestionOutputs),
         }
         const eventFilterManagerStarted = await new EventFilterManagerComponent(this.postgres).start()
         const featureFlagCalledDedupService = createFeatureFlagCalledDedupService(

--- a/nodejs/tests/helpers/ingestion-outputs.ts
+++ b/nodejs/tests/helpers/ingestion-outputs.ts
@@ -14,6 +14,7 @@ import {
     KAFKA_PERSON,
     KAFKA_PERSON_DISTINCT_ID,
     KAFKA_PERSON_MERGE_EVENTS,
+    KAFKA_USAGE_INGESTION,
 } from '~/common/config/kafka-topics'
 import { KafkaProducerWrapper } from '~/common/kafka/producer'
 import {
@@ -24,6 +25,7 @@ import {
     LOG_ENTRIES_OUTPUT,
     OVERFLOW_OUTPUT,
     TOPHOG_OUTPUT,
+    USAGE_INGESTION_OUTPUT,
 } from '~/common/outputs'
 import {
     AI_EVENTS_OUTPUT,
@@ -70,5 +72,6 @@ export function createTestIngestionOutputs(kafkaProducer: KafkaProducerWrapper) 
         [APP_METRICS_OUTPUT]: testOutput(APP_METRICS_OUTPUT, KAFKA_APP_METRICS_2, kafkaProducer),
         [LOG_ENTRIES_OUTPUT]: testOutput(LOG_ENTRIES_OUTPUT, KAFKA_LOG_ENTRIES, kafkaProducer),
         [TOPHOG_OUTPUT]: testOutput(TOPHOG_OUTPUT, KAFKA_CLICKHOUSE_TOPHOG, kafkaProducer),
+        [USAGE_INGESTION_OUTPUT]: testOutput(USAGE_INGESTION_OUTPUT, KAFKA_USAGE_INGESTION, kafkaProducer),
     })
 }

--- a/nodejs/tests/helpers/kafka.ts
+++ b/nodejs/tests/helpers/kafka.ts
@@ -32,6 +32,7 @@ import {
     KAFKA_PERSON_UNIQUE_ID,
     KAFKA_PLUGIN_LOG_ENTRIES,
     KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS,
+    KAFKA_USAGE_INGESTION,
 } from '~/common/config/kafka-topics'
 
 import { PluginsServerConfig } from '../../src/types'
@@ -103,6 +104,7 @@ export const TEST_KAFKA_TOPICS = [
     KAFKA_COHORT_MEMBERSHIP_CHANGED,
     KAFKA_PERSON_MERGE_EVENTS,
     KAFKA_CLICKHOUSE_TOPHOG,
+    KAFKA_USAGE_INGESTION,
 ]
 
 // Builds a unique topic name for a test so each test can produce to and consume from an

--- a/rust/usage-ingestion/README.md
+++ b/rust/usage-ingestion/README.md
@@ -63,9 +63,11 @@ The consumer defaults follow [WarpStream's librdkafka recommendations](https://d
 The 10-second fetch wait only bounds idle long polls because `fetch.min.bytes`
 keeps librdkafka's low-latency default of 1.
 
-Local `hogli` starts the service with both transports and pre-creates the
-`usage_ingestion` input topic, so a Kafka producer can be pointed at it
-without extra setup.
+Analytics event ingestion uses the same `USAGE_INGESTION_MODE` setting. In
+Kafka mode it writes protobuf requests through the standard ingestion output
+registry to `INGESTION_OUTPUT_USAGE_INGESTION_TOPIC`. Local `hogli` event
+ingestion defaults to Kafka mode and starts both service transports; set
+`USAGE_INGESTION_MODE=grpc` to exercise the direct endpoint instead.
 
 When `DEBUG` is set, the service writes readable, colorized logs for local
 development. It uses structured JSON logs otherwise.


### PR DESCRIPTION
## Problem

Local developers and deployments cannot route event usage through Kafka, so the transport from [#95968](https://github.com/PostHog/posthog/pull/95968) is not usable end to end.

```mermaid
flowchart LR
    Event{{Event ingestion}} --> GRPC[gRPC client]
    GRPC --> Service[Usage ingestion service]
    Service --> Output[(ClickHouse output topic)]

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Event phYellow;
    class GRPC phRed;
    class Service phBlue;
    class Output phGray;
```

## Changes

- Event ingestion can now select Kafka or gRPC with `USAGE_INGESTION_MODE`; gRPC remains the production default.
- Kafka mode sends protobuf requests through the existing ingestion outputs and ingestion-cluster producer.
- Local `hogli` event ingestion now defaults to Kafka mode; set `USAGE_INGESTION_MODE=grpc` to exercise the direct endpoint.
- Node output registrations, test helpers, and the mprocs env wiring complete the mechanical part.
- No user-facing UI changes.

```mermaid
flowchart LR
    Event{{Event ingestion}} --> Mode{Transport mode}
    Mode -->|gRPC| GRPC[gRPC listener]
    Mode -->|Kafka| Producer[Ingestion outputs]
    Producer --> Topic[(Usage input topic)]
    Topic --> Consumer[Kafka consumer]
    GRPC --> Processing[Shared process and processing]
    Consumer --> Processing
    Processing --> Output[(ClickHouse output topic)]

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Event phYellow;
    class GRPC,Producer phRed;
    class Consumer,Processing phBlue;
    class Mode,Topic,Output phGray;
```

## How did you test this code?

- Focused Jest tests verify Kafka serialization, output routing, and transport configuration.
- `pnpm --filter=@posthog/nodejs typescript:check`
- `hogli ci:preflight --fix`
- Local-only verification used one process: gRPC listened while a Kafka capture added two ClickHouse rows.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The usage-ingestion README documents the producer-side transport selection.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex in Conductor authored this PR with the /stacking-prs, /writing-tests, /run-posthog, /running-ci-preflight, and /writing-pr-descriptions skills.

The implementation reused ingestion outputs instead of adding another Kafka producer. The duplicate search found no overlap; #95968 supplies the transport runtime.


No customer data or private operational material appears in the diff.

Claude Fable 5 (Conductor) rebased this layer onto the reviewed base and moved the mprocs env var and producer-selection docs here from #95968, where nothing read them yet.


