### PR TITLE
feat(clickhouse): model the apm role

### DIFF
--- a/posthog/clickhouse/hcl/golden/dev/apm.hcl
+++ b/posthog/clickhouse/hcl/golden/dev/apm.hcl
@@ -1,0 +1,1519 @@
+database "posthog" {
+  table "kafka_logs_avro" {
+    settings = {
+      input_format_avro_allow_missing_fields = "1"
+    }
+    column "uuid" {
+      type = "String"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "trace_flags" {
+      type = "Int32"
+    }
+    column "timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "observed_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "body" {
+      type = "String"
+    }
+    column "severity_text" {
+      type = "String"
+    }
+    column "severity_number" {
+      type = "Int32"
+    }
+    column "service_name" {
+      type = "String"
+    }
+    column "resource_attributes" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "instrumentation_scope" {
+      type = "String"
+    }
+    column "event_name" {
+      type = "String"
+    }
+    column "attributes" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "retention_days" {
+      type = "Nullable(Int32)"
+    }
+    column "pattern" {
+      type = "Nullable(String)"
+    }
+    column "pattern_version" {
+      type = "Nullable(Int32)"
+    }
+    engine "kafka" {
+      collection           = "warpstream_logs"
+      topic_list           = "clickhouse_logs"
+      group_name           = "clickhouse-logs-avro-new"
+      format               = "Avro"
+      num_consumers        = 4
+      skip_broken_messages = 100
+      poll_timeout_ms      = 10000
+      poll_max_batch_size  = 1000
+      flush_interval_ms    = 10000
+      thread_per_consumer  = true
+    }
+  }
+
+  table "kafka_metrics_avro" {
+    settings = {
+      input_format_avro_allow_missing_fields = "1"
+    }
+    column "uuid" {
+      type = "String"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "trace_flags" {
+      type = "Nullable(Int32)"
+    }
+    column "timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "observed_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "service_name" {
+      type = "Nullable(String)"
+    }
+    column "metric_name" {
+      type = "Nullable(String)"
+    }
+    column "metric_type" {
+      type = "Nullable(String)"
+    }
+    column "value" {
+      type = "Nullable(Float64)"
+    }
+    column "count" {
+      type = "Nullable(Int64)"
+    }
+    column "histogram_bounds" {
+      type = "Array(Float64)"
+    }
+    column "histogram_counts" {
+      type = "Array(Int64)"
+    }
+    column "unit" {
+      type = "Nullable(String)"
+    }
+    column "aggregation_temporality" {
+      type = "Nullable(String)"
+    }
+    column "is_monotonic" {
+      type = "Nullable(UInt8)"
+    }
+    column "resource_attributes" {
+      type = "Map(String, String)"
+    }
+    column "instrumentation_scope" {
+      type = "Nullable(String)"
+    }
+    column "attributes" {
+      type = "Map(String, String)"
+    }
+    column "series_fingerprint" {
+      type = "Nullable(Int64)"
+    }
+    engine "kafka" {
+      collection           = "warpstream_metrics"
+      topic_list           = "clickhouse_metrics"
+      group_name           = "clickhouse-metrics-avro-new"
+      format               = "Avro"
+      num_consumers        = 4
+      skip_broken_messages = 100
+      poll_timeout_ms      = 10000
+      poll_max_batch_size  = 1000
+      flush_interval_ms    = 10000
+      thread_per_consumer  = true
+    }
+  }
+
+  table "kafka_trace_spans_avro" {
+    settings = {
+      input_format_avro_allow_missing_fields = "1"
+    }
+    column "uuid" {
+      type = "String"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "parent_span_id" {
+      type = "String"
+    }
+    column "trace_state" {
+      type = "String"
+    }
+    column "name" {
+      type = "String"
+    }
+    column "kind" {
+      type = "Int32"
+    }
+    column "flags" {
+      type = "Int32"
+    }
+    column "timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "end_time" {
+      type = "DateTime64(6)"
+    }
+    column "observed_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "service_name" {
+      type = "String"
+    }
+    column "resource_attributes" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "instrumentation_scope" {
+      type = "String"
+    }
+    column "attributes" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "dropped_attributes_count" {
+      type = "Int32"
+    }
+    column "events" {
+      type = "Array(String)"
+    }
+    column "dropped_events_count" {
+      type = "Int32"
+    }
+    column "links" {
+      type = "Array(String)"
+    }
+    column "dropped_links_count" {
+      type = "Int32"
+    }
+    column "status_code" {
+      type = "Int32"
+    }
+    engine "kafka" {
+      collection           = "warpstream_traces"
+      topic_list           = "clickhouse_traces"
+      group_name           = "clickhouse-traces-avro"
+      format               = "Avro"
+      num_consumers        = 4
+      skip_broken_messages = 100
+      poll_timeout_ms      = 10000
+      poll_max_batch_size  = 1000
+      flush_interval_ms    = 10000
+      thread_per_consumer  = true
+    }
+  }
+
+  table "writable_logs34" {
+    settings = {
+      background_insert_batch = "1"
+    }
+    column "time_bucket" {
+      type         = "DateTime"
+      materialized = "toStartOfDay(timestamp)"
+    }
+    column "original_expiry_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "uuid" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int32"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "trace_flags" {
+      type = "Int32"
+    }
+    column "timestamp" {
+      type  = "DateTime64(6)"
+      codec = "DoubleDelta"
+    }
+    column "observed_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "created_at" {
+      type         = "DateTime64(6)"
+      materialized = "now()"
+    }
+    column "body" {
+      type = "String"
+    }
+    column "severity_text" {
+      type = "LowCardinality(String)"
+    }
+    column "severity_number" {
+      type = "Int32"
+    }
+    column "service_name" {
+      type = "LowCardinality(String)"
+    }
+    column "resource_attributes" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "resource_fingerprint" {
+      type         = "UInt64"
+      materialized = "cityHash64(resource_attributes)"
+    }
+    column "instrumentation_scope" {
+      type = "String"
+    }
+    column "event_name" {
+      type = "String"
+    }
+    column "attributes_map_str" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "level" {
+      type  = "String"
+      alias = "severity_text"
+    }
+    column "mat_body_ipv4_matches" {
+      type  = "Array(String)"
+      alias = "extractAll(body, '(\\\\d\\\\.((25[0-5]|(2[0-4]|1(0, 1)[0-9])(0, 1)[0-9])\\\\.)(2, 2)([0-9]))')"
+    }
+    column "time_minute" {
+      type  = "DateTime"
+      alias = "toStartOfMinute(timestamp)"
+    }
+    column "attributes" {
+      type  = "Map(LowCardinality(String), String)"
+      alias = "mapApply((k, v) -> (left(k, -5), v), attributes_map_str)"
+    }
+    column "attributes_map_float" {
+      type         = "Map(LowCardinality(String), Float64)"
+      materialized = "mapFilter((k, v) -> (v IS NOT NULL), mapApply((k, v) -> (concat(left(k, -5), '__float'), toFloat64OrNull(v)), attributes_map_str))"
+    }
+    column "attributes_map_datetime" {
+      type         = "Map(LowCardinality(String), DateTime64(6))"
+      materialized = "mapFilter((k, v) -> (v IS NOT NULL), mapApply((k, v) -> (concat(left(k, -5), '__datetime'), parseDateTimeBestEffortOrNull(v, 6)), attributes_map_str))"
+    }
+    column "_partition" {
+      type = "UInt32"
+    }
+    column "_topic" {
+      type = "String"
+    }
+    column "_offset" {
+      type = "UInt64"
+    }
+    column "_bytes_uncompressed" {
+      type = "UInt64"
+    }
+    column "_bytes_compressed" {
+      type = "UInt64"
+    }
+    column "_record_count" {
+      type = "UInt64"
+    }
+    column "pattern" {
+      type = "String"
+    }
+    column "pattern_version" {
+      type = "UInt8"
+    }
+    engine "distributed" {
+      cluster_name    = "logs"
+      remote_database = "posthog"
+      remote_table    = "logs34"
+    }
+  }
+
+  table "writable_metric_samples1" {
+    column "team_id" {
+      type = "Int32"
+    }
+    column "metric_name" {
+      type = "LowCardinality(String)"
+    }
+    column "series_fingerprint" {
+      type  = "UInt64"
+      codec = "DoubleDelta"
+    }
+    column "timestamp" {
+      type  = "DateTime64(6)"
+      codec = "DoubleDelta"
+    }
+    column "value" {
+      type  = "Float64"
+      codec = "Gorilla(8)"
+    }
+    column "count" {
+      type    = "UInt64"
+      default = "1"
+    }
+    column "histogram_bounds" {
+      type = "Array(Float64)"
+    }
+    column "histogram_counts" {
+      type = "Array(UInt64)"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "trace_flags" {
+      type = "Int32"
+    }
+    engine "distributed" {
+      cluster_name    = "logs"
+      remote_database = "posthog"
+      remote_table    = "metric_samples1"
+    }
+  }
+
+  table "writable_metric_series1" {
+    column "team_id" {
+      type = "Int32"
+    }
+    column "metric_name" {
+      type = "LowCardinality(String)"
+    }
+    column "series_fingerprint" {
+      type  = "UInt64"
+      codec = "DoubleDelta"
+    }
+    column "metric_type" {
+      type = "LowCardinality(String)"
+    }
+    column "unit" {
+      type = "LowCardinality(String)"
+    }
+    column "aggregation_temporality" {
+      type = "LowCardinality(String)"
+    }
+    column "is_monotonic" {
+      type    = "Bool"
+      default = "false"
+    }
+    column "service_name" {
+      type = "LowCardinality(String)"
+    }
+    column "resource_attributes" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "attributes" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "last_seen" {
+      type  = "DateTime64(6)"
+      codec = "DoubleDelta"
+    }
+    engine "distributed" {
+      cluster_name    = "logs"
+      remote_database = "posthog"
+      remote_table    = "metric_series1"
+    }
+  }
+
+  table "writable_metrics1" {
+    column "time_bucket" {
+      type         = "DateTime"
+      materialized = "toStartOfDay(timestamp)"
+    }
+    column "uuid" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int32"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "trace_flags" {
+      type = "Int32"
+    }
+    column "timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "observed_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "created_at" {
+      type         = "DateTime64(6)"
+      materialized = "now()"
+    }
+    column "service_name" {
+      type = "LowCardinality(String)"
+    }
+    column "metric_name" {
+      type = "LowCardinality(String)"
+    }
+    column "metric_type" {
+      type = "LowCardinality(String)"
+    }
+    column "value" {
+      type = "Float64"
+    }
+    column "count" {
+      type    = "UInt64"
+      default = "1"
+    }
+    column "histogram_bounds" {
+      type = "Array(Float64)"
+    }
+    column "histogram_counts" {
+      type = "Array(UInt64)"
+    }
+    column "unit" {
+      type = "LowCardinality(String)"
+    }
+    column "aggregation_temporality" {
+      type = "LowCardinality(String)"
+    }
+    column "is_monotonic" {
+      type    = "Bool"
+      default = "false"
+    }
+    column "resource_attributes" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "resource_fingerprint" {
+      type         = "UInt64"
+      materialized = "cityHash64(resource_attributes)"
+    }
+    column "instrumentation_scope" {
+      type = "String"
+    }
+    column "attributes_map_str" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "attributes_map_float" {
+      type = "Map(LowCardinality(String), Float64)"
+    }
+    column "time_minute" {
+      type  = "DateTime"
+      alias = "toStartOfMinute(timestamp)"
+    }
+    column "attributes" {
+      type  = "Map(String, String)"
+      alias = "mapApply((k, v) -> (left(k, -5), v), attributes_map_str)"
+    }
+    engine "distributed" {
+      cluster_name    = "logs"
+      remote_database = "posthog"
+      remote_table    = "metrics1"
+    }
+  }
+
+  table "writable_metrics_kafka_metrics" {
+    column "_partition" {
+      type = "UInt32"
+    }
+    column "_topic" {
+      type = "String"
+    }
+    column "max_offset" {
+      type = "SimpleAggregateFunction(max, UInt64)"
+    }
+    column "max_observed_timestamp" {
+      type = "SimpleAggregateFunction(max, DateTime64(9))"
+    }
+    column "max_timestamp" {
+      type = "SimpleAggregateFunction(max, DateTime64(9))"
+    }
+    column "max_created_at" {
+      type = "SimpleAggregateFunction(max, DateTime64(9))"
+    }
+    column "max_lag" {
+      type = "SimpleAggregateFunction(max, UInt64)"
+    }
+    engine "distributed" {
+      cluster_name    = "logs"
+      remote_database = "posthog"
+      remote_table    = "metrics_kafka_metrics"
+    }
+  }
+
+  table "writable_query_log_archive" {
+    column "hostname" {
+      type = "LowCardinality(String)"
+    }
+    column "user" {
+      type = "LowCardinality(String)"
+    }
+    column "query_id" {
+      type = "String"
+    }
+    column "initial_query_id" {
+      type = "String"
+    }
+    column "is_initial_query" {
+      type = "UInt8"
+    }
+    column "type" {
+      type = "Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4)"
+    }
+    column "event_date" {
+      type = "Date"
+    }
+    column "event_time" {
+      type = "DateTime"
+    }
+    column "event_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_start_time" {
+      type = "DateTime"
+    }
+    column "query_start_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_duration_ms" {
+      type = "UInt64"
+    }
+    column "read_rows" {
+      type = "UInt64"
+    }
+    column "read_bytes" {
+      type = "UInt64"
+    }
+    column "written_rows" {
+      type = "UInt64"
+    }
+    column "written_bytes" {
+      type = "UInt64"
+    }
+    column "result_rows" {
+      type = "UInt64"
+    }
+    column "result_bytes" {
+      type = "UInt64"
+    }
+    column "memory_usage" {
+      type = "UInt64"
+    }
+    column "peak_threads_usage" {
+      type = "UInt64"
+    }
+    column "current_database" {
+      type = "LowCardinality(String)"
+    }
+    column "query" {
+      type = "String"
+    }
+    column "formatted_query" {
+      type = "String"
+    }
+    column "normalized_query_hash" {
+      type = "UInt64"
+    }
+    column "query_kind" {
+      type = "LowCardinality(String)"
+    }
+    column "exception_code" {
+      type = "Int32"
+    }
+    column "exception" {
+      type = "String"
+    }
+    column "stack_trace" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "log_comment" {
+      type = "JSON(max_dynamic_paths=256, access_method LowCardinality(String), alert_config_id String, api_key_label String, api_key_mask String, batch_export_id String, chargeable Bool, client_query_id String, cohort_id Int64, `dagster.job_name` String, `dagster.run_id` String, `dagster.tags.owner` String, dashboard_id Int64, experiment_feature_flag_key String, experiment_id Int64, feature LowCardinality(String), id String, insight_id Int64, is_impersonated Bool, kind LowCardinality(String), name String, org_id String, person_on_events_mode LowCardinality(String), product LowCardinality(String), query_type LowCardinality(String), request_name String, route_id String, service_name String, session_id String, table_id String, team_id Int64, `temporal.activity_id` String, `temporal.activity_type` String, `temporal.attempt` Int64, `temporal.workflow_id` String, `temporal.workflow_namespace` String, `temporal.workflow_run_id` String, `temporal.workflow_type` String, user_id Int64, warehouse_query Bool, workflow LowCardinality(String), workload LowCardinality(String), SKIP cache_key, SKIP filter, SKIP hogql_features, SKIP http_referer, SKIP http_request_id, SKIP http_user_agent, SKIP query_settings, SKIP timings, SKIP user_email)"
+    }
+    column "ProfileEvents" {
+      type = "Map(String, UInt64)"
+    }
+    engine "distributed" {
+      cluster_name    = "ops"
+      remote_database = "posthog"
+      remote_table    = "query_log_archive_buffer"
+    }
+  }
+
+  table "writable_trace_spans" {
+    column "time_bucket" {
+      type         = "DateTime"
+      materialized = "toStartOfInterval(timestamp, toIntervalHour(4))"
+    }
+    column "original_expiry_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "uuid" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int32"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "parent_span_id" {
+      type = "String"
+    }
+    column "is_root_span" {
+      type         = "Bool"
+      materialized = "replaceAll(trimRight(parent_span_id, '='), 'A', '') = ''"
+    }
+    column "trace_state" {
+      type = "String"
+    }
+    column "name" {
+      type = "LowCardinality(String)"
+    }
+    column "kind" {
+      type = "Int8"
+    }
+    column "flags" {
+      type = "UInt32"
+    }
+    column "timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "end_time" {
+      type = "DateTime64(6)"
+    }
+    column "observed_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "created_at" {
+      type         = "DateTime64(6)"
+      materialized = "now()"
+    }
+    column "duration_nano" {
+      type         = "UInt64"
+      materialized = "toUInt64(dateDiff('microsecond', timestamp, end_time)) * 1000"
+    }
+    column "status_code" {
+      type = "Int16"
+    }
+    column "service_name" {
+      type = "LowCardinality(String)"
+    }
+    column "resource_attributes" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "resource_fingerprint" {
+      type         = "UInt64"
+      materialized = "cityHash64(resource_attributes)"
+    }
+    column "instrumentation_scope" {
+      type = "String"
+    }
+    column "attributes_map_str" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "attributes" {
+      type  = "Map(LowCardinality(String), String)"
+      alias = "mapApply((k, v) -> (left(k, -5), v), attributes_map_str)"
+    }
+    column "attributes_map_float" {
+      type         = "Map(LowCardinality(String), Float64)"
+      materialized = "mapFilter((k, v) -> (v IS NOT NULL), mapApply((k, v) -> (concat(left(k, -5), '__float'), toFloat64OrNull(v)), attributes_map_str))"
+    }
+    column "attributes_map_datetime" {
+      type         = "Map(LowCardinality(String), DateTime64(6))"
+      materialized = "mapFilter((k, v) -> (v IS NOT NULL), mapApply((k, v) -> (concat(left(k, -5), '__datetime'), parseDateTimeBestEffortOrNull(v, 6)), attributes_map_str))"
+    }
+    column "dropped_attributes_count" {
+      type = "UInt32"
+    }
+    column "dropped_events_count" {
+      type = "UInt32"
+    }
+    column "dropped_links_count" {
+      type = "UInt32"
+    }
+    column "events" {
+      type = "Array(String)"
+    }
+    column "links" {
+      type = "Array(String)"
+    }
+    column "_partition" {
+      type = "UInt32"
+    }
+    column "_topic" {
+      type = "String"
+    }
+    column "_offset" {
+      type = "UInt64"
+    }
+    column "_bytes_uncompressed" {
+      type = "UInt64"
+    }
+    column "_bytes_compressed" {
+      type = "UInt64"
+    }
+    column "_record_count" {
+      type = "UInt64"
+    }
+    engine "distributed" {
+      cluster_name    = "logs"
+      remote_database = "posthog"
+      remote_table    = "trace_spans"
+    }
+  }
+
+  materialized_view "kafka_logs34_avro_mv" {
+    to_table = "posthog.writable_logs34"
+    query    = <<SQL
+SELECT
+  uuid,
+  trace_id,
+  span_id,
+  trace_flags,
+  timestamp,
+  observed_timestamp,
+  body,
+  severity_text,
+  severity_number,
+  service_name,
+  instrumentation_scope,
+  event_name,
+  mapSort(mapApply((k, v) -> (concat(k, '__str'), JSONExtractString(v)), attributes)) AS attributes_map_str,
+  mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), resource_attributes)) AS resource_attributes,
+  toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) AS team_id,
+  observed_timestamp
+  + toIntervalDay(
+    if(
+      (retention_days IS NOT NULL) AND (retention_days > 0),
+      retention_days,
+      toInt32OrDefault(_headers.value[indexOf(_headers.name, 'retention-days')], toInt32(15))
+    )
+  ) AS original_expiry_timestamp,
+  _partition,
+  _topic,
+  _offset,
+  toInt64OrDefault(_headers.value[indexOf(_headers.name, 'record_count')], toInt64(1)) AS _record_count,
+  toInt64OrNull(_headers.value[indexOf(_headers.name, 'bytes_uncompressed')]) / _record_count AS _bytes_uncompressed,
+  toInt64OrNull(_headers.value[indexOf(_headers.name, 'bytes_compressed')]) / _record_count AS _bytes_compressed,
+  ifNull(pattern, '') AS pattern,
+  toUInt8(ifNull(pattern_version, 0)) AS pattern_version
+FROM posthog.kafka_logs_avro
+SQL
+
+    column "uuid" {
+      type = "String"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "trace_flags" {
+      type = "Int32"
+    }
+    column "timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "observed_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "body" {
+      type = "String"
+    }
+    column "severity_text" {
+      type = "String"
+    }
+    column "severity_number" {
+      type = "Int32"
+    }
+    column "service_name" {
+      type = "String"
+    }
+    column "instrumentation_scope" {
+      type = "String"
+    }
+    column "event_name" {
+      type = "String"
+    }
+    column "attributes_map_str" {
+      type = "Map(String, String)"
+    }
+    column "resource_attributes" {
+      type = "Map(String, String)"
+    }
+    column "team_id" {
+      type = "Int32"
+    }
+    column "original_expiry_timestamp" {
+      type = "Nullable(DateTime64(6))"
+    }
+    column "_partition" {
+      type = "UInt64"
+    }
+    column "_topic" {
+      type = "LowCardinality(String)"
+    }
+    column "_offset" {
+      type = "UInt64"
+    }
+    column "_record_count" {
+      type = "Int64"
+    }
+    column "_bytes_uncompressed" {
+      type = "Nullable(Float64)"
+    }
+    column "_bytes_compressed" {
+      type = "Nullable(Float64)"
+    }
+    column "pattern" {
+      type = "String"
+    }
+    column "pattern_version" {
+      type = "UInt8"
+    }
+  }
+
+  materialized_view "kafka_metrics_avro_kafka_metrics_mv" {
+    to_table = "posthog.writable_metrics_kafka_metrics"
+    query    = <<SQL
+SELECT
+  _partition,
+  _topic,
+  maxSimpleState(_offset) AS max_offset,
+  maxSimpleState(observed_timestamp) AS max_observed_timestamp,
+  maxSimpleState(timestamp) AS max_timestamp,
+  maxSimpleState(now()) AS max_created_at,
+  maxSimpleState(now() - observed_timestamp) AS max_lag
+FROM posthog.kafka_metrics_avro
+GROUP BY
+  _partition, _topic
+SQL
+
+    column "_partition" {
+      type = "UInt64"
+    }
+    column "_topic" {
+      type = "LowCardinality(String)"
+    }
+    column "max_offset" {
+      type = "SimpleAggregateFunction(max, UInt64)"
+    }
+    column "max_observed_timestamp" {
+      type = "SimpleAggregateFunction(max, DateTime64(6))"
+    }
+    column "max_timestamp" {
+      type = "SimpleAggregateFunction(max, DateTime64(6))"
+    }
+    column "max_created_at" {
+      type = "SimpleAggregateFunction(max, DateTime)"
+    }
+    column "max_lag" {
+      type = "SimpleAggregateFunction(max, Decimal(18, 6))"
+    }
+  }
+
+  materialized_view "kafka_metrics_avro_mv" {
+    to_table = "posthog.writable_metrics1"
+    query    = <<SQL
+SELECT
+  uuid,
+  trace_id,
+  span_id,
+  ifNull(trace_flags, 0) AS trace_flags,
+  timestamp,
+  observed_timestamp,
+  ifNull(service_name, '') AS service_name,
+  ifNull(metric_name, '') AS metric_name,
+  ifNull(metric_type, '') AS metric_type,
+  ifNull(value, 0) AS value,
+  toUInt64(ifNull(count, 1)) AS count,
+  histogram_bounds,
+  arrayMap(x -> toUInt64(x), histogram_counts) AS histogram_counts,
+  ifNull(unit, '') AS unit,
+  ifNull(aggregation_temporality, '') AS aggregation_temporality,
+  ifNull(is_monotonic, 0) AS is_monotonic,
+  mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), resource_attributes)) AS resource_attributes,
+  ifNull(instrumentation_scope, '') AS instrumentation_scope,
+  mapSort(mapApply((k, v) -> (concat(k, '__str'), JSONExtractString(v)), attributes)) AS attributes_map_str,
+  mapSort(
+    mapFilter(
+      (k, v) -> isNotNull(v),
+      mapApply(
+        (k, v) -> (concat(k, '__float'), toFloat64OrNull(JSONExtract(v, 'String'))),
+        attributes
+      )
+    )
+  ) AS attributes_map_float,
+  toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) AS team_id
+FROM posthog.kafka_metrics_avro
+SETTINGS
+  min_insert_block_size_rows = 0,
+  min_insert_block_size_bytes = 0
+SQL
+
+    column "uuid" {
+      type = "String"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "trace_flags" {
+      type = "Int32"
+    }
+    column "timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "observed_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "service_name" {
+      type = "String"
+    }
+    column "metric_name" {
+      type = "String"
+    }
+    column "metric_type" {
+      type = "String"
+    }
+    column "value" {
+      type = "Float64"
+    }
+    column "count" {
+      type = "UInt64"
+    }
+    column "histogram_bounds" {
+      type = "Array(Float64)"
+    }
+    column "histogram_counts" {
+      type = "Array(UInt64)"
+    }
+    column "unit" {
+      type = "String"
+    }
+    column "aggregation_temporality" {
+      type = "String"
+    }
+    column "is_monotonic" {
+      type = "UInt8"
+    }
+    column "resource_attributes" {
+      type = "Map(String, String)"
+    }
+    column "instrumentation_scope" {
+      type = "String"
+    }
+    column "attributes_map_str" {
+      type = "Map(String, String)"
+    }
+    column "attributes_map_float" {
+      type = "Map(String, Nullable(Float64))"
+    }
+    column "team_id" {
+      type = "Int32"
+    }
+  }
+
+  materialized_view "kafka_metrics_avro_to_metric_samples" {
+    to_table = "posthog.writable_metric_samples1"
+    query    = <<SQL
+SELECT
+  toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) AS team_id,
+  ifNull(metric_name, '') AS metric_name,
+  reinterpretAsUInt64(assumeNotNull(series_fingerprint)) AS series_fingerprint,
+  timestamp,
+  ifNull(value, 0) AS value,
+  toUInt64(ifNull(count, 1)) AS count,
+  histogram_bounds,
+  arrayMap(x -> toUInt64(x), histogram_counts) AS histogram_counts,
+  trace_id,
+  span_id,
+  ifNull(trace_flags, 0) AS trace_flags
+FROM posthog.kafka_metrics_avro
+WHERE kafka_metrics_avro.series_fingerprint IS NOT NULL
+SETTINGS
+  min_insert_block_size_rows = 0,
+  min_insert_block_size_bytes = 0
+SQL
+
+    column "team_id" {
+      type = "Int32"
+    }
+    column "metric_name" {
+      type = "String"
+    }
+    column "series_fingerprint" {
+      type = "UInt64"
+    }
+    column "timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "value" {
+      type = "Float64"
+    }
+    column "count" {
+      type = "UInt64"
+    }
+    column "histogram_bounds" {
+      type = "Array(Float64)"
+    }
+    column "histogram_counts" {
+      type = "Array(UInt64)"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "trace_flags" {
+      type = "Int32"
+    }
+  }
+
+  materialized_view "kafka_metrics_avro_to_metric_series" {
+    to_table = "posthog.writable_metric_series1"
+    query    = <<SQL
+SELECT
+  toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) AS team_id,
+  ifNull(metric_name, '') AS metric_name,
+  reinterpretAsUInt64(assumeNotNull(series_fingerprint)) AS series_fingerprint,
+  ifNull(metric_type, '') AS metric_type,
+  ifNull(unit, '') AS unit,
+  ifNull(aggregation_temporality, '') AS aggregation_temporality,
+  ifNull(is_monotonic, 0) AS is_monotonic,
+  ifNull(service_name, '') AS service_name,
+  mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), resource_attributes)) AS resource_attributes,
+  mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), attributes)) AS attributes,
+  timestamp AS last_seen
+FROM posthog.kafka_metrics_avro
+WHERE kafka_metrics_avro.series_fingerprint IS NOT NULL
+SETTINGS
+  min_insert_block_size_rows = 0,
+  min_insert_block_size_bytes = 0
+SQL
+
+    column "team_id" {
+      type = "Int32"
+    }
+    column "metric_name" {
+      type = "String"
+    }
+    column "series_fingerprint" {
+      type = "UInt64"
+    }
+    column "metric_type" {
+      type = "String"
+    }
+    column "unit" {
+      type = "String"
+    }
+    column "aggregation_temporality" {
+      type = "String"
+    }
+    column "is_monotonic" {
+      type = "UInt8"
+    }
+    column "service_name" {
+      type = "String"
+    }
+    column "resource_attributes" {
+      type = "Map(String, String)"
+    }
+    column "attributes" {
+      type = "Map(String, String)"
+    }
+    column "last_seen" {
+      type = "DateTime64(6)"
+    }
+  }
+
+  materialized_view "kafka_trace_spans_avro_mv" {
+    to_table = "posthog.writable_trace_spans"
+    query    = <<SQL
+SELECT
+  * EXCEPT(attributes, resource_attributes, kind, flags, dropped_attributes_count, dropped_events_count, dropped_links_count, status_code),
+  toInt8(kind) AS kind,
+  toUInt32(flags) AS flags,
+  toUInt32(dropped_attributes_count) AS dropped_attributes_count,
+  toUInt32(dropped_events_count) AS dropped_events_count,
+  toUInt32(dropped_links_count) AS dropped_links_count,
+  toInt16(status_code) AS status_code,
+  mapSort(mapApply((k, v) -> (concat(k, '__str'), JSONExtractString(v)), attributes)) AS attributes_map_str,
+  mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), resource_attributes)) AS resource_attributes,
+  toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) AS team_id,
+  observed_timestamp
+  + toIntervalDay(
+    toInt32OrDefault(_headers.value[indexOf(_headers.name, 'retention-days')], toInt32(15))
+  ) AS original_expiry_timestamp,
+  _partition,
+  _topic,
+  _offset,
+  toInt64OrDefault(_headers.value[indexOf(_headers.name, 'record_count')], toInt64(1)) AS _record_count,
+  toInt64OrNull(_headers.value[indexOf(_headers.name, 'bytes_uncompressed')]) AS _bytes_uncompressed,
+  toInt64OrNull(_headers.value[indexOf(_headers.name, 'bytes_compressed')]) AS _bytes_compressed
+FROM posthog.kafka_trace_spans_avro
+SQL
+
+    column "uuid" {
+      type = "String"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "parent_span_id" {
+      type = "String"
+    }
+    column "trace_state" {
+      type = "String"
+    }
+    column "name" {
+      type = "String"
+    }
+    column "timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "end_time" {
+      type = "DateTime64(6)"
+    }
+    column "observed_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "service_name" {
+      type = "String"
+    }
+    column "instrumentation_scope" {
+      type = "String"
+    }
+    column "events" {
+      type = "Array(String)"
+    }
+    column "links" {
+      type = "Array(String)"
+    }
+    column "kind" {
+      type = "Int8"
+    }
+    column "flags" {
+      type = "UInt32"
+    }
+    column "dropped_attributes_count" {
+      type = "UInt32"
+    }
+    column "dropped_events_count" {
+      type = "UInt32"
+    }
+    column "dropped_links_count" {
+      type = "UInt32"
+    }
+    column "status_code" {
+      type = "Int16"
+    }
+    column "attributes_map_str" {
+      type = "Map(String, String)"
+    }
+    column "resource_attributes" {
+      type = "Map(String, String)"
+    }
+    column "team_id" {
+      type = "Int32"
+    }
+    column "original_expiry_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "_partition" {
+      type = "UInt64"
+    }
+    column "_topic" {
+      type = "LowCardinality(String)"
+    }
+    column "_offset" {
+      type = "UInt64"
+    }
+    column "_record_count" {
+      type = "Int64"
+    }
+    column "_bytes_uncompressed" {
+      type = "Nullable(Int64)"
+    }
+    column "_bytes_compressed" {
+      type = "Nullable(Int64)"
+    }
+  }
+
+  materialized_view "ops_query_log_archive_mv" {
+    to_table = "posthog.writable_query_log_archive"
+    query    = <<SQL
+SELECT
+  hostname,
+  user,
+  query_id,
+  initial_query_id,
+  is_initial_query,
+  type,
+  event_date,
+  event_time,
+  event_time_microseconds,
+  query_start_time,
+  query_start_time_microseconds,
+  query_duration_ms,
+  read_rows,
+  read_bytes,
+  written_rows,
+  written_bytes,
+  result_rows,
+  result_bytes,
+  memory_usage,
+  peak_threads_usage,
+  current_database,
+  query,
+  formatted_query,
+  normalized_query_hash,
+  query_kind,
+  exception_code,
+  exception,
+  stack_trace,
+  JSONExtractInt(log_comment, 'team_id') AS team_id,
+  if(isValidJSON(log_comment), log_comment, '{}') AS log_comment,
+  ProfileEvents
+FROM system.query_log
+WHERE type != 'QueryStart'
+SQL
+
+    column "hostname" {
+      type = "LowCardinality(String)"
+    }
+    column "user" {
+      type = "LowCardinality(String)"
+    }
+    column "query_id" {
+      type = "String"
+    }
+    column "initial_query_id" {
+      type = "String"
+    }
+    column "is_initial_query" {
+      type = "UInt8"
+    }
+    column "type" {
+      type = "Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4)"
+    }
+    column "event_date" {
+      type = "Date"
+    }
+    column "event_time" {
+      type = "DateTime"
+    }
+    column "event_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_start_time" {
+      type = "DateTime"
+    }
+    column "query_start_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_duration_ms" {
+      type = "UInt64"
+    }
+    column "read_rows" {
+      type = "UInt64"
+    }
+    column "read_bytes" {
+      type = "UInt64"
+    }
+    column "written_rows" {
+      type = "UInt64"
+    }
+    column "written_bytes" {
+      type = "UInt64"
+    }
+    column "result_rows" {
+      type = "UInt64"
+    }
+    column "result_bytes" {
+      type = "UInt64"
+    }
+    column "memory_usage" {
+      type = "UInt64"
+    }
+    column "peak_threads_usage" {
+      type = "UInt64"
+    }
+    column "current_database" {
+      type = "LowCardinality(String)"
+    }
+    column "query" {
+      type = "String"
+    }
+    column "formatted_query" {
+      type = "String"
+    }
+    column "normalized_query_hash" {
+      type = "UInt64"
+    }
+    column "query_kind" {
+      type = "LowCardinality(String)"
+    }
+    column "exception_code" {
+      type = "Int32"
+    }
+    column "exception" {
+      type = "String"
+    }
+    column "stack_trace" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "log_comment" {
+      type = "String"
+    }
+    column "ProfileEvents" {
+      type = "Map(LowCardinality(String), UInt64)"
+    }
+  }
+
+  view "custom_metrics" {
+    query = <<SQL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_test
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_replication_queue
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_server_crash
+UNION ALL
+SELECT *
+FROM posthog.custom_metrics_table_sizes
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_part_counts
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_dictionaries
+UNION ALL
+SELECT
+  'ClickHouseCustomMetric_S3DiskBytesUsed' AS name,
+  map('instance', hostname(), 'disk', disk_name) AS labels,
+  toFloat64(sum(bytes_on_disk)) AS value,
+  'Bytes currently used by ClickHouse parts on S3-backed disks on this node' AS help,
+  'gauge' AS type
+FROM system.parts
+WHERE disk_name IN ('s3disk', 'cache')
+GROUP BY
+  disk_name
+UNION ALL
+SELECT
+  'ClickHouseCustomMetric_MergeFailures15m' AS name,
+  map('instance', hostname()) AS labels,
+  toFloat64(count()) AS value,
+  'Number of failed merge operations in the last 15 minutes' AS help,
+  'gauge' AS type
+FROM system.part_log
+WHERE
+  (event_time >= (now() - toIntervalMinute(15)))
+AND
+  (event_type = 'MergeParts')
+AND
+  (error > 0)
+AND
+  (merge_reason != 'NotAMerge')
+AND
+  (error != 40)
+UNION ALL
+SELECT
+  'ClickHouseCustomMetric_MergeRetriesMaxPerTable15m' AS name,
+  map('instance', hostname()) AS labels,
+  toFloat64(max(cnt)) AS value,
+  'Max failed merge retries for any single table in the last 15 minutes' AS help,
+  'gauge' AS type
+FROM
+  (
+    SELECT count() AS cnt
+    FROM system.part_log
+    WHERE
+      (event_time >= (now() - toIntervalMinute(15)))
+    AND
+      (event_type = 'MergeParts')
+    AND
+      (error > 0)
+    AND
+      (merge_reason != 'NotAMerge')
+    AND
+      (error != 40)
+    GROUP BY
+      database, `table`, partition_id
+  )
+SQL
+
+  }
+}
+
+named_collection "msk_cluster" {
+  external = true
+}
+
+named_collection "warpstream_calculated_events" {
+  external = true
+}
+
+named_collection "warpstream_cyclotron" {
+  external = true
+}
+
+named_collection "warpstream_ingestion" {
+  external = true
+}
+
+named_collection "warpstream_logs" {
+  external = true
+}
+
+named_collection "warpstream_metrics" {
+  external = true
+}
+
+named_collection "warpstream_replay" {
+  external = true
+}
+
+named_collection "warpstream_shared" {
+  external = true
+}
+
+named_collection "warpstream_traces" {
+  external = true
+}

