### PR TITLE
feat(replay-vision): say why a scan batch produced nothing

### DIFF
--- a/products/replay_vision/backend/api/scanners.py
+++ b/products/replay_vision/backend/api/scanners.py
@@ -113,7 +113,12 @@ from products.replay_vision.backend.scanner_config import (
     scanner_config_error,
 )
 from products.replay_vision.backend.scanner_draft import DraftError, draft_scanner_from_goal, draft_scanner_from_goal_v2
-from products.replay_vision.backend.scanning import MAX_SESSIONS_PER_SCAN, run_inline_scan, scan_existing_scanner
+from products.replay_vision.backend.scanning import (
+    MAX_SESSIONS_PER_SCAN,
+    run_inline_scan,
+    scan_existing_scanner,
+    scan_outcome_counts,
+)
 from products.replay_vision.backend.session_limits import MAX_SESSION_ID_LENGTH
 from products.replay_vision.backend.tag_suggestions import SuggestionError, suggest_classifier_tags
 from products.replay_vision.backend.temporal.constants import VISION_SIGNALS_SOURCE_PRODUCT, VISION_SIGNALS_SOURCE_TYPE
@@ -1878,6 +1883,7 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, vi
                 "scanner_type": scanner.scanner_type,
                 "requested": len(session_ids),
                 "started": started,
+                **scan_outcome_counts(results),
             },
             team=self.team,
             request=request,
@@ -1940,6 +1946,22 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, vi
         )
         if scan.scanner is None:
             # Nothing started and nothing already existed, so there is no id to read results through.
+            # The request still happened, and reporting it only when something started would drop the
+            # fully-refused batches from the request count and bias every rate built on it.
+            report_user_action(
+                user,
+                "replay_vision_inline_scan_requested",
+                {
+                    "scan_id": None,
+                    "scanner_type": scanner_type,
+                    "model": model,
+                    "requested": len(session_ids),
+                    "started": 0,
+                    **scan_outcome_counts(scan.results),
+                },
+                team=self.team,
+                request=request,
+            )
             # Key off the outcomes: the in-flight cap can bind here too, and that is not exhaustion.
             if any(result["scan_outcome"] == "skipped_quota" for result in scan.results):
                 self._report_quota_exhausted(None, "inline")
@@ -1958,6 +1980,7 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, vi
                 "model": scanner.model,
                 "requested": len(session_ids),
                 "started": started,
+                **scan_outcome_counts(results),
             },
             team=self.team,
             request=request,

