### PR TITLE
fix(insights): refuse an update that removes an insight's query

### DIFF
--- a/products/product_analytics/backend/presentation/insight.py
+++ b/products/product_analytics/backend/presentation/insight.py
@@ -723,12 +723,22 @@ class InsightSerializer(InsightBasicSerializer):
                 "Send a query object instead. See https://posthog.com/docs/api/insights"
             )
 
-        if self.instance is None and query in (None, {}):
-            raise ValidationError(
-                {
-                    "query": "Creating an insight needs a query. See https://posthog.com/docs/api/insights",
-                }
-            )
+        if query in (None, {}):
+            if self.instance is None:
+                raise ValidationError(
+                    {
+                        "query": "Creating an insight needs a query. See https://posthog.com/docs/api/insights",
+                    }
+                )
+            if "query" in attrs:
+                # Writing the empty query would erase the stored definition, and nothing renders
+                # an insight without one, so the write is refused instead.
+                raise ValidationError(
+                    {
+                        "query": "An insight needs a query. To keep the stored one, leave query out of the "
+                        "request. See https://posthog.com/docs/api/insights",
+                    }
+                )
 
         validate_insight_write(
             query=query,

--- a/products/product_analytics/backend/tests/api/test_insight.py
+++ b/products/product_analytics/backend/tests/api/test_insight.py
@@ -143,6 +143,21 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()["attr"], "query")
 
+    def test_updating_an_insight_to_remove_its_query_is_rejected(self) -> None:
+        # An explicit null used to be written, which erased the stored definition.
+        insight = Insight.objects.create(
+            team=self.team,
+            name="Query insight",
+            query=default_pageview_query(),
+        )
+        stored_query = Insight.objects.get(pk=insight.pk).query
+
+        response = self.client.patch(f"/api/projects/{self.team.id}/insights/{insight.id}/", {"query": None})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["attr"], "query")
+        self.assertEqual(Insight.objects.get(pk=insight.pk).query, stored_query)
+
     def test_creating_query_insight_is_allowed(self) -> None:
         response = self.client.post(
             f"/api/projects/{self.team.id}/insights/",


### PR DESCRIPTION
## Problem

An insight can lose its definition. A write that clears the query empties the insight, the chart renders nothing, and the stored definition is gone.

- The API accepts an update that sends an empty query, and writes it.
- The check that requires a query runs on create only, because it is gated on `self.instance is None`.
- Production activity logs show saved insights emptied this way, days after the create-side check shipped in #93110. The evidence is internal, so it is not linkable here.
- The client that sends the empty query is not identified. `sqlEditorLogic` puts `query` in every SQL insight save, so a save whose visualization query resolves to null would produce this request. That path is not changed here.

## Changes

- An update that sends an empty query now fails with 400. The message says to leave `query` out of the request to keep the stored one.
- An update that omits `query` still keeps the stored definition. That is what a metadata-only edit sends, so renaming an insight is unaffected.
- Nothing looks different in the app. No frontend file changes.

> [!WARNING]
> This refuses a request that used to succeed. A caller that clears an insight's query on purpose gets a 400 instead. Creating an insight already answered the same way.

## How did you test this code?

- Added one case to `test_insight.py`: an update sending an empty query returns 400 and the stored query survives. It guards the data loss above. The create path was covered; no test covered the update path.
- Nine funnel tests in that file fail on master in this environment as well, before the change. They exercise the legacy funnel endpoint and are unrelated.
- Not run: the frontend suites, because no frontend file changes, and a repo-wide mypy pass, because the diff adds no types.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The insight API docs already state that a query is required.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 5) while working through the legacy insight `filters` removal. The hole surfaced from a status re-check of insights that still lack a query: one row's count grew, and its activity log showed the query deleted by an update rather than a new row being created.

Skills invoked: `/improving-drf-endpoints`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.

No duplicate: `gh pr list --state open --search` over the insight and query keywords found no open PR fixing this.

Public artifact: the diff carries no material from the session. The test builds its fixture from the repo's existing `default_pageview_query()` helper, and no customer, team, or insight identifier appears in the code or this description.
