### PR TITLE
perf(notebooks): index the notebook dependency scan

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.test.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.test.ts
@@ -17,6 +17,11 @@ describe('buildNotebookDependencyGraph', () => {
         attrs: { nodeId, returnVariable, code },
     })
 
+    const duckSqlNode = (nodeId: string, returnVariable: string, code: string): Record<string, unknown> => ({
+        type: NotebookNodeType.DuckSQL,
+        attrs: { nodeId, returnVariable, code },
+    })
+
     it('links a SQLV2 node to a downstream SQLV2 node that references it by table name', () => {
         // The "Used in" back-links depend on SQLV2 producing an export and its reader listing it as a use.
         const content = {
@@ -43,6 +48,22 @@ describe('buildNotebookDependencyGraph', () => {
         expect(graph.nodesById['b'].exports).toEqual(['sql_df_2'])
         expect(graph.downstreamUsageByNode['a'].sql_df.map((usage) => usage.nodeId)).toEqual(['c'])
         expect(graph.upstreamSourcesByNode['c'].sql_df.nodeId).toEqual('a')
+    })
+
+    it('links DuckSQL cells whose names differ only by case, unlike exact-match cells', () => {
+        // A DuckSQL cell matches a name case-insensitively, so a reference in a different case still
+        // links. This exercises the normalized index key that DuckSQL cells resolve through.
+        const content = {
+            type: 'doc',
+            content: [duckSqlNode('a', 'MyDf', 'select id from events'), duckSqlNode('b', 'out', 'select * from MYDF')],
+        }
+        const graph = buildNotebookDependencyGraph(content)
+        expect(Object.values(graph.upstreamSourcesByNode['b']).map((usage) => usage.nodeId)).toContain('a')
+        expect(
+            Object.values(graph.downstreamUsageByNode['a'])
+                .flat()
+                .map((usage) => usage.nodeId)
+        ).toContain('b')
     })
 
     it('an unnamed SQL cell is not browsable as a dataframe', () => {

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.ts
@@ -142,7 +142,7 @@ export const extractDuckSqlTables = (sql: string): string[] => {
 
 // Rough by design, like the SQL extraction above: identifiers a Python cell's code mentions,
 // with string literals, comments, and attribute tails stripped. Only ever intersected with
-// sibling exports (matchesUsage), so a false positive just marks an extra cell stale.
+// sibling exports, so a false positive just marks an extra cell stale.
 export const extractPythonIdentifiers = (code: string): string[] => {
     const cleaned = (code || '')
         .replace(/('''[\s\S]*?'''|"""[\s\S]*?""")/g, ' ')
@@ -667,13 +667,6 @@ const buildDependencyUsage = (node: NotebookDependencyNode): NotebookDependencyU
     }
 }
 
-const matchesUsage = (exportName: string, usageName: string, usageNodeType: NotebookNodeType): boolean => {
-    if (usageNodeType === NotebookNodeType.DuckSQL) {
-        return normalizeDuckSqlIdentifier(exportName) === normalizeDuckSqlIdentifier(usageName)
-    }
-    return exportName === usageName
-}
-
 export type NotebookDependencyDirection = 'upstream' | 'downstream'
 
 /** Transitive closure of a node's dependencies (or dependents), including the start node. */
@@ -873,14 +866,84 @@ export const buildNotebookDependencyGraph = (content?: JSONContent | null): Note
     const upstreamSourcesByNode: Record<string, Record<string, NotebookDependencyUsage>> = {}
     const downstreamUsageByNode: Record<string, Record<string, NotebookDependencyUsage[]>> = {}
 
-    nodes.forEach((node, nodeIndex) => {
-        const upstreamNodes = nodes.slice(0, nodeIndex)
-        const downstreamNodes = nodes.slice(nodeIndex + 1)
+    // Comparing every node with every other node is quadratic and runs on each edit. Index the
+    // exports and the uses by name once, so a node resolves its sources and its dependents by
+    // lookup instead. A non-DuckSQL cell matches a name exactly; a DuckSQL cell matches it
+    // normalized. So a name is indexed under both forms, and the consumer's type picks the key.
+    const rawKey = (name: string): string => `raw:${name}`
+    const duckKey = (name: string): string => `duck:${normalizeDuckSqlIdentifier(name)}`
+    const consumerKey = (usageName: string, consumerType: NotebookNodeType): string =>
+        consumerType === NotebookNodeType.DuckSQL ? duckKey(usageName) : rawKey(usageName)
 
+    const positionByNode = new Map<NotebookDependencyNode, number>()
+    const exportersByKey = new Map<string, NotebookDependencyNode[]>()
+    const consumersByKey = new Map<string, NotebookDependencyNode[]>()
+    const appendNode = (
+        index: Map<string, NotebookDependencyNode[]>,
+        key: string,
+        node: NotebookDependencyNode
+    ): void => {
+        const list = index.get(key)
+        // Nodes arrive in document order, so a list stays sorted by position. Skip a repeat so a cell
+        // that uses one name twice is listed once.
+        if (!list) {
+            index.set(key, [node])
+        } else if (list[list.length - 1] !== node) {
+            list.push(node)
+        }
+    }
+    nodes.forEach((node, nodeIndex) => {
+        positionByNode.set(node, nodeIndex)
+        for (const exportName of node.exports) {
+            appendNode(exportersByKey, rawKey(exportName), node)
+            appendNode(exportersByKey, duckKey(exportName), node)
+        }
+        for (const usageName of node.uses) {
+            appendNode(consumersByKey, consumerKey(usageName, node.nodeType), node)
+        }
+    })
+
+    // The earliest exporter of a name is the first entry of its list, so a source before this node
+    // exists only when that entry is before it.
+    const sourceBefore = (
+        usageName: string,
+        consumerType: NotebookNodeType,
+        position: number
+    ): NotebookDependencyNode | null => {
+        const exporters = exportersByKey.get(consumerKey(usageName, consumerType))
+        const earliest = exporters?.[0]
+        return earliest && positionByNode.get(earliest)! < position ? earliest : null
+    }
+
+    // A non-DuckSQL cell using this name lives under its raw key, a DuckSQL cell under its duck key.
+    // The two lists are disjoint and sorted, so merge them and keep the dependents after this node.
+    const dependentsAfter = (exportName: string, position: number): NotebookDependencyNode[] => {
+        const rawList = consumersByKey.get(rawKey(exportName)) ?? []
+        const duckList = consumersByKey.get(duckKey(exportName)) ?? []
+        const dependents: NotebookDependencyNode[] = []
+        let rawIndex = 0
+        let duckIndex = 0
+        while (rawIndex < rawList.length || duckIndex < duckList.length) {
+            const rawNode = rawIndex < rawList.length ? rawList[rawIndex] : null
+            const duckNode = duckIndex < duckList.length ? duckList[duckIndex] : null
+            const takeRaw =
+                rawNode !== null && (duckNode === null || positionByNode.get(rawNode)! < positionByNode.get(duckNode)!)
+            const nextNode = takeRaw ? rawNode! : duckNode!
+            if (takeRaw) {
+                rawIndex++
+            } else {
+                duckIndex++
+            }
+            if (positionByNode.get(nextNode)! > position) {
+                dependents.push(nextNode)
+            }
+        }
+        return dependents
+    }
+
+    nodes.forEach((node, nodeIndex) => {
         const upstreamSources = node.uses.reduce<Record<string, NotebookDependencyUsage>>((acc, usageName) => {
-            const source = upstreamNodes.find((upstreamNode) =>
-                upstreamNode.exports.some((exportName) => matchesUsage(exportName, usageName, node.nodeType))
-            )
+            const source = sourceBefore(usageName, node.nodeType, nodeIndex)
             if (source) {
                 acc[usageName] = buildDependencyUsage(source)
             }
@@ -888,13 +951,7 @@ export const buildNotebookDependencyGraph = (content?: JSONContent | null): Note
         }, {})
 
         const downstreamUsage = node.exports.reduce<Record<string, NotebookDependencyUsage[]>>((acc, exportName) => {
-            acc[exportName] = downstreamNodes
-                .filter((downstreamNode) =>
-                    downstreamNode.uses.some((usageName) =>
-                        matchesUsage(exportName, usageName, downstreamNode.nodeType)
-                    )
-                )
-                .map(buildDependencyUsage)
+            acc[exportName] = dependentsAfter(exportName, nodeIndex).map(buildDependencyUsage)
             return acc
         }, {})
 


### PR DESCRIPTION
## Problem

- Typing in a notebook with many Python or SQL cells lags, and the lag grows faster than the cell count.
- The dependency graph compared every cell with every other cell, so its cost grew with the square of the cell count. `notebookLogic` rebuilds the graph on each content change, so every keystroke paid that cost.

## Changes

- A dense notebook stays responsive as cells grow: the per-edit graph build now scales with the cell count, not its square.
- The scan indexes the cell exports and uses by name once, then resolves each cell's sources and dependents by lookup instead of scanning all other cells.
- A non-DuckSQL cell matches a name exactly; a DuckSQL cell matches it normalized. So a name is indexed under both forms, and the consumer's type picks the key.
- The graph output is unchanged. The upstream source stays the earliest matching cell, and the dependents stay in document order.

## How did you test this code?

- The existing `buildNotebookDependencyGraph` suite still passes, and its consumers (`notebookNodeSQLV2Logic`, `notebookNodeStalenessLogic`) still pass. These guard that the graph output did not change.
- Added one case: two DuckSQL cells whose names differ only by case still link. The prior suite covers only SQLV2 and PythonV2 (exact match), so it would not catch a break in the normalized DuckSQL key.
- Measured with a throwaway benchmark: a synthetic notebook of N SQL cells, each joining the last four frames, median of 200 runs. The benchmark is not in the diff.

| cells | before (ms) | after (ms) |
| --- | --- | --- |
| 25 | 0.094 | 0.079 |
| 50 | 0.187 | 0.144 |
| 100 | 0.491 | 0.286 |
| 200 | 1.523 | 0.582 |

The before column grows super-linearly (100 to 200 cells is 3.1x); the after column grows linearly (2.0x), so the gap widens with cell count.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: PostHog Desktop.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- This is one of a Tier-1 notebooks performance set. A sibling change caches the redundant markdown parse; another memoizes the notebook rows. This change targets the dependency scan.
- The normalized DuckSQL key mirrors the old `matchesUsage`, which the change removes. The old function normalized both sides for DuckSQL consumers and matched exactly otherwise.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