--- a/posthog/clickhouse/hcl/golden/prod-eu/apm.hcl
+++ b/posthog/clickhouse/hcl/golden/prod-eu/apm.hcl
@@ -1,0 +1,312 @@
+database "posthog" {
+  table "writable_query_log_archive" {
+    column "hostname" {
+      type = "LowCardinality(String)"
+    }
+    column "user" {
+      type = "LowCardinality(String)"
+    }
+    column "query_id" {
+      type = "String"
+    }
+    column "initial_query_id" {
+      type = "String"
+    }
+    column "is_initial_query" {
+      type = "UInt8"
+    }
+    column "type" {
+      type = "Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4)"
+    }
+    column "event_date" {
+      type = "Date"
+    }
+    column "event_time" {
+      type = "DateTime"
+    }
+    column "event_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_start_time" {
+      type = "DateTime"
+    }
+    column "query_start_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_duration_ms" {
+      type = "UInt64"
+    }
+    column "read_rows" {
+      type = "UInt64"
+    }
+    column "read_bytes" {
+      type = "UInt64"
+    }
+    column "written_rows" {
+      type = "UInt64"
+    }
+    column "written_bytes" {
+      type = "UInt64"
+    }
+    column "result_rows" {
+      type = "UInt64"
+    }
+    column "result_bytes" {
+      type = "UInt64"
+    }
+    column "memory_usage" {
+      type = "UInt64"
+    }
+    column "peak_threads_usage" {
+      type = "UInt64"
+    }
+    column "current_database" {
+      type = "LowCardinality(String)"
+    }
+    column "query" {
+      type = "String"
+    }
+    column "formatted_query" {
+      type = "String"
+    }
+    column "normalized_query_hash" {
+      type = "UInt64"
+    }
+    column "query_kind" {
+      type = "LowCardinality(String)"
+    }
+    column "exception_code" {
+      type = "Int32"
+    }
+    column "exception" {
+      type = "String"
+    }
+    column "stack_trace" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "log_comment" {
+      type = "JSON(max_dynamic_paths=256, access_method LowCardinality(String), alert_config_id String, api_key_label String, api_key_mask String, batch_export_id String, chargeable Bool, client_query_id String, cohort_id Int64, `dagster.job_name` String, `dagster.run_id` String, `dagster.tags.owner` String, dashboard_id Int64, experiment_feature_flag_key String, experiment_id Int64, feature LowCardinality(String), id String, insight_id Int64, is_impersonated Bool, kind LowCardinality(String), name String, org_id String, person_on_events_mode LowCardinality(String), product LowCardinality(String), query_type LowCardinality(String), request_name String, route_id String, service_name String, session_id String, table_id String, team_id Int64, `temporal.activity_id` String, `temporal.activity_type` String, `temporal.attempt` Int64, `temporal.workflow_id` String, `temporal.workflow_namespace` String, `temporal.workflow_run_id` String, `temporal.workflow_type` String, user_id Int64, warehouse_query Bool, workflow LowCardinality(String), workload LowCardinality(String), SKIP cache_key, SKIP filter, SKIP hogql_features, SKIP http_referer, SKIP http_request_id, SKIP http_user_agent, SKIP query_settings, SKIP timings, SKIP user_email)"
+    }
+    column "ProfileEvents" {
+      type = "Map(String, UInt64)"
+    }
+    engine "distributed" {
+      cluster_name    = "ops"
+      remote_database = "posthog"
+      remote_table    = "query_log_archive_buffer"
+    }
+  }
+
+  materialized_view "ops_query_log_archive_mv" {
+    to_table = "posthog.writable_query_log_archive"
+    query    = <<SQL
+SELECT
+  hostname,
+  user,
+  query_id,
+  initial_query_id,
+  is_initial_query,
+  type,
+  event_date,
+  event_time,
+  event_time_microseconds,
+  query_start_time,
+  query_start_time_microseconds,
+  query_duration_ms,
+  read_rows,
+  read_bytes,
+  written_rows,
+  written_bytes,
+  result_rows,
+  result_bytes,
+  memory_usage,
+  peak_threads_usage,
+  current_database,
+  query,
+  formatted_query,
+  normalized_query_hash,
+  query_kind,
+  exception_code,
+  exception,
+  stack_trace,
+  JSONExtractInt(log_comment, 'team_id') AS team_id,
+  if(isValidJSON(log_comment), log_comment, '{}') AS log_comment,
+  ProfileEvents
+FROM system.query_log
+WHERE type != 'QueryStart'
+SQL
+
+    column "hostname" {
+      type = "LowCardinality(String)"
+    }
+    column "user" {
+      type = "LowCardinality(String)"
+    }
+    column "query_id" {
+      type = "String"
+    }
+    column "initial_query_id" {
+      type = "String"
+    }
+    column "is_initial_query" {
+      type = "UInt8"
+    }
+    column "type" {
+      type = "Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4)"
+    }
+    column "event_date" {
+      type = "Date"
+    }
+    column "event_time" {
+      type = "DateTime"
+    }
+    column "event_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_start_time" {
+      type = "DateTime"
+    }
+    column "query_start_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_duration_ms" {
+      type = "UInt64"
+    }
+    column "read_rows" {
+      type = "UInt64"
+    }
+    column "read_bytes" {
+      type = "UInt64"
+    }
+    column "written_rows" {
+      type = "UInt64"
+    }
+    column "written_bytes" {
+      type = "UInt64"
+    }
+    column "result_rows" {
+      type = "UInt64"
+    }
+    column "result_bytes" {
+      type = "UInt64"
+    }
+    column "memory_usage" {
+      type = "UInt64"
+    }
+    column "peak_threads_usage" {
+      type = "UInt64"
+    }
+    column "current_database" {
+      type = "LowCardinality(String)"
+    }
+    column "query" {
+      type = "String"
+    }
+    column "formatted_query" {
+      type = "String"
+    }
+    column "normalized_query_hash" {
+      type = "UInt64"
+    }
+    column "query_kind" {
+      type = "LowCardinality(String)"
+    }
+    column "exception_code" {
+      type = "Int32"
+    }
+    column "exception" {
+      type = "String"
+    }
+    column "stack_trace" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "log_comment" {
+      type = "String"
+    }
+    column "ProfileEvents" {
+      type = "Map(LowCardinality(String), UInt64)"
+    }
+  }
+
+  view "custom_metrics" {
+    query = <<SQL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_test
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_replication_queue
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_server_crash
+UNION ALL
+SELECT *
+FROM posthog.custom_metrics_table_sizes
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_part_counts
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_dictionaries
+UNION ALL
+SELECT
+  'ClickHouseCustomMetric_S3DiskBytesUsed' AS name,
+  map('instance', hostname(), 'disk', disk_name) AS labels,
+  toFloat64(sum(bytes_on_disk)) AS value,
+  'Bytes currently used by ClickHouse parts on S3-backed disks on this node' AS help,
+  'gauge' AS type
+FROM system.parts
+WHERE disk_name IN ('s3disk', 'cache')
+GROUP BY
+  disk_name
+UNION ALL
+SELECT
+  'ClickHouseCustomMetric_MergeFailures15m' AS name,
+  map('instance', hostname()) AS labels,
+  toFloat64(count()) AS value,
+  'Number of failed merge operations in the last 15 minutes' AS help,
+  'gauge' AS type
+FROM system.part_log
+WHERE
+  (event_time >= (now() - toIntervalMinute(15)))
+AND
+  (event_type = 'MergeParts')
+AND
+  (error > 0)
+AND
+  (merge_reason != 'NotAMerge')
+AND
+  (error != 40)
+UNION ALL
+SELECT
+  'ClickHouseCustomMetric_MergeRetriesMaxPerTable15m' AS name,
+  map('instance', hostname()) AS labels,
+  toFloat64(max(cnt)) AS value,
+  'Max failed merge retries for any single table in the last 15 minutes' AS help,
+  'gauge' AS type
+FROM
+  (
+    SELECT count() AS cnt
+    FROM system.part_log
+    WHERE
+      (event_time >= (now() - toIntervalMinute(15)))
+    AND
+      (event_type = 'MergeParts')
+    AND
+      (error > 0)
+    AND
+      (merge_reason != 'NotAMerge')
+    AND
+      (error != 40)
+    GROUP BY
+      database, `table`, partition_id
+  )
+SQL
+
+  }
+}

