### PR TITLE
chore(insights): stop converting legacy filters to describe an insight edit

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -73,9 +73,9 @@ snapshots:
     components-activitylog--feature-flag-activity--light:
         hash: v1.k794b7964.5a8358a3bb67728abcc71ec423255206af014e13d1d95aaeaf2daba16bc96b45.tMsr51f9bhJSycyXPJYsOjM-kNAGQI2hFI3CbJBoyOk
     components-activitylog--insight-activity--dark:
-        hash: v1.k794b7964.41b2c011efcf7aa3223a71cfec6444fba566bd2b39ee41166320907844b0ceae.5HLSP_ex1j65lKKvsc5brJ3sK5TNdqwoJJkJy_QGmj4
+        hash: v1.k794b7964.eeb2e5b54ba0acf05e292aba372702616dc9c6326fd8bcbf4bbf1125fcb7c637.XMwf5MqrlV-FQsYrL-4Db38vN69QQAmBms5tmbFQlSw
     components-activitylog--insight-activity--light:
-        hash: v1.k794b7964.fd12a180d82b7fdaa9656b349b6772db22db42d2c5420d278cc9a4a29ab53bd7.z80OD8wV95-cjP_d3ROg7m6u-y25eLBYY6TXZG1odVg
+        hash: v1.k794b7964.94aae0b511d11de8cf139dd502bc7170494be36e74fd517187ce37048c514447.ZOKfzkSSO6DcNPVEP0DWvmeA3hHVd35t1AYL5yrrkPk
     components-activitylog--persons-activity--dark:
         hash: v1.k794b7964.432ff34c2d8dd67ca60593d6440de2eb053e4a8ddbfcc6cbfe4a25bce324f0d9.kljasPbvnNb_HfMKLGFlj58Wgh283EQnarNEpOf8J4U
     components-activitylog--persons-activity--light:

