### PR TITLE
fix(experiments): Handle deleted experiment in exposures query runner

### DIFF
--- a/products/experiments/backend/hogql_queries/experiment_exposures_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_exposures_query_runner.py
@@ -72,7 +72,10 @@ class ExperimentExposuresQueryRunner(QueryRunner):
             raise ValidationError("feature_flag key is required")
         self.exposure_criteria = self.query.exposure_criteria
 
-        self.experiment = Experiment.objects.get(id=self.query.experiment_id, team=self.team)
+        try:
+            self.experiment = Experiment.objects.get(id=self.query.experiment_id, team=self.team)
+        except Experiment.DoesNotExist:
+            raise ValidationError(f"Experiment with id {self.query.experiment_id} not found")
         self.feature_flag_key: str = self.experiment.feature_flag.key_without_tombstone()
         # From the DB flag, not the query dict — callers vary in the feature_flag shape they
         # pass (full flag object vs bare filters), and a missed group index would bypass the

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_experiment_exposures_query_runner.py
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_experiment_exposures_query_runner.py
@@ -75,6 +75,17 @@ class TestExperimentExposuresQueryRunner(ExperimentQueryRunnerBaseTest):
 
         self.assertIn("has no variants", str(ctx.exception))
 
+    def test_missing_experiment_raises_validation_error(self):
+        # Cached exposure queries can outlive their experiment; a stale id must
+        # surface as a validation error, not an uncaught Experiment.DoesNotExist.
+        query = self._null_multivariate_query()
+        query.experiment_id = self.experiment.id + 1000
+
+        with self.assertRaises(ValidationError) as ctx:
+            ExperimentExposuresQueryRunner(team=self.team, query=query)
+
+        self.assertIn("not found", str(ctx.exception))
+
     @freeze_time("2024-01-07T12:00:00Z")
     def test_exposure_query_resolves_soft_deleted_feature_flag_key(self):
         # Exposure events are captured under the flag's original key.


### PR DESCRIPTION
## Problem
The exposures query runner looks up its experiment with a bare `Experiment.objects.get()`. Cached exposure queries can outlive their experiment, so a stale id raises an uncaught `Experiment.DoesNotExist` (~92 occurrences/week in error tracking).

## Changes
Catch `Experiment.DoesNotExist` and raise `ValidationError`, matching `ExperimentQueryRunner`. Added a regression test.

## How did you test this code?
Ran the new test (`test_missing_experiment_raises_validation_error`) and mypy on the changed file.