### PR TITLE
fix(endpoints): revert stale materializations that only ever fail

### DIFF
--- a/products/endpoints/backend/tasks/tasks.py
+++ b/products/endpoints/backend/tasks/tasks.py
@@ -10,7 +10,7 @@ from structlog import get_logger
 from posthog.celery_queues import CeleryQueue
 from posthog.scoping_audit import skip_team_scope_audit
 
-from products.data_modeling.backend.facade.models import DataModelingJob
+from products.data_modeling.backend.facade.models import DataModelingJob, DataModelingJobStatus
 from products.endpoints.backend.logic.ducklake_shadow import run_ducklake_shadow_comparison
 from products.endpoints.backend.metrics import ENDPOINT_MATERIALIZATION_EVENT_TOTAL
 from products.endpoints.backend.models import EndpointVersion
@@ -60,7 +60,7 @@ def deactivate_stale_materializations() -> None:
 
     This task finds endpoint versions where:
     1. The version has an active materialization (saved_query.is_materialized = True)
-    2. The materialization has run in the past 24h (any job, or saved_query.last_run_at)
+    2. The materialization has run in the past 24h (a finished job, or saved_query.last_run_at)
     3. The materialization was enabled at least 30 days ago (saved_query.created_at)
     4. The version was last executed over 30 days ago (via API key), or it is a superseded
        version that was never executed
@@ -71,13 +71,14 @@ def deactivate_stale_materializations() -> None:
     twenty_four_hours_ago = now - timedelta(hours=24)
     stale_threshold = now - timedelta(days=STALE_THRESHOLD_DAYS)
 
-    # Any job proves the schedule is still firing, which is what this gate asks. A materialization
-    # that fails every run costs the same compute as one that succeeds, so testing for success here
-    # would exempt exactly the versions most worth reverting.
+    # Any finished run proves the schedule is still firing, which is what this gate asks. Testing
+    # for success instead would exempt the versions most worth reverting, because a run that fails
+    # costs the same compute as one that succeeds. A still-running job does not count, because
+    # reverting soft-deletes the saved query under a live workflow.
     recent_job = DataModelingJob.objects.filter(
         saved_query_id=OuterRef("saved_query_id"),
         last_run_at__gte=twenty_four_hours_ago,
-    )
+    ).exclude(status=DataModelingJobStatus.RUNNING)
     ran_recently = Q(saved_query__last_run_at__gte=twenty_four_hours_ago) | Q(Exists(recent_job))
 
     # Both stamps are written together on every API-key call, so a superseded version with no stamp

--- a/products/endpoints/backend/tasks/tasks.py
+++ b/products/endpoints/backend/tasks/tasks.py
@@ -71,10 +71,7 @@ def deactivate_stale_materializations() -> None:
     twenty_four_hours_ago = now - timedelta(hours=24)
     stale_threshold = now - timedelta(days=STALE_THRESHOLD_DAYS)
 
