### PR TITLE
fix(csp): make the enforced policy block injected scripts

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -1210,6 +1210,14 @@ class CSPMiddleware:
 
             connect_debug_url = "ws://localhost:8234" if settings.DEBUG or settings.TEST else ""
             frame_ancestors = "https://posthog.com https://preview.posthog.com https://vercel.com"
+            # The script hosts the app loads from outside PostHog: the Turnstile challenge on
+            # signup, Stripe on the billing pages, the Unlayer email editor, and the Tailwind CDN
+            # the message preference pages pull. Every one of them reports today, so the policy
+            # has never covered a script the app depends on.
+            third_party_script_src = (
+                "https://challenges.cloudflare.com https://js.stripe.com "
+                "https://editor.unlayer.com https://cdn.tailwindcss.com"
+            )
             csp_parts = [
                 "default-src 'self'",
                 f"style-src 'self' 'unsafe-inline' {resource_url} https://fonts.googleapis.com",
@@ -1218,8 +1226,10 @@ class CSPMiddleware:
                 # module still requires calling WebAssembly.instantiate from JavaScript, so it grants
                 # nothing to an attacker who cannot already run script, and nothing further to one who
                 # can. Session replay decompresses snapshots with snappy-wasm and the HogQL editor
-                # parses with a WebAssembly build, so both break without it.
-                f"script-src 'self' 'nonce-{nonce}' 'wasm-unsafe-eval' {resource_url} https://*.i.posthog.com",
+                # parses with a WebAssembly build, so both break without it. `'wasm-eval'` is the
+                # older keyword for the same permission. Safari before 16.4 understands only that
+                # one, and reports every WebAssembly compile as a violation without it.
+                f"script-src 'self' 'nonce-{nonce}' 'wasm-unsafe-eval' 'wasm-eval' {resource_url} https://*.i.posthog.com {third_party_script_src}",
                 f"font-src 'self' {resource_url} https://app-static.eu.posthog.com https://app-static-prod.posthog.com https://fonts.gstatic.com https://cdn.jsdelivr.net",
                 "worker-src 'self'",
                 "child-src 'none'",
@@ -1248,35 +1258,48 @@ class CSPMiddleware:
                 "form-action 'self'",
             ]
 
-            # The policy above is report-only, so it protects nothing. App pages still report script
-            # `eval`, inline scripts, blob workers, blob images and data fonts, so it cannot block
-            # today. This second policy does block, and carries the directives the app never
-            # violates. `object-src`, `base-uri`, `form-action` and `frame-ancestors` have no
-            # `default-src` fallback, so naming them is the only way to stop plugin embedding,
-            # base-tag hijacking, form exfiltration and framing.
+            # The policy above is report-only, so it protects nothing. App pages still report blob
+            # workers, blob images and data fonts, so it cannot block today. This second policy
+            # does block, and carries the directives the app never violates. `object-src`,
+            # `base-uri`, `form-action` and `frame-ancestors` have no `default-src` fallback, so
+            # naming them is the only way to stop plugin embedding, base-tag hijacking, form
+            # exfiltration and framing.
             #
             # `default-src 'self'` closes every directive neither policy names, but it is also the
             # fallback for every fetch directive. So each fetch directive repeats here with a value
             # that blocks nothing the app does; without that, enforcing `default-src` would clamp
             # them all. Move a tight value up from the report-only policy once its reports stop.
             permissive = f"'self' blob: data: https: {resource_url}"
