### PR TITLE
fix(desktop): mobile land new tasks directly on their chat

### DIFF
--- a/products/desktop/apps/mobile/src/app/task/index.tsx
+++ b/products/desktop/apps/mobile/src/app/task/index.tsx
@@ -297,9 +297,9 @@ export default function NewTaskScreen() {
       setAt: Date.now(),
     });
 
-    // Durably record the prompt so it survives the app being killed before
-    // creation completes; cleared once the task exists (or on failure, when
-    // the text is still live in the composer).
+    // Durably record the prompt so it survives the app being killed. Cleared
+    // once the task exists; kept on failure so the next launch can restore
+    // the draft into the composer.
     if (trimmedPrompt) {
       pendingPromptRecoveryStoreApi.set(pendingKey, trimmedPrompt);
     }
@@ -385,7 +385,6 @@ export default function NewTaskScreen() {
     } catch (creationError) {
       log.error("Failed to create task", creationError);
       pendingTaskPromptStoreApi.clear(currentPendingKey);
-      pendingPromptRecoveryStoreApi.clear(pendingKey);
     } finally {
       setCreating(false);
     }


### PR DESCRIPTION
## Problem

Someone starting a new task on mobile could lose their prompt if creation failed and the app was killed before they retried.
The composer wrote the prompt to the durable recovery store on send, then cleared that record in the catch block, so a crash between the failure and the retry left nothing for the next launch to restore.

Port of #94261, which made the desktop app land new tasks directly on their chat and keep failed prompts recoverable.

## Changes

- On task-creation failure, the durable recovery record stays. `PendingPromptRecovery` picks it up on the next launch and drops it back into the composer.
- Comment on the recovery-store write updated to reflect the new lifecycle.

The other five behaviors the desktop PR shipped are already correct on mobile, or do not apply:

- No interim screen. `NewTaskScreen` already `router.replace`s to `/task/<id>` after creation, and mobile never had a `/tasks/pending/<key>` route.
- The submitted user message shows before setup progress. The transient `pendingTaskPromptStore` seeds `TaskSessionView.optimisticUserMessage`, with attachments carried through.
- Composer and waiting message share the same layout. `TaskDetailScreen` stacks `TaskChatComposer` and `TaskSessionView` in one column already.
- Reconciling a bare initial prompt against a context-bearing echo on reopen. Mobile does not wrap prompts in `<channel_context>` or `<user_custom_instructions>`, so the transcript never carries the paired echo the desktop dedupe targets.
- Keeping the pending prompt available to the chat after creation succeeds and clearing it when initialization ends. `TaskDetailScreen` already clears the entry when the matching `user_message_chunk` arrives on SSE.

## How did you test this code?

- `pnpm --filter @posthog/mobile typecheck` and `pnpm --filter @posthog/mobile lint`: clean.
- `pnpm --filter @posthog/mobile test`: 610 tests pass across 67 files.
- No new test. The behavior lives in a callback inside `NewTaskScreen`; the store and `PendingPromptRecovery` unit tests already cover set / clear / recovery ordering, and asserting the caller no longer calls `clear` would need a full composer mount for one line.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

Traced the desktop diff, mapped each of the six behaviors onto the mobile equivalents (`pendingTaskPromptStore`, `pendingPromptRecoveryStore`, `TaskSessionView`, `NewTaskScreen`), and confirmed by grep that mobile does not emit `channel_context` / `user_custom_instructions` shadow context. The only real gap was the failure-path clear.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
