### PR TITLE
feat(replay-vision): say which teams lose scans to quota and consent

### DIFF
--- a/products/replay_vision/backend/temporal/activities/create_observation.py
+++ b/products/replay_vision/backend/temporal/activities/create_observation.py
@@ -11,8 +11,8 @@ from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
 from posthog import redis
+from posthog.event_usage import groups
 from posthog.models.organization import OrganizationMembership
-from posthog.settings import SITE_URL
 
 from products.replay_vision.backend.billing import observation_credits_for_model
 from products.replay_vision.backend.enqueue_claims import release_enqueue_claim
@@ -25,6 +25,7 @@ from products.replay_vision.backend.models.replay_scanner import ReplayScanner
 from products.replay_vision.backend.models.replay_scanner_backfill import BackfillStatus, ReplayScannerBackfill
 from products.replay_vision.backend.quota import (
     BillingPeriod,
+    QuotaState,
     ScannerBudget,
     compute_scanner_budget,
     current_period_bounds,
@@ -42,11 +43,6 @@ from products.replay_vision.backend.temporal.metrics import (
 from products.replay_vision.backend.temporal.snapshots import BackfillScannerSnapshot, ScannerSnapshot
 from products.replay_vision.backend.temporal.types import CreateObservationInputs, CreateObservationOutput
 
-# Why a scan stopped before it created an observation row. `scanner_limit` is absent because its
-# branch runs inside the admission transaction, where a Redis call and an analytics call would hold
-# a row lock across two network round trips.
-ScanBlockedReason = Literal["quota", "consent"]
-
 # One event per scanner and reason per hour. Without a gate, an org past its limit emits one event
 # for every session it refuses, which is its entire scan volume.
 _SCAN_BLOCKED_DEDUP_TTL_SECONDS = 60 * 60
@@ -59,24 +55,18 @@ def _build_scanner_snapshot(scanner: ReplayScanner) -> dict[str, Any]:
 def _capture_scan_blocked(
     *,
     scanner: ReplayScanner,
-    reason: ScanBlockedReason,
+    reason: Literal["quota", "consent"],
     triggered_by: ObservationTrigger,
-    credit_limit: int | None = None,
-    credits_used: int | None = None,
+    quota: QuotaState | None = None,
 ) -> None:
     """Internal cross-customer telemetry for a scan refused before it created a row.
 
-    A refused scan leaves nothing behind: no observation row, and so no `$recording_observed` event
-    and no scan event either. The refusal reaches only a Prometheus counter whose labels carry no
-    team, so which teams lose scans, and why, cannot be answered. Scan volume per team is
-    long-tailed, so the aggregate counter cannot stand in: a small team losing every scan disappears
-    inside a total the busiest teams dominate.
+    The Prometheus skip counters carry no team label, so this event is the only per-team record of a
+    refused scan.
     """
     dedup_key = f"@posthog/replay-vision/scan-blocked/{reason}/{scanner.pk}"
     try:
-        # SET NX is the dedup gate and the retry gate at once: an activity retry re-enters this
-        # branch, and the key is already held. A Redis failure skips the event instead of emitting
-        # it, so an outage cannot turn a fully-refused org into one event per session.
+        # Also the retry gate: an activity retry re-enters this branch and the key is already held.
         if not redis.get_client().set(dedup_key, b"1", nx=True, ex=_SCAN_BLOCKED_DEDUP_TTL_SECONDS):
             return
         posthoganalytics.capture(
@@ -86,21 +76,14 @@ def _capture_scan_blocked(
                 "reason": reason,
                 "scanner_id": str(scanner.pk),
                 "scanner_type": scanner.scanner_type,
-                # Separates the scheduled sweeps and backfills, which carry most of the spend, from
-                # the user-initiated triggers that already report their own refusals from the API.
                 "triggered_by": str(triggered_by),
                 # None for a reason that has no cap behind it, such as missing consent.
-                "credit_limit": credit_limit,
-                "credits_used": credits_used,
+                "credit_limit": quota.credit_limit if quota else None,
+                "credits_used": quota.credits_used if quota else None,
                 "team_id": scanner.team_id,
                 "organization_id": str(scanner.team.organization_id),
             },
-            # Mirrors posthog.event_usage.groups() without fetching the Team row.
-            groups={
-                "instance": SITE_URL,
-                "organization": str(scanner.team.organization_id),
-                "project": str(scanner.team.uuid),
-            },
+            groups=groups(scanner.team.organization, scanner.team),
         )
     except Exception:
         # Fail-soft: the scan is already refused and the caller returns next, so raising here would
@@ -296,13 +279,7 @@ def _create_observation(inputs: CreateObservationInputs) -> CreateObservationOut
             "Skipping observation: monthly quota exhausted",
             extra={"scanner_id": str(inputs.scanner_id), "team_id": inputs.team_id, "session_id": inputs.session_id},
         )
-        _capture_scan_blocked(
-            scanner=scanner,
-            reason="quota",
-            triggered_by=inputs.triggered_by,
-            credit_limit=quota.credit_limit,
-            credits_used=quota.credits_used,
-        )
+        _capture_scan_blocked(scanner=scanner, reason="quota", triggered_by=inputs.triggered_by, quota=quota)
         return CreateObservationOutput(
             observation_id=None,
             was_created=False,
@@ -345,6 +322,8 @@ def _create_observation(inputs: CreateObservationInputs) -> CreateObservationOut
                     reclaimed_output = _reclaim_own_pending_insert(inputs)
                     if reclaimed_output is not None:
                         return reclaimed_output
+                    # No blocked event here: this refusal holds the admission row lock, which cannot
+                    # wait on a Redis and an analytics round trip.
                     record_scanner_limit_reached("admission")
                     activity.logger.info(
                         "Skipping observation: scanner credit limit reached",

--- a/products/replay_vision/backend/temporal/activities/create_observation.py
+++ b/products/replay_vision/backend/temporal/activities/create_observation.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 from django.db import IntegrityError, OperationalError, connection, transaction
@@ -6,14 +6,21 @@ from django.db.models import F
 from django.utils import timezone
 
 import psycopg.errors
+import posthoganalytics
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
+from posthog import redis
 from posthog.models.organization import OrganizationMembership
+from posthog.settings import SITE_URL
 
 from products.replay_vision.backend.billing import observation_credits_for_model
 from products.replay_vision.backend.enqueue_claims import release_enqueue_claim
-from products.replay_vision.backend.models.replay_observation import ObservationStatus, ReplayObservation
+from products.replay_vision.backend.models.replay_observation import (
+    ObservationStatus,
+    ObservationTrigger,
+    ReplayObservation,
+)
 from products.replay_vision.backend.models.replay_scanner import ReplayScanner
 from products.replay_vision.backend.models.replay_scanner_backfill import BackfillStatus, ReplayScannerBackfill
 from products.replay_vision.backend.quota import (
@@ -23,7 +30,7 @@ from products.replay_vision.backend.quota import (
     current_period_bounds,
     quota_state,
 )
-from products.replay_vision.backend.temporal.constants import ADMISSION_BUDGET_TTL
+from products.replay_vision.backend.temporal.constants import ADMISSION_BUDGET_TTL, replay_vision_distinct_id
 from products.replay_vision.backend.temporal.decorators import track_activity
 from products.replay_vision.backend.temporal.errors import SCANNER_ADMISSION_BUSY_ERROR_TYPE
 from products.replay_vision.backend.temporal.metrics import (
@@ -35,9 +42,73 @@ from products.replay_vision.backend.temporal.metrics import (
 from products.replay_vision.backend.temporal.snapshots import BackfillScannerSnapshot, ScannerSnapshot
 from products.replay_vision.backend.temporal.types import CreateObservationInputs, CreateObservationOutput
 
+# Why a scan stopped before it created an observation row. `scanner_limit` is absent because its
+# branch runs inside the admission transaction, where a Redis call and an analytics call would hold
+# a row lock across two network round trips.
+ScanBlockedReason = Literal["quota", "consent"]
+
+# One event per scanner and reason per hour. Without a gate, an org past its limit emits one event
+# for every session it refuses, which is its entire scan volume.
+_SCAN_BLOCKED_DEDUP_TTL_SECONDS = 60 * 60
+
 
 def _build_scanner_snapshot(scanner: ReplayScanner) -> dict[str, Any]:
     return ScannerSnapshot.from_scanner(scanner).model_dump(mode="json")
+
+
+def _capture_scan_blocked(
+    *,
+    scanner: ReplayScanner,
+    reason: ScanBlockedReason,
+    triggered_by: ObservationTrigger,
+    credit_limit: int | None = None,
+    credits_used: int | None = None,
+) -> None:
+    """Internal cross-customer telemetry for a scan refused before it created a row.
+
+    A refused scan leaves nothing behind: no observation row, and so no `$recording_observed` event
+    and no scan event either. The refusal reaches only a Prometheus counter whose labels carry no
+    team, so which teams lose scans, and why, cannot be answered. Scan volume per team is
+    long-tailed, so the aggregate counter cannot stand in: a small team losing every scan disappears
+    inside a total the busiest teams dominate.
+    """
+    dedup_key = f"@posthog/replay-vision/scan-blocked/{reason}/{scanner.pk}"
+    try:
+        # SET NX is the dedup gate and the retry gate at once: an activity retry re-enters this
+        # branch, and the key is already held. A Redis failure skips the event instead of emitting
+        # it, so an outage cannot turn a fully-refused org into one event per session.
+        if not redis.get_client().set(dedup_key, b"1", nx=True, ex=_SCAN_BLOCKED_DEDUP_TTL_SECONDS):
+            return
+        posthoganalytics.capture(
+            distinct_id=replay_vision_distinct_id(scanner.team_id),
+            event="replay_vision_scan_blocked",
+            properties={
+                "reason": reason,
+                "scanner_id": str(scanner.pk),
+                "scanner_type": scanner.scanner_type,
+                # Separates the scheduled sweeps and backfills, which carry most of the spend, from
+                # the user-initiated triggers that already report their own refusals from the API.
+                "triggered_by": str(triggered_by),
+                # None for a reason that has no cap behind it, such as missing consent.
+                "credit_limit": credit_limit,
+                "credits_used": credits_used,
+                "team_id": scanner.team_id,
+                "organization_id": str(scanner.team.organization_id),
+            },
+            # Mirrors posthog.event_usage.groups() without fetching the Team row.
+            groups={
+                "instance": SITE_URL,
+                "organization": str(scanner.team.organization_id),
+                "project": str(scanner.team.uuid),
+            },
+        )
+    except Exception:
+        # Fail-soft: the scan is already refused and the caller returns next, so raising here would
+        # retry an activity whose decision cannot change.
+        activity.logger.exception(
+            "replay_vision.scan_blocked_capture_failed",
+            extra={"scanner_id": str(scanner.pk), "reason": reason},
+        )
 
 
 @activity.defn
@@ -189,6 +260,7 @@ def _create_observation(inputs: CreateObservationInputs) -> CreateObservationOut
             "Skipping observation: AI data processing not approved for organization",
             extra={"scanner_id": str(inputs.scanner_id), "team_id": inputs.team_id, "session_id": inputs.session_id},
         )
+        _capture_scan_blocked(scanner=scanner, reason="consent", triggered_by=inputs.triggered_by)
         return CreateObservationOutput(
             observation_id=None,
             was_created=False,
@@ -217,11 +289,19 @@ def _create_observation(inputs: CreateObservationInputs) -> CreateObservationOut
 
     # Deliberately check-then-act: the snapshot doesn't count enqueue claims, so a concurrent burst can
     # overshoot by at most the in-flight caps allow, which is accepted.
-    if quota_state(scanner.team.organization_id).would_exceed(observation_credits_for_model(priced_model)):
+    quota = quota_state(scanner.team.organization_id)
+    if quota.would_exceed(observation_credits_for_model(priced_model)):
         record_quota_exhausted_skip(scanner.scanner_type)
         activity.logger.info(
             "Skipping observation: monthly quota exhausted",
             extra={"scanner_id": str(inputs.scanner_id), "team_id": inputs.team_id, "session_id": inputs.session_id},
+        )
+        _capture_scan_blocked(
+            scanner=scanner,
+            reason="quota",
+            triggered_by=inputs.triggered_by,
+            credit_limit=quota.credit_limit,
+            credits_used=quota.credits_used,
         )
         return CreateObservationOutput(
             observation_id=None,

--- a/products/replay_vision/backend/tests/test_temporal.py
+++ b/products/replay_vision/backend/tests/test_temporal.py
@@ -519,11 +519,11 @@ class TestCreateObservationActivity:
             org.is_ai_data_processing_approved = False
             org.save()
 
+        # Both gates would refuse, so the consent case reporting no credit figures is what proves
+        # consent is checked first.
         with (
             patch(
                 "products.replay_vision.backend.temporal.activities.create_observation.quota_state",
-                # The consent case never reaches the quota gate, so its expected credit figures being
-                # None is what proves consent is checked first.
                 return_value=QuotaSnapshot(
                     credit_limit=5,
                     credits_used=5,
@@ -539,11 +539,22 @@ class TestCreateObservationActivity:
             for session_id in ("sess-a", "sess-b"):
                 assert self._admit(scanner, session_id).was_created is False
             assert self._admit(sibling, "sess-c").was_created is False
+            # Flip consent so the same scanner is now refused for the other reason, which the dedup
+            # key holds separately.
+            org = scanner.team.organization
+            org.is_ai_data_processing_approved = reason == "consent"
+            org.save()
+            assert self._admit(scanner, "sess-d").was_created is False
 
-        # Two sessions on one scanner share an event; a second scanner reports separately.
-        assert [c.kwargs["properties"]["scanner_id"] for c in capture.call_args_list] == [
-            str(scanner.id),
-            str(sibling.id),
+        emitted = [
+            (c.kwargs["properties"]["scanner_id"], c.kwargs["properties"]["reason"]) for c in capture.call_args_list
+        ]
+        # Two sessions on one scanner share an event; another scanner, or another reason, reports on
+        # its own.
+        assert emitted == [
+            (str(scanner.id), reason),
+            (str(sibling.id), reason),
+            (str(scanner.id), "quota" if reason == "consent" else "consent"),
         ]
         kwargs = capture.call_args_list[0].kwargs
         assert kwargs["event"] == "replay_vision_scan_blocked"

--- a/products/replay_vision/backend/tests/test_temporal.py
+++ b/products/replay_vision/backend/tests/test_temporal.py
@@ -504,6 +504,87 @@ class TestCreateObservationActivity:
 
     @parameterized.expand(
         [
+            ("quota", 5, 5),
+            ("consent", None, None),
+        ]
+    )
+    def test_blocked_scan_emits_one_event_per_scanner_and_reason(
+        self, reason: str, expected_credit_limit: int | None, expected_credits_used: int | None
+    ) -> None:
+        # A refused scan writes no observation row, so this event is the only thing that can count it.
+        scanner = _make_scanner()
+        sibling = _make_scanner(team=scanner.team, name="sibling")
+        if reason == "consent":
+            org = scanner.team.organization
+            org.is_ai_data_processing_approved = False
+            org.save()
+
+        with (
+            patch(
+                "products.replay_vision.backend.temporal.activities.create_observation.quota_state",
+                # The consent case never reaches the quota gate, so its expected credit figures being
+                # None is what proves consent is checked first.
+                return_value=QuotaSnapshot(
+                    credit_limit=5,
+                    credits_used=5,
+                    period_start=dt.datetime.now(dt.UTC),
+                    period_end=dt.datetime.now(dt.UTC),
+                    projected_monthly_credits=0,
+                ),
+            ),
+            patch(
+                "products.replay_vision.backend.temporal.activities.create_observation.posthoganalytics.capture"
+            ) as capture,
+        ):
+            for session_id in ("sess-a", "sess-b"):
+                assert self._admit(scanner, session_id).was_created is False
+            assert self._admit(sibling, "sess-c").was_created is False
+
+        # Two sessions on one scanner share an event; a second scanner reports separately.
+        assert [c.kwargs["properties"]["scanner_id"] for c in capture.call_args_list] == [
+            str(scanner.id),
+            str(sibling.id),
+        ]
+        kwargs = capture.call_args_list[0].kwargs
+        assert kwargs["event"] == "replay_vision_scan_blocked"
+        assert kwargs["distinct_id"] == f"replay-vision:{scanner.team_id}"
+        properties = kwargs["properties"]
+        assert properties["reason"] == reason
+        assert properties["scanner_type"] == "monitor"
+        # The enum's value, not its repr: a dashboard filters on the string the event carries.
+        assert properties["triggered_by"] == "schedule"
+        assert properties["credit_limit"] == expected_credit_limit
+        assert properties["credits_used"] == expected_credits_used
+        assert properties["team_id"] == scanner.team_id
+        assert properties["organization_id"] == str(scanner.team.organization_id)
+        assert kwargs["groups"]["project"] == str(scanner.team.uuid)
+
+    def test_blocked_scan_settles_and_stays_quiet_when_the_dedup_store_fails(self) -> None:
+        # The scan is already refused, so a Redis outage must neither fail the activity into a retry
+        # that reaches the same decision, nor emit the per-session flood the dedup gate exists to stop.
+        scanner = _make_scanner()
+        org = scanner.team.organization
+        org.is_ai_data_processing_approved = False
+        org.save()
+
+        with (
+            patch(
+                "products.replay_vision.backend.temporal.activities.create_observation.redis.get_client",
+                side_effect=RuntimeError("redis unreachable"),
+            ),
+            patch(
+                "products.replay_vision.backend.temporal.activities.create_observation.posthoganalytics.capture"
+            ) as capture,
+        ):
+            result = self._admit(scanner, "sess-redis-down")
+
+        assert result == CreateObservationOutput(
+            observation_id=None, was_created=False, scanner_type=scanner.scanner_type
+        )
+        capture.assert_not_called()
+
+    @parameterized.expand(
+        [
             (None, 0, True),
             (None, 10_000, True),
             (100, 0, True),


### PR DESCRIPTION
## Problem

A team whose Replay Vision scanners stopped scanning has no way to find out, and neither do we.

- A scan refused before it starts creates no observation row, so it emits no `$recording_observed` event and no scan event.
- The two refusal paths (the org's monthly credit limit, and a missing AI data processing approval) reach only a Prometheus counter.
- Those counters carry a `scanner_type` label and nothing else, so no team, org, or scanner can be identified.
- Scan volume per team is long-tailed, so the aggregate counter cannot stand in. A small team losing every scan disappears inside a total the busiest teams dominate.

The missing-approval case is the worse of the two. The scanner looks enabled and healthy in the UI, and scans nothing until somebody approves AI data processing.

## Changes

- Replay Vision emits `replay_vision_scan_blocked` when the credit limit or a missing approval stops a scan. Which teams lose scans, and why, becomes answerable for the first time.
- The event carries `reason`, so the two causes split. One needs a billing conversation and the other needs an org setting changed.
- The event carries `triggered_by`, the dispatch path that hit the refusal.
- The quota case carries `credit_limit` and `credits_used`, so how far past the cap an org sits is visible without a second query.
- A Redis `SET NX` gate holds the volume to one event per scanner and reason per hour.

The gate keys on the reason and the scanner, not the trigger. An hour of refusals on one scanner therefore reports the first trigger that arrived, so `triggered_by` reads as the dominant path rather than a full split.

Nothing user-visible changes. This is backend telemetry only, and no existing event, property, or dashboard changes.

The dedup gate is why this design beats instrumenting the refusal directly. An org past its limit refuses every session it sweeps, so an ungated event would emit at the org's entire scan volume. The same gate also absorbs activity retries, because a retry re-enters the branch and finds the key held.

> [!NOTE]
> A Redis failure skips the event rather than emitting it. Emitting on failure would turn a Redis outage into exactly the flood the gate exists to prevent.

The scanner-level credit cap keeps its Prometheus-only reporting in this PR. Its branch runs inside the admission transaction, where a Redis call and an analytics call would hold a row lock across two network round trips. A code comment records this, and a follow-up PR will hoist the capture out of that transaction and cover the third reason.

## How did you test this code?

Two new tests in the existing `TestCreateObservationActivity` block, parameterized over both reasons. The regressions they catch:

- Neither refusal path emits the event at all. Nothing asserted that before.
- The event carries the enum's repr instead of its value. A dashboard filters on the string the event carries.
- The dedup key is too coarse. A global key silences every other team, and a key without `reason` silences the second cause on a scanner.
- A Redis outage fails the activity, or floods one event per refused session. Both halves of the fail-soft decision could be removed unnoticed.

Mutation-checked rather than assumed. Five mutations, each caught: dropping the capture from the consent branch, dropping it from the quota branch, replacing `nx=True` with `nx=False`, narrowing the `except` so the Redis error propagates, and dropping `{reason}` from the dedup key.

Not run: the Temporal workflow integration suites. This sandbox has no Temporal worker. The change touches only the two skip branches of one activity, which the unit tests exercise directly.

The threaded admission tests in this file report intermittent teardown errors here. This sandbox runs Redis on 6399 and nothing on 6379, so `posthog.storage.hypercache` fails against the Django cache. Identical code produced both zero and six such errors across runs, and the same test errors on an unmodified tree, so the cause is the missing port rather than this diff.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes, and no doc enumerates these events.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code, in a session auditing Replay Vision's instrumentation. The audit ranked the scheduled paths' silence first, because the scheduled sweeps carry most of the product's scan volume and were the only dispatch path with no refusal telemetry.

Skills invoked: `/writing-tests`, `/writing-code-comments`, and `/writing-pr-descriptions`. The first shaped the choice to extend the existing test class with parameterized cases rather than add a file.

Two designs were rejected before this one. A periodic reconciler activity that enumerated orgs and recomputed quota would have reported a state rather than counting refusals, cost several aggregate queries per org per pass, and needed a `workflow.patched` marker with the non-determinism risk that carries. Reusing the existing `replay_vision_quota_exhausted` event with a fourth `trigger` value would have mixed a synthetic distinct id into an event that is person-attributed to a real user today, which would corrupt its existing unique-person count.

The scanner-level cap was in scope at the start and dropped once its branch turned out to sit inside the admission transaction. Restructuring that function to hoist the capture out is a larger change than this telemetry justifies.

No duplicate: `gh pr list --state open --search` over the quota, telemetry, and consent keywords found nothing covering this. [#96027](https://github.com/PostHog/posthog/pull/96027) reports refusal counts for the API's bulk and inline paths and does not touch this activity.

No customer data, session content, or non-public material is in this diff. The tests use the existing in-repo factories, and the operational figures behind the audit stay out of this description.

