### PR TITLE
fix(desktop): require cost labels for picker models

### DIFF
--- a/products/desktop/apps/web/src/web-agent-config.ts
+++ b/products/desktop/apps/web/src/web-agent-config.ts
@@ -1,4 +1,7 @@
-import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import type {
+  SessionConfigOption,
+  SessionConfigSelectOption,
+} from "@agentclientprotocol/sdk";
 import { getReasoningEffortOptions } from "@posthog/agent/adapters/reasoning-effort";
 import {
   getAvailableCodexModes,
@@ -17,7 +20,7 @@ import {
   isOpenAIModel,
 } from "@posthog/agent/gateway-models";
 import { getLlmGatewayUrl } from "@posthog/agent/posthog-api";
-import type { Adapter } from "@posthog/shared";
+import { type Adapter, customModelMeta } from "@posthog/shared";
 
 // Web port of AgentService.getPreviewConfigOptions (workspace-server). The
 // desktop host runs this in the Node main process; the browser can run the exact
@@ -38,7 +41,7 @@ export async function getWebPreviewConfigOptions(
       : (model: GatewayModel) =>
           isAnthropicModel(model) || isCloudflareModel(model);
 
-  const modelOptions = gatewayModels
+  const modelOptions: SessionConfigSelectOption[] = gatewayModels
     .filter((model) => modelFilter(model))
     .map((model) => ({
       value: model.id,
@@ -68,6 +71,7 @@ export async function getWebPreviewConfigOptions(
       value: resolvedModelId,
       name: resolvedModelId,
       description: "Custom model",
+      _meta: customModelMeta(),
     });
   }
 

--- a/products/desktop/packages/agent/src/adapters/base-acp-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/base-acp-agent.ts
@@ -16,7 +16,11 @@ import type {
   WriteTextFileRequest,
   WriteTextFileResponse,
 } from "@agentclientprotocol/sdk";
-import { isAnthropicModelId, restrictedModelMeta } from "@posthog/shared";
+import {
+  customModelMeta,
+  isAnthropicModelId,
+  restrictedModelMeta,
+} from "@posthog/shared";
 import {
   compareModelsForPicker,
   DEFAULT_GATEWAY_MODEL,
@@ -243,6 +247,7 @@ export abstract class BaseAcpAgent implements Agent {
         value: currentModelId,
         name: currentModelId,
         description: "Custom model",
+        _meta: customModelMeta(),
       });
     }
 

--- a/products/desktop/packages/core/src/billing/modelPricing.test.ts
+++ b/products/desktop/packages/core/src/billing/modelPricing.test.ts
@@ -1,9 +1,11 @@
+import { customModelMeta } from "@posthog/shared";
 import { describe, expect, it } from "vitest";
 import {
   estimateUncachedInputCost,
   formatModelRates,
   modelCostInfo,
   modelListPrice,
+  toModelPickerOption,
 } from "./modelPricing";
 
 describe("modelPricing", () => {
@@ -23,6 +25,23 @@ describe("modelPricing", () => {
   it("returns null for unknown models so no wrong chip ever renders", () => {
     expect(modelCostInfo("totally-unknown-model")).toBeNull();
     expect(modelListPrice("totally-unknown-model")).toBeNull();
+  });
+
+  it("requires price data for every gateway model in the picker", () => {
+    expect(() =>
+      toModelPickerOption({
+        value: "future-gateway-model",
+        name: "Future gateway model",
+      }),
+    ).toThrowError("Missing pricing for gateway model: future-gateway-model");
+
+    expect(
+      toModelPickerOption({
+        value: "local-model",
+        name: "Local model",
+        _meta: customModelMeta(),
+      }),
+    ).toMatchObject({ kind: "custom" });
   });
 
   it("matches specific families before the broader ones they contain", () => {

--- a/products/desktop/packages/core/src/billing/modelPricing.ts
+++ b/products/desktop/packages/core/src/billing/modelPricing.ts
@@ -1,3 +1,5 @@
+import { isCustomModelOption } from "@posthog/shared";
+
 /**
  * List prices per 1M tokens for every model the pickers can show, and the
  * relative per-token cost derived from them. One place on the client; keep in
@@ -24,6 +26,25 @@ export interface ModelCostInfo {
   /** True when input and output ratios diverge and the label is approximate. */
   approximate: boolean;
 }
+
+interface ModelPickerOptionBase {
+  value: string;
+  name: string;
+  _meta?: Record<string, unknown> | null;
+}
+
+export interface PricedModelPickerOption extends ModelPickerOptionBase {
+  kind: "priced";
+  cost: ModelCostInfo;
+}
+
+export interface CustomModelPickerOption extends ModelPickerOptionBase {
+  kind: "custom";
+}
+
+export type ModelPickerOption =
+  | PricedModelPickerOption
+  | CustomModelPickerOption;
 
 /** The 1× anchor every multiplier is stated against. */
 export const MODEL_COST_BASELINE_NAME = "Claude Sonnet 5";
@@ -116,6 +137,23 @@ export function modelCostInfo(modelId: string): ModelCostInfo | null {
     multiplierLabel: formatMultiplier(blended, approximate),
     approximate,
   };
+}
+
+/**
+ * Converts an ACP model into the picker contract. Gateway models require cost
+ * data; only options explicitly marked as custom can omit it.
+ */
+export function toModelPickerOption(
+  model: ModelPickerOptionBase,
+): ModelPickerOption {
+  if (isCustomModelOption(model._meta)) {
+    return { ...model, kind: "custom" };
+  }
+  const cost = modelCostInfo(model.value);
+  if (!cost) {
+    throw new Error(`Missing pricing for gateway model: ${model.value}`);
+  }
+  return { ...model, kind: "priced", cost };
 }
 
 export function estimateUncachedInputCost(

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -25,6 +25,7 @@ import {
   type BedrockGatewayVariant,
   type CloudRegion,
   classifyGatewayLimitError,
+  customModelMeta,
   type ExecutionMode,
   flattenSelectOptions,
   getBackoffDelay,
@@ -6342,6 +6343,7 @@ export class SessionService {
           option.category === "thought_level"
             ? (reasoningLabels[preferredValue] ?? preferredValue)
             : preferredValue,
+        ...(option.category === "model" ? { _meta: customModelMeta() } : {}),
       };
 
       if (option.options.length > 0 && "group" in option.options[0]) {

--- a/products/desktop/packages/shared/src/cloud-task-models.test.ts
+++ b/products/desktop/packages/shared/src/cloud-task-models.test.ts
@@ -17,6 +17,7 @@ import {
   normalizeGatewayModelsResponse,
   pickAllowedModel,
 } from "./cloud-task-models";
+import { isCustomModelOption } from "./models";
 
 const model = (
   id: string,
@@ -362,6 +363,7 @@ describe("buildProviderModelGroups", () => {
     expect(groups.at(-1)).toMatchObject({
       options: [{ value: "my-custom", description: "Custom model" }],
     });
+    expect(isCustomModelOption(groups.at(-1)?.options[0]?._meta)).toBe(true);
   });
 
   // A gateway blip answers with an empty or one-sided catalog. The picker must
@@ -392,6 +394,7 @@ describe("buildProviderModelGroups", () => {
           },
         ],
       });
+      expect(isCustomModelOption(groups[0]?.options[0]?._meta)).toBe(true);
     },
   );
 });

--- a/products/desktop/packages/shared/src/cloud-task-models.ts
+++ b/products/desktop/packages/shared/src/cloud-task-models.ts
@@ -1,6 +1,10 @@
 import type { Adapter } from "./adapter";
 import { CODEX_MODE_PRESETS } from "./execution-modes";
-import { modelHarnessMeta, restrictedModelMeta } from "./models";
+import {
+  customModelMeta,
+  modelHarnessMeta,
+  restrictedModelMeta,
+} from "./models";
 import { getReasoningEffortOptions } from "./reasoning-effort";
 
 export interface GatewayModel {
@@ -440,7 +444,10 @@ export function buildProviderModelGroups(
       value: currentValue,
       name: currentValue,
       description: "Custom model",
-      _meta: modelHarnessMeta(adapter),
+      _meta: {
+        ...modelHarnessMeta(adapter),
+        ...customModelMeta(),
+      },
     });
   }
 
@@ -492,6 +499,7 @@ export function buildCloudTaskConfigOptions(
       value: resolvedModelId,
       name: resolvedModelId,
       description: "Custom model",
+      _meta: customModelMeta(),
     });
   }
 

--- a/products/desktop/packages/shared/src/index.ts
+++ b/products/desktop/packages/shared/src/index.ts
@@ -211,8 +211,10 @@ export {
   splitMentionSegments,
 } from "./mentions";
 export {
+  customModelMeta,
   DEFAULT_OPTION_META_KEY,
   defaultEligibleModel,
+  isCustomModelOption,
   isDefaultSelectOption,
   isRestrictedModelOption,
   modelHarnessMeta,

--- a/products/desktop/packages/shared/src/models.ts
+++ b/products/desktop/packages/shared/src/models.ts
@@ -19,6 +19,22 @@ export function defaultEligibleModel(
  */
 const RESTRICTED_MODEL_META_KEY = "posthog.code/restrictedModel";
 
+/**
+ * ACP SessionConfigSelectOption `_meta` key for a model outside the gateway
+ * catalog. Picker code uses this explicit mark as the only unpriced case.
+ */
+const CUSTOM_MODEL_META_KEY = "posthog.code/customModel";
+
+export function customModelMeta(): Record<string, unknown> {
+  return { [CUSTOM_MODEL_META_KEY]: true };
+}
+
+export function isCustomModelOption(
+  meta: Record<string, unknown> | null | undefined,
+): boolean {
+  return meta?.[CUSTOM_MODEL_META_KEY] === true;
+}
+
 export function restrictedModelMeta(): Record<string, unknown> {
   return { [RESTRICTED_MODEL_META_KEY]: true };
 }

--- a/products/desktop/packages/ui/src/features/cost-management/CostChecklistPanel.tsx
+++ b/products/desktop/packages/ui/src/features/cost-management/CostChecklistPanel.tsx
@@ -286,7 +286,7 @@ function ModelChip({
       className={`inline-flex items-center gap-1.5 rounded-(--radius-2) bg-(--gray-3) px-1.5 py-0.5 ${
         emphasis ? "text-(--gray-12)" : "text-(--gray-11)"
       }`}
-      title={modelCostTitle(modelId)}
+      title={cost ? modelCostTitle(cost) : undefined}
     >
       <span className={`text-[11px] ${emphasis ? "font-medium" : ""}`}>
         {formatModelId(modelId)}

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.test.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.test.tsx
@@ -1,5 +1,11 @@
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
-import { configure, fireEvent, render, screen } from "@testing-library/react";
+import {
+  configure,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { PiModelSelector } from "./PiSessionControls";
@@ -40,6 +46,14 @@ function groupedModelOption(): SessionConfigOption {
             name: "GPT-5.5",
             value: "gpt-5.5",
             _meta: { "posthog.code/modelHarness": "codex" },
+          },
+          {
+            name: "GPT-6 Astra",
+            value: "gpt-6-astra",
+            _meta: {
+              "posthog.code/modelHarness": "codex",
+              "posthog.code/restrictedModel": true,
+            },
           },
         ],
       },
@@ -85,5 +99,29 @@ describe("PiModelSelector", () => {
     expect(onGatewayModelSelect).toHaveBeenCalledWith("gpt-5.5");
     expect(onGatewayModelSelect).toHaveBeenCalledTimes(1);
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("shows the cost multiplier beside a restricted model lock", async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(
+      <PiModelSelector
+        models={piModels}
+        currentModel={piModels[0]}
+        onChange={vi.fn()}
+        modelOption={groupedModelOption()}
+        onGatewayModelSelect={vi.fn()}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Model: Claude Opus 5" }),
+    );
+    await openSub(user, /^Model/);
+
+    const astra = await screen.findByRole("menuitemradio", {
+      name: "GPT-6 Astra",
+    });
+    expect(within(astra).getByText("5×")).toBeInTheDocument();
+    expect(astra.querySelector("svg")).toBeInTheDocument();
   });
 });

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.tsx
@@ -1,5 +1,6 @@
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 import { CaretDown, Lightning, PiIcon, Stack } from "@phosphor-icons/react";
+import { toModelPickerOption } from "@posthog/core/billing/modelPricing";
 import type {
   PiModelSelection,
   PiThinkingLevel,
@@ -17,6 +18,7 @@ import {
   DropdownMenuTrigger,
   MenuLabel,
 } from "@posthog/quill";
+import { customModelMeta } from "@posthog/shared";
 import {
   type AgentHarness,
   HarnessSubmenu,
@@ -215,18 +217,29 @@ export function PiModelSelector({
                     }
                   }}
                 >
-                  {models.map((model) => (
-                    <DropdownMenuRadioItem
-                      key={modelKey(model)}
-                      value={modelKey(model)}
-                      closeOnClick={false}
-                    >
-                      <span className="whitespace-nowrap">
-                        {modelLabel(model)}
-                      </span>
-                      <ModelCostChip modelId={model.id} />
-                    </DropdownMenuRadioItem>
-                  ))}
+                  {models.map((model) => {
+                    const pickerModel = toModelPickerOption({
+                      value: model.id,
+                      name: modelLabel(model),
+                      ...(model.provider === "posthog"
+                        ? {}
+                        : { _meta: customModelMeta() }),
+                    });
+                    return (
+                      <DropdownMenuRadioItem
+                        key={modelKey(model)}
+                        value={modelKey(model)}
+                        closeOnClick={false}
+                      >
+                        <span className="whitespace-nowrap">
+                          {pickerModel.name}
+                        </span>
+                        {pickerModel.kind === "priced" ? (
+                          <ModelCostChip cost={pickerModel.cost} />
+                        ) : null}
+                      </DropdownMenuRadioItem>
+                    );
+                  })}
                 </DropdownMenuRadioGroup>
                 <ModelCostFooter />
               </>

--- a/products/desktop/packages/ui/src/features/sessions/components/ModelCostChip.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ModelCostChip.stories.tsx
@@ -17,6 +17,11 @@ const MODELS = [
   { value: "gpt-5.6-sol", name: "GPT-5.6 Sol" },
   { value: "gpt-5.6-terra", name: "GPT-5.6 Terra" },
   { value: "gpt-5.6-luna", name: "GPT-5.6 Luna" },
+  {
+    value: "gpt-6-astra",
+    name: "GPT-6 Astra",
+    _meta: { "posthog.code/restrictedModel": true },
+  },
   { value: "glm-5.3", name: "GLM 5.3" },
   { value: "some-custom-model", name: "Custom model" },
 ];

--- a/products/desktop/packages/ui/src/features/sessions/components/ModelCostChip.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ModelCostChip.stories.tsx
@@ -1,3 +1,4 @@
+import { toModelPickerOption } from "@posthog/core/billing/modelPricing";
 import {
   Button,
   DropdownMenu,
@@ -5,6 +6,7 @@ import {
   DropdownMenuRadioGroup,
   DropdownMenuTrigger,
 } from "@posthog/quill";
+import { customModelMeta } from "@posthog/shared";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { ModelCostFooter } from "./ModelCostChip";
 import { ModelRadioItem } from "./ModelRadioItem";
@@ -23,8 +25,12 @@ const MODELS = [
     _meta: { "posthog.code/restrictedModel": true },
   },
   { value: "glm-5.3", name: "GLM 5.3" },
-  { value: "some-custom-model", name: "Custom model" },
-];
+  {
+    value: "some-custom-model",
+    name: "Custom model",
+    _meta: customModelMeta(),
+  },
+].map(toModelPickerOption);
 
 /** The model list with cost chips, held open for visual review. */
 function OpenModelList() {

--- a/products/desktop/packages/ui/src/features/sessions/components/ModelCostChip.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ModelCostChip.tsx
@@ -1,28 +1,24 @@
 import {
   formatModelRates,
   MODEL_COST_BASELINE_NAME,
-  modelCostInfo,
+  type ModelCostInfo,
 } from "@posthog/core/billing/modelPricing";
 
 /** The exact rates behind a multiplier, for the chip's title. */
-export function modelCostTitle(modelId: string): string | undefined {
-  const cost = modelCostInfo(modelId);
-  if (!cost) return undefined;
+export function modelCostTitle(cost: ModelCostInfo): string {
   return `Cost per token vs ${MODEL_COST_BASELINE_NAME} · ${formatModelRates(cost.price)}`;
 }
 
 /**
- * Per-token cost multiplier chip for model picker rows. Renders nothing for
- * unpriced models so a chip is never wrong. Presentational so the row's
- * accessible name stays the model name; the title carries the exact rates.
+ * Per-token cost multiplier chip for priced model picker rows. Presentational
+ * so the row's accessible name stays the model name; the title carries the
+ * exact rates.
  */
-export function ModelCostChip({ modelId }: { modelId: string }) {
-  const cost = modelCostInfo(modelId);
-  if (!cost) return null;
+export function ModelCostChip({ cost }: { cost: ModelCostInfo }) {
   return (
     <span
       className="ml-auto pl-3 font-normal text-[10px] text-muted-foreground/80 tabular-nums"
-      title={modelCostTitle(modelId)}
+      title={modelCostTitle(cost)}
       aria-hidden="true"
     >
       {cost.multiplierLabel}

--- a/products/desktop/packages/ui/src/features/sessions/components/ModelRadioItem.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ModelRadioItem.tsx
@@ -1,4 +1,5 @@
 import { Lock, Prohibit } from "@phosphor-icons/react";
+import type { ModelPickerOption } from "@posthog/core/billing/modelPricing";
 import {
   DropdownMenuRadioItem,
   Tooltip,
@@ -23,11 +24,7 @@ export function ModelRadioItem({
   closeOnClick,
   unavailableReason,
 }: {
-  model: {
-    value: string;
-    name: string;
-    _meta?: Record<string, unknown> | null;
-  };
+  model: ModelPickerOption;
   closeOnClick?: boolean;
   unavailableReason?: string;
 }) {
@@ -39,16 +36,14 @@ export function ModelRadioItem({
       className={restricted || unavailableReason ? "opacity-60" : undefined}
     >
       <span className="whitespace-nowrap">{model.name}</span>
-      {unavailableReason ? (
-        <Prohibit size={11} className="ml-auto text-muted-foreground" />
-      ) : (
-        <span className="ml-auto flex items-center">
-          <ModelCostChip modelId={model.value} />
-          {restricted ? (
-            <Lock size={11} className="ml-1 text-muted-foreground" />
-          ) : null}
-        </span>
-      )}
+      <span className="ml-auto flex items-center">
+        {model.kind === "priced" ? <ModelCostChip cost={model.cost} /> : null}
+        {unavailableReason ? (
+          <Prohibit size={11} className="ml-1 text-muted-foreground" />
+        ) : restricted ? (
+          <Lock size={11} className="ml-1 text-muted-foreground" />
+        ) : null}
+      </span>
     </DropdownMenuRadioItem>
   );
 

--- a/products/desktop/packages/ui/src/features/sessions/components/ModelRadioItem.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ModelRadioItem.tsx
@@ -41,10 +41,13 @@ export function ModelRadioItem({
       <span className="whitespace-nowrap">{model.name}</span>
       {unavailableReason ? (
         <Prohibit size={11} className="ml-auto text-muted-foreground" />
-      ) : restricted ? (
-        <Lock size={11} className="ml-auto text-muted-foreground" />
       ) : (
-        <ModelCostChip modelId={model.value} />
+        <span className="ml-auto flex items-center">
+          <ModelCostChip modelId={model.value} />
+          {restricted ? (
+            <Lock size={11} className="ml-1 text-muted-foreground" />
+          ) : null}
+        </span>
       )}
     </DropdownMenuRadioItem>
   );

--- a/products/desktop/packages/ui/src/features/sessions/components/ModelSelectList.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ModelSelectList.tsx
@@ -3,6 +3,7 @@ import type {
   SessionConfigSelectOptions,
 } from "@agentclientprotocol/sdk";
 import { compareModelsForPicker } from "@posthog/agent/gateway-models";
+import { toModelPickerOption } from "@posthog/core/billing/modelPricing";
 import {
   DropdownMenuGroup,
   DropdownMenuLabel,
@@ -35,7 +36,7 @@ const renderEntries = (
     .map((model) => (
       <ModelRadioItem
         key={model.value}
-        model={model}
+        model={toModelPickerOption(model)}
         closeOnClick={false}
         unavailableReason={unavailableReason?.(model.value)}
       />

--- a/products/desktop/packages/ui/src/features/sessions/components/ModelSelector.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ModelSelector.tsx
@@ -1,5 +1,6 @@
 import type { SessionConfigSelectGroup } from "@agentclientprotocol/sdk";
 import { CaretDown } from "@phosphor-icons/react";
+import { toModelPickerOption } from "@posthog/core/billing/modelPricing";
 import type { SessionService } from "@posthog/core/sessions/sessionService";
 import { SESSION_SERVICE } from "@posthog/core/sessions/sessionService";
 import { useService } from "@posthog/di/react";
@@ -114,7 +115,10 @@ export function ModelSelector({
                 {index > 0 && <DropdownMenuSeparator />}
                 <MenuLabel>{group.name}</MenuLabel>
                 {group.options.map((model) => (
-                  <ModelRadioItem key={model.value} model={model} />
+                  <ModelRadioItem
+                    key={model.value}
+                    model={toModelPickerOption(model)}
+                  />
                 ))}
               </Fragment>
             ))}
@@ -125,7 +129,10 @@ export function ModelSelector({
             onValueChange={handleChange}
           >
             {options.map((model) => (
-              <ModelRadioItem key={model.value} model={model} />
+              <ModelRadioItem
+                key={model.value}
+                model={toModelPickerOption(model)}
+              />
             ))}
           </DropdownMenuRadioGroup>
         )}

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
@@ -4,7 +4,13 @@ import {
   OPTION_DOCS_URL_META_KEY,
 } from "@posthog/shared";
 import { Theme } from "@radix-ui/themes";
-import { configure, fireEvent, render, screen } from "@testing-library/react";
+import {
+  configure,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { cloneElement } from "react";
 import { describe, expect, it, vi } from "vitest";
@@ -926,6 +932,7 @@ describe("ReasoningLevelSelector", () => {
       name: /GLM 5\.2/,
     });
 
+    expect(within(gatewayOnly).getByText("≈0.57×")).toBeInTheDocument();
     fireEvent.click(gatewayOnly);
     expect(onModelChange).not.toHaveBeenCalled();
   }, 20000);

--- a/products/desktop/packages/workspace-server/src/services/archive/archive.integration.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/archive/archive.integration.test.ts
@@ -1,4 +1,5 @@
 import { execSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -45,8 +46,11 @@ import {
 } from "@posthog/workspace-server/db/repositories/worktree-repository.mock";
 import { ArchiveService } from "./archive";
 
-async function createTempGitRepo(): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "archive-test-"));
+async function createTempRepo(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "archive-test-"));
+}
+
+function initializeGitRepo(dir: string): void {
   execSync("git init", { cwd: dir, stdio: "pipe" });
   execSync("git config user.email 'test@test.com'", {
     cwd: dir,
@@ -54,12 +58,11 @@ async function createTempGitRepo(): Promise<string> {
   });
   execSync("git config user.name 'Test'", { cwd: dir, stdio: "pipe" });
   execSync("git config commit.gpgsign false", { cwd: dir, stdio: "pipe" });
-  await fs.writeFile(path.join(dir, "README.md"), "# Test Repo");
+  writeFileSync(path.join(dir, "README.md"), "# Test Repo");
   execSync("git add . && git commit -m 'Initial commit'", {
     cwd: dir,
     stdio: "pipe",
   });
-  return dir;
 }
 
 async function pathExists(p: string): Promise<boolean> {
@@ -106,8 +109,17 @@ async function withTestContext(
   fn: (ctx: TestContext) => Promise<void>,
 ): Promise<void> {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "archive-int-"));
-  const repoPath = await createTempGitRepo();
+  const repoPath = await createTempRepo();
   const worktreeBasePath = path.join(tempDir, "worktrees");
+  let gitRepoInitialized = false;
+
+  const ensureGitRepo = (): void => {
+    if (gitRepoInitialized) {
+      return;
+    }
+    initializeGitRepo(repoPath);
+    gitRepoInitialized = true;
+  };
   await fs.mkdir(worktreeBasePath, { recursive: true });
 
   testWorktreeBasePath = worktreeBasePath;
@@ -163,12 +175,14 @@ async function withTestContext(
     archiveLogger as never,
   );
 
-  const git = (cmd: string) =>
-    execSync(`git ${cmd}`, {
+  const git = (cmd: string) => {
+    ensureGitRepo();
+    return execSync(`git ${cmd}`, {
       cwd: repoPath,
       encoding: "utf8",
       stdio: "pipe",
     }).trim();
+  };
 
   const archiveInput = () => ({ taskId: TASK_ID });
 
@@ -176,6 +190,7 @@ async function withTestContext(
     method: "detached" | "branch",
     branchName?: string,
   ) => {
+    ensureGitRepo();
     const manager = new WorktreeManager({
       mainRepoPath: repoPath,
       worktreeBasePath,


### PR DESCRIPTION
## Problem

People can lose a model's cost multiplier when the picker treats pricing and access as alternative states.

The picker accepted raw model IDs and silently omitted labels when pricing was missing.

## Changes

- Every official picker model now carries required typed cost data.
- Missing official pricing stops model conversion instead of silently removing the multiplier.
- Custom models use an explicit marker as the only unpriced case.
- Cost labels render independently from lock and unavailable indicators.

![Restricted GPT-6 Astra model with 5x cost label and lock](https://raw.githubusercontent.com/PostHog/pr-assets/38e9aba65e25bbeb6296f1a3f3e4e849eb0fcb91/2026/09/e72d4f62-dcd4-4b78-8c19-4ff56bd3c4e9.png)

## How did you test this code?

- Regression tests reject unpriced official models and allow explicitly custom models.
- UI tests confirm restricted and unavailable models keep their cost labels.
- Desktop type checks, lint, core tests, shared tests, and the full UI suite completed successfully.
- The focused agent test confirms custom model metadata survives the adapter boundary.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change. The picker now enforces its existing cost legend.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The PostHog Slack app used the /posthog-desktop and /writing-pr-descriptions skills. The final diff also received a simplification review.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1788803884013719?thread_ts=1788803884.013719&cid=C09G8Q32R6F)*
