### PR TITLE
feat(desktop): add session read state controls

### DIFF
--- a/products/desktop/apps/web/src/web-host-router.ts
+++ b/products/desktop/apps/web/src/web-host-router.ts
@@ -349,9 +349,19 @@ const workspaceStubRouter = router({
     .input(z.object({ taskId: z.string() }))
     .mutation(({ input }) => webTaskMetadataStore.togglePin(input.taskId)),
   markViewed: publicProcedure
-    .input(z.object({ taskId: z.string() }))
+    .input(
+      z.object({
+        taskId: z.string(),
+        activityAtMs: z.number().finite().optional(),
+      }),
+    )
     .mutation(({ input }) => {
-      webTaskMetadataStore.markViewed(input.taskId);
+      webTaskMetadataStore.markViewed(input.taskId, input.activityAtMs);
+    }),
+  markUnread: publicProcedure
+    .input(z.object({ taskId: z.string(), activityAtMs: z.number().finite() }))
+    .mutation(({ input }) => {
+      webTaskMetadataStore.markUnread(input.taskId, input.activityAtMs);
     }),
   markActivity: publicProcedure
     .input(z.object({ taskId: z.string() }))

--- a/products/desktop/apps/web/src/web-task-metadata-store.ts
+++ b/products/desktop/apps/web/src/web-task-metadata-store.ts
@@ -4,7 +4,7 @@ import { createRecordStore } from "./web-local-store";
 // Per-device task metadata (pins + viewed/activity timestamps) for the web host,
 // backed by localStorage. Desktop persists this in a local metadata service
 // (workspace.getPinnedTaskIds / togglePin / getAllTaskTimestamps / markViewed /
-// markActivity). The archive flow reads pins early (getPinnedTaskIds + unpin),
+// markUnread / markActivity). The archive flow reads pins early (getPinnedTaskIds + unpin),
 // so without these the whole archive rejects — hence this store.
 
 const taskMetadataSchema = z.object({
@@ -55,8 +55,34 @@ export const webTaskMetadataStore = {
     return { isPinned: pinnedAt !== null, pinnedAt };
   },
 
-  markViewed(taskId: string): void {
-    update(taskId, { lastViewedAt: new Date().toISOString() });
+  markViewed(taskId: string, activityAtMs?: number): void {
+    const metadata = store.get()[taskId] ?? EMPTY;
+    const storedActivityAtMs = metadata.lastActivityAt
+      ? Date.parse(metadata.lastActivityAt)
+      : 0;
+    update(taskId, {
+      lastViewedAt: new Date(
+        Math.max(
+          Date.now(),
+          activityAtMs ?? 0,
+          Number.isFinite(storedActivityAtMs) ? storedActivityAtMs : 0,
+        ),
+      ).toISOString(),
+    });
+  },
+
+  markUnread(taskId: string, activityAtMs: number): void {
+    const metadata = store.get()[taskId] ?? EMPTY;
+    const storedActivityAtMs = metadata.lastActivityAt
+      ? new Date(metadata.lastActivityAt).getTime()
+      : 0;
+    const effectiveActivityAtMs = Math.max(
+      activityAtMs,
+      Number.isFinite(storedActivityAtMs) ? storedActivityAtMs : 0,
+    );
+    update(taskId, {
+      lastViewedAt: new Date(effectiveActivityAtMs - 1).toISOString(),
+    });
   },
 
   markActivity(taskId: string): void {

--- a/products/desktop/packages/core/src/context-menu/context-menu.test.ts
+++ b/products/desktop/packages/core/src/context-menu/context-menu.test.ts
@@ -86,6 +86,33 @@ describe("ContextMenuService.showTaskContextMenu", () => {
     expect(await pinned).toEqual({ action: { type: "pin" } });
   });
 
+  it.each([
+    {
+      isUnread: false,
+      label: "Mark as unread",
+      otherLabel: "Mark as read",
+      action: "mark-unread" as const,
+    },
+    {
+      isUnread: true,
+      label: "Mark as read",
+      otherLabel: "Mark as unread",
+      action: "mark-read" as const,
+    },
+  ])("offers $label for the current read state", async (testCase) => {
+    const menu = new FakeContextMenu();
+    const result = makeService(menu).showTaskContextMenu({
+      ...baseTask,
+      isUnread: testCase.isUnread,
+    });
+    await menu.shown;
+
+    expect(labels(menu.lastItems)).toContain(testCase.label);
+    expect(labels(menu.lastItems)).not.toContain(testCase.otherLabel);
+    findItem(menu.lastItems, testCase.label).click();
+    expect(await result).toEqual({ action: { type: testCase.action } });
+  });
+
   it("only offers Suspend when the task has a worktree", async () => {
     const withWt = new FakeContextMenu();
     makeService(withWt).showTaskContextMenu({

--- a/products/desktop/packages/core/src/context-menu/context-menu.ts
+++ b/products/desktop/packages/core/src/context-menu/context-menu.ts
@@ -118,6 +118,7 @@ export class ContextMenuService {
       worktreePath,
       folderPath,
       isPinned,
+      isUnread,
       isSuspended,
       canStop,
       isInCommandCenter,
@@ -148,6 +149,9 @@ export class ContextMenuService {
 
     return this.showMenu<TaskAction>([
       this.item(isPinned ? "Unpin" : "Pin", { type: "pin" }),
+      this.item(isUnread ? "Mark as read" : "Mark as unread", {
+        type: isUnread ? "mark-read" : "mark-unread",
+      }),
       this.item("Rename", { type: "rename" }),
       ...(canStop
         ? [this.separator(), this.item("Stop task", { type: "stop" as const })]

--- a/products/desktop/packages/core/src/context-menu/schemas.ts
+++ b/products/desktop/packages/core/src/context-menu/schemas.ts
@@ -13,6 +13,7 @@ export const taskContextMenuInput = z.object({
   worktreePath: z.string().optional(),
   folderPath: z.string().optional(),
   isPinned: z.boolean().optional(),
+  isUnread: z.boolean().optional(),
   isSuspended: z.boolean().optional(),
   canStop: z.boolean().optional(),
   isInCommandCenter: z.boolean().optional(),
@@ -64,6 +65,8 @@ const externalAppAction = z.discriminatedUnion("type", [
 const taskAction = z.discriminatedUnion("type", [
   z.object({ type: z.literal("rename") }),
   z.object({ type: z.literal("pin") }),
+  z.object({ type: z.literal("mark-read") }),
+  z.object({ type: z.literal("mark-unread") }),
   z.object({ type: z.literal("suspend") }),
   z.object({ type: z.literal("stop") }),
   z.object({ type: z.literal("archive") }),

--- a/products/desktop/packages/core/src/tasks/contextMenuActions.test.ts
+++ b/products/desktop/packages/core/src/tasks/contextMenuActions.test.ts
@@ -25,6 +25,12 @@ describe("resolveTaskContextMenuIntent", () => {
     expect(resolveTaskContextMenuIntent({ type: "stop" }, {})).toEqual({
       type: "stop",
     });
+    expect(resolveTaskContextMenuIntent({ type: "mark-read" }, {})).toEqual({
+      type: "mark-read",
+    });
+    expect(resolveTaskContextMenuIntent({ type: "mark-unread" }, {})).toEqual({
+      type: "mark-unread",
+    });
     expect(resolveTaskContextMenuIntent({ type: "handoff" }, {})).toEqual({
       type: "handoff",
     });

--- a/products/desktop/packages/core/src/tasks/contextMenuActions.ts
+++ b/products/desktop/packages/core/src/tasks/contextMenuActions.ts
@@ -7,6 +7,8 @@ import type {
 export type TaskContextMenuIntent =
   | { type: "rename" }
   | { type: "pin" }
+  | { type: "mark-read" }
+  | { type: "mark-unread" }
   | { type: "suspend" }
   | { type: "stop" }
   | { type: "restore" }
@@ -27,6 +29,10 @@ export function resolveTaskContextMenuIntent(
       return { type: "rename" };
     case "pin":
       return { type: "pin" };
+    case "mark-read":
+      return { type: "mark-read" };
+    case "mark-unread":
+      return { type: "mark-unread" };
     case "suspend":
       return flags.isSuspended ? { type: "restore" } : { type: "suspend" };
     case "stop":

--- a/products/desktop/packages/host-router/src/routers/workspace.router.ts
+++ b/products/desktop/packages/host-router/src/routers/workspace.router.ts
@@ -35,6 +35,7 @@ import {
   listRepoCheckoutsInput,
   listRepoCheckoutsOutput,
   markActivityInput,
+  markUnreadInput,
   markViewedInput,
   reconcileCloudWorkspacesInput,
   reconcileCloudWorkspacesOutput,
@@ -202,7 +203,13 @@ export const workspaceRouter = router({
   markViewed: publicProcedure
     .input(markViewedInput)
     .mutation(({ ctx, input }) =>
-      getMetadata(ctx.container).markViewed(input.taskId),
+      getMetadata(ctx.container).markViewed(input.taskId, input.activityAtMs),
+    ),
+
+  markUnread: publicProcedure
+    .input(markUnreadInput)
+    .mutation(({ ctx, input }) =>
+      getMetadata(ctx.container).markUnread(input.taskId, input.activityAtMs),
     ),
 
   markActivity: publicProcedure

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelFeedView.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelFeedView.test.tsx
@@ -41,6 +41,12 @@ vi.mock("@posthog/ui/features/canvas/hooks/useMarkTaskActivityRead", () => ({
 vi.mock("@posthog/ui/features/sidebar/usePinnedTasks", () => ({
   usePinnedTasks: () => ({ togglePin: vi.fn() }),
 }));
+vi.mock("@posthog/ui/features/sidebar/useTaskViewed", () => ({
+  useTaskViewed: () => ({
+    markAsViewed: vi.fn(),
+    markAsUnread: vi.fn(),
+  }),
+}));
 const { archiveTask } = vi.hoisted(() => ({ archiveTask: vi.fn() }));
 vi.mock("@posthog/ui/features/archive/useArchiveTask", () => ({
   useArchiveTask: () => ({ archiveTask }),

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -17,6 +17,7 @@ import type { PrCheck } from "@posthog/core/git/router-schemas";
 import { parsePrNumber } from "@posthog/core/git-interaction/prStatus";
 import { xmlToPlainText } from "@posthog/core/message-editor/content";
 import { isTaskActivelyRunning } from "@posthog/core/sidebar/taskRunning";
+import { taskActivityAt } from "@posthog/core/tasks/taskActivity";
 import {
   AvatarGroup,
   Badge,
@@ -86,6 +87,7 @@ import {
   type SidebarPrState,
   useTaskPrStatus,
 } from "@posthog/ui/features/sidebar/useTaskPrStatus";
+import { useTaskViewed } from "@posthog/ui/features/sidebar/useTaskViewed";
 import { useRenameTask } from "@posthog/ui/features/tasks/useTaskMutations";
 import { FileIcon } from "@posthog/ui/primitives/FileIcon";
 import { useInView } from "@posthog/ui/primitives/hooks/useInView";
@@ -735,6 +737,7 @@ const FeedItem = memo(function FeedItem({
   const statusDisplay = useTaskStatusDisplay(task);
   const taskData = useChannelTaskData(task);
   const { togglePin } = usePinnedTasks();
+  const { markAsViewed, markAsUnread } = useTaskViewed();
   const { archiveTask } = useArchiveTask();
   const { renameTask } = useRenameTask();
   const commandCenterCells = useCommandCenterStore((state) => state.cells);
@@ -852,6 +855,7 @@ const FeedItem = memo(function FeedItem({
       id: task.id,
       title: task.title,
       isPinned: taskData?.isPinned ?? false,
+      isUnread: taskData?.isUnread ?? false,
       task,
       channelId: task.channel ?? undefined,
       onAddToCommandCenter: commandCenterCells.includes(task.id)
@@ -864,6 +868,10 @@ const FeedItem = memo(function FeedItem({
           toast.error("Couldn't update pin", { description: "Try again." });
         });
       },
+      activityAtMs: Date.parse(taskActivityAt(task)),
+      onMarkAsRead: (activityAtMs) => markAsViewed(task.id, activityAtMs),
+      onMarkAsUnread: () =>
+        markAsUnread(task.id, Date.parse(taskActivityAt(task))),
       onArchive: archiveTaskFromFeed,
     }),
     [
@@ -876,7 +884,10 @@ const FeedItem = memo(function FeedItem({
       task.id,
       task.title,
       taskData?.isPinned,
+      taskData?.isUnread,
       togglePin,
+      markAsViewed,
+      markAsUnread,
     ],
   );
   // A chip opens its artifact directly: canvases navigate to the canvas, files

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemHoverCard.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemHoverCard.test.tsx
@@ -63,7 +63,11 @@ function menuFor(model: ChannelItemModel): TaskRowMenuProps {
     id: model.id,
     title: model.title,
     isPinned: false,
+    isUnread: model.unread,
+    activityAtMs: model.ts,
     onTogglePin: () => {},
+    onMarkAsRead: () => {},
+    onMarkAsUnread: () => {},
   };
 }
 

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemPreview.stories.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemPreview.stories.tsx
@@ -108,10 +108,14 @@ const menu: TaskRowMenuProps = {
   id: "task-1",
   title: "Clean up the importer",
   isPinned: false,
+  isUnread: false,
+  activityAtMs: Date.parse("2026-07-17T12:00:00.000Z"),
   channelId: "channel-1",
   onRename: () => {},
   onAddToCommandCenter: () => {},
   onTogglePin: () => {},
+  onMarkAsRead: () => {},
+  onMarkAsUnread: () => {},
   onArchive: () => {},
 };
 

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -84,6 +84,8 @@ import { ChannelItemRow } from "./ChannelItemRow";
 const actions = {
   open: () => {},
   togglePin: () => {},
+  markAsRead: () => {},
+  markAsUnread: () => {},
   setPinned: () => {},
   archive: () => {},
   remove: () => {},
@@ -409,6 +411,7 @@ describe("ChannelItemRow", () => {
   // definition, so both are asserted against the same expectations.
   const MENU_ITEMS = [
     "Pin",
+    "Mark as unread",
     "Rename",
     "Add to Command Center…",
     "File to…",
@@ -453,6 +456,32 @@ describe("ChannelItemRow", () => {
 
     for (const label of MENU_ITEMS) {
       expect(screen.getByRole("menuitem", { name: label })).not.toBeNull();
+    }
+  });
+
+  it.each([
+    { unread: false, label: "Mark as unread", state: "read" },
+    { unread: true, label: "Mark as read", state: "unread" },
+  ])("offers $label for a $state task", ({ unread, label }) => {
+    const markAsRead = vi.fn();
+    const markAsUnread = vi.fn();
+    renderInList(
+      <ChannelItemRow
+        actions={{ ...actions, markAsRead, markAsUnread }}
+        isActive={false}
+        item={item({ unread })}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByText("Investigate signup drop-off"));
+    fireEvent.click(screen.getByRole("menuitem", { name: label }));
+
+    if (unread) {
+      expect(markAsRead).toHaveBeenCalledWith("task-1", item().ts);
+      expect(markAsUnread).not.toHaveBeenCalled();
+    } else {
+      expect(markAsUnread).toHaveBeenCalledWith("task-1", item().ts);
+      expect(markAsRead).not.toHaveBeenCalled();
     }
   });
 
@@ -647,6 +676,7 @@ describe("ChannelItemRow", () => {
     ).not.toBeNull();
     expect(screen.getByRole("button", { name: "File to…" })).not.toBeNull();
     expect(screen.queryByRole("button", { name: "Archive" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Mark as unread" })).toBeNull();
   });
 
   it("does not offer filing for another user's canvas", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
@@ -1,5 +1,6 @@
 import type { ChannelItemModel } from "@posthog/core/canvas/channelItems";
 import { presenceTier } from "@posthog/core/canvas/presence";
+import { taskActivityAt } from "@posthog/core/tasks/taskActivity";
 import {
   AlertDialog,
   AlertDialogClose,
@@ -65,6 +66,8 @@ import {
 export interface ChannelItemActions {
   open: (item: ChannelItemModel) => void;
   togglePin: (item: ChannelItemModel) => void;
+  markAsRead: (taskId: string, activityAtMs: number) => void;
+  markAsUnread: (taskId: string, activityAtMs: number) => void;
   /** Pins or unpins a whole batch, which a drag over the pinned run applies. */
   setPinned: (items: ChannelItemModel[], pinned: boolean) => void;
   archive: (item: ChannelItemModel) => void;
@@ -450,11 +453,22 @@ export function ChannelItemRow({
             id: item.id,
             title: item.title,
             isPinned: item.pinned,
+            isUnread: item.unread,
             task: item.task ?? undefined,
+            activityAtMs: item.task
+              ? Date.parse(taskActivityAt(item.task))
+              : item.ts,
             channelId,
             onAddToCommandCenter,
             onRename,
             onTogglePin: () => actions.togglePin(item),
+            onMarkAsRead: (activityAtMs) =>
+              actions.markAsRead(item.id, activityAtMs),
+            onMarkAsUnread: () =>
+              actions.markAsUnread(
+                item.id,
+                item.task ? Date.parse(taskActivityAt(item.task)) : item.ts,
+              ),
             onArchive: () => actions.archive(item),
             ...(canHandoff ? { onHandoff: () => setHandoffOpen(true) } : {}),
           },

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -13,6 +13,7 @@ import {
 } from "@phosphor-icons/react";
 import type { ChannelItemModel } from "@posthog/core/canvas/channelItems";
 import type { ChannelPresence } from "@posthog/core/canvas/presence";
+import { taskActivityAt } from "@posthog/core/tasks/taskActivity";
 import {
   AlertDialogClose,
   AlertDialogContent,
@@ -481,11 +482,19 @@ const SpaceTaskRow = memo(function SpaceTaskRow({
       id: item.id,
       title: item.title,
       isPinned: item.pinned,
+      isUnread: item.unread,
       task: item.task ?? undefined,
+      activityAtMs: item.task ? Date.parse(taskActivityAt(item.task)) : item.ts,
       // Ticks the space the session is already in, inside "File to…".
       channelId: spaceId,
       onAddToCommandCenter: actions.commandCenterAssigner(item.id),
       onTogglePin: () => actions.togglePin(item),
+      onMarkAsRead: (activityAtMs) => actions.markAsRead(item.id, activityAtMs),
+      onMarkAsUnread: () =>
+        actions.markAsUnread(
+          item.id,
+          item.task ? Date.parse(taskActivityAt(item.task)) : item.ts,
+        ),
       onArchive: () => actions.archive(item),
       ...(canHandoff ? { onHandoff: () => setHandoffOpen(true) } : {}),
     }),

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskFeedPane.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskFeedPane.test.tsx
@@ -18,6 +18,12 @@ vi.mock("@posthog/ui/features/sidebar/usePinnedTasks", () => ({
     setPinnedMany: vi.fn(),
   }),
 }));
+vi.mock("@posthog/ui/features/sidebar/useTaskViewed", () => ({
+  useTaskViewed: () => ({
+    markAsViewed: vi.fn(),
+    markAsUnread: vi.fn(),
+  }),
+}));
 vi.mock("@posthog/ui/features/canvas/hooks/useChannelItems", () => ({
   useChannelSessionFacts: () => ({
     needsInputTaskIds: new Set<string>(),

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskFeedPane.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskFeedPane.tsx
@@ -30,6 +30,7 @@ import {
   useTaskFeedSelectionStore,
 } from "@posthog/ui/features/canvas/stores/taskFeedSelectionStore";
 import { usePinnedTasks } from "@posthog/ui/features/sidebar/usePinnedTasks";
+import { useTaskViewed } from "@posthog/ui/features/sidebar/useTaskViewed";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { useEffect, useMemo } from "react";
@@ -49,6 +50,7 @@ export function TaskFeedPane({
   );
   const archivedTaskIds = useArchivedTaskIds();
   const { pinnedTaskIds, togglePin, setPinnedMany } = usePinnedTasks();
+  const { markAsViewed, markAsUnread } = useTaskViewed();
   const { archiveTask } = useArchiveTask();
   const sessionFacts = useChannelSessionFacts();
   const { openEdit, requestDelete, dialogs } = useSavedSearchActions(feed);
@@ -77,6 +79,8 @@ export function TaskFeedPane({
       togglePin: (item) => {
         togglePin(item.id).catch(() => toast.error("Couldn't update pin"));
       },
+      markAsRead: markAsViewed,
+      markAsUnread,
       setPinned: (pinItems, pinned) => {
         setPinnedMany(
           pinItems.map((item) => item.id),
@@ -87,7 +91,15 @@ export function TaskFeedPane({
         void archiveTask({ taskId: item.id });
       },
     }),
-    [feedId, select, togglePin, setPinnedMany, archiveTask],
+    [
+      feedId,
+      select,
+      togglePin,
+      markAsViewed,
+      markAsUnread,
+      setPinnedMany,
+      archiveTask,
+    ],
   );
 
   useEffect(() => {

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
@@ -35,6 +35,8 @@ import { useOpenBrowserTab } from "@posthog/ui/features/browser-tabs/useOpenBrow
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useFileTaskToChannel } from "@posthog/ui/features/canvas/hooks/useFileTaskToChannel";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
+import { TaskDotMark } from "@posthog/ui/features/sidebar/components/items/TaskStatusDot";
+import { taskDot } from "@posthog/ui/features/sidebar/components/items/taskStatusVocabulary";
 import { useSidebarPeekStore } from "@posthog/ui/features/sidebar/sidebarPeekStore";
 import { useHoldSidebarPeek } from "@posthog/ui/features/sidebar/useHoldSidebarPeek";
 import type { SidebarBulkActions } from "@posthog/ui/features/sidebar/useSidebarBulkActions";
@@ -62,12 +64,10 @@ import {
  * centre, pinned, filed, and deleted. `kind` decides which remaining actions
  * apply.
  */
-export interface TaskRowMenuProps {
-  kind: "task" | "canvas";
+interface TaskRowMenuBase {
   id: string;
   title: string;
   isPinned: boolean;
-  task?: Task;
   /** The channel this item is already filed to, ticked in "File to…". */
   channelId?: string;
   /** Absent when the command centre is full, which disables the item. */
@@ -84,6 +84,21 @@ export interface TaskRowMenuProps {
   /** Owner-only: handing a task to a colleague needs a confirm dialog. */
   onHandoff?: () => void;
 }
+
+export type TaskRowMenuProps = TaskRowMenuBase &
+  (
+    | {
+        kind: "task";
+        isUnread: boolean;
+        activityAtMs: number;
+        task?: Task;
+        onMarkAsRead: (activityAtMs: number) => void;
+        onMarkAsUnread: () => void;
+      }
+    | {
+        kind: "canvas";
+      }
+  );
 
 // The two menus differ only in which primitives draw them, so the item list is
 // written once against this shape. Base UI builds context menus on the same Menu
@@ -190,6 +205,18 @@ function TaskRowMenuItems({
         )}
         {menu.isPinned ? "Unpin" : "Pin"}
       </Item>
+      {isTask && (
+        <Item
+          onClick={
+            menu.isUnread
+              ? () => menu.onMarkAsRead(menu.activityAtMs)
+              : menu.onMarkAsUnread
+          }
+        >
+          <TaskDotMark dot={taskDot({ isUnread: menu.isUnread })} />
+          {menu.isUnread ? "Mark as read" : "Mark as unread"}
+        </Item>
+      )}
       {menu.onRename && (
         <Item onClick={menu.onRename}>
           <PencilSimpleIcon size={14} />

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelItems.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelItems.tsx
@@ -94,6 +94,7 @@ export function useChannelItems(channelId: string): {
   });
   const archivedTaskIds = useArchivedTaskIds();
   const { pinnedTaskIds, togglePin, setPinnedMany } = usePinnedTasks();
+  const { markAsViewed, markAsUnread } = useTaskViewed();
   const { archiveTask } = useArchiveTask({ navigateUnscoped: true });
   const {
     setPinned: setCanvasPinned,
@@ -178,6 +179,8 @@ export function useChannelItems(channelId: string): {
           toast.error("Couldn't update pin");
         });
       },
+      markAsRead: markAsViewed,
+      markAsUnread,
       // One request for the sessions and one per canvas, rather than a toggle
       // per row: pinning is a scoped mutation, so a row-at-a-time batch waits
       // out a round trip for each one.
@@ -249,6 +252,8 @@ export function useChannelItems(channelId: string): {
       navigate,
       setCanvasPinned,
       togglePin,
+      markAsViewed,
+      markAsUnread,
       setPinnedMany,
       archiveTask,
       fileDashboard,

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useRecentSpaceTasks.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useRecentSpaceTasks.test.ts
@@ -1,6 +1,40 @@
-import type { UserBasic } from "@posthog/shared/domain-types";
-import { describe, expect, it } from "vitest";
-import { spacePeople } from "./useRecentSpaceTasks";
+import type { Task, UserBasic } from "@posthog/shared/domain-types";
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  pages: [] as { tasks: Task[]; count: number }[],
+  archivedTaskIds: new Set<string>(),
+  blockedTaskIds: new Set<string>(),
+  pinnedTaskIds: new Set<string>(),
+  viewedAt: {} as Record<
+    string,
+    { lastViewedAt: number | null; lastActivityAt: number | null }
+  >,
+}));
+
+vi.mock("@posthog/ui/features/archive/useArchivedTaskIds", () => ({
+  useArchivedTaskIds: () => mocks.archivedTaskIds,
+}));
+vi.mock("@posthog/ui/features/auth/authClient", () => ({
+  useOptionalAuthenticatedClient: () => ({}),
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useBlockedSessionCount", () => ({
+  useBlockedTaskIds: () => mocks.blockedTaskIds,
+}));
+vi.mock("@posthog/ui/features/sidebar/usePinnedTasks", () => ({
+  usePinnedTasks: () => ({ pinnedTaskIds: mocks.pinnedTaskIds }),
+}));
+vi.mock("@posthog/ui/features/sidebar/useTaskViewed", () => ({
+  useTaskViewed: () => ({ timestamps: mocks.viewedAt }),
+}));
+vi.mock("@tanstack/react-query", () => ({
+  useQueries: () => mocks.pages,
+  useQuery: vi.fn(),
+  useQueryClient: vi.fn(),
+}));
+
+import { spacePeople, useRecentSpaceTasks } from "./useRecentSpaceTasks";
 
 function user(name: string): UserBasic {
   return {
@@ -12,42 +46,93 @@ function user(name: string): UserBasic {
   };
 }
 
+function task(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task-1",
+    task_number: 1,
+    slug: "task-1",
+    title: "Task",
+    description: "",
+    created_at: new Date(500).toISOString(),
+    updated_at: new Date(1_000).toISOString(),
+    last_activity_at: new Date(3_000).toISOString(),
+    origin_product: "user_created",
+    ...overrides,
+  };
+}
+
 const ADA = user("ada");
 const GRACE = user("grace");
 const ALAN = user("alan");
 
-describe("spacePeople", () => {
-  it.each([
-    {
-      case: "puts the creator first even when they ran nothing",
-      createdBy: ADA,
-      ran: [GRACE, ALAN],
-      limit: 5,
-      expected: [ADA, GRACE, ALAN],
-    },
-    {
-      case: "counts the creator once when they also ran something",
-      createdBy: ADA,
-      ran: [GRACE, ADA, GRACE],
-      limit: 5,
-      expected: [ADA, GRACE],
-    },
-    {
-      case: "keeps the creator when the cap cuts the rest",
-      createdBy: ALAN,
-      ran: [ADA, GRACE],
-      limit: 2,
-      expected: [ALAN, ADA],
-    },
-    {
-      case: "leads with whoever ran when the space has no creator",
-      createdBy: null,
-      ran: [GRACE, ADA],
-      limit: 5,
-      expected: [GRACE, ADA],
-    },
-  ])("$case", ({ createdBy, ran, limit, expected }) => {
-    const tasks = ran.map((created_by) => ({ created_by }));
-    expect(spacePeople(tasks, createdBy, limit)).toEqual(expected);
+describe("useRecentSpaceTasks", () => {
+  beforeEach(() => {
+    mocks.pages = [];
+    mocks.archivedTaskIds = new Set();
+    mocks.blockedTaskIds = new Set();
+    mocks.pinnedTaskIds = new Set();
+    mocks.viewedAt = {};
+  });
+
+  it("builds expanded-space rows from live blocked and viewed facts", () => {
+    mocks.pages = [{ tasks: [task()], count: 1 }];
+    mocks.blockedTaskIds = new Set(["task-1"]);
+    mocks.viewedAt = {
+      "task-1": { lastViewedAt: 2_000, lastActivityAt: null },
+    };
+    const spaceIds = ["space-1"];
+
+    const { result, rerender } = renderHook(() =>
+      useRecentSpaceTasks(spaceIds),
+    );
+
+    expect(result.current.get("space-1")?.items[0]).toMatchObject({
+      id: "task-1",
+      needsInput: true,
+      unread: true,
+    });
+
+    mocks.viewedAt = {
+      "task-1": { lastViewedAt: 4_000, lastActivityAt: null },
+    };
+    rerender();
+
+    expect(result.current.get("space-1")?.items[0]?.unread).toBe(false);
+  });
+
+  describe("spacePeople", () => {
+    it.each([
+      {
+        case: "puts the creator first even when they ran nothing",
+        createdBy: ADA,
+        ran: [GRACE, ALAN],
+        limit: 5,
+        expected: [ADA, GRACE, ALAN],
+      },
+      {
+        case: "counts the creator once when they also ran something",
+        createdBy: ADA,
+        ran: [GRACE, ADA, GRACE],
+        limit: 5,
+        expected: [ADA, GRACE],
+      },
+      {
+        case: "keeps the creator when the cap cuts the rest",
+        createdBy: ALAN,
+        ran: [ADA, GRACE],
+        limit: 2,
+        expected: [ALAN, ADA],
+      },
+      {
+        case: "leads with whoever ran when the space has no creator",
+        createdBy: null,
+        ran: [GRACE, ADA],
+        limit: 5,
+        expected: [GRACE, ADA],
+      },
+    ])("$case", ({ createdBy, ran, limit, expected }) => {
+      const tasks = ran.map((created_by) => ({ created_by }));
+      expect(spacePeople(tasks, createdBy, limit)).toEqual(expected);
+    });
   });
 });

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useRecentSpaceTasks.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useRecentSpaceTasks.ts
@@ -1,6 +1,7 @@
 import {
   buildChannelItems,
   type ChannelItemModel,
+  type ChannelSessionFacts,
 } from "@posthog/core/canvas/channelItems";
 import {
   type ChannelPresence,
@@ -56,6 +57,7 @@ export interface SpaceTaskPage {
 }
 
 const NO_PAGE: SpaceTaskPage = { tasks: [], count: 0 };
+const NO_WORKSPACE_FACTS: ChannelSessionFacts["workspaceByTaskId"] = new Map();
 
 /**
  * One space's page, as every caller has to ask for it: the tree's `useQueries`,
@@ -229,6 +231,11 @@ export function useRecentSpaceTasks(
         archivedTaskIds,
         pinnedTaskIds,
         ownedBy: null,
+        sessionFacts: {
+          needsInputTaskIds: blockedTaskIds,
+          viewedTimestamps: viewedAt,
+          workspaceByTaskId: NO_WORKSPACE_FACTS,
+        },
       });
       // A page that came back short is the whole space, so the count is exact
       // once the archived ones are dropped. A full page falls back to the

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useSpaceTaskActions.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useSpaceTaskActions.ts
@@ -2,6 +2,7 @@ import type { ChannelItemModel } from "@posthog/core/canvas/channelItems";
 import { useArchiveTask } from "@posthog/ui/features/archive/useArchiveTask";
 import { useCommandCenterStore } from "@posthog/ui/features/command-center/commandCenterStore";
 import { usePinnedTasks } from "@posthog/ui/features/sidebar/usePinnedTasks";
+import { useTaskViewed } from "@posthog/ui/features/sidebar/useTaskViewed";
 import { toast } from "@posthog/ui/primitives/toast";
 import { navigateToCommandCenter } from "@posthog/ui/router/navigationBridge";
 import { createContext, useContext, useEffect, useMemo, useRef } from "react";
@@ -14,6 +15,8 @@ import { createContext, useContext, useEffect, useMemo, useRef } from "react";
  */
 export interface SpaceTaskActions {
   togglePin: (item: ChannelItemModel) => void;
+  markAsRead: (taskId: string, activityAtMs: number) => void;
+  markAsUnread: (taskId: string, activityAtMs: number) => void;
   archive: (item: ChannelItemModel) => void;
   /**
    * The handler for "Add to Command Center", or nothing when every cell is
@@ -30,6 +33,7 @@ export interface SpaceTaskActions {
  */
 export function useSpaceTaskActions(): SpaceTaskActions {
   const { togglePin } = usePinnedTasks();
+  const { markAsViewed, markAsUnread } = useTaskViewed();
   const { archiveTask } = useArchiveTask();
   const cells = useCommandCenterStore((state) => state.cells);
   const assignTask = useCommandCenterStore((state) => state.assignTask);
@@ -50,6 +54,8 @@ export function useSpaceTaskActions(): SpaceTaskActions {
           toast.error("Couldn't update pin");
         });
       },
+      markAsRead: markAsViewed,
+      markAsUnread,
       archive: (item) => {
         void archiveRef.current({ taskId: item.id });
       },
@@ -63,7 +69,7 @@ export function useSpaceTaskActions(): SpaceTaskActions {
         };
       },
     }),
-    [togglePin, cells, assignTask],
+    [togglePin, markAsViewed, markAsUnread, cells, assignTask],
   );
 }
 

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterView.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterView.tsx
@@ -1,7 +1,8 @@
+import { taskActivityAt } from "@posthog/core/tasks/taskActivity";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { track } from "@posthog/ui/shell/analytics";
 import { Box, Flex } from "@radix-ui/themes";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useSetHeaderContent } from "../../../hooks/useSetHeaderContent";
 import { useTaskViewed } from "../../sidebar/useTaskViewed";
 import { useCommandCenterStore } from "../commandCenterStore";
@@ -36,15 +37,20 @@ export function CommandCenterView() {
     return indices;
   }, [cells]);
 
+  const visibleTasksRef = useRef(cells);
+  visibleTasksRef.current = cells;
   const visibleTaskIdsKey = cells
-    .map((c) => c.taskId)
+    .map((cell) => cell.task?.id)
     .filter(Boolean)
     .join(",");
 
   useEffect(() => {
     if (!visibleTaskIdsKey) return;
-    for (const taskId of visibleTaskIdsKey.split(",")) {
-      markAsViewed(taskId);
+    const visibleTaskIds = new Set(visibleTaskIdsKey.split(","));
+    for (const { task } of visibleTasksRef.current) {
+      if (task && visibleTaskIds.has(task.id)) {
+        markAsViewed(task.id, Date.parse(taskActivityAt(task)));
+      }
     }
   }, [visibleTaskIdsKey, markAsViewed]);
 

--- a/products/desktop/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
@@ -317,6 +317,8 @@ function SidebarMenuComponent() {
           worktreePath: workspace?.worktreePath ?? undefined,
           folderPath: workspace?.folderPath ?? undefined,
           isPinned,
+          isUnread: taskData.isUnread,
+          activityAtMs: taskData.lastActivityAt,
           isSuspended: taskData?.isSuspended,
           canStop:
             taskData?.taskRunEnvironment === "cloud" &&

--- a/products/desktop/packages/ui/src/features/sidebar/taskMetaApi.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/taskMetaApi.ts
@@ -31,8 +31,12 @@ export const taskViewedApi = {
     return parseTimestamps(await workspace().getAllTaskTimestamps.query());
   },
 
-  markAsViewed(taskId: string): void {
-    void workspace().markViewed.mutate({ taskId }).then(invalidateTimestamps);
+  markAsViewed(taskId: string, activityAtMs?: number): void {
+    void workspace()
+      .markViewed.mutate(
+        activityAtMs === undefined ? { taskId } : { taskId, activityAtMs },
+      )
+      .then(invalidateTimestamps);
   },
 
   markActivity(taskId: string): void {

--- a/products/desktop/packages/ui/src/features/sidebar/useTaskViewed.test.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/useTaskViewed.test.tsx
@@ -3,12 +3,14 @@ import type { RawTaskTimestamp } from "@posthog/core/sidebar/taskMeta";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { PropsWithChildren } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const TIMESTAMPS_QUERY_KEY = ["task-timestamps"];
+const NOW_MS = Date.parse("2026-01-01T00:10:00.000Z");
 const mocks = vi.hoisted(() => ({
   loadTimestamps: vi.fn(),
   markActivity: vi.fn(),
+  markUnread: vi.fn(),
   markViewed: vi.fn(),
 }));
 
@@ -31,6 +33,7 @@ vi.mock("@posthog/host-router/react", () => ({
   useHostTRPCClient: () => ({
     workspace: {
       markActivity: { mutate: mocks.markActivity },
+      markUnread: { mutate: mocks.markUnread },
       markViewed: { mutate: mocks.markViewed },
     },
   }),
@@ -38,44 +41,408 @@ vi.mock("@posthog/host-router/react", () => ({
 
 import { useTaskViewed } from "./useTaskViewed";
 
+function createDeferred<Result = void>() {
+  let resolve!: (value: Result | PromiseLike<Result>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<Result>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function createHarness(initialTimestamps: Record<string, RawTaskTimestamp>) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  queryClient.setQueryData(TIMESTAMPS_QUERY_KEY, initialTimestamps);
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  const hook = renderHook(() => useTaskViewed(), { wrapper });
+  return { queryClient, wrapper, ...hook };
+}
+
+function cachedTimestamps(
+  queryClient: QueryClient,
+): Record<string, RawTaskTimestamp> | undefined {
+  return queryClient.getQueryData(TIMESTAMPS_QUERY_KEY);
+}
+
 describe("useTaskViewed", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(Date, "now").mockReturnValue(NOW_MS);
+    mocks.loadTimestamps.mockResolvedValue({});
+    mocks.markActivity.mockResolvedValue(undefined);
+    mocks.markUnread.mockResolvedValue(undefined);
     mocks.markViewed.mockResolvedValue(undefined);
   });
 
-  it("clears unread immediately when a task is viewed", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: {
-        queries: { retry: false },
-        mutations: { retry: false },
-      },
-    });
-    const wrapper = ({ children }: PropsWithChildren) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
-    const activityAt = new Date(Date.now() - 60_000).toISOString();
-    queryClient.setQueryData<Record<string, RawTaskTimestamp>>(
-      TIMESTAMPS_QUERY_KEY,
-      {
-        "task-1": {
-          pinnedAt: null,
-          lastViewedAt: "2026-01-01T00:00:00.000Z",
-          lastActivityAt: null,
-        },
-      },
-    );
-    const { result } = renderHook(() => useTaskViewed(), { wrapper });
+  afterEach(() => vi.restoreAllMocks());
 
-    act(() => result.current.markAsViewed("task-1"));
+  it("shows unread immediately and keeps the final cache after success", async () => {
+    const request = createDeferred();
+    mocks.markUnread.mockReturnValue(request.promise);
+    const activityAt = "2026-01-01T00:01:00.000Z";
+    const initialTask = {
+      pinnedAt: null,
+      lastViewedAt: "2026-01-01T00:02:00.000Z",
+      lastActivityAt: null,
+    };
+    const { queryClient, result } = createHarness({ "task-1": initialTask });
+
+    act(() => result.current.markAsUnread("task-1", Date.parse(activityAt)));
 
     await waitFor(() => {
       expect(
         isTaskUnread(activityAt, result.current.timestamps["task-1"]),
-      ).toBe(false);
+      ).toBe(true);
     });
+    expect(cachedTimestamps(queryClient)?.["task-1"]).toEqual({
+      ...initialTask,
+      lastViewedAt: "2026-01-01T00:00:59.999Z",
+    });
+
+    request.resolve();
+    await waitFor(() => expect(queryClient.isMutating()).toBe(0));
+    expect(cachedTimestamps(queryClient)?.["task-1"]).toEqual({
+      ...initialTask,
+      lastViewedAt: "2026-01-01T00:00:59.999Z",
+    });
+  });
+
+  it("uses supplied activity to clear unread despite device clock skew", async () => {
+    const activityAtMs = Date.parse("2026-01-01T00:20:00.000Z");
+    const storedActivityAt = "2026-01-01T00:30:00.000Z";
+    const { queryClient, result } = createHarness({
+      "task-1": {
+        pinnedAt: null,
+        lastViewedAt: "2026-01-01T00:00:00.000Z",
+        lastActivityAt: storedActivityAt,
+      },
+    });
+
+    act(() => result.current.markAsViewed("task-1", activityAtMs));
+
+    await waitFor(() => expect(mocks.markViewed).toHaveBeenCalledOnce());
     expect(mocks.markViewed).toHaveBeenCalledWith({
       taskId: "task-1",
+      activityAtMs,
     });
+    expect(cachedTimestamps(queryClient)?.["task-1"]?.lastViewedAt).toBe(
+      storedActivityAt,
+    );
+  });
+
+  it("orders each task independently while applying every optimistic update immediately", async () => {
+    const firstTaskViewed = createDeferred();
+    const secondTaskViewed = createDeferred();
+    const firstTaskUnread = createDeferred();
+    mocks.markViewed.mockImplementation(({ taskId }: { taskId: string }) =>
+      taskId === "task-1" ? firstTaskViewed.promise : secondTaskViewed.promise,
+    );
+    mocks.markUnread.mockReturnValue(firstTaskUnread.promise);
+    const taskTwoInitial = {
+      pinnedAt: "2025-12-01T00:00:00.000Z",
+      lastViewedAt: null,
+      lastActivityAt: null,
+    };
+    const { queryClient, result } = createHarness({
+      "task-1": {
+        pinnedAt: null,
+        lastViewedAt: null,
+        lastActivityAt: "2026-01-01T00:01:00.000Z",
+      },
+      "task-2": taskTwoInitial,
+    });
+
+    act(() => {
+      result.current.markAsViewed("task-1");
+      result.current.markAsUnread("task-1", Date.parse("2026-01-01T00:02:00Z"));
+      result.current.markActivity("task-1");
+      result.current.markAsViewed("task-2");
+    });
+
+    await waitFor(() => expect(mocks.markViewed).toHaveBeenCalledTimes(2));
+    expect(mocks.markUnread).not.toHaveBeenCalled();
+    expect(mocks.markActivity).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(cachedTimestamps(queryClient)?.["task-1"]).toEqual({
+        pinnedAt: null,
+        lastViewedAt: "2026-01-01T00:01:59.999Z",
+        lastActivityAt: new Date(NOW_MS).toISOString(),
+      });
+      expect(cachedTimestamps(queryClient)?.["task-2"]).toEqual({
+        ...taskTwoInitial,
+        lastViewedAt: new Date(NOW_MS).toISOString(),
+      });
+    });
+
+    secondTaskViewed.resolve();
+    firstTaskViewed.resolve();
+    await waitFor(() => expect(mocks.markUnread).toHaveBeenCalledOnce());
+    expect(mocks.markActivity).not.toHaveBeenCalled();
+
+    firstTaskUnread.resolve();
+    await waitFor(() => expect(mocks.markActivity).toHaveBeenCalledOnce());
+    await waitFor(() => expect(queryClient.isMutating()).toBe(0));
+    expect(cachedTimestamps(queryClient)?.["task-1"]).toEqual({
+      pinnedAt: null,
+      lastViewedAt: "2026-01-01T00:01:59.999Z",
+      lastActivityAt: new Date(NOW_MS).toISOString(),
+    });
+    expect(cachedTimestamps(queryClient)?.["task-2"]).toEqual({
+      ...taskTwoInitial,
+      lastViewedAt: new Date(NOW_MS).toISOString(),
+    });
+  });
+
+  it("orders requests across hook instances before reconciling an older failure", async () => {
+    const firstViewedRequest = createDeferred();
+    const secondViewedRequest = createDeferred();
+    mocks.markViewed
+      .mockReturnValueOnce(firstViewedRequest.promise)
+      .mockReturnValueOnce(secondViewedRequest.promise);
+    const initialTask = {
+      pinnedAt: null,
+      lastViewedAt: "2026-01-01T00:00:00.000Z",
+      lastActivityAt: null,
+    };
+    const persistedTimestamps = {
+      "task-1": {
+        ...initialTask,
+        lastViewedAt: new Date(NOW_MS).toISOString(),
+      },
+    };
+    mocks.loadTimestamps.mockResolvedValue(persistedTimestamps);
+    const { queryClient, result, wrapper } = createHarness({
+      "task-1": initialTask,
+    });
+    const secondHook = renderHook(() => useTaskViewed(), { wrapper });
+
+    act(() => {
+      result.current.markAsViewed("task-1");
+      secondHook.result.current.markAsViewed("task-1");
+    });
+
+    await waitFor(() => expect(mocks.markViewed).toHaveBeenCalledOnce());
+    expect(cachedTimestamps(queryClient)?.["task-1"]?.lastViewedAt).toBe(
+      new Date(NOW_MS).toISOString(),
+    );
+
+    firstViewedRequest.reject(new Error("first view failed"));
+    await waitFor(() => expect(mocks.markViewed).toHaveBeenCalledTimes(2));
+    expect(mocks.loadTimestamps).not.toHaveBeenCalled();
+    expect(cachedTimestamps(queryClient)?.["task-1"]?.lastViewedAt).toBe(
+      new Date(NOW_MS).toISOString(),
+    );
+
+    secondViewedRequest.resolve();
+    await waitFor(() => expect(mocks.loadTimestamps).toHaveBeenCalled());
+    await waitFor(() => expect(queryClient.isMutating()).toBe(0));
+    expect(cachedTimestamps(queryClient)).toEqual(persistedTimestamps);
+  });
+
+  it("waits for a newer optimistic action before reconciling an older failure", async () => {
+    const viewedRequest = createDeferred();
+    const unreadRequest = createDeferred();
+    mocks.markViewed.mockReturnValue(viewedRequest.promise);
+    mocks.markUnread.mockReturnValue(unreadRequest.promise);
+    const otherTask = {
+      pinnedAt: null,
+      lastViewedAt: "2025-12-01T00:00:00.000Z",
+      lastActivityAt: null,
+    };
+    const initialTask = {
+      pinnedAt: null,
+      lastViewedAt: "2026-01-01T00:00:00.000Z",
+      lastActivityAt: "2026-01-01T00:02:00.000Z",
+    };
+    const persistedTimestamps = {
+      "task-1": {
+        ...initialTask,
+        lastViewedAt: "2026-01-01T00:01:59.999Z",
+      },
+      "task-2": otherTask,
+    };
+    mocks.loadTimestamps.mockResolvedValue(persistedTimestamps);
+    const { queryClient, result } = createHarness({
+      "task-1": initialTask,
+      "task-2": otherTask,
+    });
+
+    act(() => {
+      result.current.markAsViewed(
+        "task-1",
+        Date.parse("2026-01-01T00:03:00.000Z"),
+      );
+      result.current.markAsUnread(
+        "task-1",
+        Date.parse("2026-01-01T00:02:00.000Z"),
+      );
+    });
+    await waitFor(() => expect(mocks.markViewed).toHaveBeenCalledOnce());
+
+    viewedRequest.reject(new Error("view failed"));
+    await waitFor(() => expect(mocks.markUnread).toHaveBeenCalledOnce());
+    expect(cachedTimestamps(queryClient)?.["task-1"]?.lastViewedAt).toBe(
+      "2026-01-01T00:01:59.999Z",
+    );
+    expect(cachedTimestamps(queryClient)?.["task-2"]).toEqual(otherTask);
+
+    unreadRequest.resolve();
+    await waitFor(() => expect(mocks.loadTimestamps).toHaveBeenCalled());
+    await waitFor(() => expect(queryClient.isMutating()).toBe(0));
+    expect(cachedTimestamps(queryClient)).toEqual(persistedTimestamps);
+  });
+
+  it("keeps newer activity optimistic until the failed queue reconciles", async () => {
+    const viewedRequest = createDeferred();
+    const activityRequest = createDeferred();
+    mocks.markViewed.mockReturnValue(viewedRequest.promise);
+    mocks.markActivity.mockReturnValue(activityRequest.promise);
+    const initialTask = {
+      pinnedAt: null,
+      lastViewedAt: "2026-01-01T00:00:00.000Z",
+      lastActivityAt: "2026-01-01T00:01:00.000Z",
+    };
+    const persistedTimestamps = {
+      "task-1": {
+        ...initialTask,
+        lastActivityAt: new Date(NOW_MS + 1).toISOString(),
+      },
+    };
+    mocks.loadTimestamps.mockResolvedValue(persistedTimestamps);
+    const { queryClient, result } = createHarness({ "task-1": initialTask });
+
+    act(() => {
+      result.current.markAsViewed("task-1");
+      result.current.markActivity("task-1");
+    });
+    await waitFor(() => expect(mocks.markViewed).toHaveBeenCalledOnce());
+
+    viewedRequest.reject(new Error("view failed"));
+    await waitFor(() => expect(mocks.markActivity).toHaveBeenCalledOnce());
+    const optimisticActivityAt = new Date(NOW_MS + 1).toISOString();
+    expect(cachedTimestamps(queryClient)?.["task-1"]).toEqual({
+      ...initialTask,
+      lastViewedAt: new Date(NOW_MS).toISOString(),
+      lastActivityAt: optimisticActivityAt,
+    });
+
+    activityRequest.resolve();
+    await waitFor(() => expect(mocks.loadTimestamps).toHaveBeenCalled());
+    await waitFor(() => expect(queryClient.isMutating()).toBe(0));
+    expect(cachedTimestamps(queryClient)).toEqual(persistedTimestamps);
+  });
+
+  it("cancels a reconciliation read before a newer optimistic mutation", async () => {
+    const viewedRequest = createDeferred();
+    const activityRequest = createDeferred();
+    const reconciliationRead =
+      createDeferred<Record<string, RawTaskTimestamp>>();
+    let reconciliationSignal: AbortSignal | undefined;
+    mocks.markViewed.mockReturnValue(viewedRequest.promise);
+    mocks.markActivity.mockReturnValue(activityRequest.promise);
+    mocks.loadTimestamps.mockImplementation(
+      ({ signal }: { signal: AbortSignal }) => {
+        reconciliationSignal = signal;
+        return reconciliationRead.promise;
+      },
+    );
+    const persistedTimestamps = {
+      "task-1": {
+        pinnedAt: null,
+        lastViewedAt: "2026-01-01T00:00:00.000Z",
+        lastActivityAt: null,
+      },
+    };
+    const { queryClient, result } = createHarness(persistedTimestamps);
+
+    act(() => result.current.markAsViewed("task-1"));
+    await waitFor(() => expect(mocks.markViewed).toHaveBeenCalledOnce());
+    viewedRequest.reject(new Error("view failed"));
+    await waitFor(() => expect(mocks.loadTimestamps).toHaveBeenCalled());
+    expect(reconciliationSignal?.aborted).toBe(false);
+
+    act(() => result.current.markActivity("task-1"));
+    await waitFor(() => expect(mocks.markActivity).toHaveBeenCalledOnce());
+    expect(reconciliationSignal?.aborted).toBe(true);
+    expect(cachedTimestamps(queryClient)?.["task-1"]).toEqual({
+      ...persistedTimestamps["task-1"],
+      lastViewedAt: new Date(NOW_MS).toISOString(),
+      lastActivityAt: new Date(NOW_MS + 1).toISOString(),
+    });
+
+    reconciliationRead.resolve(persistedTimestamps);
+    activityRequest.resolve();
+    await waitFor(() => expect(queryClient.isMutating()).toBe(0));
+    expect(cachedTimestamps(queryClient)?.["task-1"]).toEqual({
+      ...persistedTimestamps["task-1"],
+      lastViewedAt: new Date(NOW_MS).toISOString(),
+      lastActivityAt: new Date(NOW_MS + 1).toISOString(),
+    });
+  });
+
+  it("removes only a failed optimistic task that had no prior cache row", async () => {
+    const request = createDeferred();
+    mocks.markActivity.mockReturnValue(request.promise);
+    const otherTask = {
+      pinnedAt: null,
+      lastViewedAt: null,
+      lastActivityAt: "2026-01-01T00:00:00.000Z",
+    };
+    const persistedTimestamps = { "task-2": otherTask };
+    mocks.loadTimestamps.mockResolvedValue(persistedTimestamps);
+    const { queryClient, result } = createHarness(persistedTimestamps);
+
+    act(() => result.current.markActivity("task-1"));
+    await waitFor(() => expect(mocks.markActivity).toHaveBeenCalledOnce());
+    expect(cachedTimestamps(queryClient)?.["task-1"]).toBeDefined();
+
+    request.reject(new Error("activity failed"));
+    await waitFor(() => expect(mocks.loadTimestamps).toHaveBeenCalled());
+    await waitFor(() => expect(queryClient.isMutating()).toBe(0));
+    expect(cachedTimestamps(queryClient)).toEqual(persistedTimestamps);
+  });
+
+  it("returns to committed state after consecutive same-field failures", async () => {
+    const firstViewedRequest = createDeferred();
+    const secondViewedRequest = createDeferred();
+    mocks.markViewed
+      .mockReturnValueOnce(firstViewedRequest.promise)
+      .mockReturnValueOnce(secondViewedRequest.promise);
+    const persistedTimestamps = {
+      "task-1": {
+        pinnedAt: null,
+        lastViewedAt: "2026-01-01T00:00:00.000Z",
+        lastActivityAt: "2026-01-01T00:01:00.000Z",
+      },
+    };
+    mocks.loadTimestamps.mockResolvedValue(persistedTimestamps);
+    const { queryClient, result } = createHarness(persistedTimestamps);
+
+    act(() => {
+      result.current.markAsViewed("task-1");
+      result.current.markAsViewed("task-1");
+    });
+
+    await waitFor(() => expect(mocks.markViewed).toHaveBeenCalledOnce());
+    expect(cachedTimestamps(queryClient)?.["task-1"]?.lastViewedAt).toBe(
+      new Date(NOW_MS).toISOString(),
+    );
+
+    firstViewedRequest.reject(new Error("first view failed"));
+    await waitFor(() => expect(mocks.markViewed).toHaveBeenCalledTimes(2));
+    expect(mocks.loadTimestamps).not.toHaveBeenCalled();
+
+    secondViewedRequest.reject(new Error("second view failed"));
+    await waitFor(() => expect(mocks.loadTimestamps).toHaveBeenCalled());
+    await waitFor(() => expect(queryClient.isMutating()).toBe(0));
+    expect(cachedTimestamps(queryClient)).toEqual(persistedTimestamps);
   });
 });

--- a/products/desktop/packages/ui/src/features/sidebar/useTaskViewed.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/useTaskViewed.ts
@@ -6,6 +6,39 @@ import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useRef } from "react";
 
+const taskMutationQueues = new Map<string, Promise<void>>();
+
+async function waitForTaskMutationQueue(taskId: string): Promise<void> {
+  let continuation = taskMutationQueues.get(taskId);
+  while (continuation) {
+    await continuation;
+    const currentContinuation = taskMutationQueues.get(taskId);
+    if (!currentContinuation || currentContinuation === continuation) {
+      return;
+    }
+    continuation = currentContinuation;
+  }
+}
+
+function enqueueTaskMutation<Result>(
+  taskId: string,
+  request: () => Promise<Result>,
+): Promise<Result> {
+  const previousRequest = taskMutationQueues.get(taskId) ?? Promise.resolve();
+  const requestPromise = previousRequest.then(request);
+  const continuation = requestPromise.then(
+    () => undefined,
+    () => undefined,
+  );
+  taskMutationQueues.set(taskId, continuation);
+  void continuation.then(() => {
+    if (taskMutationQueues.get(taskId) === continuation) {
+      taskMutationQueues.delete(taskId);
+    }
+  });
+  return requestPromise;
+}
+
 export function useTaskViewed() {
   const trpc = useHostTRPC();
   const hostClient = useHostTRPCClient();
@@ -24,91 +57,147 @@ export function useTaskViewed() {
   );
 
   const markViewedMutation = useMutation({
-    mutationFn: ({ taskId }: { taskId: string }) =>
-      hostClient.workspace.markViewed.mutate({ taskId }),
-    onMutate: async ({ taskId }) => {
+    mutationFn: ({
+      taskId,
+      activityAtMs,
+    }: {
+      taskId: string;
+      activityAtMs?: number;
+    }) =>
+      enqueueTaskMutation(taskId, () =>
+        hostClient.workspace.markViewed.mutate(
+          activityAtMs === undefined ? { taskId } : { taskId, activityAtMs },
+        ),
+      ),
+    onMutate: async ({ taskId, activityAtMs }) => {
       await queryClient.cancelQueries({ queryKey: timestampsQueryKey });
-      const previous =
+      const storedActivityAt =
         queryClient.getQueryData<Record<string, RawTaskTimestamp>>(
           timestampsQueryKey,
-        );
-      const now = new Date().toISOString();
+        )?.[taskId]?.lastActivityAt;
+      const storedActivityAtMs = storedActivityAt
+        ? Date.parse(storedActivityAt)
+        : 0;
+      const optimisticLastViewedAt = new Date(
+        Math.max(
+          Date.now(),
+          activityAtMs ?? 0,
+          Number.isFinite(storedActivityAtMs) ? storedActivityAtMs : 0,
+        ),
+      ).toISOString();
       queryClient.setQueryData<Record<string, RawTaskTimestamp>>(
         timestampsQueryKey,
-        (old) => {
-          if (!old)
-            return {
-              [taskId]: {
-                pinnedAt: null,
-                lastViewedAt: now,
-                lastActivityAt: null,
-              },
-            };
-          return {
-            ...old,
-            [taskId]: { ...old[taskId], lastViewedAt: now },
-          };
-        },
+        (old) => ({
+          ...old,
+          [taskId]: {
+            pinnedAt: old?.[taskId]?.pinnedAt ?? null,
+            lastViewedAt: optimisticLastViewedAt,
+            lastActivityAt: old?.[taskId]?.lastActivityAt ?? null,
+          },
+        }),
       );
-      return { previous };
     },
-    onError: (_, __, context) => {
-      if (context?.previous) {
-        queryClient.setQueryData(timestampsQueryKey, context.previous);
-      }
+    onError: async (_, { taskId }) => {
+      await waitForTaskMutationQueue(taskId);
+      await queryClient.invalidateQueries({ queryKey: timestampsQueryKey });
+    },
+  });
+
+  const markUnreadMutation = useMutation({
+    mutationFn: ({
+      taskId,
+      activityAtMs,
+    }: {
+      taskId: string;
+      activityAtMs: number;
+    }) =>
+      enqueueTaskMutation(taskId, () =>
+        hostClient.workspace.markUnread.mutate({ taskId, activityAtMs }),
+      ),
+    onMutate: async ({ taskId, activityAtMs }) => {
+      await queryClient.cancelQueries({ queryKey: timestampsQueryKey });
+      const storedActivityAt =
+        queryClient.getQueryData<Record<string, RawTaskTimestamp>>(
+          timestampsQueryKey,
+        )?.[taskId]?.lastActivityAt;
+      const storedActivityAtMs = storedActivityAt
+        ? new Date(storedActivityAt).getTime()
+        : 0;
+      const effectiveActivityAtMs = Math.max(
+        activityAtMs,
+        Number.isFinite(storedActivityAtMs) ? storedActivityAtMs : 0,
+      );
+      const optimisticLastViewedAt = new Date(
+        effectiveActivityAtMs - 1,
+      ).toISOString();
+      queryClient.setQueryData<Record<string, RawTaskTimestamp>>(
+        timestampsQueryKey,
+        (old) => ({
+          ...old,
+          [taskId]: {
+            pinnedAt: old?.[taskId]?.pinnedAt ?? null,
+            lastActivityAt: old?.[taskId]?.lastActivityAt ?? null,
+            lastViewedAt: optimisticLastViewedAt,
+          },
+        }),
+      );
+    },
+    onError: async (_, { taskId }) => {
+      await waitForTaskMutationQueue(taskId);
+      await queryClient.invalidateQueries({ queryKey: timestampsQueryKey });
     },
   });
 
   const markActivityMutation = useMutation({
     mutationFn: ({ taskId }: { taskId: string }) =>
-      hostClient.workspace.markActivity.mutate({ taskId }),
+      enqueueTaskMutation(taskId, () =>
+        hostClient.workspace.markActivity.mutate({ taskId }),
+      ),
     onMutate: async ({ taskId }) => {
       await queryClient.cancelQueries({ queryKey: timestampsQueryKey });
-      const previous =
+      const previousLastViewedAt =
         queryClient.getQueryData<Record<string, RawTaskTimestamp>>(
           timestampsQueryKey,
-        );
-      const existing = previous?.[taskId];
-      const lastViewedAt = existing?.lastViewedAt
-        ? new Date(existing.lastViewedAt).getTime()
+        )?.[taskId]?.lastViewedAt;
+      const lastViewedAt = previousLastViewedAt
+        ? new Date(previousLastViewedAt).getTime()
         : 0;
       const now = Date.now();
       const activityTime = Math.max(now, lastViewedAt + 1);
-      const activityIso = new Date(activityTime).toISOString();
+      const optimisticLastActivityAt = new Date(activityTime).toISOString();
       queryClient.setQueryData<Record<string, RawTaskTimestamp>>(
         timestampsQueryKey,
-        (old) => {
-          if (!old)
-            return {
-              [taskId]: {
-                pinnedAt: null,
-                lastViewedAt: null,
-                lastActivityAt: activityIso,
-              },
-            };
-          return {
-            ...old,
-            [taskId]: { ...old[taskId], lastActivityAt: activityIso },
-          };
-        },
+        (old) => ({
+          ...old,
+          [taskId]: {
+            pinnedAt: old?.[taskId]?.pinnedAt ?? null,
+            lastViewedAt: old?.[taskId]?.lastViewedAt ?? null,
+            lastActivityAt: optimisticLastActivityAt,
+          },
+        }),
       );
-      return { previous };
     },
-    onError: (_, __, context) => {
-      if (context?.previous) {
-        queryClient.setQueryData(timestampsQueryKey, context.previous);
-      }
+    onError: async (_, { taskId }) => {
+      await waitForTaskMutationQueue(taskId);
+      await queryClient.invalidateQueries({ queryKey: timestampsQueryKey });
     },
   });
 
   const markViewedMutationRef = useRef(markViewedMutation);
   markViewedMutationRef.current = markViewedMutation;
 
+  const markUnreadMutationRef = useRef(markUnreadMutation);
+  markUnreadMutationRef.current = markUnreadMutation;
+
   const markActivityMutationRef = useRef(markActivityMutation);
   markActivityMutationRef.current = markActivityMutation;
 
-  const markAsViewed = useCallback((taskId: string) => {
-    markViewedMutationRef.current.mutate({ taskId });
+  const markAsViewed = useCallback((taskId: string, activityAtMs?: number) => {
+    markViewedMutationRef.current.mutate({ taskId, activityAtMs });
+  }, []);
+
+  const markAsUnread = useCallback((taskId: string, activityAtMs: number) => {
+    markUnreadMutationRef.current.mutate({ taskId, activityAtMs });
   }, []);
 
   const markActivity = useCallback((taskId: string) => {
@@ -129,6 +218,7 @@ export function useTaskViewed() {
     timestamps,
     isLoading,
     markAsViewed,
+    markAsUnread,
     markActivity,
     getLastViewedAt,
     getLastActivityAt,

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
@@ -1,3 +1,4 @@
+import { taskActivityAt } from "@posthog/core/tasks/taskActivity";
 import type { Task } from "@posthog/shared/domain-types";
 import { Box, Flex, Text, Tooltip } from "@radix-ui/themes";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -54,7 +55,7 @@ export function TaskDetail({
 }: TaskDetailProps) {
   const taskId = initialTask.id;
   const { task } = useTaskData({ taskId, initialTask });
-  useMarkTaskViewed(taskId);
+  useMarkTaskViewed(taskId, Date.parse(taskActivityAt(task)));
 
   const effectiveRepoPath = useCwd(taskId);
 

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskOverflowMenu.test.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskOverflowMenu.test.tsx
@@ -1,0 +1,93 @@
+import type { Task } from "@posthog/shared/domain-types";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ACTIVITY_AT = "2026-07-17T12:00:00.000Z";
+const taskViewed = vi.hoisted(() => ({
+  timestamps: {} as Record<
+    string,
+    { lastViewedAt: number | null; lastActivityAt: number | null }
+  >,
+  markAsViewed: vi.fn(),
+  markAsUnread: vi.fn(),
+}));
+
+vi.mock("@posthog/di/react", () => ({ useService: () => ({}) }));
+vi.mock("@posthog/ui/features/sessions/useSession", () => ({
+  useSessionSelector: () => ({
+    isCloud: false,
+    cloudStatus: null,
+    stopRequested: false,
+    taskRunId: null,
+    supportsSummary: false,
+  }),
+}));
+vi.mock("@posthog/ui/features/sessions/sideQuestionStore", () => ({
+  useSideQuestionStore: (selector: (state: { byTaskId: object }) => unknown) =>
+    selector({ byTaskId: {} }),
+}));
+vi.mock("@posthog/ui/features/archive/useTaskArchive", () => ({
+  useTaskArchive: () => ({ requestArchive: vi.fn(), dialog: null }),
+}));
+vi.mock("@posthog/ui/features/sidebar/useTaskViewed", () => ({
+  useTaskViewed: () => taskViewed,
+}));
+vi.mock("@posthog/ui/features/sessions/components/StopCloudRunDialog", () => ({
+  StopCloudRunDialog: () => null,
+}));
+
+import { TaskOverflowMenu } from "./TaskOverflowMenu";
+
+const task = {
+  id: "task-1",
+  task_number: 1,
+  slug: "task-1",
+  title: "Investigate signup drop-off",
+  description: "",
+  created_at: ACTIVITY_AT,
+  updated_at: ACTIVITY_AT,
+  origin_product: "user_created",
+} satisfies Task;
+
+describe("TaskOverflowMenu", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    taskViewed.timestamps = {};
+  });
+
+  it.each([
+    { unread: false, label: "Mark as unread", state: "read" },
+    { unread: true, label: "Mark as read", state: "unread" },
+  ])("offers $label for a $state session", async ({ unread, label }) => {
+    const activityAtMs = Date.parse(ACTIVITY_AT);
+    taskViewed.timestamps = {
+      [task.id]: {
+        lastViewedAt: unread ? activityAtMs - 1 : activityAtMs,
+        lastActivityAt: null,
+      },
+    };
+    const user = userEvent.setup();
+    render(<TaskOverflowMenu task={task} />);
+
+    fireEvent.mouseDown(screen.getByRole("button", { name: "Task actions" }), {
+      button: 0,
+    });
+    await waitFor(() => expect(screen.getByText(label)).toBeInTheDocument());
+    await user.click(screen.getByText(label));
+
+    if (unread) {
+      expect(taskViewed.markAsViewed).toHaveBeenCalledWith(
+        task.id,
+        activityAtMs,
+      );
+      expect(taskViewed.markAsUnread).not.toHaveBeenCalled();
+    } else {
+      expect(taskViewed.markAsUnread).toHaveBeenCalledWith(
+        task.id,
+        activityAtMs,
+      );
+      expect(taskViewed.markAsViewed).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskOverflowMenu.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskOverflowMenu.tsx
@@ -4,6 +4,8 @@ import {
   SESSION_SERVICE,
   type SessionService,
 } from "@posthog/core/sessions/sessionService";
+import { isTaskUnread } from "@posthog/core/sidebar/buildSidebarData";
+import { taskActivityAt } from "@posthog/core/tasks/taskActivity";
 import { useService } from "@posthog/di/react";
 import {
   DropdownMenu,
@@ -24,6 +26,9 @@ import { StopCloudRunDialog } from "@posthog/ui/features/sessions/components/Sto
 import { startSessionSummary } from "@posthog/ui/features/sessions/sessionSummary";
 import { useSideQuestionStore } from "@posthog/ui/features/sessions/sideQuestionStore";
 import { useSessionSelector } from "@posthog/ui/features/sessions/useSession";
+import { TaskDotMark } from "@posthog/ui/features/sidebar/components/items/TaskStatusDot";
+import { taskDot } from "@posthog/ui/features/sidebar/components/items/taskStatusVocabulary";
+import { useTaskViewed } from "@posthog/ui/features/sidebar/useTaskViewed";
 import { useState } from "react";
 import { shallow } from "zustand/shallow";
 
@@ -51,6 +56,9 @@ export function TaskOverflowMenu({ task }: { task: Task }) {
     (s) => s.byTaskId[task.id]?.status === "pending",
   );
   const [stopConfirmOpen, setStopConfirmOpen] = useState(false);
+  const { timestamps, markAsViewed, markAsUnread } = useTaskViewed();
+  const activityAt = taskActivityAt(task);
+  const isUnread = isTaskUnread(activityAt, timestamps[task.id]);
   const { requestArchive, dialog: archiveDialog } = useTaskArchive(task, {
     navigateUnscoped: !task.channel,
   });
@@ -96,6 +104,16 @@ export function TaskOverflowMenu({ task }: { task: Task }) {
                 Summarize for another agent
               </DropdownMenuItem>
             )}
+            <DropdownMenuItem
+              onClick={() =>
+                isUnread
+                  ? markAsViewed(task.id, Date.parse(activityAt))
+                  : markAsUnread(task.id, Date.parse(activityAt))
+              }
+            >
+              <TaskDotMark dot={taskDot({ isUnread })} />
+              {isUnread ? "Mark as read" : "Mark as unread"}
+            </DropdownMenuItem>
             <DropdownMenuItem onClick={requestArchive}>
               Archive
               <DropdownMenuShortcut>

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useMarkTaskViewed.test.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useMarkTaskViewed.test.tsx
@@ -1,10 +1,12 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const markAsViewed = vi.hoisted(() => vi.fn());
+const taskViewed = vi.hoisted(() => ({
+  markAsViewed: vi.fn(),
+}));
 
 vi.mock("@posthog/ui/features/sidebar/useTaskViewed", () => ({
-  useTaskViewed: () => ({ markAsViewed }),
+  useTaskViewed: () => taskViewed,
 }));
 
 import { useMarkTaskViewed } from "./useMarkTaskViewed";
@@ -12,18 +14,21 @@ import { useMarkTaskViewed } from "./useMarkTaskViewed";
 describe("useMarkTaskViewed", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("marks each rendered task as viewed once", () => {
-    const { rerender } = renderHook((taskId) => useMarkTaskViewed(taskId), {
-      initialProps: "task-1",
-    });
+  it("marks only when the task id changes and uses its latest activity", () => {
+    const { rerender } = renderHook(
+      ({ taskId, activityAtMs }) => useMarkTaskViewed(taskId, activityAtMs),
+      {
+        initialProps: { taskId: "task-1", activityAtMs: 1_000 },
+      },
+    );
 
-    expect(markAsViewed).toHaveBeenLastCalledWith("task-1");
+    expect(taskViewed.markAsViewed).toHaveBeenLastCalledWith("task-1", 1_000);
 
-    markAsViewed.mockClear();
-    rerender("task-1");
-    expect(markAsViewed).not.toHaveBeenCalled();
+    taskViewed.markAsViewed.mockClear();
+    rerender({ taskId: "task-1", activityAtMs: 2_000 });
+    expect(taskViewed.markAsViewed).not.toHaveBeenCalled();
 
-    rerender("task-2");
-    expect(markAsViewed).toHaveBeenLastCalledWith("task-2");
+    rerender({ taskId: "task-2", activityAtMs: 3_000 });
+    expect(taskViewed.markAsViewed).toHaveBeenLastCalledWith("task-2", 3_000);
   });
 });

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useMarkTaskViewed.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useMarkTaskViewed.ts
@@ -1,10 +1,12 @@
 import { useTaskViewed } from "@posthog/ui/features/sidebar/useTaskViewed";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
-export function useMarkTaskViewed(taskId: string): void {
+export function useMarkTaskViewed(taskId: string, activityAtMs: number): void {
   const { markAsViewed } = useTaskViewed();
+  const activityAtMsRef = useRef(activityAtMs);
+  activityAtMsRef.current = activityAtMs;
 
   useEffect(() => {
-    markAsViewed(taskId);
+    markAsViewed(taskId, activityAtMsRef.current);
   }, [markAsViewed, taskId]);
 }

--- a/products/desktop/packages/ui/src/features/tasks/useTaskContextMenu.ts
+++ b/products/desktop/packages/ui/src/features/tasks/useTaskContextMenu.ts
@@ -10,6 +10,7 @@ import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelTaskMutations } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
 import { useExternalAppAction } from "@posthog/ui/features/external-apps/useExternalAppAction";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
+import { useTaskViewed } from "@posthog/ui/features/sidebar/useTaskViewed";
 import { useRestoreTask } from "@posthog/ui/features/suspension/useRestoreTask";
 import { useSuspendTask } from "@posthog/ui/features/suspension/useSuspendTask";
 import { useDeleteTask } from "@posthog/ui/features/tasks/useTaskCrudMutations";
@@ -27,6 +28,7 @@ export function useTaskContextMenu() {
   const { archiveTask } = useArchiveTask();
   const { suspendTask } = useSuspendTask();
   const { restoreTask } = useRestoreTask();
+  const { markAsViewed, markAsUnread } = useTaskViewed();
   // "File to…" is a Project Bluebird feature. Gate the channel fetch behind the
   // flag so the submenu (and its API request) never reaches ungated users.
   const bluebirdEnabled = useFeatureFlag(
@@ -44,6 +46,8 @@ export function useTaskContextMenu() {
         worktreePath?: string;
         folderPath?: string;
         isPinned?: boolean;
+        isUnread?: boolean;
+        activityAtMs?: number;
         isSuspended?: boolean;
         canStop?: boolean;
         runId?: string;
@@ -66,6 +70,8 @@ export function useTaskContextMenu() {
         worktreePath,
         folderPath,
         isPinned,
+        isUnread,
+        activityAtMs,
         isSuspended,
         canStop,
         runId,
@@ -87,6 +93,7 @@ export function useTaskContextMenu() {
           worktreePath,
           folderPath,
           isPinned,
+          isUnread,
           isSuspended,
           canStop,
           isInCommandCenter,
@@ -113,6 +120,14 @@ export function useTaskContextMenu() {
             break;
           case "pin":
             onTogglePin?.();
+            break;
+          case "mark-read":
+            markAsViewed(task.id, activityAtMs);
+            break;
+          case "mark-unread":
+            if (activityAtMs !== undefined) {
+              markAsUnread(task.id, activityAtMs);
+            }
             break;
           case "suspend":
             await suspendTask({ taskId: task.id, reason: "manual" });
@@ -189,6 +204,8 @@ export function useTaskContextMenu() {
       channels,
       deleteWithConfirm,
       fileTask,
+      markAsUnread,
+      markAsViewed,
       restoreTask,
       suspendTask,
       hostClient,

--- a/products/desktop/packages/workspace-server/src/services/workspace-metadata/workspace-metadata.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/workspace-metadata/workspace-metadata.test.ts
@@ -91,14 +91,78 @@ describe("WorkspaceMetadataService.markViewed", () => {
     expect(metadataRepo.findByTaskId("t1")).toBeNull();
   });
 
+  it.each([
+    {
+      suppliedActivityAtMs: Date.parse("2026-01-01T00:02:00.000Z"),
+      storedActivityAt: "2026-01-01T00:01:00.000Z",
+      expected: "2026-01-01T00:02:00.000Z",
+    },
+    {
+      suppliedActivityAtMs: Date.parse("2026-01-01T00:01:00.000Z"),
+      storedActivityAt: "2026-01-01T00:02:00.000Z",
+      expected: "2026-01-01T00:02:00.000Z",
+    },
+  ])(
+    "clamps a view to $expected when activity is ahead of the device clock",
+    ({ suppliedActivityAtMs, storedActivityAt, expected }) => {
+      const { service, repo } = createService();
+      repo.findByTaskId.mockReturnValue({
+        taskId: "t1",
+        lastActivityAt: storedActivityAt,
+      });
+
+      service.markViewed("t1", suppliedActivityAtMs);
+
+      expect(repo.updateLastViewedAt).toHaveBeenCalledWith("t1", expected);
+    },
+  );
+
   it("records the view in task_metadata for a rowless task", () => {
     const { service, repo, metadataRepo } = createService();
     repo.findByTaskId.mockReturnValue(undefined);
+    metadataRepo.upsert("t1", {
+      lastActivityAt: "2026-01-01T00:02:00.000Z",
+    });
 
-    service.markViewed("t1");
+    service.markViewed("t1", Date.parse("2026-01-01T00:01:00.000Z"));
 
     expect(repo.updateLastViewedAt).not.toHaveBeenCalled();
-    expect(metadataRepo.findByTaskId("t1")?.lastViewedAt).toBe(NOW_ISO);
+    expect(metadataRepo.findByTaskId("t1")?.lastViewedAt).toBe(
+      "2026-01-01T00:02:00.000Z",
+    );
+  });
+});
+
+describe("WorkspaceMetadataService.markUnread", () => {
+  it("records an unread timestamp on a workspace row", () => {
+    const { service, repo, metadataRepo } = createService();
+    repo.findByTaskId.mockReturnValue({
+      taskId: "t1",
+      lastActivityAt: "2026-01-01T00:01:00.000Z",
+    });
+
+    service.markUnread("t1", new Date(NOW_ISO).getTime());
+
+    expect(repo.updateLastViewedAt).toHaveBeenCalledWith(
+      "t1",
+      "2026-01-01T00:00:59.999Z",
+    );
+    expect(metadataRepo.findByTaskId("t1")).toBeNull();
+  });
+
+  it("records an unread timestamp for a rowless task", () => {
+    const { service, repo, metadataRepo } = createService();
+    repo.findByTaskId.mockReturnValue(undefined);
+    metadataRepo.upsert("t1", {
+      lastActivityAt: "2026-01-01T00:01:00.000Z",
+    });
+
+    service.markUnread("t1", new Date(NOW_ISO).getTime());
+
+    expect(repo.updateLastViewedAt).not.toHaveBeenCalled();
+    expect(metadataRepo.findByTaskId("t1")?.lastViewedAt).toBe(
+      "2026-01-01T00:00:59.999Z",
+    );
   });
 });
 

--- a/products/desktop/packages/workspace-server/src/services/workspace-metadata/workspace-metadata.ts
+++ b/products/desktop/packages/workspace-server/src/services/workspace-metadata/workspace-metadata.ts
@@ -46,9 +46,38 @@ export class WorkspaceMetadataService {
     return { isPinned: newPinnedAt !== null, pinnedAt: newPinnedAt };
   }
 
-  markViewed(taskId: string): void {
-    const lastViewedAt = new Date().toISOString();
-    if (this.workspaceRepo.findByTaskId(taskId)) {
+  markViewed(taskId: string, activityAtMs?: number): void {
+    const workspace = this.workspaceRepo.findByTaskId(taskId);
+    const metadata = workspace ?? this.taskMetadataRepo.findByTaskId(taskId);
+    const storedActivityAtMs = metadata?.lastActivityAt
+      ? Date.parse(metadata.lastActivityAt)
+      : 0;
+    const lastViewedAt = new Date(
+      Math.max(
+        Date.now(),
+        activityAtMs ?? 0,
+        Number.isFinite(storedActivityAtMs) ? storedActivityAtMs : 0,
+      ),
+    ).toISOString();
+    if (workspace) {
+      this.workspaceRepo.updateLastViewedAt(taskId, lastViewedAt);
+      return;
+    }
+    this.taskMetadataRepo.upsert(taskId, { lastViewedAt });
+  }
+
+  markUnread(taskId: string, activityAtMs: number): void {
+    const workspace = this.workspaceRepo.findByTaskId(taskId);
+    const metadata = workspace ?? this.taskMetadataRepo.findByTaskId(taskId);
+    const storedActivityAtMs = metadata?.lastActivityAt
+      ? new Date(metadata.lastActivityAt).getTime()
+      : 0;
+    const effectiveActivityAtMs = Math.max(
+      activityAtMs,
+      Number.isFinite(storedActivityAtMs) ? storedActivityAtMs : 0,
+    );
+    const lastViewedAt = new Date(effectiveActivityAtMs - 1).toISOString();
+    if (workspace) {
       this.workspaceRepo.updateLastViewedAt(taskId, lastViewedAt);
       return;
     }

--- a/products/desktop/packages/workspace-server/src/services/workspace/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/workspace/schemas.ts
@@ -219,6 +219,12 @@ export const togglePinOutput = z.object({
 
 export const markViewedInput = z.object({
   taskId: z.string(),
+  activityAtMs: z.number().finite().optional(),
+});
+
+export const markUnreadInput = z.object({
+  taskId: z.string(),
+  activityAtMs: z.number().finite(),
 });
 
 export const markActivityInput = z.object({


### PR DESCRIPTION
## Problem

People cannot keep a session as a reminder after they read it because session rows have no Read or Unread action.

## Changes

- Session menus now offer **Mark as unread** or **Mark as read** for the current state.
- Unread sessions use the existing solid yellow dot. Read sessions use the existing hollow dot.
- Marking an open session as unread keeps it open and preserves the unread state after navigation.
- Desktop and web store the state on each device with clock-safe timestamps.
- Per-session request queues preserve action order. A failed write reloads the stored state after later writes finish.

Screenshots are not included. The local development profile was signed out, so the session menus were not available for capture.

## How did you test this code?

- Focused Vitest suites cover persistence, menu actions, open-session behavior, clock skew, optimistic updates, request order, and failed-write recovery.
- `pnpm typecheck` passed for all PostHog Desktop packages.
- Scoped Biome checks, the core lint check, host boundary checks, and `hogli ci:preflight --fix` passed.
- The Electron app reached the sign-in screen. The signed-out profile prevented manual session testing.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The current product docs do not describe session read-state controls.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Pi used Explore and General agents for code discovery, implementation, and review.
- Skills used: `/posthog-desktop`, `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/test-electron-app`, `/running-ci-preflight`, and `/writing-pr-descriptions`.
- Duplicate search found [#86926](https://github.com/PostHog/posthog/pull/86926) and [#86928](https://github.com/PostHog/posthog/pull/86928). They change Activity items, not session row state.
- The diff uses repository data and invented test values only.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*