--- a/posthog/clickhouse/hcl/golden/prod-us/apm.hcl
+++ b/posthog/clickhouse/hcl/golden/prod-us/apm.hcl
@@ -1,0 +1,312 @@
+database "posthog" {
+  table "writable_query_log_archive" {
+    column "hostname" {
+      type = "LowCardinality(String)"
+    }
+    column "user" {
+      type = "LowCardinality(String)"
+    }
+    column "query_id" {
+      type = "String"
+    }
+    column "initial_query_id" {
+      type = "String"
+    }
+    column "is_initial_query" {
+      type = "UInt8"
+    }
+    column "type" {
+      type = "Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4)"
+    }
+    column "event_date" {
+      type = "Date"
+    }
+    column "event_time" {
+      type = "DateTime"
+    }
+    column "event_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_start_time" {
+      type = "DateTime"
+    }
+    column "query_start_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_duration_ms" {
+      type = "UInt64"
+    }
+    column "read_rows" {
+      type = "UInt64"
+    }
+    column "read_bytes" {
+      type = "UInt64"
+    }
+    column "written_rows" {
+      type = "UInt64"
+    }
+    column "written_bytes" {
+      type = "UInt64"
+    }
+    column "result_rows" {
+      type = "UInt64"
+    }
+    column "result_bytes" {
+      type = "UInt64"
+    }
+    column "memory_usage" {
+      type = "UInt64"
+    }
+    column "peak_threads_usage" {
+      type = "UInt64"
+    }
+    column "current_database" {
+      type = "LowCardinality(String)"
+    }
+    column "query" {
+      type = "String"
+    }
+    column "formatted_query" {
+      type = "String"
+    }
+    column "normalized_query_hash" {
+      type = "UInt64"
+    }
+    column "query_kind" {
+      type = "LowCardinality(String)"
+    }
+    column "exception_code" {
+      type = "Int32"
+    }
+    column "exception" {
+      type = "String"
+    }
+    column "stack_trace" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "log_comment" {
+      type = "JSON(max_dynamic_paths=256, access_method LowCardinality(String), alert_config_id String, api_key_label String, api_key_mask String, batch_export_id String, chargeable Bool, client_query_id String, cohort_id Int64, `dagster.job_name` String, `dagster.run_id` String, `dagster.tags.owner` String, dashboard_id Int64, experiment_feature_flag_key String, experiment_id Int64, feature LowCardinality(String), id String, insight_id Int64, is_impersonated Bool, kind LowCardinality(String), name String, org_id String, person_on_events_mode LowCardinality(String), product LowCardinality(String), query_type LowCardinality(String), request_name String, route_id String, service_name String, session_id String, table_id String, team_id Int64, `temporal.activity_id` String, `temporal.activity_type` String, `temporal.attempt` Int64, `temporal.workflow_id` String, `temporal.workflow_namespace` String, `temporal.workflow_run_id` String, `temporal.workflow_type` String, user_id Int64, warehouse_query Bool, workflow LowCardinality(String), workload LowCardinality(String), SKIP cache_key, SKIP filter, SKIP hogql_features, SKIP http_referer, SKIP http_request_id, SKIP http_user_agent, SKIP query_settings, SKIP timings, SKIP user_email)"
+    }
+    column "ProfileEvents" {
+      type = "Map(String, UInt64)"
+    }
+    engine "distributed" {
+      cluster_name    = "ops"
+      remote_database = "posthog"
+      remote_table    = "query_log_archive_buffer"
+    }
+  }
+
+  materialized_view "ops_query_log_archive_mv" {
+    to_table = "posthog.writable_query_log_archive"
+    query    = <<SQL
+SELECT
+  hostname,
+  user,
+  query_id,
+  initial_query_id,
+  is_initial_query,
+  type,
+  event_date,
+  event_time,
+  event_time_microseconds,
+  query_start_time,
+  query_start_time_microseconds,
+  query_duration_ms,
+  read_rows,
+  read_bytes,
+  written_rows,
+  written_bytes,
+  result_rows,
+  result_bytes,
+  memory_usage,
+  peak_threads_usage,
+  current_database,
+  query,
+  formatted_query,
+  normalized_query_hash,
+  query_kind,
+  exception_code,
+  exception,
+  stack_trace,
+  JSONExtractInt(log_comment, 'team_id') AS team_id,
+  if(isValidJSON(log_comment), log_comment, '{}') AS log_comment,
+  ProfileEvents
+FROM system.query_log
+WHERE type != 'QueryStart'
+SQL
+
+    column "hostname" {
+      type = "LowCardinality(String)"
+    }
+    column "user" {
+      type = "LowCardinality(String)"
+    }
+    column "query_id" {
+      type = "String"
+    }
+    column "initial_query_id" {
+      type = "String"
+    }
+    column "is_initial_query" {
+      type = "UInt8"
+    }
+    column "type" {
+      type = "Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4)"
+    }
+    column "event_date" {
+      type = "Date"
+    }
+    column "event_time" {
+      type = "DateTime"
+    }
+    column "event_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_start_time" {
+      type = "DateTime"
+    }
+    column "query_start_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_duration_ms" {
+      type = "UInt64"
+    }
+    column "read_rows" {
+      type = "UInt64"
+    }
+    column "read_bytes" {
+      type = "UInt64"
+    }
+    column "written_rows" {
+      type = "UInt64"
+    }
+    column "written_bytes" {
+      type = "UInt64"
+    }
+    column "result_rows" {
+      type = "UInt64"
+    }
+    column "result_bytes" {
+      type = "UInt64"
+    }
+    column "memory_usage" {
+      type = "UInt64"
+    }
+    column "peak_threads_usage" {
+      type = "UInt64"
+    }
+    column "current_database" {
+      type = "LowCardinality(String)"
+    }
+    column "query" {
+      type = "String"
+    }
+    column "formatted_query" {
+      type = "String"
+    }
+    column "normalized_query_hash" {
+      type = "UInt64"
+    }
+    column "query_kind" {
+      type = "LowCardinality(String)"
+    }
+    column "exception_code" {
+      type = "Int32"
+    }
+    column "exception" {
+      type = "String"
+    }
+    column "stack_trace" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "log_comment" {
+      type = "String"
+    }
+    column "ProfileEvents" {
+      type = "Map(LowCardinality(String), UInt64)"
+    }
+  }
+
+  view "custom_metrics" {
+    query = <<SQL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_test
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_replication_queue
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_server_crash
+UNION ALL
+SELECT *
+FROM posthog.custom_metrics_table_sizes
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_part_counts
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_dictionaries
+UNION ALL
+SELECT
+  'ClickHouseCustomMetric_S3DiskBytesUsed' AS name,
+  map('instance', hostname(), 'disk', disk_name) AS labels,
+  toFloat64(sum(bytes_on_disk)) AS value,
+  'Bytes currently used by ClickHouse parts on S3-backed disks on this node' AS help,
+  'gauge' AS type
+FROM system.parts
+WHERE disk_name IN ('s3disk', 'cache')
+GROUP BY
+  disk_name
+UNION ALL
+SELECT
+  'ClickHouseCustomMetric_MergeFailures15m' AS name,
+  map('instance', hostname()) AS labels,
+  toFloat64(count()) AS value,
+  'Number of failed merge operations in the last 15 minutes' AS help,
+  'gauge' AS type
+FROM system.part_log
+WHERE
+  (event_time >= (now() - toIntervalMinute(15)))
+AND
+  (event_type = 'MergeParts')
+AND
+  (error > 0)
+AND
+  (merge_reason != 'NotAMerge')
+AND
+  (error != 40)
+UNION ALL
+SELECT
+  'ClickHouseCustomMetric_MergeRetriesMaxPerTable15m' AS name,
+  map('instance', hostname()) AS labels,
+  toFloat64(max(cnt)) AS value,
+  'Max failed merge retries for any single table in the last 15 minutes' AS help,
+  'gauge' AS type
+FROM
+  (
+    SELECT count() AS cnt
+    FROM system.part_log
+    WHERE
+      (event_time >= (now() - toIntervalMinute(15)))
+    AND
+      (event_type = 'MergeParts')
+    AND
+      (error > 0)
+    AND
+      (merge_reason != 'NotAMerge')
+    AND
+      (error != 40)
+    GROUP BY
+      database, `table`, partition_id
+  )
+SQL
+
+  }
+}

