### PR TITLE
fix(experiments): report the duration floor on an empty recordings list

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -197,6 +197,11 @@ export interface ExperimentRecordingsListRenderedContext extends ExperimentRecor
     /** `gt` for a floor, `lt` for a ceiling. The viewer can flip it in the playlist filter bar. */
     duration_filter_operator: string | null
     /**
+     * How many duration filters were applied. The three properties above describe the first, so a
+     * count above one says they describe part of the set rather than all of it.
+     */
+    duration_filter_count: number
+    /**
      * Whether the applied filter differs from replay's default floor, which counts removing the
      * filter as a difference. The three properties above are null when the viewer removed it.
      */

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -183,8 +183,24 @@ export interface ExperimentRecordingsListRenderedContext extends ExperimentRecor
      */
     retention_period: string | null
     replay_opt_in: boolean
-    /** Replay's default floor drops sessions under 5 active seconds, so it can empty a list. */
+    /**
+     * Whether any duration filter was applied. Replay applies a default floor to every list, so
+     * this is true on nearly every render and separates almost nothing. A dashboard tile reads it,
+     * so its meaning is frozen; the four properties below are what answers whether the floor is
+     * why the list came back empty.
+     */
     duration_filter_active: boolean
+    /** Which duration the floor measures: `active_seconds`, `duration`, or `inactive_seconds`. */
+    duration_filter_key: string | null
+    /** The floor's threshold in seconds. */
+    duration_filter_seconds: number | null
+    /** `gt` for a floor, `lt` for a ceiling. The viewer can flip it in the playlist filter bar. */
+    duration_filter_operator: string | null
+    /**
+     * Whether the applied filter differs from replay's default floor, which counts removing the
+     * filter as a difference. The three properties above are null when the viewer removed it.
+     */
+    duration_filter_customized: boolean
     /** Whether the exposure event is ever seen with a session id. Null while the check is out. */
     exposure_linkable: boolean | null
 }

