### PR TITLE
feat(cdp): support gbraid and wbraid click identifiers for Google Ads conversions

### DIFF
--- a/nodejs/src/cdp/templates/_destinations/google_ads/google.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/google_ads/google.template.test.ts
@@ -226,11 +226,64 @@ describe('google template', () => {
             })
         )
 
-        expect(response.logs.filter((log) => log.level === 'info').map((log) => log.message)).toMatchInlineSnapshot(`
-            [
-              "No \`gclid\` or user identifiers. Skipping...",
-            ]
-        `)
+        expect(response.logs.filter((log) => log.level === 'info').map((log) => log.message)).toEqual([
+            'No `gclid`, `gbraid`, `wbraid`, or user identifiers. Skipping...',
+        ])
         expect(response.finished).toEqual(true)
+    })
+
+    it('works with gbraid when gclid is absent', async () => {
+        const response = await tester.invokeMapping(
+            'Conversion',
+            {
+                oauth: {
+                    access_token: 'access-token',
+                },
+                customerId: '1231231234/5675675678',
+                conversionActionId: '123456789',
+            },
+            createAdDestinationPayload({
+                person: {
+                    properties: {
+                        gclid: null,
+                        gbraid: 'app-click-gbraid-123',
+                    },
+                },
+            })
+        )
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toEqual(false)
+        expect(JSON.parse(response.invocation.queueParameters.body).conversions[0].gbraid).toEqual(
+            'app-click-gbraid-123'
+        )
+    })
+
+    it('works with wbraid when gclid and gbraid are absent', async () => {
+        const response = await tester.invokeMapping(
+            'Conversion',
+            {
+                oauth: {
+                    access_token: 'access-token',
+                },
+                customerId: '1231231234/5675675678',
+                conversionActionId: '123456789',
+            },
+            createAdDestinationPayload({
+                person: {
+                    properties: {
+                        gclid: null,
+                        gbraid: null,
+                        wbraid: 'web-click-wbraid-456',
+                    },
+                },
+            })
+        )
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toEqual(false)
+        expect(JSON.parse(response.invocation.queueParameters.body).conversions[0].wbraid).toEqual(
+            'web-click-wbraid-456'
+        )
     })
 })

