### PR TITLE
fix(ci): use supported HogQL float function

### DIFF
--- a/.github/scripts/weekly-slow-tests-report.mjs
+++ b/.github/scripts/weekly-slow-tests-report.mjs
@@ -47,8 +47,8 @@ const SLOW_TESTS_QUERY = `
         if(attributes['test.runner'] = 'jest' OR service_name = 'ci-frontend', 'jest', 'pytest') AS runner,
         attributes['test.selector'] AS selector,
         any(attributes['test.file']) AS file,
-        round(median(toFloat64(duration_nano)) / 1000000000, 1) AS p50_seconds,
-        round(max(toFloat64(duration_nano)) / 1000000000, 1) AS max_seconds,
+        round(median(toFloat(duration_nano)) / 1000000000, 1) AS p50_seconds,
+        round(max(toFloat(duration_nano)) / 1000000000, 1) AS max_seconds,
         uniq(resource_attributes['ci.run_id']) AS builds
     FROM posthog.trace_spans
     WHERE service_name IN {service_names}

--- a/.github/scripts/weekly-slow-tests-report.test.mjs
+++ b/.github/scripts/weekly-slow-tests-report.test.mjs
@@ -38,6 +38,8 @@ describe('weekly slow tests report', () => {
         assert.deepEqual(items, [expected])
 
         assert.match(captured.query, /attributes\['test\.outcome'\] = 'passed'/)
+        assert.match(captured.query, /median\(toFloat\(duration_nano\)\)/)
+        assert.doesNotMatch(captured.query, /toFloat64/)
         assert.match(captured.query, /lower\(resource_attributes\['ci\.repository'\]\) = lower\(\{repository\}\)/)
         assert.match(captured.query, /ci\.branch'\] = {for_branch} OR resource_attributes\['ci\.branch'\] LIKE {merge_queue_glob}/)
         assert.match(captured.query, /GROUP BY/)


### PR DESCRIPTION
[robot] This draft pull request is authored by a robot for human review.

## Problem

The weekly slow test report runs on schedule but never posts because its HogQL query fails before Slack.

The latest run returned `Unsupported function call 'toFloat64(...)'` and exited before it built the report: https://github.com/PostHog/posthog/actions/runs/34128492811

## Changes

- The report uses HogQL's supported `toFloat` function to calculate test durations.
- A regression test rejects the unsupported function in the report query.
- The change is mechanical and does not change the report's schedule or Slack output.

## How did you test this code?

- Ran `node --check .github/scripts/weekly-slow-tests-report.mjs`.
- Ran both weekly report test files with Node's test runner.
- Ran `git diff --check`.
- `hogli ci:preflight` was not available because `hogli` is not installed in this checkout.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not needed. This change fixes an internal CI report query.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- The CI failure was diagnosed from the scheduled workflow logs before editing the query.
- Skills invoked: `/debugging-ci-failures`, `/writing-tests`, `/running-ci-preflight`, and `/writing-pr-descriptions`.
- The open PR search found no existing PR for this fix.
- No customer data or private task context was added.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
