### PR TITLE
chore(tests): capture snapshot HogQL queries at the executor

### DIFF
--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -6,9 +6,10 @@ import inspect
 import logging
 import datetime as dt
 import resource
+import threading
 from collections.abc import Callable, Generator, Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from contextlib import ExitStack, contextmanager
+from contextlib import AbstractContextManager, ExitStack, contextmanager
 from functools import wraps
 from typing import Any, Optional, Union, cast
 
@@ -2305,6 +2306,9 @@ def snapshot_hogql_queries(fn_or_class):
     @wraps(fn_or_class)
     def wrapped(self, *args, **kwargs):
         captured_queries = []
+        # A paginator call reaches the executor with the page limit added, so the executor skips it.
+        # Thread-local because a runner may execute its series on worker threads.
+        paginating = threading.local()
 
         # Patch the execute_hogql_query method on the paginator to capture queries before resolution
         original_paginator_method = HogQLHasMorePaginator.execute_hogql_query
@@ -2314,52 +2318,29 @@ def snapshot_hogql_queries(fn_or_class):
             if isinstance(query, ast.SelectQuery | ast.SelectSetQuery):
                 captured_queries.append(clone_expr(query))
 
-            return original_paginator_method(paginator_self, query=query, **exec_kwargs)
+            paginating.active = True
+            try:
+                return original_paginator_method(paginator_self, query=query, **exec_kwargs)
+            finally:
+                paginating.active = False
 
-        # Patch the module-level execute_hogql_query function for direct calls
-        # We need to patch it in modules that import it directly
-        original_module_function = hogql_query_module.execute_hogql_query
+        # Patch the executor every call reaches, whichever way its caller imported execute_hogql_query
+        original_executor_method = hogql_query_module.HogQLQueryExecutor.execute
 
-        def capture_module_execute(*exec_args, **exec_kwargs):
-            # Extract the query parameter - it can be positional or keyword
-            query = exec_kwargs.get("query") if "query" in exec_kwargs else (exec_args[0] if exec_args else None)
-
+        def capture_executor_execute(executor_self):
             # Capture the query AST before it gets resolved
-            if query and isinstance(query, ast.SelectQuery | ast.SelectSetQuery):
-                captured_queries.append(clone_expr(query))
+            if not getattr(paginating, "active", False) and isinstance(
+                executor_self.query, ast.SelectQuery | ast.SelectSetQuery
+            ):
+                captured_queries.append(clone_expr(executor_self.query))
 
-            return original_module_function(*exec_args, **exec_kwargs)
+            return original_executor_method(executor_self)
 