--- a/frontend/src/scenes/experiments/ExperimentView/experimentReplayTabLogic.test.ts
+++ b/frontend/src/scenes/experiments/ExperimentView/experimentReplayTabLogic.test.ts
@@ -12,7 +12,15 @@ import { teamLogic } from 'scenes/teamLogic'
 
 import { ExperimentMetricType, NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
-import { Experiment, FilterLogicalOperator, SessionRecordingSidebarTab, TeamType } from '~/types'
+import {
+    Experiment,
+    FilterLogicalOperator,
+    PropertyFilterType,
+    PropertyOperator,
+    RecordingDurationFilter,
+    SessionRecordingSidebarTab,
+    TeamType,
+} from '~/types'
 
 import {
     experimentsInSessionExposureRetrieve,
@@ -810,6 +818,10 @@ describe('experimentReplayTabLogic', () => {
             retention_period: '90d',
             replay_opt_in: true,
             duration_filter_active: true,
+            duration_filter_key: 'active_seconds',
+            duration_filter_seconds: 5,
+            duration_filter_operator: 'gt',
+            duration_filter_customized: false,
             exposure_linkable: true,
             variant: 'test',
             exposure_scope: 'all_exposed',
@@ -819,6 +831,50 @@ describe('experimentReplayTabLogic', () => {
             watch_card_kind: null,
         })
         filled.unmount()
+    })
+
+    it.each([
+        {
+            name: 'a floor the viewer raised, on another duration key',
+            duration: [
+                {
+                    type: PropertyFilterType.Recording,
+                    key: 'duration',
+                    value: 60,
+                    operator: PropertyOperator.GreaterThan,
+                } as RecordingDurationFilter,
+            ],
+            expected: {
+                duration_filter_active: true,
+                duration_filter_key: 'duration',
+                duration_filter_seconds: 60,
+                duration_filter_operator: 'gt',
+                duration_filter_customized: true,
+            },
+        },
+        {
+            name: 'a floor the viewer removed',
+            duration: [],
+            expected: {
+                duration_filter_active: false,
+                duration_filter_key: null,
+                duration_filter_seconds: null,
+                duration_filter_operator: null,
+                duration_filter_customized: true,
+            },
+        },
+    ])('reports $name on an empty list', async ({ duration, expected }) => {
+        // Replay applies its default floor to every list, so a report that only said a duration
+        // filter was present cannot tell the floor everyone gets from one the viewer chose. The
+        // viewer edits it in the playlist's own filter bar, so the report has to read that rather
+        // than the filters the tab pushed down.
+        const captureSpy = jest.spyOn(posthog, 'capture').mockReturnValue(undefined as any)
+        logic.actions.playlistFiltersChanged({ ...logic.values.recordingsFilters, duration })
+        logic.actions.recordingsLoaded([])
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(listsRendered(captureSpy, 42)).toHaveLength(1)
+        expect(listsRendered(captureSpy, 42)[0][1]).toMatchObject(expected)
     })
 
     it('tells a refused metric filter apart from one that matched nothing, once it has answered', async () => {

--- a/frontend/src/scenes/experiments/ExperimentView/experimentReplayTabLogic.test.ts
+++ b/frontend/src/scenes/experiments/ExperimentView/experimentReplayTabLogic.test.ts
@@ -863,11 +863,39 @@ describe('experimentReplayTabLogic', () => {
                 duration_filter_customized: true,
             },
         },
+        {
+            name: 'a duration set with a second, stricter entry',
+            duration: [
+                {
+                    type: PropertyFilterType.Recording,
+                    key: 'active_seconds',
+                    value: 5,
+                    operator: PropertyOperator.GreaterThan,
+                } as RecordingDurationFilter,
+                {
+                    type: PropertyFilterType.Recording,
+                    key: 'active_seconds',
+                    value: 30,
+                    operator: PropertyOperator.GreaterThan,
+                } as RecordingDurationFilter,
+            ],
+            expected: {
+                duration_filter_active: true,
+                duration_filter_key: 'active_seconds',
+                duration_filter_seconds: 5,
+                duration_filter_operator: 'gt',
+                duration_filter_customized: true,
+            },
+        },
     ])('reports $name on an empty list', async ({ duration, expected }) => {
         // Replay applies its default floor to every list, so a report that only said a duration
         // filter was present cannot tell the floor everyone gets from one the viewer chose. The
         // viewer edits it in the playlist's own filter bar, so the report has to read that rather
         // than the filters the tab pushed down.
+        //
+        // The last case is the fail-safe one: the reported key, threshold, and operator describe
+        // the first entry, so a set whose first entry is the default must still report as
+        // customized when a later entry is what narrowed the list.
         const captureSpy = jest.spyOn(posthog, 'capture').mockReturnValue(undefined as any)
         logic.actions.playlistFiltersChanged({ ...logic.values.recordingsFilters, duration })
         logic.actions.recordingsLoaded([])

--- a/frontend/src/scenes/experiments/ExperimentView/experimentReplayTabLogic.test.ts
+++ b/frontend/src/scenes/experiments/ExperimentView/experimentReplayTabLogic.test.ts
@@ -821,6 +821,7 @@ describe('experimentReplayTabLogic', () => {
             duration_filter_key: 'active_seconds',
             duration_filter_seconds: 5,
             duration_filter_operator: 'gt',
+            duration_filter_count: 1,
             duration_filter_customized: false,
             exposure_linkable: true,
             variant: 'test',
@@ -849,6 +850,7 @@ describe('experimentReplayTabLogic', () => {
                 duration_filter_key: 'duration',
                 duration_filter_seconds: 60,
                 duration_filter_operator: 'gt',
+                duration_filter_count: 1,
                 duration_filter_customized: true,
             },
         },
@@ -860,6 +862,7 @@ describe('experimentReplayTabLogic', () => {
                 duration_filter_key: null,
                 duration_filter_seconds: null,
                 duration_filter_operator: null,
+                duration_filter_count: 0,
                 duration_filter_customized: true,
             },
         },
@@ -884,6 +887,7 @@ describe('experimentReplayTabLogic', () => {
                 duration_filter_key: 'active_seconds',
                 duration_filter_seconds: 5,
                 duration_filter_operator: 'gt',
+                duration_filter_count: 2,
                 duration_filter_customized: true,
             },
         },
@@ -895,7 +899,7 @@ describe('experimentReplayTabLogic', () => {
         //
         // The last case is the fail-safe one: the reported key, threshold, and operator describe
         // the first entry, so a set whose first entry is the default must still report as
-        // customized when a later entry is what narrowed the list.
+        // customized, and its count must say that the report names part of the set.
         const captureSpy = jest.spyOn(posthog, 'capture').mockReturnValue(undefined as any)
         logic.actions.playlistFiltersChanged({ ...logic.values.recordingsFilters, duration })
         logic.actions.recordingsLoaded([])

--- a/frontend/src/scenes/experiments/ExperimentView/experimentReplayTabLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentView/experimentReplayTabLogic.ts
@@ -251,6 +251,7 @@ export interface experimentReplayTabLogicValues {
     seenTogetherMapLoading: boolean // viewRecordingsLinkabilityLogic
     unlinkableEventNames: Set<string> // viewRecordingsLinkabilityLogic
     appliedDurationFilter: RecordingDurationFilter | null
+    appliedDurationFilterCount: number
     behaviorComparisonAvailable: boolean
     behaviorComparisonOpen: boolean
     bucketSessionIds: string[] | undefined
@@ -545,9 +546,12 @@ export interface experimentReplayTabLogicMeta {
             playlistFilters: RecordingUniversalFilters | null,
             recordingsFilters: RecordingUniversalFilters
         ) => RecordingDurationFilter | null
-        durationFilterCustomized: (
+        appliedDurationFilterCount: (
             playlistFilters: RecordingUniversalFilters | null,
-            recordingsFilters: RecordingUniversalFilters,
+            recordingsFilters: RecordingUniversalFilters
+        ) => number
+        durationFilterCustomized: (
+            appliedDurationFilterCount: number,
             appliedDurationFilter: RecordingDurationFilter | null
         ) => boolean
         listEmptyReason: (
@@ -1030,7 +1034,7 @@ export const experimentReplayTabLogic = kea<experimentReplayTabLogicType>([
         // and `lt`. Null when no duration filter is applied, which the tab does itself for a watch
         // card. The filter bar writes one entry, but the query conversion carries every duration
         // predicate through `having_predicates` and back, so a set from another writer can hold
-        // more. This describes the first entry only, and `durationFilterCustomized` covers the rest.
+        // more. This describes the first entry only, so it is reported next to the entry count.
         appliedDurationFilter: [
             (s) => [s.playlistFilters, s.recordingsFilters],
             (
@@ -1038,19 +1042,22 @@ export const experimentReplayTabLogic = kea<experimentReplayTabLogicType>([
                 recordingsFilters: RecordingUniversalFilters
             ): RecordingDurationFilter | null => (playlistFilters ?? recordingsFilters).duration[0] ?? null,
         ],
+        // How many duration filters the list ran under. The reported key, threshold, and operator
+        // describe the first, so this is what tells a reader whether they describe the whole set.
+        appliedDurationFilterCount: [
+            (s) => [s.playlistFilters, s.recordingsFilters],
+            (playlistFilters: RecordingUniversalFilters | null, recordingsFilters: RecordingUniversalFilters): number =>
+                (playlistFilters ?? recordingsFilters).duration.length,
+        ],
         // Whether the applied filter differs from replay's default floor, which counts removing it
         // as a difference. A reader needs this to tell an empty list under the floor everyone gets
         // from an empty list under a threshold the viewer chose. More than one duration filter
         // counts as a difference too, so that a second, stricter entry can never report as the
         // default that `appliedDurationFilter` read off the first.
         durationFilterCustomized: [
-            (s) => [s.playlistFilters, s.recordingsFilters, s.appliedDurationFilter],
-            (
-                playlistFilters: RecordingUniversalFilters | null,
-                recordingsFilters: RecordingUniversalFilters,
-                appliedDurationFilter: RecordingDurationFilter | null
-            ): boolean =>
-                (playlistFilters ?? recordingsFilters).duration.length > 1 ||
+            (s) => [s.appliedDurationFilterCount, s.appliedDurationFilter],
+            (appliedDurationFilterCount: number, appliedDurationFilter: RecordingDurationFilter | null): boolean =>
+                appliedDurationFilterCount > 1 ||
                 appliedDurationFilter === null ||
                 appliedDurationFilter.key !== defaultRecordingDurationFilter.key ||
                 appliedDurationFilter.value !== defaultRecordingDurationFilter.value ||
@@ -1523,6 +1530,7 @@ export const experimentReplayTabLogic = kea<experimentReplayTabLogicType>([
                 duration_filter_key: values.appliedDurationFilter?.key ?? null,
                 duration_filter_seconds: values.appliedDurationFilter?.value ?? null,
                 duration_filter_operator: values.appliedDurationFilter?.operator ?? null,
+                duration_filter_count: values.appliedDurationFilterCount,
                 duration_filter_customized: values.durationFilterCustomized,
                 exposure_linkable: values.exposureLinkable,
             })

--- a/frontend/src/scenes/experiments/ExperimentView/experimentReplayTabLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentView/experimentReplayTabLogic.ts
@@ -31,7 +31,10 @@ import {
 } from 'lib/utils/eventUsageLogic'
 import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
 import { playerSidebarLogic } from 'scenes/session-recordings/player/sidebar/playerSidebarLogic'
-import { DEFAULT_RECORDING_FILTERS } from 'scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic'
+import {
+    DEFAULT_RECORDING_FILTERS,
+    defaultRecordingDurationFilter,
+} from 'scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import {
@@ -44,6 +47,7 @@ import {
 import {
     Experiment,
     FilterLogicalOperator,
+    RecordingDurationFilter,
     RecordingUniversalFilters,
     SessionRecordingRetentionPeriod,
     SessionRecordingSidebarTab,
@@ -160,7 +164,8 @@ export type ExperimentWatchEmptyAction = 'exposure_docs' | 'replay_settings'
  *
  * `unknown_in_window` is the residue — replay is on, the run window is inside retention, and the
  * filters still matched nothing. Exposure linkage and the duration floor both live in there, which
- * is why the event carries `exposure_linkable` and `duration_filter_active` alongside the reason.
+ * is why the event carries `exposure_linkable` and the `duration_filter_*` properties alongside
+ * the reason.
  */
 export enum ExperimentReplayListEmptyReason {
     /** The project does not record sessions, so no experiment on it can have any. */
@@ -245,10 +250,12 @@ export interface experimentReplayTabLogicValues {
     linkabilityLoaded: boolean // viewRecordingsLinkabilityLogic
     seenTogetherMapLoading: boolean // viewRecordingsLinkabilityLogic
     unlinkableEventNames: Set<string> // viewRecordingsLinkabilityLogic
+    appliedDurationFilter: RecordingDurationFilter | null
     behaviorComparisonAvailable: boolean
     behaviorComparisonOpen: boolean
     bucketSessionIds: string[] | undefined
     durationFilterActive: boolean
+    durationFilterCustomized: boolean
     effectiveExposureScope: ExperimentReplayExposureScope
     effectiveMetricUuids: string[]
     effectiveVariantKey: string | null
@@ -534,6 +541,11 @@ export interface experimentReplayTabLogicMeta {
             playlistFilters: RecordingUniversalFilters | null,
             recordingsFilters: RecordingUniversalFilters
         ) => boolean
+        appliedDurationFilter: (
+            playlistFilters: RecordingUniversalFilters | null,
+            recordingsFilters: RecordingUniversalFilters
+        ) => RecordingDurationFilter | null
+        durationFilterCustomized: (appliedDurationFilter: RecordingDurationFilter | null) => boolean
         listEmptyReason: (
             currentTeam: TeamPublicType | TeamType | null,
             bucketSessionIds: string[] | undefined,
@@ -997,14 +1009,39 @@ export const experimentReplayTabLogic = kea<experimentReplayTabLogicType>([
                 return !unlinkableEventNames.has(exposureEventName)
             },
         ],
-        // Replay's default floor keeps out sessions under 5 active seconds, which is enough to empty
-        // a list on its own, so an empty-list report says whether it was applied.
+        // Whether the list ran under any duration filter at all. Replay applies a default floor to
+        // every list, so this is true on nearly every render and separates almost nothing. A
+        // dashboard tile reads it, so it keeps its meaning; `appliedDurationFilter` below is what
+        // tells a reader whether the floor emptied the list.
         durationFilterActive: [
             (s) => [s.playlistFilters, s.recordingsFilters],
             (
                 playlistFilters: RecordingUniversalFilters | null,
                 recordingsFilters: RecordingUniversalFilters
             ): boolean => (playlistFilters ?? recordingsFilters).duration.length > 0,
+        ],
+        // The duration filter the list actually ran under, which the viewer can edit in the
+        // playlist's own filter bar: they can change the threshold, swap the key between
+        // `active_seconds`, `duration`, and `inactive_seconds`, and flip the operator between `gt`
+        // and `lt`. Null when no duration filter is applied, which the tab does itself for a watch
+        // card. Only the first entry is read, because the filter bar edits one duration filter.
+        appliedDurationFilter: [
+            (s) => [s.playlistFilters, s.recordingsFilters],
+            (
+                playlistFilters: RecordingUniversalFilters | null,
+                recordingsFilters: RecordingUniversalFilters
+            ): RecordingDurationFilter | null => (playlistFilters ?? recordingsFilters).duration[0] ?? null,
+        ],
+        // Whether the applied filter differs from replay's default floor, which counts removing it
+        // as a difference. A reader needs this to tell an empty list under the floor everyone gets
+        // from an empty list under a threshold the viewer chose.
+        durationFilterCustomized: [
+            (s) => [s.appliedDurationFilter],
+            (appliedDurationFilter: RecordingDurationFilter | null): boolean =>
+                appliedDurationFilter === null ||
+                appliedDurationFilter.key !== defaultRecordingDurationFilter.key ||
+                appliedDurationFilter.value !== defaultRecordingDurationFilter.value ||
+                appliedDurationFilter.operator !== defaultRecordingDurationFilter.operator,
         ],
         /**
          * The cause to report when the list comes back with nothing, first match wins. The order is
@@ -1470,6 +1507,10 @@ export const experimentReplayTabLogic = kea<experimentReplayTabLogicType>([
                 retention_period: values.currentTeam?.session_recording_retention_period ?? null,
                 replay_opt_in: !!values.currentTeam?.session_recording_opt_in,
                 duration_filter_active: values.durationFilterActive,
+                duration_filter_key: values.appliedDurationFilter?.key ?? null,
+                duration_filter_seconds: values.appliedDurationFilter?.value ?? null,
+                duration_filter_operator: values.appliedDurationFilter?.operator ?? null,
+                duration_filter_customized: values.durationFilterCustomized,
                 exposure_linkable: values.exposureLinkable,
             })
         },

--- a/frontend/src/scenes/experiments/ExperimentView/experimentReplayTabLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentView/experimentReplayTabLogic.ts
@@ -545,7 +545,11 @@ export interface experimentReplayTabLogicMeta {
             playlistFilters: RecordingUniversalFilters | null,
             recordingsFilters: RecordingUniversalFilters
         ) => RecordingDurationFilter | null
-        durationFilterCustomized: (appliedDurationFilter: RecordingDurationFilter | null) => boolean
+        durationFilterCustomized: (
+            playlistFilters: RecordingUniversalFilters | null,
+            recordingsFilters: RecordingUniversalFilters,
+            appliedDurationFilter: RecordingDurationFilter | null
+        ) => boolean
         listEmptyReason: (
             currentTeam: TeamPublicType | TeamType | null,
             bucketSessionIds: string[] | undefined,
@@ -1024,7 +1028,9 @@ export const experimentReplayTabLogic = kea<experimentReplayTabLogicType>([
         // playlist's own filter bar: they can change the threshold, swap the key between
         // `active_seconds`, `duration`, and `inactive_seconds`, and flip the operator between `gt`
         // and `lt`. Null when no duration filter is applied, which the tab does itself for a watch
-        // card. Only the first entry is read, because the filter bar edits one duration filter.
+        // card. The filter bar writes one entry, but the query conversion carries every duration
+        // predicate through `having_predicates` and back, so a set from another writer can hold
+        // more. This describes the first entry only, and `durationFilterCustomized` covers the rest.
         appliedDurationFilter: [
             (s) => [s.playlistFilters, s.recordingsFilters],
             (
@@ -1034,10 +1040,17 @@ export const experimentReplayTabLogic = kea<experimentReplayTabLogicType>([
         ],
         // Whether the applied filter differs from replay's default floor, which counts removing it
         // as a difference. A reader needs this to tell an empty list under the floor everyone gets
-        // from an empty list under a threshold the viewer chose.
+        // from an empty list under a threshold the viewer chose. More than one duration filter
+        // counts as a difference too, so that a second, stricter entry can never report as the
+        // default that `appliedDurationFilter` read off the first.
         durationFilterCustomized: [
-            (s) => [s.appliedDurationFilter],
-            (appliedDurationFilter: RecordingDurationFilter | null): boolean =>
+            (s) => [s.playlistFilters, s.recordingsFilters, s.appliedDurationFilter],
+            (
+                playlistFilters: RecordingUniversalFilters | null,
+                recordingsFilters: RecordingUniversalFilters,
+                appliedDurationFilter: RecordingDurationFilter | null
+            ): boolean =>
+                (playlistFilters ?? recordingsFilters).duration.length > 1 ||
                 appliedDurationFilter === null ||
                 appliedDurationFilter.key !== defaultRecordingDurationFilter.key ||
                 appliedDurationFilter.value !== defaultRecordingDurationFilter.value ||


### PR DESCRIPTION
## Problem

Anyone investigating an empty recordings list on the experiment replay tab cannot tell whether the duration floor emptied it.

- `duration_filter_active` reports only that some duration filter was applied.
- Replay applies a default floor to every list, so the property reads true on empty and non-empty renders alike.
- The property therefore separates nothing, and the residual `unknown_in_window` reason stays unexplained.

## Changes

- `experiment recordings list rendered` now names the duration floor the list ran under: its key, its threshold in seconds, and its operator.
- `duration_filter_customized` says whether that floor differs from replay's default. Removing the floor counts as a difference.
- The three new scalars are null when the viewer removed the floor.
- The report reads the playlist's own filter bar, so a threshold the viewer picked is what lands, not the one the tab pushed down.
- `duration_filter_active` keeps its exact current meaning. A dashboard tile already reads it, and changing a live property mid-series corrupts the history behind that tile.
- `duration_filter_operator` is one addition beyond the brief. The filter bar lets a viewer flip `gt` to `lt`, so a threshold without its operator would read as a floor when it is a ceiling.
- `duration_filter_customized` also reads true when the filter set holds more than one duration entry. The reported key, threshold, and operator describe the first entry, so this keeps the property fail safe instead of reporting the default while a later entry narrowed the list.
- `duration_filter_count` carries the entry count, so a reader can tell whether the reported triple is the whole set. Carrying every entry instead was rejected: an array property breaks down worse than the scalars around it, and its shape is harder to change once dashboards read it.
- No filter set reaches this surface with two duration entries today. The tab's playlist sets `updateSearchParams: false`, so URL filters never arrive, and both remaining writers write a single entry. A count above one is the measurement that would say otherwise.
- Nothing looks different in the app. The tab renders the same list, and only the telemetry payload grows.

## How did you test this code?

Automated only. This sandbox runs no browser session against the tab.

- Three `test.each` cases were added to `experimentReplayTabLogic.test.ts`: a floor the viewer raised onto another duration key, a floor the viewer removed, and a set whose second entry is stricter than its first.
- The first two catch a report that reads `defaultRecordingDurationFilter`, or the tab's own filters, instead of the filters the playlist runs on. That regression would leave the new properties as useless as the one they sit beside.
- The third locks the multi-entry branch and its count, which no other case reaches.
- The existing exact-payload test now covers the default floor, which no new case needed to repeat.
- Not run: `hogli ci:preflight`, because the CLI is absent from this sandbox. CI reports the suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The change touches a telemetry payload, not documented behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code in a PostHog cloud task. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

- No duplicate: `gh pr list --state open --search` found no open PR touching this event or property.
- Public artifact: no customer conversation, ticket, or log fed this change. The production evidence behind it is stated qualitatively, with no counts.
- The multi-entry handling came from two review rounds after the first commit. The first version read the first duration entry alone and reported nothing about the rest.
- The same task carried a second, investigate-only item on `listEmptyReason`, which produced no code by instruction. Its finding sits in the task thread rather than here.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

