### PR TITLE
feat(workflows): register cohort references as entity dependencies

### DIFF
--- a/posthog/management/commands/backfill_entity_dependencies.py
+++ b/posthog/management/commands/backfill_entity_dependencies.py
@@ -1,0 +1,82 @@
+import time
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandError, CommandParser
+from django.core.paginator import Paginator
+
+import structlog
+
+from posthog.models.entity_dependencies.registry import (
+    EntityDependencyRegistryError,
+    get_source,
+    plan_instance_dependencies,
+    registered_source_types,
+    sync_instance_dependencies,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+class Command(BaseCommand):
+    help = (
+        "Rebuild entity dependency rows for every instance of a registered source type. Each instance is "
+        "synced with the same idempotent diff that runs on save, so this is both the one-time backfill for "
+        "a newly registered source and the repair tool for rows left stale by writes that skipped save(). "
+        "Default dry-run; pass --live-run to write."
+    )
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument("--source-type", required=True, help="Registered source entity type, e.g. hog_flow")
+        parser.add_argument("--team-id", type=int, default=None, help="Limit to one team")
+        parser.add_argument("--page-size", type=int, default=500, help="Instances per page (default: 500)")
+        parser.add_argument("--live-run", action="store_true", help="Write changes; without it, only report")
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        started = time.time()
+        source_type: str = options["source_type"]
+        live_run: bool = options["live_run"]
+
+        try:
+            source = get_source(source_type)
+        except EntityDependencyRegistryError:
+            raise CommandError(f"Unknown source type {source_type!r}. Registered: {registered_source_types()}")
+
+        queryset = source.get_queryset().order_by("pk")
+        if options["team_id"] is not None:
+            queryset = queryset.filter(team_id=options["team_id"])
+
+        mode = "LIVE" if live_run else "DRY RUN"
+        self.stdout.write(f"Backfilling entity dependencies for {source_type} ({mode})")
+
+        scanned = added = removed = errors = 0
+        paginator = Paginator(queryset, options["page_size"])
+        for page_number in paginator.page_range:
+            for instance in paginator.page(page_number).object_list:
+                scanned += 1
+                try:
+                    result = sync_instance_dependencies(instance) if live_run else plan_instance_dependencies(instance)
+                except Exception as e:
+                    errors += 1
+                    logger.exception(
+                        "entity_dependencies.backfill_instance_failed",
+                        source_type=source_type,
+                        source_id=str(instance.pk),
+                    )
+                    self.stderr.write(f"  failed {source_type} {instance.pk}: {e}")
+                    continue
+                added += result.added
+                removed += result.removed
+            if scanned % (options["page_size"] * 10) == 0:
+                self.stdout.write(f"  {scanned}/{paginator.count} scanned")
+
+        verb = "" if live_run else " (would be)"
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Done in {time.time() - started:.1f}s: {scanned} {source_type} scanned, "
+                f"{added} rows added{verb}, {removed} rows removed{verb}, {errors} errors"
+            )
+        )
+        if not live_run and (added or removed):
+            self.stdout.write(self.style.NOTICE("Run with --live-run to apply"))
+        if errors:
+            raise CommandError(f"{errors} instance(s) failed; see log")

--- a/posthog/models/entity_dependencies/README.md
+++ b/posthog/models/entity_dependencies/README.md
@@ -39,9 +39,21 @@ register_source(HogFlowDependencySource())
 
 `role` is a source-defined label for where the reference sits. `path` locates the reference inside the source and is part of a row's identity, so two occurrences of the same target in the same role are both kept.
 