-        # Import modules that use execute_hogql_query directly
-        patches = [
+        # Annotated because the two patches have different types, which join to object.
+        patches: list[AbstractContextManager[Any]] = [
             patch.object(HogQLHasMorePaginator, "execute_hogql_query", capture_paginator_execute),
-            patch.object(hogql_query_module, "execute_hogql_query", capture_module_execute),
+            patch.object(hogql_query_module.HogQLQueryExecutor, "execute", capture_executor_execute),
         ]
-
-        # Add patches for modules that import execute_hogql_query directly
-        try:
-            from products.web_analytics.backend.hogql_queries import web_overview
-
-            if hasattr(web_overview, "execute_hogql_query"):
-                patches.append(patch.object(web_overview, "execute_hogql_query", capture_module_execute))
-        except ImportError:
-            pass
-
-        try:
-            from products.web_analytics.backend.hogql_queries import stats_table
-
-            if hasattr(stats_table, "execute_hogql_query"):
-                patches.append(patch.object(stats_table, "execute_hogql_query", capture_module_execute))
-        except ImportError:
-            pass
-
-        try:
-            from posthog.hogql_queries.insights.trends import trends_query_runner
-
-            if hasattr(trends_query_runner, "execute_hogql_query"):
-                patches.append(patch.object(trends_query_runner, "execute_hogql_query", capture_module_execute))
-        except ImportError:
-            pass
 
         # Apply all patches
         with ExitStack() as stack:

--- a/products/model_crossing_uses_baseline.txt
+++ b/products/model_crossing_uses_baseline.txt
@@ -858,8 +858,6 @@ web_analytics:backend/hogql_queries/ posthog.tasks.alerts.test.test_alert_subscr
 web_analytics:backend/hogql_queries/ posthog.tasks.alerts.test.test_metrics_alerts drives(TrendsQuery) 1
 web_analytics:backend/hogql_queries/ posthog.tasks.alerts.test.test_trends_absolute_alerts drives(TrendsQuery) 2
 web_analytics:backend/hogql_queries/ posthog.tasks.alerts.test.test_trends_relative_alerts drives(TrendsQuery) 1
-web_analytics:backend/hogql_queries/ posthog.test.base drives(stats_table) 1
-web_analytics:backend/hogql_queries/ posthog.test.base drives(web_overview) 1
 web_analytics:backend/hogql_queries/ products.actions.backend.api.test.test_action drives(TrendsQuery) 9
 web_analytics:backend/hogql_queries/ products.alerts.backend.tests.api.test_alert drives(TrendsQuery) 7
 web_analytics:backend/hogql_queries/ products.cohorts.backend.models.test.test_util drives(TrendsQuery) 1


### PR DESCRIPTION
## Problem

Product analytics cannot take the trends query runners out of core while core's own test base imports them. `hogli product:crossings` counts that import as an outside test driving the product's wiring location, which pins `backend/hogql_queries/**` into the product's contract-check inputs and re-arms the full Django suite on every runner edit.

This is the first slice of that decoupling. The relocation itself ([#94948](https://github.com/PostHog/posthog/pull/94948)) is closed until the drivers are cleared. Refs #77396

`snapshot_hogql_queries` patched `execute_hogql_query` on a fixed list of three modules that bound the name at import time: `web_overview` and `stats_table` in web analytics, and the trends runner in core. A runner that binds the name and is not on the list is silently not captured, and `stats_table` stopped importing it, so one of the three entries already did nothing.

## Changes

- Core's test base imports no product query module. The crossings baseline drops the two `posthog.test.base` lines for web analytics, and the trends one never appears once the runners move.
- Capture happens at `HogQLQueryExecutor.execute`, which every execution reaches whatever the caller imported.
- The paginator keeps its own capture, so a paginated query is still snapshotted as the runner built it, without the page limit the caller asked for.
- A thread-local flag stops the executor capturing that same query a second time. It is thread-local because a runner may execute its series on worker threads.
- Nothing a person sees changes. This is test infrastructure, and no snapshot content moves.

## How did you test this code?

- `products/web_analytics/backend/hogql_queries/test/test_sample_web_analytics_queries.py` is the decorator's only consumer, and it passes locally with every snapshot unchanged. It covers all three paths the old list served: the paginated stats queries, the direct-bind overview queries, and the trends runner.
- `hogli product:crossings --all --write-baseline` removes exactly two lines, and the crossings repo invariant passes on the result.
- `hogli product:lint --all`, repo-wide mypy, and `hogli ci:preflight --strict` are clean.
- No new tests. The consumer's snapshots already fail if capture stops, double-counts, or changes shape, which is every way this can break.
- Not run: the rest of the Django suite. `posthog/test/base.py` reaches most of it, so CI is the check.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: Claude Code in PostHog Desktop. Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/writing-code-comments`.
- The session first tried the opposite direction, converting the three listed modules to resolve `execute_hogql_query` at call time. That works but changes production import style in two products and moves ten `@patch` targets, so the capture seam moved into core instead.
- Capturing only at the executor was also tried, and it rewrote 30 snapshots in web analytics' file by adding the paginator's page limit. The paginator capture is kept for that reason.
- No duplicate: `gh pr list --state open` found no PR touching this decorator or the capture seam.
- Public artifact: nothing here comes from the agent session. The change is core test infrastructure and a generated baseline.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
