### PR TITLE
feat(error-tracking): flush batch side effects as a consumer background task

### DIFF
--- a/nodejs/src/ingestion/pipelines/errortracking/error-tracking-consumer.test.ts
+++ b/nodejs/src/ingestion/pipelines/errortracking/error-tracking-consumer.test.ts
@@ -230,6 +230,13 @@ describe('ErrorTrackingConsumer', () => {
         return events.map((event) => createKafkaMessage(event, token ?? team.api_token))
     }
 
+    // A batch is fully processed once the returned background task (the
+    // scheduled side-effect flush) has settled, matching the consumer loop.
+    const handleBatch = async (messages: Message[]): Promise<void> => {
+        const result = await consumer.handleKafkaBatch(messages)
+        await result?.backgroundTask
+    }
+
     beforeEach(async () => {
         fixedTime = DateTime.fromObject({ year: 2025, month: 1, day: 1 }, { zone: 'UTC' })
         jest.spyOn(Date, 'now').mockReturnValue(fixedTime.toMillis())
@@ -263,7 +270,7 @@ describe('ErrorTrackingConsumer', () => {
     describe('event processing', () => {
         it('should process a basic exception event', async () => {
             const messages = createKafkaMessages([createEvent()])
-            await consumer.handleKafkaBatch(messages)
+            await handleBatch(messages)
 
             const producedMessages =
                 mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_events_json_test')
@@ -282,7 +289,7 @@ describe('ErrorTrackingConsumer', () => {
                 createEvent({ distinct_id: 'user-3' }),
             ]
             const messages = createKafkaMessages(events)
-            await consumer.handleKafkaBatch(messages)
+            await handleBatch(messages)
 
             const producedMessages =
                 mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_events_json_test')
@@ -294,7 +301,7 @@ describe('ErrorTrackingConsumer', () => {
 
         it('should include exception fingerprint and issue id from Cymbal', async () => {
             const messages = createKafkaMessages([createEvent()])
-            await consumer.handleKafkaBatch(messages)
+            await handleBatch(messages)
 
             const producedMessages =
                 mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_events_json_test')
@@ -317,7 +324,7 @@ describe('ErrorTrackingConsumer', () => {
                     },
                 }),
             ])
-            await consumer.handleKafkaBatch(messages)
+            await handleBatch(messages)
 
             const producedMessages =
                 mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_events_json_test')
@@ -349,7 +356,7 @@ describe('ErrorTrackingConsumer', () => {
                     ip: '89.160.20.129',
                 }),
             ])
-            await consumer.handleKafkaBatch(messages)
+            await handleBatch(messages)
 
             const producedMessages =
                 mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_events_json_test')
@@ -364,7 +371,7 @@ describe('ErrorTrackingConsumer', () => {
 
         it('should flush invocation results after batch processing', async () => {
             const messages = createKafkaMessages([createEvent()])
-            await consumer.handleKafkaBatch(messages)
+            await handleBatch(messages)
 
             expect(mockHogTransformer.processInvocationResults).toHaveBeenCalledTimes(1)
         })
@@ -384,7 +391,7 @@ describe('ErrorTrackingConsumer', () => {
     describe('error handling', () => {
         it('should reject events with invalid token', async () => {
             const messages = createKafkaMessages([createEvent()], 'invalid-token-that-does-not-exist')
-            await consumer.handleKafkaBatch(messages)
+            await handleBatch(messages)
 
             // Event should not be produced to output topic (team not found = dropped)
             const producedMessages =
@@ -396,7 +403,7 @@ describe('ErrorTrackingConsumer', () => {
         })
 
         it('should handle empty batch', async () => {
-            await consumer.handleKafkaBatch([])
+            await handleBatch([])
 
             const producedMessages = mockProducerObserver.getProducedKafkaMessages()
             expect(producedMessages).toHaveLength(0)
@@ -407,7 +414,7 @@ describe('ErrorTrackingConsumer', () => {
         it('should always use full person_mode', async () => {
             // Error tracking always uses full person_mode to preserve group properties
             const messages = createKafkaMessages([createEvent()])
-            await consumer.handleKafkaBatch(messages)
+            await handleBatch(messages)
 
             const producedMessages =
                 mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_events_json_test')

--- a/nodejs/src/ingestion/pipelines/errortracking/error-tracking-consumer.test.ts
+++ b/nodejs/src/ingestion/pipelines/errortracking/error-tracking-consumer.test.ts
@@ -234,7 +234,8 @@ describe('ErrorTrackingConsumer', () => {
     // scheduled side-effect flush) has settled, matching the consumer loop.
     const handleBatch = async (messages: Message[]): Promise<void> => {
         const result = await consumer.handleKafkaBatch(messages)
-        await result?.backgroundTask
+        expect(result.backgroundTask).toBeDefined()
+        await result.backgroundTask
     }
 
     beforeEach(async () => {

--- a/nodejs/src/ingestion/pipelines/errortracking/error-tracking-consumer.ts
+++ b/nodejs/src/ingestion/pipelines/errortracking/error-tracking-consumer.ts
@@ -192,7 +192,7 @@ export class ErrorTrackingConsumer {
 
         await this.kafkaConsumer.connect(async (messages) => {
             return await instrumentFn('errorTrackingConsumer.handleEachBatch', async () => {
-                await this.handleKafkaBatch(messages)
+                return await this.handleKafkaBatch(messages)
             })
         })
 
@@ -259,7 +259,7 @@ export class ErrorTrackingConsumer {
         return this.kafkaConsumer.isHealthy()
     }
 
-    public async handleKafkaBatch(messages: Message[]): Promise<void> {
+    public async handleKafkaBatch(messages: Message[]): Promise<{ backgroundTask?: Promise<unknown> }> {
         // Update offset timestamps for lag metrics
         for (const message of messages) {
             if (message.timestamp) {
@@ -278,10 +278,23 @@ export class ErrorTrackingConsumer {
                 error: error instanceof Error ? error.message : String(error),
                 size: messages.length,
             })
+            // Flush scheduled work before the error propagates and crashes the loop
+            await this.flushScheduledWork()
             throw error
-        } finally {
-            // Flush scheduled work and invocation results to prevent memory accumulation
-            await Promise.all([this.promiseScheduler.waitForAll(), this.deps.hogTransformer.processInvocationResults()])
         }
+
+        // Flushing scheduled produces is the slow tail of a batch (broker acks),
+        // so hand it to the consumer as a background task: the consumer fetches
+        // and processes the next batch while this settles, and only stores this
+        // batch's offsets once it has. CONSUMER_MAX_BACKGROUND_TASKS caps how
+        // many batches may overlap this way.
+        return {
+            backgroundTask: instrumentFn('errorTrackingConsumer.awaitScheduledWork', () => this.flushScheduledWork()),
+        }
+    }
+
+    private async flushScheduledWork(): Promise<void> {
+        // Flush scheduled work and invocation results to prevent memory accumulation
+        await Promise.all([this.promiseScheduler.waitForAll(), this.deps.hogTransformer.processInvocationResults()])
     }
 }


### PR DESCRIPTION
## Problem

During a hot-key exception burst, error tracking events arrive late: the main-lane consumer waits for each batch's Kafka produce acks before fetching the next batch, so a hot partition drains slower than it fills.

- Every produce in the pipeline (events, overflow redirects, DLQ, warnings) is a scheduled side effect, awaited only at the end-of-batch flush.
- That flush ran inline in `handleKafkaBatch`, so the ack tail sat on the batch cadence.

## Changes

- The consumer returns the side-effect flush as the Kafka consumer's `backgroundTask`. The consumer fetches and processes the next batch while the previous batch's produces settle.
- Offsets for a batch are stored only after its flush settles, so at-least-once delivery is unchanged.
- On a failed batch the flush still runs inline before the error propagates, matching the previous behavior.
- `CONSUMER_MAX_BACKGROUND_TASKS` gates the overlap: at the default of 1 the consumer still waits for the flush before the next fetch, so behavior is unchanged until the env is raised to 2+ on the error tracking lanes. The analytics ingestion consumer already uses this pattern.
- Nothing user-visible changes.

> [!NOTE]
> `CONSUMER_BACKGROUND_TASK_TIMEOUT_MS` (default 60s) now bounds the flush. A broker-ack stall past 60s crashes the pod with offsets uncommitted, where before it counted against the 180s loop-stall threshold. Raise the env on the error tracking lanes if this proves noisy.

## How did you test this code?

- Existing consumer tests now drain the returned background task. The "flush invocation results" test fails if the task stops being returned or stops flushing, which no test caught before.
- Ran the consumer test file locally: 11 tests pass.
- Not run: the full nodejs suite; CI covers it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal consumer behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code. Skills invoked: /writing-tests, /writing-pr-descriptions.
- The session traced the pipeline's produce handling first: all Kafka produces are scheduled side effects and never awaited inline, so backgrounding the flush moves the whole ack tail off the batch critical path.
- The change mirrors the analytics ingestion consumer's backgroundTask shape. `concurrentBatches` stays at 1 because pipeline compute still completes before the next feed.
- No duplicate: `gh pr list --search "error tracking background task"` found no open PR for this.

