### PR TITLE
fix(experiments): Raise validation error when baseline variant has no exposures

### DIFF
--- a/products/experiments/backend/hogql_queries/test/test_stats_config.py
+++ b/products/experiments/backend/hogql_queries/test/test_stats_config.py
@@ -361,6 +361,7 @@ class TestStatsConfig(APIBaseTest):
             split_baseline_and_test_variants(variants, baseline_key="nonexistent")
 
         self.assertIn("No exposures", str(ctx.exception))
+        self.assertEqual(ctx.exception.get_codes(), ["no_data"])
 
     @parameterized.expand(
         [

--- a/products/experiments/backend/hogql_queries/test/test_stats_config.py
+++ b/products/experiments/backend/hogql_queries/test/test_stats_config.py
@@ -3,6 +3,7 @@ from typing import cast
 from posthog.test.base import APIBaseTest
 
 from parameterized import parameterized
+from rest_framework.exceptions import ValidationError
 
 from posthog.schema import (
     EventsNode,
@@ -356,8 +357,10 @@ class TestStatsConfig(APIBaseTest):
             self.create_variant("test", sum_val=120.0, sum_squares=14500.0, samples=1000),
         ]
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValidationError) as ctx:
             split_baseline_and_test_variants(variants, baseline_key="nonexistent")
+
+        self.assertIn("No exposures", str(ctx.exception))
 
     @parameterized.expand(
         [

--- a/products/experiments/backend/hogql_queries/utils.py
+++ b/products/experiments/backend/hogql_queries/utils.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import Any, Optional, TypeVar
 
 import structlog
+from rest_framework.exceptions import ValidationError
 
 from posthog.schema import (
     ExperimentFunnelMetric,
@@ -142,7 +143,12 @@ def split_baseline_and_test_variants(
 ) -> tuple[V, list[V]]:
     control_variants = [variant for variant in variants if variant.key == baseline_key]
     if not control_variants:
-        raise ValueError("No control variant found")
+        # Expected while an experiment has no exposures for its baseline yet — a
+        # user-facing validation error, not a server error.
+        raise ValidationError(
+            f"No exposures for the '{baseline_key}' variant yet. Results can be calculated once it has data.",
+            code="no_data",
+        )
     if len(control_variants) > 1:
         raise ValueError("Multiple control variants found")
     control_variant = control_variants[0]

--- a/products/experiments/backend/temporal/test_recalculation_activities.py
+++ b/products/experiments/backend/temporal/test_recalculation_activities.py
@@ -804,7 +804,7 @@ class TestCalculateActivity(BaseTest):
             ("out_of_memory", ClickHouseQueryMemoryLimitExceeded(), "out_of_memory"),
             ("byte_limit", ServerException("too many bytes", code=307), "byte_limit"),
             ("validation_error", ValidationError("bad metric config"), "validation_error"),
-            ("config_value_error", ValueError("No control variant found"), "server_error"),
+            ("config_value_error", ValueError("Multiple control variants found"), "server_error"),
         ]
     )
     def test_permanent_error_fails_non_retryable_and_persists_on_first_attempt(


### PR DESCRIPTION
## Problem
`split_baseline_and_test_variants` raises a bare `ValueError("No control variant found")` when the baseline variant has no exposure data. This is an expected state for young or low-traffic experiments, but it surfaces as a raw server error to the user and is classified as `server_error` in the metric error event (~154 occurrences/week in error tracking).

## Changes
Raise `ValidationError(..., code="no_data")` with a message that says the baseline variant has no exposures yet. The experiment error handler already passes `ValidationError` through as user-facing and classifies it as `validation_error`. Retry semantics in recalculation are unchanged — both types are treated as permanent.

## How did you test this code?
Updated and ran the `split_baseline_and_test_variants` tests and the recalculation permanent-error tests (7 passed), plus mypy on the changed file.