+## Backfilling a source
+
+Registration only covers saves from that point on. Populate rows for existing instances once, then verify:
+
+```sh
+python manage.py backfill_entity_dependencies --source-type hog_flow            # dry run: reports adds/removes
+python manage.py backfill_entity_dependencies --source-type hog_flow --live-run
+python manage.py backfill_entity_dependencies --source-type hog_flow            # must now report 0 added, 0 removed
+```
+
+The command walks `DependencySource.get_queryset()` (every instance across teams, `--team-id` to narrow) and runs the same diff as the save signal, so it is idempotent and doubles as the repair tool. It writes only dependency rows and never saves the source, so it fires no source signals. It is a management command rather than a `RunPython` migration on purpose, following `docs/published/handbook/engineering/safe-django-migrations.md`.
+
 ## Write paths that skip `save()`
 
-`.update()`, `bulk_update`, and raw SQL fire no signals. A write path that changes reference-bearing fields this way must call `sync_instance_dependencies(instance)` itself. Audit a source's write paths when you register it; a source with an unaudited bypass drifts silently.
+`.update()`, `bulk_update`, and raw SQL fire no signals. A write path that changes reference-bearing fields this way must call `sync_instance_dependencies(instance)` itself. Audit a source's write paths when you register it; a source with an unaudited bypass drifts silently until the next backfill run.
 
 A sync that fails inside a signal receiver is logged, reported to error tracking, and counted in `entity_dependency_sync_failures_total`, but it does not block the product write. In tests it raises, so an extraction bug fails the product's own test suite instead of hiding.
 

--- a/posthog/models/entity_dependencies/registry.py
+++ b/posthog/models/entity_dependencies/registry.py
@@ -9,7 +9,7 @@ import structlog
 from prometheus_client import Counter
 
 from posthog.exceptions_capture import capture_exception
-from posthog.models.entity_dependencies.sync import remove_dependencies, sync_dependencies
+from posthog.models.entity_dependencies.sync import plan_sync, remove_dependencies, sync_dependencies
 from posthog.models.entity_dependencies.types import Reference, SyncResult
 
 logger = structlog.get_logger(__name__)
@@ -44,6 +44,14 @@ class DependencySource(ABC, Generic[M]):
 
     @abstractmethod
     def extract_references(self, instance: M) -> list[Reference]: ...
+
+    def get_queryset(self) -> models.QuerySet[M]:
+        """Every instance a backfill must visit. Cross-team by design, so fail-closed managers are unscoped."""
+        manager = self.model._default_manager
+        unscoped = getattr(manager, "unscoped", None)
+        if callable(unscoped):
+            return unscoped()
+        return manager.all()
 
 
 _sources_by_type: dict[str, DependencySource[Any]] = {}
