### PR TITLE
test(auth): render the organization revocation screens in storybook

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -9612,6 +9612,14 @@ snapshots:
         hash: v1.k794b7964.035587a8b5e312e7090802ce64658770e8203ed95a272199a59fb854d07b8e4c.xPEsURT17vLAz5gEM4ChIgLSXTy8WIipv5pZUUhoSwA
     scenes-other-org-member-invites--current-user-is-owner--light:
         hash: v1.k794b7964.f4fe409e93f3be73dbbd723a795233dafc57b47fa9a10e1586bb123bd4975dfd.oCEutKjA-YPKNncWVj3xSWMHnOgv6_xXWT7ZJr2wVqw
+    scenes-other-organization-deactivated--deactivated--dark:
+        hash: v1.k794b7964.c97f1ed943259f5567c27813c96bbb0566aca0adbf84459ee7d56b2ebea36b57.SgcQHuoYp4dLjnk797pwVsGonoLU6rH2XdLf0lrzefk
+    scenes-other-organization-deactivated--deactivated--light:
+        hash: v1.k794b7964.8b2936f2f73a9576c3f5d8108d81fadb1669eb2f65e20f5d9a79cee96d6103c5.kJep-xkW_R6RDRqH385kSLgRdomjewdycLhO5QpAdd4
+    scenes-other-organization-pending-deletion--pending-deletion--dark:
+        hash: v1.k794b7964.a6c16e6775a08807ece079306c8f686050629a1a3da244534e2b7145c25f7502.SzP_amO7Op2xfUeFilO6OGdks-qkK8byu5m22BfmTkY
+    scenes-other-organization-pending-deletion--pending-deletion--light:
+        hash: v1.k794b7964.b4d3bd0691c3b878ef1fa5a6404b79206e9de433cb52aaf2765246fea64da6c5.rllVi0no6y64yflVpXVCGrC7HibRFl84s-LXEOp4Zi0
     scenes-other-password-reset--initial--dark:
         hash: v1.k794b7964.e3d5f708ff09306e1f06f485f1e389207698e60a0388f606900b947ca5a70ec9.3XJguWf4w1HF8NIOqLCRARBInuoUXmbo9esa81izrrM
     scenes-other-password-reset--initial--light:

--- a/frontend/src/scenes/organization/Deactivated.stories.tsx
+++ b/frontend/src/scenes/organization/Deactivated.stories.tsx
@@ -30,9 +30,7 @@ const meta: Meta = {
                         team: null,
                     },
                 ],