--- a/frontend/src/lib/components/ActivityLog/__mocks__/activityLogMocks.ts
+++ b/frontend/src/lib/components/ActivityLog/__mocks__/activityLogMocks.ts
@@ -1000,6 +1000,84 @@ export const insightsActivityResponseJson: ActivityLogItem[] = [
         created_at: '2023-04-20T18:35:14.033429Z',
     },
     {
+        user: {
+            first_name: 'Employee 427',
+            email: 'test@posthog.com',
+        },
+        activity: 'updated',
+        scope: ActivityScope.INSIGHT,
+        item_id: '40',
+        detail: {
+            merge: null,
+            changes: [
+                {
+                    type: ActivityScope.INSIGHT,
+                    action: 'changed',
+                    field: 'query',
+                    after: {
+                        kind: 'InsightVizNode',
+                        source: {
+                            kind: 'TrendsQuery',
+                            series: [
+                                { kind: 'EventsNode', event: '$pageview', name: '$pageview', math: 'total' },
+                                { kind: 'EventsNode', event: 'signed up', name: 'signed up', math: 'dau' },
+                            ],
+                            interval: 'day',
+                            dateRange: { date_from: '-30d' },
+                            properties: [{ key: '$browser', type: 'event', value: ['Chrome'], operator: 'exact' }],
+                            breakdownFilter: { breakdown: '$browser', breakdown_type: 'event' },
+                            trendsFilter: { display: 'ActionsLineGraph' },
+                        },
+                    },
+                },
+            ],
+            trigger: null,
+            name: 'Pageviews and signups by browser',
+            short_id: 'HcLbVmQp' as InsightShortId,
+        },
+        created_at: '2023-04-21T09:12:44.033429Z',
+    },
+    {
+        user: {
+            first_name: 'Employee 427',
+            email: 'test@posthog.com',
+        },
+        activity: 'updated',
+        scope: ActivityScope.INSIGHT,
+        item_id: '41',
+        detail: {
+            merge: null,
+            changes: [
+                {
+                    type: ActivityScope.INSIGHT,
+                    action: 'changed',
+                    field: 'query',
+                    after: {
+                        kind: 'InsightVizNode',
+                        source: {
+                            kind: 'FunnelsQuery',
+                            series: [
+                                {
+                                    kind: 'EventsNode',
+                                    event: '$pageview',
+                                    name: '$pageview',
+                                    custom_name: 'Visited the site',
+                                },
+                                { kind: 'EventsNode', event: 'signed up', name: 'signed up' },
+                            ],
+                            dateRange: { date_from: '-14d' },
+                            funnelsFilter: { funnelVizType: 'steps' },
+                        },
+                    },
+                },
+            ],
+            trigger: null,
+            name: 'Signup funnel',
+            short_id: 'Zk3RtYw2' as InsightShortId,
+        },
+        created_at: '2023-04-21T09:14:02.033429Z',
+    },
+    {
         user: { first_name: 'Cameron', email: 'cameron@posthog.com' },
         activity: 'updated',
         scope: ActivityScope.INSIGHT,

--- a/frontend/src/scenes/saved-insights/activityDescriptions.tsx
+++ b/frontend/src/scenes/saved-insights/activityDescriptions.tsx
@@ -23,7 +23,6 @@ import { areObjectValuesEmpty } from 'lib/utils/objects'
 import { pluralize } from 'lib/utils/strings'
 import { urls } from 'scenes/urls'
 
-import { filtersToQueryNode } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
 import { HogQLQuery, InsightQueryNode, QuerySchema } from '~/queries/schema/schema-general'
 import {
     isDataTableNodeWithHogQLQuery,
@@ -83,11 +82,10 @@ const insightActionsMapping: Record<
     filters: function onChangedFilter(change) {
         const filtersAfter = change?.after as Partial<FilterType>
 
-        return areObjectValuesEmpty(filtersAfter)
-            ? null
-            : summarizeQueryChanges(
-                  filtersToQueryNode(filtersAfter, { source: 'saved_insights_activity_descriptions' })
-              )
+        // Only an insight written before queries logs this field, so these entries are years old and
+        // no new one can be written. Summarizing the definition would mean converting legacy filters,
+        // which no other read path still does, and the headline reads the same either way.
+        return areObjectValuesEmpty(filtersAfter) ? null : { description: ['changed query definition'] }
     },
     query: function onChangedQuery(change) {
         if (change?.action === 'deleted') {


### PR DESCRIPTION
## Problem

Nobody sees anything different today. This removes the last caller of the browser's legacy `filters` conversion that can never go away on its own, which is what stands between us and deleting that conversion.

- The activity log keeps each diff as it was written, so an insight edit made before insights stored queries keeps its legacy `filters` payload forever.
- Describing one converts it in the browser. Every other caller shrinks as insights get backfilled; this one cannot, because the rows are immutable history.
- US production holds 365,486 insight activity entries carrying a `filters` change, the oldest from May 2022, and 98.5% of them predate the August 2024 migration that moved insights to queries. September 2026 added 12, from one team.
- No new one can be written. The API stopped accepting filters-only insight writes in #93110.
- Nothing deletes these rows. The only retention is a read window from the AUDIT_LOGS entitlement, applied in `system.activity_logs` and the advanced activity logs viewset, and the per-insight activity feed applies no window at all.

## Changes

- An insight edit that changed legacy `filters` still reads "changed query definition" in the activity log. The headline is unchanged, because `summarizeQueryChanges` already opened with that same generic sentence.
- What goes is the block underneath it: the series, property and breakdown summary. That block is the only part the conversion produced, and it appears on entries whose insight has been query-based for two years.
- An entry whose `filters` diff is empty is still skipped, as before.
- The `InsightActivity` story gains a trends change with a breakdown and a property filter, and a funnel change. It is a tracked visual snapshot, and every entry in it that rendered a definition summary did so from legacy `filters`, so without these it would have shown no summary at all: its one `query` entry is a deletion, which the describer renders as nothing by design.

> [!NOTE]
> `components-activitylog--insight-activity` changes in both themes. Three entries lose their detail block, and two query-based entries gain one. Both are intended.

## How did you test this code?

- The two existing cases in `activityLogLogic.insight.test.tsx` cover this exactly, and both assert the headline rather than the extended block, so they pass unchanged. That is the argument for the change as much as the test for it.
- No new test for the story data: `activityLogLogic.insight.test.tsx` already asserts the extended description for a query change, including one with multiple breakdowns, so the describer logic is covered. The story entries exist to keep the rendering covered visually.
- Ran the 80 tests under `lib/components/ActivityLog/`, and the frontend typecheck reports nothing in the changed files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 5), following the legacy insight `filters` removal. The row counts come from prod Postgres through Metabase, and the caller breakdown from the `legacy_filters_to_query_node_called` event, which shows this describer at 831 of roughly 1,050 conversions in 30 days while the render path decayed to about one a day.

Considered and rejected: backfilling the activity log to rewrite those diffs into queries. It is an audit trail that customers can query through the advanced activity logs product, so rewriting what a user did is the one edit it must not take, and it would fail on exactly the rows the insight backfill could not convert.

Skills invoked: `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-pr-descriptions`.

Public artifact: no material from the session reaches the diff. The row counts quoted here are our own aggregate totals, with no customer, team, or insight identifier.

Related: [#96074](https://github.com/PostHog/posthog/pull/96074) removes the server-side conversion and adds per-surface telemetry to the remaining callers.

