### PR TITLE
fix(desktop): serialize a cloud task snapshot once per run, not per subscriber

### DIFF
--- a/products/desktop/packages/core/src/cloud-task/cloud-task-engine.ts
+++ b/products/desktop/packages/core/src/cloud-task/cloud-task-engine.ts
@@ -754,7 +754,12 @@ export class CloudTaskEngine extends TypedEventEmitter<CloudTaskEvents> {
         key,
         subscribers: existing.subscriberCount,
       });
-      void this.emitCurrentSnapshot(key);
+      // Until the first snapshot is out, the bootstrap in flight delivers it to
+      // every subscriber. Replaying here would fetch and emit the transcript a
+      // second time, and each emit is serialized once per subscription.
+      if (existing.hasEmittedSnapshot) {
+        void this.emitCurrentSnapshot(key);
+      }
       return;
     }
 

--- a/products/desktop/packages/core/src/cloud-task/cloud-task.test.ts
+++ b/products/desktop/packages/core/src/cloud-task/cloud-task.test.ts
@@ -1080,6 +1080,72 @@ describe("CloudTaskEngine", () => {
     await waitFor(() => getWatcherEmittedEntryCount() === 0);
   });
 
+  it("does not replay a snapshot for a subscriber that joins while the watcher is still bootstrapping", async () => {
+    const updates: unknown[] = [];
+    service.on(CloudTaskEvent.Update, (payload) => updates.push(payload));
+
+    const historicalEntry = {
+      type: "notification",
+      timestamp: "2026-01-01T00:00:00Z",
+      notification: {
+        jsonrpc: "2.0",
+        method: "_posthog/console",
+        params: { sessionId: "run-1", level: "info", message: "history" },
+      },
+    };
+
+    mockNetFetch
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          id: "run-1",
+          status: "in_progress",
+          stage: "build",
+          output: null,
+          error_message: null,
+          branch: "main",
+          updated_at: "2026-01-01T00:00:00Z",
+        }),
+      )
+      .mockResolvedValueOnce(
+        createJsonResponse([historicalEntry], 200, { "X-Has-More": "false" }),
+      );
+    mockStreamFetch.mockResolvedValueOnce(createOpenSseResponse(""));
+
+    const input = {
+      taskId: "task-1",
+      runId: "run-1",
+      apiHost: "https://app.example.com",
+      teamId: 2,
+    };
+    service.watch(input);
+    service.watch(input);
+
+    await waitFor(() =>
+      updates.some(
+        (update) => (update as { kind?: string }).kind === "snapshot",
+      ),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const snapshots = updates.filter(
+      (update) => (update as { kind?: string }).kind === "snapshot",
+    );
+    expect(snapshots).toHaveLength(1);
+    // One history page for the bootstrap: the second watch fetched nothing.
+    const historyFetches = mockNetFetch.mock.calls.filter(([input]) =>
+      String(input instanceof Request ? input.url : input).includes(
+        "/session_logs/",
+      ),
+    );
+    expect(historyFetches).toHaveLength(1);
+
+    // The second subscriber still counts, so one unwatch keeps the watcher up.
+    service.unwatch("task-1", "run-1");
+    const watchers = (service as unknown as { watchers: Map<string, unknown> })
+      .watchers;
+    expect(watchers.has("task-1:run-1")).toBe(true);
+  });
+
   it("ignores keepalive SSE events while keeping the stream open", async () => {
     const updates: unknown[] = [];
     service.on(CloudTaskEvent.Update, (payload) => updates.push(payload));

--- a/products/desktop/packages/core/src/cloud-task/cloudTaskClient.ts
+++ b/products/desktop/packages/core/src/cloud-task/cloudTaskClient.ts
@@ -13,6 +13,11 @@ export interface CloudTaskClient {
   }): Promise<void>;
   unwatch(taskId: string, runId: string): Promise<void>;
   retry(taskId: string, runId: string): Promise<void>;
+  /**
+   * Each subscriber calls `watch()` from `onStarted`; the host counts one
+   * subscriber per watch and drops one when the subscription ends. A subscriber
+   * that never watches would still drop a count another subscriber depends on.
+   */
   subscribe(
     taskId: string,
     runId: string,

--- a/products/desktop/packages/core/src/cloud-task/sharedCloudTaskSubscriptions.test.ts
+++ b/products/desktop/packages/core/src/cloud-task/sharedCloudTaskSubscriptions.test.ts
@@ -1,0 +1,145 @@
+import type { CloudTaskUpdatePayload } from "@posthog/shared/domain-types";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type CloudTaskSubscriptionHandlers,
+  SharedCloudTaskSubscriptions,
+} from "./sharedCloudTaskSubscriptions";
+
+type TransportHandlers = CloudTaskSubscriptionHandlers & {
+  onComplete: () => void;
+};
+
+function createTransport() {
+  const opened: Array<{
+    taskId: string;
+    runId: string;
+    handlers: TransportHandlers;
+    unsubscribe: ReturnType<typeof vi.fn>;
+  }> = [];
+  const unwatch = vi.fn(() => Promise.resolve());
+  return {
+    opened,
+    unwatch,
+    subscribe: vi.fn(
+      (taskId: string, runId: string, handlers: TransportHandlers) => {
+        const unsubscribe = vi.fn();
+        opened.push({ taskId, runId, handlers, unsubscribe });
+        return unsubscribe;
+      },
+    ),
+  };
+}
+
+function createHandlers() {
+  return {
+    onUpdate: vi.fn(),
+    onError: vi.fn(),
+    onStarted: vi.fn(),
+  };
+}
+
+const statusUpdate: CloudTaskUpdatePayload = {
+  taskId: "task-1",
+  runId: "run-1",
+  kind: "status",
+  status: "in_progress",
+  stage: null,
+  output: null,
+  errorMessage: null,
+  branch: null,
+};
+
+describe("SharedCloudTaskSubscriptions", () => {
+  it("rides every subscriber of one run on a single transport subscription", () => {
+    const transport = createTransport();
+    const shared = new SharedCloudTaskSubscriptions(transport);
+    const first = createHandlers();
+    const second = createHandlers();
+    const otherRun = createHandlers();
+
+    shared.subscribe("task-1", "run-1", first);
+    shared.subscribe("task-1", "run-1", second);
+    shared.subscribe("task-1", "run-2", otherRun);
+
+    expect(transport.subscribe).toHaveBeenCalledTimes(2);
+    expect(transport.opened.map((entry) => entry.runId)).toEqual([
+      "run-1",
+      "run-2",
+    ]);
+
+    transport.opened[0].handlers.onStarted();
+    transport.opened[0].handlers.onUpdate(statusUpdate);
+
+    expect(first.onStarted).toHaveBeenCalledTimes(1);
+    expect(second.onStarted).toHaveBeenCalledTimes(1);
+    expect(first.onUpdate).toHaveBeenCalledWith(statusUpdate);
+    expect(second.onUpdate).toHaveBeenCalledWith(statusUpdate);
+    expect(otherRun.onStarted).not.toHaveBeenCalled();
+    expect(otherRun.onUpdate).not.toHaveBeenCalled();
+  });
+
+  it("starts a late subscriber and balances its watch when it leaves before the others", async () => {
+    const transport = createTransport();
+    const shared = new SharedCloudTaskSubscriptions(transport);
+    const first = createHandlers();
+    const late = createHandlers();
+
+    const unsubscribeFirst = shared.subscribe("task-1", "run-1", first);
+    transport.opened[0].handlers.onStarted();
+
+    const unsubscribeLate = shared.subscribe("task-1", "run-1", late);
+    expect(late.onStarted).not.toHaveBeenCalled();
+    await Promise.resolve();
+    expect(late.onStarted).toHaveBeenCalledTimes(1);
+    expect(transport.subscribe).toHaveBeenCalledTimes(1);
+
+    unsubscribeLate();
+    expect(transport.unwatch).toHaveBeenCalledWith("task-1", "run-1");
+    expect(transport.opened[0].unsubscribe).not.toHaveBeenCalled();
+
+    unsubscribeFirst();
+    expect(transport.opened[0].unsubscribe).toHaveBeenCalledTimes(1);
+    // The host unwatches the last subscriber itself when the subscription ends.
+    expect(transport.unwatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not unwatch for a subscriber that left before the transport started", () => {
+    const transport = createTransport();
+    const shared = new SharedCloudTaskSubscriptions(transport);
+    const first = createHandlers();
+    const second = createHandlers();
+
+    shared.subscribe("task-1", "run-1", first);
+    const unsubscribeSecond = shared.subscribe("task-1", "run-1", second);
+
+    unsubscribeSecond();
+    transport.opened[0].handlers.onStarted();
+
+    expect(transport.unwatch).not.toHaveBeenCalled();
+    expect(second.onStarted).not.toHaveBeenCalled();
+    expect(first.onStarted).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a transport error to every subscriber and opens a fresh subscription afterwards", () => {
+    const transport = createTransport();
+    const shared = new SharedCloudTaskSubscriptions(transport);
+    const first = createHandlers();
+    const second = createHandlers();
+    const error = new Error("stream closed");
+
+    shared.subscribe("task-1", "run-1", first);
+    shared.subscribe("task-1", "run-1", second);
+    transport.opened[0].handlers.onError(error);
+
+    expect(first.onError).toHaveBeenCalledWith(error);
+    expect(second.onError).toHaveBeenCalledWith(error);
+
+    const replacement = createHandlers();
+    shared.subscribe("task-1", "run-1", replacement);
+    expect(transport.subscribe).toHaveBeenCalledTimes(2);
+
+    transport.opened[1].handlers.onUpdate(statusUpdate);
+    expect(replacement.onUpdate).toHaveBeenCalledWith(statusUpdate);
+    expect(first.onUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/products/desktop/packages/core/src/cloud-task/sharedCloudTaskSubscriptions.ts
+++ b/products/desktop/packages/core/src/cloud-task/sharedCloudTaskSubscriptions.ts
@@ -1,0 +1,133 @@
+import type { CloudTaskUpdatePayload } from "@posthog/shared/domain-types";
+
+export interface CloudTaskSubscriptionHandlers {
+  onUpdate: (update: CloudTaskUpdatePayload) => void;
+  onError: (error: unknown) => void;
+  onStarted: () => void;
+}
+
+/**
+ * The single host subscription a channel rides on. `onComplete` fires when the
+ * host ends the stream without an error.
+ */
+export interface CloudTaskSubscriptionTransport {
+  subscribe(
+    taskId: string,
+    runId: string,
+    handlers: CloudTaskSubscriptionHandlers & { onComplete: () => void },
+  ): () => void;
+  unwatch(taskId: string, runId: string): Promise<void>;
+}
+
+interface Listener {
+  handlers: CloudTaskSubscriptionHandlers;
+  started: boolean;
+}
+
+interface Channel {
+  listeners: Set<Listener>;
+  started: boolean;
+  unsubscribe: () => void;
+}
+
+function channelKey(taskId: string, runId: string): string {
+  return `${taskId}:${runId}`;
+}
+
+/**
+ * Fans one host subscription per task run out to every local subscriber.
+ *
+ * The host serializes each update once per subscription it holds, so N
+ * subscribers to one run would cost N serializations of every transcript
+ * snapshot. Sharing the subscription makes that one.
+ *
+ * Contract kept from the unshared client: each subscriber calls `watch()` from
+ * `onStarted`, and the host unwatches once when the shared subscription ends.
+ * A subscriber that leaves while others stay therefore unwatches explicitly,
+ * so the host's subscriber count still returns to zero.
+ */
+export class SharedCloudTaskSubscriptions {
+  private readonly channels = new Map<string, Channel>();
+
+  constructor(private readonly transport: CloudTaskSubscriptionTransport) {}
+
+  subscribe(
+    taskId: string,
+    runId: string,
+    handlers: CloudTaskSubscriptionHandlers,
+  ): () => void {
+    const key = channelKey(taskId, runId);
+    const channel = this.channels.get(key) ?? this.open(key, taskId, runId);
+    const listener: Listener = { handlers, started: false };
+    channel.listeners.add(listener);
+
+    if (channel.started) {
+      // A late subscriber gets the same start signal the others got, after
+      // `subscribe` has returned, as the transport would deliver it.
+      queueMicrotask(() => {
+        if (channel.listeners.has(listener) && !listener.started) {
+          listener.started = true;
+          handlers.onStarted();
+        }
+      });
+    }
+
+    return () => {
+      if (!channel.listeners.delete(listener)) {
+        return;
+      }
+      if (channel.listeners.size === 0) {
+        if (this.channels.get(key) === channel) {
+          this.channels.delete(key);
+        }
+        channel.unsubscribe();
+        return;
+      }
+      if (listener.started) {
+        void this.transport.unwatch(taskId, runId).catch(() => {});
+      }
+    };
+  }
+
+  private open(key: string, taskId: string, runId: string): Channel {
+    const channel: Channel = {
+      listeners: new Set(),
+      started: false,
+      unsubscribe: () => {},
+    };
+    this.channels.set(key, channel);
+
+    const drop = (): void => {
+      if (this.channels.get(key) === channel) {
+        this.channels.delete(key);
+      }
+    };
+
+    channel.unsubscribe = this.transport.subscribe(taskId, runId, {
+      onStarted: () => {
+        channel.started = true;
+        for (const listener of [...channel.listeners]) {
+          if (listener.started) continue;
+          listener.started = true;
+          listener.handlers.onStarted();
+        }
+      },
+      onUpdate: (update) => {
+        for (const listener of [...channel.listeners]) {
+          listener.handlers.onUpdate(update);
+        }
+      },
+      onError: (error) => {
+        // The host subscription is dead; the next subscriber opens a new one.
+        // Existing listeners keep their own recovery, as they did unshared.
+        drop();
+        for (const listener of [...channel.listeners]) {
+          listener.handlers.onError(error);
+        }
+      },
+      onComplete: drop,
+    });
+
+    return channel;
+  }
+}

--- a/products/desktop/packages/host-router/src/cloud-task-client.ts
+++ b/products/desktop/packages/host-router/src/cloud-task-client.ts
@@ -1,14 +1,33 @@
 import type { CloudTaskClient } from "@posthog/core/cloud-task/cloudTaskClient";
 import type { SendCommandInput } from "@posthog/core/cloud-task/schemas";
+import { SharedCloudTaskSubscriptions } from "@posthog/core/cloud-task/sharedCloudTaskSubscriptions";
 import type { CloudTaskUpdatePayload } from "@posthog/shared/domain-types";
 import { inject, injectable } from "inversify";
 import { HOST_TRPC_CLIENT, type HostTrpcClient } from "./client";
 
 @injectable()
 export class TrpcCloudTaskClient implements CloudTaskClient {
+  private readonly subscriptions: SharedCloudTaskSubscriptions;
+
   constructor(
     @inject(HOST_TRPC_CLIENT) private readonly client: HostTrpcClient,
-  ) {}
+  ) {
+    this.subscriptions = new SharedCloudTaskSubscriptions({
+      subscribe: (taskId, runId, handlers) => {
+        const subscription = this.client.cloudTask.onUpdate.subscribe(
+          { taskId, runId },
+          {
+            onData: handlers.onUpdate,
+            onError: handlers.onError,
+            onStarted: handlers.onStarted,
+            onComplete: handlers.onComplete,
+          },
+        );
+        return () => subscription.unsubscribe();
+      },
+      unwatch: (taskId, runId) => this.unwatch(taskId, runId),
+    });
+  }
 
   getContext(): Promise<{ apiHost: string; teamId: number } | null> {
     return this.client.cloudTask.context.query();
@@ -38,11 +57,11 @@ export class TrpcCloudTaskClient implements CloudTaskClient {
     onError: (error: unknown) => void,
     onStarted: () => void,
   ): () => void {
-    const subscription = this.client.cloudTask.onUpdate.subscribe(
-      { taskId, runId },
-      { onData: onUpdate, onError, onStarted },
-    );
-    return () => subscription.unsubscribe();
+    return this.subscriptions.subscribe(taskId, runId, {
+      onUpdate,
+      onError,
+      onStarted,
+    });
   }
 
   sendCommand(input: SendCommandInput) {


### PR DESCRIPTION
## Problem

- Opening a cloud task with a long transcript in PostHog Desktop freezes the app for several seconds (macOS shows the beach ball).
- A Chrome performance trace of one such load shows the Electron main process blocked for 7.4 s in one task, 6.6 s of it in four back-to-back superjson serializations of the same transcript snapshot (about 1.6 s each). The renderer then spends about 1.4 s receiving each copy and 0.35 s deserializing it.
- The renderer holds three `cloudTask.onUpdate` subscriptions per open cloud task (conversation events, extension events, MCP permission requests). The host serializes every update once per subscription, so one snapshot costs three serializations and three IPC deliveries.
- Each of those subscriptions calls `watch()` when it starts. `watch()` on an existing watcher replays a full snapshot, so three subscribers also produce up to three snapshots. Worst case is nine serializations of the transcript for one task load.

## Changes

- Opening a cloud task now serializes and delivers its transcript snapshot once. The load still costs one serialization (about 1.6 s for this transcript), but no longer multiplies it.
- `TrpcCloudTaskClient.subscribe` shares one host subscription per task run across all local subscribers, through a new `SharedCloudTaskSubscriptions` helper in `@posthog/core`.
  - The host still counts one subscriber per `watch()` and drops one when its subscription ends. A subscriber that leaves while others stay therefore sends an explicit `unwatch()`, so the count still returns to zero.
  - A subscriber that joins after the shared subscription started gets its `onStarted` on a microtask, so it still calls `watch()` and still gets a snapshot, as before.
- `CloudTaskEngine.watch()` no longer replays a snapshot for a subscriber that joins before the first snapshot went out. The bootstrap snapshot in flight reaches every subscriber, so the replay only fetched and emitted the transcript a second time.
- The `CloudTaskClient.subscribe` docstring states the watch/unwatch contract subscribers already depended on. Mechanical.

> [!NOTE]
> A late subscriber still triggers one snapshot replay. That keeps the existing behavior for a consumer that attaches after the transcript loaded, at one serialization instead of three. Cutting the cost of a single serialization (superjson over 2000 log entries) is a possible follow-up, not part of this PR.

## How did you test this code?

- `cloud-task.test.ts`, new case: two `watch()` calls before the bootstrap resolves emit one snapshot and fetch the history page once, and the second subscriber still counts toward the watcher's subscriber count. Fails on master with two history fetches.
- `sharedCloudTaskSubscriptions.test.ts`, new file: two subscribers to one run share one transport subscription and both get every update; a late subscriber gets `onStarted` and its departure sends one `unwatch()` while the last departure unsubscribes the transport; a subscriber that leaves before the transport started sends no `unwatch()`; a transport error reaches every subscriber and the next subscriber opens a fresh transport subscription.
- Ran `vitest` for `packages/core/src/cloud-task`, `tsc --noEmit` for `@posthog/core` and `@posthog/host-router`, and `biome check` on the touched files.
- Not run: the desktop app itself. This sandbox cannot launch Electron, so the before/after wall-clock effect on a real long transcript is unchecked. The trace analysis above is the evidence for the diagnosis.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: Claude in PostHog Desktop (pi harness). Tools: bash, read, edit, write, git_signed_commit, gh.
- Skills invoked: `/posthog-desktop`, `/writing-tests`, `/writing-pr-descriptions`.
- The user reported the freeze and attached a Chrome performance trace. The trace was analyzed with a Python script over the CPU profile samples: the main-process hot path was `transformTRPCResponse` → superjson `serialize` (walker, `addIdentity`, `findArr`), and the renderer hot path was the preload `onMessage` IPC receive plus superjson `deserialize`. Counting the serialize runs gave four identical 1.6 s serializations from one `emitCurrentSnapshot`.
- Duplicate check: `gh pr list --state open --search "cloud task subscription snapshot serialize desktop"` found no open PR for this.
- Nothing in this PR carries material from the session beyond the trace-derived timings above; no customer data is involved.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