-                // The screen reads the operator's reason off this endpoint, which
-                // `ActiveOrganizationPermission` keeps reachable for exactly this purpose. A
-                // deactivated organization has no other way to learn why it was revoked.
+                // The reason below is the only place a revoked organization learns why.
                 '/api/organizations/@current/': () => [
                     200,
                     {

--- a/frontend/src/scenes/organization/Deactivated.stories.tsx
+++ b/frontend/src/scenes/organization/Deactivated.stories.tsx
@@ -1,0 +1,56 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { App } from 'scenes/App'
+import { urls } from 'scenes/urls'
+
+import { mswDecorator } from '~/mocks/browser'
+
+import preflightJson from '../../mocks/fixtures/_preflight.json'
+
+const meta: Meta = {
+    title: 'Scenes-Other/Organization Deactivated',
+    parameters: {
+        layout: 'fullscreen',
+        viewMode: 'story',
+        mockDate: '2023-02-01',
+        pageUrl: urls.organizationDeactivated(),
+        testOptions: { waitForLoadersToDisappear: true },
+    },
+    decorators: [
+        mswDecorator({
+            get: {
+                '/_preflight': { ...preflightJson, cloud: true, realm: 'cloud' },
+                '/api/users/@me/': () => [
+                    200,
+                    {
+                        email: 'test@posthog.com',
+                        first_name: 'Test PostHog',
+                        organization: { name: 'Test org', teams: [], projects: [] },
+                        organizations: [],
+                        team: null,
+                    },
+                ],
+                // The screen reads the operator's reason off this endpoint, which
+                // `ActiveOrganizationPermission` keeps reachable for exactly this purpose. A
+                // deactivated organization has no other way to learn why it was revoked.
+                '/api/organizations/@current/': () => [
+                    200,
+                    {
+                        id: '018e1b6b-0000-0000-0000-000000000001',
+                        name: 'Test org',
+                        membership_level: 15,
+                        is_active: false,
+                        is_not_active_reason: 'Access revoked due to unpaid balance.',
+                        teams: [],
+                        projects: [],
+                    },
+                ],
+            },
+        }),
+    ],
+}
+export default meta
+
+type Story = StoryObj<{}>
+
+export const Deactivated: Story = { render: () => <App /> }

--- a/frontend/src/scenes/organization/PendingDeletion.stories.tsx
+++ b/frontend/src/scenes/organization/PendingDeletion.stories.tsx
@@ -26,8 +26,6 @@ const meta: Meta = {
                         email: 'test@posthog.com',
                         first_name: 'Test PostHog',
                         organization: { name: 'Test org', teams: [], projects: [] },
-                        // No other organizations, so the switcher stays hidden. The screen with a
-                        // switcher is a different shape and would need its own story.
                         organizations: [],
                         team: null,
                     },

--- a/frontend/src/scenes/organization/PendingDeletion.stories.tsx
+++ b/frontend/src/scenes/organization/PendingDeletion.stories.tsx
@@ -1,0 +1,54 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { App } from 'scenes/App'
+import { urls } from 'scenes/urls'
+
+import { mswDecorator } from '~/mocks/browser'
+
+import preflightJson from '../../mocks/fixtures/_preflight.json'
+
+const meta: Meta = {
+    title: 'Scenes-Other/Organization Pending Deletion',
+    parameters: {
+        layout: 'fullscreen',
+        viewMode: 'story',
+        mockDate: '2023-02-01',
+        pageUrl: urls.organizationPendingDeletion(),
+        testOptions: { waitForLoadersToDisappear: true },
+    },
+    decorators: [
+        mswDecorator({
+            get: {
+                '/_preflight': { ...preflightJson, cloud: true, realm: 'cloud' },
+                '/api/users/@me/': () => [
+                    200,
+                    {
+                        email: 'test@posthog.com',
+                        first_name: 'Test PostHog',
+                        organization: { name: 'Test org', teams: [], projects: [] },
+                        // No other organizations, so the switcher stays hidden. The screen with a
+                        // switcher is a different shape and would need its own story.
+                        organizations: [],
+                        team: null,
+                    },
+                ],
+                '/api/organizations/@current/': () => [
+                    200,
+                    {
+                        id: '018e1b6b-0000-0000-0000-000000000002',
+                        name: 'Test org',
+                        membership_level: 15,
+                        is_pending_deletion: true,
+                        teams: [],
+                        projects: [],
+                    },
+                ],
+            },
+        }),
+    ],
+}
+export default meta
+
+type Story = StoryObj<{}>
+
+export const PendingDeletion: Story = { render: () => <App /> }


### PR DESCRIPTION
## Problem

Nothing rendered either screen a revoked organization lands on — `/organization-deactivated` or `/organization-pending-deletion` — so a break in them shipped silently. Both screens are the whole experience at the moment they appear, and the deactivated one is the only place a customer reads the operator's reason for the revocation.

**Why now:** [#95887](https://github.com/PostHog/posthog/pull/95887) closes the API for a revoked organization, which makes these screens the only remaining way a customer learns what happened. They were split out of that PR because they depend on none of it — the scenes are untouched, so these stories stand alone on `master`.

## Changes

- Both revocation screens now render in Storybook, so a change that breaks one shows up as a visual diff instead of reaching a customer.
- Each story boots the real app at the screen's own URL, so the scene routing and the organization load run for real rather than being mocked around.
- The deactivated story carries an operator reason, which is the string a revoked customer actually reads.
- No production code changes — two new story files, nothing else.

The pending-deletion screen also has an organization-switcher variant, shown only to someone who belongs to another organization. That is a different shape and is deliberately not covered here.

## How did you test this code?

Ran both stories against a local Storybook and confirmed each screen renders: the deactivated screen shows "Your organization has been deactivated." followed by the operator's reason, and the pending-deletion screen shows its disassembling copy.

Both stories are picked up by the Storybook test runner, so CI captures light and dark snapshots for each. This PR introduces 4 new baselines and changes none, so the Visual Review check needs a human to approve them once.

Not checked: dark mode was not rendered locally, only light. The runner's dark snapshot is the first look at it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code, Opus 5). Skills invoked: `/writing-ui-components`, `/writing-tests`, `/stacking-prs`, `/writing-pr-descriptions`.

Split out of [#95887](https://github.com/PostHog/posthog/pull/95887) on request. The rest of that change was left as one PR: `docs/internal/ci-things-already-tried.md` records a rejected attempt to stack two closely coupled layers, with the rule "divide a change by its diff surface, not by its story", and that PR's core edits one module in 7 of its 10 commits. These stories were the only piece with no shared lines — verified by checking that the scenes are byte-identical on `master` and that the stories import nothing the other PR adds.

Modeled on the existing `ErrorProjectUnavailable.stories.tsx`, which uses the same boot-the-real-app-with-mocks approach.

Public artifact: nothing here carries session material; the work came from reading this repository.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
