### PR TITLE
chore(product-analytics): hold the trends watch scope with an invariant

### DIFF
--- a/posthog/test/repo_invariants/test_model_crossing_uses.py
+++ b/posthog/test/repo_invariants/test_model_crossing_uses.py
@@ -19,6 +19,10 @@ and runs; `drives(<Name>)` is a name it imports from there. `hogli product:lint`
 in the product's contract-check inputs while a line stands, so the isolated tests stay sound. A new
 line is a new outside test that drives product code, and that test belongs in the product.
 
+A product may watch one subtree of that location instead of the whole of it, once every other
+subtree has no line left. The second test below holds that scope: it fails when a line names
+something outside the watched subtree, because the watch would then miss the code the line drives.
+
 The check is strict equality, not "no worse than": a line that disappears must be deleted from the
 file in the same change, so the file can never go stale behind the code.
 
@@ -27,7 +31,14 @@ Regenerate after removing uses:
     bin/hogli product:crossings --all --write-baseline
 """
 
-from hogli_commands.product.crossings import BASELINE_PATH, all_crossing_uses, disallowed_uses, read_baseline
+from hogli_commands.product.crossings import (
+    BASELINE_PATH,
+    all_crossing_uses,
+    disallowed_uses,
+    names_defined_in,
+    read_baseline,
+    wiring_location_label,
+)
 
 REGENERATE = "bin/hogli product:crossings --all --write-baseline"
 
@@ -56,4 +67,28 @@ def test_disallowed_crossing_uses_match_the_baseline() -> None:
         "products/architecture.md § Wiring couplings can add a line.\n"
         f"A '-' line means a use went away — good, but the file must record that too. Run: {REGENERATE}\n"
         f"{report}"
+    )
+
+
+# product_analytics watches backend/hogql_queries/trends/ alone, because trends is the only subtree
+# tests outside the product still drive. These are the query kinds whose dispatch reaches it. Do not
+# extend this set to release a line for another subtree: widen the inputs in
+# products/product_analytics/turbo.json instead, or the suite stops re-running on a change the line
+# says it must cover.
+TRENDS_KINDS = frozenset({"TrendsQuery", "CalendarHeatmapQuery"})
+WATCHED_SUBTREE = "backend/hogql_queries/trends/"
+
+
+def test_product_analytics_drives_only_the_watched_subtree() -> None:
+    label = wiring_location_label("product_analytics", "backend/hogql_queries/")
+    watched = {f"drives({name})" for name in TRENDS_KINDS | names_defined_in("product_analytics", WATCHED_SUBTREE)}
+    outside = sorted(
+        line for line in read_baseline() if line.startswith(f"{label} ") and line.split()[2] not in watched
+    )
+    assert not outside, (
+        f"{BASELINE_PATH.name} has drives lines for product_analytics that name code outside "
+        f"{WATCHED_SUBTREE}, which is the only subtree products/product_analytics/turbo.json watches. "
+        "A change to the subtree the line names would skip the Django suite. Either move the driving "
+        "test into the product, or widen the contract-check inputs to backend/hogql_queries/**.\n"
+        + "\n".join(f"  {line}" for line in outside)
     )

--- a/products/architecture.md
+++ b/products/architecture.md
@@ -108,7 +108,7 @@ These cross the boundary as classes — allowed only under all three rules:
    Nothing is declared. Move the driving tests into the product, regenerate the baseline, and the input may leave.
    A location with several subtrees may be watched one subtree at a time.
    `product_analytics` watches `backend/hogql_queries/trends/` alone, because trends is the only subtree an outside test still drives, so its funnels, retention, lifecycle, paths and stickiness runners change without re-running the suite.
-   The lint reads coverage per location rather than per subtree, so nothing mechanical holds that scope yet.
+   The lint reads coverage per location rather than per subtree, so it cannot hold that scope; the repo invariant `test_product_analytics_drives_only_the_watched_subtree` does, and it fails when a line names code outside the watched subtree.
    The other locations stay in the inputs by presence until their channel (Celery task names, Temporal workflow names, Max tool names) is read the same way.
 3. **Validated registration.**
    Registration points check `issubclass(cls, Base)` and reject anything else.

--- a/tools/hogli-commands/hogli_commands/product/crossings.py
+++ b/tools/hogli-commands/hogli_commands/product/crossings.py
@@ -803,6 +803,15 @@ def _wiring_location_exports(product: str, location: str) -> dict[_Export, str]:
     return exports
 
 
+def names_defined_in(product: str, location: str) -> frozenset[str]:
+    """The names a wiring location, or a subtree of one, defines and hands out.
+
+    A product may watch one subtree of a computed wiring location rather than the whole of it, and
+    that is only sound while every `drives(...)` line names something inside the watched subtree.
+    This is how such a check reads the subtree."""
+    return frozenset(export.name for export in _wiring_location_exports(product, location))
+
+
 def _top_level_names(tree: ast.Module) -> list[str]:
     """Every public name a module defines at top level: classes, functions, and assigned constants."""
     names: list[str] = []


### PR DESCRIPTION
## Problem

The layer below watches one subtree of a wiring location: `products/product_analytics/turbo.json` lists `backend/hogql_queries/trends/**` rather than the whole of `backend/hogql_queries/`. That keeps the skip for the five subtrees no outside test drives any more.

It is sound only while trends is the one subtree an outside test drives, and nothing checks that. `_input_covers` treats a directory location as covered by any input inside it, so the narrow input satisfies the isolation lint whatever the `drives(...)` lines name. A test written next year that runs a funnels query would leave that subtree unwatched, and a funnels change would then skip the Django suite the test needs.

Refs #77396

## Changes

- A future outside test that drives a subtree the inputs do not watch fails a repo invariant instead of silently reducing what CI runs. The message names both remedies: move the driving test into the product, or widen the inputs to the whole location.
- The check reads the crossings baseline and requires every `product_analytics:backend/hogql_queries/` line to name one of two trends query kinds, or a name the trends subtree defines.
- `names_defined_in(product, location)` in `crossings.py` supplies that second set. It reports the names a location, or one subtree of it, defines and hands out, facade lazy re-exports included, so a runner rename does not need a matching edit here.
- `products/architecture.md` points at the invariant, next to the subtree-watching rule the layer below added.
- It lives in `posthog/test/repo_invariants/` because its input is the repo-wide baseline. That directory runs in the `repo-checks` job on every backend PR, drafts and products-only PRs included, which is exactly when a new driving test appears.

## How did you test this code?

- The invariant catches the regression it exists for: appending `product_analytics:backend/hogql_queries/ posthog.api.test.test_fake drives(FunnelsQuery) 1` to the baseline fails the test, which prints the offending line and the two remedies. Without the check that line changes nothing.
- No existing test covers this. The neighbouring baseline ratchet asserts that the file matches the repo; it says nothing about whether the watched subtree is the one the lines name.
- 113 tests pass across the invariants and the crossings command tests, `hogli product:lint --all` green across 76 products, `hogli lint:tach` validates both passes, mypy clean, `hogli ci:preflight --strict` reports 0 failures.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/architecture.md` names the invariant beside the subtree-watching rule.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: Claude Code in PostHog Desktop. Skills invoked: `/writing-tests`, `/stacking-prs`, `/writing-pr-descriptions`.
- Split out of [#96095](https://github.com/PostHog/posthog/pull/96095) on request, so the relocation carries only what it needs and the machinery gets its own review. It sits on top because the state it asserts exists only after the move.
- The stack is three layers: [#96490](https://github.com/PostHog/posthog/pull/96490) flips the product test lane to persons-on-events, #96095 moves trends, then this.
- The hardcoded pair of kind names is deliberate. Computing which kinds reach a subtree means resolving the dispatch table through the facade's lazy map, which is a larger change to the scan; the pair fails closed, and the comment above it says to widen the inputs rather than extend the list.
- Public artifact: nothing here comes from the agent session.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*


---
_Generated by [Claude Code](https://claude.ai/code)_