### PR TITLE
fix(mcp): stop the model restating results a chart already renders

### DIFF
--- a/services/mcp/src/lib/build-tool-result.ts
+++ b/services/mcp/src/lib/build-tool-result.ts
@@ -86,6 +86,17 @@ export function markExecPayload(payload: ToolResultPayload): ToolResultPayload {
 export const STRUCTURED_CONTENT_ONLY_TEXT = "Full result is in this response's structuredContent field."
 
 /**
+ * Footer appended to the text channel when the same data also renders as an
+ * interactive chart for the user (see `includeUiResponseMeta` in
+ * `buildToolResultPayload`). Inline-exec UI-app hosts (PostHog Desktop, Claude
+ * Code, Cowork) mount that chart from `_meta` without the model knowing — the
+ * model only sees the formatted table — so left alone it transcribes the table
+ * back into its own reply on top of the chart the host already rendered.
+ */
+export const UI_RESOURCE_RENDERED_HINT =
+    'An interactive chart of this data is already shown to the user. Do not repeat the full results in your reply — summarize the key findings instead.'
+
+/**
  * Estimate output tokens from what the client actually receives — the serialized
  * TOON/JSON/formatted string, not the raw handler object. TOON is materially
  * smaller than JSON for tabular results, so measuring the raw object would
@@ -202,6 +213,14 @@ export function buildToolResultPayload(opts: BuildToolResultOptions): ToolResult
         if (discoveryHint) {
             text = `${text}\n\n${discoveryHint}`
         }
+    }
+
+    // Same gating as the discovery hint above, plus `includeUiResponseMeta`: that flag is
+    // only set by the exec wrapper's inline-exec-UI-app branch, so it's the signal that a
+    // chart will actually render from this response's `_meta.ui.resourceUri` — telling the
+    // model to stand down only makes sense when a chart is really about to appear.
+    if (includeUiResponseMeta && hasUiResource && !isStringResult && !useJson && !structuredContentOnly) {
+        text = `${text}\n\n${UI_RESOURCE_RENDERED_HINT}`
     }
 
     const payload: ToolResultPayload = {

--- a/services/mcp/tests/unit/build-tool-result.test.ts
+++ b/services/mcp/tests/unit/build-tool-result.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
     EXEC_BUILT_PAYLOAD,
     STRUCTURED_CONTENT_ONLY_TEXT,
+    UI_RESOURCE_RENDERED_HINT,
     estimateResponseTokens,
     markExecPayload,
     buildToolResultPayload,
@@ -92,6 +93,9 @@ describe('buildToolResultPayload — query-trends for Claude Code', () => {
         })
         // Override key must not leak into structuredContent.
         expect(payload.structuredContent).not.toHaveProperty(POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY)
+        // No chart is going to render for this caller (no `includeUiResponseMeta`), so telling
+        // the model one already has would be false — regression guard for the hint's gating.
+        expect(payload.content[0]!.text).not.toContain(UI_RESOURCE_RENDERED_HINT)
     })
 
     it('keeps structuredContent when suppression is omitted', () => {
@@ -198,8 +202,10 @@ describe('buildToolResultPayload — inline-exec UI host (forceUiDataToMeta)', (
             distinctId: 'd',
         })
 
-        // Model reads the compact table, not the verbose JSON.
-        expect(payload.content[0]!.text).toBe(FORMATTED_TABLE)
+        // Model reads the compact table, not the verbose JSON, plus a note that a chart already
+        // covers it — otherwise the model transcribes the table into its own reply on top of
+        // the chart the host renders from this same response's `_meta.ui.resourceUri`.
+        expect(payload.content[0]!.text).toBe(`${FORMATTED_TABLE}\n\n${UI_RESOURCE_RENDERED_HINT}`)
         expect(payload).not.toHaveProperty('structuredContent')
         // The UI app hydrates from _meta since structuredContent was dropped.
         expect(payload._meta?.[APP_DATA_META_KEY]).toMatchObject({ results: expect.any(Array) })

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { parse as parseYaml } from 'yaml'
 import { z } from 'zod'
 
-import { STRUCTURED_CONTENT_ONLY_TEXT } from '@/lib/build-tool-result'
+import { STRUCTURED_CONTENT_ONLY_TEXT, UI_RESOURCE_RENDERED_HINT } from '@/lib/build-tool-result'
 import { PostHogApiError, ToolInputValidationError } from '@/lib/errors'
 import { estimateTokens } from '@/lib/estimate-tokens'
 import { buildQueryToolsBlock, buildToolDomainsCompact } from '@/lib/instructions'
@@ -363,8 +363,8 @@ describe('exec tool', () => {
                     _meta: { ui: { resourceUri: string }; [key: string]: unknown }
                 }
 
-                // Model sees ONLY the compact table, not the raw results JSON.
-                expect(result.content[0]!.text).toBe('Date|count\n2026-05-07|6')
+                // Model sees the compact table plus the rendered-chart hint, not the raw results JSON.
+                expect(result.content[0]!.text).toBe(`Date|count\n2026-05-07|6\n\n${UI_RESOURCE_RENDERED_HINT}`)
                 // Top-level structuredContent is dropped so coding agents don't surface it.
                 expect(result.structuredContent).toBeUndefined()
                 // The UI app's data (with analytics) rides on _meta instead.


### PR DESCRIPTION
## Problem

People using an inline-exec UI-app host (PostHog Desktop, Claude Code, Cowork) see a query's chart render, then get a final reply that repeats the same numbers as a table underneath it.

The chart mounts entirely on the client. The model that writes the final reply never learns it rendered, so it answers from the same compact table it was handed and duplicates the chart in prose.

## Changes

- A tool response that carries a UI chart now ends with a short note telling the model a chart is already visible, so its reply can summarize instead of repeat the table.
- The note only appears on the exact response that will actually render a chart (gated on the same flag the `exec` wrapper sets only for that case) — a client with no chart mounted sees no new text.

## How did you test this code?

Added two assertions to `services/mcp/tests/unit/build-tool-result.test.ts`, in the existing `buildToolResultPayload` test blocks:
- The note is present on the response that renders a chart (a formatted table on an inline-exec UI host) — guards a regression that silently drops the fix.
- The note is absent when no chart renders (no `includeUiResponseMeta`) — guards a false "chart is shown" claim reaching a client that never mounts one.

Ran `npx vitest run tests/unit/build-tool-result.test.ts` (23 passed) and `pnpm run fix` (lint + format, clean). Not run: a full monorepo typecheck — this checkout's `tsgo` fails on missing `@posthog/quill` types in several unrelated MCP UI-app files that predate this change; confirmed none of the reported errors reference the two files this PR touches. Not run: an end-to-end check against a live MCP client.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal server-side prompt behavior with no documented setting.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Split out from [#95878](https://github.com/PostHog/posthog/pull/95878), which fixed a PostHog Desktop-only bug where a chart never rendered for Codex-driven sessions. Once that chart started rendering, the reporting user noticed the model's final answer still duplicated the chart's data as text — this PR addresses that follow-on report. Opened separately because it touches `services/mcp`, the production MCP server every client connects to, rather than Desktop's own code.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.