+            # A browser blocks an http:// frame inside an https:// page as mixed content, so on a
+            # secure deployment `http:` reaches only a loopback target. It stays where the app
+            # itself runs over http, which covers local development and a plain self-hosted
+            # install. Heatmaps, the toolbar browser and site previews frame the URLs a team
+            # authorized, and almost none of those are http:// targets.
+            frame_src_http = "" if settings.SITE_URL.startswith("https://") else " http:"
             enforced_parts = [
                 "default-src 'self'",
                 "object-src 'none'",
                 "base-uri 'self'",
                 "form-action 'self'",
                 "manifest-src 'self'",
-                # A nonce here would make browsers ignore 'unsafe-inline' and block inline scripts.
-                f"script-src {permissive} 'unsafe-inline' 'unsafe-eval'",
+                # Scripts are the one directive that can block today. Every inline script the app
+                # serves carries the nonce, and the report-only policy named the external hosts
+                # above. What is left violating it comes from a browser extension or from a page
+                # the replay player renders inside our origin, and neither may run. A source list
+                # with a nonce makes browsers ignore `'unsafe-inline'`, so this list omits it, and
+                # omits the `https:` and `data:` sources that would let any host serve script.
+                #
+                # `'unsafe-eval'` is here because the app still calls eval, and stays out of the
+                # report-only policy so those calls keep reporting until they are gone.
+                f"script-src 'self' 'nonce-{nonce}' 'unsafe-eval' 'wasm-unsafe-eval' 'wasm-eval' "
+                f"{resource_url} https://*.i.posthog.com {third_party_script_src}",
                 f"style-src {permissive} 'unsafe-inline'",
                 f"img-src {permissive}",
                 f"font-src {permissive}",
                 f"media-src {permissive}",
                 f"worker-src {permissive}",
                 f"child-src {permissive}",
-                # Heatmaps, the toolbar browser and site previews frame the URLs a team
-                # authorized, and those include http:// targets such as http://localhost:3000.
-                f"frame-src {permissive} http:",
+                f"frame-src {permissive}{frame_src_http}",
                 f"connect-src {permissive} wss: {connect_debug_url}".rstrip(),
             ]
             # `xframe_options_exempt` marks a response a customer is meant to frame on their own

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -1916,17 +1916,29 @@ class TestCSPMiddleware(APIBaseTest):
             assert directive in enforced
         # Enforcing default-src clamps every fetch directive through the fallback, so the ones the
         # app still violates have to be named with a value that blocks nothing.
-        for directive in ["script-src", "style-src", "img-src", "font-src", "worker-src", "frame-src"]:
+        for directive in ["style-src", "img-src", "font-src", "worker-src", "frame-src"]:
             assert f"{directive} 'self' blob: data: https:" in enforced
-        # Heatmaps, the toolbar browser and site previews frame the URLs a team authorized, and
-        # those include http:// targets such as http://localhost:3000.
-        frame_src = next(part for part in enforced.split("; ") if part.startswith("frame-src "))
-        assert "http:" in frame_src.split()
-        # A nonce makes browsers ignore 'unsafe-inline', which would block the app's inline scripts.
-        assert "'unsafe-inline' 'unsafe-eval'" in enforced
-        assert "nonce-" not in enforced
-        # The tight value of each of those directives stays report-only until its reports stop.
+        # script-src is the directive that blocks an injected script. It runs the app's own inline
+        # scripts from the nonce and names every host the app loads script from, so it must carry
+        # neither 'unsafe-inline' nor a scheme source that lets any host serve script.
+        script_src = next(part for part in enforced.split("; ") if part.startswith("script-src "))
+        assert "'nonce-" in script_src
+        assert "'unsafe-inline'" not in script_src
+        assert "https:" not in script_src.split()
+        assert "data:" not in script_src.split()
+        assert "https://challenges.cloudflare.com" in script_src
+        # The tight value of each of the other directives stays report-only until its reports stop.
         assert "worker-src 'self';" in response["Content-Security-Policy-Report-Only"]
+
+    @parameterized.expand([("https", "https://us.posthog.com", False), ("http", "http://localhost:8000", True)])
+    def test_enforced_frame_src_permits_http_where_the_app_runs_on_http(self, _name, site_url, expected):
+        # Heatmaps, the toolbar browser and site previews frame the URLs a team authorized. A
+        # browser blocks an http:// frame inside an https:// page as mixed content, so http: earns
+        # its place only where the app itself runs over http.
+        with override_settings(SITE_URL=site_url):
+            enforced = self._html_response()["Content-Security-Policy"]
+        frame_src = next(part for part in enforced.split("; ") if part.startswith("frame-src "))
+        assert ("http:" in frame_src.split()) is expected
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

