### PR TITLE
feat(desktop): add a canvas copy link button

### DIFF
--- a/products/desktop/docs/DEEP-LINKS.md
+++ b/products/desktop/docs/DEEP-LINKS.md
@@ -152,6 +152,10 @@ that resolves to a web interstitial in PostHog Cloud, which fires this scheme
 (or offers the desktop-app download). That way the link works for anyone,
 whether or not they have the app.
 
+Use the link button in the canvas toolbar to copy this link without opening a
+menu. The button has a "Copy link to canvas" tooltip, like the session link
+button. "Copy link" also remains in the canvas options menu.
+
 | Segment | Required | Description |
 |---|---|---|
 | `<channelId>` | Yes | Channel (folder) row id the canvas lives under. |

--- a/products/desktop/packages/ui/src/features/canvas/components/ShellLayout.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ShellLayout.tsx
@@ -22,6 +22,9 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { ChannelBreadcrumb } from "@posthog/ui/features/canvas/components/ChannelBreadcrumb";
@@ -170,7 +173,23 @@ function FreeformEditControls({
   };
 
   return (
-    <Flex align="center" gap="2" className="no-drag">
+    <div className="no-drag flex items-center gap-2">
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              size="icon-sm"
+              aria-label="Copy link to canvas"
+              onClick={() =>
+                void copyCanvasLink(channelId, dashboardId, "canvas")
+              }
+            >
+              <LinkIcon size={14} />
+            </Button>
+          }
+        />
+        <TooltipContent side="bottom">Copy link to canvas</TooltipContent>
+      </Tooltip>
       {editing && (
         // Autosave status — a non-interactive button showing a spinner while a
         // context save is in flight, "Saved" otherwise.
@@ -275,7 +294,7 @@ function FreeformEditControls({
         )}
         {editing ? "Done" : "Edit"}
       </Button>
-    </Flex>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Problem

**Why:** Canvas users must open a menu to copy a link. Sessions already have a visible link button.

## Changes

- Add a canvas toolbar link button with the same icon, size, and tooltip pattern as sessions.
- Keep the existing menu action, link format, feedback, and analytics.
- Mechanical: replace the changed toolbar layout with a plain element and Tailwind classes.

## How did you test this code?

- Ran the existing `ShellLayout.test.tsx` suite and the changed-file Biome check.
- Ran `hogli ci:preflight --fix`; no failures. Root Markdown formatting was skipped because root Node dependencies are absent.
- No browser visual check. No new test: the button calls the existing link helper without new logic.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated `products/desktop/docs/DEEP-LINKS.md` with the toolbar action.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Created with Codex, shell tools, GitHub CLI, and the signed-commit tool. Skills: `posthog-desktop`, `writing-tests`, `writing-pr-descriptions`, and `running-ci-preflight`.

The open-PR search found [#93058](https://github.com/PostHog/posthog/pull/93058), which adds a broader sharing dialog. This change only adds direct access to the existing copy action. No matching open issue was found.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
