### PR TITLE
feat(desktop): suggest agreed follow-up tasks

### DIFF
--- a/products/desktop/apps/code/src/main/deep-links.ts
+++ b/products/desktop/apps/code/src/main/deep-links.ts
@@ -31,7 +31,7 @@ export function registerDeepLinkHandlers(): void {
   // Handle deep link URLs on macOS
   app.on("open-url", (event, url) => {
     event.preventDefault();
-    log.info("open-url event received", { url, appReady: app.isReady() });
+    log.info("open-url event received", { appReady: app.isReady() });
 
     if (!app.isReady()) {
       pendingDeepLinkUrl = url;
@@ -44,14 +44,13 @@ export function registerDeepLinkHandlers(): void {
 
   // Handle deep link URLs on Windows/Linux (second instance sends URL via command line)
   app.on("second-instance", (_event, commandLine) => {
+    const url = findDeepLinkUrlInArgs(commandLine);
     log.info("second-instance event received", {
-      commandLine: commandLine.join(" "),
       argCount: commandLine.length,
+      hasDeepLink: Boolean(url),
     });
 
-    const url = findDeepLinkUrlInArgs(commandLine);
     if (url) {
-      log.info("Deep link URL found in second-instance args", { url });
       getDeepLinkService().handleUrl(url);
       focusMainWindow("second-instance deep link");
     } else {

--- a/products/desktop/apps/code/src/main/services/deep-link/service.test.ts
+++ b/products/desktop/apps/code/src/main/services/deep-link/service.test.ts
@@ -8,14 +8,16 @@ const mockAppLifecycle = vi.hoisted(() => ({
   registerDeepLinkScheme: vi.fn(),
 }));
 
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+}));
+
 vi.mock("../../utils/logger.js", () => ({
   logger: {
-    scope: () => ({
-      info: vi.fn(),
-      error: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn(),
-    }),
+    scope: () => mockLogger,
   },
 }));
 
@@ -164,6 +166,9 @@ describe("DeepLinkService", () => {
           "posthog-code://auth/callback?token=secret&redirect=home",
         );
         expect(handler).toHaveBeenCalled();
+        expect(JSON.stringify(mockLogger.info.mock.calls)).not.toContain(
+          "secret",
+        );
       });
 
       it("handles empty path", () => {
@@ -212,10 +217,15 @@ describe("DeepLinkService", () => {
     });
 
     describe("error handling", () => {
-      it("returns false for non-matching protocols", () => {
-        expect(service.handleUrl("https://example.com")).toBe(false);
+      it("returns false for non-matching protocols without logging their data", () => {
+        expect(
+          service.handleUrl("https://example.com?token=secret-value"),
+        ).toBe(false);
         expect(service.handleUrl("myapp://task/123")).toBe(false);
         expect(service.handleUrl("file:///path/to/file")).toBe(false);
+        expect(JSON.stringify(mockLogger.warn.mock.calls)).not.toContain(
+          "secret-value",
+        );
       });
 
       it("returns false for URLs without main key", () => {

--- a/products/desktop/apps/code/src/main/services/deep-link/service.ts
+++ b/products/desktop/apps/code/src/main/services/deep-link/service.ts
@@ -78,15 +78,13 @@ export class DeepLinkService implements IDeepLinkRegistry {
    * in production only, legacy twig:// and array:// protocols.
    */
   public handleUrl(url: string): boolean {
-    log.info("Received deep link:", url);
-
     const primary = getDeeplinkProtocol(isDevBuild());
     const isPrimaryProtocol = url.startsWith(`${primary}://`);
     const isLegacyProtocol =
       !isDevBuild() && LEGACY_PROTOCOLS.some((p) => url.startsWith(`${p}://`));
 
     if (!isPrimaryProtocol && !isLegacyProtocol) {
-      log.warn("URL does not match protocol:", url);
+      log.warn("URL does not match a registered deep link protocol");
       return false;
     }
 
@@ -97,25 +95,28 @@ export class DeepLinkService implements IDeepLinkRegistry {
       const mainKey = parsedUrl.hostname;
 
       if (!mainKey) {
-        log.warn("Deep link has no main key:", url);
+        log.warn("Deep link has no main key");
         return false;
       }
 
       const handler = this.handlers.get(mainKey);
       if (!handler) {
-        log.warn("No handler registered for deep link key:", mainKey);
+        log.warn("No handler registered for deep link key");
         return false;
       }
+
+      log.info("Received deep link", {
+        protocol: parsedUrl.protocol,
+        mainKey,
+      });
 
       // Extract path segments after the main key (strip leading slash)
       const pathSegments = parsedUrl.pathname.slice(1);
 
-      log.info(
-        `Routing deep link to '${mainKey}' handler with path: ${pathSegments || "(empty)"}`,
-      );
+      log.info(`Routing deep link to '${mainKey}' handler`);
       return handler(pathSegments, parsedUrl.searchParams);
-    } catch (error) {
-      log.error("Failed to parse deep link URL:", error);
+    } catch {
+      log.error("Failed to parse deep link URL");
       return false;
     }
   }

--- a/products/desktop/packages/agent/src/adapters/local-tools/tools/show-actions.ts
+++ b/products/desktop/packages/agent/src/adapters/local-tools/tools/show-actions.ts
@@ -21,7 +21,11 @@ const SHOW_ACTIONS_TOOL_DESCRIPTION =
   "`prompt` (and `repo` when given). It never sends a prompt in the current " +
   "session. The user reads, edits, and sends the new task. Do not use " +
   "`compose` for an approval, a confirmation, or more work in the current " +
-  "task. Ask the user in your message instead. " +
+  "task. Ask the user in your message instead. When you and the user " +
+  "explicitly agree on a separate follow-up, offer one `compose` action. " +
+  "Turn that agreement into a self-contained prompt with the goal, relevant " +
+  "context, constraints, and expected result. Include the repository when you " +
+  "know it. Do not offer the action when the follow-up is tentative. " +
   "A `compose` action also takes an optional `description`, which no other " +
   "kind accepts. Giving one draws that button as a larger card instead of a " +
   "pill, so use it for the offers that matter most. Write one short sentence " +

--- a/products/desktop/packages/core/src/deep-links/newTaskLinkResolver.test.ts
+++ b/products/desktop/packages/core/src/deep-links/newTaskLinkResolver.test.ts
@@ -32,6 +32,7 @@ describe("NewTaskLinkResolver", () => {
       repo: "acme/web",
       model: "sonnet",
       mode: "plan",
+      source: "agent_action",
     };
 
     const result = await resolver.resolve(payload);
@@ -46,7 +47,10 @@ describe("NewTaskLinkResolver", () => {
     });
     expect(result.analytics.event).toBe(ANALYTICS_EVENTS.DEEP_LINK_NEW_TASK);
     if (result.analytics.event !== ANALYTICS_EVENTS.DEEP_LINK_NEW_TASK) return;
-    expect(result.analytics.properties.has_prompt).toBe(true);
+    expect(result.analytics.properties).toMatchObject({
+      has_prompt: true,
+      source: "agent_action",
+    });
   });
 
   it.each([

--- a/products/desktop/packages/core/src/deep-links/newTaskLinkResolver.ts
+++ b/products/desktop/packages/core/src/deep-links/newTaskLinkResolver.ts
@@ -75,6 +75,7 @@ export class NewTaskLinkResolver {
           has_repo: !!payload.repo,
           mode: payload.mode,
           model: payload.model,
+          source: payload.source,
         },
       },
     };

--- a/products/desktop/packages/core/src/links/new-task-link.test.ts
+++ b/products/desktop/packages/core/src/links/new-task-link.test.ts
@@ -153,13 +153,15 @@ describe("NewTaskLinkService", () => {
       );
     });
 
-    it("passes shared params (repo, mode, model)", () => {
+    it("passes shared params and the agent action source", () => {
       const listener = vi.fn();
       service.on(NewTaskLinkEvent.Action, listener);
 
       mockDeepLink._invoke(
         "new",
-        new URLSearchParams("prompt=test&repo=org/repo&mode=cloud&model=opus"),
+        new URLSearchParams(
+          "prompt=test&repo=org/repo&mode=cloud&model=opus&source=agent_action",
+        ),
       );
 
       expect(listener).toHaveBeenCalledWith({
@@ -168,6 +170,7 @@ describe("NewTaskLinkService", () => {
         repo: "org/repo",
         mode: "cloud",
         model: "opus",
+        source: "agent_action",
       });
     });
   });

--- a/products/desktop/packages/core/src/links/new-task-link.ts
+++ b/products/desktop/packages/core/src/links/new-task-link.ts
@@ -74,12 +74,14 @@ export class NewTaskLinkService extends TypedEventEmitter<NewTaskLinkEvents> {
     const payload: NewTaskLinkPayload = {
       action: "new",
       prompt,
+      source:
+        params.get("source") === "agent_action" ? "agent_action" : undefined,
       ...shared,
     };
 
     this.log.info("Handling new task link", {
       hasPrompt: !!prompt,
-      repo: shared.repo,
+      hasRepository: !!shared.repo,
     });
     return this.emitOrQueue(payload);
   }
@@ -107,7 +109,7 @@ export class NewTaskLinkService extends TypedEventEmitter<NewTaskLinkEvents> {
 
     this.log.info("Handling plan link", {
       planLength: plan.length,
-      repo: shared.repo,
+      hasRepository: !!shared.repo,
     });
     return this.emitOrQueue(payload);
   }
@@ -122,7 +124,7 @@ export class NewTaskLinkService extends TypedEventEmitter<NewTaskLinkEvents> {
 
     const parsed = parseGitHubIssueUrl(url);
     if (!parsed) {
-      this.log.warn("Issue link has invalid GitHub issue URL", { url });
+      this.log.warn("Issue link has invalid GitHub issue URL");
       return false;
     }
 
@@ -136,11 +138,7 @@ export class NewTaskLinkService extends TypedEventEmitter<NewTaskLinkEvents> {
       ...shared,
     };
 
-    this.log.info("Handling issue link", {
-      owner: parsed.owner,
-      repo: parsed.repo,
-      number: parsed.number,
-    });
+    this.log.info("Handling issue link");
     return this.emitOrQueue(payload);
   }
 

--- a/products/desktop/packages/shared/src/agent-actions.test.ts
+++ b/products/desktop/packages/shared/src/agent-actions.test.ts
@@ -24,7 +24,9 @@ describe("buildActionUrl", () => {
     it("builds a new-task link with only the prompt when no repo is given", () => {
       expect(
         buildActionUrl({ kind: "compose", prompt: "Fix the login bug" }, PROD),
-      ).toBe("posthog-code://new?prompt=Fix%20the%20login%20bug");
+      ).toBe(
+        "posthog-code://new?prompt=Fix%20the%20login%20bug&source=agent_action",
+      );
     });
 
     it("appends the repo when one is given", () => {
@@ -38,7 +40,7 @@ describe("buildActionUrl", () => {
           PROD,
         ),
       ).toBe(
-        "posthog-code://new?prompt=Fix%20the%20login%20bug&repo=posthog%2Fposthog",
+        "posthog-code://new?prompt=Fix%20the%20login%20bug&repo=posthog%2Fposthog&source=agent_action",
       );
     });
 
@@ -56,6 +58,7 @@ describe("buildActionUrl", () => {
       expect(host).toBe("new");
       expect(params.get("prompt")).toBe(prompt);
       expect(params.get("repo")).toBeNull();
+      expect(params.get("source")).toBe("agent_action");
     });
 
     it("round-trips a repo containing characters that need encoding", () => {
@@ -161,7 +164,7 @@ describe("buildActionUrl", () => {
       [
         "compose",
         { kind: "compose", prompt: "Do it" },
-        "posthog-code-dev://new?prompt=Do%20it",
+        "posthog-code-dev://new?prompt=Do%20it&source=agent_action",
       ],
       [
         "open_space",

--- a/products/desktop/packages/shared/src/agent-actions.ts
+++ b/products/desktop/packages/shared/src/agent-actions.ts
@@ -16,9 +16,10 @@ const requiredField = z.string().trim().min(1);
 const composeFields = {
   kind: z.literal("compose"),
   prompt: requiredField.describe(
-    "Text to prefill in a separate new task. This does not send a prompt in " +
-      "the current session. Do not use compose for approval, confirmation, " +
-      "or continued work in the current task.",
+    "Text to prefill in a separate new task. Make the prompt self-contained " +
+      "with the goal, relevant context, constraints, and expected result. " +
+      "This does not send a prompt in the current session. Do not use compose " +
+      "for approval, confirmation, or continued work in the current task.",
   ),
   repo: requiredField
     .optional()
@@ -130,7 +131,7 @@ export function buildActionUrl(action: AgentAction, scheme: string): string {
       const query = action.repo
         ? `${prompt}&repo=${encodeURIComponent(action.repo)}`
         : prompt;
-      return `${scheme}://new?${query}`;
+      return `${scheme}://new?${query}&source=agent_action`;
     }
     case "open_space":
       return `${scheme}://channel/${encodeURIComponent(action.channel_id)}`;

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -465,6 +465,7 @@ export interface DeepLinkNewTaskProperties {
   has_repo: boolean;
   mode?: string;
   model?: string;
+  source?: "agent_action";
 }
 
 export interface DeepLinkPlanProperties {

--- a/products/desktop/packages/shared/src/deep-links.ts
+++ b/products/desktop/packages/shared/src/deep-links.ts
@@ -117,7 +117,11 @@ export interface NewTaskSharedParams {
 }
 
 export type NewTaskLinkPayload =
-  | ({ action: "new"; prompt?: string } & NewTaskSharedParams)
+  | ({
+      action: "new";
+      prompt?: string;
+      source?: "agent_action";
+    } & NewTaskSharedParams)
   | ({ action: "plan"; plan: string } & NewTaskSharedParams)
   | ({
       action: "issue";


### PR DESCRIPTION
## Problem

Users must retype a separate follow-up when an agent leaves the agreed work in prose.

The context wiki stores durable knowledge. It intentionally excludes active work and operational todos.

## Changes

- Agents now offer an editable new-task prompt after explicit agreement on a separate follow-up.
- The prompt includes the goal, relevant context, constraints, expected result, and known repository.
- The existing action card and task composer provide the visible flow. No visual component changed.
- The `Deep link new task` event now identifies drafts opened from agent actions.
- Deep-link logs no longer capture prompts, repositories, query parameters, or command-line values.

No screenshots are needed because this change uses the existing action card.

## How did you test this code?

- Targeted Vitest suites cover action links, link parsing, analytics attribution, tool exposure, and log redaction.
- `pnpm typecheck` passed for the full Desktop workspace.
- Biome passed on all changed files.
- The full agent suite could not run because sandbox rules block its test-only `git commit` commands.
- `hogli ci:preflight --fix` could not run because this sandbox has no `hogli`, Flox, or Python command.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs change. The change uses the existing action card and task composer.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The PostHog Desktop task agent used Explore subagents, PostHog MCP, and repository tools.

Invoked skills: `/posthog-desktop`, `/subagent-orchestration`, `/querying-posthog-data`, `/writing-user-facing-copy`, `/writing-tests`, `/instrument-product-analytics`, `/writing-code-comments`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `/writing-simplified-technical-english`.

The duplicate search found no open PR. The diff contains no private task material.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
