### PR TITLE
perf(notebooks): reuse unchanged cell parses while editing a SQL cell

### DIFF
--- a/frontend/src/lib/components/MarkdownNotebook/markdown.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/markdown.ts
@@ -23,6 +23,7 @@ import {
     isNotebookPropValue,
     normalizeInlineMarks,
     normalizeInlineNodes,
+    seedNodeFingerprint,
 } from './utils'
 
 type BlockParseResult = {
@@ -1379,7 +1380,29 @@ function makeComponentFallbackParagraph(raw: string): NotebookTextBlockNode {
     }
 }
 
+// Parsing a component tag JSON-decodes its props and fingerprinting re-encodes them, so for a
+// cell that stores a result envelope both costs track the stored result, not the code. Every
+// document parse re-reads every tag, so an unchanged tag (identical raw source) reuses the
+// previously parsed node and its fingerprint. Prop objects are shared between the copies; that
+// is safe because parsed props are never mutated in place (edits build new props objects).
+// Evicted oldest-first under a total size budget, since one tag can carry large cached results.
+const COMPONENT_TAG_CACHE_MAX_ENTRIES = 512
+const COMPONENT_TAG_CACHE_MAX_TOTAL_CHARS = 16_000_000
+const componentTagCache = new Map<string, { node: NotebookComponentBlockNode; fingerprint: string }>()
+let componentTagCacheTotalChars = 0
+
 function parseComponentTag(raw: string): { node: NotebookComponentBlockNode | null; error?: NotebookParseError } {
+    const cached = componentTagCache.get(raw)
+    if (cached) {
+        componentTagCache.delete(raw)
+        componentTagCache.set(raw, cached)
+        // A shallow copy per use: the parse assigns each occurrence its own id, and the cached
+        // template must not see that (or any later startsGroup flag).
+        const node = { ...cached.node }
+        seedNodeFingerprint(node, cached.fingerprint)
+        return { node }
+    }
+
     const match = raw.match(/^<([A-Z][A-Za-z0-9]*)([\s\S]*?)(?:\/>|>[\s\S]*<\/\1>)$/)
     if (!match) {
         return {
@@ -1393,16 +1416,28 @@ function parseComponentTag(raw: string): { node: NotebookComponentBlockNode | nu
     }
 
     const propParseResult = parseComponentProps(match[2] ?? '')
-    return {
-        node: {
-            id: '',
-            type: 'component',
-            tagName: match[1],
-            props: propParseResult.props,
-            raw,
-            errors: propParseResult.errors.length ? propParseResult.errors : undefined,
-        },
+    const node: NotebookComponentBlockNode = {
+        id: '',
+        type: 'component',
+        tagName: match[1],
+        props: propParseResult.props,
+        raw,
+        errors: propParseResult.errors.length ? propParseResult.errors : undefined,
     }
+    componentTagCache.set(raw, { node: { ...node }, fingerprint: getNodeFingerprint(node) })
+    componentTagCacheTotalChars += raw.length
+    while (
+        componentTagCache.size > COMPONENT_TAG_CACHE_MAX_ENTRIES ||
+        componentTagCacheTotalChars > COMPONENT_TAG_CACHE_MAX_TOTAL_CHARS
+    ) {
+        const oldestRaw = componentTagCache.keys().next().value
+        if (oldestRaw === undefined) {
+            break
+        }
+        componentTagCache.delete(oldestRaw)
+        componentTagCacheTotalChars -= oldestRaw.length
+    }
+    return { node }
 }
 
 function parseComponentProps(source: string): PropParseResult {
@@ -1640,6 +1675,11 @@ function getOrderedComponentPropEntries(props: NotebookComponentProps): [string,
     ]
 }
 
+// The whole tag re-serializes when any prop changes, so a big unchanged value (the result
+// envelope of a cell whose code is being typed into) would re-encode on every keystroke.
+// Keyed by object identity, which is safe because prop values are never mutated in place.
+const serializedPropObjectCache = new WeakMap<object, string>()
+
 function serializePropValue(value: NotebookPropValue): string {
     if (typeof value === 'string') {
         return JSON.stringify(value)
@@ -1647,7 +1687,13 @@ function serializePropValue(value: NotebookPropValue): string {
     if (typeof value === 'number' || typeof value === 'boolean' || value === null) {
         return `{${String(value)}}`
     }
-    return `{${JSON.stringify(value)}}`
+    const cachedValue = serializedPropObjectCache.get(value)
+    if (cachedValue !== undefined) {
+        return cachedValue
+    }
+    const serialized = `{${JSON.stringify(value)}}`
+    serializedPropObjectCache.set(value, serialized)
+    return serialized
 }
 
 function serializeImageNode(node: NotebookComponentBlockNode): string {

--- a/frontend/src/lib/components/MarkdownNotebook/markdownRoundTrip.test.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/markdownRoundTrip.test.ts
@@ -288,6 +288,22 @@ describe('markdown round trip', () => {
         })
     })
 
+    describe('repeated parses', () => {
+        it('gives duplicate tags distinct ids and never shares nodes between parses', () => {
+            // The component tag cache reuses parse results by raw source. If it handed out the
+            // cached node itself instead of a copy, the second occurrence (or a later parse of
+            // the same markdown) would overwrite the first one's id in place.
+            const markdown = '<SQLV2 code="select 1" />\n\n<SQLV2 code="select 1" />'
+            const first = parseMarkdownNotebook(markdown)
+            const second = parseMarkdownNotebook(markdown)
+
+            expect(first.nodes).toHaveLength(2)
+            expect(first.nodes[0].id).not.toEqual(first.nodes[1].id)
+            expect(second.nodes.map((node) => node.id)).toEqual(first.nodes.map((node) => node.id))
+            expect(second.nodes[0]).not.toBe(first.nodes[0])
+        })
+    })
+
     describe('html comments', () => {
         it('parses a standalone comment line into a Comment node', () => {
             const document = parseMarkdownNotebook('# Title\n\n<!-- reviewer note -->\n\nBody')

--- a/frontend/src/lib/components/MarkdownNotebook/utils.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/utils.ts
@@ -118,6 +118,12 @@ export function getNodeFingerprint(node: NotebookBlockNode): string {
     return fingerprint
 }
 
+/** Adopt a known fingerprint for a node copy whose fingerprint inputs are shared with the
+ * original (same tagName and props), so the copy skips re-encoding them. */
+export function seedNodeFingerprint(node: NotebookBlockNode, fingerprint: string): void {
+    nodeFingerprintCache.set(node, fingerprint)
+}
+
 function getUncachedNodeFingerprint(node: NotebookBlockNode): string {
     if (node.type === 'paragraph' || node.type === 'heading' || node.type === 'blockquote') {
         return JSON.stringify({

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.ts
@@ -1,4 +1,5 @@
 import { parseMarkdownNotebook } from 'lib/components/MarkdownNotebook/markdown'
+import { NotebookComponentBlockNode } from 'lib/components/MarkdownNotebook/types'
 import { JSONContent } from 'lib/components/RichContentEditor/types'
 
 import { NOTEBOOK_NODE_TYPE_TO_MARKDOWN_TAG, getSqlV2PropsFromQueryProp } from '../Notebook/markdownNotebookV2'
@@ -323,6 +324,35 @@ export const getUniqueSqlV2ReturnVariable = (
     return resolvedReturnVariable
 }
 
+// Every content change re-runs several collectors, and each one re-expands the same markdown
+// attribute. The parse JSON-decodes every cell's props (stored result envelopes included), so
+// it dominates the per-keystroke cost of editing a cell — cache the parsed component blocks
+// per markdown string so one edit pays for one parse. The blocks are shared, read-only input
+// for the walkers below. A few entries, so notebooks mounted side by side don't evict each other.
+const MARKDOWN_COMPONENT_BLOCK_CACHE_MAX_ENTRIES = 4
+const markdownComponentBlockCache = new Map<string, NotebookComponentBlockNode[]>()
+
+const getMarkdownNotebookComponentBlocks = (markdown: string): NotebookComponentBlockNode[] => {
+    const cachedBlocks = markdownComponentBlockCache.get(markdown)
+    if (cachedBlocks) {
+        markdownComponentBlockCache.delete(markdown)
+        markdownComponentBlockCache.set(markdown, cachedBlocks)
+        return cachedBlocks
+    }
+    const blocks = parseMarkdownNotebook(markdown).nodes.filter(
+        (block): block is NotebookComponentBlockNode => block.type === 'component'
+    )
+    markdownComponentBlockCache.set(markdown, blocks)
+    while (markdownComponentBlockCache.size > MARKDOWN_COMPONENT_BLOCK_CACHE_MAX_ENTRIES) {
+        const oldestMarkdown = markdownComponentBlockCache.keys().next().value
+        if (oldestMarkdown === undefined) {
+            break
+        }
+        markdownComponentBlockCache.delete(oldestMarkdown)
+    }
+    return blocks
+}
+
 // Markdown notebooks hold their cells as component tags inside a single markdown attribute,
 // so walking the tiptap JSON alone never finds them. Expand the given cell tag into
 // tiptap-shaped nodes so the collectors and the dependency graph see the same cells in both
@@ -342,10 +372,7 @@ const expandMarkdownNotebookNodesOfTypes = (node: any, nodeTypes: NotebookNodeTy
             nodeTypeByTag.set(tag, nodeType)
         }
     }
-    return parseMarkdownNotebook(node.attrs.markdown).nodes.flatMap((block): JSONContent[] => {
-        if (block.type !== 'component') {
-            return []
-        }
+    return getMarkdownNotebookComponentBlocks(node.attrs.markdown).flatMap((block): JSONContent[] => {
         const nodeType = nodeTypeByTag.get(block.tagName)
         if (!nodeType) {
             return []

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.ts
@@ -1,5 +1,4 @@
 import { parseMarkdownNotebook } from 'lib/components/MarkdownNotebook/markdown'
-import { NotebookComponentBlockNode } from 'lib/components/MarkdownNotebook/types'
 import { JSONContent } from 'lib/components/RichContentEditor/types'
 
 import { NOTEBOOK_NODE_TYPE_TO_MARKDOWN_TAG, getSqlV2PropsFromQueryProp } from '../Notebook/markdownNotebookV2'
@@ -324,35 +323,6 @@ export const getUniqueSqlV2ReturnVariable = (
     return resolvedReturnVariable
 }
 
-// Every content change re-runs several collectors, and each one re-expands the same markdown
-// attribute. The parse JSON-decodes every cell's props (stored result envelopes included), so
-// it dominates the per-keystroke cost of editing a cell — cache the parsed component blocks
-// per markdown string so one edit pays for one parse. The blocks are shared, read-only input
-// for the walkers below. A few entries, so notebooks mounted side by side don't evict each other.
-const MARKDOWN_COMPONENT_BLOCK_CACHE_MAX_ENTRIES = 4
-const markdownComponentBlockCache = new Map<string, NotebookComponentBlockNode[]>()
-
-const getMarkdownNotebookComponentBlocks = (markdown: string): NotebookComponentBlockNode[] => {
-    const cachedBlocks = markdownComponentBlockCache.get(markdown)
-    if (cachedBlocks) {
-        markdownComponentBlockCache.delete(markdown)
-        markdownComponentBlockCache.set(markdown, cachedBlocks)
-        return cachedBlocks
-    }
-    const blocks = parseMarkdownNotebook(markdown).nodes.filter(
-        (block): block is NotebookComponentBlockNode => block.type === 'component'
-    )
-    markdownComponentBlockCache.set(markdown, blocks)
-    while (markdownComponentBlockCache.size > MARKDOWN_COMPONENT_BLOCK_CACHE_MAX_ENTRIES) {
-        const oldestMarkdown = markdownComponentBlockCache.keys().next().value
-        if (oldestMarkdown === undefined) {
-            break
-        }
-        markdownComponentBlockCache.delete(oldestMarkdown)
-    }
-    return blocks
-}
-
 // Markdown notebooks hold their cells as component tags inside a single markdown attribute,
 // so walking the tiptap JSON alone never finds them. Expand the given cell tag into
 // tiptap-shaped nodes so the collectors and the dependency graph see the same cells in both
@@ -372,7 +342,10 @@ const expandMarkdownNotebookNodesOfTypes = (node: any, nodeTypes: NotebookNodeTy
             nodeTypeByTag.set(tag, nodeType)
         }
     }
-    return getMarkdownNotebookComponentBlocks(node.attrs.markdown).flatMap((block): JSONContent[] => {
+    return parseMarkdownNotebook(node.attrs.markdown).nodes.flatMap((block): JSONContent[] => {
+        if (block.type !== 'component') {
+            return []
+        }
         const nodeType = nodeTypeByTag.get(block.tagName)
         if (!nodeType) {
             return []


### PR DESCRIPTION
## Problem

- Typing in a SQL or Python cell of a markdown notebook lags, and the lag grows with the results the notebook has stored, not with what the user types.
- Cells persist their result envelopes (rows, and base64 images on Python cells) inside the markdown component tags.
- Every keystroke commits the document, and the content selectors re-parse the full markdown. Each parse JSON-decodes every cell's stored result and re-encodes it again for node fingerprints.
- Serializing the document back re-encodes the edited cell's whole result envelope on every keystroke, even though only its code changed.

Complements [#96326](https://github.com/PostHog/posthog/pull/96326) (dependency graph scan) and #95652 (one shared parse per edit across collectors). This PR removes the result-proportional cost inside each parse and serialize.

## Changes

- Typing in a result-heavy notebook stays responsive: in a benchmark on a 20-cell notebook with 50-row results (676 KB of markdown), the per-keystroke selector cost dropped from 49 ms to 23 ms with this PR alone, and to 7.6 ms combined with a shared collector parse like #95652.
- The parser reuses a parsed component tag, and its fingerprint, when the tag's raw source is unchanged, so a re-parse only decodes the edited cell. Each use gets a shallow node copy, so per-document ids stay independent; the shared props are safe because parsed props are never mutated in place.
- The serializer memoizes object prop values by identity, so the edited cell's unchanged result envelope is not re-encoded per keystroke.
- The tag cache evicts oldest-first under a total size budget; the prop cache is a WeakMap.
- No behavior changes: parse and serialize output are byte-identical, and duplicate tags keep their occurrence-based ids.

## How did you test this code?

- All existing `MarkdownNotebook` and `scenes/notebooks` Jest suites pass, guarding that parse and serialize output did not change.
- Added one test: repeated parses of the same markdown give duplicate tags distinct ids and share no node objects between parses. No existing test parses the same markdown twice, so none would catch the tag cache handing out its cached node instead of a copy.
- Measured with a throwaway benchmark (not committed): the three content selectors run per keystroke on a synthetic 20-cell notebook with 50-row result envelopes.
- Not run: Playwright and backend suites; the change is confined to frontend markdown parse and serialize code. The full `tsgo` check reports only pre-existing errors from the unbuilt quill workspace in this sandbox, identical on master.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code (PostHog Desktop task) from a request to analyze where SQL-cell editing time goes in markdown notebooks and ship fixes.
- Skills invoked: /writing-tests, /writing-pr-descriptions.
- No duplicate: an initial version also shared one parse across the collectors; that duplicated open #95652, so it was reverted in this branch and only the parser-level caches remain. #93637 targets React render and effect costs on the same surface and does not overlap these caches.
- Public artifact: benchmark data and fixtures are synthetic; nothing from the session is included.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
