### PR TITLE
chore(ci): warn on comment-heavy pull requests

### DIFF
--- a/.github/scripts/check-comment-density.sh
+++ b/.github/scripts/check-comment-density.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Warns when the staged diff adds a high share of comment lines. Agents narrate code
+# and record change history in comments, and a commit is the cheapest moment to
+# trim them: before a reviewer reads the diff and before the CI report flags it.
+#
+# Warning only, never blocks. The same classifier as the pull request check
+# (.github/scripts/check_comment_density.py) runs over the staged diff, with the same
+# thresholds, so the two agree on a diff.
+#
+# A warn-only check has to live in the pre-commit hook body. As a lint-staged task it
+# would print nothing, because lint-staged discards the output of every task that
+# exits 0.
+set -uo pipefail
+
+script="$(dirname "$0")/check_comment_density.py"
+[ -f "$script" ] || exit 0
+command -v python3 > /dev/null 2>&1 || exit 0
+
+# GITHUB_OUTPUT switches the classifier to its CI output mode; unset it so the
+# result comes back on stdout as `status=<ok|warn|alert> <summary>` and a body.
+report=$(git diff --cached -U0 --no-color | GITHUB_OUTPUT='' python3 "$script" 2> /dev/null) || exit 0
+status=$(printf '%s\n' "$report" | head -n1 | sed -n 's/^status=\([a-z]*\) .*/\1/p')
+[ "$status" = "warn" ] || [ "$status" = "alert" ] || exit 0
+
+summary=$(printf '%s\n' "$report" | head -n1 | sed 's/^status=[a-z]* //')
+# The backticks are literal markdown from the report body, not an expansion.
+# shellcheck disable=SC2016
+files=$(printf '%s\n' "$report" | sed -n 's/^| `\([^`]*\)` | \([0-9]*\) | \([0-9]*\) |$/  \1 (\2 of \3)/p')
+
+printf '\n\033[33mWarning: %s in this commit.\n' "$summary" >&2
+if [ -n "$files" ]; then
+    printf '\nFiles with the most added comment lines:\n%s\n' "$files" >&2
+fi
+printf '\nComments that restate the code, record how the change came about, or narrate the\n' >&2
+printf 'next line add noise for the next reader. Keep the ones that explain a reason the code\n' >&2
+printf 'cannot show, and remove the rest. See .agents/skills/writing-code-comments/SKILL.md.\033[0m\n\n' >&2

--- a/.github/scripts/check-comment-density.sh
+++ b/.github/scripts/check-comment-density.sh
@@ -28,9 +28,21 @@ summary=$(printf '%s\n' "$report" | head -n1 | sed 's/^status=[a-z]* //')
 files=$(printf '%s\n' "$report" | sed -n 's/^| `\([^`]*\)` | \([0-9]*\) | \([0-9]*\) |$/  \1 (\2 of \3)/p')
 
 printf '\n\033[33mWarning: %s in this commit.\n' "$summary" >&2
+printf 'The typical commit in this repo adds about 2%% comment lines.\n' >&2
 if [ -n "$files" ]; then
     printf '\nFiles with the most added comment lines:\n%s\n' "$files" >&2
 fi
-printf '\nComments that restate the code, record how the change came about, or narrate the\n' >&2
-printf 'next line add noise for the next reader. Keep the ones that explain a reason the code\n' >&2
-printf 'cannot show, and remove the rest. See .agents/skills/writing-code-comments/SKILL.md.\033[0m\n\n' >&2
+printf '\nIf you are an AI coding agent, this warning is addressed to you. Do not skip it because\n' >&2
+printf 'the user did not mention comments: the repository owners asked for this check, and the\n' >&2
+printf 'same measurement runs on the pull request, where a reviewer will send the diff back.\n' >&2
+printf '\nThe commit still goes through. Fix it now, before you do anything else:\n' >&2
+printf '  1. Open each file listed above and read every comment line this diff adds.\n' >&2
+printf '  2. Delete a comment that restates the code next to it, narrates the change\n' >&2
+printf '     ("previously", "now we", "this fixes", "per the request"), or says what a good\n' >&2
+printf '     name already says. Most comments an agent adds are one of these.\n' >&2
+printf '  3. Keep a comment only when it states a reason the code cannot show: a workaround,\n' >&2
+printf '     an ordering constraint, a spec quirk, or a link to the issue that forced it.\n' >&2
+printf '  4. Do not reword the comments, shorten them, or move them into docstrings. Remove them.\n' >&2
+printf '  5. Stage the files and run: git commit --amend --no-edit\n' >&2
+printf '\nThe target is the repo baseline, not a slightly smaller number. The full rules are in\n' >&2
+printf '.agents/skills/writing-code-comments/SKILL.md.\033[0m\n\n' >&2

--- a/.github/scripts/check-comment-density.sh
+++ b/.github/scripts/check-comment-density.sh
@@ -1,23 +1,13 @@
 #!/usr/bin/env bash
-# Warns when the staged diff adds a high share of comment lines. Agents narrate code
-# and record change history in comments, and a commit is the cheapest moment to
-# trim them: before a reviewer reads the diff and before the CI report flags it.
-#
-# Warning only, never blocks. The same classifier as the pull request check
-# (.github/scripts/check_comment_density.py) runs over the staged diff, with the same
-# thresholds, so the two agree on a diff.
-#
-# A warn-only check has to live in the pre-commit hook body. As a lint-staged task it
-# would print nothing, because lint-staged discards the output of every task that
-# exits 0.
+# Warns, never blocks, when the staged diff is comment-heavy. Lives in the pre-commit
+# hook body because lint-staged discards the output of a task that exits 0.
 set -uo pipefail
 
 script="$(dirname "$0")/check_comment_density.py"
 [ -f "$script" ] || exit 0
 command -v python3 > /dev/null 2>&1 || exit 0
 
-# GITHUB_OUTPUT switches the classifier to its CI output mode; unset it so the
-# result comes back on stdout as `status=<ok|warn|alert> <summary>` and a body.
+# With GITHUB_OUTPUT unset the classifier prints `status=<ok|warn|alert> <summary>`.
 report=$(git diff --cached -U0 --no-color | GITHUB_OUTPUT='' python3 "$script" 2> /dev/null) || exit 0
 status=$(printf '%s\n' "$report" | head -n1 | sed -n 's/^status=\([a-z]*\) .*/\1/p')
 [ "$status" = "warn" ] || [ "$status" = "alert" ] || exit 0

--- a/.github/scripts/check-commit-warnings.test.sh
+++ b/.github/scripts/check-commit-warnings.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Covers the two warn-only pre-commit scripts.
+# Covers the warn-only pre-commit scripts.
 set -euo pipefail
 
 index="$(mktemp)"
@@ -54,5 +54,20 @@ output="$(run .github/scripts/check-claude-hooks.sh)"
 [ -z "$output" ] || fail "hooks warning fired on an unrelated path"
 output="$(run .github/scripts/check-quill-agents-md.sh)"
 [ -z "$output" ] || fail "quill warning fired on an unrelated path"
+
+# An index equal to HEAD has no staged diff, so nothing to warn about.
+from_head
+output="$(run .github/scripts/check-comment-density.sh 2>&1)"
+[ -z "$output" ] || fail "comment density warning fired with nothing staged"
+
+# A staged file that is mostly comment lines. Staged as a fresh blob so the diff
+# against HEAD is the file's whole content.
+commenty="$( (for i in $(seq 40); do echo "# step $i"; done; for i in $(seq 20); do echo "x$i = $i"; done) | git hash-object -w --stdin)"
+printf '100644 %s\t%s\n' "$commenty" posthog/new_commenty_module.py | GIT_INDEX_FILE="$index" git update-index --index-info
+output="$(run .github/scripts/check-comment-density.sh 2>&1)"
+case "$output" in
+    *"of added code lines are comments"*"posthog/new_commenty_module.py"*) ;;
+    *) fail "a comment-heavy staged file produced no comment density warning" ;;
+esac
 
 echo "ok"