@@ -99,6 +107,17 @@ def sync_instance_dependencies(instance: models.Model) -> SyncResult:
     """
     source = _source_for_instance(instance)
     return sync_dependencies(
+        team_id=_team_id_of(instance),
+        source_type=source.entity_type,
+        source_id=str(instance.pk),
+        references=source.extract_references(instance),
+    )
+
+
+def plan_instance_dependencies(instance: models.Model) -> SyncResult:
+    """Report what `sync_instance_dependencies` would change, without writing. Used by dry runs."""
+    source = _source_for_instance(instance)
+    return plan_sync(
         team_id=_team_id_of(instance),
         source_type=source.entity_type,
         source_id=str(instance.pk),

--- a/posthog/models/entity_dependencies/sync.py
+++ b/posthog/models/entity_dependencies/sync.py
@@ -1,6 +1,8 @@
+import uuid
 from collections.abc import Iterable
 
 from django.db import connection, transaction
+from django.db.models import QuerySet
 
 from posthog.models.entity_dependencies.models import EntityDependency
 from posthog.models.entity_dependencies.types import Reference, SyncResult
@@ -21,7 +23,7 @@ def sync_dependencies(*, team_id: int, source_type: str, source_id: str, referen
     with transaction.atomic():
         _lock_source(source_type, source_id)
         scoped = EntityDependency.objects.for_team(team_id, canonical=True)
-        stored = {_to_reference(row): row.id for row in scoped.filter(source_type=source_type, source_id=source_id)}
+        stored = _stored_references(scoped, source_type, source_id)
 
         to_add = desired - stored.keys()
         to_remove = [row_id for reference, row_id in stored.items() if reference not in desired]
@@ -48,6 +50,15 @@ def sync_dependencies(*, team_id: int, source_type: str, source_id: str, referen
     return SyncResult(added=len(to_add), removed=len(to_remove))
 
 
+def plan_sync(*, team_id: int, source_type: str, source_id: str, references: Iterable[Reference]) -> SyncResult:
+    """Report what `sync_dependencies` would change for this input, without writing anything."""
+    team_id = resolve_effective_team_id(team_id)
+    desired = set(references)
+    scoped = EntityDependency.objects.for_team(team_id, canonical=True)
+    stored = _stored_references(scoped, source_type, source_id)
+    return SyncResult(added=len(desired - stored.keys()), removed=len(stored.keys() - desired))
+
+
 def remove_dependencies(*, team_id: int, source_type: str, source_id: str) -> int:
     with transaction.atomic():
         _lock_source(source_type, source_id)
@@ -63,6 +74,12 @@ def _lock_source(source_type: str, source_id: str) -> None:
     # above safe against a concurrent sync of the same source.
     with connection.cursor() as cursor:
         cursor.execute("SELECT pg_advisory_xact_lock(hashtext(%s))", [f"entity_dependency:{source_type}:{source_id}"])
+
+
+def _stored_references(
+    scoped: QuerySet[EntityDependency], source_type: str, source_id: str
+) -> dict[Reference, uuid.UUID]:
+    return {_to_reference(row): row.id for row in scoped.filter(source_type=source_type, source_id=source_id)}
 
 
 def _to_reference(row: EntityDependency) -> Reference:

--- a/products/workflows/backend/apps.py
+++ b/products/workflows/backend/apps.py
@@ -5,3 +5,8 @@ class WorkflowsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "products.workflows.backend"
     label = "workflows"
+
+    def ready(self) -> None:
+        # Registers HogFlow as an entity dependency source once the model registry is populated.
+        # Kept in its own light module so django.setup() does not pull the API module in.
+        from products.workflows.backend import entity_dependencies  # noqa: F401, PLC0415

--- a/products/workflows/backend/entity_dependencies.py
+++ b/products/workflows/backend/entity_dependencies.py
@@ -1,0 +1,116 @@
+from collections.abc import Iterator
+from typing import Any
+
+from posthog.models.entity_dependencies.registry import DependencySource, register_source
+from posthog.models.entity_dependencies.types import Reference
+
+from products.workflows.backend.models.hog_flow.hog_flow import HogFlow
+
+# Batch and schedule triggers resolve their audience offline from precalculated cohort membership,
+# which is why only these two get the audience role: the impact rules for a cohort change differ
+# from a cohort used as an event-time filter.
+AUDIENCE_TRIGGER_TYPES = frozenset({"batch", "schedule"})
+
+
+class HogFlowDependencySource(DependencySource[HogFlow]):
+    entity_type = "hog_flow"
+    model = HogFlow
+
+    def extract_references(self, instance: HogFlow) -> list[Reference]:
+        if instance.status == HogFlow.State.ARCHIVED:
+            return []
+        live = {"trigger": instance.trigger, "actions": instance.actions, "conversion": instance.conversion}
+        references = list(_cohort_references(live, role_prefix="", path_prefix=""))
+        if isinstance(instance.draft, dict):
+            references.extend(_cohort_references(instance.draft, role_prefix="draft:", path_prefix="draft."))
+        return references
+
+
+def _cohort_references(content: dict[str, Any], *, role_prefix: str, path_prefix: str) -> Iterator[Reference]:
+    """Walk every filter slot of a workflow's content (live or draft) for cohort property filters.
+
+    Only known filter slots are visited, so free-form action inputs and the percentage buckets of
+    `random_cohort_branch` (which are not cohorts) can never produce a reference.
+    """
+    trigger_config = _as_dict(_as_dict(content.get("trigger")).get("config"))
+    trigger_role = "trigger_audience" if trigger_config.get("type") in AUDIENCE_TRIGGER_TYPES else "trigger_filter"
+    yield from _references_in(
+        trigger_config.get("filters"), role=role_prefix + trigger_role, path=path_prefix + "trigger.config.filters"
+    )
+
+    for action in _as_list(content.get("actions")):
+        if not isinstance(action, dict):
+            continue
+        config = _as_dict(action.get("config"))
+        action_path = f"{path_prefix}actions[{action.get('id')}].config"
+        if action.get("type") == "conditional_branch":
+            for index, condition in enumerate(_as_list(config.get("conditions"))):
+                yield from _references_in(
+                    _as_dict(condition).get("filters"),
+                    role=role_prefix + "branch_condition",
+                    path=f"{action_path}.conditions[{index}].filters",
+                )
+        elif action.get("type") == "wait_until_condition":
+            yield from _references_in(
+                _as_dict(config.get("condition")).get("filters"),
+                role=role_prefix + "wait_condition",
+                path=f"{action_path}.condition.filters",
+            )
+            for index, event in enumerate(_as_list(config.get("events"))):
+                yield from _references_in(
+                    _as_dict(event).get("filters"),
+                    role=role_prefix + "wait_condition",
+                    path=f"{action_path}.events[{index}].filters",
+                )
+
+    conversion = _as_dict(content.get("conversion"))
+    yield from _references_in(
+        conversion.get("filters"), role=role_prefix + "conversion", path=path_prefix + "conversion.filters"
+    )
+    for index, event in enumerate(_as_list(conversion.get("events"))):
+        yield from _references_in(
+            _as_dict(event).get("filters"),
+            role=role_prefix + "conversion",
+            path=f"{path_prefix}conversion.events[{index}].filters",
+        )
+
+
+def _references_in(node: Any, *, role: str, path: str) -> Iterator[Reference]:
+    # A cohort property filter is `{key: "id", type: "cohort", value: <id>, operator: "in"}`. Filters
+    # nest (property groups, per-event properties), so walk every dict and list below the slot.
+    if isinstance(node, dict):
+        if node.get("type") == "cohort" and node.get("value") is not None:
+            values = node["value"] if isinstance(node["value"], list) else [node["value"]]
+            for value in values:
+                cohort_id = _cohort_id(value)
+                if cohort_id is not None:
+                    yield Reference(target_type="cohort", target_id=cohort_id, role=role, path=path)
+            return
+        for key, child in node.items():
+            yield from _references_in(child, role=role, path=f"{path}.{key}")
+    elif isinstance(node, list):
+        for index, child in enumerate(node):
+            yield from _references_in(child, role=role, path=f"{path}[{index}]")
+
+
+def _cohort_id(value: Any) -> str | None:
+    # Cohort ids arrive as ints or numeric strings depending on the client; anything else cannot
+    # name a cohort and is skipped rather than recorded as a bogus target.
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, str) and value.isdigit():
+        return str(int(value))
+    return None
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+register_source(HogFlowDependencySource())

--- a/products/workflows/backend/management/commands/backfill_conversion_filters_to_events.py
+++ b/products/workflows/backend/management/commands/backfill_conversion_filters_to_events.py
@@ -1,5 +1,7 @@
 from django.core.management.base import BaseCommand
 
+from posthog.models.entity_dependencies.registry import sync_instance_dependencies
+
 from products.workflows.backend.models.hog_flow.hog_flow import HogFlow
 
 
@@ -52,8 +54,11 @@ class Command(BaseCommand):
                 f"team_id={flow.team_id} status={flow.status}"
             )
             if live_run:
-                # .update() avoids bumping updated_at / firing save signals for a backfill.
+                # .update() avoids bumping updated_at / firing save signals for a backfill, so the
+                # dependency rows that the save signal would have refreshed are synced explicitly.
                 HogFlow.objects.filter(pk=flow.pk).update(conversion=new_conversion)
+                flow.conversion = new_conversion
+                sync_instance_dependencies(flow)
             relocated += 1
 
         verb = "relocated" if live_run else "to relocate"

--- a/products/workflows/backend/test/test_entity_dependencies.py
+++ b/products/workflows/backend/test/test_entity_dependencies.py
@@ -1,0 +1,199 @@
+from io import StringIO
+from typing import Any
+
+from posthog.test.base import BaseTest
+
+from django.core.management import call_command
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.models import EntityDependency
+from posthog.models.entity_dependencies.types import Reference
+
+from products.workflows.backend.entity_dependencies import HogFlowDependencySource
+from products.workflows.backend.models.hog_flow.hog_flow import HogFlow
+
+
+def _cohort(cohort_id: Any) -> dict[str, Any]:
+    return {"key": "id", "type": "cohort", "value": cohort_id, "operator": "in"}
+
+
+def _trigger(trigger_type: str, filters: dict[str, Any]) -> dict[str, Any]:
+    return {"type": "trigger", "config": {"type": trigger_type, "filters": filters}}
+
+
+def _ref(cohort_id: str, role: str, path: str) -> Reference:
+    return Reference(target_type="cohort", target_id=cohort_id, role=role, path=path)
+
+
+class TestHogFlowDependencySourceExtraction(SimpleTestCase):
+    @parameterized.expand(
+        [
+            (
+                "event_trigger_filters_including_per_event_properties",
+                {
+                    "trigger": _trigger(
+                        "event",
+                        {"events": [{"id": "$pageview", "properties": [_cohort(7)]}], "properties": [_cohort(5)]},
+                    )
+                },
+                {
+                    _ref("7", "trigger_filter", "trigger.config.filters.events[0].properties[0]"),
+                    _ref("5", "trigger_filter", "trigger.config.filters.properties[0]"),
+                },
+            ),
+            (
+                "batch_audience_with_string_id",
+                {"trigger": _trigger("batch", {"properties": [_cohort("9")]})},
+                {_ref("9", "trigger_audience", "trigger.config.filters.properties[0]")},
+            ),
+            (
+                "schedule_audience",
+                {"trigger": _trigger("schedule", {"properties": [_cohort(2)]})},
+                {_ref("2", "trigger_audience", "trigger.config.filters.properties[0]")},
+            ),
+            (
+                "conditional_branch_conditions",
+                {
+                    "actions": [
+                        {
+                            "id": "a1",
+                            "type": "conditional_branch",
+                            "config": {
+                                "conditions": [
+                                    {"filters": {"properties": []}},
+                                    {"filters": {"properties": [_cohort(3)]}},
+                                ]
+                            },
+                        }
+                    ]
+                },
+                {_ref("3", "branch_condition", "actions[a1].config.conditions[1].filters.properties[0]")},
+            ),
+            (
+                "wait_until_condition",
+                {
+                    "actions": [
+                        {
+                            "id": "w1",
+                            "type": "wait_until_condition",
+                            "config": {
+                                "condition": {"filters": {"properties": [_cohort(4)]}},
+                                "max_wait_duration": "1d",
+                            },
+                        }
+                    ]
+                },
+                {_ref("4", "wait_condition", "actions[w1].config.condition.filters.properties[0]")},
+            ),
+            (
+                "conversion_property_filters_and_event_goals",
+                {"conversion": {"filters": [_cohort(6)], "events": [{"filters": {"properties": [_cohort(8)]}}]}},
+                {
+                    _ref("6", "conversion", "conversion.filters[0]"),
+                    _ref("8", "conversion", "conversion.events[0].filters.properties[0]"),
+                },
+            ),
+            (
+                "draft_content_gets_the_draft_prefix",
+                {
+                    "draft": {
+                        "trigger": _trigger("batch", {"properties": [_cohort(11)]}),
+                        "actions": [],
+                        "conversion": None,
+                    }
+                },
+                {_ref("11", "draft:trigger_audience", "draft.trigger.config.filters.properties[0]")},
+            ),
+            (
+                "multi_value_cohort_filter_yields_one_reference_per_cohort",
+                {"trigger": _trigger("event", {"properties": [_cohort([1, 2])]})},
+                {
+                    _ref("1", "trigger_filter", "trigger.config.filters.properties[0]"),
+                    _ref("2", "trigger_filter", "trigger.config.filters.properties[0]"),
+                },
+            ),
+            (
+                "random_cohort_branch_buckets_are_not_cohorts",
+                {
+                    "actions": [
+                        {
+                            "id": "r1",
+                            "type": "random_cohort_branch",
+                            "config": {"cohorts": [{"percentage": 50}, {"percentage": 50}]},
+                        }
+                    ]
+                },
+                set(),
+            ),
+            (
+                "non_numeric_cohort_values_are_skipped",
+                {"trigger": _trigger("event", {"properties": [_cohort("not-an-id"), _cohort(True), _cohort(None)]})},
+                set(),
+            ),
+            (
+                "archived_workflows_have_no_references",
+                {"status": HogFlow.State.ARCHIVED, "trigger": _trigger("batch", {"properties": [_cohort(5)]})},
+                set(),
+            ),
+        ]
+    )
+    def test_extract_references(self, _name: str, fields: dict[str, Any], expected: set[Reference]) -> None:
+        flow = HogFlow(team_id=1, name="Flow", **fields)
+
+        assert set(HogFlowDependencySource().extract_references(flow)) == expected
+
+
+class TestHogFlowDependencyWiring(BaseTest):
+    def _rows(self) -> set[tuple[str, str, str]]:
+        rows = EntityDependency.objects.for_team(self.team.id).filter(source_type="hog_flow")
+        return {(row.source_id, row.target_id, row.role) for row in rows}
+
+    def test_saving_a_workflow_records_its_cohort_references_and_archiving_removes_them(self) -> None:
+        flow = HogFlow.objects.create(
+            team=self.team, name="Flow", trigger=_trigger("batch", {"properties": [_cohort(5)]})
+        )
+        assert self._rows() == {(str(flow.id), "5", "trigger_audience")}
+
+        flow.status = HogFlow.State.ARCHIVED
+        flow.save()
+        assert self._rows() == set()
+
+    def test_backfill_command_rebuilds_rows_that_signals_did_not_write(self) -> None:
+        HogFlow.objects.create(team=self.team, name="A", trigger=_trigger("batch", {"properties": [_cohort(5)]}))
+        HogFlow.objects.create(team=self.team, name="B", conversion={"filters": [_cohort(6)], "events": []})
+        HogFlow.objects.create(team=self.team, name="C")
+        EntityDependency.objects.for_team(self.team.id).filter(source_type="hog_flow").delete()
+
+        dry_run = StringIO()
+        call_command(
+            "backfill_entity_dependencies", "--source-type", "hog_flow", "--team-id", self.team.id, stdout=dry_run
+        )
+        assert "3 hog_flow scanned, 2 rows added (would be), 0 rows removed (would be), 0 errors" in dry_run.getvalue()
+        assert self._rows() == set()
+
+        live_run = StringIO()
+        call_command(
+            "backfill_entity_dependencies",
+            "--source-type",
+            "hog_flow",
+            "--team-id",
+            self.team.id,
+            "--live-run",
+            stdout=live_run,
+        )
+        assert "2 rows added, 0 rows removed, 0 errors" in live_run.getvalue()
+        assert {(target, role) for _, target, role in self._rows()} == {("5", "trigger_audience"), ("6", "conversion")}
+
+        rerun = StringIO()
+        call_command(
+            "backfill_entity_dependencies",
+            "--source-type",
+            "hog_flow",
+            "--team-id",
+            self.team.id,
+            "--live-run",
+            stdout=rerun,
+        )
+        assert "0 rows added, 0 rows removed, 0 errors" in rerun.getvalue()


### PR DESCRIPTION
## Problem

A workflow that targets a cohort has no record of that reference anywhere outside its own JSON, so nothing can tell a cohort's editor that workflows depend on it.

- Layer 2 of the entity dependency registry, stacked on #96109, which added the `EntityDependency` table and the write path but registered no source.
- Without a registered source and a backfill, the table stays empty and the cohort-side surfaces planned next (a "Used in" panel, an impact preview before a cohort change) have nothing to show.

## Changes

- Every `HogFlow` save now records the cohorts it references as `EntityDependency` rows, one per occurrence, with a role that says how the cohort is used: `trigger_filter`, `trigger_audience` (batch and schedule), `branch_condition`, `wait_condition`, or `conversion`. Draft content is recorded with a `draft:` prefix.
- Archiving a workflow removes its rows; unarchiving recreates them.
- Nothing is user-visible yet. The rows feed the read API and the cohort scene panel in the next layer.
- `python manage.py backfill_entity_dependencies --source-type hog_flow` populates rows for existing workflows. It is dry-run by default, reports adds and removes, and reruns as a no-op, so it also repairs rows after a write that skipped `save()`.
- Only the known filter slots are walked, so free-form action inputs and the percentage buckets of `random_cohort_branch` (a traffic split, not a `Cohort`) can never produce a reference.
- The one `HogFlow` write path that bypasses `save()` for a reference-bearing field (`backfill_conversion_filters_to_events`) now syncs rows explicitly. The other `bulk_update` sites touch fields that hold no references.
- Mechanical: `DependencySource.get_queryset()` and `plan_sync()` in core (the backfill's iteration and dry-run primitives), app-ready registration in `WorkflowsConfig.ready()`, README update.

## How did you test this code?

- `products/workflows/backend/test/test_entity_dependencies.py`:
  - a no-DB parameterized matrix over every filter slot, draft prefixing, per-event properties, multi-value filters, numeric-string ids, non-numeric values, archived workflows, and the `random_cohort_branch` negative case (an extractor that misses a slot, or walks into action inputs, fails here)
  - saving a workflow writes rows and archiving removes them, through the real app-ready registration (a dropped or renamed `ready()` import fails here)
  - the backfill command in dry-run writes nothing and reports the right counts, in live mode writes the rows, and a rerun reports zero changes
- Ran the affected suites locally: `products/workflows/backend/api/test/test_hog_flow.py` (351 tests), the draft/publish API tests, the `assertNumQueries` test in `test_template_input_usage.py`, and the core `test_sync.py`. `hogli lint:tach` validates the import boundaries.
- Not run: the backfill against production data. That happens after merge, dry-run first on dev, then EU and US, and the dry-run after the live run must report zero changes.
- The ClickHouse and async-migration steps of `bin/migrate-check` fail in this sandbox because its ClickHouse is not provisioned; this PR adds no migration.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`posthog/models/entity_dependencies/README.md` gains a "Backfilling a source" section. No user-facing docs change, because nothing user-visible changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code via PostHog Desktop. Skills invoked: `/stacking-prs`, `/writing-tests`, `/writing-dataclasses`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Stacked on #96109 at the user's request so the whole registry can be checked out from one branch and tested end to end.
- Decisions during the session: walk only known filter slots instead of the whole config (precision over recall, see the `random_cohort_branch` trap); test the backfill through the real `hog_flow` source rather than a synthetic one so the test also covers app-ready registration; keep `HogFlowRevision` out of the registry because revisions are immutable history.
- No customer material was used. Test data is invented.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
