### PR TITLE
fix(desktop): speed up checkpoint test setup

### DIFF
--- a/products/desktop/packages/git/src/sagas/checkpoint.test.ts
+++ b/products/desktop/packages/git/src/sagas/checkpoint.test.ts
@@ -1,7 +1,7 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createGitClient } from "../client";
 import {
   CaptureCheckpointSaga,
@@ -12,7 +12,7 @@ import {
   RevertCheckpointSaga,
 } from "./checkpoint";
 
-async function setupRepo(): Promise<string> {
+async function createRepoTemplate(): Promise<string> {
   const dir = await mkdtemp(path.join(tmpdir(), "posthog-code-checkpoint-"));
   const git = createGitClient(dir);
   await git.init();
@@ -25,6 +25,17 @@ async function setupRepo(): Promise<string> {
   await git.add(["a.txt", "b.txt"]);
   await git.commit("initial");
 
+  return dir;
+}
+
+let repoTemplate: string;
+
+async function setupRepo(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "posthog-code-checkpoint-"));
+  await cp(repoTemplate, dir, {
+    recursive: true,
+    filter: (source) => !source.endsWith("fsmonitor--daemon.ipc"),
+  });
   return dir;
 }
 
@@ -82,6 +93,13 @@ async function revertCheckpoint(
 }
 
 describe("checkpoint sagas", () => {
+  beforeAll(async () => {
+    repoTemplate = await createRepoTemplate();
+  });
+
+  afterAll(async () => {
+    await rm(repoTemplate, { recursive: true, force: true });
+  });
   it("captures and reverts worktree + index + untracked", async () => {
     await withRepo(async (repoPath) => {
       const git = createGitClient(repoPath);


### PR DESCRIPTION
## Problem

The Desktop test suite spends time rebuilding identical Git repositories for each checkpoint case.

## Changes

- Checkpoint tests copy one initialized repository template for each isolated case.
- Each case keeps its own writable repository, so test mutations stay isolated.
- No user-visible behavior changes.

## How did you test this code?

- Ran `PATH=/usr/bin:/bin pnpm --filter=@posthog/git exec vitest run src/sagas/checkpoint.test.ts`.
- The command covers the checkpoint saga regression cases.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not applicable.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Skills invoked: `/stacking-prs`, `/writing-tests`, `/writing-pr-descriptions`.
This layer follows [PR #96218](https://github.com/PostHog/posthog/pull/96218).

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*