### PR TITLE
fix(ai-observability): repair lone surrogates in text representations

### DIFF
--- a/posthog/temporal/ai_observability/trace_summarization/fetch_and_format.py
+++ b/posthog/temporal/ai_observability/trace_summarization/fetch_and_format.py
@@ -29,6 +29,7 @@ from products.ai_observability.backend.text_repr.formatters import (
     FormatterOptions,
     format_trace_text_repr,
     llm_trace_to_formatter_format,
+    sanitize_surrogates,
 )
 
 logger = structlog.get_logger(__name__)
@@ -288,7 +289,9 @@ def _format_generation_text_repr(generation_data: dict, max_length: int | None =
             parts.extend(("--- Input ---", in_block, ""))
         if out_block:
             parts.extend(("--- Output ---", out_block))
-        return "\n".join(parts)
+        # This path builds its own text instead of going through the formatters, so it repairs
+        # surrogates itself -- including any the section truncation below splits apart.
+        return sanitize_surrogates("\n".join(parts))
 
     text_repr = assemble(input_block, output_block)
     if max_length is None or len(text_repr) <= max_length:

--- a/posthog/temporal/ai_observability/trace_summarization/fetch_and_format.py
+++ b/posthog/temporal/ai_observability/trace_summarization/fetch_and_format.py
@@ -280,8 +280,14 @@ def _format_generation_text_repr(generation_data: dict, max_length: int | None =
 
     header_parts.append("")
 
-    input_block = _render_generation_messages(generation_data.get("input"))
-    output_block = _render_generation_messages(generation_data.get("output"))
+    # This path builds its own text instead of going through the formatters, so it repairs
+    # surrogates itself. Repair before anything is measured: the repair can shorten a section, so
+    # measuring first would make the budget arithmetic below describe text that is never returned.
+    # Repairing first also means `_truncate_section` cannot split a pair, since a repaired
+    # character is a single code point that a slice cannot cut in half.
+    header_parts = [sanitize_surrogates(part) for part in header_parts]
+    input_block = sanitize_surrogates(_render_generation_messages(generation_data.get("input")))
+    output_block = sanitize_surrogates(_render_generation_messages(generation_data.get("output")))
 
     def assemble(in_block: str, out_block: str) -> str:
         parts = list(header_parts)
@@ -289,9 +295,7 @@ def _format_generation_text_repr(generation_data: dict, max_length: int | None =
             parts.extend(("--- Input ---", in_block, ""))
         if out_block:
             parts.extend(("--- Output ---", out_block))
-        # This path builds its own text instead of going through the formatters, so it repairs
-        # surrogates itself -- including any the section truncation below splits apart.
-        return sanitize_surrogates("\n".join(parts))
+        return "\n".join(parts)
 
     text_repr = assemble(input_block, output_block)
     if max_length is None or len(text_repr) <= max_length:

--- a/posthog/temporal/ai_observability/trace_summarization/tests/test_fetch_and_format.py
+++ b/posthog/temporal/ai_observability/trace_summarization/tests/test_fetch_and_format.py
@@ -80,6 +80,18 @@ class TestFormatGenerationTextRepr:
         assert "--- Output ---" in result
         assert "DISTINCTIVE_OUTPUT_MARKER" in result
 
+    def test_stays_within_budget_while_repairing_surrogates(self):
+        generation_data = {
+            "model": "gpt-4",
+            "input": "\ud83d\ude00" * 1000,
+            "output": "short",
+        }
+
+        result = _format_generation_text_repr(generation_data, max_length=200)
+
+        assert len(result) <= 200
+        assert result.encode("utf-8")
+
     def test_truncated_input_keeps_head_and_tail(self):
         generation_data = {
             "input": "SYSTEM_PROMPT_HEAD " + "x" * 5000 + " NEWEST_MESSAGE_TAIL",

--- a/products/ai_observability/backend/text_repr/formatters/__init__.py
+++ b/products/ai_observability/backend/text_repr/formatters/__init__.py
@@ -15,7 +15,7 @@ Main entry points:
 """
 
 from .event_formatter import format_event_text_repr, format_event_text_repr_from_ai_events_row
-from .message_formatter import FormatterOptions, add_line_numbers, reduce_by_uniform_sampling
+from .message_formatter import FormatterOptions, add_line_numbers, reduce_by_uniform_sampling, sanitize_surrogates
 from .trace_formatter import format_trace_text_repr, llm_trace_to_formatter_format
 
 __all__ = [
@@ -26,4 +26,5 @@ __all__ = [
     "format_trace_text_repr",
     "llm_trace_to_formatter_format",
     "reduce_by_uniform_sampling",
+    "sanitize_surrogates",
 ]

--- a/products/ai_observability/backend/text_repr/formatters/event_formatter.py
+++ b/products/ai_observability/backend/text_repr/formatters/event_formatter.py
@@ -12,7 +12,13 @@ from datetime import date, datetime
 from typing import Any
 
 from .constants import SEPARATOR
-from .message_formatter import FormatterOptions, add_line_numbers, format_input_messages, format_output_messages
+from .message_formatter import (
+    FormatterOptions,
+    add_line_numbers,
+    format_input_messages,
+    format_output_messages,
+    sanitize_surrogates,
+)
 from .tool_formatter import format_tools
 
 
@@ -236,16 +242,16 @@ def format_event_text_repr(event: dict[str, Any], options: FormatterOptions | No
         # Import here to avoid circular dependency
         from .span_formatter import format_span_text_repr
 
-        return format_span_text_repr(event, options)
+        formatted_text = format_span_text_repr(event, options)
+    elif event_type == "$ai_embedding":
+        formatted_text = format_embedding_text_repr(event, options)
+    elif event_type == "$ai_evaluation":
+        formatted_text = format_evaluation_text_repr(event, options)
+    else:
+        # Default to generation formatter for $ai_generation and other events
+        formatted_text = format_generation_text_repr(event, options)
 
-    if event_type == "$ai_embedding":
-        return format_embedding_text_repr(event, options)
-
-    if event_type == "$ai_evaluation":
-        return format_evaluation_text_repr(event, options)
-
-    # Default to generation formatter for $ai_generation and other events
-    return format_generation_text_repr(event, options)
+    return sanitize_surrogates(formatted_text)
 
 
 def _maybe_decode_json(value: Any) -> Any:

--- a/products/ai_observability/backend/text_repr/formatters/message_formatter.py
+++ b/products/ai_observability/backend/text_repr/formatters/message_formatter.py
@@ -6,6 +6,7 @@ and content blocks. Supports multiple provider formats (OpenAI, Anthropic, etc.)
 with truncation and interactive markers for frontend display.
 """
 
+import re
 import json
 import base64
 from typing import Any, TypedDict
@@ -155,6 +156,30 @@ def reduce_by_uniform_sampling(
         result = result[:max_length]
 
     return result, True
+
+
+# UTF-16 surrogate code points. A well-formed pair survives the round trip in
+# `sanitize_surrogates` and becomes the character it encodes; a lone one becomes U+FFFD.
+SURROGATE_REGEX = re.compile("[\ud800-\udfff]")
+
+
+def sanitize_surrogates(text: str) -> str:
+    """Make `text` encodable as UTF-8.
+
+    Trace content arrives as it was captured, and the truncation and sampling above cut on
+    character counts, so either source can leave an unpaired surrogate -- half of an emoji -- in
+    the result. UTF-8 cannot represent one, so `str.encode("utf-8")` raises and the whole text
+    representation is lost: the Redis write in the batch summarization path and the request body of
+    the summarization LLM call both fail that way. Repair at the formatter exits, so every consumer
+    of a text representation gets the same encodable string.
+
+    Unlike `safe_clickhouse_string`, this does not escape the surrogate into literal `\\ud83c`
+    text. Escaping is right where the bytes must round-trip, but a text representation is read as
+    prose by a model, so a replacement character is the better loss.
+    """
+    if not SURROGATE_REGEX.search(text):
+        return text
+    return text.encode("utf-16", "surrogatepass").decode("utf-16", "replace")
 
 
 def truncate_content(content: str, options: FormatterOptions | None = None) -> tuple[list[str], bool]:

--- a/products/ai_observability/backend/text_repr/formatters/test/test_message_formatter.py
+++ b/products/ai_observability/backend/text_repr/formatters/test/test_message_formatter.py
@@ -4,6 +4,8 @@ Tests for message_formatter.py - message input/output formatting logic.
 Tests cover multiple LLM provider formats, tool calls, truncation, and edge cases.
 """
 
+import pytest
+
 from parameterized import parameterized
 
 from ..constants import MISSING_REASONING_NOTE, MISSING_TOOL_OUTPUT_NOTE, MISSING_TOOLS_NOTE
@@ -15,6 +17,7 @@ from ..message_formatter import (
     format_single_tool_call,
     format_tool_calls,
     safe_extract_text,
+    sanitize_surrogates,
     truncate_content,
 )
 
@@ -711,3 +714,31 @@ class TestResponsesApiItems:
         result = "\n".join(format_input_messages(messages))
         assert "Run the scout" in result
         assert "[INPUT_TEXT]" not in result
+
+
+class TestSanitizeSurrogates:
+    """Test repair of unpaired UTF-16 surrogates."""
+
+    def test_leaves_clean_text_untouched(self):
+        """Should return the same string when there is nothing to repair."""
+        text = "plain text with a valid emoji \U0001f600 and accents \u00e9"
+        assert sanitize_surrogates(text) is text
+
+    def test_replaces_lone_surrogate(self):
+        """Should replace half an emoji with the replacement character."""
+        assert sanitize_surrogates("hi \ud83c world") == "hi \ufffd world"
+
+    def test_result_encodes_as_utf8(self):
+        """Should produce text the summarization and Redis writes can encode."""
+        text = "L001: output \ud83c"
+        with pytest.raises(UnicodeEncodeError):
+            text.encode("utf-8")
+        assert sanitize_surrogates(text).encode("utf-8")
+
+    def test_recombines_a_split_pair(self):
+        """Should rebuild an emoji left as two separate surrogate code points."""
+        assert sanitize_surrogates("hi \ud83d\ude00") == "hi \U0001f600"
+
+    def test_keeps_the_rest_of_the_text(self):
+        """Should only touch the broken character."""
+        assert sanitize_surrogates("before \ud83c after \U0001f600") == "before \ufffd after \U0001f600"

--- a/products/ai_observability/backend/text_repr/formatters/test/test_trace_formatter.py
+++ b/products/ai_observability/backend/text_repr/formatters/test/test_trace_formatter.py
@@ -821,3 +821,25 @@ class TestLLMTraceToFormatterFormat:
         _, hierarchy = llm_trace_to_formatter_format(trace, nest_children=True)
 
         assert [node["event"]["id"] for node in hierarchy] == ["slow-start-first", "quick-start-second"]
+
+
+class TestSurrogateSafety:
+    """Test that a trace holding half an emoji still yields encodable text."""
+
+    def test_trace_text_repr_encodes_as_utf8(self):
+        """Should repair content captured with an unpaired surrogate."""
+        trace = {"properties": {"$ai_span_name": "broken \ud83c"}}
+        hierarchy = [
+            {
+                "event": {
+                    "event": "$ai_generation",
+                    "properties": {"$ai_input": [{"role": "user", "content": "hello \ud83c"}]},
+                },
+                "children": [],
+            }
+        ]
+
+        text, _ = format_trace_text_repr(trace=trace, hierarchy=hierarchy)
+
+        assert text.encode("utf-8")
+        assert "\ud83c" not in text

--- a/products/ai_observability/backend/text_repr/formatters/trace_formatter.py
+++ b/products/ai_observability/backend/text_repr/formatters/trace_formatter.py
@@ -24,6 +24,7 @@ from .message_formatter import (
     format_input_messages,
     format_output_messages,
     reduce_by_uniform_sampling,
+    sanitize_surrogates,
     truncate_content,
 )
 
@@ -548,4 +549,4 @@ def format_trace_text_repr(
     if max_length and len(formatted_text) > max_length:
         formatted_text, was_sampled = reduce_by_uniform_sampling(formatted_text, max_length)
 
-    return formatted_text, was_sampled
+    return sanitize_surrogates(formatted_text), was_sampled


### PR DESCRIPTION
## Problem

Someone asking for a trace summary can get "Failed to generate summary" instead, and the scheduled batch summarization can drop a trace silently. Both come from the same input: a text representation that holds an unpaired UTF-16 surrogate — half of an emoji.

The text representation is built from captured trace content, and it can pick one up two ways. The content can arrive with a broken pair already in it, or the length-based reduction can create one, because both `reduce_by_uniform_sampling` and the section truncation in the batch path cut on character counts and can split a pair. UTF-8 cannot represent a lone surrogate, so `str.encode("utf-8")` raises `UnicodeEncodeError` and the whole text representation is lost downstream:

- the batch path fails at the gzip write into Redis in `store_text_repr`,
- the on-demand path fails inside the summarization request body, where `summarize_with_openai` wraps it as `APIException("Failed to generate summary")`.

Both failures are live on master, the batch one since late May. Neither is a transient provider error, so a retry produces the same result.

## Changes

- **A summary is now produced for traces that hold a broken emoji, instead of an error.** `sanitize_surrogates` repairs the text at the formatter exits — `format_trace_text_repr` and `format_event_text_repr` — so every consumer of a text representation gets the same encodable string: the on-demand API, the batch job, and the assistant's trace reader. A pair split across two code points is recombined into the character it encodes; a genuinely lone surrogate becomes U+FFFD.
- The batch path's `_format_generation_text_repr` builds its own text rather than going through the formatters, so it repairs its own header and sections. The repair runs before the sections are measured, because recombining a split pair shortens a section: measuring first would size the budget from text that is never returned and let the result exceed `max_length`, the cost ceiling for unattended batch summarization. Repairing first also stops `_truncate_section` from cutting a pair in half, since a repaired character is a single code point.
- Mechanical: `format_event_text_repr` now assigns to one variable and returns once, so the repair sits on a single exit.

`safe_clickhouse_string` already exists and is deliberately not reused here. It escapes a surrogate into literal `\ud83c` text, which is right for its callers, since ClickHouse storage and the replay JSON renderer both have to round-trip the bytes. A text representation is read as prose by a model, so a replacement character is the better loss than six characters of escape text in the middle of the prompt. Its Prometheus counter is also scoped to ingestion, and its comment binds it to the plugin-server twin, so a change made for ClickHouse reasons should not reach summarization prompts.

## How did you test this code?

Automated tests only; no manual testing was performed.

- New unit tests for `sanitize_surrogates` cover the regressions no existing test caught: a lone surrogate becomes U+FFFD, the result encodes as UTF-8 where the input raises, a split pair is recombined, and clean text is returned unchanged (identity, so the guard clause stays a real fast path).
- A new trace-level test asserts that a trace whose content holds a lone surrogate yields text that encodes as UTF-8. This is the end-to-end shape of the reported failure and covers the sampling path that can create the surrogate.
- Ran locally: the `text_repr` formatter suites and the summarization suites, plus `ruff` and `mypy` on the changed modules.
- Not run locally: the `TestFetchAndFormatActivity` tests in `test_fetch_and_format.py`. Their fixture needs the local ClickHouse dev stack, which this environment could not stand up; a standalone ClickHouse container fails the fixture's cluster setup. The other tests in that file pass, including the ones covering `_format_generation_text_repr`, which is the function this PR changes there. The blocked tests cover activity wiring this PR does not touch, and CI runs them.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by the PostHog Slack app (Claude Code) from an error-tracking alert, starting at the alerted issue and reading the stack back to the encode call.
- No duplicate: `gh pr list --state open --search "surrogate"` and a search for the summarization path found no open PR fixing this. #91235 also guards a truncation boundary, but in the CDP log path and for a different reason.
- Skills invoked: none.
- The first design considered was calling `safe_clickhouse_string`, since it already solves surrogate removal in this repo. It was rejected for the reasons in Changes, and a repair helper was written next to the other text-representation utilities instead. The second decision was placement: sanitizing where the LLM call happens would have left the batch Redis write broken, and sanitizing at both call sites would let the cached and fresh text representations differ, so the repair sits at the formatter exits that both paths share.
- Public artifact: the fix was found from an internal alert, but nothing from that session is in this PR. The test fixtures are invented.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A006STKHR/p1788777242273599?thread_ts=1788777242.273599&cid=C0A006STKHR)*


