### PR TITLE
fix(workflows): put both team email cap keys in one valkey cluster slot

### DIFF
--- a/nodejs/src/cdp/services/messaging/email.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.test.ts
@@ -16,7 +16,7 @@ import { TeamWorkflowsConfigService } from '../managers/team-workflows-config.se
 import { RateLimiterService } from '../rate-limiter/rate-limiter.service'
 import { selectEmailSenderIntegrationId } from './email-sender-selection'
 import { EmailSuppressionService, emailSuppressionConfigFromEnv } from './email-suppression.service'
-import { EmailService, parseAddressList, sanitizeEmailSubject, teamEmailCapBuckets } from './email.service'
+import { EmailService, parseAddressList, sanitizeEmailSubject } from './email.service'
 import { MailDevAPI } from './helpers/maildev'
 import { EmailTrackingCodeSigner } from './helpers/tracking-code'
 
@@ -64,19 +64,6 @@ describe('parseAddressList', () => {
         expect(parseAddressList(undefined)).toBeUndefined()
         expect(parseAddressList('')).toBeUndefined()
         expect(parseAddressList(',')).toBeUndefined()
-    })
-})
-
-describe('teamEmailCapBuckets', () => {
-    it('gives both bucket keys the same cluster hash tag', () => {
-        // Enforce mode claims both keys in one Lua call, and clustered Valkey hashes only the
-        // substring inside the first {...}. Keys without a shared hash tag pass here against
-        // single-node Valkey but fail every claim in production with a CROSSSLOT error, which
-        // fail-closed turns into delaying every send.
-        const keys = teamEmailCapBuckets(42, 100, 1000).map((bucket) => bucket.key)
-        const hashTags = keys.map((key) => key.match(/\{([^}]+)\}/)?.[1])
-        expect(hashTags[0]).toBeTruthy()
-        expect(hashTags[1]).toBe(hashTags[0])
     })
 })
 

--- a/nodejs/src/cdp/services/messaging/email.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.test.ts
@@ -16,7 +16,7 @@ import { TeamWorkflowsConfigService } from '../managers/team-workflows-config.se
 import { RateLimiterService } from '../rate-limiter/rate-limiter.service'
 import { selectEmailSenderIntegrationId } from './email-sender-selection'
 import { EmailSuppressionService, emailSuppressionConfigFromEnv } from './email-suppression.service'
-import { EmailService, parseAddressList, sanitizeEmailSubject } from './email.service'
+import { EmailService, parseAddressList, sanitizeEmailSubject, teamEmailCapBuckets } from './email.service'
 import { MailDevAPI } from './helpers/maildev'
 import { EmailTrackingCodeSigner } from './helpers/tracking-code'
 
@@ -64,6 +64,19 @@ describe('parseAddressList', () => {
         expect(parseAddressList(undefined)).toBeUndefined()
         expect(parseAddressList('')).toBeUndefined()
         expect(parseAddressList(',')).toBeUndefined()
+    })
+})
+
+describe('teamEmailCapBuckets', () => {
+    it('gives both bucket keys the same cluster hash tag', () => {
+        // Enforce mode claims both keys in one Lua call, and clustered Valkey hashes only the
+        // substring inside the first {...}. Keys without a shared hash tag pass here against
+        // single-node Valkey but fail every claim in production with a CROSSSLOT error, which
+        // fail-closed turns into delaying every send.
+        const keys = teamEmailCapBuckets(42, 100, 1000).map((bucket) => bucket.key)
+        const hashTags = keys.map((key) => key.match(/\{([^}]+)\}/)?.[1])
+        expect(hashTags[0]).toBeTruthy()
+        expect(hashTags[1]).toBe(hashTags[0])
     })
 })
 

--- a/nodejs/src/cdp/services/messaging/email.service.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.ts
@@ -167,11 +167,14 @@ type TeamEmailCapBucket = {
     label: string
 }
 