--- a/nodejs/src/cdp/templates/_destinations/google_ads/google.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/google_ads/google.template.ts
@@ -27,6 +27,26 @@ const build_inputs = (): HogFunctionInputSchemaType[] => {
             required: false,
         },
         {
+            key: 'gbraid',
+            type: 'string',
+            label: 'Google Click ID for App-to-Web (gbraid)',
+            description:
+                'The Google click ID (gbraid) associated with iOS app-to-web conversions. Sent when gclid is not present.',
+            default: '{person.properties.gbraid ?? person.properties.$initial_gbraid}',
+            secret: false,
+            required: false,
+        },
+        {
+            key: 'wbraid',
+            type: 'string',
+            label: 'Google Click ID for Web-to-App (wbraid)',
+            description:
+                'The Google click ID (wbraid) associated with iOS web-to-app conversions. Sent when gclid and gbraid are not present.',
+            default: '{person.properties.wbraid ?? person.properties.$initial_wbraid}',
+            secret: false,
+            required: false,
+        },
+        {
             key: 'conversionDateTime',
             type: 'string',
             label: 'Conversion Date Time',
@@ -107,8 +127,8 @@ if (not empty(inputs.phone)) {
     userIdentifiers := arrayPushBack(userIdentifiers, {'hashed_phone_number': sha256Hex(lower(trim(inputs.phone)))})
 }
 
-if (empty(inputs.gclid) and empty(userIdentifiers)) {
-    print('No \`gclid\` or user identifiers. Skipping...')
+if (empty(inputs.gclid) and empty(inputs.gbraid) and empty(inputs.wbraid) and empty(userIdentifiers)) {
+    print('No \`gclid\`, \`gbraid\`, \`wbraid\`, or user identifiers. Skipping...')
     return
 }
 
@@ -118,6 +138,10 @@ let conversion := {
 }
 if (not empty(inputs.gclid)) {
     conversion.gclid := inputs.gclid
+} else if (not empty(inputs.gbraid)) {
+    conversion.gbraid := inputs.gbraid
+} else if (not empty(inputs.wbraid)) {
+    conversion.wbraid := inputs.wbraid
 }
 if (not empty(userIdentifiers)) {
     conversion.user_identifiers := userIdentifiers

--- a/posthog/models/integration/google_ads.py
+++ b/posthog/models/integration/google_ads.py
@@ -52,6 +52,11 @@ class GoogleAdsIntegration:
         return WebClient(self.integration.sensitive_config["access_token"])
 
     def list_google_ads_conversion_actions(self, customer_id, parent_id=None) -> list[dict]:
+        """List conversion actions for a Google Ads customer account.
+
+        Used by CDP conversion destinations to attribute events via click identifiers (gclid, gbraid, wbraid)
+        or enhanced user identifiers (hashed email and phone).
+        """
         response = requests.request(
             "POST",
             f"https://googleads.googleapis.com/v24/customers/{customer_id}/googleAds:searchStream",

--- a/posthog/models/test/integration/test_google_ads.py
+++ b/posthog/models/test/integration/test_google_ads.py
@@ -154,3 +154,16 @@ class TestGoogleAdsIntegrationModel(BaseTest):
             GoogleAdsIntegration(self._integration()).list_google_ads_accessible_accounts()
 
         assert mock_request.call_count == 3
+
+    @override_settings(GOOGLE_ADS_DEVELOPER_TOKEN="dev_token")
+    @patch("posthog.models.integration.google_ads.requests.request")
+    def test_list_conversion_actions_queries_stream(self, mock_request):
+        stream_response = MagicMock(status_code=200)
+        stream_response.json.return_value = [
+            {"results": [{"conversionAction": {"id": "12345", "name": "Purchase"}}]}
+        ]
+        mock_request.return_value = stream_response
+
+        actions = GoogleAdsIntegration(self._integration()).list_google_ads_conversion_actions("6501924158")
+        assert len(actions) == 1
+        assert actions[0]["id"] == "12345"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -35,6 +35,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.generated_
 from products.warehouse_sources.backend.temporal.data_imports.sources.google_ads.configs import (
     GoogleAdsResumeConfig,
     clean_customer_id,
+    format_customer_id,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.google_ads.google_ads import (
     GOOGLE_ADS_INCREMENTAL_WINDOW_DAYS,
@@ -76,6 +77,19 @@ class TestCleanCustomerId:
     )
     def test_strips_to_bare_digits(self, raw, expected):
         assert clean_customer_id(raw) == expected
+
+
+class TestFormatCustomerId:
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("1234567890", "123-456-7890"),
+            ("123-456-7890", "123-456-7890"),
+            ("123", "123"),
+        ],
+    )
+    def test_formats_bare_customer_id(self, raw, expected):
+        assert format_customer_id(raw) == expected
 
 
 class TestGoogleAdsValidateConfig:


### PR DESCRIPTION
## Description

Adds support for `gbraid` and `wbraid` iOS click identifiers to Google Ads conversion destination template in CDP, with fallback prioritization so Google Ads does not reject conversions with conflicting click IDs.

Fixes #95999.

### Changes (5 files)
- **`nodejs/src/cdp/templates/_destinations/google_ads/google.template.ts`**: Added `gbraid` and `wbraid` inputs mapping to `{person.properties.gbraid ?? person.properties.$initial_gbraid}` and `{person.properties.wbraid ?? person.properties.$initial_wbraid}`, with exclusive fallback logic (`gclid` -> `gbraid` -> `wbraid`).
- **`nodejs/src/cdp/templates/_destinations/google_ads/google.template.test.ts`**: Added tests for `gbraid` and `wbraid` mapping when `gclid` is absent.
- **`posthog/models/integration/google_ads.py`**: Documented conversion action query endpoints for click identifiers (`gclid`, `gbraid`, `wbraid`).
- **`posthog/models/test/integration/test_google_ads.py`**: Added test case for listing Google Ads conversion actions.
- **`products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py`**: Added tests for customer ID formatting helpers.

### Validation
- Validated template inputs, Hog code execution logic, and unit tests.
