### PR TITLE
fix(data-warehouse): say to reconnect when a source's OAuth connection is gone

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/source.py
@@ -132,8 +132,10 @@ class IntercomSource(SimpleSource[IntercomSourceConfig], OAuthMixin):
     ) -> tuple[bool, str | None]:
         try:
             integration = self.get_oauth_integration(config.intercom_integration_id, team_id)
-        except ValueError as e:
-            return False, str(e)
+        except ValueError:
+            # get_oauth_integration raises ValueError("Integration not found: <id>") for an
+            # integration that was deleted or disconnected while the source still references it.
+            return False, "Intercom integration not found. Please reconnect your Intercom integration."
 
         if not integration.access_token:
             return False, "Intercom integration has no access token. Please reconnect."

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/tests/test_intercom_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/tests/test_intercom_source.py
@@ -156,12 +156,12 @@ class TestIntercomSource:
         "products.warehouse_sources.backend.temporal.data_imports.sources.intercom.source.IntercomSource.get_oauth_integration"
     )
     def test_validate_credentials_integration_value_error(self, mock_get_integration):
-        mock_get_integration.side_effect = ValueError("integration not found")
+        mock_get_integration.side_effect = ValueError("Integration not found: 162559")
 
         is_valid, error = self.source.validate_credentials(self.config, self.team_id)
 
         assert is_valid is False
-        assert error == "integration not found"
+        assert error == "Intercom integration not found. Please reconnect your Intercom integration."
 
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.intercom.source.IntercomSource.get_oauth_integration"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pinterest_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pinterest_ads/source.py
@@ -193,6 +193,11 @@ class PinterestAdsSource(ResumableSource[PinterestAdsSourceConfig, PinterestAdsR
             self.get_oauth_integration(config.pinterest_ads_integration_id, team_id)
             return True, None
         except Exception as e:
+            if isinstance(e, ValueError) and "Integration not found" in str(e):
+                # The integration was deleted/disconnected while the source still references it —
+                # an expected user state, not an error worth reporting (get_oauth_integration raises
+                # ValueError("Integration not found: <id>")).
+                return False, "Pinterest Ads integration not found. Please reconnect your Pinterest Ads integration."
             capture_exception(e)
             return False, f"Failed to validate Pinterest Ads credentials: {str(e)}"
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pinterest_ads/tests/test_pinterest_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pinterest_ads/tests/test_pinterest_source.py
@@ -45,21 +45,33 @@ class TestPinterestAdsSource:
         assert is_valid is True
         assert error_message is None
 
+    @pytest.mark.parametrize(
+        "side_effect,expected_error_fragment,expect_capture_called",
+        [
+            # A deleted/disconnected integration is an expected user state — surface a clean
+            # "reconnect" message and do NOT report it to error tracking.
+            (ValueError("Integration not found: 162559"), "Pinterest Ads integration not found", False),
+            # Anything else is genuinely unexpected and must still be captured.
+            (Exception("OAuth error"), "Failed to validate Pinterest Ads credentials", True),
+        ],
+    )
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.pinterest_ads.source.PinterestAdsSource.get_oauth_integration"
     )
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.pinterest_ads.source.capture_exception"
     )
-    def test_validate_credentials_integration_error(self, mock_capture, mock_get_oauth):
-        mock_get_oauth.side_effect = Exception("Integration not found")
+    def test_validate_credentials_integration_error(
+        self, mock_capture, mock_get_oauth, side_effect, expected_error_fragment, expect_capture_called
+    ):
+        mock_get_oauth.side_effect = side_effect
 
         is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
 
         assert is_valid is False
         assert error_message is not None
-        assert "Failed to validate Pinterest Ads credentials" in error_message
-        mock_capture.assert_called_once()
+        assert expected_error_fragment in error_message
+        assert mock_capture.called is expect_capture_called
 
     def test_get_schemas(self):
         schemas = self.source.get_schemas(self.config, self.team_id)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snapchat_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snapchat_ads/source.py