-function teamEmailCapBuckets(teamId: number, hourlyCap: number, dailyCap: number): TeamEmailCapBucket[] {
+// The `{teamId}` hash tag puts both bucket keys in the same cluster slot. Enforce mode claims
+// both keys in one Lua call (claimAllOrNothingPair), and clustered Valkey rejects a multi-key
+// call whose keys hash to different slots with a CROSSSLOT error.
+export function teamEmailCapBuckets(teamId: number, hourlyCap: number, dailyCap: number): TeamEmailCapBucket[] {
     return [
         {
             name: 'hour',
-            key: `@posthog/team-email-rate-hour/${teamId}`,
+            key: `@posthog/team-email-rate-hour/{${teamId}}`,
             capacity: hourlyCap,
             refillPerSecond: hourlyCap / 3600,
             ttlSeconds: TEAM_EMAIL_HOUR_BUCKET_TTL_SECONDS,
@@ -179,7 +182,7 @@ function teamEmailCapBuckets(teamId: number, hourlyCap: number, dailyCap: number
         },
         {
             name: 'day',
-            key: `@posthog/team-email-rate-day/${teamId}`,
+            key: `@posthog/team-email-rate-day/{${teamId}}`,
             capacity: dailyCap,
             refillPerSecond: dailyCap / 86400,
             ttlSeconds: TEAM_EMAIL_DAY_BUCKET_TTL_SECONDS,

--- a/nodejs/src/cdp/services/rate-limiter/rate-limiter.service.ts
+++ b/nodejs/src/cdp/services/rate-limiter/rate-limiter.service.ts
@@ -240,6 +240,11 @@ export class RateLimiterService {
      * nothing, so a caller that retries a multi-token claim cannot drain the buckets while never
      * succeeding. Returns which bucket denied (index into `buckets`), or null when granted.
      * Runtime errors deny with `deniedIndex: null` — fail-closed, like claimUpTo.
+     *
+     * On clustered Valkey the two keys must hash to the same slot (give them the same `{...}`
+     * hash tag), because the Lua script touches both keys in one call and the cluster rejects
+     * cross-slot calls with a CROSSSLOT error. Single-node Valkey accepts any pair of keys, so
+     * tests and local dev do not catch a violation; production does, on every claim.
      */
     public async claimAllOrNothingPair(
         buckets: [Omit<ClaimRequest, 'requested'>, Omit<ClaimRequest, 'requested'>],

--- a/nodejs/src/cdp/services/rate-limiter/rate-limiter.valkey.integration.test.ts
+++ b/nodejs/src/cdp/services/rate-limiter/rate-limiter.valkey.integration.test.ts
@@ -1,0 +1,46 @@
+import Redis from 'ioredis'
+
+import { RedisClient, RedisClientPipeline, RedisV2 } from '~/common/redis/redis-v2'
+
+import { teamEmailCapBuckets } from '../messaging/email.service'
+import { RateLimiterService } from './rate-limiter.service'
+
+const host = process.env.CDP_VALKEY_HOST ?? '127.0.0.1'
+const port = Number(process.env.CDP_VALKEY_PORT ?? 6390)
+
+describe('RateLimiterService on Valkey Cluster', () => {
+    let valkey: Redis.Redis
+    let valkeyPool: RedisV2
+
+    beforeAll(async () => {
+        valkey = new Redis(port, host, { maxRetriesPerRequest: 1 })
+        await valkey.ping()
+        valkeyPool = {
+            useClient: async (_options, callback) => callback(valkey as unknown as RedisClient),
+            usePipeline: async (_options, callback) => {
+                const pipeline = valkey.pipeline() as RedisClientPipeline
+                callback(pipeline)
+                return pipeline.exec()
+            },
+        }
+    })
+
+    afterAll(async () => {
+        await valkey.quit()
+    })
+
+    it('pair-claims the team email cap buckets without a cross-slot rejection', async () => {
+        // Prove the backing store enforces cluster key-slot rules. Without this, swapping the
+        // compose service for a non-cluster Valkey would make the claim below pass vacuously.
+        await expect(valkey.mget('rate-limiter-test-key-a', 'rate-limiter-test-key-b')).rejects.toThrow('CROSSSLOT')
+
+        // A fresh team id per run keeps the buckets cold, so a full grant is the only correct
+        // outcome. The cluster container keeps data between local runs.
+        const teamId = Math.floor(Math.random() * 1_000_000_000)
+        const buckets = teamEmailCapBuckets(teamId, 50, 100)
+        const limiter = new RateLimiterService(valkeyPool, { name: 'team-email-cluster-test' })
+
+        const claim = await limiter.claimAllOrNothingPair([buckets[0], buckets[1]], 10)
+        expect(claim).toEqual({ granted: true, deniedIndex: null })
+    })
+})


### PR DESCRIPTION
## Problem

- With the team email sending caps in enforce mode, every workflow email send is delayed and rescheduled, so no workflow email goes out.
- Enforce mode claims the hour bucket and the day bucket in one Lua call (`claimAllOrNothingPair`).
- The production email Valkey runs in cluster mode. The two bucket keys hash to different slots, so the cluster rejects every claim with a CROSSSLOT error.
- The limiter fails closed on errors, which turns every claim into a denial.
- Shadow mode claims each bucket in its own single-key call, so shadow traffic never exercised this path.

## Changes

- Both bucket keys now carry the team id in a `{...}` hash tag, for example `@posthog/team-email-rate-hour/{123}`. Both keys hash on the tag, land in one slot, and pair claims succeed.
- The key rename abandons the old bucket state, so every team starts once with a fresh allowance.
- Mechanical: the `claimAllOrNothingPair` docstring now states the same-slot constraint for callers.
- Nothing user-visible changes; sends resume under the intended caps.

> [!WARNING]
> Enforce mode must stay off until the email worker runs this fix. With the old image, enforce mode delays every workflow email send.

## How did you test this code?

- Added an integration test that pair-claims the real bucket keys against the dev stack's cluster-mode `valkey-cluster` service, which enforces the same CROSSSLOT rule as production. CI already starts that service for the nodejs suite.
- The test fails with the old keys and passes with the hash-tagged keys; both outcomes were verified locally.
- The test first asserts a tagless `MGET` throws CROSSSLOT, so a swap to a non-cluster backing store cannot make it pass vacuously.
- The rest of the email service suite runs in CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code diagnosed the failure from the tier rollout metrics and worker logs, then wrote this fix. Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions. No open PR fixes this; `gh pr list --search "crossslot"` found nothing. A key-format unit test from the first commit was replaced by the cluster integration test, following the precedent in `hog-watcher.valkey.integration.test.ts`.

