### PR TITLE
feat(conversations): fill ticket thread and collapse the reply box

### DIFF
--- a/frontend/src/lib/components/RichContentEditor/index.tsx
+++ b/frontend/src/lib/components/RichContentEditor/index.tsx
@@ -62,12 +62,14 @@ export const useRichContentEditor = ({
     onCreate = () => {},
     onUpdate = () => {},
     onSelectionUpdate = () => {},
+    autoFocus = false,
 }: RichContentEditorProps): TTEditor => {
     const editor = useEditor({
         shouldRerenderOnTransaction: false,
         extensions,
         editable: !disabled,
         content: initialContent,
+        autofocus: autoFocus,
         onSelectionUpdate: onSelectionUpdate,
         onUpdate: ({ editor }) => onUpdate(editor.getJSON()),
         onCreate: ({ editor }) => onCreate(editor),

--- a/products/conversations/frontend/components/Chat/ChatView.tsx
+++ b/products/conversations/frontend/components/Chat/ChatView.tsx
@@ -31,6 +31,8 @@ export interface ChatViewProps {
     fillParent?: boolean
     /** Show a one-line field until the user focuses it, then the full composer. */
     collapseUntilActive?: boolean
+    /** When this changes, the collapsed composer closes. Ticket navigation reuses the same mount. */
+    threadId?: string
     /** Channel the ticket came from; drives the reply placeholder and send-button logo */
     channel?: TicketChannel
     /** Whether to show the "Send as private" option in the message input */
@@ -94,6 +96,7 @@ export function ChatView({
     maxHeight,
     fillParent = false,
     collapseUntilActive = false,
+    threadId,
     channel,
     showPrivateOption = false,
     unreadCustomerCount,
@@ -179,6 +182,7 @@ export function ChatView({
                     editingMessageId={editingMessageId}
                     onCancelEdit={onCancelEdit}
                     collapseUntilActive={collapseUntilActive}
+                    threadId={threadId}
                 />
             </div>
         </LemonCard>

--- a/products/conversations/frontend/components/Chat/ChatView.tsx
+++ b/products/conversations/frontend/components/Chat/ChatView.tsx
@@ -2,6 +2,8 @@ import { JSONContent } from '@tiptap/core'
 
 import { LemonCard } from '@posthog/lemon-ui'
 
+import { cn } from 'lib/utils/css-classes'
+
 import type { AiReplyFeedbackRating, ChatMessage, Ticket, TicketChannel, TicketStatus } from '../../types'
 import { MessageInput } from './MessageInput'
 import { MessageList, type TimelineExtra } from './MessageList'
@@ -24,6 +26,11 @@ export interface ChatViewProps {
     header?: React.ReactNode
     minHeight?: string
     maxHeight?: string
+    /** Fill a bounded parent (the ticket scene pane). Do not opt in when the parent height is auto:
+     *  overflow-hidden plus a 0 min-height list would collapse the thread. */
+    fillParent?: boolean
+    /** Show a one-line field until the user focuses it, then the full composer. */
+    collapseUntilActive?: boolean
     /** Channel the ticket came from; drives the reply placeholder and send-button logo */
     channel?: TicketChannel
     /** Whether to show the "Send as private" option in the message input */
@@ -85,6 +92,8 @@ export function ChatView({
     header,
     minHeight,
     maxHeight,
+    fillParent = false,
+    collapseUntilActive = false,
     channel,
     showPrivateOption = false,
     unreadCustomerCount,
@@ -116,11 +125,14 @@ export function ChatView({
     fullEmailLoadingMessageId,
     onViewFullEmail,
 }: ChatViewProps): JSX.Element {
-    const listMinHeight = minHeight ?? '400px'
-    const listMaxHeight = maxHeight ?? '600px'
+    const listMinHeight = minHeight ?? (fillParent ? '0' : '400px')
+    const listMaxHeight = maxHeight ?? (fillParent ? 'none' : '600px')
 
     return (
-        <LemonCard hoverEffect={false} className="flex flex-col overflow-hidden p-3">
+        <LemonCard
+            hoverEffect={false}
+            className={cn('flex flex-col overflow-hidden p-3', fillParent && 'h-full min-h-0 flex-1')}
+        >
             {header}
             <MessageList
                 messages={messages}
@@ -146,7 +158,7 @@ export function ChatView({
                 fullEmailLoadingMessageId={fullEmailLoadingMessageId}
                 onViewFullEmail={onViewFullEmail}
             />
-            <div className="border-t pt-3">
+            <div className="border-t pt-3 shrink-0">
                 <MessageInput
                     onSendMessage={onSendMessage}
                     messageSending={messageSending}
@@ -166,6 +178,7 @@ export function ChatView({
                     unsavedTicketChanges={unsavedTicketChanges}
                     editingMessageId={editingMessageId}
                     onCancelEdit={onCancelEdit}
+                    collapseUntilActive={collapseUntilActive}
                 />
             </div>
         </LemonCard>

--- a/products/conversations/frontend/components/Chat/MessageInput.test.tsx
+++ b/products/conversations/frontend/components/Chat/MessageInput.test.tsx
@@ -18,18 +18,26 @@ jest.mock('../Editor', () => {
             onCreate,
             onPressCmdEnter,
             disabled,
+            autoFocus,
         }: {
             onCreate: (editor: unknown) => void
             onPressCmdEnter: () => void
             disabled?: boolean
+            autoFocus?: boolean
         }) => {
             React.useEffect(() => {
-                onCreate({
+                const el = document.querySelector('[data-attr="support-editor"]') as HTMLElement | null
+                const editor = {
                     getJSON: () => ({ type: 'doc' }),
                     clear: () => {},
                     setContent: () => {},
                     isEmpty: () => false,
-                })
+                    focus: () => el?.focus(),
+                }
+                onCreate(editor)
+                if (autoFocus) {
+                    editor.focus()
+                }
                 // eslint-disable-next-line react-hooks/exhaustive-deps
             }, [])
             return React.createElement(
@@ -112,6 +120,43 @@ describe('MessageInput', () => {
         await userEvent.click(screen.getByText(`${verb} and set pending`))
         expect(onSendMessage).toHaveBeenCalledTimes(1)
         expect(onSendMessage).toHaveBeenCalledWith('hello', { type: 'doc' }, isPrivate, expect.any(Function), 'pending')
+    })
+})
+
+describe('MessageInput collapsed composer', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('shows a one-line field until focused, then the full composer', async () => {
+        render(
+            <Provider>
+                <MessageInput onSendMessage={jest.fn()} messageSending={false} collapseUntilActive />
+            </Provider>
+        )
+
+        expect(screen.queryByTestId('support-editor')).not.toBeInTheDocument()
+        await userEvent.click(screen.getByPlaceholderText('Type your message...'))
+        expect(screen.getByTestId('support-editor')).toBeInTheDocument()
+        expect(screen.getByTestId('support-editor')).toHaveFocus()
+    })
+
+    test.each([
+        ['draft content', { draftContent: { type: 'doc', content: [] } }],
+        ['editing a message', { editingMessageId: 'note-1' }],
+    ])('starts expanded with %s', (_name, extraProps) => {
+        render(
+            <Provider>
+                <MessageInput onSendMessage={jest.fn()} messageSending={false} collapseUntilActive {...extraProps} />
+            </Provider>
+        )
+
+        expect(screen.getByTestId('support-editor')).toBeInTheDocument()
+        expect(screen.queryByPlaceholderText('Type your message...')).not.toBeInTheDocument()
     })
 })
 

--- a/products/conversations/frontend/components/Chat/MessageInput.test.tsx
+++ b/products/conversations/frontend/components/Chat/MessageInput.test.tsx
@@ -145,6 +145,36 @@ describe('MessageInput collapsed composer', () => {
         expect(screen.getByTestId('support-editor')).toHaveFocus()
     })
 
+    it('collapses again when the thread id changes', async () => {
+        const { rerender } = render(
+            <Provider>
+                <MessageInput
+                    onSendMessage={jest.fn()}
+                    messageSending={false}
+                    collapseUntilActive
+                    threadId="ticket-a"
+                />
+            </Provider>
+        )
+
+        await userEvent.click(screen.getByPlaceholderText('Type your message...'))
+        expect(screen.getByTestId('support-editor')).toBeInTheDocument()
+
+        rerender(
+            <Provider>
+                <MessageInput
+                    onSendMessage={jest.fn()}
+                    messageSending={false}
+                    collapseUntilActive
+                    threadId="ticket-b"
+                />
+            </Provider>
+        )
+
+        expect(screen.queryByTestId('support-editor')).not.toBeInTheDocument()
+        expect(screen.getByPlaceholderText('Type your message...')).toBeInTheDocument()
+    })
+
     test.each([
         ['draft content', { draftContent: { type: 'doc', content: [] } }],
         ['editing a message', { editingMessageId: 'note-1' }],

--- a/products/conversations/frontend/components/Chat/MessageInput.tsx
+++ b/products/conversations/frontend/components/Chat/MessageInput.tsx
@@ -57,6 +57,8 @@ export interface MessageInputProps {
     onCancelEdit?: () => void
     /** Show a one-line field until focused, then the full composer. */
     collapseUntilActive?: boolean
+    /** When this changes, the collapsed composer closes. Ticket navigation reuses the same mount. */
+    threadId?: string
 }
 
 export function MessageInput({
@@ -82,11 +84,17 @@ export function MessageInput({
     editingMessageId = null,
     onCancelEdit,
     collapseUntilActive = false,
+    threadId,
 }: MessageInputProps): JSX.Element {
     const [isEmpty, setIsEmpty] = useState(!draftContent)
     const [isUploading, setIsUploading] = useState(false)
     const [localIsPrivate, setLocalIsPrivate] = useState(false)
     const [composerExpanded, setComposerExpanded] = useState(false)
+    const lastThreadIdRef = useRef(threadId)
+    if (lastThreadIdRef.current !== threadId) {
+        lastThreadIdRef.current = threadId
+        setComposerExpanded(false)
+    }
     const editorRef = useRef<RichContentEditorType | null>(null)
     const lastSeededEditId = useRef<string | null>(null)
     const draftContentRef = useRef(draftContent)

--- a/products/conversations/frontend/components/Chat/MessageInput.tsx
+++ b/products/conversations/frontend/components/Chat/MessageInput.tsx
@@ -253,9 +253,10 @@ export function MessageInput({
         return (
             <LemonInput
                 fullWidth
-                readOnly
+                value=""
                 placeholder={getReplyPlaceholder(channel)}
                 disabledReason={sendControlDisabledReason}
+                onChange={() => setComposerExpanded(true)}
                 onFocus={() => setComposerExpanded(true)}
                 data-attr="message-input-collapsed"
             />

--- a/products/conversations/frontend/components/Chat/MessageInput.tsx
+++ b/products/conversations/frontend/components/Chat/MessageInput.tsx
@@ -2,7 +2,7 @@ import { JSONContent } from '@tiptap/core'
 import { useEffect, useRef, useState } from 'react'
 
 import { IconLock } from '@posthog/icons'
-import { LemonButton, LemonCheckbox, LemonSwitch, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonCheckbox, LemonInput, LemonSwitch, Tooltip } from '@posthog/lemon-ui'
 
 import { RichContentEditorType } from 'lib/components/RichContentEditor/types'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
@@ -55,6 +55,8 @@ export interface MessageInputProps {
     editingMessageId?: string | null
     /** Cancel edit mode and restore the previous draft */
     onCancelEdit?: () => void
+    /** Show a one-line field until focused, then the full composer. */
+    collapseUntilActive?: boolean
 }
 
 export function MessageInput({
@@ -79,10 +81,12 @@ export function MessageInput({
     unsavedTicketChanges,
     editingMessageId = null,
     onCancelEdit,
+    collapseUntilActive = false,
 }: MessageInputProps): JSX.Element {
     const [isEmpty, setIsEmpty] = useState(!draftContent)
     const [isUploading, setIsUploading] = useState(false)
     const [localIsPrivate, setLocalIsPrivate] = useState(false)
+    const [composerExpanded, setComposerExpanded] = useState(false)
     const editorRef = useRef<RichContentEditorType | null>(null)
     const lastSeededEditId = useRef<string | null>(null)
     const draftContentRef = useRef(draftContent)
@@ -92,6 +96,12 @@ export function MessageInput({
     useEffect(() => {
         setIsEmpty(!draftContent)
     }, [draftContent])
+
+    useEffect(() => {
+        if (composerExpanded) {
+            editorRef.current?.focus()
+        }
+    }, [composerExpanded])
 
     // SupportEditor only applies initialContent at mount; seed/restore via setContent on edit transitions.
     // Defer seeding so kea listeners can apply setDraftContent before we read it.
@@ -237,11 +247,27 @@ export function MessageInput({
               ? 'Sending is disabled'
               : undefined
 
+    const showFullComposer = !collapseUntilActive || composerExpanded || !!draftContent || !!editingMessageId
+
+    if (!showFullComposer) {
+        return (
+            <LemonInput
+                fullWidth
+                readOnly
+                placeholder={getReplyPlaceholder(channel)}
+                disabledReason={sendControlDisabledReason}
+                onFocus={() => setComposerExpanded(true)}
+                data-attr="message-input-collapsed"
+            />
+        )
+    }
+
     return (
         <div>
             <SupportEditor
                 initialContent={typeof draftContent === 'string' ? null : draftContent}
                 placeholder={resolvedPlaceholder}
+                autoFocus={composerExpanded}
                 onCreate={(editor) => {
                     editorRef.current = editor
                     if (draftContent) {

--- a/products/conversations/frontend/components/Editor/SupportEditor.tsx
+++ b/products/conversations/frontend/components/Editor/SupportEditor.tsx
@@ -158,6 +158,7 @@ export type SupportEditorProps = {
     disabled?: boolean
     minRows?: number
     className?: string
+    autoFocus?: boolean
 }
 
 const DEFAULT_INITIAL_CONTENT: JSONContent = {
@@ -477,6 +478,7 @@ export function SupportEditor({
     disabled = false,
     minRows,
     className,
+    autoFocus = false,
 }: SupportEditorProps): JSX.Element {
     const [isDragging, setIsDragging] = useState<boolean>(false)
     const [ttEditor, setTTEditor] = useState<TTEditor | null>(null)
@@ -523,6 +525,7 @@ export function SupportEditor({
         onSelectionUpdate: () => {
             setEditorState((n) => n + 1)
         },
+        autoFocus,
     })
 
     const dropRef = useRef<HTMLDivElement>(null)
@@ -615,7 +618,7 @@ export function SupportEditor({
             <EditorContent
                 editor={editor}
                 className="SupportEditor__content p-2"
-                autoFocus
+                autoFocus={autoFocus}
                 style={minRows ? { minHeight: `${minRows * 1.5}em` } : undefined}
             />
             <div className="flex justify-between p-0.5">

--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -260,6 +260,7 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                     <ChatView
                         fillParent
                         collapseUntilActive
+                        threadId={ticketId}
                         threadExtras={[...reportTimelineExtras(linkedReports), ...discussionExtras]}
                         messages={chatMessages}
                         messagesLoading={messagesLoading}

--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -260,7 +260,6 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                     <ChatView
                         fillParent
                         collapseUntilActive
-                        minHeight="300px"
                         threadExtras={[...reportTimelineExtras(linkedReports), ...discussionExtras]}
                         messages={chatMessages}
                         messagesLoading={messagesLoading}

--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -224,7 +224,7 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
     }
 
     return (
-        <SceneContent className="lg:min-h-0 lg:flex-1">
+        <SceneContent className="flex-1 min-h-0 pb-4">
             <SceneTitleSection
                 name={`Ticket: ${ticket?.ticket_number?.toString() || ticket?.id || ''}`}
                 nameSuffix={
@@ -248,14 +248,19 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                 )}
             </LemonModal>
 
-            <div className="flex flex-col lg:flex-row items-start lg:min-h-0 lg:flex-1">
+            {/* Overflow clipping is only safe side-by-side, where the thread has a bounded height.
+                Stacked, the thread is content-sized; clipping here would collapse it. */}
+            <div className="flex flex-col gap-y-4 @min-[48rem]/main-content:flex-row @min-[48rem]/main-content:flex-1 @min-[48rem]/main-content:min-h-0 @min-[48rem]/main-content:overflow-hidden">
                 <div
                     style={{ width: chatPanelWidth(desiredSize) }}
-                    className="relative shrink-0 pr-2 max-w-full lg:max-w-[calc(100%-300px)] mb-4 lg:mb-0"
+                    className="relative shrink-0 max-w-full min-h-80  @min-[48rem]/main-content:pr-2 @min-[48rem]/main-content:max-w-[calc(100%-300px)] @min-[48rem]/main-content:h-full @min-[48rem]/main-content:min-h-0 @min-[48rem]/main-content:flex @min-[48rem]/main-content:flex-col"
                     ref={chatPanelRef}
                 >
                     {/* Main conversation area */}
                     <ChatView
+                        fillParent
+                        collapseUntilActive
+                        minHeight="300px"
                         threadExtras={[...reportTimelineExtras(linkedReports), ...discussionExtras]}
                         messages={chatMessages}
                         messagesLoading={messagesLoading}
@@ -279,8 +284,6 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                         unsavedTicketChanges={unsavedTicketChanges}
                         replyDisabledReason={replyDisabledReason}
                         sendDisabledReason={sendDisabledReason}
-                        minHeight="min(400px, calc(100svh - 20rem))"
-                        maxHeight="calc(100svh - 20rem)"
                         latestAiMessageId={latestAiMessage?.id ?? null}
                         feedbackByMessageId={feedbackByMessageId}
                         showAiReplyFeedback={aiSuggestionsEnabled}
@@ -295,13 +298,13 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                         fullEmailLoadingMessageId={fullEmailContentLoading ? fullEmailMessageId : null}
                         onViewFullEmail={loadFullEmail}
                     />
-                    <div className="hidden lg:block">
+                    <div className="hidden @min-[48rem]/main-content:block">
                         <Resizer {...resizerLogicProps} className="z-20" />
                     </div>
                 </div>
 
                 {/* Sidebar with all metadata */}
-                <div className="space-y-4 flex-1 min-w-[300px] pl-2 lg:h-full lg:min-h-0 lg:overflow-y-auto lg:pb-4">
+                <div className="space-y-4 flex-1 min-w-[300px] @min-[48rem]/main-content:h-full @min-[48rem]/main-content:pl-2 @min-[48rem]/main-content:min-h-0 @min-[48rem]/main-content:overflow-y-auto">
                     <LemonCard hoverEffect={false} className="p-3">
                         {/* Customer */}
                         {ticket?.distinct_id && (


### PR DESCRIPTION
## Problem

Support agents who open a ticket see unused space below the thread.
They also see the full reply editor before they start typing.
The thread used a viewport-minus-offset height, so leftover space sat empty.
The composer mounted the editor, toolbar, and send controls on load.

## Changes

- The ticket thread fills the leftover height of the scene, the same way My Tickets does.
- The metadata sidebar scrolls on its own.
- Layout switches at 48rem of main content, not at the `lg` viewport breakpoint.
- The reply box starts as one line: "Type your message...".
- A click or focus opens the full editor, and the caret is already in it.
- A saved draft or a note edit still opens the full composer.
- Mechanical: `fillParent` / `collapseUntilActive` on ChatView, and TipTap autofocus on expand.


<img width="800" height="541" alt="ezgif-24cc2f723a37cec6" src="https://github.com/user-attachments/assets/d5f4ceb6-efcf-4949-bc41-7f092864f3fe" />



## How did you test this code?

Jest on `MessageInput.test.tsx` covers:
- the composer stays one line until focus
- a draft or note edit opens the full composer
- expand puts focus in the editor (avoids a second click)
