### PR TITLE
fix(desktop): close insight hover card after navigation

### DIFF
--- a/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.test.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.test.tsx
@@ -122,7 +122,7 @@ describe("EvidenceRefChip", () => {
     expect(screen.queryByRole("link")).toBeNull();
   });
 
-  it("opens the card from keyboard focus on a linked reference", () => {
+  it("opens the card from keyboard focus and closes it after navigation", () => {
     signIn();
     renderInTheme(
       <EvidenceRefChip target={{ kind: "insight", id: "9pQx3" }}>
@@ -135,9 +135,13 @@ describe("EvidenceRefChip", () => {
     // real elements a keyboard user can Tab to.
     const dialog = screen.getByRole("dialog");
     expect(dialog).toBeDefined();
-    expect(
-      screen.getByRole("button", { name: /Open in PostHog/ }),
-    ).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: /Open in PostHog/ }));
+
+    expect(openExternalUrl).toHaveBeenCalledWith(
+      "https://us.posthog.com/project/2/insights/9pQx3",
+    );
+    expect(screen.queryByRole("dialog")).toBeNull();
   });
 
   it("lets the card follow the active theme instead of forcing dark", () => {

--- a/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.tsx
@@ -352,11 +352,13 @@ function EvidenceHoverCardLoader({
   target,
   children,
   url,
+  onOpen,
   onExpand,
 }: {
   target: EvidenceLinkTarget;
   children: ReactNode;
   url: string | null;
+  onOpen: (url: string) => void;
   onExpand?: (label: string) => void;
 }) {
   const client = useOptionalAuthenticatedClient();
@@ -408,6 +410,7 @@ function EvidenceHoverCardLoader({
       url={url ?? resolvedUrl}
       preview={preview}
       loadState={loadState}
+      onOpen={onOpen}
       onExpand={onExpand}
     >
       {children}
@@ -461,6 +464,11 @@ export function EvidenceRefChip({
   const openPostHogObjectTab = usePanelLayoutStore(
     (state) => state.openPostHogObjectTab,
   );
+
+  const openFromHoverCard = (targetUrl: string): void => {
+    setOpen(false);
+    openExternalUrl(targetUrl);
+  };
 
   const openReference = (event: MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault();
@@ -542,6 +550,7 @@ export function EvidenceRefChip({
               <EvidenceHoverCardLoader
                 target={target}
                 url={url}
+                onOpen={openFromHoverCard}
                 onExpand={expand}
               >
                 {children}


### PR DESCRIPTION
## Problem

Insight hover cards remain open after users select "Open in PostHog". The stale card can cover the next view.

## Changes

- The insight hover card closes before it opens the PostHog page.
- The card appearance does not change. No screenshot is needed because this change only removes the stale overlay.

## How did you test this code?

- `pnpm --filter @posthog/ui test -- src/features/editor/components/EvidenceRefChip.test.tsx`
- `pnpm typecheck`
- `uv run bin/hogli ci:preflight --fix`
- The updated component test catches a card that stays open after external navigation.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This fix does not change a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Desktop used the Explore agent and local code tools.
- Skills: `/posthog-desktop`, `/quill-code`, `/writing-ui-components`, `/writing-tests`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `/writing-simplified-technical-english`.
- The duplicate search found no open PR for this issue.
- The diff contains no private task material.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*