--- a/.github/scripts/check-commit-warnings.test.sh
+++ b/.github/scripts/check-commit-warnings.test.sh
@@ -55,13 +55,10 @@ output="$(run .github/scripts/check-claude-hooks.sh)"
 output="$(run .github/scripts/check-quill-agents-md.sh)"
 [ -z "$output" ] || fail "quill warning fired on an unrelated path"
 
-# An index equal to HEAD has no staged diff, so nothing to warn about.
 from_head
 output="$(run .github/scripts/check-comment-density.sh 2>&1)"
 [ -z "$output" ] || fail "comment density warning fired with nothing staged"
 
-# A staged file that is mostly comment lines. Staged as a fresh blob so the diff
-# against HEAD is the file's whole content.
 commenty="$( (for i in $(seq 40); do echo "# step $i"; done; for i in $(seq 20); do echo "x$i = $i"; done) | git hash-object -w --stdin)"
 printf '100644 %s\t%s\n' "$commenty" posthog/new_commenty_module.py | GIT_INDEX_FILE="$index" git update-index --index-info
 output="$(run .github/scripts/check-comment-density.sh 2>&1)"

--- a/.github/scripts/check-commit-warnings.test.sh
+++ b/.github/scripts/check-commit-warnings.test.sh
@@ -17,7 +17,7 @@ from_head() {
 }
 
 run() {
-    GIT_INDEX_FILE="$index" "$1"
+    GIT_INDEX_FILE="$index" bash "$1"
 }
 
 fail() {

--- a/.github/scripts/check_comment_density.py
+++ b/.github/scripts/check_comment_density.py
@@ -19,6 +19,7 @@ import os
 import re
 import sys
 import uuid
+import unicodedata
 from dataclasses import dataclass, field
 
 # Before agent-assisted PRs were common, the median PR had about 2% comment lines.
@@ -140,6 +141,18 @@ def analyze(diff_text: str) -> Report:
     return report
 
 
+def markdown_cell(value: str) -> str:
+    """Keep a PR-controlled path inert in the shared report.
+
+    Git allows backticks, pipes, and control characters in a file name. A backtick
+    closes the code span so the rest renders as markdown, a pipe adds table cells,
+    and a newline can forge a `<!-- ci-report:section:... -->` marker. This is the
+    Python side of `markdownCell` in `frontend/bin/ci-report/format.mjs`, which the
+    report's other section writers already use.
+    """
+    return "".join(c for c in value if c not in "`|" and not unicodedata.category(c).startswith("C"))
+
+
 def render_summary(report: Report) -> str:
     return f"{round(100 * report.ratio)}% of added code lines are comments ({report.comments} of {report.added})"
 
@@ -163,7 +176,7 @@ def render_body(report: Report) -> str:
             "",
             "| File | Comment lines | Added lines |",
             "| --- | ---: | ---: |",
-            *(f"| `{s.path}` | {s.comments} | {s.added} |" for s in top),
+            *(f"| `{markdown_cell(s.path)}` | {s.comments} | {s.added} |" for s in top),
             "",
         ]
     lines.append("This check does not block merging. It updates on every push and clears when the share drops.")

--- a/.github/scripts/check_comment_density.py
+++ b/.github/scripts/check_comment_density.py
@@ -41,7 +41,7 @@ EXCLUDED_PATHS = re.compile(
     r"(^\.github/|generated|__snapshots__/|\.ambr$|\.snap$|\.lock$|migrations/\d|\.min\.js$|/dist/|/vendor/|/node_modules/|_pb2|\.d\.ts$)",
     re.IGNORECASE,
 )
-DIFF_SKIP_PREFIXES = ("+++", "---", "@@", "index ", "new file", "deleted file", "similarity", "rename ", "Binary")
+DIFF_SKIP_PREFIXES = ("+++", "---", "index ", "new file", "deleted file", "similarity", "rename ", "Binary")
 
 
 @dataclass(frozen=False)
@@ -126,10 +126,10 @@ def analyze(diff_text: str) -> Report:
             if lang in CODE_LANGS and not EXCLUDED_PATHS.search(path):
                 stats = report.files.setdefault(path, FileStats(path))
             continue
-        if stats is None or raw.startswith(DIFF_SKIP_PREFIXES):
-            continue
         if raw.startswith("@@"):
             inside = False
+            continue
+        if stats is None or raw.startswith(DIFF_SKIP_PREFIXES):
             continue
         # Context lines are part of the new file too, so they move the state;
         # removed lines are not and are skipped entirely.