--- a/products/replay_vision/backend/scanning.py
+++ b/products/replay_vision/backend/scanning.py
@@ -38,6 +38,34 @@ from products.replay_vision.backend.temporal.constants import (
 # One page of recordings. Above this the in-flight caps bind long before the batch does.
 MAX_SESSIONS_PER_SCAN = 200
 
+# Every outcome `start_observations` can report, mirroring the API's `scan_outcome` choices. Listed so a
+# batch reports all of them and a zero is a measured zero rather than a key nobody wrote.
+SCAN_OUTCOMES: tuple[str, ...] = (
+    "started",
+    "already_running",
+    "already_scanned",
+    "skipped_limit",
+    "skipped_quota",
+    "skipped_scanner_limit",
+    "failed",
+)
+
+
+def scan_outcome_counts(results: list[dict[str, str]]) -> dict[str, int]:
+    """Per-outcome counts for one batch, shaped as analytics properties.
+
+    A batch reports how many sessions it asked for and how many started, which says how many produced
+    nothing but never why. A reused answer costs nothing and is a cache hit; a quota skip is a customer
+    hitting a wall. Those need opposite responses and are indistinguishable today. The counts sum to the
+    number of sessions requested.
+    """
+    counts: dict[str, int] = dict.fromkeys(SCAN_OUTCOMES, 0)
+    for result in results:
+        outcome = str(result["scan_outcome"])
+        # An outcome outside the known set still counts, so the sum keeps holding if one is added.
+        counts[outcome] = counts.get(outcome, 0) + 1
+    return {f"outcome_{outcome}": count for outcome, count in counts.items()}
+
 
 @dataclass(frozen=True, kw_only=True)
 class ScanHeadroom:

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -3773,8 +3773,8 @@ class TestInlineScanAction(_VisionAPITestCase):
     def test_a_fully_refused_scan_still_reports_the_request(
         self, mock_sync_connect: MagicMock, mock_async_to_sync: MagicMock
     ) -> None:
-        # A batch where nothing starts mints no scanner and used to return before reporting anything, so
-        # the refused requests were missing from the request count and every rate built on it was biased.
+        # A batch where nothing starts mints no scanner, but the request still happened. The endpoint must
+        # report it, or the refused batches drop out of the request count and bias every rate built on it.
         mock_sync_connect.return_value = MagicMock()
         mock_async_to_sync.return_value = MagicMock()
 

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -2505,6 +2505,16 @@ class TestBulkObserveAction(_VisionAPITestCase):
         events = [call.args[1] for call in report.call_args_list]
         self.assertEqual(events, ["replay_vision_bulk_scan_started", "replay_vision_quota_exhausted"])
         self.assertEqual(report.call_args.args[2]["trigger"], "bulk")
+        # `requested` minus `started` says two sessions produced nothing but never that quota was why.
+        bulk_properties = report.call_args_list[0].args[2]
+        self.assertEqual(bulk_properties["outcome_skipped_quota"], 1)
+        self.assertEqual(bulk_properties["outcome_started"], 1)
+        # Every outcome is reported, so an untaken path is a measured zero rather than a missing key.
+        self.assertEqual(bulk_properties["outcome_already_scanned"], 0)
+        self.assertEqual(
+            sum(value for key, value in bulk_properties.items() if key.startswith("outcome_")),
+            bulk_properties["requested"],
+        )
 
     def test_bulk_observe_reports_the_scanner_limit_as_the_skip_reason(
         self, mock_sync_connect: MagicMock, mock_async_to_sync: MagicMock
@@ -3759,6 +3769,28 @@ class TestInlineScanAction(_VisionAPITestCase):
             status=ObservationStatus.SUCCEEDED,
             completed_at=timezone.now(),
         )
+
+    def test_a_fully_refused_scan_still_reports_the_request(
+        self, mock_sync_connect: MagicMock, mock_async_to_sync: MagicMock
+    ) -> None:
+        # A batch where nothing starts mints no scanner and used to return before reporting anything, so
+        # the refused requests were missing from the request count and every rate built on it was biased.
+        mock_sync_connect.return_value = MagicMock()
+        mock_async_to_sync.return_value = MagicMock()
+
+        with patch("products.replay_vision.backend.quota.MONTHLY_CREDIT_QUOTA", 0):
+            with patch("products.replay_vision.backend.api.scanners.report_user_action") as report:
+                resp = self._scan()
+
+        self.assertEqual(resp.status_code, 202, resp.json())
+        self.assertIsNone(resp.json()["scan_id"])
+        events = [call.args[1] for call in report.call_args_list]
+        self.assertIn("replay_vision_inline_scan_requested", events)
+        properties = report.call_args_list[events.index("replay_vision_inline_scan_requested")].args[2]
+        self.assertIsNone(properties["scan_id"])
+        self.assertEqual(properties["started"], 0)
+        self.assertEqual(properties["requested"], 1)
+        self.assertEqual(properties["outcome_skipped_quota"], 1)
 
     def test_same_prompt_reuses_one_scan_and_a_different_prompt_gets_its_own(
         self, mock_sync_connect: MagicMock, mock_async_to_sync: MagicMock


### PR DESCRIPTION
## Problem

A person scans a batch of recordings, most of them produce nothing, and nobody can tell them why. Support cannot either.

- A bulk or inline scan reports `requested` and `started`. The difference says how many sessions produced nothing, never why.
- A reused answer costs the customer nothing and is a cache hit. A quota skip is a customer hitting a wall. They need opposite responses and look identical today.
- The reasons already exist. `start_observations` computes one of seven outcomes per session and puts them in the response body, and the event throws them away.

An inline scan where nothing starts is worse. It mints no scanner and returns before reporting anything, so a fully refused batch produces no event at all.

## Changes

- `replay_vision_bulk_scan_started` and `replay_vision_inline_scan_requested` now carry a count per outcome: `outcome_started`, `outcome_already_scanned`, `outcome_skipped_quota`, and one for each remaining reason. A batch that produced nothing now says which wall it hit.
- Every outcome is reported on every batch, so an untaken path is a measured zero rather than a missing key. The counts sum to `requested`, which a test asserts.
- A fully refused inline scan now reports the request, with a null `scan_id`.

Nothing user-visible changes. The API response body, the serializers, and the seven outcome values are untouched, and no OpenAPI schema changes.

> [!WARNING]
> `replay_vision_inline_scan_requested` volume rises, because it was undercounting. Fully refused batches never fired it, so any existing rate built on that event has a denominator missing exactly the requests that failed hardest. A chart of it will step up on deploy.

The counts are flat integers rather than one nested object, so each is directly usable in a breakdown or a formula without a JSON path.

## How did you test this code?

Two tests, both mutation-checked rather than assumed:

- The existing bulk quota test now asserts the outcome counts on the event, including a zero for an untaken path and the sum invariant against `requested`. Extending it beat a new test, because it already produced the mixed `started` plus `skipped_quota` batch this needs. Zeroing the counts in `scan_outcome_counts` fails it.
- A new test covers the fully refused inline scan reporting its request. Suppressing that event fails it, and nothing else in the suite noticed.

Also ran the full `TestBulkObserveAction`, `TestInlineScanAction`, and `test_max_tools` suites, since `max_tools` consumes the same result shape.

Not run: anything needing Temporal or ClickHouse, because this environment has neither. The change is confined to the DRF action bodies and one pure helper.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code, in a session auditing Replay Vision's instrumentation. The audit found the bulk path discards reasons it has already computed, and reading the code turned up the second, larger gap: the fully refused inline path emits nothing.

Skills invoked: `/writing-tests`, `/writing-code-comments`, and `/writing-pr-descriptions`. The first drove extending the existing bulk test rather than adding a standalone one.

The undercount fix is deliberately in this PR rather than a follow-up. Adding outcome counts while leaving refused batches unreported would produce reason percentages against a biased denominator, which is worse than no counts.

Stacked on nothing, but related to `posthog/vision-scan-outcome-events`, which counts individual scans that end without a result. The two do not overlap in files.

No customer data, session content, or non-public material is in this diff.