--- a/posthog/clickhouse/hcl/manifest.hcl
+++ b/posthog/clickhouse/hcl/manifest.hcl
@@ -42,6 +42,17 @@ role "logs" {
   env "prod-eu" { layers = ["roles/shared", "roles/coshared/named_collections", "roles/coshared/custom_metrics", "roles/logs/base", "roles/logs/traces", "roles/logs/traces_kafka_metrics", "roles/logs/metrics", "roles/logs/shared", "roles/logs/prod", "roles/logs/prod-eu"] }
 }
 
+# APM satellite: the ingestion-apm nodes. Every env runs the shared custom_metrics
+# suite and writes into the query log archive, but not the query_log_archive reader
+# itself. dev additionally runs the APM ingest chain -- the Kafka consumers for logs,
+# traces and metrics and the writable proxies they feed -- which the prod envs still
+# run on their logs nodes.
+role "apm" {
+  env "dev"     { layers = ["roles/shared/qla_write.hcl", "roles/coshared/named_collections", "roles/coshared/custom_metrics", "roles/apm/dev"] }
+  env "prod-us" { layers = ["roles/shared/qla_write.hcl", "roles/coshared/custom_metrics"] }
+  env "prod-eu" { layers = ["roles/shared/qla_write.hcl", "roles/coshared/custom_metrics"] }
+}
+
 # AI_EVENTS satellite (LLM analytics). local/hobby run the MSK variant
 # (kafka_ai_events_json + ai_events_json_mv) with a sharded_ai_events data table
 # + distributed ai_events reader; US/EU run the WarpStream variant

