### PR TITLE
feat(desktop): watch replay evidence in a modal player

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -224,19 +224,50 @@ interface RecordingExportRow {
     end_offset_s?: number | null;
     timestamp?: number | null;
     duration?: number | null;
-    speed?: number | null;
+    video_duration_s?: number | null;
+    truncated?: boolean | null;
+    inactivity_periods?: Array<{
+      ts_from_s?: number | null;
+      ts_to_s?: number | null;
+      active?: boolean | null;
+      recording_ts_from_s?: number | null;
+      recording_ts_to_s?: number | null;
+    }> | null;
   } | null;
 }
 
-/** A rendered mp4 of one window of a session recording. */
+/**
+ * One stretch of the session, and where it landed in the rendered clip. An
+ * idle stretch is dropped from the render, so it occupies no clip time and its
+ * two clip values are equal.
+ */
+export interface RecordingClipSegment {
+  /** Session time the stretch covers, in seconds from the session start. */
+  sessionFromSeconds: number;
+  sessionToSeconds: number | null;
+  /** Where the stretch sits in the rendered clip, in seconds. */
+  clipFromSeconds: number;
+  clipToSeconds: number;
+  active: boolean;
+}
+
+/** A rendered mp4 of a session recording. */
 export interface RecordingExport {
   id: number;
   /** Where the clip starts in the session, in seconds from the session start. */
   startOffsetSeconds: number;
   /** Where the clip ends in the session. Null when the render did not record it. */
   endOffsetSeconds: number | null;
-  /** Playback speed the clip rendered at, so clip time maps back to session time. */
-  speed: number;
+  /** Rendered length of the clip. Null on a render that did not record it. */
+  clipDurationSeconds: number | null;
+  /** The render stopped early, so the clip can end before the session does. */
+  truncated: boolean;
+  /**
+   * Session time to clip time, stretch by stretch. The render drops the idle
+   * stretches of a session, so clip time runs behind session time by however
+   * much idle time came before it. Empty on a render that kept every stretch.
+   */
+  segments: RecordingClipSegment[];
 }
 
 type SessionLogsPage =
@@ -6718,9 +6749,9 @@ export class PostHogAPIClient {
   }
 
   /**
-   * Read the clip window off an export row. A rendered recording covers one
-   * window of the session at one playback speed, so a caller needs both to map
-   * a moment in the session onto a time in the clip.
+   * Read the clip window and the session-to-clip time map off an export row.
+   * The render drops the idle stretches of a session, so a caller cannot treat
+   * a session offset as a clip time.
    */
   private parseRecordingExport(row: RecordingExportRow): RecordingExport {
     const context = row.export_context ?? {};
@@ -6728,11 +6759,29 @@ export class PostHogAPIClient {
     const endOffsetSeconds =
       context.end_offset_s ??
       (context.duration != null ? startOffsetSeconds + context.duration : null);
+
+    const segments: RecordingClipSegment[] = [];
+    for (const period of context.inactivity_periods ?? []) {
+      if (period.ts_from_s == null || period.recording_ts_from_s == null) {
+        continue;
+      }
+      segments.push({
+        sessionFromSeconds: period.ts_from_s,
+        sessionToSeconds: period.ts_to_s ?? null,
+        clipFromSeconds: period.recording_ts_from_s,
+        clipToSeconds: period.recording_ts_to_s ?? period.recording_ts_from_s,
+        active: period.active !== false,
+      });
+    }
+    segments.sort((a, b) => a.sessionFromSeconds - b.sessionFromSeconds);
+
     return {
       id: row.id,
       startOffsetSeconds,
       endOffsetSeconds,
-      speed: context.speed && context.speed > 0 ? context.speed : 1,
+      clipDurationSeconds: context.video_duration_s ?? null,
+      truncated: context.truncated === true,
+      segments,
     };
   }
 

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -216,6 +216,29 @@ export interface TaskRunSessionLogsResult {
   truncatedHeadCount: number;
 }
 
+interface RecordingExportRow {
+  id: number;
+  has_content?: boolean;
+  export_context?: {
+    start_offset_s?: number | null;
+    end_offset_s?: number | null;
+    timestamp?: number | null;
+    duration?: number | null;
+    speed?: number | null;
+  } | null;
+}
+
+/** A rendered mp4 of one window of a session recording. */
+export interface RecordingExport {
+  id: number;
+  /** Where the clip starts in the session, in seconds from the session start. */
+  startOffsetSeconds: number;
+  /** Where the clip ends in the session. Null when the render did not record it. */
+  endOffsetSeconds: number | null;
+  /** Playback speed the clip rendered at, so clip time maps back to session time. */
+  speed: number;
+}
+
 type SessionLogsPage =
   | { ok: true; entries: StoredLogEntry[]; headers: Headers }
   | { ok: false; status: number; statusText: string };
@@ -6694,11 +6717,48 @@ export class PostHogAPIClient {
     }
   }
 
-  /** Find an exported asset by session recording ID. */
-  async findExportBySessionRecordingId(
+  /**
+   * Read the clip window off an export row. A rendered recording covers one
+   * window of the session at one playback speed, so a caller needs both to map
+   * a moment in the session onto a time in the clip.
+   */
+  private parseRecordingExport(row: RecordingExportRow): RecordingExport {
+    const context = row.export_context ?? {};
+    const startOffsetSeconds = context.start_offset_s ?? context.timestamp ?? 0;
+    const endOffsetSeconds =
+      context.end_offset_s ??
+      (context.duration != null ? startOffsetSeconds + context.duration : null);
+    return {
+      id: row.id,
+      startOffsetSeconds,
+      endOffsetSeconds,
+      speed: context.speed && context.speed > 0 ? context.speed : 1,
+    };
+  }
+
+  /** Get one exported recording clip, with the window of the session it covers. */
+  async getRecordingExport(
+    projectId: number,
+    exportId: number,
+  ): Promise<RecordingExport | null> {
+    const urlPath = `/api/projects/${projectId}/exports/${exportId}/`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: urlPath,
+    });
+    if (!response.ok) return null;
+    const row = (await response.json()) as RecordingExportRow;
+    if (row.has_content === false) return null;
+    return this.parseRecordingExport(row);
+  }
+
+  /** Find the rendered clip for a session recording, with the window it covers. */
+  async findRecordingExport(
     projectId: number,
     sessionRecordingId: string,
-  ): Promise<number | null> {
+  ): Promise<RecordingExport | null> {
     const urlPath = `/api/projects/${projectId}/exports/`;
     const url = new URL(`${this.api.baseUrl}${urlPath}`);
     url.searchParams.set("session_recording_id", sessionRecordingId);
@@ -6710,10 +6770,10 @@ export class PostHogAPIClient {
     });
     if (!response.ok) return null;
     const data = (await response.json()) as {
-      results?: Array<{ id: number; has_content: boolean }>;
+      results?: RecordingExportRow[];
     };
     const match = data.results?.find((e) => e.has_content);
