### PR TITLE
fix(usage-ingestion): delimit usage counter scopes

### DIFF
--- a/rust/usage-ingestion/src/counters.rs
+++ b/rust/usage-ingestion/src/counters.rs
@@ -241,8 +241,8 @@ impl CounterStore for RedisCounterStore {
 
 pub fn counter_key(scope: &CounterScope, bucket: Bucket) -> String {
     let scope = match scope {
-        CounterScope::Team(team_id) => format!("team:{team_id}"),
-        CounterScope::Organization(organization_id) => format!("org:{organization_id}"),
+        CounterScope::Team(team_id) => format!("team={team_id}"),
+        CounterScope::Organization(organization_id) => format!("org={organization_id}"),
     };
     format!(
         "usage:v1:{{{scope}}}:{}:{}",
@@ -420,10 +420,17 @@ mod tests {
         assert!(team.entries.values().all(|quantity| *quantity == 5));
         assert_eq!(
             counter_key(&CounterScope::Team(42), Bucket::Hour(477_336)),
-            "usage:v1:{team:42}:h:477336"
+            "usage:v1:{team=42}:h:477336"
         );
-        assert!(counter_key(&CounterScope::Team(42), Bucket::Hour(477_336)).contains("{team:42}"));
-        assert!(counter_key(&CounterScope::Team(42), Bucket::Day(19_889)).contains("{team:42}"));
+        assert!(counter_key(&CounterScope::Team(42), Bucket::Hour(477_336)).contains("{team=42}"));
+        assert!(counter_key(&CounterScope::Team(42), Bucket::Day(19_889)).contains("{team=42}"));
+        assert_eq!(
+            counter_key(
+                &CounterScope::Organization(organization_id),
+                Bucket::Day(19_889)
+            ),
+            "usage:v1:{org=00000000-0000-0000-0000-000000000000}:d:19889"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

- Redis-browser users cannot identify a counter scope as one segment because colons split organization and project labels.

## Changes

- Redis-browser users now see `org=<uuid>` and `team=<id>` as one key segment.
- Redis Cluster still receives the existing hash tag, so hourly and daily counters stay in one slot.
- The change is mechanical and does not alter counter fields, buckets, or expiry.

## How did you test this code?

- The focused counter test checks the team and organization key formats and preserves the hash tag.
- `cargo fmt --check` passed.
- Not run: the Valkey Cluster integration test. The change preserves its hash-tag behavior.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. This internal Redis key format does not change a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex implemented the requested key-format change with `/ponytail` and `/writing-pr-descriptions`.
- The duplicate PR search found no open matching PR.
- The committed change contains no session-derived or sensitive material.