--- a/posthog/clickhouse/hcl/roles/apm/dev/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/apm/dev/tables.hcl
@@ -1,0 +1,1187 @@
+# The APM ingest chain, as dev runs it on its ingestion-apm nodes: the Kafka
+# consumers for logs, traces and metrics, their views, and the writable proxies
+# they feed. The prod envs still run this chain on their logs nodes, so an object
+# the logs role already declares is restated here rather than declared twice. dev
+# also tunes its consumers smaller than prod does.
+database "posthog" {
+  table "kafka_logs_avro" {
+    override = true
+    settings = {
+      input_format_avro_allow_missing_fields = "1"
+    }
+    column "uuid" {
+      type = "String"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "trace_flags" {
+      type = "Int32"
+    }
+    column "timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "observed_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "body" {
+      type = "String"
+    }
+    column "severity_text" {
+      type = "String"
+    }
+    column "severity_number" {
+      type = "Int32"
+    }
+    column "service_name" {
+      type = "String"
+    }
+    column "resource_attributes" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "instrumentation_scope" {
+      type = "String"
+    }
+    column "event_name" {
+      type = "String"
+    }
+    column "attributes" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "retention_days" {
+      type = "Nullable(Int32)"
+    }
+    column "pattern" {
+      type = "Nullable(String)"
+    }
+    column "pattern_version" {
+      type = "Nullable(Int32)"
+    }
+    engine "kafka" {
+      collection           = "warpstream_logs"
+      topic_list           = "clickhouse_logs"
+      group_name           = "clickhouse-logs-avro-new"
+      format               = "Avro"
+      num_consumers        = 4
+      skip_broken_messages = 100
+      poll_timeout_ms      = 10000
+      poll_max_batch_size  = 1000
+      flush_interval_ms    = 10000
+      thread_per_consumer  = true
+    }
+  }
+
+  table "kafka_metrics_avro" {
+    override = true
+    settings = {
+      input_format_avro_allow_missing_fields = "1"
+    }
+    column "uuid" {
+      type = "String"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "trace_flags" {
+      type = "Nullable(Int32)"
+    }
+    column "timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "observed_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "service_name" {
+      type = "Nullable(String)"
+    }
+    column "metric_name" {
+      type = "Nullable(String)"
+    }
+    column "metric_type" {
+      type = "Nullable(String)"
+    }
+    column "value" {
+      type = "Nullable(Float64)"
+    }
+    column "count" {
+      type = "Nullable(Int64)"
+    }
+    column "histogram_bounds" {
+      type = "Array(Float64)"
+    }
+    column "histogram_counts" {
+      type = "Array(Int64)"
+    }
+    column "unit" {
+      type = "Nullable(String)"
+    }
+    column "aggregation_temporality" {
+      type = "Nullable(String)"
+    }
+    column "is_monotonic" {
+      type = "Nullable(UInt8)"
+    }
+    column "resource_attributes" {
+      type = "Map(String, String)"
+    }
+    column "instrumentation_scope" {
+      type = "Nullable(String)"
+    }
+    column "attributes" {
+      type = "Map(String, String)"
+    }
+    column "series_fingerprint" {
+      type = "Nullable(Int64)"
+    }
+    engine "kafka" {
+      collection           = "warpstream_metrics"
+      topic_list           = "clickhouse_metrics"
+      group_name           = "clickhouse-metrics-avro-new"
+      format               = "Avro"
+      num_consumers        = 4
+      skip_broken_messages = 100
+      poll_timeout_ms      = 10000
+      poll_max_batch_size  = 1000
+      flush_interval_ms    = 10000
+      thread_per_consumer  = true
+    }
+  }
+
+  table "kafka_trace_spans_avro" {
+    override = true
+    settings = {
+      input_format_avro_allow_missing_fields = "1"
+    }
+    column "uuid" {
+      type = "String"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "parent_span_id" {
+      type = "String"
+    }
+    column "trace_state" {
+      type = "String"
+    }
+    column "name" {
+      type = "String"
+    }
+    column "kind" {
+      type = "Int32"
+    }
+    column "flags" {
+      type = "Int32"
+    }
+    column "timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "end_time" {
+      type = "DateTime64(6)"
+    }
+    column "observed_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "service_name" {
+      type = "String"
+    }
+    column "resource_attributes" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "instrumentation_scope" {
+      type = "String"
+    }
+    column "attributes" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "dropped_attributes_count" {
+      type = "Int32"
+    }
+    column "events" {
+      type = "Array(String)"
+    }
+    column "dropped_events_count" {
+      type = "Int32"
+    }
+    column "links" {
+      type = "Array(String)"
+    }
+    column "dropped_links_count" {
+      type = "Int32"
+    }
+    column "status_code" {
+      type = "Int32"
+    }
+    engine "kafka" {
+      collection           = "warpstream_traces"
+      topic_list           = "clickhouse_traces"
+      group_name           = "clickhouse-traces-avro"
+      format               = "Avro"
+      num_consumers        = 4
+      skip_broken_messages = 100
+      poll_timeout_ms      = 10000
+      poll_max_batch_size  = 1000
+      flush_interval_ms    = 10000
+      thread_per_consumer  = true
+    }
+  }
+
+  table "writable_logs34" {
+    override = true
+    settings = {
+      background_insert_batch = "1"
+    }
+    column "time_bucket" {
+      type         = "DateTime"
+      materialized = "toStartOfDay(timestamp)"
+    }
+    column "original_expiry_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "uuid" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int32"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "trace_flags" {
+      type = "Int32"
+    }
+    column "timestamp" {
+      type  = "DateTime64(6)"
+      codec = "DoubleDelta"
+    }
+    column "observed_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "created_at" {
+      type         = "DateTime64(6)"
+      materialized = "now()"
+    }
+    column "body" {
+      type = "String"
+    }
+    column "severity_text" {
+      type = "LowCardinality(String)"
+    }
+    column "severity_number" {
+      type = "Int32"
+    }
+    column "service_name" {
+      type = "LowCardinality(String)"
+    }
+    column "resource_attributes" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "resource_fingerprint" {
+      type         = "UInt64"
+      materialized = "cityHash64(resource_attributes)"
+    }
+    column "instrumentation_scope" {
+      type = "String"
+    }
+    column "event_name" {
+      type = "String"
+    }
+    column "attributes_map_str" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "level" {
+      type  = "String"
+      alias = "severity_text"
+    }
+    column "mat_body_ipv4_matches" {
+      type  = "Array(String)"
+      alias = "extractAll(body, '(\\\\d\\\\.((25[0-5]|(2[0-4]|1(0, 1)[0-9])(0, 1)[0-9])\\\\.)(2, 2)([0-9]))')"
+    }
+    column "time_minute" {
+      type  = "DateTime"
+      alias = "toStartOfMinute(timestamp)"
+    }
+    column "attributes" {
+      type  = "Map(LowCardinality(String), String)"
+      alias = "mapApply((k, v) -> (left(k, -5), v), attributes_map_str)"
+    }
+    column "attributes_map_float" {
+      type         = "Map(LowCardinality(String), Float64)"
+      materialized = "mapFilter((k, v) -> (v IS NOT NULL), mapApply((k, v) -> (concat(left(k, -5), '__float'), toFloat64OrNull(v)), attributes_map_str))"
+    }
+    column "attributes_map_datetime" {
+      type         = "Map(LowCardinality(String), DateTime64(6))"
+      materialized = "mapFilter((k, v) -> (v IS NOT NULL), mapApply((k, v) -> (concat(left(k, -5), '__datetime'), parseDateTimeBestEffortOrNull(v, 6)), attributes_map_str))"
+    }
+    column "_partition" {
+      type = "UInt32"
+    }
+    column "_topic" {
+      type = "String"
+    }
+    column "_offset" {
+      type = "UInt64"
+    }
+    column "_bytes_uncompressed" {
+      type = "UInt64"
+    }
+    column "_bytes_compressed" {
+      type = "UInt64"
+    }
+    column "_record_count" {
+      type = "UInt64"
+    }
+    column "pattern" {
+      type = "String"
+    }
+    column "pattern_version" {
+      type = "UInt8"
+    }
+    engine "distributed" {
+      cluster_name    = "logs"
+      remote_database = "posthog"
+      remote_table    = "logs34"
+    }
+  }
+
+  table "writable_metric_samples1" {
+    column "team_id" {
+      type = "Int32"
+    }
+    column "metric_name" {
+      type = "LowCardinality(String)"
+    }
+    column "series_fingerprint" {
+      type  = "UInt64"
+      codec = "DoubleDelta"
+    }
+    column "timestamp" {
+      type  = "DateTime64(6)"
+      codec = "DoubleDelta"
+    }
+    column "value" {
+      type  = "Float64"
+      codec = "Gorilla(8)"
+    }
+    column "count" {
+      type    = "UInt64"
+      default = "1"
+    }
+    column "histogram_bounds" {
+      type = "Array(Float64)"
+    }
+    column "histogram_counts" {
+      type = "Array(UInt64)"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "trace_flags" {
+      type = "Int32"
+    }
+    engine "distributed" {
+      cluster_name    = "logs"
+      remote_database = "posthog"
+      remote_table    = "metric_samples1"
+    }
+  }
+
+  table "writable_metric_series1" {
+    column "team_id" {
+      type = "Int32"
+    }
+    column "metric_name" {
+      type = "LowCardinality(String)"
+    }
+    column "series_fingerprint" {
+      type  = "UInt64"
+      codec = "DoubleDelta"
+    }
+    column "metric_type" {
+      type = "LowCardinality(String)"
+    }
+    column "unit" {
+      type = "LowCardinality(String)"
+    }
+    column "aggregation_temporality" {
+      type = "LowCardinality(String)"
+    }
+    column "is_monotonic" {
+      type    = "Bool"
+      default = "false"
+    }
+    column "service_name" {
+      type = "LowCardinality(String)"
+    }
+    column "resource_attributes" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "attributes" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "last_seen" {
+      type  = "DateTime64(6)"
+      codec = "DoubleDelta"
+    }
+    engine "distributed" {
+      cluster_name    = "logs"
+      remote_database = "posthog"
+      remote_table    = "metric_series1"
+    }
+  }
+
+  table "writable_metrics1" {
+    column "time_bucket" {
+      type         = "DateTime"
+      materialized = "toStartOfDay(timestamp)"
+    }
+    column "uuid" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int32"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "trace_flags" {
+      type = "Int32"
+    }
+    column "timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "observed_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "created_at" {
+      type         = "DateTime64(6)"
+      materialized = "now()"
+    }
+    column "service_name" {
+      type = "LowCardinality(String)"
+    }
+    column "metric_name" {
+      type = "LowCardinality(String)"
+    }
+    column "metric_type" {
+      type = "LowCardinality(String)"
+    }
+    column "value" {
+      type = "Float64"
+    }
+    column "count" {
+      type    = "UInt64"
+      default = "1"
+    }
+    column "histogram_bounds" {
+      type = "Array(Float64)"
+    }
+    column "histogram_counts" {
+      type = "Array(UInt64)"
+    }
+    column "unit" {
+      type = "LowCardinality(String)"
+    }
+    column "aggregation_temporality" {
+      type = "LowCardinality(String)"
+    }
+    column "is_monotonic" {
+      type    = "Bool"
+      default = "false"
+    }
+    column "resource_attributes" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "resource_fingerprint" {
+      type         = "UInt64"
+      materialized = "cityHash64(resource_attributes)"
+    }
+    column "instrumentation_scope" {
+      type = "String"
+    }
+    column "attributes_map_str" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "attributes_map_float" {
+      type = "Map(LowCardinality(String), Float64)"
+    }
+    column "time_minute" {
+      type  = "DateTime"
+      alias = "toStartOfMinute(timestamp)"
+    }
+    column "attributes" {
+      type  = "Map(String, String)"
+      alias = "mapApply((k, v) -> (left(k, -5), v), attributes_map_str)"
+    }
+    engine "distributed" {
+      cluster_name    = "logs"
+      remote_database = "posthog"
+      remote_table    = "metrics1"
+    }
+  }
+
+  table "writable_metrics_kafka_metrics" {
+    column "_partition" {
+      type = "UInt32"
+    }
+    column "_topic" {
+      type = "String"
+    }
+    column "max_offset" {
+      type = "SimpleAggregateFunction(max, UInt64)"
+    }
+    column "max_observed_timestamp" {
+      type = "SimpleAggregateFunction(max, DateTime64(9))"
+    }
+    column "max_timestamp" {
+      type = "SimpleAggregateFunction(max, DateTime64(9))"
+    }
+    column "max_created_at" {
+      type = "SimpleAggregateFunction(max, DateTime64(9))"
+    }
+    column "max_lag" {
+      type = "SimpleAggregateFunction(max, UInt64)"
+    }
+    engine "distributed" {
+      cluster_name    = "logs"
+      remote_database = "posthog"
+      remote_table    = "metrics_kafka_metrics"
+    }
+  }
+
+  table "writable_trace_spans" {
+    column "time_bucket" {
+      type         = "DateTime"
+      materialized = "toStartOfInterval(timestamp, toIntervalHour(4))"
+    }
+    column "original_expiry_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "uuid" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int32"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "parent_span_id" {
+      type = "String"
+    }
+    column "is_root_span" {
+      type         = "Bool"
+      materialized = "replaceAll(trimRight(parent_span_id, '='), 'A', '') = ''"
+    }
+    column "trace_state" {
+      type = "String"
+    }
+    column "name" {
+      type = "LowCardinality(String)"
+    }
+    column "kind" {
+      type = "Int8"
+    }
+    column "flags" {
+      type = "UInt32"
+    }
+    column "timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "end_time" {
+      type = "DateTime64(6)"
+    }
+    column "observed_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "created_at" {
+      type         = "DateTime64(6)"
+      materialized = "now()"
+    }
+    column "duration_nano" {
+      type         = "UInt64"
+      materialized = "toUInt64(dateDiff('microsecond', timestamp, end_time)) * 1000"
+    }
+    column "status_code" {
+      type = "Int16"
+    }
+    column "service_name" {
+      type = "LowCardinality(String)"
+    }
+    column "resource_attributes" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "resource_fingerprint" {
+      type         = "UInt64"
+      materialized = "cityHash64(resource_attributes)"
+    }
+    column "instrumentation_scope" {
+      type = "String"
+    }
+    column "attributes_map_str" {
+      type = "Map(LowCardinality(String), String)"
+    }
+    column "attributes" {
+      type  = "Map(LowCardinality(String), String)"
+      alias = "mapApply((k, v) -> (left(k, -5), v), attributes_map_str)"
+    }
+    column "attributes_map_float" {
+      type         = "Map(LowCardinality(String), Float64)"
+      materialized = "mapFilter((k, v) -> (v IS NOT NULL), mapApply((k, v) -> (concat(left(k, -5), '__float'), toFloat64OrNull(v)), attributes_map_str))"
+    }
+    column "attributes_map_datetime" {
+      type         = "Map(LowCardinality(String), DateTime64(6))"
+      materialized = "mapFilter((k, v) -> (v IS NOT NULL), mapApply((k, v) -> (concat(left(k, -5), '__datetime'), parseDateTimeBestEffortOrNull(v, 6)), attributes_map_str))"
+    }
+    column "dropped_attributes_count" {
+      type = "UInt32"
+    }
+    column "dropped_events_count" {
+      type = "UInt32"
+    }
+    column "dropped_links_count" {
+      type = "UInt32"
+    }
+    column "events" {
+      type = "Array(String)"
+    }
+    column "links" {
+      type = "Array(String)"
+    }
+    column "_partition" {
+      type = "UInt32"
+    }
+    column "_topic" {
+      type = "String"
+    }
+    column "_offset" {
+      type = "UInt64"
+    }
+    column "_bytes_uncompressed" {
+      type = "UInt64"
+    }
+    column "_bytes_compressed" {
+      type = "UInt64"
+    }
+    column "_record_count" {
+      type = "UInt64"
+    }
+    engine "distributed" {
+      cluster_name    = "logs"
+      remote_database = "posthog"
+      remote_table    = "trace_spans"
+    }
+  }
+
+  materialized_view "kafka_logs34_avro_mv" {
+    override = true
+    to_table = "posthog.writable_logs34"
+    query    = <<SQL
+SELECT
+  uuid,
+  trace_id,
+  span_id,
+  trace_flags,
+  timestamp,
+  observed_timestamp,
+  body,
+  severity_text,
+  severity_number,
+  service_name,
+  instrumentation_scope,
+  event_name,
+  mapSort(mapApply((k, v) -> (concat(k, '__str'), JSONExtractString(v)), attributes)) AS attributes_map_str,
+  mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), resource_attributes)) AS resource_attributes,
+  toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) AS team_id,
+  observed_timestamp
+  + toIntervalDay(
+    if(
+      (retention_days IS NOT NULL) AND (retention_days > 0),
+      retention_days,
+      toInt32OrDefault(_headers.value[indexOf(_headers.name, 'retention-days')], toInt32(15))
+    )
+  ) AS original_expiry_timestamp,
+  _partition,
+  _topic,
+  _offset,
+  toInt64OrDefault(_headers.value[indexOf(_headers.name, 'record_count')], toInt64(1)) AS _record_count,
+  toInt64OrNull(_headers.value[indexOf(_headers.name, 'bytes_uncompressed')]) / _record_count AS _bytes_uncompressed,
+  toInt64OrNull(_headers.value[indexOf(_headers.name, 'bytes_compressed')]) / _record_count AS _bytes_compressed,
+  ifNull(pattern, '') AS pattern,
+  toUInt8(ifNull(pattern_version, 0)) AS pattern_version
+FROM posthog.kafka_logs_avro
+SQL
+
+    column "uuid" {
+      type = "String"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "trace_flags" {
+      type = "Int32"
+    }
+    column "timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "observed_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "body" {
+      type = "String"
+    }
+    column "severity_text" {
+      type = "String"
+    }
+    column "severity_number" {
+      type = "Int32"
+    }
+    column "service_name" {
+      type = "String"
+    }
+    column "instrumentation_scope" {
+      type = "String"
+    }
+    column "event_name" {
+      type = "String"
+    }
+    column "attributes_map_str" {
+      type = "Map(String, String)"
+    }
+    column "resource_attributes" {
+      type = "Map(String, String)"
+    }
+    column "team_id" {
+      type = "Int32"
+    }
+    column "original_expiry_timestamp" {
+      type = "Nullable(DateTime64(6))"
+    }
+    column "_partition" {
+      type = "UInt64"
+    }
+    column "_topic" {
+      type = "LowCardinality(String)"
+    }
+    column "_offset" {
+      type = "UInt64"
+    }
+    column "_record_count" {
+      type = "Int64"
+    }
+    column "_bytes_uncompressed" {
+      type = "Nullable(Float64)"
+    }
+    column "_bytes_compressed" {
+      type = "Nullable(Float64)"
+    }
+    column "pattern" {
+      type = "String"
+    }
+    column "pattern_version" {
+      type = "UInt8"
+    }
+  }
+
+  materialized_view "kafka_metrics_avro_kafka_metrics_mv" {
+    override = true
+    to_table = "posthog.writable_metrics_kafka_metrics"
+    query    = <<SQL
+SELECT
+  _partition,
+  _topic,
+  maxSimpleState(_offset) AS max_offset,
+  maxSimpleState(observed_timestamp) AS max_observed_timestamp,
+  maxSimpleState(timestamp) AS max_timestamp,
+  maxSimpleState(now()) AS max_created_at,
+  maxSimpleState(now() - observed_timestamp) AS max_lag
+FROM posthog.kafka_metrics_avro
+GROUP BY
+  _partition, _topic
+SQL
+
+    column "_partition" {
+      type = "UInt64"
+    }
+    column "_topic" {
+      type = "LowCardinality(String)"
+    }
+    column "max_offset" {
+      type = "SimpleAggregateFunction(max, UInt64)"
+    }
+    column "max_observed_timestamp" {
+      type = "SimpleAggregateFunction(max, DateTime64(6))"
+    }
+    column "max_timestamp" {
+      type = "SimpleAggregateFunction(max, DateTime64(6))"
+    }
+    column "max_created_at" {
+      type = "SimpleAggregateFunction(max, DateTime)"
+    }
+    column "max_lag" {
+      type = "SimpleAggregateFunction(max, Decimal(18, 6))"
+    }
+  }
+
+  materialized_view "kafka_metrics_avro_mv" {
+    override = true
+    to_table = "posthog.writable_metrics1"
+    query    = <<SQL
+SELECT
+  uuid,
+  trace_id,
+  span_id,
+  ifNull(trace_flags, 0) AS trace_flags,
+  timestamp,
+  observed_timestamp,
+  ifNull(service_name, '') AS service_name,
+  ifNull(metric_name, '') AS metric_name,
+  ifNull(metric_type, '') AS metric_type,
+  ifNull(value, 0) AS value,
+  toUInt64(ifNull(count, 1)) AS count,
+  histogram_bounds,
+  arrayMap(x -> toUInt64(x), histogram_counts) AS histogram_counts,
+  ifNull(unit, '') AS unit,
+  ifNull(aggregation_temporality, '') AS aggregation_temporality,
+  ifNull(is_monotonic, 0) AS is_monotonic,
+  mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), resource_attributes)) AS resource_attributes,
+  ifNull(instrumentation_scope, '') AS instrumentation_scope,
+  mapSort(mapApply((k, v) -> (concat(k, '__str'), JSONExtractString(v)), attributes)) AS attributes_map_str,
+  mapSort(
+    mapFilter(
+      (k, v) -> isNotNull(v),
+      mapApply(
+        (k, v) -> (concat(k, '__float'), toFloat64OrNull(JSONExtract(v, 'String'))),
+        attributes
+      )
+    )
+  ) AS attributes_map_float,
+  toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) AS team_id
+FROM posthog.kafka_metrics_avro
+SETTINGS
+  min_insert_block_size_rows = 0,
+  min_insert_block_size_bytes = 0
+SQL
+
+    column "uuid" {
+      type = "String"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "trace_flags" {
+      type = "Int32"
+    }
+    column "timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "observed_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "service_name" {
+      type = "String"
+    }
+    column "metric_name" {
+      type = "String"
+    }
+    column "metric_type" {
+      type = "String"
+    }
+    column "value" {
+      type = "Float64"
+    }
+    column "count" {
+      type = "UInt64"
+    }
+    column "histogram_bounds" {
+      type = "Array(Float64)"
+    }
+    column "histogram_counts" {
+      type = "Array(UInt64)"
+    }
+    column "unit" {
+      type = "String"
+    }
+    column "aggregation_temporality" {
+      type = "String"
+    }
+    column "is_monotonic" {
+      type = "UInt8"
+    }
+    column "resource_attributes" {
+      type = "Map(String, String)"
+    }
+    column "instrumentation_scope" {
+      type = "String"
+    }
+    column "attributes_map_str" {
+      type = "Map(String, String)"
+    }
+    column "attributes_map_float" {
+      type = "Map(String, Nullable(Float64))"
+    }
+    column "team_id" {
+      type = "Int32"
+    }
+  }
+
+  materialized_view "kafka_metrics_avro_to_metric_samples" {
+    override = true
+    to_table = "posthog.writable_metric_samples1"
+    query    = <<SQL
+SELECT
+  toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) AS team_id,
+  ifNull(metric_name, '') AS metric_name,
+  reinterpretAsUInt64(assumeNotNull(series_fingerprint)) AS series_fingerprint,
+  timestamp,
+  ifNull(value, 0) AS value,
+  toUInt64(ifNull(count, 1)) AS count,
+  histogram_bounds,
+  arrayMap(x -> toUInt64(x), histogram_counts) AS histogram_counts,
+  trace_id,
+  span_id,
+  ifNull(trace_flags, 0) AS trace_flags
+FROM posthog.kafka_metrics_avro
+WHERE kafka_metrics_avro.series_fingerprint IS NOT NULL
+SETTINGS
+  min_insert_block_size_rows = 0,
+  min_insert_block_size_bytes = 0
+SQL
+
+    column "team_id" {
+      type = "Int32"
+    }
+    column "metric_name" {
+      type = "String"
+    }
+    column "series_fingerprint" {
+      type = "UInt64"
+    }
+    column "timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "value" {
+      type = "Float64"
+    }
+    column "count" {
+      type = "UInt64"
+    }
+    column "histogram_bounds" {
+      type = "Array(Float64)"
+    }
+    column "histogram_counts" {
+      type = "Array(UInt64)"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "trace_flags" {
+      type = "Int32"
+    }
+  }
+
+  materialized_view "kafka_metrics_avro_to_metric_series" {
+    override = true
+    to_table = "posthog.writable_metric_series1"
+    query    = <<SQL
+SELECT
+  toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) AS team_id,
+  ifNull(metric_name, '') AS metric_name,
+  reinterpretAsUInt64(assumeNotNull(series_fingerprint)) AS series_fingerprint,
+  ifNull(metric_type, '') AS metric_type,
+  ifNull(unit, '') AS unit,
+  ifNull(aggregation_temporality, '') AS aggregation_temporality,
+  ifNull(is_monotonic, 0) AS is_monotonic,
+  ifNull(service_name, '') AS service_name,
+  mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), resource_attributes)) AS resource_attributes,
+  mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), attributes)) AS attributes,
+  timestamp AS last_seen
+FROM posthog.kafka_metrics_avro
+WHERE kafka_metrics_avro.series_fingerprint IS NOT NULL
+SETTINGS
+  min_insert_block_size_rows = 0,
+  min_insert_block_size_bytes = 0
+SQL
+
+    column "team_id" {
+      type = "Int32"
+    }
+    column "metric_name" {
+      type = "String"
+    }
+    column "series_fingerprint" {
+      type = "UInt64"
+    }
+    column "metric_type" {
+      type = "String"
+    }
+    column "unit" {
+      type = "String"
+    }
+    column "aggregation_temporality" {
+      type = "String"
+    }
+    column "is_monotonic" {
+      type = "UInt8"
+    }
+    column "service_name" {
+      type = "String"
+    }
+    column "resource_attributes" {
+      type = "Map(String, String)"
+    }
+    column "attributes" {
+      type = "Map(String, String)"
+    }
+    column "last_seen" {
+      type = "DateTime64(6)"
+    }
+  }
+
+  materialized_view "kafka_trace_spans_avro_mv" {
+    override = true
+    to_table = "posthog.writable_trace_spans"
+    query    = <<SQL
+SELECT
+  * EXCEPT(attributes, resource_attributes, kind, flags, dropped_attributes_count, dropped_events_count, dropped_links_count, status_code),
+  toInt8(kind) AS kind,
+  toUInt32(flags) AS flags,
+  toUInt32(dropped_attributes_count) AS dropped_attributes_count,
+  toUInt32(dropped_events_count) AS dropped_events_count,
+  toUInt32(dropped_links_count) AS dropped_links_count,
+  toInt16(status_code) AS status_code,
+  mapSort(mapApply((k, v) -> (concat(k, '__str'), JSONExtractString(v)), attributes)) AS attributes_map_str,
+  mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), resource_attributes)) AS resource_attributes,
+  toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) AS team_id,
+  observed_timestamp
+  + toIntervalDay(
+    toInt32OrDefault(_headers.value[indexOf(_headers.name, 'retention-days')], toInt32(15))
+  ) AS original_expiry_timestamp,
+  _partition,
+  _topic,
+  _offset,
+  toInt64OrDefault(_headers.value[indexOf(_headers.name, 'record_count')], toInt64(1)) AS _record_count,
+  toInt64OrNull(_headers.value[indexOf(_headers.name, 'bytes_uncompressed')]) AS _bytes_uncompressed,
+  toInt64OrNull(_headers.value[indexOf(_headers.name, 'bytes_compressed')]) AS _bytes_compressed
+FROM posthog.kafka_trace_spans_avro
+SQL
+
+    column "uuid" {
+      type = "String"
+    }
+    column "trace_id" {
+      type = "String"
+    }
+    column "span_id" {
+      type = "String"
+    }
+    column "parent_span_id" {
+      type = "String"
+    }
+    column "trace_state" {
+      type = "String"
+    }
+    column "name" {
+      type = "String"
+    }
+    column "timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "end_time" {
+      type = "DateTime64(6)"
+    }
+    column "observed_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "service_name" {
+      type = "String"
+    }
+    column "instrumentation_scope" {
+      type = "String"
+    }
+    column "events" {
+      type = "Array(String)"
+    }
+    column "links" {
+      type = "Array(String)"
+    }
+    column "kind" {
+      type = "Int8"
+    }
+    column "flags" {
+      type = "UInt32"
+    }
+    column "dropped_attributes_count" {
+      type = "UInt32"
+    }
+    column "dropped_events_count" {
+      type = "UInt32"
+    }
+    column "dropped_links_count" {
+      type = "UInt32"
+    }
+    column "status_code" {
+      type = "Int16"
+    }
+    column "attributes_map_str" {
+      type = "Map(String, String)"
+    }
+    column "resource_attributes" {
+      type = "Map(String, String)"
+    }
+    column "team_id" {
+      type = "Int32"
+    }
+    column "original_expiry_timestamp" {
+      type = "DateTime64(6)"
+    }
+    column "_partition" {
+      type = "UInt64"
+    }
+    column "_topic" {
+      type = "LowCardinality(String)"
+    }
+    column "_offset" {
+      type = "UInt64"
+    }
+    column "_record_count" {
+      type = "Int64"
+    }
+    column "_bytes_uncompressed" {
+      type = "Nullable(Int64)"
+    }
+    column "_bytes_compressed" {
+      type = "Nullable(Int64)"
+    }
+  }
+}

