### PR TITLE
feat(metrics): add alpha banner and feedback survey button

### DIFF
--- a/products/metrics/frontend/MetricsScene.tsx
+++ b/products/metrics/frontend/MetricsScene.tsx
@@ -1,7 +1,9 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
+import posthog from 'posthog-js'
 
-import { LemonTabs } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonTabs } from '@posthog/lemon-ui'
 
+import { IconFeedback } from 'lib/lemon-ui/icons'
 import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
@@ -23,6 +25,8 @@ import { metricsFeaturePreviewGate } from './featurePreviewGate'
 import { MetricsSceneActiveTab, metricsSceneLogic } from './metricsSceneLogic'
 
 export const METRICS_LOGIC_KEY = 'metrics'
+
+const METRICS_FEEDBACK_SURVEY_ID = '01a07c35-6be3-0000-16b3-4cd66a6873f3'
 
 const TABS: { key: MetricsSceneActiveTab; label: string; 'data-attr': string }[] = [
     { key: 'overview', label: 'Overview', 'data-attr': 'metrics-scene-tab-overview' },
@@ -72,6 +76,10 @@ const MetricsSceneContent = (): JSX.Element => {
     // races the has_metrics check instead of waiting on the setup prompt to resolve.
     useMountedLogic(metricNamePickerLogic)
 
+    const onFeedbackClick = (): void => {
+        posthog.displaySurvey(METRICS_FEEDBACK_SURVEY_ID)
+    }
+
     return (
         <>
             <SceneTitleSection
@@ -80,7 +88,23 @@ const MetricsSceneContent = (): JSX.Element => {
                 resourceType={{
                     type: sceneConfigurations[Scene.Metrics].iconType || 'default_icon_type',
                 }}
+                actions={
+                    <LemonButton size="small" type="secondary" icon={<IconFeedback />} onClick={onFeedbackClick}>
+                        Feedback
+                    </LemonButton>
+                }
             />
+            <LemonBanner
+                type="warning"
+                dismissKey="metrics-alpha-notice"
+                action={{
+                    icon: <IconFeedback />,
+                    children: 'Share feedback',
+                    onClick: onFeedbackClick,
+                }}
+            >
+                Metrics is in alpha. Please share feedback on how to improve the product.
+            </LemonBanner>
             <LemonTabs<MetricsSceneActiveTab>
                 activeKey={activeTab}
                 onChange={(tab) => {


### PR DESCRIPTION
## Problem

People who open the Metrics scene get no signal that the product is in alpha, and no way to send feedback from the page. Tracing already shows a dismissible beta banner and a Feedback button that open a survey. Metrics needs the same.

## Changes

- The Metrics scene shows a dismissible warning banner: "Metrics is in alpha. Please share feedback on how to improve the product." with a "Share feedback" action.
- The scene title has a "Feedback" button next to it.
- Both open the Metrics feedback survey through `posthog.displaySurvey`, the same pattern the Tracing scene uses.

**Why:** The alpha state of Metrics should be visible in the product, and users need a low-friction path to give feedback while it is still early.

## How did you test this code?

- Ran `oxfmt --check` on the changed file. It passes.
- Not run: TypeScript check or a browser render (no `node_modules` in the sandbox). The change mirrors `products/tracing/frontend/TracingScene.tsx` line for line, with the same imports.
- No tests added: the change is presentational and has no logic beyond opening a survey.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with the PostHog Slack app from a [Slack thread](https://posthog.slack.com/archives/C08S66N93FX/p1788790109599019).
- A new "Metrics Feedback" survey was created in the PostHog internal project to back the button; its ID is hard-coded here, as with Tracing.
- Duplicate check: `gh pr list --state open --search "metrics alpha banner feedback"` found no related PR.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S66N93FX/p1788790109599019)*
