### PR TITLE
feat(logs): mask vendor ids in log patterns under version 5

### DIFF
--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -135,8 +135,6 @@ describe('log-pattern-mask', () => {
         })
 
         it.each([
-            ['a stripe subscription id', 'renewing sub_9RtVn2QwMkJd3FxPbZs6Hy today', 'renewing <ID> today'],
-            ['a clerk user id', 'synced user_2KpXr8ZmTq5NvBw7Ld3Cjs ok', 'synced <ID> ok'],
             ['a ulid-shaped id', 'claimed org_01ABCDEF23GHJK45MNPQRS67 lease', 'claimed <ID> lease'],
             [
                 'an id inside a url path',
@@ -147,10 +145,6 @@ describe('log-pattern-mask', () => {
             expect(maskString(input).masked).toEqual(expected)
         })
 
-        // The uppercase-and-digit pair is the only thing between this rule and ordinary snake_case
-        // English, which is spelled exactly like a prefixed id. `active_entitlements` and
-        // `balance_transactions` are Stripe URL path segments, so masking either would merge distinct
-        // endpoints onto one pattern — the reverse of what the rule is for.
         it.each([
             ['a snake_case word', 'listing push_subscriptions for team', 'listing push_subscriptions for team'],
             [
@@ -158,16 +152,9 @@ describe('log-pattern-mask', () => {
                 'GET /v1/entitlements/active_entitlements?limit=100',
                 'GET /v1/entitlements/active_entitlements?limit=<N>',
             ],
-            ['another snake_case word', 'pydantic_serializer failed', 'pydantic_serializer failed'],
-            [
-                'a third snake_case word',
-                'fetching balance_transactions page 2',
-                'fetching balance_transactions page <N>',
-            ],
             ['a body of digits only', 'folder team_123456 ready', 'folder team_123456 ready'],
             ['a body of lowercase and digits', 'repo repo_0a1b2c3d synced', 'repo repo_0a1b2c3d synced'],
-            // A lowercase run longer than the prefix cap has no word start the rule can reach, so it
-            // matches nothing rather than matching from the middle and emitting a truncated stem.
+            ['a body of letters but no digit', 'saw ref_QzWmTbKx once', 'saw ref_QzWmTbKx once'],
             ['a prefix past the cap', 'saw verylongprefix_Zq8xTv2wPn once', 'saw verylongprefix_Zq8xTv2wPn once'],
         ])('id does not claim %s', (_name, input, expected) => {
             expect(maskString(input).masked).toEqual(expected)
@@ -508,8 +495,7 @@ describe('log-pattern-mask', () => {
             'Jan  2 03:04:05 host sshd: accepted from 10.0.0.1',
             'built sha a3f9c1d2 at 1724495000 into deadbeefdeadbeef00',
             'charging cus_Qz4WmTb7Kx9pLr for user_2KpXr8ZmTq5NvBw7Ld3Cjs',
-            // An uppercase UUID behind a prefix matches both `id` and `uuid`, and `id` starts earlier.
-            // The chain only agrees with the single pass while `id` is listed first.
+            // An uppercase UUID behind a prefix: `id` and `uuid` both match, so the chain must run `id` first.
             'trace_0A1B2C3D-4E5F-6789-ABCD-EF0123456789 started',
         ]
 

--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -38,6 +38,7 @@ describe('log-pattern-mask', () => {
             ['ctime without a zone', 'booted Mon Jan 12 03:04:05 2026 ok', 'booted <TIMESTAMP> ok'],
             ['httpdate', 'expires Mon, 02 Jan 2026 03:04:05 GMT now', 'expires <TIMESTAMP> now'],
             ['syslogtime', 'Jan  2 03:04:05 host sshd: accepted', '<TIMESTAMP> host sshd: accepted'],
+            ['id', 'charging cus_Qz4WmTb7Kx9pLr now', 'charging <ID> now'],
             ['uuid', 'request 0f2d6faf-07e3-4cff-bf47-7efa1024aee2 failed', 'request <UUID> failed'],
             ['email', 'user alice@example.com rejected', 'user <EMAIL> rejected'],
             ['hex0x', 'fault at 0xdeadBEEF handler', 'fault at <HEX> handler'],
@@ -55,6 +56,11 @@ describe('log-pattern-mask', () => {
             ['email starting with digits is not mangled by num', '99bottles@example.com sent', '<EMAIL> sent'],
             ['email domain is not claimed by host', 'user@example.com sent', '<EMAIL> sent'],
             ['hex-looking labels are claimed by host, not hex', 'from deadbeefdeadbeef.com now', 'from <HOST> now'],
+            [
+                'a lowercase uuid behind a prefix stays a uuid, because the id rule needs an uppercase letter',
+                'job_0f2d6faf-07e3-4cff-bf47-7efa1024aee2 queued',
+                'job_<UUID> queued',
+            ],
             ['dotted quad stays an ip, not a host', 'from 10.0.0.1 now', 'from <IP> now'],
             ['host in a url masks whole', 'GET https://api.example.io/v2/users', 'GET https://<HOST>/v2/users'],
             [
@@ -128,6 +134,45 @@ describe('log-pattern-mask', () => {
             expect(maskString(input).masked).toEqual(expected)
         })
 
+        it.each([
+            ['a stripe subscription id', 'renewing sub_9RtVn2QwMkJd3FxPbZs6Hy today', 'renewing <ID> today'],
+            ['a clerk user id', 'synced user_2KpXr8ZmTq5NvBw7Ld3Cjs ok', 'synced <ID> ok'],
+            ['a ulid-shaped id', 'claimed org_01ABCDEF23GHJK45MNPQRS67 lease', 'claimed <ID> lease'],
+            [
+                'an id inside a url path',
+                'GET /v1/customers/cus_Vn8QjTz3Rw6Kp2/payment_methods',
+                'GET /v1/customers/<ID>/payment_methods',
+            ],
+        ])('id masks %s', (_name, input, expected) => {
+            expect(maskString(input).masked).toEqual(expected)
+        })
+
+        // The uppercase-and-digit pair is the only thing between this rule and ordinary snake_case
+        // English, which is spelled exactly like a prefixed id. `active_entitlements` and
+        // `balance_transactions` are Stripe URL path segments, so masking either would merge distinct
+        // endpoints onto one pattern — the reverse of what the rule is for.
+        it.each([
+            ['a snake_case word', 'listing push_subscriptions for team', 'listing push_subscriptions for team'],
+            [
+                'a snake_case url path segment',
+                'GET /v1/entitlements/active_entitlements?limit=100',
+                'GET /v1/entitlements/active_entitlements?limit=<N>',
+            ],
+            ['another snake_case word', 'pydantic_serializer failed', 'pydantic_serializer failed'],
+            [
+                'a third snake_case word',
+                'fetching balance_transactions page 2',
+                'fetching balance_transactions page <N>',
+            ],
+            ['a body of digits only', 'folder team_123456 ready', 'folder team_123456 ready'],
+            ['a body of lowercase and digits', 'repo repo_0a1b2c3d synced', 'repo repo_0a1b2c3d synced'],
+            // A lowercase run longer than the prefix cap has no word start the rule can reach, so it
+            // matches nothing rather than matching from the middle and emitting a truncated stem.
+            ['a prefix past the cap', 'saw verylongprefix_Zq8xTv2wPn once', 'saw verylongprefix_Zq8xTv2wPn once'],
+        ])('id does not claim %s', (_name, input, expected) => {
+            expect(maskString(input).masked).toEqual(expected)
+        })
+
         // The hex rule needs a letter, which is what keeps its 8-char floor off plain numbers. Without
         // the letter, every id, epoch, and byte count of 8 or more digits would read as `<HEX>`.
         it.each([
@@ -185,6 +230,7 @@ describe('log-pattern-mask', () => {
                 ctime: 0,
                 httpdate: 0,
                 syslogtime: 0,
+                id: 0,
                 uuid: 0,
                 email: 2,
                 host: 1,
@@ -328,6 +374,7 @@ describe('log-pattern-mask', () => {
             'mail ops@example.com via api.example.com at 10.0.0.7 slot 0xdeadbeef',
             'checksum deadbeefdeadbeef00 verified',
             'built sha a3f9c1d2 from 1724495000',
+            'charging cus_Qz4WmTb7Kx9pLr for org_01ABCDEF23GHJK45MNPQRS67',
             '{"10.0.0.1":1,"10.0.0.2":2}',
             ...MESSAGE_KEYS.map((key) => JSON.stringify({ [key]: 'served 3 requests', level: 'info' })),
             '{"msg":"loses 2","message":"wins 1"}',
@@ -361,6 +408,7 @@ describe('log-pattern-mask', () => {
         const SHAPE_DIGESTS: Record<number, string> = {
             3: 'd7b045b1054244d1',
             4: '357baaab19f622df',
+            5: 'c505078a36e3406f',
         }
 
         /**
@@ -459,6 +507,10 @@ describe('log-pattern-mask', () => {
             '10.0.0.1 - - [02/Jan/2026:03:04:05 +0000] "GET /v0/export" 200 35',
             'Jan  2 03:04:05 host sshd: accepted from 10.0.0.1',
             'built sha a3f9c1d2 at 1724495000 into deadbeefdeadbeef00',
+            'charging cus_Qz4WmTb7Kx9pLr for user_2KpXr8ZmTq5NvBw7Ld3Cjs',
+            // An uppercase UUID behind a prefix matches both `id` and `uuid`, and `id` starts earlier.
+            // The chain only agrees with the single pass while `id` is listed first.
+            'trace_0A1B2C3D-4E5F-6789-ABCD-EF0123456789 started',
         ]
 
         it.each(corpus.map((line) => [line] as const))('%s', (line) => {

--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -55,6 +55,7 @@ describe('log-pattern-mask', () => {
             ['ip octets are not eaten by num', 'peer 192.168.0.1:8080 up', 'peer <IP>:<N> up'],
             ['email starting with digits is not mangled by num', '99bottles@example.com sent', '<EMAIL> sent'],
             ['email domain is not claimed by host', 'user@example.com sent', '<EMAIL> sent'],
+            ['email with an id-shaped local part is not split by id', 'john_D2oe@example.com sent', '<EMAIL> sent'],
             ['hex-looking labels are claimed by host, not hex', 'from deadbeefdeadbeef.com now', 'from <HOST> now'],
             [
                 'a lowercase uuid behind a prefix stays a uuid, because the id rule needs an uppercase letter',
@@ -140,6 +141,12 @@ describe('log-pattern-mask', () => {
                 'an id inside a url path',
                 'GET /v1/customers/cus_Vn8QjTz3Rw6Kp2/payment_methods',
                 'GET /v1/customers/<ID>/payment_methods',
+            ],
+            ['a hyphenated id whole', 'span sess_3Ih3uQk-9Xz2 closed', 'span <ID> closed'],
+            [
+                'an uppercase uuid behind a prefix whole, tail included',
+                'trace_0A1B2C3D-4E5F-6789-ABCD-EF0123456789 started',
+                '<ID> started',
             ],
         ])('id masks %s', (_name, input, expected) => {
             expect(maskString(input).masked).toEqual(expected)
@@ -395,7 +402,7 @@ describe('log-pattern-mask', () => {
         const SHAPE_DIGESTS: Record<number, string> = {
             3: 'd7b045b1054244d1',
             4: '357baaab19f622df',
-            5: 'c505078a36e3406f',
+            5: '130ce70d5eeff09e',
         }
 
         /**
@@ -497,6 +504,8 @@ describe('log-pattern-mask', () => {
             'charging cus_Qz4WmTb7Kx9pLr for user_2KpXr8ZmTq5NvBw7Ld3Cjs',
             // An uppercase UUID behind a prefix: `id` and `uuid` both match, so the chain must run `id` first.
             'trace_0A1B2C3D-4E5F-6789-ABCD-EF0123456789 started',
+            // An id-shaped local part: `id` and `email` match at one offset, so the chain must run `email` first.
+            'john_D2oe@example.com sent',
         ]
 
         it.each(corpus.map((line) => [line] as const))('%s', (line) => {

--- a/nodejs/src/logs/log-pattern-mask.ts
+++ b/nodejs/src/logs/log-pattern-mask.ts
@@ -131,22 +131,9 @@ export const MASK_RULES: readonly MaskRule[] = [
         pattern: `\\b(?:${WEEKDAY} )?${MONTH} {1,2}${DAY_OF_MONTH} ${TIME_OF_DAY}`,
         replacement: '<TIMESTAMP>',
     },
-    // Vendor ids: a short lowercase prefix, an underscore, then a base62 body, as in Stripe
-    // `cus_`/`sub_`, Clerk `user_`, Vercel `dpl_`, and ULID-shaped `org_`. No rule below reaches
-    // them, because the body carries no interior word boundary and `num` and `hex` both need one.
-    //
-    // The body must carry an uppercase letter *and* a digit. That pair is the whole guard: ordinary
-    // snake_case English (`push_subscriptions`, `active_entitlements`) has the same prefix-and-
-    // underscore shape, and masking it would merge distinct endpoints onto one pattern. RE2 has no
-    // lookahead, so "contains both" is spelled as the two orders they can appear in. A length floor
-    // cannot ride on that spelling, so the body has none; the pair alone rejects prose.
-    //
-    // `\b` holds the prefix to a word start, so a lowercase run longer than the prefix cap matches
-    // nothing rather than matching mid-word and emitting a truncated stem.
-    //
-    // Listed ahead of `uuid`: this rule's match starts at the prefix, so the single pass already
-    // prefers it on an overlap, and the sequential chain must run it first for the two to agree.
-    // The agreement corpus asserts this with an uppercase UUID behind a prefix.
+    // Prefixed vendor ids (Stripe `cus_`/`sub_`, Clerk `user_`, ULID-shaped `org_`). The body needs
+    // an uppercase letter and a digit to stay off snake_case words; RE2 lacks lookahead, so both
+    // orders are spelled out. Keep listed ahead of `uuid` (asserted by the agreement corpus).
     {
         name: 'id',
         pattern: '\\b[a-z]{2,10}_(?:[A-Za-z0-9]*[A-Z][A-Za-z0-9]*[0-9]|[A-Za-z0-9]*[0-9][A-Za-z0-9]*[A-Z])[A-Za-z0-9]*',

--- a/nodejs/src/logs/log-pattern-mask.ts
+++ b/nodejs/src/logs/log-pattern-mask.ts
@@ -131,34 +131,22 @@ export const MASK_RULES: readonly MaskRule[] = [
         pattern: `\\b(?:${WEEKDAY} )?${MONTH} {1,2}${DAY_OF_MONTH} ${TIME_OF_DAY}`,
         replacement: '<TIMESTAMP>',
     },
-    // Vendor ids: a short lowercase prefix, an underscore, then a base62 body. Stripe (`cus_`, `sub_`,
-    // `seti_`), Clerk (`user_`), Vercel (`dpl_`) and ULID-shaped ids (`org_`, `partition_`) all take
-    // this shape, and none of the rules below reach them. The body opens on an underscore and closes
-    // on the end of a word, so it carries no interior word boundary: `num` and `hex` both need one and
-    // both skip the token, and the id survives into the pattern. One line per id is one pattern per
-    // line, which is the single largest source of pattern cardinality in real traffic.
+    // Vendor ids: a short lowercase prefix, an underscore, then a base62 body, as in Stripe
+    // `cus_`/`sub_`, Clerk `user_`, Vercel `dpl_`, and ULID-shaped `org_`. No rule below reaches
+    // them, because the body carries no interior word boundary and `num` and `hex` both need one.
     //
-    // The body must carry an uppercase letter *and* a digit. That pair is the whole guard, because the
-    // prefix and the underscore are also how ordinary snake_case English is spelled: without it,
-    // `push_subscriptions`, `pydantic_serializer` and `override_properties` all mask. Two of the words
-    // this rejects, `active_entitlements` and `balance_transactions`, are Stripe URL path segments, so
-    // masking them would merge distinct endpoints onto one pattern — the reverse of the rule's purpose.
+    // The body must carry an uppercase letter *and* a digit. That pair is the whole guard: ordinary
+    // snake_case English (`push_subscriptions`, `active_entitlements`) has the same prefix-and-
+    // underscore shape, and masking it would merge distinct endpoints onto one pattern. RE2 has no
+    // lookahead, so "contains both" is spelled as the two orders they can appear in. A length floor
+    // cannot ride on that spelling, so the body has none; the pair alone rejects prose.
     //
-    // RE2 has no lookahead, so "contains both" is spelled as the two orders they can appear in. That
-    // same limit is why the body carries no minimum length: a length floor and a contains-both
-    // requirement cannot ride on one RE2 expression together, and the pair is the half that rejects
-    // prose. A short body still needs both classes to match, and neither an English word nor a bare
-    // count has either.
+    // `\b` holds the prefix to a word start, so a lowercase run longer than the prefix cap matches
+    // nothing rather than matching mid-word and emitting a truncated stem.
     //
-    // `\b` holds the prefix to a word start. Without it the prefix can begin mid-word and emit a
-    // truncated stem, so one id shape reaches the pattern under two spellings. A lowercase run longer
-    // than the prefix cap then matches nothing at all rather than matching from the middle, which is
-    // the safe way to lose it.
-    //
-    // Listed ahead of `uuid`, and so ahead of every rule whose match can only start inside the body.
-    // The single pass takes the earliest start, and this rule starts at the prefix, so it already wins
-    // there; the chain has to run it in the same place or the two disagree. An uppercase UUID behind a
-    // prefix is the case that separates them, and it is in the agreement corpus.
+    // Listed ahead of `uuid`: this rule's match starts at the prefix, so the single pass already
+    // prefers it on an overlap, and the sequential chain must run it first for the two to agree.
+    // The agreement corpus asserts this with an uppercase UUID behind a prefix.
     {
         name: 'id',
         pattern: '\\b[a-z]{2,10}_(?:[A-Za-z0-9]*[A-Z][A-Za-z0-9]*[0-9]|[A-Za-z0-9]*[0-9][A-Za-z0-9]*[A-Z])[A-Za-z0-9]*',

--- a/nodejs/src/logs/log-pattern-mask.ts
+++ b/nodejs/src/logs/log-pattern-mask.ts
@@ -35,9 +35,9 @@ export type MaskRuleName =
     | 'ctime'
     | 'httpdate'
     | 'syslogtime'
+    | 'email'
     | 'id'
     | 'uuid'
-    | 'email'
     | 'host'
     | 'hex0x'
     | 'hex'
@@ -131,12 +131,18 @@ export const MASK_RULES: readonly MaskRule[] = [
         pattern: `\\b(?:${WEEKDAY} )?${MONTH} {1,2}${DAY_OF_MONTH} ${TIME_OF_DAY}`,
         replacement: '<TIMESTAMP>',
     },
-    // Prefixed vendor ids (Stripe `cus_`/`sub_`, Clerk `user_`, ULID-shaped `org_`). The body needs
-    // an uppercase letter and a digit to stay off snake_case words; RE2 lacks lookahead, so both
-    // orders are spelled out. Keep listed ahead of `uuid` (asserted by the agreement corpus).
+    // Listed ahead of `id`, which would otherwise take a local part shaped like `john_D2oe` and leave
+    // the domain to `host`.
+    { name: 'email', pattern: '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}', replacement: '<EMAIL>' },
+    // Prefixed vendor ids (Stripe `cus_`/`sub_`, Clerk `user_`, ULID-shaped `org_`). The first segment
+    // needs an uppercase letter and a digit to stay off snake_case words; RE2 lacks lookahead, so both
+    // orders are spelled out. Hyphen-joined segments belong to the id, so a hyphenated token masks
+    // whole instead of leaving its tail behind as literals. Listed ahead of `uuid` so the sequential
+    // chain agrees with the single pass on a prefixed uppercase UUID.
     {
         name: 'id',
-        pattern: '\\b[a-z]{2,10}_(?:[A-Za-z0-9]*[A-Z][A-Za-z0-9]*[0-9]|[A-Za-z0-9]*[0-9][A-Za-z0-9]*[A-Z])[A-Za-z0-9]*',
+        pattern:
+            '\\b[a-z]{2,10}_(?:[A-Za-z0-9]*[A-Z][A-Za-z0-9]*[0-9]|[A-Za-z0-9]*[0-9][A-Za-z0-9]*[A-Z])[A-Za-z0-9]*(?:-[A-Za-z0-9]+)*',
         replacement: '<ID>',
     },
     {
@@ -144,7 +150,6 @@ export const MASK_RULES: readonly MaskRule[] = [
         pattern: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',
         replacement: '<UUID>',
     },
-    { name: 'email', pattern: '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}', replacement: '<EMAIL>' },
     // The suffix list carries no `so` or `sh`. Both are real TLDs, but the rule cannot tell a host
     // from a filename, and shared object and shell script names reach it far more often than a
     // Somali or Saint Helenian domain does. With them in the list, `libssl.so` and `deploy.sh` both

--- a/nodejs/src/logs/log-pattern-mask.ts
+++ b/nodejs/src/logs/log-pattern-mask.ts
@@ -2,7 +2,7 @@ import { createTrackedRE2 } from '~/common/utils/tracked-re2'
 
 import { parseLogBodyForIngestion } from './log-body-parse'
 
-export const PATTERN_VERSION = 4
+export const PATTERN_VERSION = 5
 
 /**
  * Everything here shapes the emitted pattern, so it sits inside `PATTERN_VERSION`: two records may
@@ -35,6 +35,7 @@ export type MaskRuleName =
     | 'ctime'
     | 'httpdate'
     | 'syslogtime'
+    | 'id'
     | 'uuid'
     | 'email'
     | 'host'
@@ -129,6 +130,39 @@ export const MASK_RULES: readonly MaskRule[] = [
         name: 'syslogtime',
         pattern: `\\b(?:${WEEKDAY} )?${MONTH} {1,2}${DAY_OF_MONTH} ${TIME_OF_DAY}`,
         replacement: '<TIMESTAMP>',
+    },
+    // Vendor ids: a short lowercase prefix, an underscore, then a base62 body. Stripe (`cus_`, `sub_`,
+    // `seti_`), Clerk (`user_`), Vercel (`dpl_`) and ULID-shaped ids (`org_`, `partition_`) all take
+    // this shape, and none of the rules below reach them. The body opens on an underscore and closes
+    // on the end of a word, so it carries no interior word boundary: `num` and `hex` both need one and
+    // both skip the token, and the id survives into the pattern. One line per id is one pattern per
+    // line, which is the single largest source of pattern cardinality in real traffic.
+    //
+    // The body must carry an uppercase letter *and* a digit. That pair is the whole guard, because the
+    // prefix and the underscore are also how ordinary snake_case English is spelled: without it,
+    // `push_subscriptions`, `pydantic_serializer` and `override_properties` all mask. Two of the words
+    // this rejects, `active_entitlements` and `balance_transactions`, are Stripe URL path segments, so
+    // masking them would merge distinct endpoints onto one pattern — the reverse of the rule's purpose.
+    //
+    // RE2 has no lookahead, so "contains both" is spelled as the two orders they can appear in. That
+    // same limit is why the body carries no minimum length: a length floor and a contains-both
+    // requirement cannot ride on one RE2 expression together, and the pair is the half that rejects
+    // prose. A short body still needs both classes to match, and neither an English word nor a bare
+    // count has either.
+    //
+    // `\b` holds the prefix to a word start. Without it the prefix can begin mid-word and emit a
+    // truncated stem, so one id shape reaches the pattern under two spellings. A lowercase run longer
+    // than the prefix cap then matches nothing at all rather than matching from the middle, which is
+    // the safe way to lose it.
+    //
+    // Listed ahead of `uuid`, and so ahead of every rule whose match can only start inside the body.
+    // The single pass takes the earliest start, and this rule starts at the prefix, so it already wins
+    // there; the chain has to run it in the same place or the two disagree. An uppercase UUID behind a
+    // prefix is the case that separates them, and it is in the agreement corpus.
+    {
+        name: 'id',
+        pattern: '\\b[a-z]{2,10}_(?:[A-Za-z0-9]*[A-Z][A-Za-z0-9]*[0-9]|[A-Za-z0-9]*[0-9][A-Za-z0-9]*[A-Z])[A-Za-z0-9]*',
+        replacement: '<ID>',
     },
     {
         name: 'uuid',


### PR DESCRIPTION
## Problem

Anyone grouping logs by pattern sees one pattern per log line for a large family of messages, so grouping does nothing for them. Prefixed base62 identifiers — Stripe `cus_`/`sub_`/`seti_`, Clerk `user_`, Vercel `dpl_`, ULID-shaped `org_` and `partition_` — reach the emitted pattern unmasked.

No existing rule touches them. The body opens on an underscore and closes on the end of a word, so it carries no interior word boundary. `num` and `hex` each need one, so both skip the token and the id lands in the pattern.

Sampling the current version 4 output on real traffic, this is the single largest source of pattern cardinality. It is also a privacy point: a Stripe customer id is a customer identifier, and it currently sits in an indexed column.

## Changes

- Log patterns now collapse a prefixed identifier to `<ID>`, so lines that differ only by that id group together. A new `id` mask rule does the work.
- The rule requires an uppercase letter **and** a digit in the body. That pair is the guard, because a lowercase prefix and an underscore are also how ordinary snake_case English is spelled. Without it `push_subscriptions` and `pydantic_serializer` mask, and so do the API path segments `active_entitlements` and `balance_transactions` — merging distinct endpoints onto one pattern, which is the reverse of the point.
- A hyphenated id such as `sess_3Ih3uQk-9Xz2` masks whole. Hyphen-joined segments belong to the id, so no tail survives as literals. An uppercase UUID behind a prefix masks to `<ID>` the same way.
- An email whose local part reads like an id, such as `john_D2oe@example.com`, still masks to `<EMAIL>`. The `email` rule now sits ahead of `id`, which would otherwise take the local part and leave the domain to `host`.
- `PATTERN_VERSION` moves to 5, with its digest recorded. Consumers already compare patterns only within one version.
- Mechanical: the rule-fires expectation and the two ratchet corpora gain the new rule.

Two design notes a reviewer should not have to derive:

- RE2 has no lookahead, so "contains both an uppercase and a digit" is spelled as the two orders they can appear in. The same limit is why the body carries no minimum length — a length floor and a contains-both requirement cannot ride on one expression together, and the pair is the half that rejects prose.
- The rule is listed ahead of `uuid`, and so ahead of every rule whose match can only start inside the body. The single pass takes the earliest start and this rule starts at the prefix, so the sequential chain has to run it in the same place or the two disagree. An uppercase UUID behind a prefix is the case that separates them, and it is in the agreement corpus.
- Order alone cannot keep that UUID whole, because `id` starts at the prefix and `uuid` starts six characters later. The hyphen tail on the `id` body is what keeps it whole. The prefix literal is lost in that case, while a lowercase UUID behind a prefix keeps it as `job_<UUID>`. Keeping the prefix needs a capture group, which the rule engine forbids.

## How did you test this code?

Automated, run locally: `jest src/logs/log-pattern-mask.test.ts src/logs/log-pattern-stage.test.ts`. Prettier and eslint clean on both files.

The new coverage catches regressions no existing test did:

- Dropping either half of the uppercase-and-digit guard. The negative table fails on ordinary snake_case words and on API path segments, which is the failure that would silently merge endpoints.
- Removing the `\b` prefix anchor. A lowercase run longer than the prefix cap must match nothing rather than matching from the middle and emitting a truncated stem.
- Reordering the rule after `uuid`. The agreement corpus fails, because the single pass and the sequential chain then disagree on an uppercase UUID behind a prefix.
- A body of digits only, or of lowercase and digits, must stay unmasked — those belong to other rules.
- Dropping the hyphen tail. The `id masks` table fails on a hyphenated id and on an uppercase UUID behind a prefix, which would otherwise shred into short hex literals.
- Moving `email` back behind `id`. The ordering table and the agreement corpus both fail on an id-shaped local part.

Beyond the unit tests, three candidate rules were measured against live version 4 patterns over several five-minute windows spanning daytime, overnight, weekend, and version 3 output. Two candidates were rejected on that evidence: a rule without the character-class guard rewrote a meaningful share of stable, high-frequency templates, and a looser digit-and-letter variant still mis-masked a Kubernetes CRD kind. The shipped rule altered no high-frequency template in any window, and cut distinct patterns by roughly two thirds in each. The one high-frequency template it did alter on inspection turned out to be a correct mask: two near-identical templates that differed only by embedded ids, which the rule merges into one.

The two review findings were checked against live log bodies through Metabase before the fix. Both shapes occur in production. A prefixed UUID is nearly always lowercase, which the rule already left whole, and the uppercase form is rare. An email with an id-shaped local part did not appear in the window checked. Hyphen tails after an `id` match are token fragments, not words, so consuming them is the correct mask. The shipped `id` pattern was then run over the same slice with ClickHouse's RE2 and claimed no prefix the earlier pattern did not.

Not checked: no ingestion run against a live pipeline, and no measurement of masking CPU cost with the extra alternation in the combined expression.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing docs cover the mask rule set.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a Slack thread that started as a question about whether pattern version 4 improved on version 3. Measuring that found version 4 flat on total cardinality, and sampling the tail found this one unmasked family behind most of it. The rule was then designed, tested against live patterns, tightened after the first candidate proved to over-mask, and validated across several windows before any code was written.

Repo skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The hyphen tail and the `email` order came from a second session (Claude Code, human-driven) that worked through the review comments, checked each against live bodies through Metabase, and re-recorded the version 5 digest.

Public artifact: the work drew on production log data. Every identifier in the test fixtures is invented rather than transcribed, and no counts, customer identifiers, or thread contents appear in the code or this description. An earlier draft of the tests did carry transcribed ids; they were replaced before the first commit.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S66N93FX/p1788782624882879)*