--- a/posthog/clickhouse/hcl/sql/dev/apm.sql
+++ b/posthog/clickhouse/hcl/sql/dev/apm.sql
@@ -1,0 +1,475 @@
+-- AUTO-GENERATED from the declarative HCL by ops/gen-sql.sh — do not edit.
+-- Full CREATE schema for the dev/apm node. Apply to a fresh ClickHouse to build it.
+
+CREATE TABLE posthog.kafka_logs_avro (
+  uuid String,
+  trace_id String,
+  span_id String,
+  trace_flags Int32,
+  timestamp DateTime64(6),
+  observed_timestamp DateTime64(6),
+  body String,
+  severity_text String,
+  severity_number Int32,
+  service_name String,
+  resource_attributes Map(LowCardinality(String), String),
+  instrumentation_scope String,
+  event_name String,
+  attributes Map(LowCardinality(String), String),
+  retention_days Nullable(Int32),
+  pattern Nullable(String),
+  pattern_version Nullable(Int32)
+) ENGINE = Kafka(warpstream_logs) SETTINGS input_format_avro_allow_missing_fields = 1, kafka_flush_interval_ms = 10000, kafka_format = 'Avro', kafka_group_name = 'clickhouse-logs-avro-new', kafka_num_consumers = 4, kafka_poll_max_batch_size = 1000, kafka_poll_timeout_ms = 10000, kafka_skip_broken_messages = 100, kafka_thread_per_consumer = 1, kafka_topic_list = 'clickhouse_logs';
+CREATE TABLE posthog.kafka_metrics_avro (
+  uuid String,
+  trace_id String,
+  span_id String,
+  trace_flags Nullable(Int32),
+  timestamp DateTime64(6),
+  observed_timestamp DateTime64(6),
+  service_name Nullable(String),
+  metric_name Nullable(String),
+  metric_type Nullable(String),
+  value Nullable(Float64),
+  count Nullable(Int64),
+  histogram_bounds Array(Float64),
+  histogram_counts Array(Int64),
+  unit Nullable(String),
+  aggregation_temporality Nullable(String),
+  is_monotonic Nullable(UInt8),
+  resource_attributes Map(String, String),
+  instrumentation_scope Nullable(String),
+  attributes Map(String, String),
+  series_fingerprint Nullable(Int64)
+) ENGINE = Kafka(warpstream_metrics) SETTINGS input_format_avro_allow_missing_fields = 1, kafka_flush_interval_ms = 10000, kafka_format = 'Avro', kafka_group_name = 'clickhouse-metrics-avro-new', kafka_num_consumers = 4, kafka_poll_max_batch_size = 1000, kafka_poll_timeout_ms = 10000, kafka_skip_broken_messages = 100, kafka_thread_per_consumer = 1, kafka_topic_list = 'clickhouse_metrics';
+CREATE TABLE posthog.kafka_trace_spans_avro (
+  uuid String,
+  trace_id String,
+  span_id String,
+  parent_span_id String,
+  trace_state String,
+  name String,
+  kind Int32,
+  flags Int32,
+  timestamp DateTime64(6),
+  end_time DateTime64(6),
+  observed_timestamp DateTime64(6),
+  service_name String,
+  resource_attributes Map(LowCardinality(String), String),
+  instrumentation_scope String,
+  attributes Map(LowCardinality(String), String),
+  dropped_attributes_count Int32,
+  events Array(String),
+  dropped_events_count Int32,
+  links Array(String),
+  dropped_links_count Int32,
+  status_code Int32
+) ENGINE = Kafka(warpstream_traces) SETTINGS input_format_avro_allow_missing_fields = 1, kafka_flush_interval_ms = 10000, kafka_format = 'Avro', kafka_group_name = 'clickhouse-traces-avro', kafka_num_consumers = 4, kafka_poll_max_batch_size = 1000, kafka_poll_timeout_ms = 10000, kafka_skip_broken_messages = 100, kafka_thread_per_consumer = 1, kafka_topic_list = 'clickhouse_traces';
+CREATE TABLE posthog.writable_logs34 (
+  time_bucket DateTime MATERIALIZED toStartOfDay(timestamp),
+  original_expiry_timestamp DateTime64(6),
+  uuid String,
+  team_id Int32,
+  trace_id String,
+  span_id String,
+  trace_flags Int32,
+  timestamp DateTime64(6) CODEC(DoubleDelta),
+  observed_timestamp DateTime64(6),
+  created_at DateTime64(6) MATERIALIZED now(),
+  body String,
+  severity_text LowCardinality(String),
+  severity_number Int32,
+  service_name LowCardinality(String),
+  resource_attributes Map(LowCardinality(String), String),
+  resource_fingerprint UInt64 MATERIALIZED cityHash64(resource_attributes),
+  instrumentation_scope String,
+  event_name String,
+  attributes_map_str Map(LowCardinality(String), String),
+  level String ALIAS severity_text,
+  mat_body_ipv4_matches Array(String) ALIAS extractAll(body, '(\\d\\.((25[0-5]|(2[0-4]|1(0, 1)[0-9])(0, 1)[0-9])\\.)(2, 2)([0-9]))'),
+  time_minute DateTime ALIAS toStartOfMinute(timestamp),
+  attributes Map(LowCardinality(String), String) ALIAS mapApply((k, v) -> (left(k, -5), v), attributes_map_str),
+  attributes_map_float Map(LowCardinality(String), Float64) MATERIALIZED mapFilter((k, v) -> (v IS NOT NULL), mapApply((k, v) -> (concat(left(k, -5), '__float'), toFloat64OrNull(v)), attributes_map_str)),
+  attributes_map_datetime Map(LowCardinality(String), DateTime64(6)) MATERIALIZED mapFilter((k, v) -> (v IS NOT NULL), mapApply((k, v) -> (concat(left(k, -5), '__datetime'), parseDateTimeBestEffortOrNull(v, 6)), attributes_map_str)),
+  _partition UInt32,
+  _topic String,
+  _offset UInt64,
+  _bytes_uncompressed UInt64,
+  _bytes_compressed UInt64,
+  _record_count UInt64,
+  pattern String,
+  pattern_version UInt8
+) ENGINE = Distributed('logs', 'posthog', 'logs34') SETTINGS background_insert_batch = 1;
+CREATE TABLE posthog.writable_metric_samples1 (
+  team_id Int32,
+  metric_name LowCardinality(String),
+  series_fingerprint UInt64 CODEC(DoubleDelta),
+  timestamp DateTime64(6) CODEC(DoubleDelta),
+  value Float64 CODEC(Gorilla(8)),
+  count UInt64 DEFAULT 1,
+  histogram_bounds Array(Float64),
+  histogram_counts Array(UInt64),
+  trace_id String,
+  span_id String,
+  trace_flags Int32
+) ENGINE = Distributed('logs', 'posthog', 'metric_samples1');
+CREATE TABLE posthog.writable_metric_series1 (
+  team_id Int32,
+  metric_name LowCardinality(String),
+  series_fingerprint UInt64 CODEC(DoubleDelta),
+  metric_type LowCardinality(String),
+  unit LowCardinality(String),
+  aggregation_temporality LowCardinality(String),
+  is_monotonic Bool DEFAULT false,
+  service_name LowCardinality(String),
+  resource_attributes Map(LowCardinality(String), String),
+  attributes Map(LowCardinality(String), String),
+  last_seen DateTime64(6) CODEC(DoubleDelta)
+) ENGINE = Distributed('logs', 'posthog', 'metric_series1');
+CREATE TABLE posthog.writable_metrics1 (
+  time_bucket DateTime MATERIALIZED toStartOfDay(timestamp),
+  uuid String,
+  team_id Int32,
+  trace_id String,
+  span_id String,
+  trace_flags Int32,
+  timestamp DateTime64(6),
+  observed_timestamp DateTime64(6),
+  created_at DateTime64(6) MATERIALIZED now(),
+  service_name LowCardinality(String),
+  metric_name LowCardinality(String),
+  metric_type LowCardinality(String),
+  value Float64,
+  count UInt64 DEFAULT 1,
+  histogram_bounds Array(Float64),
+  histogram_counts Array(UInt64),
+  unit LowCardinality(String),
+  aggregation_temporality LowCardinality(String),
+  is_monotonic Bool DEFAULT false,
+  resource_attributes Map(LowCardinality(String), String),
+  resource_fingerprint UInt64 MATERIALIZED cityHash64(resource_attributes),
+  instrumentation_scope String,
+  attributes_map_str Map(LowCardinality(String), String),
+  attributes_map_float Map(LowCardinality(String), Float64),
+  time_minute DateTime ALIAS toStartOfMinute(timestamp),
+  attributes Map(String, String) ALIAS mapApply((k, v) -> (left(k, -5), v), attributes_map_str)
+) ENGINE = Distributed('logs', 'posthog', 'metrics1');
+CREATE TABLE posthog.writable_metrics_kafka_metrics (
+  _partition UInt32,
+  _topic String,
+  max_offset SimpleAggregateFunction(max, UInt64),
+  max_observed_timestamp SimpleAggregateFunction(max, DateTime64(9)),
+  max_timestamp SimpleAggregateFunction(max, DateTime64(9)),
+  max_created_at SimpleAggregateFunction(max, DateTime64(9)),
+  max_lag SimpleAggregateFunction(max, UInt64)
+) ENGINE = Distributed('logs', 'posthog', 'metrics_kafka_metrics');
+CREATE TABLE posthog.writable_query_log_archive (
+  hostname LowCardinality(String),
+  user LowCardinality(String),
+  query_id String,
+  initial_query_id String,
+  is_initial_query UInt8,
+  type Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4),
+  event_date Date,
+  event_time DateTime,
+  event_time_microseconds DateTime64(6),
+  query_start_time DateTime,
+  query_start_time_microseconds DateTime64(6),
+  query_duration_ms UInt64,
+  read_rows UInt64,
+  read_bytes UInt64,
+  written_rows UInt64,
+  written_bytes UInt64,
+  result_rows UInt64,
+  result_bytes UInt64,
+  memory_usage UInt64,
+  peak_threads_usage UInt64,
+  current_database LowCardinality(String),
+  query String,
+  formatted_query String,
+  normalized_query_hash UInt64,
+  query_kind LowCardinality(String),
+  exception_code Int32,
+  exception String,
+  stack_trace String,
+  team_id Int64,
+  log_comment JSON(max_dynamic_paths=256, access_method LowCardinality(String), alert_config_id String, api_key_label String, api_key_mask String, batch_export_id String, chargeable Bool, client_query_id String, cohort_id Int64, `dagster.job_name` String, `dagster.run_id` String, `dagster.tags.owner` String, dashboard_id Int64, experiment_feature_flag_key String, experiment_id Int64, feature LowCardinality(String), id String, insight_id Int64, is_impersonated Bool, kind LowCardinality(String), name String, org_id String, person_on_events_mode LowCardinality(String), product LowCardinality(String), query_type LowCardinality(String), request_name String, route_id String, service_name String, session_id String, table_id String, team_id Int64, `temporal.activity_id` String, `temporal.activity_type` String, `temporal.attempt` Int64, `temporal.workflow_id` String, `temporal.workflow_namespace` String, `temporal.workflow_run_id` String, `temporal.workflow_type` String, user_id Int64, warehouse_query Bool, workflow LowCardinality(String), workload LowCardinality(String), SKIP cache_key, SKIP filter, SKIP hogql_features, SKIP http_referer, SKIP http_request_id, SKIP http_user_agent, SKIP query_settings, SKIP timings, SKIP user_email),
+  ProfileEvents Map(String, UInt64)
+) ENGINE = Distributed('ops', 'posthog', 'query_log_archive_buffer');
+CREATE TABLE posthog.writable_trace_spans (
+  time_bucket DateTime MATERIALIZED toStartOfInterval(timestamp, toIntervalHour(4)),
+  original_expiry_timestamp DateTime64(6),
+  uuid String,
+  team_id Int32,
+  trace_id String,
+  span_id String,
+  parent_span_id String,
+  is_root_span Bool MATERIALIZED replaceAll(trimRight(parent_span_id, '='), 'A', '') = '',
+  trace_state String,
+  name LowCardinality(String),
+  kind Int8,
+  flags UInt32,
+  timestamp DateTime64(6),
+  end_time DateTime64(6),
+  observed_timestamp DateTime64(6),
+  created_at DateTime64(6) MATERIALIZED now(),
+  duration_nano UInt64 MATERIALIZED toUInt64(dateDiff('microsecond', timestamp, end_time)) * 1000,
+  status_code Int16,
+  service_name LowCardinality(String),
+  resource_attributes Map(LowCardinality(String), String),
+  resource_fingerprint UInt64 MATERIALIZED cityHash64(resource_attributes),
+  instrumentation_scope String,
+  attributes_map_str Map(LowCardinality(String), String),
+  attributes Map(LowCardinality(String), String) ALIAS mapApply((k, v) -> (left(k, -5), v), attributes_map_str),
+  attributes_map_float Map(LowCardinality(String), Float64) MATERIALIZED mapFilter((k, v) -> (v IS NOT NULL), mapApply((k, v) -> (concat(left(k, -5), '__float'), toFloat64OrNull(v)), attributes_map_str)),
+  attributes_map_datetime Map(LowCardinality(String), DateTime64(6)) MATERIALIZED mapFilter((k, v) -> (v IS NOT NULL), mapApply((k, v) -> (concat(left(k, -5), '__datetime'), parseDateTimeBestEffortOrNull(v, 6)), attributes_map_str)),
+  dropped_attributes_count UInt32,
+  dropped_events_count UInt32,
+  dropped_links_count UInt32,
+  events Array(String),
+  links Array(String),
+  _partition UInt32,
+  _topic String,
+  _offset UInt64,
+  _bytes_uncompressed UInt64,
+  _bytes_compressed UInt64,
+  _record_count UInt64
+) ENGINE = Distributed('logs', 'posthog', 'trace_spans');
+CREATE MATERIALIZED VIEW posthog.kafka_logs34_avro_mv TO posthog.writable_logs34 (uuid String, trace_id String, span_id String, trace_flags Int32, timestamp DateTime64(6), observed_timestamp DateTime64(6), body String, severity_text String, severity_number Int32, service_name String, instrumentation_scope String, event_name String, attributes_map_str Map(String, String), resource_attributes Map(String, String), team_id Int32, original_expiry_timestamp Nullable(DateTime64(6)), _partition UInt64, _topic LowCardinality(String), _offset UInt64, _record_count Int64, _bytes_uncompressed Nullable(Float64), _bytes_compressed Nullable(Float64), pattern String, pattern_version UInt8) AS SELECT
+  uuid,
+  trace_id,
+  span_id,
+  trace_flags,
+  timestamp,
+  observed_timestamp,
+  body,
+  severity_text,
+  severity_number,
+  service_name,
+  instrumentation_scope,
+  event_name,
+  mapSort(mapApply((k, v) -> (concat(k, '__str'), JSONExtractString(v)), attributes)) AS attributes_map_str,
+  mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), resource_attributes)) AS resource_attributes,
+  toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) AS team_id,
+  observed_timestamp
+  + toIntervalDay(
+    if(
+      (retention_days IS NOT NULL) AND (retention_days > 0),
+      retention_days,
+      toInt32OrDefault(_headers.value[indexOf(_headers.name, 'retention-days')], toInt32(15))
+    )
+  ) AS original_expiry_timestamp,
+  _partition,
+  _topic,
+  _offset,
+  toInt64OrDefault(_headers.value[indexOf(_headers.name, 'record_count')], toInt64(1)) AS _record_count,
+  toInt64OrNull(_headers.value[indexOf(_headers.name, 'bytes_uncompressed')]) / _record_count AS _bytes_uncompressed,
+  toInt64OrNull(_headers.value[indexOf(_headers.name, 'bytes_compressed')]) / _record_count AS _bytes_compressed,
+  ifNull(pattern, '') AS pattern,
+  toUInt8(ifNull(pattern_version, 0)) AS pattern_version
+FROM posthog.kafka_logs_avro;
+CREATE MATERIALIZED VIEW posthog.kafka_metrics_avro_kafka_metrics_mv TO posthog.writable_metrics_kafka_metrics (_partition UInt64, _topic LowCardinality(String), max_offset SimpleAggregateFunction(max, UInt64), max_observed_timestamp SimpleAggregateFunction(max, DateTime64(6)), max_timestamp SimpleAggregateFunction(max, DateTime64(6)), max_created_at SimpleAggregateFunction(max, DateTime), max_lag SimpleAggregateFunction(max, Decimal(18, 6))) AS SELECT
+  _partition,
+  _topic,
+  maxSimpleState(_offset) AS max_offset,
+  maxSimpleState(observed_timestamp) AS max_observed_timestamp,
+  maxSimpleState(timestamp) AS max_timestamp,
+  maxSimpleState(now()) AS max_created_at,
+  maxSimpleState(now() - observed_timestamp) AS max_lag
+FROM posthog.kafka_metrics_avro
+GROUP BY
+  _partition, _topic;
+CREATE MATERIALIZED VIEW posthog.kafka_metrics_avro_mv TO posthog.writable_metrics1 (uuid String, trace_id String, span_id String, trace_flags Int32, timestamp DateTime64(6), observed_timestamp DateTime64(6), service_name String, metric_name String, metric_type String, value Float64, count UInt64, histogram_bounds Array(Float64), histogram_counts Array(UInt64), unit String, aggregation_temporality String, is_monotonic UInt8, resource_attributes Map(String, String), instrumentation_scope String, attributes_map_str Map(String, String), attributes_map_float Map(String, Nullable(Float64)), team_id Int32) AS SELECT
+  uuid,
+  trace_id,
+  span_id,
+  ifNull(trace_flags, 0) AS trace_flags,
+  timestamp,
+  observed_timestamp,
+  ifNull(service_name, '') AS service_name,
+  ifNull(metric_name, '') AS metric_name,
+  ifNull(metric_type, '') AS metric_type,
+  ifNull(value, 0) AS value,
+  toUInt64(ifNull(count, 1)) AS count,
+  histogram_bounds,
+  arrayMap(x -> toUInt64(x), histogram_counts) AS histogram_counts,
+  ifNull(unit, '') AS unit,
+  ifNull(aggregation_temporality, '') AS aggregation_temporality,
+  ifNull(is_monotonic, 0) AS is_monotonic,
+  mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), resource_attributes)) AS resource_attributes,
+  ifNull(instrumentation_scope, '') AS instrumentation_scope,
+  mapSort(mapApply((k, v) -> (concat(k, '__str'), JSONExtractString(v)), attributes)) AS attributes_map_str,
+  mapSort(
+    mapFilter(
+      (k, v) -> isNotNull(v),
+      mapApply(
+        (k, v) -> (concat(k, '__float'), toFloat64OrNull(JSONExtract(v, 'String'))),
+        attributes
+      )
+    )
+  ) AS attributes_map_float,
+  toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) AS team_id
+FROM posthog.kafka_metrics_avro
+SETTINGS
+  min_insert_block_size_rows = 0,
+  min_insert_block_size_bytes = 0;
+CREATE MATERIALIZED VIEW posthog.kafka_metrics_avro_to_metric_samples TO posthog.writable_metric_samples1 (team_id Int32, metric_name String, series_fingerprint UInt64, timestamp DateTime64(6), value Float64, count UInt64, histogram_bounds Array(Float64), histogram_counts Array(UInt64), trace_id String, span_id String, trace_flags Int32) AS SELECT
+  toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) AS team_id,
+  ifNull(metric_name, '') AS metric_name,
+  reinterpretAsUInt64(assumeNotNull(series_fingerprint)) AS series_fingerprint,
+  timestamp,
+  ifNull(value, 0) AS value,
+  toUInt64(ifNull(count, 1)) AS count,
+  histogram_bounds,
+  arrayMap(x -> toUInt64(x), histogram_counts) AS histogram_counts,
+  trace_id,
+  span_id,
+  ifNull(trace_flags, 0) AS trace_flags
+FROM posthog.kafka_metrics_avro
+WHERE kafka_metrics_avro.series_fingerprint IS NOT NULL
+SETTINGS
+  min_insert_block_size_rows = 0,
+  min_insert_block_size_bytes = 0;
+CREATE MATERIALIZED VIEW posthog.kafka_metrics_avro_to_metric_series TO posthog.writable_metric_series1 (team_id Int32, metric_name String, series_fingerprint UInt64, metric_type String, unit String, aggregation_temporality String, is_monotonic UInt8, service_name String, resource_attributes Map(String, String), attributes Map(String, String), last_seen DateTime64(6)) AS SELECT
+  toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) AS team_id,
+  ifNull(metric_name, '') AS metric_name,
+  reinterpretAsUInt64(assumeNotNull(series_fingerprint)) AS series_fingerprint,
+  ifNull(metric_type, '') AS metric_type,
+  ifNull(unit, '') AS unit,
+  ifNull(aggregation_temporality, '') AS aggregation_temporality,
+  ifNull(is_monotonic, 0) AS is_monotonic,
+  ifNull(service_name, '') AS service_name,
+  mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), resource_attributes)) AS resource_attributes,
+  mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), attributes)) AS attributes,
+  timestamp AS last_seen
+FROM posthog.kafka_metrics_avro
+WHERE kafka_metrics_avro.series_fingerprint IS NOT NULL
+SETTINGS
+  min_insert_block_size_rows = 0,
+  min_insert_block_size_bytes = 0;
+CREATE MATERIALIZED VIEW posthog.kafka_trace_spans_avro_mv TO posthog.writable_trace_spans (uuid String, trace_id String, span_id String, parent_span_id String, trace_state String, name String, timestamp DateTime64(6), end_time DateTime64(6), observed_timestamp DateTime64(6), service_name String, instrumentation_scope String, events Array(String), links Array(String), kind Int8, flags UInt32, dropped_attributes_count UInt32, dropped_events_count UInt32, dropped_links_count UInt32, status_code Int16, attributes_map_str Map(String, String), resource_attributes Map(String, String), team_id Int32, original_expiry_timestamp DateTime64(6), _partition UInt64, _topic LowCardinality(String), _offset UInt64, _record_count Int64, _bytes_uncompressed Nullable(Int64), _bytes_compressed Nullable(Int64)) AS SELECT
+  * EXCEPT(attributes, resource_attributes, kind, flags, dropped_attributes_count, dropped_events_count, dropped_links_count, status_code),
+  toInt8(kind) AS kind,
+  toUInt32(flags) AS flags,
+  toUInt32(dropped_attributes_count) AS dropped_attributes_count,
+  toUInt32(dropped_events_count) AS dropped_events_count,
+  toUInt32(dropped_links_count) AS dropped_links_count,
+  toInt16(status_code) AS status_code,
+  mapSort(mapApply((k, v) -> (concat(k, '__str'), JSONExtractString(v)), attributes)) AS attributes_map_str,
+  mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), resource_attributes)) AS resource_attributes,
+  toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) AS team_id,
+  observed_timestamp
+  + toIntervalDay(
+    toInt32OrDefault(_headers.value[indexOf(_headers.name, 'retention-days')], toInt32(15))
+  ) AS original_expiry_timestamp,
+  _partition,
+  _topic,
+  _offset,
+  toInt64OrDefault(_headers.value[indexOf(_headers.name, 'record_count')], toInt64(1)) AS _record_count,
+  toInt64OrNull(_headers.value[indexOf(_headers.name, 'bytes_uncompressed')]) AS _bytes_uncompressed,
+  toInt64OrNull(_headers.value[indexOf(_headers.name, 'bytes_compressed')]) AS _bytes_compressed
+FROM posthog.kafka_trace_spans_avro;
+CREATE MATERIALIZED VIEW posthog.ops_query_log_archive_mv TO posthog.writable_query_log_archive (hostname LowCardinality(String), user LowCardinality(String), query_id String, initial_query_id String, is_initial_query UInt8, type Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4), event_date Date, event_time DateTime, event_time_microseconds DateTime64(6), query_start_time DateTime, query_start_time_microseconds DateTime64(6), query_duration_ms UInt64, read_rows UInt64, read_bytes UInt64, written_rows UInt64, written_bytes UInt64, result_rows UInt64, result_bytes UInt64, memory_usage UInt64, peak_threads_usage UInt64, current_database LowCardinality(String), query String, formatted_query String, normalized_query_hash UInt64, query_kind LowCardinality(String), exception_code Int32, exception String, stack_trace String, team_id Int64, log_comment String, ProfileEvents Map(LowCardinality(String), UInt64)) AS SELECT
+  hostname,
+  user,
+  query_id,
+  initial_query_id,
+  is_initial_query,
+  type,
+  event_date,
+  event_time,
+  event_time_microseconds,
+  query_start_time,
+  query_start_time_microseconds,
+  query_duration_ms,
+  read_rows,
+  read_bytes,
+  written_rows,
+  written_bytes,
+  result_rows,
+  result_bytes,
+  memory_usage,
+  peak_threads_usage,
+  current_database,
+  query,
+  formatted_query,
+  normalized_query_hash,
+  query_kind,
+  exception_code,
+  exception,
+  stack_trace,
+  JSONExtractInt(log_comment, 'team_id') AS team_id,
+  if(isValidJSON(log_comment), log_comment, '{}') AS log_comment,
+  ProfileEvents
+FROM system.query_log
+WHERE type != 'QueryStart';
+CREATE VIEW posthog.custom_metrics AS SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_test
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_replication_queue
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_server_crash
+UNION ALL
+SELECT *
+FROM posthog.custom_metrics_table_sizes
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_part_counts
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_dictionaries
+UNION ALL
+SELECT
+  'ClickHouseCustomMetric_S3DiskBytesUsed' AS name,
+  map('instance', hostname(), 'disk', disk_name) AS labels,
+  toFloat64(sum(bytes_on_disk)) AS value,
+  'Bytes currently used by ClickHouse parts on S3-backed disks on this node' AS help,
+  'gauge' AS type
+FROM system.parts
+WHERE disk_name IN ('s3disk', 'cache')
+GROUP BY
+  disk_name
+UNION ALL
+SELECT
+  'ClickHouseCustomMetric_MergeFailures15m' AS name,
+  map('instance', hostname()) AS labels,
+  toFloat64(count()) AS value,
+  'Number of failed merge operations in the last 15 minutes' AS help,
+  'gauge' AS type
+FROM system.part_log
+WHERE
+  (event_time >= (now() - toIntervalMinute(15)))
+AND
+  (event_type = 'MergeParts')
+AND
+  (error > 0)
+AND
+  (merge_reason != 'NotAMerge')
+AND
+  (error != 40)
+UNION ALL
+SELECT
+  'ClickHouseCustomMetric_MergeRetriesMaxPerTable15m' AS name,
+  map('instance', hostname()) AS labels,
+  toFloat64(max(cnt)) AS value,
+  'Max failed merge retries for any single table in the last 15 minutes' AS help,
+  'gauge' AS type
+FROM
+  (
+    SELECT count() AS cnt
+    FROM system.part_log
+    WHERE
+      (event_time >= (now() - toIntervalMinute(15)))
+    AND
+      (event_type = 'MergeParts')
+    AND
+      (error > 0)
+    AND
+      (merge_reason != 'NotAMerge')
+    AND
+      (error != 40)
+    GROUP BY
+      database, `table`, partition_id
+  );