@@ -169,6 +169,11 @@ class SnapchatAdsSource(ResumableSource[SnapchatAdsSourceConfig, SnapchatResumeC
             self.get_oauth_integration(config.snapchat_integration_id, team_id)
             return True, None
         except Exception as e:
+            if isinstance(e, ValueError) and "Integration not found" in str(e):
+                # The integration was deleted/disconnected while the source still references it —
+                # an expected user state, not an error worth reporting (get_oauth_integration raises
+                # ValueError("Integration not found: <id>")).
+                return False, "Snapchat Ads integration not found. Please reconnect your Snapchat Ads integration."
             capture_exception(e)
             return False, f"Failed to validate Snapchat Ads credentials: {str(e)}"
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snapchat_ads/tests/test_snapchat_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snapchat_ads/tests/test_snapchat_ads.py
@@ -767,6 +767,26 @@ class TestBreakdownEndpointConfig:
         ]
 
 
+class TestValidateCredentials:
+    @parameterized.expand(
+        [
+            # A deleted/disconnected integration is an expected user state — surface a clean
+            # "reconnect" message rather than the internal id the ValueError carries.
+            ("missing_integration", ValueError("Integration not found: 123"), "Snapchat Ads integration not found"),
+            ("unexpected_error", Exception("OAuth error"), "Failed to validate Snapchat Ads credentials"),
+        ]
+    )
+    def test_oauth_failures(self, _name: str, side_effect: Exception, expected_fragment: str) -> None:
+        source = SnapchatAdsSource()
+        config = MagicMock(ad_account_id="123", snapchat_integration_id=456)
+
+        with patch.object(source, "get_oauth_integration", side_effect=side_effect):
+            is_valid, error = source.validate_credentials(config, team_id=1)
+
+        assert is_valid is False
+        assert error is not None and expected_fragment in error
+
+
 class TestSchemaDefaults:
     def test_breakdown_tables_are_opt_in_and_the_rest_stay_on(self) -> None:
         # Breakdown tables multiply every day by its dimension values, so they must not be

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/source.py
@@ -213,6 +213,11 @@ class TikTokAdsSource(ResumableSource[TikTokAdsSourceConfig, TikTokAdsResumeConf
             self.get_oauth_integration(config.tiktok_integration_id, team_id)
             return True, None
         except Exception as e:
+            if isinstance(e, ValueError) and "Integration not found" in str(e):
+                # The integration was deleted/disconnected while the source still references it —
+                # an expected user state, not an error worth reporting (get_oauth_integration raises
+                # ValueError("Integration not found: <id>")).
+                return False, "TikTok Ads integration not found. Please reconnect your TikTok Ads integration."
             capture_exception(e)
             return False, f"Failed to validate TikTok Ads credentials: {str(e)}"
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_source.py
@@ -473,13 +473,21 @@ class TestTikTokAdsSource:
             with pytest.raises(ValueError, match="TikTok Ads access token not found"):
                 self.source.source_for_pipeline(self.config, MagicMock(), inputs)
 
-    def test_validate_credentials_exception_handling(self):
+    @parameterized.expand(
+        [
+            # A deleted/disconnected integration is an expected user state — surface a clean
+            # "reconnect" message rather than the internal id the ValueError carries.
+            ("missing_integration", ValueError("Integration not found: 123"), "TikTok Ads integration not found"),
+            ("unexpected_error", Exception("Network error"), "Failed to validate TikTok Ads credentials"),
+        ]
+    )
+    def test_validate_credentials_exception_handling(self, _name, side_effect, expected_error_fragment):
         config = TikTokAdsSourceConfig(advertiser_id="123456789", tiktok_integration_id=123)
 
         with patch.object(self.source, "get_oauth_integration") as mock_get_integration:
-            mock_get_integration.side_effect = Exception("Network error")
+            mock_get_integration.side_effect = side_effect
 
             is_valid, error = self.source.validate_credentials(config, self.team_id)
 
             assert is_valid is False
-            assert "Failed to validate TikTok Ads credentials" in str(error)
+            assert expected_error_fragment in str(error)


### PR DESCRIPTION
## Problem

A customer whose Intercom, Pinterest Ads, Snapchat Ads or TikTok Ads connection was disconnected sees an internal error in the source wizard instead of being told to reconnect.

- The message reads `Integration not found: 162559`, or `Failed to validate TikTok Ads credentials: Integration not found: 162559`.
- It names no next step, and it echoes an internal id back at the customer.
- Bing Ads, Reddit Ads and LinkedIn Ads already branch on this case and ask the customer to reconnect, so the same failure reads differently depending on which connector you picked.

Replay Vision observations of the new-source flow show this state is reached often: people disconnect and reconnect an integration mid-setup, and a stale connection id is left behind on the source.

## Changes

- The four connectors now say `<Source> integration not found. Please reconnect your <Source> integration.`, word for word as their siblings do.
- A missing connection no longer reports to error tracking, matching the sibling sources. It is an expected customer state, not a defect.
- Genuinely unexpected validation errors keep the existing generic message and still report to error tracking.

Nothing else changes. Sync behavior, schemas and the credential probes themselves are untouched.

## How did you test this code?

Automated only. Every connector's `validate_credentials` now has a case for both branches.

- Pinterest Ads and TikTok Ads had one case that only covered the unexpected-error path, so removing the new branch would not have failed a test. Both are now parameterized over the two branches.
- Snapchat Ads had no `validate_credentials` coverage at all; a small test class covers the two branches.
- Intercom's existing case asserted the raw `str(e)` passthrough and now asserts the customer-facing message.

Not run: the wizard itself, which needs a live provider connection to reach this state.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented behavior or setting changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code (Opus 5) from a batch of Replay Vision session summaries of the data-warehouse new-source flow. Skills invoked: `/writing-pr-descriptions`.

- No duplicate: `gh pr list --state open` searched for "integration not found", "reconnect", "oauth accounts" and "source wizard". The two nearest open PRs are #91331 (HubSpot 401 classification during sync) and #85146 (stale wizard toasts); neither touches these connectors' credential validation.
- Public artifact: nothing from the session reached the diff. The observations describe customer sessions and are not quoted, paraphrased, or used as fixture data. The one id in a test (`162559`) is copied from the existing Bing Ads test.
- The wider `Failed to validate <X> credentials: {e}` fallback still leaks exception text across many connectors. That is a separate sweep and is deliberately out of scope here.