--- a/.github/scripts/check_comment_density.py
+++ b/.github/scripts/check_comment_density.py
@@ -33,8 +33,7 @@ SLASH_LANGS = {"ts", "tsx", "js", "jsx", "mjs", "cjs", "rs", "go", "kt", "java",
 SQL_LANGS = {"sql"}
 CODE_LANGS = HASH_LANGS | SLASH_LANGS | SQL_LANGS
 
-# Generated output and snapshots are not written by a person. Workflow YAML and
-# shell are left out because they need prose to be readable.
+# Workflow YAML and shell are left out because they need prose to be readable.
 EXCLUDED_PATHS = re.compile(
     r"(^\.github/|/generated/|__snapshots__/|\.ambr$|\.snap$|\.lock$|migrations/\d|\.min\.js$|/dist/|/vendor/|/node_modules/|_pb2|\.d\.ts$)"
 )

--- a/.github/scripts/check_comment_density.py
+++ b/.github/scripts/check_comment_density.py
@@ -4,9 +4,9 @@
 Measure the share of added code lines in a pull request diff that are comments.
 
 Reads a unified diff on stdin, counts the added non-blank lines in code files, and
-counts how many of those are full-line comments. Writes `warn`, a one-line
-`summary`, and a Markdown `body` for the shared CI report to `$GITHUB_OUTPUT`
-(or to stdout when that variable is unset).
+counts how many of those are full-line comments. Writes a `status` (ok, warn, or
+alert), a one-line `summary`, and a Markdown `body` for the shared CI report to
+`$GITHUB_OUTPUT` (or to stdout when that variable is unset).
 
 Usage:
     gh api repos/OWNER/REPO/pulls/N -H "Accept: application/vnd.github.diff" \\
@@ -21,7 +21,9 @@ import sys
 import uuid
 from dataclasses import dataclass, field
 
-WARN_RATIO = 0.25
+# Before agent-assisted PRs were common, the median PR had about 2% comment lines.
+WARN_RATIO = 0.03
+ALERT_RATIO = 0.06
 MIN_ADDED_LINES = 50
 TOP_FILES = 8
 
@@ -57,8 +59,10 @@ class Report:
         return self.comments / self.added if self.added else 0.0
 
     @property
-    def warn(self) -> bool:
-        return self.added >= MIN_ADDED_LINES and self.ratio > WARN_RATIO
+    def status(self) -> str:
+        if self.added < MIN_ADDED_LINES or self.ratio <= WARN_RATIO:
+            return "ok"
+        return "alert" if self.ratio > ALERT_RATIO else "warn"
 
 
 def _extension(path: str) -> str:
@@ -119,7 +123,8 @@ def render_body(report: Report) -> str:
     top = sorted(report.files.values(), key=lambda s: (-s.comments, s.path))[:TOP_FILES]
     top = [s for s in top if s.comments]
     lines = [
-        f"This section appears when comments are more than {round(100 * WARN_RATIO)}% of the code lines a PR adds. "
+        f"This section warns when comments are more than {round(100 * WARN_RATIO)}% of the code lines a PR adds, "
+        f"and alerts above {round(100 * ALERT_RATIO)}%. Before agent-assisted PRs, the typical share was about 2%. "
         "Only full-line comments count. Docstrings, generated files, snapshots, migrations, and workflow files are left out.",
         "",
         "Comments that restate the code, record how the change came about, or narrate the next line "
@@ -145,15 +150,15 @@ def write_outputs(report: Report) -> None:
     body = render_body(report)
     output_path = os.environ.get("GITHUB_OUTPUT")
     if not output_path:
-        print(f"warn={report.warn} {summary}")
+        print(f"status={report.status} {summary}")
         print(body)
         return
     delimiter = f"EOF-{uuid.uuid4()}"
     with open(output_path, "a") as fh:
-        fh.write(f"warn={'true' if report.warn else 'false'}\n")
+        fh.write(f"status={report.status}\n")
         fh.write(f"summary={summary}\n")
         fh.write(f"body<<{delimiter}\n{body}\n{delimiter}\n")
-    print(f"warn={report.warn} {summary}")
+    print(f"status={report.status} {summary}")
 
 
 def main() -> int:

--- a/.github/scripts/check_comment_density.py
+++ b/.github/scripts/check_comment_density.py
@@ -69,6 +69,31 @@ def _extension(path: str) -> str:
     return name.rsplit(".", 1)[-1].lower() if "." in name else ""
 
 
+def _classify_slash(line: str, in_block: bool) -> tuple[bool, bool]:
+    """Return (is_comment, in_block after this line) for a `//` and `/* */` language."""
+    if in_block:
+        return True, "*/" not in line
+    if line.startswith("//"):
+        return True, False
+    if line.startswith(("/*", "{/*")):
+        end = line.find("*/")
+        if end == -1:
+            return True, True
+        # `/* note */ doWork()` is code with a leading comment, not a comment line.
+        return line[end + 2 :].strip(" }") == "", False
+    # A `*` continuation line of a block whose opener sits outside the hunk. Rust
+    # dereferences (`*x = 1`) have no space after the star.
+    return line == "*" or line.startswith(("* ", "*/")), False
+
+
+def _is_comment(lang: str, line: str) -> bool:
+    if lang in HASH_LANGS:
+        return line.startswith("#") and not line.startswith("#!")
+    if lang in SQL_LANGS:
+        return line.startswith("--")
+    return False
+
+
 def analyze(diff_text: str) -> Report:
     report = Report()
     lang = ""
@@ -84,28 +109,29 @@ def analyze(diff_text: str) -> Report:
             if lang in CODE_LANGS and not EXCLUDED_PATHS.search(path):
                 stats = report.files.setdefault(path, FileStats(path))
             continue
-        if stats is None or raw.startswith(DIFF_SKIP_PREFIXES) or not raw.startswith("+"):
+        if stats is None or raw.startswith(DIFF_SKIP_PREFIXES):
+            continue
+        if raw.startswith("@@"):
+            in_block = False
+            continue
+        # Context lines are part of the new file too, so they move the block state;
+        # removed lines are not and are skipped entirely.
+        added = raw.startswith("+")
+        if not added and not raw.startswith(" "):
             continue
         line = raw[1:].strip()
         if not line:
             continue
 
+        if lang in SLASH_LANGS:
+            is_comment, in_block = _classify_slash(line, in_block)
+        else:
+            is_comment = _is_comment(lang, line)
+        if not added:
+            continue
+
         stats.added += 1
         report.added += 1
-        is_comment = False
-        if lang in HASH_LANGS:
-            is_comment = line.startswith("#") and not line.startswith("#!")
-        elif lang in SLASH_LANGS:
-            if in_block:
-                is_comment = True
-                in_block = "*/" not in line
-            elif line.startswith(("/*", "{/*")):
-                is_comment = True
-                in_block = "*/" not in line
-            else:
-                is_comment = line.startswith(("//", "*"))
-        elif lang in SQL_LANGS:
-            is_comment = line.startswith("--")
         if is_comment:
             stats.comments += 1
             report.comments += 1

--- a/.github/scripts/check_comment_density.py
+++ b/.github/scripts/check_comment_density.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# ruff: noqa: T201 allow print statements
+"""
+Measure the share of added code lines in a pull request diff that are comments.
+
+Reads a unified diff on stdin, counts the added non-blank lines in code files, and
+counts how many of those are full-line comments. Writes `warn` and a Markdown
+comment body to `$GITHUB_OUTPUT` (or to stdout when that variable is unset).
+
+Usage:
+    gh api repos/OWNER/REPO/pulls/N -H "Accept: application/vnd.github.diff" \\
+        | python3 .github/scripts/check_comment_density.py
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import uuid
+from dataclasses import dataclass, field
+
+WARN_RATIO = 0.25
+MIN_ADDED_LINES = 50
+TOP_FILES = 8
+
+# Docstrings are not counted, so Python is measured on `#` lines only.
+HASH_LANGS = {"py", "pyi", "rb"}
+SLASH_LANGS = {"ts", "tsx", "js", "jsx", "mjs", "cjs", "rs", "go", "kt", "java", "swift", "c", "h", "cpp", "hog"}
+SQL_LANGS = {"sql"}
+CODE_LANGS = HASH_LANGS | SLASH_LANGS | SQL_LANGS
+
+# Generated output and snapshots are not written by a person. Workflow YAML and
+# shell are left out because they need prose to be readable.
+EXCLUDED_PATHS = re.compile(
+    r"(^\.github/|/generated/|__snapshots__/|\.ambr$|\.snap$|\.lock$|migrations/\d|\.min\.js$|/dist/|/vendor/|/node_modules/|_pb2|\.d\.ts$)"
+)
+DIFF_SKIP_PREFIXES = ("+++", "---", "@@", "index ", "new file", "deleted file", "similarity", "rename ", "Binary")
+
+COMMENT_MARKER = "<!-- pr-comment-density -->"
+
+
+@dataclass(frozen=False)
+class FileStats:
+    path: str
+    added: int = 0
+    comments: int = 0
+
+
+@dataclass(frozen=False)
+class Report:
+    added: int = 0
+    comments: int = 0
+    files: dict[str, FileStats] = field(default_factory=dict)
+
+    @property
+    def ratio(self) -> float:
+        return self.comments / self.added if self.added else 0.0
+
+    @property
+    def warn(self) -> bool:
+        return self.added >= MIN_ADDED_LINES and self.ratio > WARN_RATIO
+
+
+def _extension(path: str) -> str:
+    name = path.rsplit("/", 1)[-1]
+    return name.rsplit(".", 1)[-1].lower() if "." in name else ""
+
+
+def analyze(diff_text: str) -> Report:
+    report = Report()
+    lang = ""
+    stats: FileStats | None = None
+    in_block = False
+
+    for raw in diff_text.splitlines():
+        if raw.startswith("diff --git "):
+            path = raw.split(" b/", 1)[-1]
+            lang = _extension(path)
+            stats = None
+            in_block = False
+            if lang in CODE_LANGS and not EXCLUDED_PATHS.search(path):
+                stats = report.files.setdefault(path, FileStats(path))
+            continue
+        if stats is None or raw.startswith(DIFF_SKIP_PREFIXES) or not raw.startswith("+"):
+            continue
+        line = raw[1:].strip()
+        if not line:
+            continue
+
+        stats.added += 1
+        report.added += 1
+        is_comment = False
+        if lang in HASH_LANGS:
+            is_comment = line.startswith("#") and not line.startswith("#!")
+        elif lang in SLASH_LANGS:
+            if in_block:
+                is_comment = True
+                in_block = "*/" not in line
+            elif line.startswith(("/*", "{/*")):
+                is_comment = True
+                in_block = "*/" not in line
+            else:
+                is_comment = line.startswith(("//", "*"))
+        elif lang in SQL_LANGS:
+            is_comment = line.startswith("--")
+        if is_comment:
+            stats.comments += 1
+            report.comments += 1
+
+    report.files = {p: s for p, s in report.files.items() if s.added}
+    return report
+
+
+def render_comment(report: Report) -> str:
+    pct = round(100 * report.ratio)
+    top = sorted(report.files.values(), key=lambda s: (-s.comments, s.path))[:TOP_FILES]
+    top = [s for s in top if s.comments]
+    lines = [
+        COMMENT_MARKER,
+        "### Comment-heavy changes",
+        "",
+        f"About **{pct}%** of the code lines this PR adds are comments ({report.comments} of {report.added}). "
+        f"This note appears when the share is above {round(100 * WARN_RATIO)}%.",
+        "",
+        "Comments that restate the code, record how the change came about, or narrate the next line "
+        "add noise for the next reader. Keep the comments that explain a reason the code cannot show, "
+        "and remove the rest. See `.agents/skills/writing-code-comments/SKILL.md` for the house rules.",
+        "",
+    ]
+    if top:
+        lines += [
+            "Files with the most added comment lines:",
+            "",
+            "| File | Comment lines | Added lines |",
+            "| --- | ---: | ---: |",
+            *(f"| `{s.path}` | {s.comments} | {s.added} |" for s in top),
+            "",
+        ]
+    lines.append("This check does not block merging. It updates on every push and goes away when the share drops.")
+    return "\n".join(lines)
+
+
+def write_outputs(report: Report) -> None:
+    body = render_comment(report)
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        print(f"added={report.added} comments={report.comments} ratio={report.ratio:.3f} warn={report.warn}")
+        print(body)
+        return
+    delimiter = f"EOF-{uuid.uuid4()}"
+    with open(output_path, "a") as fh:
+        fh.write(f"warn={'true' if report.warn else 'false'}\n")
+        fh.write(f"added={report.added}\ncomments={report.comments}\n")
+        fh.write(f"body<<{delimiter}\n{body}\n{delimiter}\n")
+    print(f"added={report.added} comments={report.comments} ratio={report.ratio:.1%} warn={report.warn}")
+
+
+def main() -> int:
+    write_outputs(analyze(sys.stdin.read()))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_comment_density.py
+++ b/.github/scripts/check_comment_density.py
@@ -4,8 +4,9 @@
 Measure the share of added code lines in a pull request diff that are comments.
 
 Reads a unified diff on stdin, counts the added non-blank lines in code files, and
-counts how many of those are full-line comments. Writes `warn` and a Markdown
-comment body to `$GITHUB_OUTPUT` (or to stdout when that variable is unset).
+counts how many of those are full-line comments. Writes `warn`, a one-line
+`summary`, and a Markdown `body` for the shared CI report to `$GITHUB_OUTPUT`
+(or to stdout when that variable is unset).
 
 Usage:
     gh api repos/OWNER/REPO/pulls/N -H "Accept: application/vnd.github.diff" \\
@@ -36,8 +37,6 @@ EXCLUDED_PATHS = re.compile(
     r"(^\.github/|/generated/|__snapshots__/|\.ambr$|\.snap$|\.lock$|migrations/\d|\.min\.js$|/dist/|/vendor/|/node_modules/|_pb2|\.d\.ts$)"
 )
 DIFF_SKIP_PREFIXES = ("+++", "---", "@@", "index ", "new file", "deleted file", "similarity", "rename ", "Binary")
-
-COMMENT_MARKER = "<!-- pr-comment-density -->"
 
 
 @dataclass(frozen=False)
@@ -112,16 +111,16 @@ def analyze(diff_text: str) -> Report:
     return report
 
 
-def render_comment(report: Report) -> str:
-    pct = round(100 * report.ratio)
+def render_summary(report: Report) -> str:
+    return f"{round(100 * report.ratio)}% of added code lines are comments ({report.comments} of {report.added})"
+
+
+def render_body(report: Report) -> str:
     top = sorted(report.files.values(), key=lambda s: (-s.comments, s.path))[:TOP_FILES]
     top = [s for s in top if s.comments]
     lines = [
-        COMMENT_MARKER,
-        "### Comment-heavy changes",
-        "",
-        f"About **{pct}%** of the code lines this PR adds are comments ({report.comments} of {report.added}). "
-        f"This note appears when the share is above {round(100 * WARN_RATIO)}%.",
+        f"This section appears when comments are more than {round(100 * WARN_RATIO)}% of the code lines a PR adds. "
+        "Only full-line comments count. Docstrings, generated files, snapshots, migrations, and workflow files are left out.",
         "",
         "Comments that restate the code, record how the change came about, or narrate the next line "
         "add noise for the next reader. Keep the comments that explain a reason the code cannot show, "
@@ -137,23 +136,24 @@ def render_comment(report: Report) -> str:
             *(f"| `{s.path}` | {s.comments} | {s.added} |" for s in top),
             "",
         ]
-    lines.append("This check does not block merging. It updates on every push and goes away when the share drops.")
+    lines.append("This check does not block merging. It updates on every push and clears when the share drops.")
     return "\n".join(lines)
 
 
 def write_outputs(report: Report) -> None:
-    body = render_comment(report)
+    summary = render_summary(report)
+    body = render_body(report)
     output_path = os.environ.get("GITHUB_OUTPUT")
     if not output_path:
-        print(f"added={report.added} comments={report.comments} ratio={report.ratio:.3f} warn={report.warn}")
+        print(f"warn={report.warn} {summary}")
         print(body)
         return
     delimiter = f"EOF-{uuid.uuid4()}"
     with open(output_path, "a") as fh:
         fh.write(f"warn={'true' if report.warn else 'false'}\n")
-        fh.write(f"added={report.added}\ncomments={report.comments}\n")
+        fh.write(f"summary={summary}\n")
         fh.write(f"body<<{delimiter}\n{body}\n{delimiter}\n")
-    print(f"added={report.added} comments={report.comments} ratio={report.ratio:.1%} warn={report.warn}")
+    print(f"warn={report.warn} {summary}")
 
 
 def main() -> int:

--- a/.github/scripts/check_comment_density.py
+++ b/.github/scripts/check_comment_density.py
@@ -35,8 +35,11 @@ SQL_LANGS = {"sql"}
 CODE_LANGS = HASH_LANGS | SLASH_LANGS | SQL_LANGS
 
 # Workflow YAML and shell are left out because they need prose to be readable.
+# `generated` anywhere in the path covers `/generated/`, `*.generated.ts`, and
+# `generated_configs/`, which all carry a generator header over little code.
 EXCLUDED_PATHS = re.compile(
-    r"(^\.github/|/generated/|__snapshots__/|\.ambr$|\.snap$|\.lock$|migrations/\d|\.min\.js$|/dist/|/vendor/|/node_modules/|_pb2|\.d\.ts$)"
+    r"(^\.github/|generated|__snapshots__/|\.ambr$|\.snap$|\.lock$|migrations/\d|\.min\.js$|/dist/|/vendor/|/node_modules/|_pb2|\.d\.ts$)",
+    re.IGNORECASE,
 )
 DIFF_SKIP_PREFIXES = ("+++", "---", "@@", "index ", "new file", "deleted file", "similarity", "rename ", "Binary")
 
@@ -82,40 +85,53 @@ def _classify_slash(line: str, in_block: bool) -> tuple[bool, bool]:
             return True, True
         # `/* note */ doWork()` is code with a leading comment, not a comment line.
         return line[end + 2 :].strip(" }") == "", False
-    # A `*` continuation line of a block whose opener sits outside the hunk. Rust
-    # dereferences (`*x = 1`) have no space after the star.
-    return line == "*" or line.startswith(("* ", "*/")), False
+    return False, False
 
 
-def _is_comment(lang: str, line: str) -> bool:
+def _classify_hash(line: str, in_string: bool) -> tuple[bool, bool]:
+    """Return (is_comment, in_string after this line) for Python.
+
+    A `#` line inside a triple-quoted string (a prompt, a SQL template) is text,
+    not a comment.
+    """
+    toggles = (line.count('"""') + line.count("'''")) % 2 == 1
+    if in_string:
+        return False, not toggles
+    return line.startswith("#") and not line.startswith("#!"), toggles
+
+
+def _classify(lang: str, line: str, inside: bool) -> tuple[bool, bool]:
+    if lang in SLASH_LANGS:
+        return _classify_slash(line, inside)
     if lang in HASH_LANGS:
-        return line.startswith("#") and not line.startswith("#!")
+        return _classify_hash(line, inside)
     if lang in SQL_LANGS:
-        return line.startswith("--")
-    return False
+        return line.startswith("--"), False
+    return False, False
 
 
 def analyze(diff_text: str) -> Report:
     report = Report()
     lang = ""
     stats: FileStats | None = None
-    in_block = False
+    # True inside a block comment or a triple-quoted string that spans lines.
+    inside = False
 
     for raw in diff_text.splitlines():
         if raw.startswith("diff --git "):
             path = raw.split(" b/", 1)[-1]
             lang = _extension(path)
             stats = None
-            in_block = False
+            inside = False
             if lang in CODE_LANGS and not EXCLUDED_PATHS.search(path):
                 stats = report.files.setdefault(path, FileStats(path))
             continue
         if stats is None or raw.startswith(DIFF_SKIP_PREFIXES):
             continue
         if raw.startswith("@@"):
-            in_block = False
+            inside = False
             continue
-        # Context lines are part of the new file too, so they move the block state;
+        # Context lines are part of the new file too, so they move the state;
         # removed lines are not and are skipped entirely.
         added = raw.startswith("+")
         if not added and not raw.startswith(" "):
@@ -124,10 +140,7 @@ def analyze(diff_text: str) -> Report:
         if not line:
             continue
 
-        if lang in SLASH_LANGS:
-            is_comment, in_block = _classify_slash(line, in_block)
-        else:
-            is_comment = _is_comment(lang, line)
+        is_comment, inside = _classify(lang, line, inside)
         if not added:
             continue
 

--- a/.github/scripts/post-comment-density-section.mjs
+++ b/.github/scripts/post-comment-density-section.mjs
@@ -6,9 +6,9 @@ import { clearSectionIfPresent, postSection } from '../../frontend/bin/ci-report
 const SECTION_ID = 'comment-density'
 
 async function main() {
-    const { WARN, SUMMARY, BODY } = process.env
-    if (WARN === 'true') {
-        await postSection({ id: SECTION_ID, status: 'warn', summary: SUMMARY, body: BODY })
+    const { STATUS, SUMMARY, BODY } = process.env
+    if (STATUS === 'warn' || STATUS === 'alert') {
+        await postSection({ id: SECTION_ID, status: STATUS, summary: SUMMARY, body: BODY })
         return
     }
     await clearSectionIfPresent({ id: SECTION_ID, summary: SUMMARY, body: BODY })

--- a/.github/scripts/post-comment-density-section.mjs
+++ b/.github/scripts/post-comment-density-section.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import { pathToFileURL } from 'node:url'
+
+import { clearSectionIfPresent, postSection } from '../../frontend/bin/ci-report/update-ci-report.mjs'
+
+const SECTION_ID = 'comment-density'
+
+async function main() {
+    const { WARN, SUMMARY, BODY } = process.env
+    if (WARN === 'true') {
+        await postSection({ id: SECTION_ID, status: 'warn', summary: SUMMARY, body: BODY })
+        return
+    }
+    await clearSectionIfPresent({ id: SECTION_ID, summary: SUMMARY, body: BODY })
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    await main()
+}

--- a/.github/scripts/post-comment-density-section.mjs
+++ b/.github/scripts/post-comment-density-section.mjs
@@ -1,12 +1,42 @@
 #!/usr/bin/env node
 import { pathToFileURL } from 'node:url'
 
-import { clearSectionIfPresent, postSection } from '../../frontend/bin/ci-report/update-ci-report.mjs'
+import {
+    clearSectionIfPresent,
+    isReportComment,
+    listPrComments,
+    parseSections,
+    postSection,
+    resolvePrContext,
+} from '../../frontend/bin/ci-report/update-ci-report.mjs'
 
 const SECTION_ID = 'comment-density'
 
+// A push whose diff could not be fetched must not leave the previous push's
+// warning standing as if it described this one.
+async function markUnmeasured() {
+    const context = resolvePrContext(`marking "${SECTION_ID}" unmeasured`)
+    if (!context) {
+        return
+    }
+    const reportComment = (await listPrComments(context)).find(isReportComment)
+    if (!reportComment || !parseSections(reportComment.body).has(SECTION_ID)) {
+        return
+    }
+    await postSection({
+        id: SECTION_ID,
+        status: 'info',
+        summary: 'not measured on this push',
+        body: 'The PR diff could not be fetched for this push (usually because it is too large for the API), so the comment share was not measured. The previous result no longer applies.',
+    })
+}
+
 async function main() {
-    const { STATUS, SUMMARY, BODY } = process.env
+    const { AVAILABLE, STATUS, SUMMARY, BODY } = process.env
+    if (AVAILABLE !== 'true') {
+        await markUnmeasured()
+        return
+    }
     if (STATUS === 'warn' || STATUS === 'alert') {
         await postSection({ id: SECTION_ID, status: STATUS, summary: SUMMARY, body: BODY })
         return

--- a/.github/scripts/test_check_comment_density.py
+++ b/.github/scripts/test_check_comment_density.py
@@ -117,3 +117,10 @@ def test_render_body_lists_comment_heavy_files_first() -> None:
     diff = diff_for("posthog/a.py", "+# one\n+x = 1\n") + diff_for("posthog/b.py", "+# one\n+# two\n+y = 2\n")
     body = check_comment_density.render_body(check_comment_density.analyze(diff))
     assert body.index("`posthog/b.py` | 2 | 3") < body.index("`posthog/a.py` | 1 | 2")
+
+
+def test_render_body_keeps_hostile_file_paths_inert() -> None:
+    diff = diff_for("posthog/x`|@user|`y.py", "+# one\n+# two\n+z = 3\n")
+    body = check_comment_density.render_body(check_comment_density.analyze(diff))
+    assert "| `posthog/x@usery.py` | 2 | 3 |" in body
+    assert "`|" not in body

--- a/.github/scripts/test_check_comment_density.py
+++ b/.github/scripts/test_check_comment_density.py
@@ -52,11 +52,29 @@ def diff_for(path: str, body: str) -> str:
                 +// full line
                 +{/* jsx style */}
                 +const b = 2
+                +/* note */ doWork()
+                +*ptr = 1
                 """,
             ),
-            7,
+            9,
             5,
             id="typescript-block-and-line-comments",
+        ),
+        pytest.param(
+            diff_for(
+                "frontend/src/lib/other.ts",
+                """
+                 /**
+                + * doc line added inside a block that opened in context
+                + */
+                +const c = 3
+                -/*
+                +const d = 4
+                """,
+            ),
+            4,
+            2,
+            id="block-state-follows-context-lines-not-removed-lines",
         ),
         pytest.param(
             diff_for("frontend/src/generated/api.ts", "+// generated\n+// generated\n")

--- a/.github/scripts/test_check_comment_density.py
+++ b/.github/scripts/test_check_comment_density.py
@@ -93,8 +93,7 @@ def test_warn_requires_min_size_and_ratio_above_threshold(
     assert report.warn is expected_warn
 
 
-def test_render_comment_lists_marker_and_comment_heavy_files_first() -> None:
+def test_render_body_lists_comment_heavy_files_first() -> None:
     diff = diff_for("posthog/a.py", "+# one\n+x = 1\n") + diff_for("posthog/b.py", "+# one\n+# two\n+y = 2\n")
-    body = check_comment_density.render_comment(check_comment_density.analyze(diff))
-    assert body.startswith(check_comment_density.COMMENT_MARKER)
+    body = check_comment_density.render_body(check_comment_density.analyze(diff))
     assert body.index("`posthog/b.py` | 2 | 3") < body.index("`posthog/a.py` | 1 | 2")

--- a/.github/scripts/test_check_comment_density.py
+++ b/.github/scripts/test_check_comment_density.py
@@ -35,11 +35,16 @@ def diff_for(path: str, body: str) -> str:
                 +
                 -# removed comment
                 -removed = 2
+                +PROMPT = '''
+                +# Markdown heading inside a string
+                +## Use this when:
+                +'''
+                +# a real comment after the string
                 """,
             ),
-            3,
-            1,
-            id="python-hash-shebang-and-removed-lines",
+            8,
+            2,
+            id="python-hash-shebang-strings-and-removed-lines",
         ),
         pytest.param(
             diff_for(
@@ -78,6 +83,8 @@ def diff_for(path: str, body: str) -> str:
         ),
         pytest.param(
             diff_for("frontend/src/generated/api.ts", "+// generated\n+// generated\n")
+            + diff_for("frontend/src/lib/agentScopes.generated.ts", "+// AUTO-GENERATED\n+// Do not edit\n")
+            + diff_for("products/x/backend/generated_configs/ably.py", "+# generated\n+# do not edit\n")
             + diff_for(".github/workflows/ci.yml", "+# yaml prose\n+run: echo\n")
             + diff_for("posthog/test/__snapshots__/x.ambr", "+# name: test\n")
             + diff_for("docs/readme.md", "+<!-- not code -->\n")

--- a/.github/scripts/test_check_comment_density.py
+++ b/.github/scripts/test_check_comment_density.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import sys
+import textwrap
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).with_name("check_comment_density.py")
+SPEC = importlib.util.spec_from_file_location("check_comment_density", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+check_comment_density = importlib.util.module_from_spec(SPEC)
+sys.modules["check_comment_density"] = check_comment_density
+SPEC.loader.exec_module(check_comment_density)
+
+
+def diff_for(path: str, body: str) -> str:
+    header = (
+        f"diff --git a/{path} b/{path}\nindex 0000000..1111111 100644\n--- a/{path}\n+++ b/{path}\n@@ -1,0 +1,9 @@\n"
+    )
+    return header + textwrap.dedent(body).lstrip("\n")
+
+
+@pytest.mark.parametrize(
+    "diff,expected_added,expected_comments",
+    [
+        pytest.param(
+            diff_for(
+                "posthog/api/thing.py",
+                """
+                +#!/usr/bin/env python3
+                +# explain why
+                +x = 1  # trailing comments are code lines
+                +
+                -# removed comment
+                -removed = 2
+                """,
+            ),
+            3,
+            1,
+            id="python-hash-shebang-and-removed-lines",
+        ),
+        pytest.param(
+            diff_for(
+                "frontend/src/lib/thing.ts",
+                """
+                +/**
+                + * Block comment line
+                + */
+                +const a = 1 // trailing
+                +// full line
+                +{/* jsx style */}
+                +const b = 2
+                """,
+            ),
+            7,
+            5,
+            id="typescript-block-and-line-comments",
+        ),
+        pytest.param(
+            diff_for("frontend/src/generated/api.ts", "+// generated\n+// generated\n")
+            + diff_for(".github/workflows/ci.yml", "+# yaml prose\n+run: echo\n")
+            + diff_for("posthog/test/__snapshots__/x.ambr", "+# name: test\n")
+            + diff_for("docs/readme.md", "+<!-- not code -->\n")
+            + diff_for("posthog/hogql/q.sql", "+-- sql comment\n+SELECT 1\n"),
+            2,
+            1,
+            id="excluded-paths-and-non-code-files-are-ignored",
+        ),
+    ],
+)
+def test_analyze_counts_added_code_lines_and_full_line_comments(
+    diff: str, expected_added: int, expected_comments: int
+) -> None:
+    report = check_comment_density.analyze(diff)
+    assert (report.added, report.comments) == (expected_added, expected_comments)
+
+
+@pytest.mark.parametrize(
+    "code_lines,comment_lines,expected_warn",
+    [
+        pytest.param(10, 30, False, id="below-min-added-lines-never-warns"),
+        pytest.param(40, 10, False, id="at-threshold-does-not-warn"),
+        pytest.param(35, 15, True, id="above-threshold-warns"),
+    ],
+)
+def test_warn_requires_min_size_and_ratio_above_threshold(
+    code_lines: int, comment_lines: int, expected_warn: bool
+) -> None:
+    body = "".join("+x = 1\n" for _ in range(code_lines)) + "".join("+# c\n" for _ in range(comment_lines))
+    report = check_comment_density.analyze(diff_for("posthog/a.py", body))
+    assert report.warn is expected_warn
+
+
+def test_render_comment_lists_marker_and_comment_heavy_files_first() -> None:
+    diff = diff_for("posthog/a.py", "+# one\n+x = 1\n") + diff_for("posthog/b.py", "+# one\n+# two\n+y = 2\n")
+    body = check_comment_density.render_comment(check_comment_density.analyze(diff))
+    assert body.startswith(check_comment_density.COMMENT_MARKER)
+    assert body.index("`posthog/b.py` | 2 | 3") < body.index("`posthog/a.py` | 1 | 2")

--- a/.github/scripts/test_check_comment_density.py
+++ b/.github/scripts/test_check_comment_density.py
@@ -78,19 +78,21 @@ def test_analyze_counts_added_code_lines_and_full_line_comments(
 
 
 @pytest.mark.parametrize(
-    "code_lines,comment_lines,expected_warn",
+    "code_lines,comment_lines,expected_status",
     [
-        pytest.param(10, 30, False, id="below-min-added-lines-never-warns"),
-        pytest.param(40, 10, False, id="at-threshold-does-not-warn"),
-        pytest.param(35, 15, True, id="above-threshold-warns"),
+        pytest.param(10, 30, "ok", id="below-min-added-lines-is-always-ok"),
+        pytest.param(97, 3, "ok", id="at-warn-threshold-is-ok"),
+        pytest.param(96, 4, "warn", id="above-warn-threshold-warns"),
+        pytest.param(94, 6, "warn", id="at-alert-threshold-warns"),
+        pytest.param(93, 7, "alert", id="above-alert-threshold-alerts"),
     ],
 )
-def test_warn_requires_min_size_and_ratio_above_threshold(
-    code_lines: int, comment_lines: int, expected_warn: bool
+def test_status_requires_min_size_and_steps_up_with_ratio(
+    code_lines: int, comment_lines: int, expected_status: str
 ) -> None:
     body = "".join("+x = 1\n" for _ in range(code_lines)) + "".join("+# c\n" for _ in range(comment_lines))
     report = check_comment_density.analyze(diff_for("posthog/a.py", body))
-    assert report.warn is expected_warn
+    assert report.status == expected_status
 
 
 def test_render_body_lists_comment_heavy_files_first() -> None:

--- a/.github/scripts/test_check_comment_density.py
+++ b/.github/scripts/test_check_comment_density.py
@@ -131,3 +131,19 @@ def test_render_body_keeps_hostile_file_paths_inert() -> None:
     body = check_comment_density.render_body(check_comment_density.analyze(diff))
     assert "| `posthog/x@usery.py` | 2 | 3 |" in body
     assert "`|" not in body
+
+
+def test_block_comment_state_does_not_carry_across_hunks() -> None:
+    diff = (
+        "diff --git a/frontend/src/lib/thing.ts b/frontend/src/lib/thing.ts\n"
+        "--- a/frontend/src/lib/thing.ts\n"
+        "+++ b/frontend/src/lib/thing.ts\n"
+        "@@ -1 +1 @@\n"
+        "-/** old summary\n"
+        "+/** new summary\n"
+        "@@ -40,0 +40,2 @@\n"
+        "+export const a = 1\n"
+        "+export const b = 2\n"
+    )
+    report = check_comment_density.analyze(diff)
+    assert (report.added, report.comments) == (3, 1)

--- a/.github/workflows/pr-comment-density.yml
+++ b/.github/workflows/pr-comment-density.yml
@@ -48,9 +48,9 @@ jobs:
               run: python3 .github/scripts/check_comment_density.py < pr.diff
 
             - name: Post to the CI report
-              if: steps.diff.outputs.available == 'true'
               env:
                   GITHUB_TOKEN: ${{ github.token }}
+                  AVAILABLE: ${{ steps.diff.outputs.available }}
                   STATUS: ${{ steps.measure.outputs.status }}
                   SUMMARY: ${{ steps.measure.outputs.summary }}
                   BODY: ${{ steps.measure.outputs.body }}

--- a/.github/workflows/pr-comment-density.yml
+++ b/.github/workflows/pr-comment-density.yml
@@ -55,7 +55,7 @@ jobs:
               if: steps.diff.outputs.available == 'true'
               env:
                   GITHUB_TOKEN: ${{ github.token }}
-                  WARN: ${{ steps.measure.outputs.warn }}
+                  STATUS: ${{ steps.measure.outputs.status }}
                   SUMMARY: ${{ steps.measure.outputs.summary }}
                   BODY: ${{ steps.measure.outputs.body }}
               run: node .github/scripts/post-comment-density-section.mjs

--- a/.github/workflows/pr-comment-density.yml
+++ b/.github/workflows/pr-comment-density.yml
@@ -1,0 +1,72 @@
+name: PR comment density
+
+# Reusable workflow, called by pr-housekeeping.yml on PR open and push.
+# Push-cancels-previous-push comes from the caller's concurrency group.
+#
+# Warn-only: when a large share of the added code lines are comments, it
+# leaves one sticky comment on the PR and removes it once the share drops.
+
+on:
+    workflow_call:
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    comment-density:
+        name: Warn on comment-heavy diffs
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+        # The fork token cannot write comments, and the queue's batch PR is the
+        # union of PRs that were each already checked.
+        if: github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.head_ref, 'trunk-merge/')
+
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/scripts/check_comment_density.py
+                  sparse-checkout-cone-mode: false
+
+            # The API diff is the PR compared with its merge base, so no history
+            # fetch is needed. It refuses very large diffs; those are skipped.
+            - name: Fetch PR diff
+              id: diff
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+              run: |
+                  if gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" -H "Accept: application/vnd.github.diff" > pr.diff; then
+                      echo "available=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "::notice::Could not fetch the PR diff (too large or unavailable); skipping the comment density check."
+                      echo "available=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Measure comment share
+              id: measure
+              if: steps.diff.outputs.available == 'true'
+              run: python3 .github/scripts/check_comment_density.py < pr.diff
+
+            - name: Update the sticky comment
+              if: steps.diff.outputs.available == 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  WARN: ${{ steps.measure.outputs.warn }}
+                  BODY: ${{ steps.measure.outputs.body }}
+              run: |
+                  set -euo pipefail
+                  marker='<!-- pr-comment-density -->'
+                  existing_id=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+                      --jq "map(select(.body | startswith(\"$marker\"))) | .[0].id // empty" | head -n1)
+
+                  if [ "$WARN" = "true" ]; then
+                      if [ -n "$existing_id" ]; then
+                          gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}" -f body="$BODY" > /dev/null
+                      else
+                          gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -f body="$BODY" > /dev/null
+                      fi
+                  elif [ -n "$existing_id" ]; then
+                      gh api -X DELETE "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}"
+                  fi

--- a/.github/workflows/pr-comment-density.yml
+++ b/.github/workflows/pr-comment-density.yml
@@ -4,7 +4,7 @@ name: PR comment density
 # Push-cancels-previous-push comes from the caller's concurrency group.
 #
 # Warn-only: when a large share of the added code lines are comments, it
-# leaves one sticky comment on the PR and removes it once the share drops.
+# adds a section to the shared CI report and clears it once the share drops.
 
 on:
     workflow_call:
@@ -25,7 +25,10 @@ jobs:
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
-                  sparse-checkout: .github/scripts/check_comment_density.py
+                  sparse-checkout: |
+                      .github/scripts/check_comment_density.py
+                      .github/scripts/post-comment-density-section.mjs
+                      frontend/bin/ci-report
                   sparse-checkout-cone-mode: false
 
             # The API diff is the PR compared with its merge base, so no history
@@ -48,25 +51,11 @@ jobs:
               if: steps.diff.outputs.available == 'true'
               run: python3 .github/scripts/check_comment_density.py < pr.diff
 
-            - name: Update the sticky comment
+            - name: Post to the CI report
               if: steps.diff.outputs.available == 'true'
               env:
-                  GH_TOKEN: ${{ github.token }}
-                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  GITHUB_TOKEN: ${{ github.token }}
                   WARN: ${{ steps.measure.outputs.warn }}
+                  SUMMARY: ${{ steps.measure.outputs.summary }}
                   BODY: ${{ steps.measure.outputs.body }}
-              run: |
-                  set -euo pipefail
-                  marker='<!-- pr-comment-density -->'
-                  existing_id=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-                      --jq "map(select(.body | startswith(\"$marker\"))) | .[0].id // empty" | head -n1)
-
-                  if [ "$WARN" = "true" ]; then
-                      if [ -n "$existing_id" ]; then
-                          gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}" -f body="$BODY" > /dev/null
-                      else
-                          gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -f body="$BODY" > /dev/null
-                      fi
-                  elif [ -n "$existing_id" ]; then
-                      gh api -X DELETE "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}"
-                  fi
+              run: node .github/scripts/post-comment-density-section.mjs

--- a/.github/workflows/pr-comment-density.yml
+++ b/.github/workflows/pr-comment-density.yml
@@ -2,9 +2,6 @@ name: PR comment density
 
 # Reusable workflow, called by pr-housekeeping.yml on PR open and push.
 # Push-cancels-previous-push comes from the caller's concurrency group.
-#
-# Warn-only: when a large share of the added code lines are comments, it
-# adds a section to the shared CI report and clears it once the share drops.
 
 on:
     workflow_call:
@@ -31,8 +28,7 @@ jobs:
                       frontend/bin/ci-report
                   sparse-checkout-cone-mode: false
 
-            # The API diff is the PR compared with its merge base, so no history
-            # fetch is needed. It refuses very large diffs; those are skipped.
+            # The API diff needs no history fetch. It refuses very large diffs.
             - name: Fetch PR diff
               id: diff
               env:

--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -96,6 +96,13 @@ jobs:
             GH_APP_POSTHOG_ASSIGN_REVIEWERS_APP_ID: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_APP_ID }}
             GH_APP_POSTHOG_ASSIGN_REVIEWERS_PRIVATE_KEY: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_PRIVATE_KEY }}
 
+    comment-density:
+        if: contains(fromJSON('["opened", "synchronize", "reopened"]'), github.event.action)
+        uses: ./.github/workflows/pr-comment-density.yml
+        permissions:
+            contents: read
+            pull-requests: write
+
     resolve-bot-comments:
         if: github.event.action == 'synchronize'
         uses: ./.github/workflows/pr-resolve-outdated-bot-comments.yml

--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -97,7 +97,11 @@ jobs:
             GH_APP_POSTHOG_ASSIGN_REVIEWERS_PRIVATE_KEY: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_PRIVATE_KEY }}
 
     comment-density:
-        if: contains(fromJSON('["opened", "synchronize", "reopened"]'), github.event.action)
+        # Also on a base retarget: the measured diff is base-relative, so a
+        # retarget changes it with no push to remeasure on.
+        if: >-
+            contains(fromJSON('["opened", "synchronize", "reopened"]'), github.event.action)
+            || (github.event.action == 'edited' && github.event.changes.base != null)
         uses: ./.github/workflows/pr-comment-density.yml
         permissions:
             contents: read

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -51,6 +51,7 @@ jobs:
                   [ -f .github/scripts/check-commit-warnings.test.sh ] || exit 0
                   shellcheck .github/scripts/check-claude-hooks.sh \
                       .github/scripts/check-quill-agents-md.sh \
+                      .github/scripts/check-comment-density.sh \
                       .github/scripts/check-commit-warnings.test.sh
                   .github/scripts/check-commit-warnings.test.sh
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -51,10 +51,8 @@ if [ -x .github/scripts/check-quill-agents-md.sh ]; then
     .github/scripts/check-quill-agents-md.sh || true
 fi
 
-# Same deal for a staged diff that is mostly comment lines: warn at the commit,
-# where trimming them is cheapest, using the classifier the PR check runs.
-# Run through bash rather than testing -x, so a checkout that lost the
-# executable bit still runs the check.
+# Same deal for a comment-heavy staged diff. Run through bash: the script lands
+# without its executable bit.
 if [ -f .github/scripts/check-comment-density.sh ]; then
     bash .github/scripts/check-comment-density.sh || true
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -53,8 +53,10 @@ fi
 
 # Same deal for a staged diff that is mostly comment lines: warn at the commit,
 # where trimming them is cheapest, using the classifier the PR check runs.
-if [ -x .github/scripts/check-comment-density.sh ]; then
-    .github/scripts/check-comment-density.sh || true
+# Run through bash rather than testing -x, so a checkout that lost the
+# executable bit still runs the check.
+if [ -f .github/scripts/check-comment-density.sh ]; then
+    bash .github/scripts/check-comment-density.sh || true
 fi
 
 # Activate Flox environment if available and not already active

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -51,6 +51,12 @@ if [ -x .github/scripts/check-quill-agents-md.sh ]; then
     .github/scripts/check-quill-agents-md.sh || true
 fi
 
+# Same deal for a staged diff that is mostly comment lines: warn at the commit,
+# where trimming them is cheapest, using the classifier the PR check runs.
+if [ -x .github/scripts/check-comment-density.sh ]; then
+    .github/scripts/check-comment-density.sh || true
+fi
+
 # Activate Flox environment if available and not already active
 # This ensures lint-staged commands work in GUI Git clients (GitHub Desktop, etc.)
 if command -v flox > /dev/null 2>&1 && [ -d ".flox/cache" ] && [ -z "$FLOX_ENV" ]; then

--- a/frontend/bin/ci-report/update-ci-report.mjs
+++ b/frontend/bin/ci-report/update-ci-report.mjs
@@ -17,6 +17,7 @@ export const SECTIONS = [
     { id: 'trunk-lane', title: 'Trunk lane' },
     { id: 'complexity-python', title: 'Complexity (Python)' },
     { id: 'complexity-ts', title: 'Complexity (TypeScript)' },
+    { id: 'comment-density', title: 'Comment density' },
     { id: 'bundle-size', title: 'Bundle size' },
     { id: 'eager-graph', title: 'Eager graph' },
     { id: 'toolbar-size', title: 'Toolbar bundle' },


### PR DESCRIPTION
## Problem

Reviewers have no signal when a PR adds far more comment lines than code lines. Agent-assisted PRs tend to narrate the code or record the change history in comments, and the reviewer finds out only by reading the whole diff.

Before agent-assisted PRs were common, the median PR had about 2% comment lines. A scan of the last month of merged PRs put the median near 10%, with a tail of PRs where a quarter or more of the added lines were comments.

## Changes

- A PR whose added code lines are more than 3% comments now gets a ⚠️ "Comment density" section in the shared CI report comment. Above 6% the section shows 🚨. It names the share and lists the files with the most added comment lines.
- The section updates on every push and clears when the share drops below the threshold. It never blocks merging. No separate bot comment is posted.
- Diffs under 50 added code lines are skipped, so a small fix with two explanatory comments does not trigger it.
- Only full-line comments count. Trailing comments and Python docstrings count as code.
- Generated code, snapshots, lockfiles, migrations, and everything under `.github/` are left out, because workflow YAML and shell need prose to be readable.
- The check runs as a new job under the existing `pr-housekeeping.yml` parent, so it adds no workflow dispatch. It reads the diff from the GitHub API rather than fetching history, and skips with a notice when the API refuses a very large diff.
- Same-repo PRs only, because the fork token cannot write to the report.
- The same classifier also runs from the pre-commit hook as a warn-only check. A commit whose staged diff crosses the threshold prints the share and the top files in the terminal, so an agent or a person can trim the comments before the diff reaches a PR. It never blocks the commit. The queue's `trunk-merge/` PRs are skipped.

## How did you test this code?

- `.github/scripts/test_check_comment_density.py` covers the three regressions a rewrite of the classifier would most likely cause: a block comment in TypeScript stops being tracked across lines, an excluded path (generated code, `.github/`, snapshots) starts counting, and the status fires on a diff below the minimum size or at exactly a threshold.
- Ran the script locally against two recently merged PRs through the same API call the workflow uses: a CI-only PR measured zero counted lines, and a SQL migration PR measured a high share and rendered the expected table.
- `.github/scripts/check-commit-warnings.test.sh` gains two cases: a clean index prints nothing, and a staged file that is mostly comment lines prints the warning with the file path. This is the wiring test for the hook script; the classifier's own behavior is covered by the Python tests.
- `bin/hogli lint:workflows`, `actionlint`, `shellcheck`, and `ruff` pass locally.
- Not run: the workflow itself. It runs for the first time on this PR.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The check is internal to CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built by the PostHog Slack app from a request in a Slack thread. Skills invoked: `/authoring-ci-workflows`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`. No open PR or issue covers this check (`gh pr list --search "comment density"` and `gh issue list --search "comment density"` found nothing). A reviewer on the thread asked for the output to go into the shared CI report rather than a standalone comment, so the first iteration's sticky comment was replaced with a CI report section. The same reviewer set the 3% warn and 6% alert thresholds from the pre-agent median, and asked for the commit-time warning so agents see it before opening a PR. No material from the session is in the diff; the threshold and minimum size came from a scan of public merge history on `master`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S66N93FX/p1788790752766709?thread_ts=1788790752.766709&cid=C08S66N93FX)*



