### PR TITLE
feat(warehouse-sources): promote WooCommerce source to GA

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/woocommerce/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/woocommerce/source.py
@@ -267,7 +267,7 @@ class WooCommerceSource(
             ),
             iconPath="/static/services/woocommerce.png",
             docsUrl="https://posthog.com/docs/cdp/sources/woocommerce",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.GA,
             fields=cast(
                 list[FieldType],
                 [


### PR DESCRIPTION
## Problem

People setting up a WooCommerce import see the source marked "alpha" in the new-source wizard, which reads as "not ready to depend on". It is ready.

- The source has been live for more than three months.
- Its import error rate sits well below the 2.5% bar for promotion.

## Changes

- The WooCommerce tile in the source catalog now shows the GA status instead of the alpha label.
- `releaseStatus` moves from `ReleaseStatus.ALPHA` to `ReleaseStatus.GA` in the source config.
- Nothing else changes. The source carries no `unreleasedSource` flag and no `featureFlag` gate, so there is no gating to remove alongside the status.

## How did you test this code?

No behavior, schema, or sync logic changed, so no new tests.

- Ran the WooCommerce source tests locally: the 101 tests that need no database pass.
- Not run: the 15 webhook-template tests in the same directory, because this sandbox has no Postgres. CI covers them.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The user-facing doc does not state a release stage.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code (PostHog Desktop cloud task).
- Skills invoked: `/implementing-warehouse-sources` for where release status lives and the `ReleaseStatus` enum convention, `/writing-pr-descriptions` for this body.
- No duplicate: searched open PRs for "woocommerce", "releaseStatus", and "promote", and listed the data warehouse maintainer's open PRs. Nothing addresses this promotion.
- Public artifact: the diff is one enum value; nothing in this PR carries material from the agent session. Exact team counts and error percentages stay out of this description because the repo is public.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

