### PR TITLE
fix(experiments): remove pointless single tab on staff tools scene

### DIFF
--- a/frontend/src/scenes/experiments/staff/ExperimentsStaffTools.tsx
+++ b/frontend/src/scenes/experiments/staff/ExperimentsStaffTools.tsx
@@ -502,206 +502,171 @@ export function ExperimentsStaffTools(): JSX.Element {
             />
 
             <LemonTabs
-                activeKey="experiments"
+                activeKey={experimentsTab}
+                onChange={setExperimentsTab}
                 tabs={[
                     {
-                        key: 'experiments',
-                        label: 'Experiments',
+                        key: 'slowest_queries',
+                        label: 'Slowest queries',
                         content: (
-                            <LemonTabs
-                                activeKey={experimentsTab}
-                                onChange={setExperimentsTab}
-                                tabs={[
-                                    {
-                                        key: 'slowest_queries',
-                                        label: 'Slowest queries',
-                                        content: (
-                                            <>
-                                                <div className="flex flex-wrap gap-2 mb-4 items-center">
-                                                    {TIME_RANGE_OPTIONS.map(({ label, hours }) => (
-                                                        <LemonButton
-                                                            key={hours}
-                                                            type={hoursBack === hours ? 'primary' : 'tertiary'}
-                                                            size="small"
-                                                            onClick={() => setHoursBack(hours)}
-                                                        >
-                                                            {label}
-                                                        </LemonButton>
-                                                    ))}
-                                                    <LemonInput
-                                                        type="number"
-                                                        min={1}
-                                                        size="small"
-                                                        placeholder="Team ID"
-                                                        value={teamIdFilter ? Number(teamIdFilter) : undefined}
-                                                        onChange={(value) =>
-                                                            setTeamIdFilter(value != null ? String(value) : '')
-                                                        }
-                                                        className="w-32"
-                                                    />
-                                                    <LemonInput
-                                                        type="number"
-                                                        min={1}
-                                                        size="small"
-                                                        placeholder="Experiment ID"
-                                                        value={
-                                                            experimentIdFilter ? Number(experimentIdFilter) : undefined
-                                                        }
-                                                        onChange={(value) =>
-                                                            setExperimentIdFilter(value != null ? String(value) : '')
-                                                        }
-                                                        className="w-36"
-                                                    />
-                                                    <LemonSelect
-                                                        size="small"
-                                                        value={metricTypeFilter}
-                                                        onChange={(value) => setMetricTypeFilter(value ?? '')}
-                                                        options={METRIC_TYPE_OPTIONS}
-                                                        className="w-44"
-                                                    />
-                                                    <LemonSelect
-                                                        size="small"
-                                                        value={exceptionCodeFilter}
-                                                        onChange={(value) => setExceptionCodeFilter(value ?? '')}
-                                                        options={EXCEPTION_CODE_OPTIONS}
-                                                        className="w-44"
-                                                    />
-                                                    <LemonButton
-                                                        type="secondary"
-                                                        size="small"
-                                                        onClick={() => loadSlowestQueries()}
-                                                        disabledReason={
-                                                            slowestQueriesLoading ? 'Loading...' : undefined
-                                                        }
-                                                    >
-                                                        Refresh
-                                                    </LemonButton>
-                                                </div>
-                                                <LemonTable
-                                                    columns={slowestQueryColumns}
-                                                    dataSource={slowestQueries}
-                                                    loading={slowestQueriesLoading}
-                                                    emptyState="No queries found in this time range"
-                                                    pagination={{ pageSize: 20 }}
-                                                    className="overflow-visible! flex-none!"
-                                                    expandable={{
-                                                        expandedRowRender: function ExpandedQuery(item) {
-                                                            return (
-                                                                <div className="flex flex-col gap-2 p-2">
-                                                                    <QueryStats {...item} />
-                                                                    <div className="font-mono text-xs text-muted flex flex-wrap items-center gap-x-3 gap-y-1">
-                                                                        <span>
-                                                                            query_id:{' '}
-                                                                            <CopyToClipboardInline description="query ID">
-                                                                                {item.query_id}
-                                                                            </CopyToClipboardInline>
-                                                                        </span>
-                                                                        {item.experiment_query_group_id && (
-                                                                            <span>
-                                                                                group:{' '}
-                                                                                <CopyToClipboardInline description="group ID">
-                                                                                    {item.experiment_query_group_id}
-                                                                                </CopyToClipboardInline>
-                                                                            </span>
-                                                                        )}
-                                                                        <LinkMetabaseQuery queryId={item.query_id} />
-                                                                    </div>
-                                                                    {item.sub_queries &&
-                                                                        item.sub_queries.length > 0 && (
-                                                                            <div>
-                                                                                <h4 className="mb-1">
-                                                                                    Sub-queries (precompute builds)
-                                                                                </h4>
-                                                                                <LemonTable
-                                                                                    size="small"
-                                                                                    columns={subQueryColumns}
-                                                                                    dataSource={item.sub_queries}
-                                                                                    expandable={{
-                                                                                        expandedRowRender:
-                                                                                            function ExpandedSubQuery(
-                                                                                                sub
-                                                                                            ) {
-                                                                                                return (
-                                                                                                    <div className="flex flex-col gap-2 p-2">
-                                                                                                        <QueryStats
-                                                                                                            {...sub}
-                                                                                                        />
-                                                                                                        <CodeSnippet
-                                                                                                            language={
-                                                                                                                Language.SQL
-                                                                                                            }
-                                                                                                            thing="query"
-                                                                                                            maxLinesWithoutExpansion={
-                                                                                                                10
-                                                                                                            }
-                                                                                                        >
-                                                                                                            {sub.query}
-                                                                                                        </CodeSnippet>
-                                                                                                    </div>
-                                                                                                )
-                                                                                            },
-                                                                                    }}
-                                                                                />
+                            <>
+                                <div className="flex flex-wrap gap-2 mb-4 items-center">
+                                    {TIME_RANGE_OPTIONS.map(({ label, hours }) => (
+                                        <LemonButton
+                                            key={hours}
+                                            type={hoursBack === hours ? 'primary' : 'tertiary'}
+                                            size="small"
+                                            onClick={() => setHoursBack(hours)}
+                                        >
+                                            {label}
+                                        </LemonButton>
+                                    ))}
+                                    <LemonInput
+                                        type="number"
+                                        min={1}
+                                        size="small"
+                                        placeholder="Team ID"
+                                        value={teamIdFilter ? Number(teamIdFilter) : undefined}
+                                        onChange={(value) => setTeamIdFilter(value != null ? String(value) : '')}
+                                        className="w-32"
+                                    />
+                                    <LemonInput
+                                        type="number"
+                                        min={1}
+                                        size="small"
+                                        placeholder="Experiment ID"
+                                        value={experimentIdFilter ? Number(experimentIdFilter) : undefined}
+                                        onChange={(value) => setExperimentIdFilter(value != null ? String(value) : '')}
+                                        className="w-36"
+                                    />
+                                    <LemonSelect
+                                        size="small"
+                                        value={metricTypeFilter}
+                                        onChange={(value) => setMetricTypeFilter(value ?? '')}
+                                        options={METRIC_TYPE_OPTIONS}
+                                        className="w-44"
+                                    />
+                                    <LemonSelect
+                                        size="small"
+                                        value={exceptionCodeFilter}
+                                        onChange={(value) => setExceptionCodeFilter(value ?? '')}
+                                        options={EXCEPTION_CODE_OPTIONS}
+                                        className="w-44"
+                                    />
+                                    <LemonButton
+                                        type="secondary"
+                                        size="small"
+                                        onClick={() => loadSlowestQueries()}
+                                        disabledReason={slowestQueriesLoading ? 'Loading...' : undefined}
+                                    >
+                                        Refresh
+                                    </LemonButton>
+                                </div>
+                                <LemonTable
+                                    columns={slowestQueryColumns}
+                                    dataSource={slowestQueries}
+                                    loading={slowestQueriesLoading}
+                                    emptyState="No queries found in this time range"
+                                    pagination={{ pageSize: 20 }}
+                                    className="overflow-visible! flex-none!"
+                                    expandable={{
+                                        expandedRowRender: function ExpandedQuery(item) {
+                                            return (
+                                                <div className="flex flex-col gap-2 p-2">
+                                                    <QueryStats {...item} />
+                                                    <div className="font-mono text-xs text-muted flex flex-wrap items-center gap-x-3 gap-y-1">
+                                                        <span>
+                                                            query_id:{' '}
+                                                            <CopyToClipboardInline description="query ID">
+                                                                {item.query_id}
+                                                            </CopyToClipboardInline>
+                                                        </span>
+                                                        {item.experiment_query_group_id && (
+                                                            <span>
+                                                                group:{' '}
+                                                                <CopyToClipboardInline description="group ID">
+                                                                    {item.experiment_query_group_id}
+                                                                </CopyToClipboardInline>
+                                                            </span>
+                                                        )}
+                                                        <LinkMetabaseQuery queryId={item.query_id} />
+                                                    </div>
+                                                    {item.sub_queries && item.sub_queries.length > 0 && (
+                                                        <div>
+                                                            <h4 className="mb-1">Sub-queries (precompute builds)</h4>
+                                                            <LemonTable
+                                                                size="small"
+                                                                columns={subQueryColumns}
+                                                                dataSource={item.sub_queries}
+                                                                expandable={{
+                                                                    expandedRowRender: function ExpandedSubQuery(sub) {
+                                                                        return (
+                                                                            <div className="flex flex-col gap-2 p-2">
+                                                                                <QueryStats {...sub} />
+                                                                                <CodeSnippet
+                                                                                    language={Language.SQL}
+                                                                                    thing="query"
+                                                                                    maxLinesWithoutExpansion={10}
+                                                                                >
+                                                                                    {sub.query}
+                                                                                </CodeSnippet>
                                                                             </div>
-                                                                        )}
-                                                                    {item.exception && (
-                                                                        <CodeSnippet
-                                                                            language={Language.Text}
-                                                                            thing="error"
-                                                                            maxLinesWithoutExpansion={5}
-                                                                        >
-                                                                            {item.exception}
-                                                                        </CodeSnippet>
-                                                                    )}
-                                                                    <CodeSnippet
-                                                                        language={Language.SQL}
-                                                                        thing="query"
-                                                                        maxLinesWithoutExpansion={10}
-                                                                    >
-                                                                        {item.query}
-                                                                    </CodeSnippet>
-                                                                </div>
-                                                            )
-                                                        },
-                                                    }}
-                                                />
+                                                                        )
+                                                                    },
+                                                                }}
+                                                            />
+                                                        </div>
+                                                    )}
+                                                    {item.exception && (
+                                                        <CodeSnippet
+                                                            language={Language.Text}
+                                                            thing="error"
+                                                            maxLinesWithoutExpansion={5}
+                                                        >
+                                                            {item.exception}
+                                                        </CodeSnippet>
+                                                    )}
+                                                    <CodeSnippet
+                                                        language={Language.SQL}
+                                                        thing="query"
+                                                        maxLinesWithoutExpansion={10}
+                                                    >
+                                                        {item.query}
+                                                    </CodeSnippet>
+                                                </div>
+                                            )
+                                        },
+                                    }}
+                                />
 
-                                                <h2 className="mt-8">Precomputation</h2>
-                                                <LemonInput
-                                                    type="search"
-                                                    placeholder="Search by organization name..."
-                                                    value={search}
-                                                    onChange={setSearch}
-                                                    className="mb-4 max-w-md"
-                                                />
-                                                <LemonTable
-                                                    columns={precomputationColumns}
-                                                    dataSource={precomputationTeams}
-                                                    loading={precomputationTeamsLoading}
-                                                    emptyState={
-                                                        search
-                                                            ? 'No teams found'
-                                                            : 'No teams have precomputation enabled'
-                                                    }
-                                                    pagination={{ pageSize: 20 }}
-                                                    className="overflow-visible! flex-none!"
-                                                />
-                                            </>
-                                        ),
-                                    },
-                                    {
-                                        key: 'precompute_overview',
-                                        label: 'Precompute overview',
-                                        content: <PrecomputeOverview />,
-                                    },
-                                    {
-                                        key: 'cache_health',
-                                        label: 'Cache health',
-                                        content: <CacheHealth />,
-                                    },
-                                ]}
-                            />
+                                <h2 className="mt-8">Precomputation</h2>
+                                <LemonInput
+                                    type="search"
+                                    placeholder="Search by organization name..."
+                                    value={search}
+                                    onChange={setSearch}
+                                    className="mb-4 max-w-md"
+                                />
+                                <LemonTable
+                                    columns={precomputationColumns}
+                                    dataSource={precomputationTeams}
+                                    loading={precomputationTeamsLoading}
+                                    emptyState={search ? 'No teams found' : 'No teams have precomputation enabled'}
+                                    pagination={{ pageSize: 20 }}
+                                    className="overflow-visible! flex-none!"
+                                />
+                            </>
                         ),
+                    },
+                    {
+                        key: 'precompute_overview',
+                        label: 'Precompute overview',
+                        content: <PrecomputeOverview />,
+                    },
+                    {
+                        key: 'cache_health',
+                        label: 'Cache health',
+                        content: <CacheHealth />,
                     },
                 ]}
             />


### PR DESCRIPTION
## Problem

The `/experiments/staff` scene wraps its tabs (Slowest queries, Precompute overview, Cache health) in an outer tab bar with a single "Experiments" tab. A single-tab bar adds nothing.

## Changes

- The outer "Experiments" tab bar is gone; the inner tabs now render directly under the page title.
- Mechanical: the inner `LemonTabs` moved up one level, no logic changes.

## How did you test this code?

Mechanical unwrap of a static wrapper. Not run: frontend typecheck (light worktree without node_modules); CI covers it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None (staff-only internal tooling).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: /wt, /writing-ui-components, /writing-pr-descriptions.
