### PR TITLE
fix(error-tracking): sanitize release metadata before storage

### DIFF
--- a/products/error_tracking/backend/logic/__init__.py
+++ b/products/error_tracking/backend/logic/__init__.py
@@ -314,6 +314,44 @@ def release_hash_exists(team_id: int, hash_id: str) -> bool:
     return ErrorTrackingRelease.objects.filter(team_id=team_id, hash_id=hash_id).exists()
 
 
+def _sanitize_release_remote_url(remote_url: str) -> str:
+    query_start = remote_url.find("?")
+    fragment_start = remote_url.find("#")
+    sanitized_end = min(
+        (position for position in (query_start, fragment_start) if position >= 0),
+        default=len(remote_url),
+    )
+    scheme_end = remote_url.find("://", 0, sanitized_end)
+    if scheme_end < 0:
+        return remote_url[:sanitized_end]
+
+    authority_start = scheme_end + 3
+    authority_end = remote_url.find("/", authority_start, sanitized_end)
+    if authority_end < 0:
+        authority_end = sanitized_end
+    credentials_end = remote_url.rfind("@", authority_start, authority_end)
+    if credentials_end < 0:
+        return remote_url[:sanitized_end]
+
+    return remote_url[:authority_start] + remote_url[credentials_end + 1 : sanitized_end]
+
+
+def _sanitize_release_metadata(metadata: dict | None) -> dict | None:
+    if not isinstance(metadata, dict):
+        return metadata
+    git_metadata = metadata.get("git")
+    if not isinstance(git_metadata, dict):
+        return metadata
+    remote_url = git_metadata.get("remote_url")
+    if not isinstance(remote_url, str):
+        return metadata
+
+    sanitized_remote_url = _sanitize_release_remote_url(remote_url)
+    if sanitized_remote_url == remote_url:
+        return metadata
+    return {**metadata, "git": {**git_metadata, "remote_url": sanitized_remote_url}}
+
+
 def create_release(
     team_id: int,
     *,
@@ -329,7 +367,7 @@ def create_release(
         hash_id=resolved_hash_id,
         defaults={
             "id": release_id,
-            "metadata": metadata,
+            "metadata": _sanitize_release_metadata(metadata),
             "project": str(project),
             "version": str(version),
         },
@@ -352,7 +390,7 @@ def update_release(
     if release is None:
         return None
     if metadata:
-        release.metadata = metadata
+        release.metadata = _sanitize_release_metadata(metadata)
     if version:
         release.version = str(version)
     if project:

--- a/products/error_tracking/backend/logic/__init__.py
+++ b/products/error_tracking/backend/logic/__init__.py
@@ -338,7 +338,7 @@ def _sanitize_release_remote_url(remote_url: str) -> str:
     return remote_url[:authority_start] + remote_url[credentials_end + 1 : sanitized_end]
 
 
-def _sanitize_release_metadata(metadata: dict | None) -> dict | None:
+def sanitize_release_metadata(metadata: dict | None) -> dict | None:
     if not isinstance(metadata, dict):
         return metadata
     git_metadata = metadata.get("git")
@@ -369,7 +369,7 @@ def create_release(
         hash_id=resolved_hash_id,
         defaults={
             "id": release_id,
-            "metadata": _sanitize_release_metadata(metadata),
+            "metadata": sanitize_release_metadata(metadata),
             "project": str(project),
             "version": str(version),
         },
@@ -392,7 +392,7 @@ def update_release(
     if release is None:
         return None
     if metadata:
-        release.metadata = _sanitize_release_metadata(metadata)
+        release.metadata = sanitize_release_metadata(metadata)
     if version:
         release.version = str(version)
     if project:

--- a/products/error_tracking/backend/logic/__init__.py
+++ b/products/error_tracking/backend/logic/__init__.py
@@ -321,11 +321,13 @@ def _sanitize_release_remote_url(remote_url: str) -> str:
         (position for position in (query_start, fragment_start) if position >= 0),
         default=len(remote_url),
     )
-    scheme_end = remote_url.find("://", 0, sanitized_end)
-    if scheme_end < 0:
-        return remote_url[:sanitized_end]
-
-    authority_start = scheme_end + 3
+    if remote_url.startswith("//"):
+        authority_start = 2
+    else:
+        scheme_end = remote_url.find("://", 0, sanitized_end)
+        if scheme_end < 0:
+            return remote_url[:sanitized_end]
+        authority_start = scheme_end + 3
     authority_end = remote_url.find("/", authority_start, sanitized_end)
     if authority_end < 0:
         authority_end = sanitized_end

--- a/products/error_tracking/backend/management/commands/backfill_error_tracking_release_metadata.py
+++ b/products/error_tracking/backend/management/commands/backfill_error_tracking_release_metadata.py
@@ -1,0 +1,130 @@
+"""Sanitize Git remote URLs stored in error tracking release metadata.
+
+Run this command after the release write sanitizer is deployed so concurrent writes cannot
+reintroduce credentials behind the backfill cursor.
+
+Usage:
+    python manage.py backfill_error_tracking_release_metadata
+    python manage.py backfill_error_tracking_release_metadata --live-run
+    python manage.py backfill_error_tracking_release_metadata --live-run --batch-size 500
+    python manage.py backfill_error_tracking_release_metadata --live-run --start-after-id <release-uuid>
+"""
+
+from __future__ import annotations
+
+import logging
+from argparse import ArgumentParser
+from uuid import UUID
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.db.models import QuerySet
+
+import structlog
+
+from products.error_tracking.backend.logic import sanitize_release_metadata
+from products.error_tracking.backend.models import ErrorTrackingRelease
+
+logger = structlog.get_logger(__name__)
+
+DEFAULT_BATCH_SIZE = 1_000
+SANITIZABLE_REMOTE_URL_PATTERN = r"^(//|[^/?#]+://)[^/?#]*@|[?#]"
+
+
+class Command(BaseCommand):
+    help = "Remove credentials, query parameters, and fragments from stored error tracking release Git remotes."
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "--live-run",
+            action="store_true",
+            help="Update stored release metadata. The default is a dry run.",
+        )
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=DEFAULT_BATCH_SIZE,
+            help=f"Number of matching releases to process per transaction. The default is {DEFAULT_BATCH_SIZE}.",
+        )
+        parser.add_argument(
+            "--start-after-id",
+            type=UUID,
+            default=None,
+            help="Resume after this release UUID.",
+        )
+
+    def handle(
+        self,
+        *,
+        live_run: bool,
+        batch_size: int,
+        start_after_id: UUID | None,
+        **options: object,
+    ) -> None:
+        logger.setLevel(logging.INFO)
+        if batch_size <= 0:
+            raise CommandError("Batch size must be greater than zero.")
+
+        end_id = ErrorTrackingRelease.objects.order_by("-id").values_list("id", flat=True).first()
+        if end_id is None or (start_after_id is not None and start_after_id >= end_id):
+            logger.info("release_metadata_backfill_complete", matched=0, updated=0)
+            return
+
+        mode = "LIVE" if live_run else "DRY-RUN"
+        logger.info(
+            "release_metadata_backfill_starting",
+            mode=mode,
+            batch_size=batch_size,
+            start_after_id=str(start_after_id) if start_after_id is not None else None,
+            end_id=str(end_id),
+        )
+
+        matched_total = 0
+        updated_total = 0
+        cursor = start_after_id
+        while candidate_ids := self._get_candidate_ids(after_id=cursor, end_id=end_id, batch_size=batch_size):
+            cursor = candidate_ids[-1]
+            matched_total += len(candidate_ids)
+            if live_run:
+                updated_total += self._sanitize_releases(candidate_ids)
+
+            logger.info(
+                "release_metadata_backfill_progress",
+                matched=matched_total,
+                updated=updated_total,
+                last_release_id=str(cursor),
+            )
+
+        logger.info(
+            "release_metadata_backfill_complete",
+            matched=matched_total,
+            updated=updated_total,
+            last_release_id=str(cursor) if cursor is not None else None,
+        )
+
+    def _get_candidate_ids(self, *, after_id: UUID | None, end_id: UUID, batch_size: int) -> list[UUID]:
+        candidates = ErrorTrackingRelease.objects.filter(
+            id__lte=end_id,
+            metadata__git__remote_url__regex=SANITIZABLE_REMOTE_URL_PATTERN,
+        )
+        if after_id is not None:
+            candidates = candidates.filter(id__gt=after_id)
+
+        return list(candidates.order_by("id").values_list("id", flat=True)[:batch_size])
+
+    def _sanitize_releases(self, candidate_ids: list[UUID]) -> int:
+        with transaction.atomic():
+            releases: QuerySet[ErrorTrackingRelease] = ErrorTrackingRelease.objects.select_for_update().filter(
+                id__in=candidate_ids
+            )
+            releases_to_update: list[ErrorTrackingRelease] = []
+            for release in releases.only("id", "metadata"):
+                sanitized_metadata = sanitize_release_metadata(release.metadata)
+                if sanitized_metadata == release.metadata:
+                    continue
+                release.metadata = sanitized_metadata
+                releases_to_update.append(release)
+
+            if releases_to_update:
+                ErrorTrackingRelease.objects.bulk_update(releases_to_update, ["metadata"])
+            return len(releases_to_update)

--- a/products/error_tracking/backend/management/commands/test/test_backfill_error_tracking_release_metadata.py
+++ b/products/error_tracking/backend/management/commands/test/test_backfill_error_tracking_release_metadata.py
@@ -1,0 +1,73 @@
+from posthog.test.base import BaseTest
+
+from products.error_tracking.backend.management.commands.backfill_error_tracking_release_metadata import Command
+from products.error_tracking.backend.models import ErrorTrackingRelease
+
+
+class TestBackfillErrorTrackingReleaseMetadata(BaseTest):
+    def test_backfill_sanitizes_existing_remote_urls_in_batches(self) -> None:
+        credential_release = ErrorTrackingRelease.objects.create(
+            team=self.team,
+            hash_id="credential-release",
+            version="1.0.0",
+            project="example-project",
+            metadata={
+                "git": {
+                    "commit_id": "abc123",
+                    "remote_url": "https://deploy-user:fake-token@example.com/repository.git",
+                }
+            },
+        )
+        query_release = ErrorTrackingRelease.objects.create(
+            team=self.team,
+            hash_id="query-release",
+            version="1.0.1",
+            project="example-project",
+            metadata={
+                "git": {
+                    "commit_id": "def456",
+                    "remote_url": "https://example.com/repository.git?access_token=fake-token#build",
+                }
+            },
+        )
+        clean_release = ErrorTrackingRelease.objects.create(
+            team=self.team,
+            hash_id="clean-release",
+            version="1.0.2",
+            project="example-project",
+            metadata={"git": {"remote_url": "git@example.com:group/repository.git"}, "provider": "example"},
+        )
+
+        Command().handle(live_run=False, batch_size=1, start_after_id=None)
+
+        credential_release.refresh_from_db()
+        query_release.refresh_from_db()
+        assert credential_release.metadata == {
+            "git": {
+                "commit_id": "abc123",
+                "remote_url": "https://deploy-user:fake-token@example.com/repository.git",
+            }
+        }
+        assert query_release.metadata == {
+            "git": {
+                "commit_id": "def456",
+                "remote_url": "https://example.com/repository.git?access_token=fake-token#build",
+            }
+        }
+
+        Command().handle(live_run=True, batch_size=1, start_after_id=None)
+        Command().handle(live_run=True, batch_size=1, start_after_id=None)
+
+        credential_release.refresh_from_db()
+        query_release.refresh_from_db()
+        clean_release.refresh_from_db()
+        assert credential_release.metadata == {
+            "git": {"commit_id": "abc123", "remote_url": "https://example.com/repository.git"}
+        }
+        assert query_release.metadata == {
+            "git": {"commit_id": "def456", "remote_url": "https://example.com/repository.git"}
+        }
+        assert clean_release.metadata == {
+            "git": {"remote_url": "git@example.com:group/repository.git"},
+            "provider": "example",
+        }

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -1734,7 +1734,7 @@ class TestErrorTracking(APIBaseTest):
                 "metadata": {
                     "git": {
                         "commit_id": "def456",
-                        "remote_url": "https://x-access-token:secret@example.com/repository.git?access_token=query-secret",
+                        "remote_url": "//x-access-token:secret@example.com/repository.git?access_token=query-secret",
                     }
                 }
             },
@@ -1743,7 +1743,7 @@ class TestErrorTracking(APIBaseTest):
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
         release.refresh_from_db()
-        assert release.metadata == {"git": {"commit_id": "def456", "remote_url": "https://example.com/repository.git"}}
+        assert release.metadata == {"git": {"commit_id": "def456", "remote_url": "//example.com/repository.git"}}
 
     def test_fetch_release_by_hash_id(self) -> None:
         release = ErrorTrackingRelease.objects.create(

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -1707,6 +1707,44 @@ class TestErrorTracking(APIBaseTest):
         self.assertEqual(activity.status_code, expected_status)
         return activity.json()
 
+    def test_release_writes_strip_credentials_from_remote_url(self) -> None:
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/releases",
+            data={
+                "version": "1.0.0",
+                "project": "my-project",
+                "hash_id": "test-hash-123",
+                "metadata": {
+                    "git": {
+                        "commit_id": "abc123",
+                        "remote_url": "https://user:password@example.com/repository.git?token=query#token=fragment",
+                    }
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        release = ErrorTrackingRelease.objects.get(team=self.team, hash_id="test-hash-123")
+        assert release.metadata == {"git": {"commit_id": "abc123", "remote_url": "https://example.com/repository.git"}}
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/error_tracking/releases/{release.id}",
+            data={
+                "metadata": {
+                    "git": {
+                        "commit_id": "def456",
+                        "remote_url": "https://x-access-token:secret@example.com/repository.git?access_token=query-secret",
+                    }
+                }
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        release.refresh_from_db()
+        assert release.metadata == {"git": {"commit_id": "def456", "remote_url": "https://example.com/repository.git"}}
+
     def test_fetch_release_by_hash_id(self) -> None:
         release = ErrorTrackingRelease.objects.create(
             team=self.team,


### PR DESCRIPTION
## Problem

Project members can retrieve Git credentials that older release uploads stored in release metadata.

The event projection fix in #95925 protects exception events, but it does not protect release APIs or existing PostgreSQL rows.

## Changes

- New release writes remove URL user information, query parameters, and fragments before storage.
- A dry-run management command sanitizes existing rows in bounded, resumable batches.
- Operators run the backfill after deployment so old web processes cannot reintroduce credentials behind its cursor.
- The backfill locks only matching rows in each batch and rechecks their current metadata before updating them.
- Nothing looks different in the UI.

## How did you test this code?

- The API regression test covers sanitized release creation and updates.
- The backfill regression test covers dry runs, small batches, preserved metadata, and idempotent reruns.
- Ran the two targeted regression tests.
- Ran repo-wide mypy and `hogli ci:preflight --fix`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The API contract remains unchanged, and the management command documents its operator workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented this change with Jujutsu, GitHub CLI, and read-only production query planning.

Skills invoked: `/error-tracking`, `/django-migrations`, `/improving-drf-endpoints`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/querying-production-databases-via-metabase`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `/pr`.

The backfill uses a post-deployment management command instead of a Django migration to avoid a rolling-deploy write race.

The duplicate search found #95807, which sanitizes the CLI path only. This PR enforces sanitization for every backend release write and cleans existing rows.

All committed test data is invented and uses reserved example domains.