-    # Any finished run proves the schedule is still firing, which is what this gate asks. Testing
-    # for success instead would exempt the versions most worth reverting, because a run that fails
-    # costs the same compute as one that succeeds. A still-running job does not count, because
-    # reverting soft-deletes the saved query under a live workflow.
+    # A still-running job does not count: reverting soft-deletes the saved query under a live workflow.
     recent_job = DataModelingJob.objects.filter(
         saved_query_id=OuterRef("saved_query_id"),
         last_run_at__gte=twenty_four_hours_ago,

--- a/products/endpoints/backend/tasks/tasks.py
+++ b/products/endpoints/backend/tasks/tasks.py
@@ -10,7 +10,7 @@ from structlog import get_logger
 from posthog.celery_queues import CeleryQueue
 from posthog.scoping_audit import skip_team_scope_audit
 
-from products.data_modeling.backend.facade.models import DataModelingJob, DataModelingJobStatus
+from products.data_modeling.backend.facade.models import DataModelingJob
 from products.endpoints.backend.logic.ducklake_shadow import run_ducklake_shadow_comparison
 from products.endpoints.backend.metrics import ENDPOINT_MATERIALIZATION_EVENT_TOTAL
 from products.endpoints.backend.models import EndpointVersion
@@ -60,7 +60,7 @@ def deactivate_stale_materializations() -> None:
 
     This task finds endpoint versions where:
     1. The version has an active materialization (saved_query.is_materialized = True)
-    2. The materialization has run in the past 24h (a completed job, or saved_query.last_run_at)
+    2. The materialization has run in the past 24h (any job, or saved_query.last_run_at)
     3. The materialization was enabled at least 30 days ago (saved_query.created_at)
     4. The version was last executed over 30 days ago (via API key), or it is a superseded
        version that was never executed
@@ -71,9 +71,11 @@ def deactivate_stale_materializations() -> None:
     twenty_four_hours_ago = now - timedelta(hours=24)
     stale_threshold = now - timedelta(days=STALE_THRESHOLD_DAYS)
 
+    # Any job proves the schedule is still firing, which is what this gate asks. A materialization
+    # that fails every run costs the same compute as one that succeeds, so testing for success here
+    # would exempt exactly the versions most worth reverting.
     recent_job = DataModelingJob.objects.filter(
         saved_query_id=OuterRef("saved_query_id"),
-        status=DataModelingJobStatus.COMPLETED,
         last_run_at__gte=twenty_four_hours_ago,
     )
     ran_recently = Q(saved_query__last_run_at__gte=twenty_four_hours_ago) | Q(Exists(recent_job))

--- a/products/endpoints/backend/tests/test_deactivate_stale_materializations.py
+++ b/products/endpoints/backend/tests/test_deactivate_stale_materializations.py
@@ -222,8 +222,14 @@ class TestDeactivateStaleMaterializationsTask(BaseTest):
         version.refresh_from_db()
         assert version.saved_query is None
 
+    @parameterized.expand(
+        [
+            ("completed", DataModelingJob.Status.COMPLETED),
+            ("failed", DataModelingJob.Status.FAILED),
+        ]
+    )
     @mock.patch("products.endpoints.backend.tasks.tasks._deactivate_version_materialization")
-    def test_selects_stale_version_whose_saved_query_last_run_at_is_never_written(self, mock_deactivate):
+    def test_selects_stale_version_from_a_recent_job_whatever_its_outcome(self, _name, job_status, mock_deactivate):
         now = timezone.now()
         _, version = self._create_materialized_endpoint(
             name="v2_scheduled",
@@ -234,7 +240,7 @@ class TestDeactivateStaleMaterializationsTask(BaseTest):
         DataModelingJob.objects.create(
             team=self.team,
             saved_query=version.saved_query,
-            status=DataModelingJob.Status.COMPLETED,
+            status=job_status,
             last_run_at=now - timedelta(hours=1),
         )
 

--- a/products/endpoints/backend/tests/test_deactivate_stale_materializations.py
+++ b/products/endpoints/backend/tests/test_deactivate_stale_materializations.py
@@ -224,12 +224,15 @@ class TestDeactivateStaleMaterializationsTask(BaseTest):
 
     @parameterized.expand(
         [
-            ("completed", DataModelingJob.Status.COMPLETED),
-            ("failed", DataModelingJob.Status.FAILED),
+            ("completed", DataModelingJob.Status.COMPLETED, True),
+            ("failed", DataModelingJob.Status.FAILED, True),
+            ("still_running", DataModelingJob.Status.RUNNING, False),
         ]
     )
     @mock.patch("products.endpoints.backend.tasks.tasks._deactivate_version_materialization")
-    def test_selects_stale_version_from_a_recent_job_whatever_its_outcome(self, _name, job_status, mock_deactivate):
+    def test_selects_stale_version_from_a_recent_finished_job(
+        self, _name, job_status, expect_deactivation, mock_deactivate
+    ):
         now = timezone.now()
         _, version = self._create_materialized_endpoint(
             name="v2_scheduled",
@@ -246,6 +249,9 @@ class TestDeactivateStaleMaterializationsTask(BaseTest):
 
         deactivate_stale_materializations()
 
+        if not expect_deactivation:
+            mock_deactivate.assert_not_called()
+            return
         mock_deactivate.assert_called_once()
         assert mock_deactivate.call_args[0][0].id == version.id
 


### PR DESCRIPTION
## Problem

An endpoint version nobody queries keeps materializing on schedule, and pays for every run, when its materialization fails each time.

- `deactivate_stale_materializations` reverts a materialization that still runs on a schedule but that no request has used in 30 days.
- It read "still runs" as a completed data modeling job in the past 24 hours.
- A materialization that fails every run writes no completed job, so the task read it as already stopped and left it alone.
- The second signal, `saved_query.last_run_at`, is not written by the v2 data modeling backend, so the completed-job test was the only one left.
- The exempted versions are the ones most worth reverting: failing, unqueried, and still scheduled. Both production regions hold versions in this state today.

## Changes

- A stale endpoint version whose materialization only ever fails is now reverted, and stops being scheduled.
- The 24 hour activity test counts any finished data modeling job, whatever its outcome. A failed run proves the schedule fires as well as a completed run does.
- A job that is still running does not count. Its row is written before materialization starts, so reverting on it would soft-delete the saved query under a live workflow.
- No other gate moves. The 30 day staleness threshold, the materialization age floor, and the superseded rule are unchanged.
- Nothing a user sees changes, so there is no screenshot. The effect is a schedule that stops firing.

## How did you test this code?

- The existing single-job test became a parameterized trio covering a completed job, a failed job, and a job still running.
- The regressions it catches: a stale version whose only recent jobs failed must be selected for reverting, and one whose only recent job is still running must be left alone. No existing case used a non-completed job status.
- The failed case fails against master and passes here. The running case fails if the exclusion is removed.
- Not run: repo-wide suites. Only this file's suite ran locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote the change under direction. Skills invoked: `/writing-tests` to gate the new case, `/writing-pr-descriptions` for this body.

The defect surfaced while measuring an unrelated fix to the same task in production. The measurement asked which superseded versions were still burning compute, and this group answered every staleness test yet was never reverted. Reading the gate explained why. No production data reached this PR: the test builds its own endpoint, version, and job rows.

Searched open PRs for an existing fix (`deactivate_stale_materializations`, and a broader term); nothing covers this.