-    return match?.id ?? null;
+    return match ? this.parseRecordingExport(match) : null;
   }
 
   /** Get the presigned content URL for an exported asset (e.g. rasterized recording). */

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
@@ -579,7 +579,7 @@ function SessionProblemSignalCard({
           sessionId={extra.session_id}
           seekSeconds={
             extra.start_time
-              ? (colonOffsetToSeconds(extra.start_time) ?? undefined)
+              ? colonOffsetToSeconds(extra.start_time)
               : undefined
           }
         />
@@ -641,6 +641,22 @@ function SessionProblemSignalCard({
   );
 }
 
+function RecordingPlayerLink({ url, label }: { url: string; label: string }) {
+  return (
+    <Flex mt="1" justify="end">
+      <a
+        href={url}
+        target="_blank"
+        rel="noreferrer"
+        className="inline-flex items-center gap-1 text-[12px] text-gray-10 hover:text-gray-12"
+      >
+        {label}
+        <ArrowSquareOutIcon size={12} />
+      </a>
+    </Flex>
+  );
+}
+
 function SessionRecordingVideo({
   exportedAssetId,
   sessionId,
@@ -648,8 +664,7 @@ function SessionRecordingVideo({
 }: {
   exportedAssetId?: number;
   sessionId: string;
-  /** Recording-relative offset (seconds) the player should open at. */
-  seekSeconds?: number;
+  seekSeconds?: number | null;
 }) {
   const projectId = useAuthStateValue((state) => state.currentProjectId);
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -674,26 +689,13 @@ function SessionRecordingVideo({
   );
 
   const playerUrl = sessionRecordingUrl(sessionId, {
-    secondsOffsetFromStart: seekSeconds ?? null,
+    secondsOffsetFromStart: seekSeconds,
   });
 
-  // No playable mp4 export: fall back to a link that opens the recording in the
-  // PostHog web player, so the evidence stays one click away from the real thing.
   if (videoQuery.isError || videoQuery.data === null) {
-    if (!playerUrl) return null;
-    return (
-      <Flex mt="2" justify="end">
-        <a
-          href={playerUrl}
-          target="_blank"
-          rel="noreferrer"
-          className="inline-flex items-center gap-1 text-[12px] text-gray-10 hover:text-gray-12"
-        >
-          Watch the recording
-          <ArrowSquareOutIcon size={12} />
-        </a>
-      </Flex>
-    );
+    return playerUrl ? (
+      <RecordingPlayerLink url={playerUrl} label="Watch the recording" />
+    ) : null;
   }
   if (videoQuery.isLoading || videoQuery.data === undefined) {
     return (
@@ -722,17 +724,7 @@ function SessionRecordingVideo({
         }}
       />
       {playerUrl && (
-        <Flex mt="1" justify="end">
-          <a
-            href={playerUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center gap-1 text-[12px] text-gray-10 hover:text-gray-12"
-          >
-            Open full recording
-            <ArrowSquareOutIcon size={12} />
-          </a>
-        </Flex>
+        <RecordingPlayerLink url={playerUrl} label="Open full recording" />
       )}
     </Box>
   );

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
@@ -643,7 +643,7 @@ function SessionProblemSignalCard({
 
 function RecordingPlayerLink({ url, label }: { url: string; label: string }) {
   return (
-    <Flex mt="1" justify="end">
+    <div className="mt-1 flex justify-end">
       <a
         href={url}
         target="_blank"
@@ -653,7 +653,7 @@ function RecordingPlayerLink({ url, label }: { url: string; label: string }) {
         {label}
         <ArrowSquareOutIcon size={12} />
       </a>
-    </Flex>
+    </div>
   );
 }
 
@@ -699,12 +699,17 @@ function SessionRecordingVideo({
   }
   if (videoQuery.isLoading || videoQuery.data === undefined) {
     return (
-      <Box
-        mt="2"
-        className="flex h-24 items-center justify-center rounded bg-gray-3 text-[12px] text-gray-9"
-      >
-        Loading recording…
-      </Box>
+      <>
+        <Box
+          mt="2"
+          className="flex h-24 items-center justify-center rounded bg-gray-3 text-[12px] text-gray-9"
+        >
+          Loading recording…
+        </Box>
+        {playerUrl && (
+          <RecordingPlayerLink url={playerUrl} label="Watch the recording" />
+        )}
+      </>
     );
   }
 

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
@@ -30,6 +30,7 @@ import {
 } from "@posthog/ui/utils/posthogLinks";
 import { Badge, Box, Flex, Text } from "@radix-ui/themes";
 import { type ReactNode, useCallback, useMemo, useRef, useState } from "react";
+import { clipTimeForMoment } from "./recordingClipTime";
 import {
   type SignalInteractionAction,
   SignalInteractionContext,
@@ -728,24 +729,6 @@ function EvidenceActionPill({
 }
 
 /**
- * Map a moment in the session onto a time in the clip. A render covers one
- * window of the session at one speed, so the moment is only reachable when it
- * falls inside that window.
- */
-function clipTimeForMoment(
-  clip: RecordingExport,
-  sessionOffsetSeconds: number,
-  clipDuration: number,
-): number | null {
-  const clipTime =
-    (sessionOffsetSeconds - clip.startOffsetSeconds) / clip.speed;
-  if (!Number.isFinite(clipTime) || clipTime < 0 || clipTime > clipDuration) {
-    return null;
-  }
-  return clipTime;
-}
-
-/**
  * The recording affordance on an evidence card: a pill that opens the rendered
  * clip in a modal player, at the moment the finding describes. The clip
  * downloads only once that modal opens, so a report full of evidence costs one
@@ -765,7 +748,9 @@ function SessionRecordingPreview({
   const hasFiredPlayRef = useRef(false);
   const interaction = useSignalInteraction();
   const [open, setOpen] = useState(false);
-  const [momentReachable, setMomentReachable] = useState(false);
+  // Null until the clip reports its length, since only then can the player say
+  // whether the moment is in it.
+  const [momentReachable, setMomentReachable] = useState<boolean | null>(null);
 
   const exportQuery = useAuthenticatedQuery<RecordingExport | null>(
     ["recording-export", projectId, exportedAssetId, sessionId],
@@ -799,17 +784,16 @@ function SessionRecordingPreview({
   const seekToMoment = useCallback(() => {
     const video = videoRef.current;
     if (!video || seekSeconds == null || clip == null) return;
-    const target = clipTimeForMoment(clip, seekSeconds, video.duration);
-    if (target != null) video.currentTime = target;
+    const target = clipTimeForMoment(clip, seekSeconds);
+    if (target == null) return;
+    video.currentTime = Math.min(target, video.duration);
   }, [clip, seekSeconds]);
 
   const handleLoadedMetadata = useCallback(() => {
-    const video = videoRef.current;
-    if (!video || seekSeconds == null || clip == null) return;
-    const target = clipTimeForMoment(clip, seekSeconds, video.duration);
-    setMomentReachable(target != null);
-    if (target != null) video.currentTime = target;
-  }, [clip, seekSeconds]);
+    if (seekSeconds == null || clip == null) return;
+    setMomentReachable(clipTimeForMoment(clip, seekSeconds) != null);
+    seekToMoment();
+  }, [clip, seekSeconds, seekToMoment]);
 
   // No clip was rendered for this session, so the web player is the only route
   // to the recording.
@@ -846,9 +830,11 @@ function SessionRecordingPreview({
           <DialogHeader>
             <DialogTitle>Session recording</DialogTitle>
             <DialogDescription>
-              {momentLabel
-                ? `The rendered clip, at ${momentLabel} in the session.`
-                : "The rendered clip from this session."}
+              {momentLabel == null
+                ? "The rendered clip from this session."
+                : momentReachable === false
+                  ? `The clip stops before ${momentLabel}. Open the session in PostHog to reach that moment.`
+                  : `The rendered clip, at ${momentLabel} in the session.`}
             </DialogDescription>
           </DialogHeader>
           <DialogBody>
@@ -883,7 +869,7 @@ function SessionRecordingPreview({
             </div>
           </DialogBody>
           <DialogFooter className="sm:items-center sm:justify-between">
-            {momentLabel && momentReachable ? (
+            {momentLabel && momentReachable === true ? (
               <Button variant="outline" size="sm" onClick={seekToMoment}>
                 Back to {momentLabel}
               </Button>

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
@@ -158,6 +158,20 @@ interface ErrorTrackingExtra {
   fingerprint?: string;
 }
 
+interface ScannerFindingExtra {
+  scanner_name?: string;
+  session_id?: string;
+  problem_type?: string;
+  start_time?: number;
+  end_time?: number;
+  exported_asset_id?: number;
+  distinct_id?: string;
+  recording_start_time?: string;
+  recording_end_time?: string;
+  recording_duration?: number;
+  recording_active_seconds?: number;
+}
+
 function resolveLabels(
   raw: GitHubIssueExtra["labels"],
 ): { name: string; color?: string }[] {
@@ -249,6 +263,12 @@ function isSessionExtra(
   extra: Record<string, unknown>,
 ): extra is Record<string, unknown> & SessionProblemExtra {
   return "session_id" in extra && "segment_title" in extra;
+}
+
+function isScannerFindingExtra(
+  extra: Record<string, unknown>,
+): extra is Record<string, unknown> & ScannerFindingExtra {
+  return "session_id" in extra && "scanner_name" in extra;
 }
 
 function isErrorTrackingExtra(
@@ -541,6 +561,17 @@ function formatSessionDuration(seconds: number): string {
   return remainMins > 0 ? `${hrs}h ${remainMins}m` : `${hrs}h`;
 }
 
+function colonOffset(seconds: number): string {
+  const total = Math.round(seconds);
+  const mins = Math.floor(total / 60);
+  const secs = total % 60;
+  const hrs = Math.floor(mins / 60);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return hrs > 0
+    ? `${pad(hrs)}:${pad(mins % 60)}:${pad(secs)}`
+    : `${pad(mins)}:${pad(secs)}`;
+}
+
 function SessionProblemSignalCard({
   signal,
   extra,
@@ -729,6 +760,72 @@ function SessionRecordingVideo({
       {playerUrl && (
         <RecordingPlayerLink url={playerUrl} label="Open full recording" />
       )}
+    </Box>
+  );
+}
+
+function ScannerFindingSignalCard({
+  signal,
+  extra,
+  verified,
+  codePaths,
+  dataQueried,
+}: {
+  signal: Signal;
+  extra: ScannerFindingExtra;
+  verified?: boolean;
+  codePaths?: string[];
+  dataQueried?: string;
+}) {
+  return (
+    <Box className="min-w-0 overflow-hidden rounded-(--radius-2) border border-(--gray-6) bg-gray-1 p-3">
+      <SignalCardHeader signal={signal} verified={verified} />
+      {extra.scanner_name && (
+        <Text mt="1" className="font-medium text-[14px] text-gray-11" as="p">
+          {extra.scanner_name}
+        </Text>
+      )}
+      <CollapsibleBody body={signal.content} />
+
+      {extra.session_id && (
+        <SessionRecordingVideo
+          exportedAssetId={extra.exported_asset_id}
+          sessionId={extra.session_id}
+          seekSeconds={extra.start_time}
+        />
+      )}
+
+      <Flex
+        align="center"
+        gap="2"
+        wrap="wrap"
+        mt="2"
+        className="text-[12px] text-gray-10"
+      >
+        {extra.distinct_id && (
+          <Text className="font-mono text-[12px]">
+            {extra.distinct_id.slice(0, 10)}…
+          </Text>
+        )}
+        {extra.start_time != null && extra.end_time != null && (
+          <>
+            <span>·</span>
+            <span>
+              {colonOffset(extra.start_time)} – {colonOffset(extra.end_time)}
+            </span>
+          </>
+        )}
+        {extra.recording_duration != null && (
+          <>
+            <span>·</span>
+            <span>
+              {formatSessionDuration(extra.recording_duration)} session
+            </span>
+          </>
+        )}
+      </Flex>
+      <CodePathsCollapsible paths={codePaths ?? []} />
+      <DataQueriedCollapsible text={dataQueried ?? ""} />
     </Box>
   );
 }
@@ -939,6 +1036,19 @@ export function SignalCard({
   if (signal.source_product === "session_replay" && isSessionExtra(extra)) {
     content = (
       <SessionProblemSignalCard
+        signal={signal}
+        extra={extra}
+        verified={verified}
+        codePaths={codePaths}
+        dataQueried={dataQueried}
+      />
+    );
+  } else if (
+    signal.source_product === "replay_vision" &&
+    isScannerFindingExtra(extra)
+  ) {
+    content = (
+      <ScannerFindingSignalCard
         signal={signal}
         extra={extra}
         verified={verified}

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
@@ -245,12 +245,10 @@ function isLlmEvalExtra(
   return "evaluation_id" in extra && "trace_id" in extra;
 }
 
-function isSessionProblemExtra(
+function isSessionExtra(
   extra: Record<string, unknown>,
 ): extra is Record<string, unknown> & SessionProblemExtra {
-  return (
-    "session_id" in extra && "problem_type" in extra && "segment_title" in extra
-  );
+  return "session_id" in extra && "segment_title" in extra;
 }
 
 function isErrorTrackingExtra(
@@ -938,11 +936,7 @@ export function SignalCard({
   );
 
   let content: React.ReactNode;
-  if (
-    signal.source_product === "session_replay" &&
-    signal.source_type === "session_problem" &&
-    isSessionProblemExtra(extra)
-  ) {
+  if (signal.source_product === "session_replay" && isSessionExtra(extra)) {
     content = (
       <SessionProblemSignalCard
         signal={signal}

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
@@ -3,8 +3,17 @@ import {
   CaretDownIcon,
   CaretRightIcon,
   CheckCircleIcon,
+  PlayIcon,
   TagIcon,
 } from "@phosphor-icons/react";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@posthog/quill";
 import type { Signal, SignalFindingContent } from "@posthog/shared/types";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
@@ -603,7 +612,7 @@ function SessionProblemSignalCard({
       <CollapsibleBody body={signal.content} />
 
       {extra.session_id && (
-        <SessionRecordingVideo
+        <SessionRecordingPreview
           exportedAssetId={extra.exported_asset_id}
           sessionId={extra.session_id}
           seekSeconds={
@@ -686,7 +695,33 @@ function RecordingPlayerLink({ url, label }: { url: string; label: string }) {
   );
 }
 
-function SessionRecordingVideo({
+const RECORDING_ROW_CLASS =
+  "group mt-2 flex w-full items-center gap-3 rounded-(--radius-3) border border-(--gray-5) bg-(--gray-2) px-3 py-2.5 text-left no-underline transition-colors hover:border-(--gray-7) hover:bg-(--gray-3)";
+
+function RecordingRowLabel({
+  title,
+  detail,
+}: {
+  title: string;
+  detail: string;
+}) {
+  return (
+    <span className="min-w-0 flex-1">
+      <span className="block font-medium text-[13px] text-gray-12">
+        {title}
+      </span>
+      <span className="block truncate text-[12px] text-gray-10">{detail}</span>
+    </span>
+  );
+}
+
+/**
+ * The recording affordance on an evidence card: a row that opens the captured
+ * clip in a modal player, seeked to the moment the finding describes. The clip
+ * downloads only once that modal opens, so a report full of evidence costs one
+ * cheap lookup per card rather than one mp4 per card.
+ */
+function SessionRecordingPreview({
   exportedAssetId,
   sessionId,
   seekSeconds,
@@ -696,71 +731,145 @@ function SessionRecordingVideo({
   seekSeconds?: number | null;
 }) {
   const projectId = useAuthStateValue((state) => state.currentProjectId);
-  const videoRef = useRef<HTMLVideoElement>(null);
   const hasFiredPlayRef = useRef(false);
   const interaction = useSignalInteraction();
-  const videoQuery = useAuthenticatedQuery<string | null>(
-    ["export-video", projectId, exportedAssetId, sessionId],
+  const [open, setOpen] = useState(false);
+
+  const assetQuery = useAuthenticatedQuery<number | null>(
+    ["recording-export-asset", projectId, exportedAssetId, sessionId],
     async (client) => {
       if (!projectId) return null;
-      let assetId: number | null = exportedAssetId ?? null;
-      // If no asset ID in the signal, look up the export by session_id
-      if (assetId == null) {
-        assetId = await client.findExportBySessionRecordingId(
-          projectId,
-          sessionId,
-        );
-        if (assetId == null) return null;
-      }
-      return client.getExportContentUrl(projectId, assetId);
+      if (exportedAssetId != null) return exportedAssetId;
+      return await client.findExportBySessionRecordingId(projectId, sessionId);
     },
     { enabled: !!projectId, staleTime: Infinity },
+  );
+  const assetId = assetQuery.data ?? null;
+
+  const clipQuery = useAuthenticatedQuery<string | null>(
+    ["recording-export-content", projectId, assetId],
+    async (client) => {
+      if (!projectId || assetId == null) return null;
+      return await client.getExportContentUrl(projectId, assetId);
+    },
+    { enabled: open && !!projectId && assetId != null, staleTime: Infinity },
   );
 
   const playerUrl = sessionRecordingUrl(sessionId, {
     secondsOffsetFromStart: seekSeconds,
   });
+  const startLabel = seekSeconds != null ? colonOffset(seekSeconds) : null;
 
-  if (videoQuery.isError || videoQuery.data === null) {
-    return playerUrl ? (
-      <RecordingPlayerLink url={playerUrl} label="Watch the recording" />
-    ) : null;
-  }
-  if (videoQuery.isLoading || videoQuery.data === undefined) {
+  // No clip was exported for this session, so the web player is the only route
+  // to the recording.
+  if (assetQuery.isError || (assetQuery.isFetched && assetId == null)) {
+    if (!playerUrl) return null;
     return (
-      <>
-        <Box
-          mt="2"
-          className="flex h-24 items-center justify-center rounded bg-gray-3 text-[12px] text-gray-9"
-        >
-          Loading recording…
-        </Box>
-        {playerUrl && (
-          <RecordingPlayerLink url={playerUrl} label="Watch the recording" />
-        )}
-      </>
+      <a
+        href={playerUrl}
+        target="_blank"
+        rel="noreferrer"
+        className={RECORDING_ROW_CLASS}
+      >
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-(--gray-4) text-gray-11 transition-colors group-hover:bg-(--gray-5)">
+          <PlayIcon size={15} weight="fill" className="translate-x-[1px]" />
+        </span>
+        <RecordingRowLabel
+          title="Watch the recording"
+          detail={
+            startLabel
+              ? `Opens in PostHog at ${startLabel}`
+              : "Opens in PostHog"
+          }
+        />
+        <ArrowSquareOutIcon
+          size={13}
+          className="shrink-0 text-gray-9 transition-colors group-hover:text-gray-11"
+        />
+      </a>
     );
   }
 
+  const clipUnavailable = clipQuery.isError || clipQuery.data === null;
+  const clipPending = !clipUnavailable && clipQuery.data == null;
+
   return (
-    <Box mt="2" className="overflow-hidden rounded">
-      <video
-        ref={videoRef}
-        src={videoQuery.data}
-        controls
-        muted
-        preload="metadata"
-        className="max-h-[300px] w-full rounded"
-        onPlay={() => {
-          if (hasFiredPlayRef.current) return;
-          hasFiredPlayRef.current = true;
-          interaction?.onInteraction({ type: "play_session_recording" });
-        }}
-      />
-      {playerUrl && (
-        <RecordingPlayerLink url={playerUrl} label="Open full recording" />
-      )}
-    </Box>
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className={`${RECORDING_ROW_CLASS} cursor-pointer`}
+      >
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-(--accent-9) text-white shadow-sm transition-transform duration-150 group-hover:scale-105">
+          <PlayIcon size={15} weight="fill" className="translate-x-[1px]" />
+        </span>
+        <RecordingRowLabel
+          title="Watch the recording"
+          detail={
+            startLabel
+              ? `Plays from ${startLabel}`
+              : "Plays the captured moment"
+          }
+        />
+        <CaretRightIcon
+          size={13}
+          className="shrink-0 text-gray-9 transition-transform duration-150 group-hover:translate-x-0.5 group-hover:text-gray-11"
+        />
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent size="wide">
+          <DialogHeader>
+            <DialogTitle>Session recording</DialogTitle>
+            <DialogDescription>
+              {startLabel
+                ? `The captured clip, from ${startLabel} in the session.`
+                : "The captured clip from this session."}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogBody>
+            <div className="overflow-hidden rounded-(--radius-2) bg-black">
+              {clipUnavailable ? (
+                <div className="flex aspect-video items-center justify-center px-6 text-center text-[13px] text-gray-10">
+                  This clip is no longer available.
+                </div>
+              ) : clipPending ? (
+                <div className="flex aspect-video items-center justify-center text-[13px] text-gray-10">
+                  Loading the recording…
+                </div>
+              ) : (
+                <video
+                  src={clipQuery.data ?? undefined}
+                  controls
+                  autoPlay
+                  muted
+                  playsInline
+                  className="aspect-video w-full"
+                  onLoadedMetadata={(event) => {
+                    const video = event.currentTarget;
+                    // Exported clips sometimes already start at the moment, so
+                    // only seek when the clip actually runs past it.
+                    if (seekSeconds != null && video.duration > seekSeconds) {
+                      video.currentTime = seekSeconds;
+                    }
+                  }}
+                  onPlay={() => {
+                    if (hasFiredPlayRef.current) return;
+                    hasFiredPlayRef.current = true;
+                    interaction?.onInteraction({
+                      type: "play_session_recording",
+                    });
+                  }}
+                />
+              )}
+            </div>
+          </DialogBody>
+          {playerUrl && (
+            <RecordingPlayerLink url={playerUrl} label="Open in PostHog" />
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 
@@ -788,7 +897,7 @@ function ScannerFindingSignalCard({
       <CollapsibleBody body={signal.content} />
 
       {extra.session_id && (
-        <SessionRecordingVideo
+        <SessionRecordingPreview
           exportedAssetId={extra.exported_asset_id}
           sessionId={extra.session_id}
           seekSeconds={extra.start_time}

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
@@ -6,11 +6,14 @@ import {
   PlayIcon,
   TagIcon,
 } from "@phosphor-icons/react";
+import type { RecordingExport } from "@posthog/api-client/posthog-client";
 import {
+  Button,
   Dialog,
   DialogBody,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@posthog/quill";
@@ -26,7 +29,7 @@ import {
   sessionRecordingUrl,
 } from "@posthog/ui/utils/posthogLinks";
 import { Badge, Box, Flex, Text } from "@radix-ui/themes";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { type ReactNode, useCallback, useMemo, useRef, useState } from "react";
 import {
   type SignalInteractionAction,
   SignalInteractionContext,
@@ -679,45 +682,72 @@ function SessionProblemSignalCard({
   );
 }
 
-function RecordingPlayerLink({ url, label }: { url: string; label: string }) {
-  return (
-    <div className="mt-1 flex justify-end">
-      <a
-        href={url}
-        target="_blank"
-        rel="noreferrer"
-        className="inline-flex items-center gap-1 text-[12px] text-gray-10 hover:text-gray-12"
-      >
-        {label}
-        <ArrowSquareOutIcon size={12} />
-      </a>
-    </div>
-  );
-}
-
-const RECORDING_ROW_CLASS =
-  "group mt-2 flex w-full items-center gap-3 rounded-(--radius-3) border border-(--gray-5) bg-(--gray-2) px-3 py-2.5 text-left no-underline transition-colors hover:border-(--gray-7) hover:bg-(--gray-3)";
-
-function RecordingRowLabel({
-  title,
-  detail,
+/**
+ * A compact action on an evidence card: a glyph and a label in a pill, sized to
+ * sit beside the card's metadata. Every evidence type puts its affordance in
+ * this one shape, so a card gains an action without gaining a block.
+ */
+function EvidenceActionPill({
+  glyph,
+  label,
+  href,
+  onClick,
 }: {
-  title: string;
-  detail: string;
+  glyph: ReactNode;
+  label: string;
+  href?: string;
+  onClick?: () => void;
 }) {
-  return (
-    <span className="min-w-0 flex-1">
-      <span className="block font-medium text-[13px] text-gray-12">
-        {title}
+  const className =
+    "group inline-flex items-center gap-1.5 rounded-full border border-(--gray-5) bg-(--gray-2) py-1 pr-2.5 pl-1.5 font-medium text-[12px] text-gray-11 no-underline transition-colors hover:border-(--gray-7) hover:bg-(--gray-3) hover:text-gray-12";
+  const body = (
+    <>
+      <span className="flex size-4 items-center justify-center rounded-full bg-(--accent-9) text-white transition-transform duration-150 group-hover:scale-110">
+        {glyph}
       </span>
-      <span className="block truncate text-[12px] text-gray-10">{detail}</span>
-    </span>
+      {label}
+    </>
+  );
+
+  if (href) {
+    return (
+      <a href={href} target="_blank" rel="noreferrer" className={className}>
+        {body}
+      </a>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`${className} cursor-pointer`}
+    >
+      {body}
+    </button>
   );
 }
 
 /**
- * The recording affordance on an evidence card: a row that opens the captured
- * clip in a modal player, seeked to the moment the finding describes. The clip
+ * Map a moment in the session onto a time in the clip. A render covers one
+ * window of the session at one speed, so the moment is only reachable when it
+ * falls inside that window.
+ */
+function clipTimeForMoment(
+  clip: RecordingExport,
+  sessionOffsetSeconds: number,
+  clipDuration: number,
+): number | null {
+  const clipTime =
+    (sessionOffsetSeconds - clip.startOffsetSeconds) / clip.speed;
+  if (!Number.isFinite(clipTime) || clipTime < 0 || clipTime > clipDuration) {
+    return null;
+  }
+  return clipTime;
+}
+
+/**
+ * The recording affordance on an evidence card: a pill that opens the rendered
+ * clip in a modal player, at the moment the finding describes. The clip
  * downloads only once that modal opens, so a report full of evidence costs one
  * cheap lookup per card rather than one mp4 per card.
  */
@@ -731,62 +761,68 @@ function SessionRecordingPreview({
   seekSeconds?: number | null;
 }) {
   const projectId = useAuthStateValue((state) => state.currentProjectId);
+  const videoRef = useRef<HTMLVideoElement>(null);
   const hasFiredPlayRef = useRef(false);
   const interaction = useSignalInteraction();
   const [open, setOpen] = useState(false);
+  const [momentReachable, setMomentReachable] = useState(false);
 
-  const assetQuery = useAuthenticatedQuery<number | null>(
-    ["recording-export-asset", projectId, exportedAssetId, sessionId],
+  const exportQuery = useAuthenticatedQuery<RecordingExport | null>(
+    ["recording-export", projectId, exportedAssetId, sessionId],
     async (client) => {
       if (!projectId) return null;
-      if (exportedAssetId != null) return exportedAssetId;
-      return await client.findExportBySessionRecordingId(projectId, sessionId);
+      return exportedAssetId != null
+        ? await client.getRecordingExport(projectId, exportedAssetId)
+        : await client.findRecordingExport(projectId, sessionId);
     },
     { enabled: !!projectId, staleTime: Infinity },
   );
-  const assetId = assetQuery.data ?? null;
+  const clip = exportQuery.data ?? null;
 
   const clipQuery = useAuthenticatedQuery<string | null>(
-    ["recording-export-content", projectId, assetId],
+    ["recording-clip", projectId, clip?.id],
     async (client) => {
-      if (!projectId || assetId == null) return null;
-      return await client.getExportContentUrl(projectId, assetId);
+      if (!projectId || clip == null) return null;
+      return await client.getExportContentUrl(projectId, clip.id);
     },
-    { enabled: open && !!projectId && assetId != null, staleTime: Infinity },
+    { enabled: open && !!projectId && clip != null, staleTime: Infinity },
   );
 
   const playerUrl = sessionRecordingUrl(sessionId, {
     secondsOffsetFromStart: seekSeconds,
   });
-  const startLabel = seekSeconds != null ? colonOffset(seekSeconds) : null;
+  const momentLabel = seekSeconds != null ? colonOffset(seekSeconds) : null;
+  const pillLabel = momentLabel
+    ? `Watch at ${momentLabel}`
+    : "Watch the recording";
 
-  // No clip was exported for this session, so the web player is the only route
+  const seekToMoment = useCallback(() => {
+    const video = videoRef.current;
+    if (!video || seekSeconds == null || clip == null) return;
+    const target = clipTimeForMoment(clip, seekSeconds, video.duration);
+    if (target != null) video.currentTime = target;
+  }, [clip, seekSeconds]);
+
+  const handleLoadedMetadata = useCallback(() => {
+    const video = videoRef.current;
+    if (!video || seekSeconds == null || clip == null) return;
+    const target = clipTimeForMoment(clip, seekSeconds, video.duration);
+    setMomentReachable(target != null);
+    if (target != null) video.currentTime = target;
+  }, [clip, seekSeconds]);
+
+  // No clip was rendered for this session, so the web player is the only route
   // to the recording.
-  if (assetQuery.isError || (assetQuery.isFetched && assetId == null)) {
+  if (exportQuery.isError || (exportQuery.isFetched && clip == null)) {
     if (!playerUrl) return null;
     return (
-      <a
-        href={playerUrl}
-        target="_blank"
-        rel="noreferrer"
-        className={RECORDING_ROW_CLASS}
-      >
-        <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-(--gray-4) text-gray-11 transition-colors group-hover:bg-(--gray-5)">
-          <PlayIcon size={15} weight="fill" className="translate-x-[1px]" />
-        </span>
-        <RecordingRowLabel
-          title="Watch the recording"
-          detail={
-            startLabel
-              ? `Opens in PostHog at ${startLabel}`
-              : "Opens in PostHog"
-          }
+      <div className="mt-2 flex">
+        <EvidenceActionPill
+          glyph={<ArrowSquareOutIcon size={9} weight="bold" />}
+          label={pillLabel}
+          href={playerUrl}
         />
-        <ArrowSquareOutIcon
-          size={13}
-          className="shrink-0 text-gray-9 transition-colors group-hover:text-gray-11"
-        />
-      </a>
+      </div>
     );
   }
 
@@ -795,36 +831,24 @@ function SessionRecordingPreview({
 
   return (
     <>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        className={`${RECORDING_ROW_CLASS} cursor-pointer`}
-      >
-        <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-(--accent-9) text-white shadow-sm transition-transform duration-150 group-hover:scale-105">
-          <PlayIcon size={15} weight="fill" className="translate-x-[1px]" />
-        </span>
-        <RecordingRowLabel
-          title="Watch the recording"
-          detail={
-            startLabel
-              ? `Plays from ${startLabel}`
-              : "Plays the captured moment"
+      <div className="mt-2 flex">
+        <EvidenceActionPill
+          glyph={
+            <PlayIcon size={9} weight="fill" className="translate-x-[0.5px]" />
           }
+          label={pillLabel}
+          onClick={() => setOpen(true)}
         />
-        <CaretRightIcon
-          size={13}
-          className="shrink-0 text-gray-9 transition-transform duration-150 group-hover:translate-x-0.5 group-hover:text-gray-11"
-        />
-      </button>
+      </div>
 
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent size="wide">
           <DialogHeader>
             <DialogTitle>Session recording</DialogTitle>
             <DialogDescription>
-              {startLabel
-                ? `The captured clip, from ${startLabel} in the session.`
-                : "The captured clip from this session."}
+              {momentLabel
+                ? `The rendered clip, at ${momentLabel} in the session.`
+                : "The rendered clip from this session."}
             </DialogDescription>
           </DialogHeader>
           <DialogBody>
@@ -839,20 +863,14 @@ function SessionRecordingPreview({
                 </div>
               ) : (
                 <video
+                  ref={videoRef}
                   src={clipQuery.data ?? undefined}
                   controls
                   autoPlay
                   muted
                   playsInline
                   className="aspect-video w-full"
-                  onLoadedMetadata={(event) => {
-                    const video = event.currentTarget;
-                    // Exported clips sometimes already start at the moment, so
-                    // only seek when the clip actually runs past it.
-                    if (seekSeconds != null && video.duration > seekSeconds) {
-                      video.currentTime = seekSeconds;
-                    }
-                  }}
+                  onLoadedMetadata={handleLoadedMetadata}
                   onPlay={() => {
                     if (hasFiredPlayRef.current) return;
                     hasFiredPlayRef.current = true;
@@ -864,9 +882,26 @@ function SessionRecordingPreview({
               )}
             </div>
           </DialogBody>
-          {playerUrl && (
-            <RecordingPlayerLink url={playerUrl} label="Open in PostHog" />
-          )}
+          <DialogFooter className="sm:items-center sm:justify-between">
+            {momentLabel && momentReachable ? (
+              <Button variant="outline" size="sm" onClick={seekToMoment}>
+                Back to {momentLabel}
+              </Button>
+            ) : (
+              <span />
+            )}
+            {playerUrl && (
+              <a
+                href={playerUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-[12px] text-gray-10 no-underline hover:text-gray-12"
+              >
+                Open in PostHog
+                <ArrowSquareOutIcon size={12} />
+              </a>
+            )}
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </>

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
@@ -11,7 +11,11 @@ import { MarkdownRenderer } from "@posthog/ui/features/editor/components/Markdow
 import { getSourceProductMeta } from "@posthog/ui/features/inbox/components/utils/source-product-icons";
 import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
 import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
-import { errorTrackingIssueUrl } from "@posthog/ui/utils/posthogLinks";
+import {
+  colonOffsetToSeconds,
+  errorTrackingIssueUrl,
+  sessionRecordingUrl,
+} from "@posthog/ui/utils/posthogLinks";
 import { Badge, Box, Flex, Text } from "@radix-ui/themes";
 import { useCallback, useMemo, useRef, useState } from "react";
 import {
@@ -573,6 +577,11 @@ function SessionProblemSignalCard({
         <SessionRecordingVideo
           exportedAssetId={extra.exported_asset_id}
           sessionId={extra.session_id}
+          seekSeconds={
+            extra.start_time
+              ? (colonOffsetToSeconds(extra.start_time) ?? undefined)
+              : undefined
+          }
         />
       )}
 
@@ -635,9 +644,12 @@ function SessionProblemSignalCard({
 function SessionRecordingVideo({
   exportedAssetId,
   sessionId,
+  seekSeconds,
 }: {
   exportedAssetId?: number;
   sessionId: string;
+  /** Recording-relative offset (seconds) the player should open at. */
+  seekSeconds?: number;
 }) {
   const projectId = useAuthStateValue((state) => state.currentProjectId);
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -661,7 +673,28 @@ function SessionRecordingVideo({
     { enabled: !!projectId, staleTime: Infinity },
   );
 
-  if (videoQuery.isError || videoQuery.data === null) return null;
+  const playerUrl = sessionRecordingUrl(sessionId, {
+    secondsOffsetFromStart: seekSeconds ?? null,
+  });
+
+  // No playable mp4 export: fall back to a link that opens the recording in the
+  // PostHog web player, so the evidence stays one click away from the real thing.
+  if (videoQuery.isError || videoQuery.data === null) {
+    if (!playerUrl) return null;
+    return (
+      <Flex mt="2" justify="end">
+        <a
+          href={playerUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-1 text-[12px] text-gray-10 hover:text-gray-12"
+        >
+          Watch the recording
+          <ArrowSquareOutIcon size={12} />
+        </a>
+      </Flex>
+    );
+  }
   if (videoQuery.isLoading || videoQuery.data === undefined) {
     return (
       <Box
@@ -688,6 +721,19 @@ function SessionRecordingVideo({
           interaction?.onInteraction({ type: "play_session_recording" });
         }}
       />
+      {playerUrl && (
+        <Flex mt="1" justify="end">
+          <a
+            href={playerUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 text-[12px] text-gray-10 hover:text-gray-12"
+          >
+            Open full recording
+            <ArrowSquareOutIcon size={12} />
+          </a>
+        </Flex>
+      )}
     </Box>
   );
 }

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/recordingClipTime.test.ts
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/recordingClipTime.test.ts
@@ -1,0 +1,105 @@
+import type {
+  RecordingClipSegment,
+  RecordingExport,
+} from "@posthog/api-client/posthog-client";
+import { describe, expect, it } from "vitest";
+import { clipTimeForMoment } from "./recordingClipTime";
+
+function makeClip(overrides: Partial<RecordingExport> = {}): RecordingExport {
+  return {
+    id: 1,
+    startOffsetSeconds: 0,
+    endOffsetSeconds: null,
+    clipDurationSeconds: null,
+    truncated: false,
+    segments: [],
+    ...overrides,
+  };
+}
+
+function segment(
+  sessionFrom: number,
+  sessionTo: number,
+  clipFrom: number,
+  clipTo: number,
+  active = true,
+): RecordingClipSegment {
+  return {
+    sessionFromSeconds: sessionFrom,
+    sessionToSeconds: sessionTo,
+    clipFromSeconds: clipFrom,
+    clipToSeconds: clipTo,
+    active,
+  };
+}
+
+describe("clipTimeForMoment", () => {
+  describe("a render that kept every stretch", () => {
+    it.each([
+      ["a whole-session clip", 0, 120, 120],
+      ["a clip whose window opens late", 100, 160, 60],
+    ])("maps %s", (_label, startOffset, sessionOffset, expected) => {
+      const clip = makeClip({
+        startOffsetSeconds: startOffset,
+        clipDurationSeconds: 300,
+      });
+      expect(clipTimeForMoment(clip, sessionOffset)).toBe(expected);
+    });
+
+    it.each([
+      ["the moment sits before the window", 100, 40],
+      ["the moment sits past the clip's end", 0, 400],
+    ])("returns null when %s", (_label, startOffset, sessionOffset) => {
+      const clip = makeClip({
+        startOffsetSeconds: startOffset,
+        clipDurationSeconds: 300,
+      });
+      expect(clipTimeForMoment(clip, sessionOffset)).toBeNull();
+    });
+  });
+
+  describe("a render that dropped idle stretches", () => {
+    // 0-60s active, 60-300s idle and dropped, 300-360s active. A 5:00 session
+    // renders as a 2:00 clip.
+    const clip = makeClip({
+      clipDurationSeconds: 120,
+      segments: [
+        segment(0, 60, 0, 60),
+        segment(60, 300, 60, 60, false),
+        segment(300, 360, 60, 120),
+      ],
+    });
+
+    it.each([
+      ["inside the first active stretch", 30, 30],
+      ["at the boundary into the dropped stretch", 60, 60],
+      ["inside the second active stretch", 330, 90],
+      ["at the very end of the clip", 360, 120],
+    ])("maps a moment %s", (_label, sessionOffset, expected) => {
+      expect(clipTimeForMoment(clip, sessionOffset)).toBe(expected);
+    });
+
+    it("resolves a moment inside a dropped stretch to the next frame", () => {
+      expect(clipTimeForMoment(clip, 200)).toBe(60);
+    });
+
+    it("maps a moment past the clip's length, which a subtraction would reject", () => {
+      // The bug this replaced: 330s in the session is only 90s into the clip,
+      // but a session-minus-start subtraction reads 330 > 120 and gives up.
+      const target = clipTimeForMoment(clip, 330);
+      expect(target).not.toBeNull();
+      expect(target).toBeLessThan(clip.clipDurationSeconds ?? 0);
+    });
+
+    it("returns null for a moment the render never reached", () => {
+      expect(clipTimeForMoment(clip, 420)).toBeNull();
+    });
+
+    it("returns the clip start for a moment before the first stretch", () => {
+      const late = makeClip({
+        segments: [segment(100, 160, 0, 60)],
+      });
+      expect(clipTimeForMoment(late, 40)).toBe(0);
+    });
+  });
+});

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/recordingClipTime.ts
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/recordingClipTime.ts
@@ -1,0 +1,48 @@
+import type { RecordingExport } from "@posthog/api-client/posthog-client";
+
+/**
+ * Map a moment in the session onto a time in the rendered clip.
+ *
+ * A render drops the idle stretches of a session, so clip time runs behind
+ * session time by however much idle time came before the moment: a moment 7
+ * minutes into a session can sit 4 minutes into the clip. The render records
+ * where each stretch landed, so walk those rather than subtracting offsets.
+ *
+ * A moment that fell inside a dropped stretch has no frame of its own and
+ * resolves to the first frame after it. Null means the clip does not reach the
+ * moment, which happens when the render stopped early.
+ */
+export function clipTimeForMoment(
+  clip: RecordingExport,
+  sessionOffsetSeconds: number,
+): number | null {
+  if (clip.segments.length === 0) {
+    // The render kept every stretch, so the clip runs in session order from
+    // wherever its window opens.
+    const clipTime = sessionOffsetSeconds - clip.startOffsetSeconds;
+    if (clipTime < 0) return null;
+    if (
+      clip.clipDurationSeconds != null &&
+      clipTime > clip.clipDurationSeconds
+    ) {
+      return null;
+    }
+    return clipTime;
+  }
+
+  for (const segment of clip.segments) {
+    if (sessionOffsetSeconds < segment.sessionFromSeconds) {
+      return segment.clipFromSeconds;
+    }
+    const sessionTo = segment.sessionToSeconds ?? segment.sessionFromSeconds;
+    if (sessionOffsetSeconds <= sessionTo) {
+      if (!segment.active) return segment.clipFromSeconds;
+      const intoSegment = sessionOffsetSeconds - segment.sessionFromSeconds;
+      return Math.min(
+        segment.clipFromSeconds + intoSegment,
+        segment.clipToSeconds,
+      );
+    }
+  }
+  return null;
+}

--- a/products/desktop/packages/ui/src/utils/posthogLinks.test.ts
+++ b/products/desktop/packages/ui/src/utils/posthogLinks.test.ts
@@ -113,6 +113,12 @@ describe("colonOffsetToSeconds", () => {
     ["too many parts", "1:2:3:4"],
     ["a non-numeric part", "ab:cd"],
     ["a negative part", "-1:00"],
+    ["an empty segment", "1::2"],
+    ["a hex literal", "0x10:00"],
+    ["scientific notation", "1e308:00"],
+    ["padded whitespace", " 1 : 2 "],
+    ["seconds of 60", "1:60"],
+    ["minutes of 60 in HH:MM:SS", "1:60:00"],
   ])("returns null for %s", (_label, offset) => {
     expect(colonOffsetToSeconds(offset)).toBeNull();
   });

--- a/products/desktop/packages/ui/src/utils/posthogLinks.test.ts
+++ b/products/desktop/packages/ui/src/utils/posthogLinks.test.ts
@@ -1,8 +1,10 @@
 import {
   canvasShareUrl,
+  colonOffsetToSeconds,
   errorTrackingIssueUrl,
   inboxReportUrl,
   parseShareLink,
+  sessionRecordingUrl,
 } from "@posthog/ui/utils/posthogLinks";
 import { describe, expect, it, vi } from "vitest";
 
@@ -94,5 +96,55 @@ describe("errorTrackingIssueUrl", () => {
     ).toBe(
       "https://us.posthog.com/project/123/error_tracking/old-issue-id?fingerprint=fp%2Fvalue%20with%20spaces%26eq%3D1",
     );
+  });
+});
+
+describe("colonOffsetToSeconds", () => {
+  it.each([
+    ["MM:SS", "01:47", 107],
+    ["HH:MM:SS", "1:02:03", 3723],
+    ["zero-padded minutes", "10:00", 600],
+  ])("parses %s", (_label, offset, expected) => {
+    expect(colonOffsetToSeconds(offset)).toBe(expected);
+  });
+
+  it.each([
+    ["a bare number", "47"],
+    ["too many parts", "1:2:3:4"],
+    ["a non-numeric part", "ab:cd"],
+    ["a negative part", "-1:00"],
+  ])("returns null for %s", (_label, offset) => {
+    expect(colonOffsetToSeconds(offset)).toBeNull();
+  });
+});
+
+describe("sessionRecordingUrl", () => {
+  it("links to the recording without a seek offset", () => {
+    expect(
+      sessionRecordingUrl("session-id-1", undefined, {
+        projectId: 123,
+        cloudRegion: "us",
+      }),
+    ).toBe("https://us.posthog.com/project/123/replay/session-id-1");
+  });
+
+  it("includes a ?t= seek offset when provided", () => {
+    expect(
+      sessionRecordingUrl(
+        "session-id-1",
+        { secondsOffsetFromStart: 107 },
+        { projectId: 123, cloudRegion: "us" },
+      ),
+    ).toBe("https://us.posthog.com/project/123/replay/session-id-1?t=107");
+  });
+
+  it("omits the offset when it is explicitly null", () => {
+    expect(
+      sessionRecordingUrl(
+        "session-id-1",
+        { secondsOffsetFromStart: null },
+        { projectId: 123, cloudRegion: "us" },
+      ),
+    ).toBe("https://us.posthog.com/project/123/replay/session-id-1");
   });
 });

--- a/products/desktop/packages/ui/src/utils/posthogLinks.ts
+++ b/products/desktop/packages/ui/src/utils/posthogLinks.ts
@@ -241,7 +241,6 @@ export function errorTrackingIssueUrl(
   }, overrides);
 }
 
-/** Parse a recording-relative "MM:SS" / "HH:MM:SS" offset to whole seconds. */
 export function colonOffsetToSeconds(offset: string): number | null {
   const parts = offset.split(":");
   if (parts.length < 2 || parts.length > 3) return null;
@@ -251,10 +250,6 @@ export function colonOffsetToSeconds(offset: string): number | null {
   return Math.round(h * 3600 + m * 60 + s);
 }
 
-/**
- * PostHog web URL that opens a session recording in the replay player, seeking to
- * `secondsOffsetFromStart` when given (mirrors `replaySingle` in the web app).
- */
 export function sessionRecordingUrl(
   sessionId: string,
   options?: { secondsOffsetFromStart?: number | null },

--- a/products/desktop/packages/ui/src/utils/posthogLinks.ts
+++ b/products/desktop/packages/ui/src/utils/posthogLinks.ts
@@ -244,10 +244,12 @@ export function errorTrackingIssueUrl(
 export function colonOffsetToSeconds(offset: string): number | null {
   const parts = offset.split(":");
   if (parts.length < 2 || parts.length > 3) return null;
+  if (parts.some((p) => !/^\d+$/.test(p))) return null;
   const nums = parts.map(Number);
-  if (nums.some((n) => !Number.isFinite(n) || n < 0)) return null;
   const [h, m, s] = parts.length === 3 ? nums : [0, nums[0], nums[1]];
-  return Math.round(h * 3600 + m * 60 + s);
+  if (m >= 60 || s >= 60) return null;
+  const total = h * 3600 + m * 60 + s;
+  return Number.isSafeInteger(total) ? total : null;
 }
 
 export function sessionRecordingUrl(

--- a/products/desktop/packages/ui/src/utils/posthogLinks.ts
+++ b/products/desktop/packages/ui/src/utils/posthogLinks.ts
@@ -240,3 +240,30 @@ export function errorTrackingIssueUrl(
       : path;
   }, overrides);
 }
+
+/** Parse a recording-relative "MM:SS" / "HH:MM:SS" offset to whole seconds. */
+export function colonOffsetToSeconds(offset: string): number | null {
+  const parts = offset.split(":");
+  if (parts.length < 2 || parts.length > 3) return null;
+  const nums = parts.map(Number);
+  if (nums.some((n) => !Number.isFinite(n) || n < 0)) return null;
+  const [h, m, s] = parts.length === 3 ? nums : [0, nums[0], nums[1]];
+  return Math.round(h * 3600 + m * 60 + s);
+}
+
+/**
+ * PostHog web URL that opens a session recording in the replay player, seeking to
+ * `secondsOffsetFromStart` when given (mirrors `replaySingle` in the web app).
+ */
+export function sessionRecordingUrl(
+  sessionId: string,
+  options?: { secondsOffsetFromStart?: number | null },
+  overrides?: LinkOverrides,
+): string | null {
+  return withProjectId((pid) => {
+    const path = `/project/${pid}/replay/${encodeURIComponent(sessionId)}`;
+    return options?.secondsOffsetFromStart != null
+      ? `${path}?t=${options.secondsOffsetFromStart}`
+      : path;
+  }, overrides);
+}

--- a/products/signals/frontend/inbox/components/signalCards/RecordingPreview.tsx
+++ b/products/signals/frontend/inbox/components/signalCards/RecordingPreview.tsx
@@ -9,6 +9,7 @@ import { sessionRecordingInfoLogic } from 'lib/components/ViewRecordingButton/se
 import { RecordingPlayerType, useRecordingButton } from 'lib/components/ViewRecordingButton/ViewRecordingButton'
 import { Dayjs } from 'lib/dayjs'
 import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
 
 import { getExportsContentRetrieveUrl } from '~/generated/core/api'
 
@@ -50,8 +51,13 @@ export function RecordingPreview({ sessionId, seekTime, exportedAssetId, alt }: 
         hasRecording,
     })
 
+    const playerUrl = urls.replaySingle(
+        sessionId,
+        seekTime ? { unixTimestampMillis: seekTime.valueOf() } : undefined
+    )
+
     return (
-        <>
+        <div className="mb-2">
             <button
                 type="button"
                 onClick={openRecording}
@@ -59,7 +65,7 @@ export function RecordingPreview({ sessionId, seekTime, exportedAssetId, alt }: 
                 title={typeof disabledReason === 'string' ? disabledReason : undefined}
                 aria-label="Play recording"
                 data-attr="inbox-signal-recording-preview"
-                className="group relative w-full aspect-video rounded overflow-hidden border bg-surface-secondary mb-2 cursor-pointer disabled:cursor-default disabled:opacity-70"
+                className="group relative w-full aspect-video rounded overflow-hidden border bg-surface-secondary cursor-pointer disabled:cursor-default disabled:opacity-70"
             >
                 {thumbnailSrc && (
                     // Defer this full-frame screenshot: the evidence rail opens expanded and can hold
@@ -89,9 +95,19 @@ export function RecordingPreview({ sessionId, seekTime, exportedAssetId, alt }: 
                     )}
                 </div>
             </button>
+            <div className="flex justify-end mt-1">
+                <a
+                    href={playerUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-xs text-tertiary hover:text-primary"
+                >
+                    Open full recording
+                </a>
+            </div>
             {hasRecording === false && (
-                <p className="text-xs text-tertiary mb-2">This recording is no longer available.</p>
+                <p className="text-xs text-tertiary mt-1">This recording is no longer available.</p>
             )}
-        </>
+        </div>
     )
 }

--- a/products/signals/frontend/inbox/components/signalCards/RecordingPreview.tsx
+++ b/products/signals/frontend/inbox/components/signalCards/RecordingPreview.tsx
@@ -9,7 +9,6 @@ import { sessionRecordingInfoLogic } from 'lib/components/ViewRecordingButton/se
 import { RecordingPlayerType, useRecordingButton } from 'lib/components/ViewRecordingButton/ViewRecordingButton'
 import { Dayjs } from 'lib/dayjs'
 import { teamLogic } from 'scenes/teamLogic'
-import { urls } from 'scenes/urls'
 
 import { getExportsContentRetrieveUrl } from '~/generated/core/api'
 
@@ -51,13 +50,8 @@ export function RecordingPreview({ sessionId, seekTime, exportedAssetId, alt }: 
         hasRecording,
     })
 
-    const playerUrl = urls.replaySingle(
-        sessionId,
-        seekTime ? { unixTimestampMillis: seekTime.valueOf() } : undefined
-    )
-
     return (
-        <div className="mb-2">
+        <>
             <button
                 type="button"
                 onClick={openRecording}
@@ -65,7 +59,7 @@ export function RecordingPreview({ sessionId, seekTime, exportedAssetId, alt }: 
                 title={typeof disabledReason === 'string' ? disabledReason : undefined}
                 aria-label="Play recording"
                 data-attr="inbox-signal-recording-preview"
-                className="group relative w-full aspect-video rounded overflow-hidden border bg-surface-secondary cursor-pointer disabled:cursor-default disabled:opacity-70"
+                className="group relative w-full aspect-video rounded overflow-hidden border bg-surface-secondary mb-2 cursor-pointer disabled:cursor-default disabled:opacity-70"
             >
                 {thumbnailSrc && (
                     // Defer this full-frame screenshot: the evidence rail opens expanded and can hold
@@ -95,19 +89,9 @@ export function RecordingPreview({ sessionId, seekTime, exportedAssetId, alt }: 
                     )}
                 </div>
             </button>
-            <div className="flex justify-end mt-1">
-                <a
-                    href={playerUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-xs text-tertiary hover:text-primary"
-                >
-                    Open full recording
-                </a>
-            </div>
             {hasRecording === false && (
-                <p className="text-xs text-tertiary mt-1">This recording is no longer available.</p>
+                <p className="text-xs text-tertiary mb-2">This recording is no longer available.</p>
             )}
-        </div>
+        </>
     )
 }


### PR DESCRIPTION
## Problem

A person reading a Self-driving report in the desktop app cannot watch the session a replay finding describes. The evidence ends at the summary.

- The card rendered a bare video element. With no exported clip the recording area stayed blank, so the report offered no route to the session at all.
- With a clip, the video sat inline and pushed the rest of the card down, and it downloaded in full on render whether or not anybody watched it.
- Replay Vision scanner findings fell through to the generic card, which shows no recording under any condition.

## Changes

- The evidence card now carries one row: a play badge, "Watch the recording", and the moment the clip starts from. Clicking it opens the recording in a modal player that autoplays and seeks to that moment.
- A session with no exported clip keeps the same row and opens the PostHog web player instead, at the same moment.
- Replay Vision scanner findings get this card too, so a scanner report reaches its recording like a session report does.
- The clip downloads when the modal opens, not when the card renders. A report full of evidence now costs one cheap export lookup per card instead of one mp4 per card.
- Mechanical: `sessionRecordingUrl` and `colonOffsetToSeconds` helpers in `posthogLinks.ts`, and the session card matches any `session_replay` signal rather than only `session_problem`.

The row and the modal use quill `Dialog` plus `div` and Tailwind, so the file gains no Radix layout primitives.

**Screenshots:** not captured. The desktop app does not launch in this sandbox, so the row and the modal are unverified visually. A reviewer running the app should check both against the report detail view.

## How did you test this code?

- `colonOffsetToSeconds` and `sessionRecordingUrl` have unit tests in `packages/ui/src/utils/posthogLinks.test.ts`. The parser cases catch malformed offsets — an empty segment, a hex literal, scientific notation, minutes or seconds of 60 — each of which previously produced a wrong or `NaN` `?t=` seek.
- `tsc --noEmit` and `biome check` are clean on the touched files.
- Not run: the desktop app itself, and any visual check of the new row or modal.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: Claude Code in a PostHog Desktop cloud task.
- Skills invoked: `/writing-pr-descriptions` for this body. The desktop guide's UI rules shaped the markup: quill components with `div` and Tailwind, and no new Radix imports in a touched file.
- The change moved twice across the session. It started as a link under the inline video, then a link on every session card. Testing against a real report showed the report used a Replay Vision scanner finding, which had no card branch at all, so the dispatch gained one. The inline video became a modal player last.
- One commit on this branch touched the web inbox card (`products/signals/frontend`) and a later commit reverted it. The change belongs in the desktop app, and the web app has its own affordance already.
- No duplicate: `gh pr list --state open --search` for inbox and recording PRs returned only unrelated web-app replay fixes.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