--- a/posthog/clickhouse/hcl/sql/prod-eu/apm.sql
+++ b/posthog/clickhouse/hcl/sql/prod-eu/apm.sql
@@ -1,0 +1,140 @@
+-- AUTO-GENERATED from the declarative HCL by ops/gen-sql.sh — do not edit.
+-- Full CREATE schema for the prod-eu/apm node. Apply to a fresh ClickHouse to build it.
+
+CREATE TABLE posthog.writable_query_log_archive (
+  hostname LowCardinality(String),
+  user LowCardinality(String),
+  query_id String,
+  initial_query_id String,
+  is_initial_query UInt8,
+  type Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4),
+  event_date Date,
+  event_time DateTime,
+  event_time_microseconds DateTime64(6),
+  query_start_time DateTime,
+  query_start_time_microseconds DateTime64(6),
+  query_duration_ms UInt64,
+  read_rows UInt64,
+  read_bytes UInt64,
+  written_rows UInt64,
+  written_bytes UInt64,
+  result_rows UInt64,
+  result_bytes UInt64,
+  memory_usage UInt64,
+  peak_threads_usage UInt64,
+  current_database LowCardinality(String),
+  query String,
+  formatted_query String,
+  normalized_query_hash UInt64,
+  query_kind LowCardinality(String),
+  exception_code Int32,
+  exception String,
+  stack_trace String,
+  team_id Int64,
+  log_comment JSON(max_dynamic_paths=256, access_method LowCardinality(String), alert_config_id String, api_key_label String, api_key_mask String, batch_export_id String, chargeable Bool, client_query_id String, cohort_id Int64, `dagster.job_name` String, `dagster.run_id` String, `dagster.tags.owner` String, dashboard_id Int64, experiment_feature_flag_key String, experiment_id Int64, feature LowCardinality(String), id String, insight_id Int64, is_impersonated Bool, kind LowCardinality(String), name String, org_id String, person_on_events_mode LowCardinality(String), product LowCardinality(String), query_type LowCardinality(String), request_name String, route_id String, service_name String, session_id String, table_id String, team_id Int64, `temporal.activity_id` String, `temporal.activity_type` String, `temporal.attempt` Int64, `temporal.workflow_id` String, `temporal.workflow_namespace` String, `temporal.workflow_run_id` String, `temporal.workflow_type` String, user_id Int64, warehouse_query Bool, workflow LowCardinality(String), workload LowCardinality(String), SKIP cache_key, SKIP filter, SKIP hogql_features, SKIP http_referer, SKIP http_request_id, SKIP http_user_agent, SKIP query_settings, SKIP timings, SKIP user_email),
+  ProfileEvents Map(String, UInt64)
+) ENGINE = Distributed('ops', 'posthog', 'query_log_archive_buffer');
+CREATE MATERIALIZED VIEW posthog.ops_query_log_archive_mv TO posthog.writable_query_log_archive (hostname LowCardinality(String), user LowCardinality(String), query_id String, initial_query_id String, is_initial_query UInt8, type Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4), event_date Date, event_time DateTime, event_time_microseconds DateTime64(6), query_start_time DateTime, query_start_time_microseconds DateTime64(6), query_duration_ms UInt64, read_rows UInt64, read_bytes UInt64, written_rows UInt64, written_bytes UInt64, result_rows UInt64, result_bytes UInt64, memory_usage UInt64, peak_threads_usage UInt64, current_database LowCardinality(String), query String, formatted_query String, normalized_query_hash UInt64, query_kind LowCardinality(String), exception_code Int32, exception String, stack_trace String, team_id Int64, log_comment String, ProfileEvents Map(LowCardinality(String), UInt64)) AS SELECT
+  hostname,
+  user,
+  query_id,
+  initial_query_id,
+  is_initial_query,
+  type,
+  event_date,
+  event_time,
+  event_time_microseconds,
+  query_start_time,
+  query_start_time_microseconds,
+  query_duration_ms,
+  read_rows,
+  read_bytes,
+  written_rows,
+  written_bytes,
+  result_rows,
+  result_bytes,
+  memory_usage,
+  peak_threads_usage,
+  current_database,
+  query,
+  formatted_query,
+  normalized_query_hash,
+  query_kind,
+  exception_code,
+  exception,
+  stack_trace,
+  JSONExtractInt(log_comment, 'team_id') AS team_id,
+  if(isValidJSON(log_comment), log_comment, '{}') AS log_comment,
+  ProfileEvents
+FROM system.query_log
+WHERE type != 'QueryStart';
+CREATE VIEW posthog.custom_metrics AS SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_test
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_replication_queue
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_server_crash
+UNION ALL
+SELECT *
+FROM posthog.custom_metrics_table_sizes
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_part_counts
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_dictionaries
+UNION ALL
+SELECT
+  'ClickHouseCustomMetric_S3DiskBytesUsed' AS name,
+  map('instance', hostname(), 'disk', disk_name) AS labels,
+  toFloat64(sum(bytes_on_disk)) AS value,
+  'Bytes currently used by ClickHouse parts on S3-backed disks on this node' AS help,
+  'gauge' AS type
+FROM system.parts
+WHERE disk_name IN ('s3disk', 'cache')
+GROUP BY
+  disk_name
+UNION ALL
+SELECT
+  'ClickHouseCustomMetric_MergeFailures15m' AS name,
+  map('instance', hostname()) AS labels,
+  toFloat64(count()) AS value,
+  'Number of failed merge operations in the last 15 minutes' AS help,
+  'gauge' AS type
+FROM system.part_log
+WHERE
+  (event_time >= (now() - toIntervalMinute(15)))
+AND
+  (event_type = 'MergeParts')
+AND
+  (error > 0)
+AND
+  (merge_reason != 'NotAMerge')
+AND
+  (error != 40)
+UNION ALL
+SELECT
+  'ClickHouseCustomMetric_MergeRetriesMaxPerTable15m' AS name,
+  map('instance', hostname()) AS labels,
+  toFloat64(max(cnt)) AS value,
+  'Max failed merge retries for any single table in the last 15 minutes' AS help,
+  'gauge' AS type
+FROM
+  (
+    SELECT count() AS cnt
+    FROM system.part_log
+    WHERE
+      (event_time >= (now() - toIntervalMinute(15)))
+    AND
+      (event_type = 'MergeParts')
+    AND
+      (error > 0)
+    AND
+      (merge_reason != 'NotAMerge')
+    AND
+      (error != 40)
+    GROUP BY
+      database, `table`, partition_id
+  );