- Anyone on an app page still has no protection against an injected script, and the Mozilla Observatory grades `us.posthog.com` a B+ because of it.
- #96110 adds an enforced `Content-Security-Policy` next to the report-only one. Its `script-src` is `'self' blob: data: https: https://*.posthog.com 'unsafe-inline' 'unsafe-eval'`.
- That source list runs any script from any https host, plus any inline script. It closes plugin embedding, base-tag hijacking, form posts and framing, and leaves script injection open.
- The Observatory reads `script-src`. `'unsafe-inline'`, `data:` and `https:` each mark a policy unsafe on their own, so the grade does not move. Base #96110 on this and the enforced header still reads as "almost no policy".

Builds on #96110, which this PR uses as its base branch. Refs #92144.

## Changes

- An injected script no longer runs on an app page. The enforced `script-src` carries the request nonce and names the hosts the app loads script from, so the app's own scripts run and nothing else does.
- Turnstile on signup, Stripe on billing, the Unlayer email editor and the Tailwind CDN on the message preference pages keep working. The report-only policy never named them, so they violated it on every load, and an enforced `script-src` without them would have broken each one.
- WebAssembly stops reporting a violation on older Safari. Those versions read only the legacy `'wasm-eval'` keyword, which now sits next to `'wasm-unsafe-eval'`.
- `http:` leaves the enforced `frame-src` on an https deployment. A browser blocks an http:// frame inside an https:// page as mixed content, so the directive only ever reached a loopback target. It stays where the app itself runs over http, which covers local development and a plain self-hosted install.
- Every other fetch directive keeps the permissive value from #96110, so nothing else changes.

> [!NOTE]
> `'unsafe-eval'` stays in the enforced policy, because the app's own bundles still call `eval`. It is deliberately absent from the report-only policy, so those calls keep reporting until someone removes them. Removing the last one is the step from grade A to A+.

Expected Observatory result: `csp-implemented-with-unsafe-eval` instead of `csp-implemented-with-unsafe-inline`. That is a 10-point penalty in place of a 20-point one, so the score moves from 80 to 90 and the grade from B+ to A.

Nothing looks different in the app, so there is no screenshot.

## How did you test this code?

- `TestCSPMiddleware` now asserts that the enforced `script-src` carries a nonce and holds no `'unsafe-inline'`, no bare `https:` and no `data:`. That is the regression this PR exists to prevent: any one of those three tokens silently turns the directive back into a no-op, and no other test would notice.
- A parameterized case covers `frame-src` per deployment scheme, which is the one directive whose value can stop a page from rendering.
- The three suites that assert on CSP headers pass locally: `posthog/test/test_middleware.py`, `posthog/api/test/test_render_query.py` and `posthog/api/test/test_sharing.py`, plus `test_uploaded_media.py`, `test_external_surveys.py` and `test_message_assets.py`.
- Not checked: no browser ran against this policy. The allowlist comes from the violation stream the report-only policy already collects, so a script host that never reports would not appear in it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code in a PostHog cloud task, prompted to review the Mozilla Observatory grade for `us.posthog.com` and improve the CSP part of it.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/writing-simplified-technical-english`.
- The allowlist and the `frame-src` decision come from reading the CSP violation reports the app already sends to its own project, then confirming each host against this repository. The scoring claims come from reading `mdn/mdn-http-observatory`, which grades the enforced header only.
- No duplicate: `gh pr list --state open --search "csp"` found #96110, which this PR extends rather than replaces. Its enforced header is the plumbing; this PR fixes the one directive that decides whether the header does anything.
- Public artifact: nothing here carries session material. The hosts named are ones this repository already references.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
