### PR TITLE
fix(desktop): update task space optimistically

### DIFF
--- a/products/desktop/AGENTS.md
+++ b/products/desktop/AGENTS.md
@@ -55,6 +55,7 @@ Hosts:
 11. tRPC routers are one-line forwards over services. No inline business logic.
 12. Use Inversify with `@inversifyjs/strongly-typed`. Define each token as a standalone `export const TOKEN = Symbol.for("posthog.<area>.<thing>")` beside its `interface`/service — never an object-literal token bag (`TOKENS = { X: Symbol.for(...) }`), because object properties are not `unique symbol` and cannot key a binding map. Every composition root declares a `BindingMap` interface (token → bound type) and constructs `new TypedContainer<BindingMap>()`, so a mistyped bind or a resolve of an unbound token fails at compile time. Bind in the feature module. Do not use `@provide` or `*Port` naming.
 13. Use `@posthog/quill` for rendering-layer primitives. Never import Radix — see [UI Components](#ui-components). Routing is TanStack Router contributed per feature.
+14. Make each user action optimistic when its expected result is reversible. Update all visible state and route context immediately. Restore the prior state if the request fails. If a safe rollback is not possible, show an explicit pending state.
 
 Hard boundary: `@posthog/core` and `@posthog/ui` never import host transports. No `trpcClient`, `electron`, or `node:*`.
 

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityDetailPane.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityDetailPane.tsx
@@ -60,7 +60,7 @@ export function ActivityDetailPane() {
 
   if (!task) return <TaskDetailSkeleton />;
 
-  const { channelId } = selected;
+  const channelId = task.channel ?? selected.channelId;
   const channelName = channels.find((c) => c.id === channelId)?.name;
 
   return (

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
@@ -151,7 +151,7 @@ function TaskRowMenuItems({
   const isTask = menu.kind === "task";
   const analysisTask = isTask && menu.task?.latest_run ? menu.task : null;
   const { channels } = useChannels({ enabled: bluebirdEnabled });
-  const fileToChannel = useFileTaskToChannel();
+  const fileToChannel = useFileTaskToChannel({ enabled: bluebirdEnabled });
   const openBrowserTab = useOpenBrowserTab();
 
   const channelItems: MenuFlyoutItem[] = channels.map((channel) => ({

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
@@ -32,7 +32,10 @@ import {
 import { PROJECT_BLUEBIRD_FLAG } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { useOpenBrowserTab } from "@posthog/ui/features/browser-tabs/useOpenBrowserTab";
-import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
+import {
+  type Channel,
+  useChannels,
+} from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useFileTaskToChannel } from "@posthog/ui/features/canvas/hooks/useFileTaskToChannel";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useSidebarPeekStore } from "@posthog/ui/features/sidebar/sidebarPeekStore";
@@ -52,6 +55,9 @@ import {
   useMemo,
   useState,
 } from "react";
+
+/** Stable empty list, so a gated-off channels array keeps a steady identity. */
+const EMPTY_CHANNELS: Channel[] = [];
 
 /**
  * What a row's menu can do. The row owns the handlers because they're the same
@@ -142,15 +148,20 @@ function TaskRowMenuItems({
   menu: TaskRowMenuProps;
 }) {
   const { Item, Sub, SubTrigger } = parts;
-  // "File to…" is a Project Bluebird feature; gate the channel fetch behind the
-  // flag so neither the submenu nor its request reaches ungated users.
+  // "File to…" is a Project Bluebird feature. `enabled: false` stops the
+  // request but still hands back whatever an ungated surface elsewhere put in
+  // the shared cache, so the flag has to gate the list itself: an empty list is
+  // what keeps the submenu off an ungated user's row.
   const bluebirdEnabled = useFeatureFlag(
     PROJECT_BLUEBIRD_FLAG,
     import.meta.env.DEV,
   );
   const isTask = menu.kind === "task";
   const analysisTask = isTask && menu.task?.latest_run ? menu.task : null;
-  const { channels } = useChannels({ enabled: bluebirdEnabled });
+  const { channels: fetchedChannels } = useChannels({
+    enabled: bluebirdEnabled,
+  });
+  const channels = bluebirdEnabled ? fetchedChannels : EMPTY_CHANNELS;
   const fileToChannel = useFileTaskToChannel({ enabled: bluebirdEnabled });
   const openBrowserTab = useOpenBrowserTab();
 

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
@@ -224,7 +224,7 @@ function TaskRowMenuItems({
               onSelect={(channelId) =>
                 menu.kind === "canvas"
                   ? menu.onFile?.(channelId)
-                  : fileToChannel(channelId, menu.id, menu.title)
+                  : fileToChannel(channelId, menu.id)
               }
             />
           </MenuSubFlyout>

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelFeed.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelFeed.test.ts
@@ -1,0 +1,17 @@
+import type { Task } from "@posthog/shared/domain-types";
+import { describe, expect, it } from "vitest";
+import { filterTasksByPendingFilings } from "./useChannelFeed";
+
+describe("filterTasksByPendingFilings", () => {
+  it("removes a task from its source feed while filing is pending", () => {
+    const task = { id: "task-1" } as Task;
+    const filings = [
+      { channelId: "destination", taskId: "task-1", submittedAt: 1 },
+    ];
+
+    expect(filterTasksByPendingFilings([task], "source", filings)).toEqual([]);
+    expect(filterTasksByPendingFilings([task], "destination", filings)).toEqual(
+      [task],
+    );
+  });
+});

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelFeed.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelFeed.ts
@@ -5,6 +5,11 @@ import {
   SPACE_QUERY_GC_TIME_MS,
   SPACE_QUERY_STALE_TIME_MS,
 } from "./spaceQueryPolicy";
+import {
+  latestPendingTaskFilings,
+  type PendingTaskFiling,
+  usePendingTaskFilings,
+} from "./usePendingTaskFilings";
 
 // Feeds are multiplayer: poll fast enough that a teammate's new task card and
 // run-status flips feel live without a dedicated push channel.
@@ -13,6 +18,18 @@ export const channelFeedQueryRoot = ["channel-feed"] as const;
 
 export function channelFeedQueryKey(channelId: string | undefined) {
   return [...channelFeedQueryRoot, channelId ?? "none"] as const;
+}
+
+export function filterTasksByPendingFilings(
+  tasks: Task[],
+  channelId: string | undefined,
+  pendingFilings: PendingTaskFiling[],
+): Task[] {
+  const latestByTask = latestPendingTaskFilings(pendingFilings);
+  return tasks.filter((task) => {
+    const filing = latestByTask.get(task.id);
+    return !filing || filing.channelId === channelId;
+  });
 }
 
 /**
@@ -42,12 +59,15 @@ export function useChannelFeed(channelId: string | undefined): {
       staleTime: SPACE_QUERY_STALE_TIME_MS,
     },
   );
+  const pendingFilings = usePendingTaskFilings();
   const tasks = useMemo(
     () =>
-      [...(query.data ?? [])].sort((a, b) =>
-        a.created_at.localeCompare(b.created_at),
-      ),
-    [query.data],
+      filterTasksByPendingFilings(
+        [...(query.data ?? [])],
+        channelId,
+        pendingFilings,
+      ).sort((a, b) => a.created_at.localeCompare(b.created_at)),
+    [channelId, pendingFilings, query.data],
   );
   return { tasks, isLoading: query.isLoading };
 }

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.test.tsx
@@ -1,7 +1,25 @@
+import type { Task } from "@posthog/shared/domain-types";
+import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
+import { channelFeedQueryKey } from "@posthog/ui/features/canvas/hooks/useChannelFeed";
+import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  reject: (error: Error) => void;
+  resolve: (value: T) => void;
+} {
+  let reject!: (error: Error) => void;
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
 
 const LIST_PATH = [["channelTasks", "list"]];
 const listKey = (channelId: string) => [
@@ -10,7 +28,11 @@ const listKey = (channelId: string) => [
 ];
 
 const mutations = vi.hoisted(() => ({
-  file: vi.fn().mockResolvedValue({ taskId: "t1", channelId: "dest" }),
+  file: vi.fn().mockResolvedValue({
+    taskId: "t1",
+    channelId: "dest",
+    createdAt: 1,
+  }),
   unfile: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -54,7 +76,12 @@ describe("useChannelTaskMutations", () => {
     queryClient
       .getQueryCache()
       .getAll()
-      .filter((query) => query.state.isInvalidated)
+      .filter(
+        (query) =>
+          query.state.isInvalidated &&
+          Array.isArray(query.queryKey[0]) &&
+          query.queryKey[0][0] === "channelTasks",
+      )
       .map(
         (query) =>
           (query.queryKey[1] as { input: { channelId: string } }).input
@@ -69,9 +96,29 @@ describe("useChannelTaskMutations", () => {
     });
     // A user who has browsed around holds a list per channel visited. Only the
     // ones a filed task actually moves between should be refetched.
-    queryClient.setQueryData(listKey("source"), [{ taskId: "t1" }]);
-    queryClient.setQueryData(listKey("dest"), [{ taskId: "t2" }]);
-    queryClient.setQueryData(listKey("unrelated"), [{ taskId: "t3" }]);
+    queryClient.setQueryData(listKey("source"), [
+      { channelId: "source", taskId: "t1", createdAt: 1 },
+    ]);
+    queryClient.setQueryData(listKey("dest"), [
+      { channelId: "dest", taskId: "t2", createdAt: 2 },
+    ]);
+    queryClient.setQueryData(listKey("unrelated"), [
+      { channelId: "unrelated", taskId: "t3", createdAt: 3 },
+    ]);
+    const task = {
+      id: "t1",
+      channel: "source",
+      title: "Move this task",
+    } as Task;
+    const destinationTask = {
+      id: "t2",
+      channel: "dest",
+      title: "Destination task",
+    } as Task;
+    queryClient.setQueryData(taskKeys.list(), [task]);
+    queryClient.setQueryData(taskKeys.detail("t1"), task);
+    queryClient.setQueryData(channelFeedQueryKey("source"), [task]);
+    queryClient.setQueryData(channelFeedQueryKey("dest"), [destinationTask]);
   });
 
   it("filing a task invalidates only its old and new channel", async () => {
@@ -82,6 +129,175 @@ describe("useChannelTaskMutations", () => {
     });
 
     expect(invalidatedChannels()).toEqual(["dest", "source"]);
+  });
+
+  it("moves a task between cached channels before filing completes", async () => {
+    let resolveFile:
+      | ((value: {
+          taskId: string;
+          channelId: string;
+          createdAt: number;
+        }) => void)
+      | null = null;
+    mutations.file.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFile = resolve;
+        }),
+    );
+    const { result } = renderHook(() => useChannelTaskMutations(), { wrapper });
+    let filing: Promise<unknown>;
+
+    await act(async () => {
+      filing = result.current.fileTask("dest", "t1");
+      await Promise.resolve();
+    });
+
+    expect(queryClient.getQueryData(listKey("source"))).toEqual([]);
+    expect(queryClient.getQueryData(listKey("dest"))).toEqual([
+      { channelId: "dest", taskId: "t2", createdAt: 2 },
+      { channelId: "dest", taskId: "t1", createdAt: 1 },
+    ]);
+    expect(queryClient.getQueryData(listKey("unrelated"))).toEqual([
+      { channelId: "unrelated", taskId: "t3", createdAt: 3 },
+    ]);
+    expect(queryClient.getQueryData<Task>(taskKeys.detail("t1"))?.channel).toBe(
+      "dest",
+    );
+    expect(
+      queryClient.getQueryData<Task[]>(taskKeys.list())?.[0]?.channel,
+    ).toBe("dest");
+    expect(queryClient.getQueryData(channelFeedQueryKey("source"))).toEqual([]);
+    expect(
+      queryClient
+        .getQueryData<Task[]>(channelFeedQueryKey("dest"))
+        ?.map((task) => [task.id, task.channel]),
+    ).toEqual([
+      ["t2", "dest"],
+      ["t1", "dest"],
+    ]);
+    await act(async () => {
+      resolveFile?.({ taskId: "t1", channelId: "dest", createdAt: 4 });
+      await filing;
+    });
+
+    expect(queryClient.getQueryData(listKey("dest"))).toEqual([
+      { channelId: "dest", taskId: "t2", createdAt: 2 },
+      { channelId: "dest", taskId: "t1", createdAt: 4 },
+    ]);
+  });
+
+  it("restores cached channels when filing fails", async () => {
+    let rejectFile: ((error: Error) => void) | null = null;
+    mutations.file.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectFile = reject;
+        }),
+    );
+    const { result } = renderHook(() => useChannelTaskMutations(), { wrapper });
+    let filing: Promise<unknown>;
+
+    await act(async () => {
+      filing = result.current.fileTask("dest", "t1");
+      await Promise.resolve();
+    });
+
+    expect(queryClient.getQueryData(listKey("source"))).toEqual([]);
+    queryClient.setQueryData(listKey("unrelated"), [
+      { channelId: "unrelated", taskId: "t3", createdAt: 3 },
+      { channelId: "unrelated", taskId: "t4", createdAt: 4 },
+    ]);
+
+    await act(async () => {
+      rejectFile?.(new Error("Request failed"));
+      await filing.catch(() => undefined);
+    });
+
+    expect(queryClient.getQueryData(listKey("source"))).toEqual([
+      { channelId: "source", taskId: "t1", createdAt: 1 },
+    ]);
+    expect(queryClient.getQueryData(listKey("dest"))).toEqual([
+      { channelId: "dest", taskId: "t2", createdAt: 2 },
+    ]);
+    expect(queryClient.getQueryData(listKey("unrelated"))).toEqual([
+      { channelId: "unrelated", taskId: "t3", createdAt: 3 },
+      { channelId: "unrelated", taskId: "t4", createdAt: 4 },
+    ]);
+    expect(queryClient.getQueryData<Task>(taskKeys.detail("t1"))?.channel).toBe(
+      "source",
+    );
+    expect(
+      queryClient.getQueryData<Task[]>(taskKeys.list())?.[0]?.channel,
+    ).toBe("source");
+    expect(
+      queryClient
+        .getQueryData<Task[]>(channelFeedQueryKey("source"))
+        ?.map((task) => [task.id, task.channel]),
+    ).toEqual([["t1", "source"]]);
+    expect(
+      queryClient
+        .getQueryData<Task[]>(channelFeedQueryKey("dest"))
+        ?.map((task) => [task.id, task.channel]),
+    ).toEqual([["t2", "dest"]]);
+  });
+
+  it("does not roll back a newer filing of the same task", async () => {
+    const firstRequest = deferred<{
+      taskId: string;
+      channelId: string;
+      createdAt: number;
+    }>();
+    const secondRequest = deferred<{
+      taskId: string;
+      channelId: string;
+      createdAt: number;
+    }>();
+    mutations.file
+      .mockImplementationOnce(() => firstRequest.promise)
+      .mockImplementationOnce(() => secondRequest.promise);
+    const { result } = renderHook(() => useChannelTaskMutations(), { wrapper });
+
+    let firstFiling = Promise.resolve<unknown>(undefined);
+    let secondFiling = Promise.resolve<unknown>(undefined);
+    await act(async () => {
+      firstFiling = result.current.fileTask("dest", "t1");
+      await Promise.resolve();
+      secondFiling = result.current.fileTask("dest", "t1");
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      firstRequest.reject(new Error("First request failed"));
+      await firstFiling.catch(() => undefined);
+    });
+
+    expect(
+      queryClient
+        .getQueryData<{ taskId: string }[]>(listKey("dest"))
+        ?.map((record) => record.taskId),
+    ).toEqual(["t2", "t1"]);
+
+    await act(async () => {
+      secondRequest.resolve({ taskId: "t1", channelId: "dest", createdAt: 5 });
+      await secondFiling;
+    });
+  });
+
+  it("marks a new optimistic destination query as auth scoped", async () => {
+    queryClient.removeQueries({ queryKey: listKey("new-dest"), exact: true });
+    const { result } = renderHook(() => useChannelTaskMutations(), { wrapper });
+
+    await act(async () => {
+      await result.current.fileTask("new-dest", "t1");
+    });
+
+    expect(
+      queryClient.getQueryCache().find({
+        queryKey: listKey("new-dest"),
+        exact: true,
+      })?.meta,
+    ).toMatchObject(AUTH_SCOPED_QUERY_META);
   });
 
   it("filing a task invalidates a channel whose list is still loading", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.test.tsx
@@ -242,6 +242,26 @@ describe("useChannelTasks", () => {
     expect(mocks.listFetches.third).toBe(0);
   });
 
+  it("invalidates the space tree and saved searches when filing succeeds", async () => {
+    const treeKey = ["space-tree-tasks", "source"];
+    const searchKey = ["task-feed-results", "space:source"];
+    queryClient.setQueryData(treeKey, { tasks: [], count: 0 });
+    queryClient.setQueryData(searchKey, { tasks: [], isComplete: true });
+    mocks.file.mockResolvedValueOnce({
+      channelId: "dest",
+      taskId: "t1",
+      createdAt: 1,
+    });
+    const { result } = renderHook(useFilingHarness, { wrapper });
+
+    await act(async () => {
+      await result.current.mutations.fileTask("dest", "t1");
+    });
+
+    expect(queryClient.getQueryState(treeKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(searchKey)?.isInvalidated).toBe(true);
+  });
+
   it("invalidates channel lists when unfiling succeeds", async () => {
     const { result } = renderHook(() => useChannelTaskMutations(), { wrapper });
 

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.test.tsx
@@ -167,6 +167,39 @@ describe("useChannelTasks", () => {
     });
   });
 
+  it("sends overlapping filings of one task in order", async () => {
+    const firstRequest = deferred<FilingResult>();
+    const secondRequest = deferred<FilingResult>();
+    mocks.file
+      .mockReturnValueOnce(firstRequest.promise)
+      .mockReturnValueOnce(secondRequest.promise);
+    const filedChannels = (): string[] =>
+      mocks.file.mock.calls.map(
+        (call) => (call[0] as { channelId: string }).channelId,
+      );
+    const { result } = renderHook(useFilingHarness, { wrapper });
+    let firstFiling = Promise.resolve<unknown>(undefined);
+    let secondFiling = Promise.resolve<unknown>(undefined);
+
+    act(() => {
+      firstFiling = result.current.mutations.fileTask("dest", "t1");
+      secondFiling = result.current.mutations.fileTask("third", "t1");
+    });
+
+    await waitFor(() => expect(filedChannels()).toEqual(["dest"]));
+
+    await act(async () => {
+      firstRequest.resolve({ channelId: "dest", taskId: "t1", createdAt: 1 });
+      await firstFiling;
+    });
+    await waitFor(() => expect(filedChannels()).toEqual(["dest", "third"]));
+
+    await act(async () => {
+      secondRequest.resolve({ channelId: "third", taskId: "t1", createdAt: 1 });
+      await secondFiling;
+    });
+  });
+
   it("shows a task only in its latest pending destination", () => {
     const records = [{ channelId: "source", taskId: "t1", createdAt: 1 }];
     const filings = [

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.test.tsx
@@ -32,6 +32,7 @@ const listKey = (channelId: string) => [
 
 const mocks = vi.hoisted(() => ({
   file: vi.fn(),
+  listFetches: {} as Record<string, number>,
   rows: {} as Record<string, FilingResult[]>,
   unfile: vi.fn().mockResolvedValue(undefined),
 }));
@@ -42,13 +43,20 @@ vi.mock("@posthog/host-router/react", () => ({
       list: {
         mutationKey: () => FILE_KEY,
         pathFilter: () => ({ queryKey: LIST_PATH }),
+        queryFilter: ({ channelId }: { channelId: string }) => ({
+          queryKey: listKey(channelId),
+        }),
         queryOptions: (
           { channelId }: { channelId: string },
           options: object,
         ) => ({
           ...options,
           queryKey: listKey(channelId),
-          queryFn: async () => mocks.rows[channelId] ?? [],
+          queryFn: async () => {
+            mocks.listFetches[channelId] =
+              (mocks.listFetches[channelId] ?? 0) + 1;
+            return mocks.rows[channelId] ?? [];
+          },
         }),
       },
       file: {
@@ -98,6 +106,7 @@ describe("useChannelTasks", () => {
     queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
+    mocks.listFetches = { source: 0, dest: 0, third: 0 };
     mocks.rows = {
       source: [{ channelId: "source", taskId: "t1", createdAt: 1 }],
       dest: [{ channelId: "dest", taskId: "t2", createdAt: 2 }],
@@ -212,6 +221,25 @@ describe("useChannelTasks", () => {
     expect(applyPendingTaskFilings([], "third", filings)).toEqual([
       { channelId: "third", taskId: "t1", createdAt: 3 },
     ]);
+  });
+
+  it("refetches only the channel lists a filing changes", async () => {
+    const request = deferred<FilingResult>();
+    mocks.file.mockReturnValueOnce(request.promise);
+    const { result } = renderHook(useFilingHarness, { wrapper });
+    let filing = Promise.resolve<unknown>(undefined);
+
+    act(() => {
+      filing = result.current.mutations.fileTask("dest", "t1");
+    });
+    await act(async () => {
+      request.resolve({ channelId: "dest", taskId: "t1", createdAt: 1 });
+      await filing;
+    });
+
+    expect(mocks.listFetches.source).toBe(1);
+    expect(mocks.listFetches.dest).toBe(1);
+    expect(mocks.listFetches.third).toBe(0);
   });
 
   it("invalidates channel lists when unfiling succeeds", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.test.tsx
@@ -1,11 +1,13 @@
-import type { Task } from "@posthog/shared/domain-types";
-import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
-import { channelFeedQueryKey } from "@posthog/ui/features/canvas/hooks/useChannelFeed";
-import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+interface FilingResult {
+  taskId: string;
+  channelId: string;
+  createdAt: number;
+}
 
 function deferred<T>(): {
   promise: Promise<T>;
@@ -22,17 +24,15 @@ function deferred<T>(): {
 }
 
 const LIST_PATH = [["channelTasks", "list"]];
+const FILE_KEY = [["channelTasks", "file"]];
 const listKey = (channelId: string) => [
   ...LIST_PATH,
   { input: { channelId }, type: "query" },
 ];
 
-const mutations = vi.hoisted(() => ({
-  file: vi.fn().mockResolvedValue({
-    taskId: "t1",
-    channelId: "dest",
-    createdAt: 1,
-  }),
+const mocks = vi.hoisted(() => ({
+  file: vi.fn(),
+  rows: {} as Record<string, FilingResult[]>,
   unfile: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -40,30 +40,42 @@ vi.mock("@posthog/host-router/react", () => ({
   useHostTRPC: () => ({
     channelTasks: {
       list: {
+        mutationKey: () => FILE_KEY,
         pathFilter: () => ({ queryKey: LIST_PATH }),
-        queryFilter: ({ channelId }: { channelId: string }) => ({
+        queryOptions: (
+          { channelId }: { channelId: string },
+          options: object,
+        ) => ({
+          ...options,
           queryKey: listKey(channelId),
+          queryFn: async () => mocks.rows[channelId] ?? [],
         }),
       },
       file: {
+        mutationKey: () => FILE_KEY,
         mutationOptions: (options: object) => ({
           ...options,
-          mutationFn: mutations.file,
+          mutationKey: FILE_KEY,
+          mutationFn: mocks.file,
         }),
       },
       unfile: {
         mutationOptions: (options: object) => ({
           ...options,
-          mutationFn: mutations.unfile,
+          mutationFn: mocks.unfile,
         }),
       },
     },
   }),
 }));
 
-import { useChannelTaskMutations } from "./useChannelTasks";
+import {
+  applyPendingTaskFilings,
+  useChannelTaskMutations,
+  useChannelTasks,
+} from "./useChannelTasks";
 
-describe("useChannelTaskMutations", () => {
+describe("useChannelTasks", () => {
   let queryClient: QueryClient;
 
   function wrapper({ children }: { children: ReactNode }) {
@@ -72,257 +84,115 @@ describe("useChannelTaskMutations", () => {
     );
   }
 
-  const invalidatedChannels = () =>
-    queryClient
-      .getQueryCache()
-      .getAll()
-      .filter(
-        (query) =>
-          query.state.isInvalidated &&
-          Array.isArray(query.queryKey[0]) &&
-          query.queryKey[0][0] === "channelTasks",
-      )
-      .map(
-        (query) =>
-          (query.queryKey[1] as { input: { channelId: string } }).input
-            .channelId,
-      )
-      .sort();
+  function useFilingHarness() {
+    return {
+      source: useChannelTasks("source"),
+      destination: useChannelTasks("dest"),
+      third: useChannelTasks("third"),
+      mutations: useChannelTaskMutations(),
+    };
+  }
 
   beforeEach(() => {
     vi.clearAllMocks();
     queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
-    // A user who has browsed around holds a list per channel visited. Only the
-    // ones a filed task actually moves between should be refetched.
-    queryClient.setQueryData(listKey("source"), [
-      { channelId: "source", taskId: "t1", createdAt: 1 },
-    ]);
-    queryClient.setQueryData(listKey("dest"), [
-      { channelId: "dest", taskId: "t2", createdAt: 2 },
-    ]);
-    queryClient.setQueryData(listKey("unrelated"), [
-      { channelId: "unrelated", taskId: "t3", createdAt: 3 },
-    ]);
-    const task = {
-      id: "t1",
-      channel: "source",
-      title: "Move this task",
-    } as Task;
-    const destinationTask = {
-      id: "t2",
-      channel: "dest",
-      title: "Destination task",
-    } as Task;
-    queryClient.setQueryData(taskKeys.list(), [task]);
-    queryClient.setQueryData(taskKeys.detail("t1"), task);
-    queryClient.setQueryData(channelFeedQueryKey("source"), [task]);
-    queryClient.setQueryData(channelFeedQueryKey("dest"), [destinationTask]);
+    mocks.rows = {
+      source: [{ channelId: "source", taskId: "t1", createdAt: 1 }],
+      dest: [{ channelId: "dest", taskId: "t2", createdAt: 2 }],
+      third: [],
+    };
+    for (const [channelId, rows] of Object.entries(mocks.rows)) {
+      queryClient.setQueryData(listKey(channelId), rows);
+    }
   });
 
-  it("filing a task invalidates only its old and new channel", async () => {
-    const { result } = renderHook(() => useChannelTaskMutations(), { wrapper });
+  it("moves a task between visible channels while filing is pending", async () => {
+    const request = deferred<FilingResult>();
+    mocks.file.mockReturnValueOnce(request.promise);
+    const { result } = renderHook(useFilingHarness, { wrapper });
+    let filing = Promise.resolve<unknown>(undefined);
 
-    await act(async () => {
-      await result.current.fileTask("dest", "t1");
+    act(() => {
+      filing = result.current.mutations.fileTask("dest", "t1");
     });
 
-    expect(invalidatedChannels()).toEqual(["dest", "source"]);
-  });
-
-  it("moves a task between cached channels before filing completes", async () => {
-    let resolveFile:
-      | ((value: {
-          taskId: string;
-          channelId: string;
-          createdAt: number;
-        }) => void)
-      | null = null;
-    mutations.file.mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          resolveFile = resolve;
-        }),
-    );
-    const { result } = renderHook(() => useChannelTaskMutations(), { wrapper });
-    let filing: Promise<unknown>;
-
-    await act(async () => {
-      filing = result.current.fileTask("dest", "t1");
-      await Promise.resolve();
+    await waitFor(() => {
+      expect(result.current.source.tasks).toEqual([]);
+      expect(
+        result.current.destination.tasks.map((task) => task.taskId),
+      ).toEqual(["t2", "t1"]);
     });
 
-    expect(queryClient.getQueryData(listKey("source"))).toEqual([]);
-    expect(queryClient.getQueryData(listKey("dest"))).toEqual([
+    mocks.rows.source = [];
+    mocks.rows.dest = [
       { channelId: "dest", taskId: "t2", createdAt: 2 },
       { channelId: "dest", taskId: "t1", createdAt: 1 },
-    ]);
-    expect(queryClient.getQueryData(listKey("unrelated"))).toEqual([
-      { channelId: "unrelated", taskId: "t3", createdAt: 3 },
-    ]);
-    expect(queryClient.getQueryData<Task>(taskKeys.detail("t1"))?.channel).toBe(
-      "dest",
-    );
-    expect(
-      queryClient.getQueryData<Task[]>(taskKeys.list())?.[0]?.channel,
-    ).toBe("dest");
-    expect(queryClient.getQueryData(channelFeedQueryKey("source"))).toEqual([]);
-    expect(
-      queryClient
-        .getQueryData<Task[]>(channelFeedQueryKey("dest"))
-        ?.map((task) => [task.id, task.channel]),
-    ).toEqual([
-      ["t2", "dest"],
-      ["t1", "dest"],
-    ]);
+    ];
     await act(async () => {
-      resolveFile?.({ taskId: "t1", channelId: "dest", createdAt: 4 });
+      request.resolve({ channelId: "dest", taskId: "t1", createdAt: 1 });
       await filing;
     });
 
-    expect(queryClient.getQueryData(listKey("dest"))).toEqual([
-      { channelId: "dest", taskId: "t2", createdAt: 2 },
-      { channelId: "dest", taskId: "t1", createdAt: 4 },
-    ]);
+    expect(result.current.source.tasks).toEqual([]);
+    expect(result.current.destination.tasks.map((task) => task.taskId)).toEqual(
+      ["t2", "t1"],
+    );
   });
 
-  it("restores cached channels when filing fails", async () => {
-    let rejectFile: ((error: Error) => void) | null = null;
-    mutations.file.mockImplementationOnce(
-      () =>
-        new Promise((_resolve, reject) => {
-          rejectFile = reject;
-        }),
-    );
-    const { result } = renderHook(() => useChannelTaskMutations(), { wrapper });
-    let filing: Promise<unknown>;
+  it("shows the server-backed channels again when filing fails", async () => {
+    const request = deferred<FilingResult>();
+    mocks.file.mockReturnValueOnce(request.promise);
+    const { result } = renderHook(useFilingHarness, { wrapper });
+    let filing = Promise.resolve<unknown>(undefined);
 
-    await act(async () => {
-      filing = result.current.fileTask("dest", "t1");
-      await Promise.resolve();
+    act(() => {
+      filing = result.current.mutations.fileTask("dest", "t1");
     });
-
-    expect(queryClient.getQueryData(listKey("source"))).toEqual([]);
-    queryClient.setQueryData(listKey("unrelated"), [
-      { channelId: "unrelated", taskId: "t3", createdAt: 3 },
-      { channelId: "unrelated", taskId: "t4", createdAt: 4 },
-    ]);
+    await waitFor(() => expect(result.current.source.tasks).toEqual([]));
 
     await act(async () => {
-      rejectFile?.(new Error("Request failed"));
+      request.reject(new Error("Request failed"));
       await filing.catch(() => undefined);
     });
 
-    expect(queryClient.getQueryData(listKey("source"))).toEqual([
-      { channelId: "source", taskId: "t1", createdAt: 1 },
+    await waitFor(() => {
+      expect(result.current.source.tasks.map((task) => task.taskId)).toEqual([
+        "t1",
+      ]);
+      expect(
+        result.current.destination.tasks.map((task) => task.taskId),
+      ).toEqual(["t2"]);
+    });
+  });
+
+  it("shows a task only in its latest pending destination", () => {
+    const records = [{ channelId: "source", taskId: "t1", createdAt: 1 }];
+    const filings = [
+      { channelId: "dest", taskId: "t1", submittedAt: 2 },
+      { channelId: "third", taskId: "t1", submittedAt: 3 },
+    ];
+
+    expect(applyPendingTaskFilings(records, "source", filings)).toEqual([]);
+    expect(applyPendingTaskFilings([], "dest", filings)).toEqual([]);
+    expect(applyPendingTaskFilings([], "third", filings)).toEqual([
+      { channelId: "third", taskId: "t1", createdAt: 3 },
     ]);
-    expect(queryClient.getQueryData(listKey("dest"))).toEqual([
-      { channelId: "dest", taskId: "t2", createdAt: 2 },
-    ]);
-    expect(queryClient.getQueryData(listKey("unrelated"))).toEqual([
-      { channelId: "unrelated", taskId: "t3", createdAt: 3 },
-      { channelId: "unrelated", taskId: "t4", createdAt: 4 },
-    ]);
-    expect(queryClient.getQueryData<Task>(taskKeys.detail("t1"))?.channel).toBe(
-      "source",
-    );
-    expect(
-      queryClient.getQueryData<Task[]>(taskKeys.list())?.[0]?.channel,
-    ).toBe("source");
-    expect(
-      queryClient
-        .getQueryData<Task[]>(channelFeedQueryKey("source"))
-        ?.map((task) => [task.id, task.channel]),
-    ).toEqual([["t1", "source"]]);
-    expect(
-      queryClient
-        .getQueryData<Task[]>(channelFeedQueryKey("dest"))
-        ?.map((task) => [task.id, task.channel]),
-    ).toEqual([["t2", "dest"]]);
   });
 
-  it("does not roll back a newer filing of the same task", async () => {
-    const firstRequest = deferred<{
-      taskId: string;
-      channelId: string;
-      createdAt: number;
-    }>();
-    const secondRequest = deferred<{
-      taskId: string;
-      channelId: string;
-      createdAt: number;
-    }>();
-    mutations.file
-      .mockImplementationOnce(() => firstRequest.promise)
-      .mockImplementationOnce(() => secondRequest.promise);
-    const { result } = renderHook(() => useChannelTaskMutations(), { wrapper });
-
-    let firstFiling = Promise.resolve<unknown>(undefined);
-    let secondFiling = Promise.resolve<unknown>(undefined);
-    await act(async () => {
-      firstFiling = result.current.fileTask("dest", "t1");
-      await Promise.resolve();
-      secondFiling = result.current.fileTask("dest", "t1");
-      await Promise.resolve();
-    });
-
-    await act(async () => {
-      firstRequest.reject(new Error("First request failed"));
-      await firstFiling.catch(() => undefined);
-    });
-
-    expect(
-      queryClient
-        .getQueryData<{ taskId: string }[]>(listKey("dest"))
-        ?.map((record) => record.taskId),
-    ).toEqual(["t2", "t1"]);
-
-    await act(async () => {
-      secondRequest.resolve({ taskId: "t1", channelId: "dest", createdAt: 5 });
-      await secondFiling;
-    });
-  });
-
-  it("marks a new optimistic destination query as auth scoped", async () => {
-    queryClient.removeQueries({ queryKey: listKey("new-dest"), exact: true });
-    const { result } = renderHook(() => useChannelTaskMutations(), { wrapper });
-
-    await act(async () => {
-      await result.current.fileTask("new-dest", "t1");
-    });
-
-    expect(
-      queryClient.getQueryCache().find({
-        queryKey: listKey("new-dest"),
-        exact: true,
-      })?.meta,
-    ).toMatchObject(AUTH_SCOPED_QUERY_META);
-  });
-
-  it("filing a task invalidates a channel whose list is still loading", async () => {
-    // A first load has no cached membership to check, and its request may have
-    // gone out before the mutation. Skipping it lets the pre-mutation response
-    // land and sit fresh, leaving the task showing in the space it left.
-    queryClient
-      .getQueryCache()
-      .build(queryClient, { queryKey: listKey("loading") });
-    const { result } = renderHook(() => useChannelTaskMutations(), { wrapper });
-
-    await act(async () => {
-      await result.current.fileTask("dest", "t1");
-    });
-
-    expect(invalidatedChannels()).toEqual(["dest", "loading", "source"]);
-  });
-
-  it("unfiling a task invalidates only the channel that listed it", async () => {
+  it("invalidates channel lists when unfiling succeeds", async () => {
     const { result } = renderHook(() => useChannelTaskMutations(), { wrapper });
 
     await act(async () => {
       await result.current.unfileTask("t1");
     });
 
-    expect(invalidatedChannels()).toEqual(["source"]);
+    expect(
+      queryClient
+        .getQueryCache()
+        .find({ queryKey: listKey("source"), exact: true })?.state
+        .isInvalidated,
+    ).toBe(true);
   });
 });

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import type { ReactNode } from "react";
+import type { ReactElement, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 interface FilingResult {
@@ -86,13 +86,18 @@ import {
 describe("useChannelTasks", () => {
   let queryClient: QueryClient;
 
-  function wrapper({ children }: { children: ReactNode }) {
+  function wrapper({ children }: { children: ReactNode }): ReactElement {
     return (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
   }
 
-  function useFilingHarness() {
+  function useFilingHarness(): {
+    source: ReturnType<typeof useChannelTasks>;
+    destination: ReturnType<typeof useChannelTasks>;
+    third: ReturnType<typeof useChannelTasks>;
+    mutations: ReturnType<typeof useChannelTaskMutations>;
+  } {
     return {
       source: useChannelTasks("source"),
       destination: useChannelTasks("dest"),

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.ts
@@ -1,12 +1,94 @@
 import type { ChannelTaskRecord } from "@posthog/core/canvas/channelTaskSchemas";
 import { useHostTRPC } from "@posthog/host-router/react";
+import type { Task } from "@posthog/shared/domain-types";
 import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  channelFeedQueryKey,
+  channelFeedQueryRoot,
+} from "@posthog/ui/features/canvas/hooks/useChannelFeed";
+import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
+import {
+  type QueryClient,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import {
   SPACE_QUERY_GC_TIME_MS,
   SPACE_QUERY_REFETCH_INTERVAL_MS,
   SPACE_QUERY_STALE_TIME_MS,
 } from "./spaceQueryPolicy";
+
+const latestFilings = new WeakMap<QueryClient, Map<string, symbol>>();
+
+function latestFilingsFor(queryClient: QueryClient): Map<string, symbol> {
+  const existing = latestFilings.get(queryClient);
+  if (existing) return existing;
+  const filings = new Map<string, symbol>();
+  latestFilings.set(queryClient, filings);
+  return filings;
+}
+
+function restoreChannelTaskRecord(
+  current: ChannelTaskRecord[] | undefined,
+  previous: ChannelTaskRecord[] | undefined,
+  taskId: string,
+): ChannelTaskRecord[] | undefined {
+  const previousRecord = previous?.find((record) => record.taskId === taskId);
+  const withoutTask = current?.filter((record) => record.taskId !== taskId);
+  if (!previousRecord) return withoutTask;
+  if (!withoutTask) return previous;
+
+  const previousIndex = previous?.findIndex(
+    (record) => record.taskId === taskId,
+  );
+  const insertAt = Math.min(
+    previousIndex ?? withoutTask.length,
+    withoutTask.length,
+  );
+  return [
+    ...withoutTask.slice(0, insertAt),
+    previousRecord,
+    ...withoutTask.slice(insertAt),
+  ];
+}
+
+function restoreTaskRecord(
+  current: Task[] | undefined,
+  previous: Task[] | undefined,
+  taskId: string,
+): Task[] | undefined {
+  const previousTask = previous?.find((task) => task.id === taskId);
+  const withoutTask = current?.filter((task) => task.id !== taskId);
+  if (!previousTask) return withoutTask;
+  if (!withoutTask) return previous;
+
+  const previousIndex = previous?.findIndex((task) => task.id === taskId);
+  const insertAt = Math.min(
+    previousIndex ?? withoutTask.length,
+    withoutTask.length,
+  );
+  return [
+    ...withoutTask.slice(0, insertAt),
+    previousTask,
+    ...withoutTask.slice(insertAt),
+  ];
+}
+
+function restoreTaskChannel(
+  current: Task[] | undefined,
+  previous: Task[] | undefined,
+  taskId: string,
+  optimisticChannelId: string,
+): Task[] | undefined {
+  const previousTask = previous?.find((task) => task.id === taskId);
+  if (!previousTask) return current;
+  return current?.map((task) =>
+    task.id === taskId && task.channel === optimisticChannelId
+      ? previousTask
+      : task,
+  );
+}
 
 /** Tasks filed to a channel — the task's `channel` field on the tasks API. */
 export function useChannelTasks(channelId: string | undefined): {
@@ -33,24 +115,11 @@ export function useChannelTaskMutations() {
   const trpc = useHostTRPC();
   const queryClient = useQueryClient();
 
-  /**
-   * Filing moves a task, so at most two lists change: the channel it lands in
-   * and whichever one still shows it. Every other cached channel is untouched,
-   * and someone who has browsed a lot of channels holds a lot of those.
-   */
-  const invalidateAffected = (taskId: string, channelId?: string) => {
-    if (channelId) {
-      void queryClient.invalidateQueries(
-        trpc.channelTasks.list.queryFilter({ channelId }),
-      );
-    }
+  const invalidateTaskLists = (taskId: string) => {
     void queryClient.invalidateQueries({
       ...trpc.channelTasks.list.pathFilter(),
       predicate: (query) => {
         const tasks = query.state.data as ChannelTaskRecord[] | undefined;
-        // A list still loading has no membership to check, and its in-flight
-        // request may have been sent before this mutation. Refetch rather than
-        // let a pre-mutation response land and sit fresh.
         if (!tasks) return true;
         return tasks.some((record) => record.taskId === taskId);
       },
@@ -59,13 +128,220 @@ export function useChannelTaskMutations() {
 
   const file = useMutation(
     trpc.channelTasks.file.mutationOptions({
-      onSuccess: (_data, variables) =>
-        invalidateAffected(variables.taskId, variables.channelId),
+      onMutate: async (variables) => {
+        const filingToken = Symbol(variables.taskId);
+        latestFilingsFor(queryClient).set(variables.taskId, filingToken);
+        const listFilter = trpc.channelTasks.list.pathFilter();
+        await Promise.all([
+          queryClient.cancelQueries(listFilter),
+          queryClient.cancelQueries({ queryKey: taskKeys.lists() }),
+          queryClient.cancelQueries({ queryKey: channelFeedQueryRoot }),
+          queryClient.cancelQueries({
+            queryKey: taskKeys.detail(variables.taskId),
+          }),
+        ]);
+
+        const previousQueries =
+          queryClient.getQueriesData<ChannelTaskRecord[]>(listFilter);
+        const previousTaskQueries = queryClient.getQueriesData<Task[]>({
+          queryKey: taskKeys.lists(),
+        });
+        const previousTaskDetail = queryClient.getQueryData<Task>(
+          taskKeys.detail(variables.taskId),
+        );
+        const previousChannelFeedQueries = queryClient.getQueriesData<Task[]>({
+          queryKey: channelFeedQueryRoot,
+        });
+        const destinationFeedKey = channelFeedQueryKey(variables.channelId);
+        const destinationFeedExisted =
+          queryClient.getQueryState(destinationFeedKey) !== undefined;
+        const destinationFilter = trpc.channelTasks.list.queryFilter({
+          channelId: variables.channelId,
+        });
+        const destinationQueryExisted =
+          queryClient.getQueryState(destinationFilter.queryKey) !== undefined;
+        const previousRecord = previousQueries
+          .flatMap(([, records]) => records ?? [])
+          .find((record) => record.taskId === variables.taskId);
+        const optimisticRecord: ChannelTaskRecord = {
+          channelId: variables.channelId,
+          taskId: variables.taskId,
+          createdAt: previousRecord?.createdAt ?? Date.now(),
+        };
+        const optimisticTask = [
+          previousTaskDetail,
+          ...previousTaskQueries.flatMap(([, tasks]) => tasks ?? []),
+          ...previousChannelFeedQueries.flatMap(([, tasks]) => tasks ?? []),
+        ].find((task) => task?.id === variables.taskId);
+
+        queryClient.setQueriesData<ChannelTaskRecord[]>(listFilter, (records) =>
+          records?.filter((record) => record.taskId !== variables.taskId),
+        );
+        queryClient.setQueryDefaults(destinationFilter.queryKey, {
+          meta: AUTH_SCOPED_QUERY_META,
+        });
+        queryClient.setQueryData<ChannelTaskRecord[]>(
+          destinationFilter.queryKey,
+          (records) => [...(records ?? []), optimisticRecord],
+        );
+        queryClient.setQueriesData<Task[]>(
+          { queryKey: taskKeys.lists() },
+          (tasks) =>
+            tasks?.map((task) =>
+              task.id === variables.taskId
+                ? { ...task, channel: variables.channelId }
+                : task,
+            ),
+        );
+        queryClient.setQueryData<Task>(
+          taskKeys.detail(variables.taskId),
+          (task) =>
+            task ? { ...task, channel: variables.channelId } : undefined,
+        );
+        queryClient.setQueriesData<Task[]>(
+          { queryKey: channelFeedQueryRoot },
+          (tasks) => tasks?.filter((task) => task.id !== variables.taskId),
+        );
+        if (destinationFeedExisted && optimisticTask) {
+          queryClient.setQueryData<Task[]>(destinationFeedKey, (tasks) => [
+            ...(tasks ?? []).filter((task) => task.id !== variables.taskId),
+            { ...optimisticTask, channel: variables.channelId },
+          ]);
+        }
+
+        const affectedQueryKeys = previousQueries
+          .filter(
+            ([, records]) =>
+              !records ||
+              records.some((record) => record.taskId === variables.taskId),
+          )
+          .map(([queryKey]) => queryKey);
+
+        return {
+          affectedQueryKeys,
+          filingToken,
+          destinationFilter,
+          destinationQueryExisted,
+          previousChannelFeedQueries,
+          previousQueries,
+          previousTaskDetail,
+          previousTaskQueries,
+        };
+      },
+      onSuccess: (record, variables, context) => {
+        if (
+          !context ||
+          latestFilingsFor(queryClient).get(variables.taskId) !==
+            context.filingToken
+        ) {
+          return;
+        }
+        queryClient.setQueryData<ChannelTaskRecord[]>(
+          context.destinationFilter.queryKey,
+          (records) =>
+            records?.map((current) =>
+              current.taskId === variables.taskId &&
+              current.channelId === variables.channelId
+                ? record
+                : current,
+            ),
+        );
+      },
+      onError: (_error, variables, context) => {
+        if (
+          !context ||
+          latestFilingsFor(queryClient).get(variables.taskId) !==
+            context.filingToken
+        ) {
+          return;
+        }
+        const destinationRecords = queryClient.getQueryData<
+          ChannelTaskRecord[]
+        >(context.destinationFilter.queryKey);
+        const ownsOptimisticMove = destinationRecords?.some(
+          (record) =>
+            record.taskId === variables.taskId &&
+            record.channelId === variables.channelId,
+        );
+        if (!ownsOptimisticMove) return;
+
+        for (const [queryKey, previousRecords] of context.previousQueries) {
+          queryClient.setQueryData<ChannelTaskRecord[]>(queryKey, (current) =>
+            restoreChannelTaskRecord(
+              current,
+              previousRecords,
+              variables.taskId,
+            ),
+          );
+        }
+        for (const [queryKey, previousTasks] of context.previousTaskQueries) {
+          queryClient.setQueryData<Task[]>(queryKey, (current) =>
+            restoreTaskChannel(
+              current,
+              previousTasks,
+              variables.taskId,
+              variables.channelId,
+            ),
+          );
+        }
+        for (const [
+          queryKey,
+          previousTasks,
+        ] of context.previousChannelFeedQueries) {
+          queryClient.setQueryData<Task[]>(queryKey, (current) =>
+            restoreTaskRecord(current, previousTasks, variables.taskId),
+          );
+        }
+        queryClient.setQueryData<Task>(
+          taskKeys.detail(variables.taskId),
+          (current) =>
+            current?.channel === variables.channelId
+              ? context.previousTaskDetail
+              : current,
+        );
+        if (!context.destinationQueryExisted) {
+          queryClient.setQueryData<ChannelTaskRecord[]>(
+            context.destinationFilter.queryKey,
+            (current) =>
+              current?.filter((record) => record.taskId !== variables.taskId),
+          );
+          const current = queryClient.getQueryData<ChannelTaskRecord[]>(
+            context.destinationFilter.queryKey,
+          );
+          if (!current || current.length === 0) {
+            queryClient.removeQueries({
+              queryKey: context.destinationFilter.queryKey,
+              exact: true,
+            });
+          }
+        }
+      },
+      onSettled: (_data, _error, variables, context) => {
+        if (
+          !context ||
+          latestFilingsFor(queryClient).get(variables.taskId) !==
+            context.filingToken
+        ) {
+          return;
+        }
+        latestFilingsFor(queryClient).delete(variables.taskId);
+        for (const queryKey of [
+          ...context.affectedQueryKeys,
+          context.destinationFilter.queryKey,
+        ]) {
+          void queryClient.invalidateQueries({ queryKey, exact: true });
+        }
+        void queryClient.invalidateQueries({ queryKey: channelFeedQueryRoot });
+        void queryClient.invalidateQueries({ queryKey: taskKeys.lists() });
+        void queryClient.invalidateQueries({
+          queryKey: taskKeys.detail(variables.taskId),
+        });
+      },
     }),
   );
   const unfile = useMutation(
     trpc.channelTasks.unfile.mutationOptions({
-      onSuccess: (_data, variables) => invalidateAffected(variables.taskId),
+      onSuccess: (_data, variables) => invalidateTaskLists(variables.taskId),
     }),
   );
 

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.ts
@@ -1,96 +1,48 @@
 import type { ChannelTaskRecord } from "@posthog/core/canvas/channelTaskSchemas";
 import { useHostTRPC } from "@posthog/host-router/react";
-import type { Task } from "@posthog/shared/domain-types";
 import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
-import {
-  channelFeedQueryKey,
-  channelFeedQueryRoot,
-} from "@posthog/ui/features/canvas/hooks/useChannelFeed";
+import { channelFeedQueryRoot } from "@posthog/ui/features/canvas/hooks/useChannelFeed";
 import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
-import {
-  type QueryClient,
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
 import {
   SPACE_QUERY_GC_TIME_MS,
   SPACE_QUERY_REFETCH_INTERVAL_MS,
   SPACE_QUERY_STALE_TIME_MS,
 } from "./spaceQueryPolicy";
+import {
+  latestPendingTaskFilings,
+  type PendingTaskFiling,
+  usePendingTaskFilings,
+} from "./usePendingTaskFilings";
 
-const latestFilings = new WeakMap<QueryClient, Map<string, symbol>>();
+export function applyPendingTaskFilings(
+  records: ChannelTaskRecord[],
+  channelId: string,
+  pendingFilings: PendingTaskFiling[],
+): ChannelTaskRecord[] {
+  const latestByTask = latestPendingTaskFilings(pendingFilings);
 
-function latestFilingsFor(queryClient: QueryClient): Map<string, symbol> {
-  const existing = latestFilings.get(queryClient);
-  if (existing) return existing;
-  const filings = new Map<string, symbol>();
-  latestFilings.set(queryClient, filings);
-  return filings;
+  const visible = records.filter((record) => {
+    const filing = latestByTask.get(record.taskId);
+    return !filing || filing.channelId === channelId;
+  });
+  const visibleTaskIds = new Set(visible.map((record) => record.taskId));
+
+  for (const filing of latestByTask.values()) {
+    if (filing.channelId === channelId && !visibleTaskIds.has(filing.taskId)) {
+      visible.push({
+        channelId,
+        taskId: filing.taskId,
+        createdAt: filing.submittedAt,
+      });
+    }
+  }
+
+  return visible;
 }
 
-function restoreChannelTaskRecord(
-  current: ChannelTaskRecord[] | undefined,
-  previous: ChannelTaskRecord[] | undefined,
-  taskId: string,
-): ChannelTaskRecord[] | undefined {
-  const previousRecord = previous?.find((record) => record.taskId === taskId);
-  const withoutTask = current?.filter((record) => record.taskId !== taskId);
-  if (!previousRecord) return withoutTask;
-  if (!withoutTask) return previous;
-
-  const previousIndex = previous?.findIndex(
-    (record) => record.taskId === taskId,
-  );
-  const insertAt = Math.min(
-    previousIndex ?? withoutTask.length,
-    withoutTask.length,
-  );
-  return [
-    ...withoutTask.slice(0, insertAt),
-    previousRecord,
-    ...withoutTask.slice(insertAt),
-  ];
-}
-
-function restoreTaskRecord(
-  current: Task[] | undefined,
-  previous: Task[] | undefined,
-  taskId: string,
-): Task[] | undefined {
-  const previousTask = previous?.find((task) => task.id === taskId);
-  const withoutTask = current?.filter((task) => task.id !== taskId);
-  if (!previousTask) return withoutTask;
-  if (!withoutTask) return previous;
-
-  const previousIndex = previous?.findIndex((task) => task.id === taskId);
-  const insertAt = Math.min(
-    previousIndex ?? withoutTask.length,
-    withoutTask.length,
-  );
-  return [
-    ...withoutTask.slice(0, insertAt),
-    previousTask,
-    ...withoutTask.slice(insertAt),
-  ];
-}
-
-function restoreTaskChannel(
-  current: Task[] | undefined,
-  previous: Task[] | undefined,
-  taskId: string,
-  optimisticChannelId: string,
-): Task[] | undefined {
-  const previousTask = previous?.find((task) => task.id === taskId);
-  if (!previousTask) return current;
-  return current?.map((task) =>
-    task.id === taskId && task.channel === optimisticChannelId
-      ? previousTask
-      : task,
-  );
-}
-
-/** Tasks filed to a channel — the task's `channel` field on the tasks API. */
+/** Tasks filed to a channel, including pending moves into or out of it. */
 export function useChannelTasks(channelId: string | undefined): {
   tasks: ChannelTaskRecord[];
   isLoading: boolean;
@@ -108,247 +60,44 @@ export function useChannelTasks(channelId: string | undefined): {
       },
     ),
   );
-  return { tasks: data ?? [], isLoading };
+  const pendingFilings = usePendingTaskFilings();
+  const tasks = useMemo(
+    () => applyPendingTaskFilings(data ?? [], channelId ?? "", pendingFilings),
+    [channelId, data, pendingFilings],
+  );
+
+  return { tasks, isLoading };
 }
 
 export function useChannelTaskMutations() {
   const trpc = useHostTRPC();
   const queryClient = useQueryClient();
 
-  const invalidateTaskLists = (taskId: string) => {
-    void queryClient.invalidateQueries({
-      ...trpc.channelTasks.list.pathFilter(),
-      predicate: (query) => {
-        const tasks = query.state.data as ChannelTaskRecord[] | undefined;
-        if (!tasks) return true;
-        return tasks.some((record) => record.taskId === taskId);
-      },
-    });
-  };
+  const reconcileTaskFiling = (taskId: string): Promise<unknown[]> =>
+    Promise.all([
+      queryClient.invalidateQueries(trpc.channelTasks.list.pathFilter()),
+      queryClient.invalidateQueries({ queryKey: taskKeys.lists() }),
+      queryClient.invalidateQueries({ queryKey: taskKeys.detail(taskId) }),
+      queryClient.invalidateQueries({ queryKey: channelFeedQueryRoot }),
+    ]);
 
   const file = useMutation(
     trpc.channelTasks.file.mutationOptions({
-      onMutate: async (variables) => {
-        const filingToken = Symbol(variables.taskId);
-        latestFilingsFor(queryClient).set(variables.taskId, filingToken);
-        const listFilter = trpc.channelTasks.list.pathFilter();
-        await Promise.all([
-          queryClient.cancelQueries(listFilter),
-          queryClient.cancelQueries({ queryKey: taskKeys.lists() }),
-          queryClient.cancelQueries({ queryKey: channelFeedQueryRoot }),
-          queryClient.cancelQueries({
-            queryKey: taskKeys.detail(variables.taskId),
-          }),
-        ]);
-
-        const previousQueries =
-          queryClient.getQueriesData<ChannelTaskRecord[]>(listFilter);
-        const previousTaskQueries = queryClient.getQueriesData<Task[]>({
-          queryKey: taskKeys.lists(),
-        });
-        const previousTaskDetail = queryClient.getQueryData<Task>(
-          taskKeys.detail(variables.taskId),
-        );
-        const previousChannelFeedQueries = queryClient.getQueriesData<Task[]>({
-          queryKey: channelFeedQueryRoot,
-        });
-        const destinationFeedKey = channelFeedQueryKey(variables.channelId);
-        const destinationFeedExisted =
-          queryClient.getQueryState(destinationFeedKey) !== undefined;
-        const destinationFilter = trpc.channelTasks.list.queryFilter({
-          channelId: variables.channelId,
-        });
-        const destinationQueryExisted =
-          queryClient.getQueryState(destinationFilter.queryKey) !== undefined;
-        const previousRecord = previousQueries
-          .flatMap(([, records]) => records ?? [])
-          .find((record) => record.taskId === variables.taskId);
-        const optimisticRecord: ChannelTaskRecord = {
-          channelId: variables.channelId,
-          taskId: variables.taskId,
-          createdAt: previousRecord?.createdAt ?? Date.now(),
-        };
-        const optimisticTask = [
-          previousTaskDetail,
-          ...previousTaskQueries.flatMap(([, tasks]) => tasks ?? []),
-          ...previousChannelFeedQueries.flatMap(([, tasks]) => tasks ?? []),
-        ].find((task) => task?.id === variables.taskId);
-
-        queryClient.setQueriesData<ChannelTaskRecord[]>(listFilter, (records) =>
-          records?.filter((record) => record.taskId !== variables.taskId),
-        );
-        queryClient.setQueryDefaults(destinationFilter.queryKey, {
-          meta: AUTH_SCOPED_QUERY_META,
-        });
-        queryClient.setQueryData<ChannelTaskRecord[]>(
-          destinationFilter.queryKey,
-          (records) => [...(records ?? []), optimisticRecord],
-        );
-        queryClient.setQueriesData<Task[]>(
-          { queryKey: taskKeys.lists() },
-          (tasks) =>
-            tasks?.map((task) =>
-              task.id === variables.taskId
-                ? { ...task, channel: variables.channelId }
-                : task,
-            ),
-        );
-        queryClient.setQueryData<Task>(
-          taskKeys.detail(variables.taskId),
-          (task) =>
-            task ? { ...task, channel: variables.channelId } : undefined,
-        );
-        queryClient.setQueriesData<Task[]>(
-          { queryKey: channelFeedQueryRoot },
-          (tasks) => tasks?.filter((task) => task.id !== variables.taskId),
-        );
-        if (destinationFeedExisted && optimisticTask) {
-          queryClient.setQueryData<Task[]>(destinationFeedKey, (tasks) => [
-            ...(tasks ?? []).filter((task) => task.id !== variables.taskId),
-            { ...optimisticTask, channel: variables.channelId },
-          ]);
-        }
-
-        const affectedQueryKeys = previousQueries
-          .filter(
-            ([, records]) =>
-              !records ||
-              records.some((record) => record.taskId === variables.taskId),
-          )
-          .map(([queryKey]) => queryKey);
-
-        return {
-          affectedQueryKeys,
-          filingToken,
-          destinationFilter,
-          destinationQueryExisted,
-          previousChannelFeedQueries,
-          previousQueries,
-          previousTaskDetail,
-          previousTaskQueries,
-        };
-      },
-      onSuccess: (record, variables, context) => {
-        if (
-          !context ||
-          latestFilingsFor(queryClient).get(variables.taskId) !==
-            context.filingToken
-        ) {
-          return;
-        }
-        queryClient.setQueryData<ChannelTaskRecord[]>(
-          context.destinationFilter.queryKey,
-          (records) =>
-            records?.map((current) =>
-              current.taskId === variables.taskId &&
-              current.channelId === variables.channelId
-                ? record
-                : current,
-            ),
-        );
-      },
-      onError: (_error, variables, context) => {
-        if (
-          !context ||
-          latestFilingsFor(queryClient).get(variables.taskId) !==
-            context.filingToken
-        ) {
-          return;
-        }
-        const destinationRecords = queryClient.getQueryData<
-          ChannelTaskRecord[]
-        >(context.destinationFilter.queryKey);
-        const ownsOptimisticMove = destinationRecords?.some(
-          (record) =>
-            record.taskId === variables.taskId &&
-            record.channelId === variables.channelId,
-        );
-        if (!ownsOptimisticMove) return;
-
-        for (const [queryKey, previousRecords] of context.previousQueries) {
-          queryClient.setQueryData<ChannelTaskRecord[]>(queryKey, (current) =>
-            restoreChannelTaskRecord(
-              current,
-              previousRecords,
-              variables.taskId,
-            ),
-          );
-        }
-        for (const [queryKey, previousTasks] of context.previousTaskQueries) {
-          queryClient.setQueryData<Task[]>(queryKey, (current) =>
-            restoreTaskChannel(
-              current,
-              previousTasks,
-              variables.taskId,
-              variables.channelId,
-            ),
-          );
-        }
-        for (const [
-          queryKey,
-          previousTasks,
-        ] of context.previousChannelFeedQueries) {
-          queryClient.setQueryData<Task[]>(queryKey, (current) =>
-            restoreTaskRecord(current, previousTasks, variables.taskId),
-          );
-        }
-        queryClient.setQueryData<Task>(
-          taskKeys.detail(variables.taskId),
-          (current) =>
-            current?.channel === variables.channelId
-              ? context.previousTaskDetail
-              : current,
-        );
-        if (!context.destinationQueryExisted) {
-          queryClient.setQueryData<ChannelTaskRecord[]>(
-            context.destinationFilter.queryKey,
-            (current) =>
-              current?.filter((record) => record.taskId !== variables.taskId),
-          );
-          const current = queryClient.getQueryData<ChannelTaskRecord[]>(
-            context.destinationFilter.queryKey,
-          );
-          if (!current || current.length === 0) {
-            queryClient.removeQueries({
-              queryKey: context.destinationFilter.queryKey,
-              exact: true,
-            });
-          }
-        }
-      },
-      onSettled: (_data, _error, variables, context) => {
-        if (
-          !context ||
-          latestFilingsFor(queryClient).get(variables.taskId) !==
-            context.filingToken
-        ) {
-          return;
-        }
-        latestFilingsFor(queryClient).delete(variables.taskId);
-        for (const queryKey of [
-          ...context.affectedQueryKeys,
-          context.destinationFilter.queryKey,
-        ]) {
-          void queryClient.invalidateQueries({ queryKey, exact: true });
-        }
-        void queryClient.invalidateQueries({ queryKey: channelFeedQueryRoot });
-        void queryClient.invalidateQueries({ queryKey: taskKeys.lists() });
-        void queryClient.invalidateQueries({
-          queryKey: taskKeys.detail(variables.taskId),
-        });
+      onSuccess: (_record, variables) => reconcileTaskFiling(variables.taskId),
+      onError: (_error, variables) => {
+        void reconcileTaskFiling(variables.taskId);
       },
     }),
   );
   const unfile = useMutation(
     trpc.channelTasks.unfile.mutationOptions({
-      onSuccess: (_data, variables) => invalidateTaskLists(variables.taskId),
+      onSuccess: (_data, variables) => reconcileTaskFiling(variables.taskId),
     }),
   );
 
   return {
     fileTask: (channelId: string, taskId: string) =>
       file.mutateAsync({ channelId, taskId }),
-    // Unfiling clears the task's channel field, so it's keyed on the task id.
     unfileTask: (taskId: string) => unfile.mutateAsync({ taskId }),
     isFiling: file.isPending,
     isUnfiling: unfile.isPending,

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.ts
@@ -2,6 +2,8 @@ import type { ChannelTaskRecord } from "@posthog/core/canvas/channelTaskSchemas"
 import { useHostTRPC } from "@posthog/host-router/react";
 import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
 import { channelFeedQueryRoot } from "@posthog/ui/features/canvas/hooks/useChannelFeed";
+import { spaceTreeTasksQueryRoot } from "@posthog/ui/features/canvas/hooks/useRecentSpaceTasks";
+import { taskFeedResultsQueryRoot } from "@posthog/ui/features/canvas/hooks/useTaskFeedResults";
 import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
@@ -117,6 +119,11 @@ export function useChannelTaskMutations() {
       queryClient.invalidateQueries({ queryKey: taskKeys.lists() }),
       queryClient.invalidateQueries({ queryKey: taskKeys.detail(taskId) }),
       queryClient.invalidateQueries({ queryKey: channelFeedQueryRoot }),
+      // The space tree and a saved space search each ask the server for one
+      // space's sessions, so a move makes both ends wrong, and both poll far
+      // slower than the move takes.
+      queryClient.invalidateQueries({ queryKey: spaceTreeTasksQueryRoot }),
+      queryClient.invalidateQueries({ queryKey: taskFeedResultsQueryRoot }),
     ]);
 
   const file = useMutation(

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.ts
@@ -16,6 +16,11 @@ import {
   usePendingTaskFilings,
 } from "./usePendingTaskFilings";
 
+// Filing and unfiling both write the task's space, and the request that
+// arrives last decides it. One scope for both sends overlapping moves in the
+// order the user made them, instead of racing them.
+const TASK_CHANNEL_MUTATION_SCOPE = { id: "task-channel" };
+
 export function applyPendingTaskFilings(
   records: ChannelTaskRecord[],
   channelId: string,
@@ -83,6 +88,7 @@ export function useChannelTaskMutations() {
 
   const file = useMutation(
     trpc.channelTasks.file.mutationOptions({
+      scope: TASK_CHANNEL_MUTATION_SCOPE,
       onSuccess: (_record, variables) => reconcileTaskFiling(variables.taskId),
       onError: (_error, variables) => {
         void reconcileTaskFiling(variables.taskId);
@@ -91,6 +97,7 @@ export function useChannelTaskMutations() {
   );
   const unfile = useMutation(
     trpc.channelTasks.unfile.mutationOptions({
+      scope: TASK_CHANNEL_MUTATION_SCOPE,
       onSuccess: (_data, variables) => reconcileTaskFiling(variables.taskId),
     }),
   );

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTasks.ts
@@ -78,9 +78,42 @@ export function useChannelTaskMutations() {
   const trpc = useHostTRPC();
   const queryClient = useQueryClient();
 
-  const reconcileTaskFiling = (taskId: string): Promise<unknown[]> =>
+  /**
+   * Filing moves a task, so at most two channel lists change: the one it lands
+   * in and whichever one still shows it. Every other cached channel is
+   * untouched, and someone who has browsed a lot of channels holds a lot of
+   * those.
+   */
+  const invalidateChannelLists = (
+    taskId: string,
+    channelId?: string,
+  ): Promise<unknown> => {
+    const listsShowingTask = queryClient.invalidateQueries({
+      ...trpc.channelTasks.list.pathFilter(),
+      predicate: (query) => {
+        const tasks = query.state.data as ChannelTaskRecord[] | undefined;
+        // A list still loading has no membership to check, and its in-flight
+        // request may have been sent before this mutation. Refetch rather than
+        // let a pre-mutation response land and sit fresh.
+        if (!tasks) return true;
+        return tasks.some((record) => record.taskId === taskId);
+      },
+    });
+    if (!channelId) return listsShowingTask;
+    return Promise.all([
+      listsShowingTask,
+      queryClient.invalidateQueries(
+        trpc.channelTasks.list.queryFilter({ channelId }),
+      ),
+    ]);
+  };
+
+  const reconcileTaskFiling = (
+    taskId: string,
+    channelId?: string,
+  ): Promise<unknown[]> =>
     Promise.all([
-      queryClient.invalidateQueries(trpc.channelTasks.list.pathFilter()),
+      invalidateChannelLists(taskId, channelId),
       queryClient.invalidateQueries({ queryKey: taskKeys.lists() }),
       queryClient.invalidateQueries({ queryKey: taskKeys.detail(taskId) }),
       queryClient.invalidateQueries({ queryKey: channelFeedQueryRoot }),
@@ -89,9 +122,10 @@ export function useChannelTaskMutations() {
   const file = useMutation(
     trpc.channelTasks.file.mutationOptions({
       scope: TASK_CHANNEL_MUTATION_SCOPE,
-      onSuccess: (_record, variables) => reconcileTaskFiling(variables.taskId),
+      onSuccess: (_record, variables) =>
+        reconcileTaskFiling(variables.taskId, variables.channelId),
       onError: (_error, variables) => {
-        void reconcileTaskFiling(variables.taskId);
+        void reconcileTaskFiling(variables.taskId, variables.channelId);
       },
     }),
   );

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useFileTaskToChannel.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useFileTaskToChannel.test.tsx
@@ -1,0 +1,204 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  reject: (error: Error) => void;
+  resolve: (value: T) => void;
+} {
+  let reject!: (error: Error) => void;
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+const mocks = vi.hoisted(() => ({
+  activeChannelId: "source" as string | undefined,
+  activeTaskId: "task-1" as string | undefined,
+  channels: [
+    { id: "source", name: "Source" },
+    { id: "dest", name: "Destination" },
+  ],
+  fileTask: vi.fn(),
+  navigate: vi.fn(),
+  pathname: "/spaces/source/tasks/task-1",
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock("@posthog/ui/features/canvas/hooks/useChannelTasks", () => ({
+  useChannelTaskMutations: () => ({ fileTask: mocks.fileTask }),
+}));
+
+vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
+  useChannels: () => ({ channels: mocks.channels }),
+}));
+
+vi.mock("@posthog/ui/primitives/toast", () => ({
+  toast: { error: mocks.toastError, success: mocks.toastSuccess },
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mocks.navigate,
+  useParams: ({ select }: { select: (params: unknown) => unknown }) =>
+    select({
+      channelId: mocks.activeChannelId,
+      taskId: mocks.activeTaskId,
+    }),
+  useRouter: () => ({
+    state: {
+      location: {
+        get pathname() {
+          return mocks.pathname;
+        },
+      },
+    },
+  }),
+}));
+
+import { useFileTaskToChannel } from "./useFileTaskToChannel";
+
+describe("useFileTaskToChannel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.activeChannelId = "source";
+    mocks.activeTaskId = "task-1";
+    mocks.pathname = "/spaces/source/tasks/task-1";
+    mocks.navigate.mockImplementation(
+      ({ to, params }: { to: string; params: Record<string, string> }) => {
+        mocks.pathname = to
+          .replace("$channelId", params.channelId ?? "")
+          .replace("$taskId", params.taskId);
+        return Promise.resolve();
+      },
+    );
+  });
+
+  it("moves the active task route before filing completes", async () => {
+    let resolveFile: (() => void) | null = null;
+    mocks.fileTask.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFile = resolve;
+        }),
+    );
+    const { result } = renderHook(() => useFileTaskToChannel());
+    let filing = Promise.resolve();
+
+    act(() => {
+      filing = result.current("dest", "task-1", "Move this task");
+    });
+
+    expect(mocks.navigate).toHaveBeenCalledWith({
+      to: "/spaces/$channelId/tasks/$taskId",
+      params: { channelId: "dest", taskId: "task-1" },
+      replace: true,
+    });
+
+    await act(async () => {
+      resolveFile?.();
+      await filing;
+    });
+  });
+
+  it("restores the source after a pending route move completes", async () => {
+    const fileRequest = deferred<void>();
+    const routeMove = deferred<void>();
+    mocks.fileTask.mockImplementationOnce(() => fileRequest.promise);
+    mocks.navigate.mockImplementationOnce(() =>
+      routeMove.promise.then(() => {
+        mocks.pathname = "/spaces/dest/tasks/task-1";
+      }),
+    );
+    const { result } = renderHook(() => useFileTaskToChannel());
+
+    let filing = Promise.resolve();
+    act(() => {
+      filing = result.current("dest", "task-1", "Move this task");
+    });
+
+    fileRequest.reject(new Error("Request failed"));
+    await Promise.resolve();
+    expect(mocks.navigate).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      routeMove.resolve();
+      await filing;
+    });
+
+    expect(mocks.navigate).toHaveBeenLastCalledWith({
+      to: "/spaces/$channelId/tasks/$taskId",
+      params: { channelId: "source", taskId: "task-1" },
+      replace: true,
+    });
+  });
+
+  it("does not roll back a newer filing of the same task", async () => {
+    const firstRequest = deferred<void>();
+    const secondRequest = deferred<void>();
+    mocks.fileTask
+      .mockImplementationOnce(() => firstRequest.promise)
+      .mockImplementationOnce(() => secondRequest.promise);
+    const { result } = renderHook(() => useFileTaskToChannel());
+
+    let firstFiling = Promise.resolve();
+    let secondFiling = Promise.resolve();
+    act(() => {
+      firstFiling = result.current("dest", "task-1", "Move this task");
+      secondFiling = result.current("dest", "task-1", "Move this task");
+    });
+
+    await act(async () => {
+      firstRequest.reject(new Error("First request failed"));
+      await firstFiling;
+    });
+
+    expect(mocks.navigate).toHaveBeenCalledTimes(2);
+    expect(mocks.pathname).toBe("/spaces/dest/tasks/task-1");
+
+    await act(async () => {
+      secondRequest.resolve();
+      await secondFiling;
+    });
+  });
+
+  it.each([
+    ["restores the source route", "/spaces/dest/tasks/task-1", 2],
+    ["keeps a later route", "/activity", 1],
+  ])("%s when filing fails", async (_label, pathBeforeFailure, callCount) => {
+    let rejectFile: ((error: Error) => void) | null = null;
+    mocks.fileTask.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectFile = reject;
+        }),
+    );
+    const { result } = renderHook(() => useFileTaskToChannel());
+    let filing = Promise.resolve();
+
+    act(() => {
+      filing = result.current("dest", "task-1", "Move this task");
+    });
+    mocks.pathname = pathBeforeFailure;
+
+    await act(async () => {
+      rejectFile?.(new Error("Request failed"));
+      await filing;
+    });
+
+    expect(mocks.navigate).toHaveBeenCalledTimes(callCount);
+    if (callCount === 2) {
+      expect(mocks.navigate).toHaveBeenLastCalledWith({
+        to: "/spaces/$channelId/tasks/$taskId",
+        params: { channelId: "source", taskId: "task-1" },
+        replace: true,
+      });
+    }
+    expect(mocks.toastError).toHaveBeenCalledWith("Couldn't file task", {
+      description: "Request failed",
+    });
+  });
+});

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useFileTaskToChannel.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useFileTaskToChannel.test.tsx
@@ -206,6 +206,40 @@ describe("useFileTaskToChannel", () => {
     },
   );
 
+  it("restores the space a successful filing settled on", async () => {
+    const firstRequest = deferred<void>();
+    const secondRequest = deferred<void>();
+    mocks.fileTask
+      .mockReturnValueOnce(firstRequest.promise)
+      .mockReturnValueOnce(secondRequest.promise);
+    const { rerender, result } = renderHook(() => useFileTaskToChannel());
+    let firstFiling = Promise.resolve();
+    let secondFiling = Promise.resolve();
+
+    act(() => {
+      firstFiling = result.current("dest", "task-1");
+    });
+    mocks.activeChannelId = "dest";
+    rerender();
+
+    act(() => {
+      secondFiling = result.current("other", "task-1");
+    });
+
+    await act(async () => {
+      firstRequest.resolve();
+      await firstFiling;
+      secondRequest.reject(new Error("Second request failed"));
+      await secondFiling;
+    });
+
+    expect(mocks.navigate).toHaveBeenLastCalledWith({
+      to: "/spaces/$channelId/tasks/$taskId",
+      params: { channelId: "dest", taskId: "task-1" },
+      replace: true,
+    });
+  });
+
   it("does not replace a later route when filing fails", async () => {
     const request = deferred<void>();
     mocks.fileTask.mockReturnValueOnce(request.promise);

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useFileTaskToChannel.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useFileTaskToChannel.test.tsx
@@ -15,16 +15,32 @@ function deferred<T>(): {
   return { promise, reject, resolve };
 }
 
+function routerStub(): { state: { location: { pathname: string } } } {
+  return {
+    state: {
+      location: {
+        get pathname() {
+          return mocks.pathname;
+        },
+      },
+    },
+  };
+}
+
 const mocks = vi.hoisted(() => ({
   activeChannelId: "source" as string | undefined,
   activeTaskId: "task-1" as string | undefined,
   channels: [
     { id: "source", name: "Source" },
     { id: "dest", name: "Destination" },
+    { id: "other", name: "Other" },
   ],
   fileTask: vi.fn(),
   navigate: vi.fn(),
   pathname: "/spaces/source/tasks/task-1",
+  // useRouter hands back the one router instance, and the hook keys its
+  // in-flight filings on it, so a stub per render would lose them.
+  router: {} as { state: { location: { pathname: string } } },
   toastError: vi.fn(),
   toastSuccess: vi.fn(),
 }));
@@ -45,15 +61,7 @@ vi.mock("@tanstack/react-router", () => ({
       channelId: mocks.activeChannelId,
       taskId: mocks.activeTaskId,
     }),
-  useRouter: () => ({
-    state: {
-      location: {
-        get pathname() {
-          return mocks.pathname;
-        },
-      },
-    },
-  }),
+  useRouter: () => mocks.router,
 }));
 
 import { useFileTaskToChannel } from "./useFileTaskToChannel";
@@ -64,6 +72,7 @@ describe("useFileTaskToChannel", () => {
     mocks.activeChannelId = "source";
     mocks.activeTaskId = "task-1";
     mocks.pathname = "/spaces/source/tasks/task-1";
+    mocks.router = routerStub();
     mocks.navigate.mockImplementation(
       ({ to, params }: { to: string; params: Record<string, string> }) => {
         mocks.pathname = to
@@ -154,6 +163,48 @@ describe("useFileTaskToChannel", () => {
       await secondFiling;
     });
   });
+
+  it.each([
+    { name: "a third space", secondChannelId: "other" },
+    { name: "the same space", secondChannelId: "dest" },
+  ])(
+    "restores the first space when an overlapping filing to $name fails",
+    async ({ secondChannelId }) => {
+      const firstRequest = deferred<void>();
+      const secondRequest = deferred<void>();
+      mocks.fileTask
+        .mockReturnValueOnce(firstRequest.promise)
+        .mockReturnValueOnce(secondRequest.promise);
+      const { rerender, result } = renderHook(() => useFileTaskToChannel());
+      let firstFiling = Promise.resolve();
+      let secondFiling = Promise.resolve();
+
+      act(() => {
+        firstFiling = result.current("dest", "task-1");
+      });
+      // The first optimistic move settles before the second click, so the
+      // route params name the destination the way a real re-render would.
+      mocks.activeChannelId = "dest";
+      rerender();
+
+      act(() => {
+        secondFiling = result.current(secondChannelId, "task-1");
+      });
+
+      await act(async () => {
+        firstRequest.reject(new Error("First request failed"));
+        secondRequest.reject(new Error("Second request failed"));
+        await Promise.all([firstFiling, secondFiling]);
+      });
+
+      expect(mocks.navigate).toHaveBeenLastCalledWith({
+        to: "/spaces/$channelId/tasks/$taskId",
+        params: { channelId: "source", taskId: "task-1" },
+        replace: true,
+      });
+      expect(mocks.pathname).toBe("/spaces/source/tasks/task-1");
+    },
+  );
 
   it("does not replace a later route when filing fails", async () => {
     const request = deferred<void>();

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useFileTaskToChannel.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useFileTaskToChannel.test.tsx
@@ -32,15 +32,12 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@posthog/ui/features/canvas/hooks/useChannelTasks", () => ({
   useChannelTaskMutations: () => ({ fileTask: mocks.fileTask }),
 }));
-
 vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
   useChannels: () => ({ channels: mocks.channels }),
 }));
-
 vi.mock("@posthog/ui/primitives/toast", () => ({
   toast: { error: mocks.toastError, success: mocks.toastSuccess },
 }));
-
 vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => mocks.navigate,
   useParams: ({ select }: { select: (params: unknown) => unknown }) =>
@@ -78,18 +75,13 @@ describe("useFileTaskToChannel", () => {
   });
 
   it("moves the active task route before filing completes", async () => {
-    let resolveFile: (() => void) | null = null;
-    mocks.fileTask.mockImplementationOnce(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveFile = resolve;
-        }),
-    );
+    const request = deferred<void>();
+    mocks.fileTask.mockReturnValueOnce(request.promise);
     const { result } = renderHook(() => useFileTaskToChannel());
     let filing = Promise.resolve();
 
     act(() => {
-      filing = result.current("dest", "task-1", "Move this task");
+      filing = result.current("dest", "task-1");
     });
 
     expect(mocks.navigate).toHaveBeenCalledWith({
@@ -99,30 +91,28 @@ describe("useFileTaskToChannel", () => {
     });
 
     await act(async () => {
-      resolveFile?.();
+      request.resolve();
       await filing;
     });
   });
 
   it("restores the source after a pending route move completes", async () => {
-    const fileRequest = deferred<void>();
+    const request = deferred<void>();
     const routeMove = deferred<void>();
-    mocks.fileTask.mockImplementationOnce(() => fileRequest.promise);
+    mocks.fileTask.mockReturnValueOnce(request.promise);
     mocks.navigate.mockImplementationOnce(() =>
       routeMove.promise.then(() => {
         mocks.pathname = "/spaces/dest/tasks/task-1";
       }),
     );
     const { result } = renderHook(() => useFileTaskToChannel());
-
     let filing = Promise.resolve();
-    act(() => {
-      filing = result.current("dest", "task-1", "Move this task");
-    });
 
-    fileRequest.reject(new Error("Request failed"));
+    act(() => {
+      filing = result.current("dest", "task-1");
+    });
+    request.reject(new Error("Request failed"));
     await Promise.resolve();
-    expect(mocks.navigate).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       routeMove.resolve();
@@ -140,15 +130,15 @@ describe("useFileTaskToChannel", () => {
     const firstRequest = deferred<void>();
     const secondRequest = deferred<void>();
     mocks.fileTask
-      .mockImplementationOnce(() => firstRequest.promise)
-      .mockImplementationOnce(() => secondRequest.promise);
+      .mockReturnValueOnce(firstRequest.promise)
+      .mockReturnValueOnce(secondRequest.promise);
     const { result } = renderHook(() => useFileTaskToChannel());
-
     let firstFiling = Promise.resolve();
     let secondFiling = Promise.resolve();
+
     act(() => {
-      firstFiling = result.current("dest", "task-1", "Move this task");
-      secondFiling = result.current("dest", "task-1", "Move this task");
+      firstFiling = result.current("dest", "task-1");
+      secondFiling = result.current("dest", "task-1");
     });
 
     await act(async () => {
@@ -165,38 +155,23 @@ describe("useFileTaskToChannel", () => {
     });
   });
 
-  it.each([
-    ["restores the source route", "/spaces/dest/tasks/task-1", 2],
-    ["keeps a later route", "/activity", 1],
-  ])("%s when filing fails", async (_label, pathBeforeFailure, callCount) => {
-    let rejectFile: ((error: Error) => void) | null = null;
-    mocks.fileTask.mockImplementationOnce(
-      () =>
-        new Promise<void>((_resolve, reject) => {
-          rejectFile = reject;
-        }),
-    );
+  it("does not replace a later route when filing fails", async () => {
+    const request = deferred<void>();
+    mocks.fileTask.mockReturnValueOnce(request.promise);
     const { result } = renderHook(() => useFileTaskToChannel());
     let filing = Promise.resolve();
 
     act(() => {
-      filing = result.current("dest", "task-1", "Move this task");
+      filing = result.current("dest", "task-1");
     });
-    mocks.pathname = pathBeforeFailure;
+    mocks.pathname = "/activity";
 
     await act(async () => {
-      rejectFile?.(new Error("Request failed"));
+      request.reject(new Error("Request failed"));
       await filing;
     });
 
-    expect(mocks.navigate).toHaveBeenCalledTimes(callCount);
-    if (callCount === 2) {
-      expect(mocks.navigate).toHaveBeenLastCalledWith({
-        to: "/spaces/$channelId/tasks/$taskId",
-        params: { channelId: "source", taskId: "task-1" },
-        replace: true,
-      });
-    }
+    expect(mocks.navigate).toHaveBeenCalledTimes(1);
     expect(mocks.toastError).toHaveBeenCalledWith("Couldn't file task", {
       description: "Request failed",
     });

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useFileTaskToChannel.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useFileTaskToChannel.ts
@@ -1,7 +1,18 @@
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelTaskMutations } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
 import { toast } from "@posthog/ui/primitives/toast";
+import { useNavigate, useParams, useRouter } from "@tanstack/react-router";
 import { useCallback } from "react";
+
+const latestRouteFilings = new WeakMap<object, Map<string, symbol>>();
+
+function latestRouteFilingsFor(router: object): Map<string, symbol> {
+  const existing = latestRouteFilings.get(router);
+  if (existing) return existing;
+  const filings = new Map<string, symbol>();
+  latestRouteFilings.set(router, filings);
+  return filings;
+}
 
 /**
  * Files a task to a space and reports the outcome, naming the space in the
@@ -9,28 +20,74 @@ import { useCallback } from "react";
  * tasks the same way — filing is a mutation plus the two toasts that make it
  * legible, and duplicating that is how the two paths drift.
  */
-export function useFileTaskToChannel(): (
-  channelId: string,
-  taskId: string,
-  taskTitle: string,
-) => Promise<void> {
+export function useFileTaskToChannel(options?: {
+  enabled?: boolean;
+}): (channelId: string, taskId: string, taskTitle: string) => Promise<void> {
   const { fileTask } = useChannelTaskMutations();
-  const { channels } = useChannels();
+  const { channels } = useChannels(options);
+  const navigate = useNavigate();
+  const router = useRouter();
+  const activeTaskId = useParams({
+    strict: false,
+    select: (params) => params.taskId,
+  });
+  const activeChannelId = useParams({
+    strict: false,
+    select: (params) => params.channelId,
+  });
 
   return useCallback(
     async (channelId: string, taskId: string) => {
+      const filingToken = Symbol(taskId);
+      latestRouteFilingsFor(router).set(taskId, filingToken);
+      const moveActiveRoute =
+        activeTaskId === taskId && activeChannelId !== channelId;
+      const filing = fileTask(channelId, taskId);
+      const routeMove = moveActiveRoute
+        ? navigate({
+            to: "/spaces/$channelId/tasks/$taskId",
+            params: { channelId, taskId },
+            replace: true,
+          })
+        : null;
+
       try {
-        await fileTask(channelId, taskId);
+        await filing;
         const channelName = channels.find(
           (channel) => channel.id === channelId,
         )?.name;
         toast.success(channelName ? `Filed to ${channelName}` : "Task filed");
       } catch (error) {
+        await routeMove?.catch(() => undefined);
+        const optimisticPath = `/spaces/${channelId}/tasks/${taskId}`;
+        if (
+          latestRouteFilingsFor(router).get(taskId) === filingToken &&
+          moveActiveRoute &&
+          router.state.location.pathname === optimisticPath
+        ) {
+          if (activeChannelId) {
+            void navigate({
+              to: "/spaces/$channelId/tasks/$taskId",
+              params: { channelId: activeChannelId, taskId },
+              replace: true,
+            });
+          } else {
+            void navigate({
+              to: "/tasks/$taskId",
+              params: { taskId },
+              replace: true,
+            });
+          }
+        }
         toast.error("Couldn't file task", {
           description: error instanceof Error ? error.message : String(error),
         });
+      } finally {
+        if (latestRouteFilingsFor(router).get(taskId) === filingToken) {
+          latestRouteFilingsFor(router).delete(taskId);
+        }
       }
     },
-    [channels, fileTask],
+    [activeChannelId, activeTaskId, channels, fileTask, navigate, router],
   );
 }

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useFileTaskToChannel.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useFileTaskToChannel.ts
@@ -22,7 +22,7 @@ function latestRouteFilingsFor(router: object): Map<string, symbol> {
  */
 export function useFileTaskToChannel(options?: {
   enabled?: boolean;
-}): (channelId: string, taskId: string, taskTitle: string) => Promise<void> {
+}): (channelId: string, taskId: string) => Promise<void> {
   const { fileTask } = useChannelTaskMutations();
   const { channels } = useChannels(options);
   const navigate = useNavigate();

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useFileTaskToChannel.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useFileTaskToChannel.ts
@@ -71,6 +71,12 @@ export function useFileTaskToChannel(options?: {
 
       try {
         await filing;
+        // The server holds this space now, so a newer filing of the same task
+        // must roll back to here instead of to where the run started.
+        const laterFiling = routeFilings.get(taskId);
+        if (laterFiling?.origin && laterFiling.token !== filingToken) {
+          laterFiling.origin = { channelId };
+        }
         const channelName = channels.find(
           (channel) => channel.id === channelId,
         )?.name;
@@ -78,19 +84,22 @@ export function useFileTaskToChannel(options?: {
       } catch (error) {
         await routeMove?.catch(() => undefined);
         const optimisticPath = `/spaces/${channelId}/tasks/${taskId}`;
+        // Read the origin back from the map, because an earlier filing that
+        // succeeded moves it to the space the server settled on.
+        const pending = routeFilings.get(taskId);
         // The pathname match is what says the route needs restoring, rather
         // than whether this call moved it: a retry to the same destination
         // moves nothing and still leaves the route on the failed space.
         if (
-          routeFilings.get(taskId)?.token === filingToken &&
-          origin &&
-          origin.channelId !== channelId &&
+          pending?.token === filingToken &&
+          pending.origin &&
+          pending.origin.channelId !== channelId &&
           router.state.location.pathname === optimisticPath
         ) {
-          if (origin.channelId) {
+          if (pending.origin.channelId) {
             void navigate({
               to: "/spaces/$channelId/tasks/$taskId",
-              params: { channelId: origin.channelId, taskId },
+              params: { channelId: pending.origin.channelId, taskId },
               replace: true,
             });
           } else {

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useFileTaskToChannel.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useFileTaskToChannel.ts
@@ -4,12 +4,22 @@ import { toast } from "@posthog/ui/primitives/toast";
 import { useNavigate, useParams, useRouter } from "@tanstack/react-router";
 import { useCallback } from "react";
 
-const latestRouteFilings = new WeakMap<object, Map<string, symbol>>();
+interface RouteFiling {
+  /**
+   * The route the task sat on before the first filing of this run, or null
+   * when the task was not the open route.
+   */
+  origin: { channelId: string | undefined } | null;
+  /** Marks the newest filing, so an older failure cannot move the route. */
+  token: symbol;
+}
 
-function latestRouteFilingsFor(router: object): Map<string, symbol> {
+const latestRouteFilings = new WeakMap<object, Map<string, RouteFiling>>();
+
+function latestRouteFilingsFor(router: object): Map<string, RouteFiling> {
   const existing = latestRouteFilings.get(router);
   if (existing) return existing;
-  const filings = new Map<string, symbol>();
+  const filings = new Map<string, RouteFiling>();
   latestRouteFilings.set(router, filings);
   return filings;
 }
@@ -38,8 +48,16 @@ export function useFileTaskToChannel(options?: {
 
   return useCallback(
     async (channelId: string, taskId: string) => {
+      const routeFilings = latestRouteFilingsFor(router);
       const filingToken = Symbol(taskId);
-      latestRouteFilingsFor(router).set(taskId, filingToken);
+      // Hold the origin of the first filing in a run. A filing that starts
+      // while another is in flight reads an activeChannelId that the earlier
+      // optimistic move already changed, so a rollback to it would leave the
+      // route on a space the task never entered.
+      const origin =
+        routeFilings.get(taskId)?.origin ??
+        (activeTaskId === taskId ? { channelId: activeChannelId } : null);
+      routeFilings.set(taskId, { origin, token: filingToken });
       const moveActiveRoute =
         activeTaskId === taskId && activeChannelId !== channelId;
       const filing = fileTask(channelId, taskId);
@@ -60,15 +78,19 @@ export function useFileTaskToChannel(options?: {
       } catch (error) {
         await routeMove?.catch(() => undefined);
         const optimisticPath = `/spaces/${channelId}/tasks/${taskId}`;
+        // The pathname match is what says the route needs restoring, rather
+        // than whether this call moved it: a retry to the same destination
+        // moves nothing and still leaves the route on the failed space.
         if (
-          latestRouteFilingsFor(router).get(taskId) === filingToken &&
-          moveActiveRoute &&
+          routeFilings.get(taskId)?.token === filingToken &&
+          origin &&
+          origin.channelId !== channelId &&
           router.state.location.pathname === optimisticPath
         ) {
-          if (activeChannelId) {
+          if (origin.channelId) {
             void navigate({
               to: "/spaces/$channelId/tasks/$taskId",
-              params: { channelId: activeChannelId, taskId },
+              params: { channelId: origin.channelId, taskId },
               replace: true,
             });
           } else {
@@ -83,8 +105,8 @@ export function useFileTaskToChannel(options?: {
           description: error instanceof Error ? error.message : String(error),
         });
       } finally {
-        if (latestRouteFilingsFor(router).get(taskId) === filingToken) {
-          latestRouteFilingsFor(router).delete(taskId);
+        if (routeFilings.get(taskId)?.token === filingToken) {
+          routeFilings.delete(taskId);
         }
       }
     },

--- a/products/desktop/packages/ui/src/features/canvas/hooks/usePendingTaskFilings.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/usePendingTaskFilings.ts
@@ -1,0 +1,46 @@
+import { useHostTRPC } from "@posthog/host-router/react";
+import { useMutationState } from "@tanstack/react-query";
+
+export interface PendingTaskFiling {
+  channelId: string;
+  taskId: string;
+  submittedAt: number;
+}
+
+function isTaskFilingVariables(
+  value: unknown,
+): value is Pick<PendingTaskFiling, "channelId" | "taskId"> {
+  if (!value || typeof value !== "object") return false;
+  return (
+    "channelId" in value &&
+    typeof value.channelId === "string" &&
+    "taskId" in value &&
+    typeof value.taskId === "string"
+  );
+}
+
+export function latestPendingTaskFilings(
+  filings: PendingTaskFiling[],
+): Map<string, PendingTaskFiling> {
+  const latestByTask = new Map<string, PendingTaskFiling>();
+  for (const filing of filings) {
+    latestByTask.set(filing.taskId, filing);
+  }
+  return latestByTask;
+}
+
+export function usePendingTaskFilings(): PendingTaskFiling[] {
+  const trpc = useHostTRPC();
+  return useMutationState({
+    filters: {
+      mutationKey: trpc.channelTasks.file.mutationKey(),
+      status: "pending",
+    },
+    select: (mutation): PendingTaskFiling | null => {
+      const variables = mutation.state.variables;
+      return isTaskFilingVariables(variables)
+        ? { ...variables, submittedAt: mutation.state.submittedAt }
+        : null;
+    },
+  }).filter((filing): filing is PendingTaskFiling => filing !== null);
+}

--- a/products/desktop/packages/ui/src/features/canvas/hooks/usePendingTaskFilings.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/usePendingTaskFilings.ts
@@ -1,5 +1,6 @@
 import { useHostTRPC } from "@posthog/host-router/react";
 import { useMutationState } from "@tanstack/react-query";
+import { useMemo } from "react";
 
 export interface PendingTaskFiling {
   channelId: string;
@@ -31,7 +32,7 @@ export function latestPendingTaskFilings(
 
 export function usePendingTaskFilings(): PendingTaskFiling[] {
   const trpc = useHostTRPC();
-  return useMutationState({
+  const filings = useMutationState({
     filters: {
       mutationKey: trpc.channelTasks.file.mutationKey(),
       status: "pending",
@@ -42,5 +43,14 @@ export function usePendingTaskFilings(): PendingTaskFiling[] {
         ? { ...variables, submittedAt: mutation.state.submittedAt }
         : null;
     },
-  }).filter((filing): filing is PendingTaskFiling => filing !== null);
+  });
+  // useMutationState keeps one array while no filing changes, so memoize the
+  // type guard to keep that identity. Callers list this array in useMemo
+  // dependencies, and a fresh array each render would repeat the feed sort and
+  // the sidebar item build on every unrelated render.
+  return useMemo(
+    () =>
+      filings.filter((filing): filing is PendingTaskFiling => filing !== null),
+    [filings],
+  );
 }

--- a/products/desktop/packages/ui/src/features/tasks/useTaskContextMenu.test.tsx
+++ b/products/desktop/packages/ui/src/features/tasks/useTaskContextMenu.test.tsx
@@ -1,0 +1,99 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  showTaskContextMenu: vi.fn(),
+  useChannels: vi.fn(),
+  useFeatureFlag: vi.fn(),
+}));
+
+vi.mock("@posthog/host-router/react", () => ({
+  useHostTRPCClient: () => ({
+    contextMenu: {
+      showTaskContextMenu: { mutate: hoisted.showTaskContextMenu },
+    },
+  }),
+}));
+
+vi.mock("@posthog/ui/features/archive/useArchiveTask", () => ({
+  useArchiveTask: () => ({ archiveTask: vi.fn() }),
+}));
+
+vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
+  useChannels: hoisted.useChannels,
+}));
+
+vi.mock("@posthog/ui/features/canvas/hooks/useFileTaskToChannel", () => ({
+  useFileTaskToChannel: () => vi.fn(),
+}));
+
+vi.mock("@posthog/ui/features/external-apps/useExternalAppAction", () => ({
+  useExternalAppAction: () => vi.fn(),
+}));
+
+vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
+  useFeatureFlag: hoisted.useFeatureFlag,
+}));
+
+vi.mock("@posthog/ui/features/suspension/useRestoreTask", () => ({
+  useRestoreTask: () => ({ restoreTask: vi.fn() }),
+}));
+
+vi.mock("@posthog/ui/features/suspension/useSuspendTask", () => ({
+  useSuspendTask: () => ({ suspendTask: vi.fn() }),
+}));
+
+vi.mock("@posthog/ui/features/tasks/useTaskCrudMutations", () => ({
+  useDeleteTask: () => ({ deleteWithConfirm: vi.fn() }),
+}));
+
+import { useTaskContextMenu } from "./useTaskContextMenu";
+
+const SUPPORT_CHANNEL = {
+  id: "c1",
+  name: "support",
+  channelType: "public" as const,
+  starred: false,
+};
+
+describe("useTaskContextMenu", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.showTaskContextMenu.mockResolvedValue({ action: null });
+    hoisted.useChannels.mockReturnValue({
+      channels: [SUPPORT_CHANNEL],
+      isLoading: false,
+    });
+  });
+
+  async function openMenu() {
+    const { result } = renderHook(() => useTaskContextMenu());
+    await act(() =>
+      result.current.showContextMenu({ id: "t1", title: "Task" }, {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      } as unknown as React.MouseEvent),
+    );
+  }
+
+  // `enabled: false` stops the fetch but still hands back whatever an ungated
+  // surface already put in the shared cache, so the flag has to gate the list.
+  it.each([
+    { expectedChannels: [SUPPORT_CHANNEL], flag: "on", flagEnabled: true },
+    { expectedChannels: [], flag: "off", flagEnabled: false },
+  ])(
+    "sends the native menu the project's spaces with the bluebird flag $flag",
+    async ({ expectedChannels, flagEnabled }) => {
+      hoisted.useFeatureFlag.mockReturnValue(flagEnabled);
+
+      await openMenu();
+
+      expect(hoisted.showTaskContextMenu).toHaveBeenCalledWith(
+        expect.objectContaining({ channels: expectedChannels }),
+      );
+      expect(hoisted.useChannels).toHaveBeenCalledWith({
+        enabled: flagEnabled,
+      });
+    },
+  );
+});

--- a/products/desktop/packages/ui/src/features/tasks/useTaskContextMenu.ts
+++ b/products/desktop/packages/ui/src/features/tasks/useTaskContextMenu.ts
@@ -7,13 +7,12 @@ import { PROJECT_BLUEBIRD_FLAG } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { useArchiveTask } from "@posthog/ui/features/archive/useArchiveTask";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
-import { useChannelTaskMutations } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
+import { useFileTaskToChannel } from "@posthog/ui/features/canvas/hooks/useFileTaskToChannel";
 import { useExternalAppAction } from "@posthog/ui/features/external-apps/useExternalAppAction";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useRestoreTask } from "@posthog/ui/features/suspension/useRestoreTask";
 import { useSuspendTask } from "@posthog/ui/features/suspension/useSuspendTask";
 import { useDeleteTask } from "@posthog/ui/features/tasks/useTaskCrudMutations";
-import { toast } from "@posthog/ui/primitives/toast";
 import { logger } from "@posthog/ui/shell/logger";
 import { useCallback, useState } from "react";
 
@@ -34,7 +33,7 @@ export function useTaskContextMenu() {
     import.meta.env.DEV,
   );
   const { channels } = useChannels({ enabled: bluebirdEnabled });
-  const { fileTask } = useChannelTaskMutations();
+  const fileTaskToChannel = useFileTaskToChannel({ enabled: bluebirdEnabled });
 
   const showContextMenu = useCallback(
     async (
@@ -149,20 +148,7 @@ export function useTaskContextMenu() {
             await onHandoff?.();
             break;
           case "file-to-channel":
-            try {
-              await fileTask(intent.channelId, task.id);
-              const channelName = channels.find(
-                (channel) => channel.id === intent.channelId,
-              )?.name;
-              toast.success(
-                channelName ? `Filed to ${channelName}` : "Task filed",
-              );
-            } catch (error) {
-              toast.error("Couldn't file task", {
-                description:
-                  error instanceof Error ? error.message : String(error),
-              });
-            }
+            await fileTaskToChannel(intent.channelId, task.id, task.title);
             break;
           case "external-app": {
             const effectivePath = resolveExternalAppPath(
@@ -188,7 +174,7 @@ export function useTaskContextMenu() {
       archiveTask,
       channels,
       deleteWithConfirm,
-      fileTask,
+      fileTaskToChannel,
       restoreTask,
       suspendTask,
       hostClient,

--- a/products/desktop/packages/ui/src/features/tasks/useTaskContextMenu.ts
+++ b/products/desktop/packages/ui/src/features/tasks/useTaskContextMenu.ts
@@ -148,7 +148,7 @@ export function useTaskContextMenu() {
             await onHandoff?.();
             break;
           case "file-to-channel":
-            await fileTaskToChannel(intent.channelId, task.id, task.title);
+            await fileTaskToChannel(intent.channelId, task.id);
             break;
           case "external-app": {
             const effectivePath = resolveExternalAppPath(

--- a/products/desktop/packages/ui/src/features/tasks/useTaskContextMenu.ts
+++ b/products/desktop/packages/ui/src/features/tasks/useTaskContextMenu.ts
@@ -6,7 +6,10 @@ import { useHostTRPCClient } from "@posthog/host-router/react";
 import { PROJECT_BLUEBIRD_FLAG } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { useArchiveTask } from "@posthog/ui/features/archive/useArchiveTask";
-import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
+import {
+  type Channel,
+  useChannels,
+} from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useFileTaskToChannel } from "@posthog/ui/features/canvas/hooks/useFileTaskToChannel";
 import { useExternalAppAction } from "@posthog/ui/features/external-apps/useExternalAppAction";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
@@ -18,6 +21,9 @@ import { useCallback, useState } from "react";
 
 const log = logger.scope("context-menu");
 
+/** Stable empty list, so a gated-off channels array keeps a steady identity. */
+const EMPTY_CHANNELS: Channel[] = [];
+
 export function useTaskContextMenu() {
   const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
   const hostClient = useHostTRPCClient();
@@ -26,13 +32,19 @@ export function useTaskContextMenu() {
   const { archiveTask } = useArchiveTask();
   const { suspendTask } = useSuspendTask();
   const { restoreTask } = useRestoreTask();
-  // "File to…" is a Project Bluebird feature. Gate the channel fetch behind the
-  // flag so the submenu (and its API request) never reaches ungated users.
+  // "File to…" is a Project Bluebird feature. `enabled: false` stops the
+  // request but still hands back whatever an ungated surface elsewhere put in
+  // the shared cache, so the flag has to gate the list itself: the native menu
+  // builds its submenu from these channels and leaves it out when there are
+  // none.
   const bluebirdEnabled = useFeatureFlag(
     PROJECT_BLUEBIRD_FLAG,
     import.meta.env.DEV,
   );
-  const { channels } = useChannels({ enabled: bluebirdEnabled });
+  const { channels: fetchedChannels } = useChannels({
+    enabled: bluebirdEnabled,
+  });
+  const channels = bluebirdEnabled ? fetchedChannels : EMPTY_CHANNELS;
   const fileTaskToChannel = useFileTaskToChannel({ enabled: bluebirdEnabled });
 
   const showContextMenu = useCallback(


### PR DESCRIPTION
## Problem

A moved task keeps its old space in the Desktop breadcrumb until the user opens it again.

The stale route and task caches make a successful filing appear to do nothing.

## Changes

- An open task changes to its destination space immediately, so the breadcrumb and link show the new owner.
- Task lists and feeds update before the server reply. A failed move restores the prior state.
- Concurrent filings cannot let an older failure replace a newer move.
- Both task menu paths use the same flag-gated filing flow.
- The Desktop guide now requires optimistic UI for reversible user actions.

No screenshot is included. The change updates existing UI only after the filing action.

## How did you test this code?

- `pnpm --filter @posthog/ui test` covers the complete UI unit suite.
- New hook tests cover pending lists, pending feeds, failures, route races, and concurrent route moves.
- `pnpm typecheck` checks all Desktop packages.
- Biome and the host-boundary check pass on the changed files.
- `hogli ci:preflight --fix` could not run because this environment has no PostHog Python environment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated `products/desktop/AGENTS.md`. No user documentation changes are required.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Desktop used repository tools, planning agents, and read-only review agents.

Skills used: posthog-desktop, writing-ui-components, writing-tests, writing-user-facing-copy, writing-code-comments, running-ci-preflight, writing-pr-descriptions, and writing-simplified-technical-English.

The thermo-nuclear code quality review replaced cache replication with a shared pending-mutation model. The final strict review found no blockers.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