--- a/posthog/clickhouse/hcl/sql/prod-us/apm.sql
+++ b/posthog/clickhouse/hcl/sql/prod-us/apm.sql
@@ -1,0 +1,140 @@
+-- AUTO-GENERATED from the declarative HCL by ops/gen-sql.sh — do not edit.
+-- Full CREATE schema for the prod-us/apm node. Apply to a fresh ClickHouse to build it.
+
+CREATE TABLE posthog.writable_query_log_archive (
+  hostname LowCardinality(String),
+  user LowCardinality(String),
+  query_id String,
+  initial_query_id String,
+  is_initial_query UInt8,
+  type Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4),
+  event_date Date,
+  event_time DateTime,
+  event_time_microseconds DateTime64(6),
+  query_start_time DateTime,
+  query_start_time_microseconds DateTime64(6),
+  query_duration_ms UInt64,
+  read_rows UInt64,
+  read_bytes UInt64,
+  written_rows UInt64,
+  written_bytes UInt64,
+  result_rows UInt64,
+  result_bytes UInt64,
+  memory_usage UInt64,
+  peak_threads_usage UInt64,
+  current_database LowCardinality(String),
+  query String,
+  formatted_query String,
+  normalized_query_hash UInt64,
+  query_kind LowCardinality(String),
+  exception_code Int32,
+  exception String,
+  stack_trace String,
+  team_id Int64,
+  log_comment JSON(max_dynamic_paths=256, access_method LowCardinality(String), alert_config_id String, api_key_label String, api_key_mask String, batch_export_id String, chargeable Bool, client_query_id String, cohort_id Int64, `dagster.job_name` String, `dagster.run_id` String, `dagster.tags.owner` String, dashboard_id Int64, experiment_feature_flag_key String, experiment_id Int64, feature LowCardinality(String), id String, insight_id Int64, is_impersonated Bool, kind LowCardinality(String), name String, org_id String, person_on_events_mode LowCardinality(String), product LowCardinality(String), query_type LowCardinality(String), request_name String, route_id String, service_name String, session_id String, table_id String, team_id Int64, `temporal.activity_id` String, `temporal.activity_type` String, `temporal.attempt` Int64, `temporal.workflow_id` String, `temporal.workflow_namespace` String, `temporal.workflow_run_id` String, `temporal.workflow_type` String, user_id Int64, warehouse_query Bool, workflow LowCardinality(String), workload LowCardinality(String), SKIP cache_key, SKIP filter, SKIP hogql_features, SKIP http_referer, SKIP http_request_id, SKIP http_user_agent, SKIP query_settings, SKIP timings, SKIP user_email),
+  ProfileEvents Map(String, UInt64)
+) ENGINE = Distributed('ops', 'posthog', 'query_log_archive_buffer');
+CREATE MATERIALIZED VIEW posthog.ops_query_log_archive_mv TO posthog.writable_query_log_archive (hostname LowCardinality(String), user LowCardinality(String), query_id String, initial_query_id String, is_initial_query UInt8, type Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4), event_date Date, event_time DateTime, event_time_microseconds DateTime64(6), query_start_time DateTime, query_start_time_microseconds DateTime64(6), query_duration_ms UInt64, read_rows UInt64, read_bytes UInt64, written_rows UInt64, written_bytes UInt64, result_rows UInt64, result_bytes UInt64, memory_usage UInt64, peak_threads_usage UInt64, current_database LowCardinality(String), query String, formatted_query String, normalized_query_hash UInt64, query_kind LowCardinality(String), exception_code Int32, exception String, stack_trace String, team_id Int64, log_comment String, ProfileEvents Map(LowCardinality(String), UInt64)) AS SELECT
+  hostname,
+  user,
+  query_id,
+  initial_query_id,
+  is_initial_query,
+  type,
+  event_date,
+  event_time,
+  event_time_microseconds,
+  query_start_time,
+  query_start_time_microseconds,
+  query_duration_ms,
+  read_rows,
+  read_bytes,
+  written_rows,
+  written_bytes,
+  result_rows,
+  result_bytes,
+  memory_usage,
+  peak_threads_usage,
+  current_database,
+  query,
+  formatted_query,
+  normalized_query_hash,
+  query_kind,
+  exception_code,
+  exception,
+  stack_trace,
+  JSONExtractInt(log_comment, 'team_id') AS team_id,
+  if(isValidJSON(log_comment), log_comment, '{}') AS log_comment,
+  ProfileEvents
+FROM system.query_log
+WHERE type != 'QueryStart';
+CREATE VIEW posthog.custom_metrics AS SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_test
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_replication_queue
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_server_crash
+UNION ALL
+SELECT *
+FROM posthog.custom_metrics_table_sizes
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_part_counts
+UNION ALL
+SELECT * REPLACE(toFloat64(value) AS value)
+FROM posthog.custom_metrics_dictionaries
+UNION ALL
+SELECT
+  'ClickHouseCustomMetric_S3DiskBytesUsed' AS name,
+  map('instance', hostname(), 'disk', disk_name) AS labels,
+  toFloat64(sum(bytes_on_disk)) AS value,
+  'Bytes currently used by ClickHouse parts on S3-backed disks on this node' AS help,
+  'gauge' AS type
+FROM system.parts
+WHERE disk_name IN ('s3disk', 'cache')
+GROUP BY
+  disk_name
+UNION ALL
+SELECT
+  'ClickHouseCustomMetric_MergeFailures15m' AS name,
+  map('instance', hostname()) AS labels,
+  toFloat64(count()) AS value,
+  'Number of failed merge operations in the last 15 minutes' AS help,
+  'gauge' AS type
+FROM system.part_log
+WHERE
+  (event_time >= (now() - toIntervalMinute(15)))
+AND
+  (event_type = 'MergeParts')
+AND
+  (error > 0)
+AND
+  (merge_reason != 'NotAMerge')
+AND
+  (error != 40)
+UNION ALL
+SELECT
+  'ClickHouseCustomMetric_MergeRetriesMaxPerTable15m' AS name,
+  map('instance', hostname()) AS labels,
+  toFloat64(max(cnt)) AS value,
+  'Max failed merge retries for any single table in the last 15 minutes' AS help,
+  'gauge' AS type
+FROM
+  (
+    SELECT count() AS cnt
+    FROM system.part_log
+    WHERE
+      (event_time >= (now() - toIntervalMinute(15)))
+    AND
+      (event_type = 'MergeParts')
+    AND
+      (error > 0)
+    AND
+      (merge_reason != 'NotAMerge')
+    AND
+      (error != 40)
+    GROUP BY
+      database, `table`, partition_id
+  );


### PR DESCRIPTION
## Problem

Every environment runs `ingestion-apm` nodes and nothing described them. Four on dev, eighteen on each prod cluster, and no role in the manifest covered any of them.

- A role absent from the manifest silently drops out of `hclexp plan`, so those nodes have never been reconciled against anything.
- Five objects on them (`writable_metrics1`, `writable_metric_samples1`, `writable_metric_series1`, `writable_metrics_kafka_metrics`, `writable_trace_spans`) are declared nowhere in this repo at all.
- dev has moved its whole APM ingest chain onto these nodes while the prod clusters still run it on their logs nodes, and neither arrangement was written down.

## Changes

- Reconcile covers the `apm` role on dev, prod-us and prod-eu. Each golden reproduces its node exactly.
- All three environments compose the same shared path there: the query log archive writer and the custom metrics suite. None of them runs the `query_log_archive` reader, so the role composes `roles/shared/qla_write.hcl` rather than all of `roles/shared`.
- dev additionally composes `roles/apm/dev`, holding the Kafka consumers for logs, traces and metrics, their views, and the five writable proxies that were previously undeclared.
- The ten objects the logs role already declares are restated with `override = true` rather than declared a second time. dev runs its consumers smaller than prod does: four consumers instead of eight, longer poll timeouts, and an Avro setting for missing fields.
- Mechanical: goldens and sql are generated for the new role. No existing golden or sql file changes, and the duplicates baseline is untouched.

> [!NOTE]
> This is additive. It adds a role and its layers; it does not move anything between existing roles. The prod clusters' logs nodes keep the ingest chain exactly as they have it.

## How did you test this code?

- `check.sh` passes: five envs validate (cloud envs now at 8 roles), 34 compositions match their goldens, duplicates match the baseline of 2, sql is fresh.
- Each apm golden was diffed against every apm node dump in PostHog/clickhouse-schema, not a sample: 40 nodes across the three environments, zero mismatches.
- `check-cloud.sh` confirms posthog-cloud-infra still composes in all three envs with its duplicates baseline unchanged.
- `hogli ci:preflight --strict` reports 0 failures.
- Not checked: no live ClickHouse was available, so `check-live.sh` never ran.
- No new tests. The change is schema declarations, gated by `check.sh` in CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`manifest.hcl` documents what the apm nodes run in each environment and why dev differs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/writing-pr-descriptions`.

Found while reconciling master against the node dumps. Seven objects on dev looked like a logs role that had missed two migrations; they turned out to exist on dev's `ingestion-apm` nodes instead, which led to the unmodeled role. The prod clusters were then found to run eighteen such nodes each.

The alternative to restating the ten shared objects was splitting the logs role's ingest and storage layers so both roles could compose the ingest half. That is the tidier end state, but it would move objects between existing layers and risk changing what the logs nodes compose, for no gain in what this PR asserts. Left as follow-up.

**Public artifact:** everything here derives from this repository and the node dumps. No hostnames, credentials, or customer identifiers are in the diff.

