### PR TITLE
fix(dashboards): reject breakdown colors the dashboard cannot use

### DIFF
--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -2264,13 +2264,16 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
 
     @parameterized.expand(
         [
-            ("object_keyed_by_breakdown_value", {"Chrome": "preset-1"}),
+            ("object_keyed_by_breakdown_value", {"Chrome": "preset-1"}, "breakdown_colors"),
             # Belongs at the endpoint, not in the field matrix: the update is a PATCH, so DRF
-            # resolves the entry's required keys against the serializer's partial flag.
-            ("entry_under_snake_case_keys", [{"breakdown_value": "good", "color": "#36a854"}]),
+            # resolves the entry's required keys against the serializer's partial flag. An error
+            # inside an entry names the entry and the key, so the attr carries a path.
+            ("entry_missing_the_color_token", [{"breakdownValue": "Chrome"}], "breakdown_colors__0__colorToken"),
         ]
     )
-    def test_dashboard_rejects_breakdown_colors_that_cannot_apply(self, _name: str, value: object) -> None:
+    def test_dashboard_rejects_breakdown_colors_that_cannot_apply(
+        self, _name: str, value: object, expected_attr: str
+    ) -> None:
         # Wiring guard: the viewset has to reject the value rather than store it. The shape matrix
         # lives in products/dashboards/backend/api/test/test_dashboard_filters_validation.py, which
         # needs no database.
@@ -2282,7 +2285,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             expected_status=status.HTTP_400_BAD_REQUEST,
         )
 
-        self.assertEqual(response["attr"], "breakdown_colors")
+        self.assertEqual(response["attr"], expected_attr)
         dashboard.refresh_from_db()
         self.assertEqual(dashboard.breakdown_colors, [])
 

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -2262,6 +2262,22 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         duplicated_dashboard = Dashboard.objects.get(id=response["id"])
         self.assertEqual(duplicated_dashboard.breakdown_colors, breakdown_colors)
 
+    def test_dashboard_rejects_breakdown_colors_entries_that_cannot_apply(self) -> None:
+        # Wiring guard: the viewset has to reject the value rather than store it. The shape matrix
+        # lives in products/dashboards/backend/api/test/test_dashboard_filters_validation.py, which
+        # needs no database.
+        dashboard = Dashboard.objects.create(team=self.team, name="Dashboard", created_by=self.user)
+
+        _, response = self.dashboard_api.update_dashboard(
+            dashboard.pk,
+            {"breakdown_colors": {"Chrome": "preset-1"}},
+            expected_status=status.HTTP_400_BAD_REQUEST,
+        )
+
+        self.assertEqual(response["attr"], "breakdown_colors")
+        dashboard.refresh_from_db()
+        self.assertEqual(dashboard.breakdown_colors, [])
+
     def test_dashboard_duplication_copies_variables(self):
         """Test that variables are copied during duplication"""
         variable = InsightVariable.objects.create(

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -2262,7 +2262,15 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         duplicated_dashboard = Dashboard.objects.get(id=response["id"])
         self.assertEqual(duplicated_dashboard.breakdown_colors, breakdown_colors)
 
-    def test_dashboard_rejects_breakdown_colors_entries_that_cannot_apply(self) -> None:
+    @parameterized.expand(
+        [
+            ("object_keyed_by_breakdown_value", {"Chrome": "preset-1"}),
+            # Belongs at the endpoint, not in the field matrix: the update is a PATCH, so DRF
+            # resolves the entry's required keys against the serializer's partial flag.
+            ("entry_under_snake_case_keys", [{"breakdown_value": "good", "color": "#36a854"}]),
+        ]
+    )
+    def test_dashboard_rejects_breakdown_colors_that_cannot_apply(self, _name: str, value: object) -> None:
         # Wiring guard: the viewset has to reject the value rather than store it. The shape matrix
         # lives in products/dashboards/backend/api/test/test_dashboard_filters_validation.py, which
         # needs no database.
@@ -2270,7 +2278,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
 
         _, response = self.dashboard_api.update_dashboard(
             dashboard.pk,
-            {"breakdown_colors": {"Chrome": "preset-1"}},
+            {"breakdown_colors": value},
             expected_status=status.HTTP_400_BAD_REQUEST,
         )
 

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -113,6 +113,7 @@ from products.dashboards.backend.api.dashboard_template_json_schema_parser impor
 from products.dashboards.backend.api.widget_openapi_serializers import (
     WIDGET_BATCH_ADD_OPENAPI_HELP,
     AddDashboardWidgetRequestOpenApi,
+    BreakdownColorConfigSerializer,
     DashboardWidgetConfigField,
     PatchedDashboardOpenApiSerializer,
     UpdateDashboardWidgetRequestOpenApi,
@@ -1211,6 +1212,23 @@ class DashboardCustomizationSerializer(serializers.Serializer):
     )
 
 
+class BreakdownColorsField(serializers.ListField):
+    # The child serializer decides whether an entry is valid, but it does not decide what gets
+    # stored or returned. It rewrites an entry rather than describing it: it drops a key it does not
+    # declare and adds a null for a declared key the entry omits. So both directions validate
+    # through the child and then use the entries as given.
+    #
+    # This matters in both directions because the dashboard saves the whole color list back. Letting
+    # the child shape a write would drop a key the frontend persists before this serializer learns
+    # about it, and the loss would only surface as colors disappearing after a later save.
+    def to_internal_value(self, data: Any) -> Any:
+        super().to_internal_value(data)
+        return data
+
+    def to_representation(self, data: Any) -> Any:
+        return data
+
+
 class DashboardMetadataSerializer(DashboardBasicSerializer):
     filters = serializers.SerializerMethodField()
     variables = serializers.SerializerMethodField()
@@ -1219,7 +1237,15 @@ class DashboardMetadataSerializer(DashboardBasicSerializer):
     effective_restriction_level = serializers.SerializerMethodField()
     access_control_version = serializers.SerializerMethodField()
     is_shared = serializers.BooleanField(source="is_sharing_enabled", read_only=True, required=False)
-    breakdown_colors = serializers.JSONField(required=False, help_text="Custom color mapping for breakdown values.")
+    breakdown_colors = BreakdownColorsField(
+        child=BreakdownColorConfigSerializer(),
+        required=False,
+        allow_null=True,
+        help_text=(
+            "Colors pinned to specific breakdown values across the dashboard's tiles. "
+            "A list of entries, not an object keyed by breakdown value. Send an empty list to clear them."
+        ),
+    )
     data_color_theme_id = serializers.IntegerField(
         required=False, allow_null=True, help_text="ID of the color theme used for chart visualizations."
     )

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -1215,14 +1215,19 @@ class DashboardCustomizationSerializer(serializers.Serializer):
 class BreakdownColorsField(serializers.ListField):
     # The child serializer decides whether an entry is valid, but it does not decide what gets
     # stored or returned. It rewrites an entry rather than describing it: it drops a key it does not
-    # declare and adds a null for a declared key the entry omits. So both directions validate
-    # through the child and then use the entries as given.
+    # declare and adds a null for a declared key the entry omits. So both directions validate the
+    # entries and then use them as given.
     #
     # This matters in both directions because the dashboard saves the whole color list back. Letting
     # the child shape a write would drop a key the frontend persists before this serializer learns
     # about it, and the loss would only surface as colors disappearing after a later save.
+    #
+    # The write validates through an unbound list, not through `self.child`. DRF resolves `required`
+    # against the root serializer's partial flag, and a dashboard PATCH is partial, so a bound child
+    # skips a missing key instead of failing it, and this field would store the entry as given. An
+    # unbound list is its own root, so the required keys hold on a PATCH too.
     def to_internal_value(self, data: Any) -> Any:
-        super().to_internal_value(data)
+        serializers.ListField(child=BreakdownColorConfigSerializer()).to_internal_value(data)
         return data
 
     def to_representation(self, data: Any) -> Any:

--- a/products/dashboards/backend/api/test/test_dashboard_filters_validation.py
+++ b/products/dashboards/backend/api/test/test_dashboard_filters_validation.py
@@ -65,10 +65,13 @@ class TestDashboardTileFiltersOverridesValidation(SimpleTestCase):
 
 
 class TestDashboardBreakdownColorsValidation(SimpleTestCase):
-    def _field(self) -> serializers.Field:
+    def _field(self, partial: bool) -> serializers.Field:
         # Read the field off the serializer rather than building one, so the cases bind to the shape
         # the endpoint actually validates against.
-        return DashboardSerializer().fields["breakdown_colors"]
+        #
+        # Both modes, because DRF resolves `required` against the root serializer's partial flag
+        # and a dashboard PATCH is partial.
+        return DashboardSerializer(partial=partial).fields["breakdown_colors"]
 
     @parameterized.expand(
         [
@@ -79,19 +82,23 @@ class TestDashboardBreakdownColorsValidation(SimpleTestCase):
             ("entry_missing_the_color_token", [{"breakdownValue": "Chrome"}]),
             ("entry_missing_the_breakdown_value", [{"colorToken": "preset-1"}]),
             ("bare_breakdown_values", ["Chrome", "Firefox"]),
+            ("empty_entry", [{}]),
             # A token names a slot in the color theme, so any other string resolves to nothing.
             # getColorFromToken parses the N out of `preset-N`, and a hex value yields
             # theme['preset-NaN'].
             ("hex_color_token", [{"breakdownValue": "Chrome", "colorToken": "#3fb950"}]),
             ("unresolvable_color_token", [{"breakdownValue": "Chrome", "colorToken": "blue"}]),
+            ("color_token_slot_zero", [{"breakdownValue": "Chrome", "colorToken": "preset-0"}]),
+            ("color_token_non_ascii_digits", [{"breakdownValue": "Chrome", "colorToken": "preset-١"}]),
             # The two shapes that crashed the dashboard scene on every load.
             ("object_keyed_by_breakdown_value", {"Chrome": "preset-1"}),
             ("empty_object", {}),
         ]
     )
     def test_rejects(self, _name: str, value: object) -> None:
-        with self.assertRaises(serializers.ValidationError):
-            self._field().run_validation(value)
+        for partial in (False, True):
+            with self.subTest(partial=partial), self.assertRaises(serializers.ValidationError):
+                self._field(partial=partial).run_validation(value)
 
     @parameterized.expand(
         [
@@ -116,13 +123,20 @@ class TestDashboardBreakdownColorsValidation(SimpleTestCase):
             # A theme may carry more slots than the default palette, and the token wraps past its
             # end, so the pattern must not cap the index.
             ("color_token_past_the_default_palette", [{"breakdownValue": "Chrome", "colorToken": "preset-99"}]),
+            (
+                "null_breakdown_property",
+                [{"breakdownValue": "Chrome", "colorToken": "preset-1", "breakdownProperty": None}],
+            ),
+            ("null_source", [{"breakdownValue": "Chrome", "colorToken": "preset-1", "source": None}]),
             # Clearing every color, and the nullable column's own value.
             ("empty_list", []),
             ("null", None),
         ]
     )
     def test_accepts(self, _name: str, value: object) -> None:
-        assert self._field().run_validation(value) == value
+        for partial in (False, True):
+            with self.subTest(partial=partial):
+                assert self._field(partial=partial).run_validation(value) == value
 
     @parameterized.expand([("write", "run_validation"), ("read", "to_representation")])
     def test_keeps_a_key_the_child_serializer_does_not_declare_on(self, _name: str, method: str) -> None:
@@ -141,4 +155,4 @@ class TestDashboardBreakdownColorsValidation(SimpleTestCase):
             }
         ]
 
-        assert getattr(self._field(), method)(entries) == entries
+        assert getattr(self._field(partial=False), method)(entries) == entries

--- a/products/dashboards/backend/api/test/test_dashboard_filters_validation.py
+++ b/products/dashboards/backend/api/test/test_dashboard_filters_validation.py
@@ -1,5 +1,6 @@
 from django.test import SimpleTestCase
 
+from parameterized import parameterized
 from rest_framework import serializers
 
 from products.dashboards.backend.api.dashboard import DashboardSerializer
@@ -61,3 +62,83 @@ class TestDashboardTileFiltersOverridesValidation(SimpleTestCase):
     def test_allows_clearing_tile_filters_overrides(self):
         result = DashboardSerializer._extract_display_defaults({"filters_overrides": None})
         assert result["filters_overrides"] is None
+
+
+class TestDashboardBreakdownColorsValidation(SimpleTestCase):
+    def _field(self) -> serializers.Field:
+        # Read the field off the serializer rather than building one, so the cases bind to the shape
+        # the endpoint actually validates against.
+        return DashboardSerializer().fields["breakdown_colors"]
+
+    @parameterized.expand(
+        [
+            # Both keys decide which value gets which color, so an entry without them can never
+            # apply. Callers wrote all of these while the field accepted any JSON.
+            ("entry_under_snake_case_keys", [{"breakdown_value": "good", "color": "#36a854"}]),
+            ("hex_color_under_the_wrong_key", [{"breakdownValue": "good", "color": "#36a854"}]),
+            ("entry_missing_the_color_token", [{"breakdownValue": "Chrome"}]),
+            ("entry_missing_the_breakdown_value", [{"colorToken": "preset-1"}]),
+            ("bare_breakdown_values", ["Chrome", "Firefox"]),
+            # A token names a slot in the color theme, so any other string resolves to nothing.
+            # getColorFromToken parses the N out of `preset-N`, and a hex value yields
+            # theme['preset-NaN'].
+            ("hex_color_token", [{"breakdownValue": "Chrome", "colorToken": "#3fb950"}]),
+            ("unresolvable_color_token", [{"breakdownValue": "Chrome", "colorToken": "blue"}]),
+            # The two shapes that crashed the dashboard scene on every load.
+            ("object_keyed_by_breakdown_value", {"Chrome": "preset-1"}),
+            ("empty_object", {}),
+        ]
+    )
+    def test_rejects(self, _name: str, value: object) -> None:
+        with self.assertRaises(serializers.ValidationError):
+            self._field().run_validation(value)
+
+    @parameterized.expand(
+        [
+            ("minimal_entry", [{"breakdownValue": "Chrome", "colorToken": "preset-1"}]),
+            (
+                "every_key",
+                [
+                    {
+                        "breakdownValue": "Chrome",
+                        "colorToken": "preset-1",
+                        "breakdownType": "event",
+                        "breakdownProperty": "event::$browser",
+                        "source": "manual",
+                    }
+                ],
+            ),
+            # A cleared color keeps its entry with a null token, so the key is required but a value
+            # for it is not.
+            ("null_color_token", [{"breakdownValue": "Chrome", "colorToken": None}]),
+            # A breakdown value can legitimately be the empty string.
+            ("blank_breakdown_value", [{"breakdownValue": "", "colorToken": "preset-1"}]),
+            # A theme may carry more slots than the default palette, and the token wraps past its
+            # end, so the pattern must not cap the index.
+            ("color_token_past_the_default_palette", [{"breakdownValue": "Chrome", "colorToken": "preset-99"}]),
+            # Clearing every color, and the nullable column's own value.
+            ("empty_list", []),
+            ("null", None),
+        ]
+    )
+    def test_accepts(self, _name: str, value: object) -> None:
+        assert self._field().run_validation(value) == value
+
+    @parameterized.expand([("write", "run_validation"), ("read", "to_representation")])
+    def test_keeps_a_key_the_child_serializer_does_not_declare_on(self, _name: str, method: str) -> None:
+        # The child serializer rewrites an entry rather than describing it, so neither direction may
+        # run entries through it. Without this, `somethingAddedLater` disappears and the entry gains
+        # an explicit null `breakdownProperty`, which is data loss on a perfectly valid entry.
+        #
+        # Both directions matter because the dashboard saves the whole color list back, so a key
+        # dropped on write is gone from a round trip even when the read preserves it.
+        entries = [
+            {
+                "breakdownValue": "Chrome",
+                "colorToken": "preset-1",
+                "source": "manual",
+                "somethingAddedLater": "kept",
+            }
+        ]
+
+        assert getattr(self._field(), method)(entries) == entries

--- a/products/dashboards/backend/api/widget_openapi_serializers.py
+++ b/products/dashboards/backend/api/widget_openapi_serializers.py
@@ -10,6 +10,7 @@ from products.dashboards.backend.widget_specs.openapi import (
     WIDGET_BATCH_ADD_OPENAPI_HELP,
     WIDGET_CONFIG_SERIALIZERS,
     AddDashboardWidgetRequestOpenApi,
+    BreakdownColorConfigSerializer,
     DashboardPatchTileOpenApiSerializer,
     DashboardPatchWidgetOpenApiSerializer,
     DashboardWidgetConfigField,
@@ -22,6 +23,7 @@ from products.dashboards.backend.widget_specs.openapi import (
 
 __all__ = [
     "AddDashboardWidgetRequestOpenApi",
+    "BreakdownColorConfigSerializer",
     "DashboardPatchTileOpenApiSerializer",
     "DashboardPatchWidgetOpenApiSerializer",
     "DashboardWidgetConfigField",

--- a/products/dashboards/backend/widget_specs/openapi.py
+++ b/products/dashboards/backend/widget_specs/openapi.py
@@ -273,6 +273,46 @@ class DashboardFiltersOpenApiSerializer(serializers.Serializer):
     )
 
 
+class BreakdownColorConfigSerializer(serializers.Serializer):
+    breakdownValue = serializers.CharField(
+        allow_blank=True,
+        help_text="The breakdown value this color applies to, as it appears in the chart legend.",
+    )
+    # A token names a slot in the dashboard's color theme, not a color. getColorFromToken parses the
+    # N out and indexes the theme with it, so any other string yields theme['preset-NaN'], which is
+    # undefined. The pattern rather than a fixed range, because a theme may carry more slots than the
+    # default palette and the token wraps past its end.
+    colorToken = serializers.RegexField(
+        r"^preset-\d+$",
+        allow_null=True,
+        help_text=(
+            "Palette slot to color the value with, as `preset-1` upwards. Not a CSS color: a hex "
+            "value is rejected. Null leaves the value on its default color."
+        ),
+    )
+    breakdownType = serializers.CharField(
+        required=False,
+        allow_null=True,
+        help_text="Breakdown type the value came from, such as `event`, `person`, `session`, or `cohort`.",
+    )
+    breakdownProperty = serializers.CharField(
+        required=False,
+        help_text=(
+            "Breakdown property the color is scoped to, so the color applies only to tiles that break "
+            "down by that property. Omit to apply it under every property."
+        ),
+    )
+    # `source` is also the name of a Field attribute on the Serializer base class, which mypy reads as
+    # a shadowed assignment. SerializerMetaclass pops every declared field out of the class namespace,
+    # so the base attribute survives and the entry key stays `source`, which is what the frontend
+    # persists.
+    source = serializers.ChoiceField(  # type: ignore[assignment]
+        choices=["auto", "manual"],
+        required=False,
+        help_text="`manual` for a color a person picked, `auto` for one the dashboard assigned.",
+    )
+
+
 class PatchedDashboardOpenApiSerializer(serializers.Serializer):
     """OpenAPI-only PATCH body for dashboards (agents/MCP).
 
@@ -287,9 +327,14 @@ class PatchedDashboardOpenApiSerializer(serializers.Serializer):
         required=False,
         help_text="Dashboard-level filters (date range and properties) applied across all tiles as the source of truth.",
     )
-    breakdown_colors = serializers.JSONField(
+    breakdown_colors = serializers.ListField(
+        child=BreakdownColorConfigSerializer(),
         required=False,
-        help_text="Custom color mapping for breakdown values.",
+        allow_null=True,
+        help_text=(
+            "Colors pinned to specific breakdown values across the dashboard's tiles. "
+            "A list of entries, not an object keyed by breakdown value. Send an empty list to clear them."
+        ),
     )
     data_color_theme_id = serializers.IntegerField(
         required=False,

--- a/products/dashboards/backend/widget_specs/openapi.py
+++ b/products/dashboards/backend/widget_specs/openapi.py
@@ -282,8 +282,12 @@ class BreakdownColorConfigSerializer(serializers.Serializer):
     # N out and indexes the theme with it, so any other string yields theme['preset-NaN'], which is
     # undefined. The pattern rather than a fixed range, because a theme may carry more slots than the
     # default palette and the token wraps past its end.
+    #
+    # The slot starts at 1 and its digits must be ASCII. getColorFromToken wraps the index as
+    # ((N - 1) % slots) + 1, so `preset-0` reads theme['preset-0'], and JavaScript parseInt reads
+    # another script's digits as NaN.
     colorToken = serializers.RegexField(
-        r"^preset-\d+$",
+        r"^preset-[1-9][0-9]*$",
         allow_null=True,
         help_text=(
             "Palette slot to color the value with, as `preset-1` upwards. Not a CSS color: a hex "
@@ -295,8 +299,12 @@ class BreakdownColorConfigSerializer(serializers.Serializer):
         allow_null=True,
         help_text="Breakdown type the value came from, such as `event`, `person`, `session`, or `cohort`.",
     )
+    # Null means the same as omitted for both keys below: the frontend reads
+    # `breakdownProperty != null` for property scoping, and treats an entry with no source as a
+    # manual pin. So an explicit null must not fail a write.
     breakdownProperty = serializers.CharField(
         required=False,
+        allow_null=True,
         help_text=(
             "Breakdown property the color is scoped to, so the color applies only to tiles that break "
             "down by that property. Omit to apply it under every property."
@@ -309,6 +317,7 @@ class BreakdownColorConfigSerializer(serializers.Serializer):
     source = serializers.ChoiceField(  # type: ignore[assignment]
         choices=["auto", "manual"],
         required=False,
+        allow_null=True,
         help_text="`manual` for a color a person picked, `auto` for one the dashboard assigned.",
     )
 

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -423,6 +423,41 @@ export type DashboardApiPersistedVariables = { [key: string]: unknown } | null
 export type DashboardApiTilesItem = { [key: string]: unknown }
 
 /**
+ * * `auto` - auto
+ * * `manual` - manual
+ */
+export type BreakdownColorConfigSourceEnumApi =
+    (typeof BreakdownColorConfigSourceEnumApi)[keyof typeof BreakdownColorConfigSourceEnumApi]
+
+export const BreakdownColorConfigSourceEnumApi = {
+    Auto: 'auto',
+    Manual: 'manual',
+} as const
+
+export interface BreakdownColorConfigApi {
+    /** The breakdown value this color applies to, as it appears in the chart legend. */
+    breakdownValue: string
+    /**
+     * Palette slot to color the value with, as `preset-1` upwards. Not a CSS color: a hex value is rejected. Null leaves the value on its default color.
+     * @nullable
+     * @pattern ^preset-\d+$
+     */
+    colorToken: string | null
+    /**
+     * Breakdown type the value came from, such as `event`, `person`, `session`, or `cohort`.
+     * @nullable
+     */
+    breakdownType?: string | null
+    /** Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property. */
+    breakdownProperty?: string
+    /** `manual` for a color a person picked, `auto` for one the dashboard assigned.
+     *
+     * * `auto` - auto
+     * * `manual` - manual */
+    source?: BreakdownColorConfigSourceEnumApi
+}
+
+/**
  * * `tight` - tight
  * * `condensed` - condensed
  * * `standard` - standard
@@ -508,8 +543,11 @@ export interface DashboardApi {
     readonly filters: DashboardApiFilters
     /** @nullable */
     readonly variables: DashboardApiVariables
-    /** Custom color mapping for breakdown values. */
-    breakdown_colors?: unknown
+    /**
+     * Colors pinned to specific breakdown values across the dashboard's tiles. A list of entries, not an object keyed by breakdown value. Send an empty list to clear them.
+     * @nullable
+     */
+    breakdown_colors?: BreakdownColorConfigApi[] | null
     /**
      * ID of the color theme used for chart visualizations.
      * @nullable
@@ -1112,8 +1150,11 @@ export interface PatchedPatchedDashboardOpenApiApi {
     pinned?: boolean
     /** Dashboard-level filters (date range and properties) applied across all tiles as the source of truth. */
     filters?: DashboardFiltersOpenApiApi
-    /** Custom color mapping for breakdown values. */
-    breakdown_colors?: unknown
+    /**
+     * Colors pinned to specific breakdown values across the dashboard's tiles. A list of entries, not an object keyed by breakdown value. Send an empty list to clear them.
+     * @nullable
+     */
+    breakdown_colors?: BreakdownColorConfigApi[] | null
     /**
      * ID of the color theme used for chart visualizations.
      * @nullable

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -440,7 +440,7 @@ export interface BreakdownColorConfigApi {
     /**
      * Palette slot to color the value with, as `preset-1` upwards. Not a CSS color: a hex value is rejected. Null leaves the value on its default color.
      * @nullable
-     * @pattern ^preset-\d+$
+     * @pattern ^preset-[1-9][0-9]*$
      */
     colorToken: string | null
     /**
@@ -448,13 +448,16 @@ export interface BreakdownColorConfigApi {
      * @nullable
      */
     breakdownType?: string | null
-    /** Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property. */
-    breakdownProperty?: string
+    /**
+     * Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property.
+     * @nullable
+     */
+    breakdownProperty?: string | null
     /** `manual` for a color a person picked, `auto` for one the dashboard assigned.
      *
      * * `auto` - auto
      * * `manual` - manual */
-    source?: BreakdownColorConfigSourceEnumApi
+    source?: BreakdownColorConfigSourceEnumApi | null
 }
 
 /**

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -271,6 +271,7 @@ export const DashboardTemplatesCopyBetweenProjectsCreateBody = /* @__PURE__ */ z
 
 export const dashboardsCreateBodyNameMax = 400
 
+export const dashboardsCreateBodyBreakdownColorsItemColorTokenRegExp = new RegExp('^preset-\\d+$')
 export const dashboardsCreateBodyDeleteInsightsDefault = false
 
 export const DashboardsCreateBody = /* @__PURE__ */ zod
@@ -280,7 +281,44 @@ export const DashboardsCreateBody = /* @__PURE__ */ zod
         pinned: zod.boolean().optional(),
         last_accessed_at: zod.iso.datetime({ offset: true }).nullish(),
         deleted: zod.boolean().optional(),
-        breakdown_colors: zod.unknown().optional().describe('Custom color mapping for breakdown values.'),
+        breakdown_colors: zod
+            .array(
+                zod.object({
+                    breakdownValue: zod
+                        .string()
+                        .describe('The breakdown value this color applies to, as it appears in the chart legend.'),
+                    colorToken: zod
+                        .string()
+                        .regex(dashboardsCreateBodyBreakdownColorsItemColorTokenRegExp)
+                        .nullable()
+                        .describe(
+                            'Palette slot to color the value with, as `preset-1` upwards. Not a CSS color: a hex value is rejected. Null leaves the value on its default color.'
+                        ),
+                    breakdownType: zod
+                        .string()
+                        .nullish()
+                        .describe(
+                            'Breakdown type the value came from, such as `event`, `person`, `session`, or `cohort`.'
+                        ),
+                    breakdownProperty: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property.'
+                        ),
+                    source: zod
+                        .enum(['auto', 'manual'])
+                        .describe('\* `auto` - auto\n\* `manual` - manual')
+                        .optional()
+                        .describe(
+                            '`manual` for a color a person picked, `auto` for one the dashboard assigned.\n\n\* `auto` - auto\n\* `manual` - manual'
+                        ),
+                })
+            )
+            .nullish()
+            .describe(
+                "Colors pinned to specific breakdown values across the dashboard's tiles. A list of entries, not an object keyed by breakdown value. Send an empty list to clear them."
+            ),
         data_color_theme_id: zod.number().nullish().describe('ID of the color theme used for chart visualizations.'),
         tags: zod.array(zod.unknown()).optional(),
         restriction_level: zod
@@ -334,6 +372,7 @@ export const DashboardsCollaboratorsCreateBody = /* @__PURE__ */ zod.object({
 
 export const dashboardsUpdateBodyNameMax = 400
 
+export const dashboardsUpdateBodyBreakdownColorsItemColorTokenRegExp = new RegExp('^preset-\\d+$')
 export const dashboardsUpdateBodyDeleteInsightsDefault = false
 
 export const DashboardsUpdateBody = /* @__PURE__ */ zod
@@ -343,7 +382,44 @@ export const DashboardsUpdateBody = /* @__PURE__ */ zod
         pinned: zod.boolean().optional(),
         last_accessed_at: zod.iso.datetime({ offset: true }).nullish(),
         deleted: zod.boolean().optional(),
-        breakdown_colors: zod.unknown().optional().describe('Custom color mapping for breakdown values.'),
+        breakdown_colors: zod
+            .array(
+                zod.object({
+                    breakdownValue: zod
+                        .string()
+                        .describe('The breakdown value this color applies to, as it appears in the chart legend.'),
+                    colorToken: zod
+                        .string()
+                        .regex(dashboardsUpdateBodyBreakdownColorsItemColorTokenRegExp)
+                        .nullable()
+                        .describe(
+                            'Palette slot to color the value with, as `preset-1` upwards. Not a CSS color: a hex value is rejected. Null leaves the value on its default color.'
+                        ),
+                    breakdownType: zod
+                        .string()
+                        .nullish()
+                        .describe(
+                            'Breakdown type the value came from, such as `event`, `person`, `session`, or `cohort`.'
+                        ),
+                    breakdownProperty: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property.'
+                        ),
+                    source: zod
+                        .enum(['auto', 'manual'])
+                        .describe('\* `auto` - auto\n\* `manual` - manual')
+                        .optional()
+                        .describe(
+                            '`manual` for a color a person picked, `auto` for one the dashboard assigned.\n\n\* `auto` - auto\n\* `manual` - manual'
+                        ),
+                })
+            )
+            .nullish()
+            .describe(
+                "Colors pinned to specific breakdown values across the dashboard's tiles. A list of entries, not an object keyed by breakdown value. Send an empty list to clear them."
+            ),
         data_color_theme_id: zod.number().nullish().describe('ID of the color theme used for chart visualizations.'),
         tags: zod.array(zod.unknown()).optional(),
         restriction_level: zod
@@ -387,6 +463,8 @@ export const DashboardsUpdateBody = /* @__PURE__ */ zod
     .describe('Serializer mixin that handles tags for objects.')
 
 export const dashboardsPartialUpdateBodyNameMax = 400
+
+export const dashboardsPartialUpdateBodyBreakdownColorsItemColorTokenRegExp = new RegExp('^preset-\\d+$')
 
 export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneOneLimitDefault = 25
 export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneOneLimitMax = 50
@@ -479,7 +557,44 @@ export const DashboardsPartialUpdateBody = /* @__PURE__ */ zod
             .describe(
                 'Dashboard-level filters (date range and properties) applied across all tiles as the source of truth.'
             ),
-        breakdown_colors: zod.unknown().optional().describe('Custom color mapping for breakdown values.'),
+        breakdown_colors: zod
+            .array(
+                zod.object({
+                    breakdownValue: zod
+                        .string()
+                        .describe('The breakdown value this color applies to, as it appears in the chart legend.'),
+                    colorToken: zod
+                        .string()
+                        .regex(dashboardsPartialUpdateBodyBreakdownColorsItemColorTokenRegExp)
+                        .nullable()
+                        .describe(
+                            'Palette slot to color the value with, as `preset-1` upwards. Not a CSS color: a hex value is rejected. Null leaves the value on its default color.'
+                        ),
+                    breakdownType: zod
+                        .string()
+                        .nullish()
+                        .describe(
+                            'Breakdown type the value came from, such as `event`, `person`, `session`, or `cohort`.'
+                        ),
+                    breakdownProperty: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property.'
+                        ),
+                    source: zod
+                        .enum(['auto', 'manual'])
+                        .describe('\* `auto` - auto\n\* `manual` - manual')
+                        .optional()
+                        .describe(
+                            '`manual` for a color a person picked, `auto` for one the dashboard assigned.\n\n\* `auto` - auto\n\* `manual` - manual'
+                        ),
+                })
+            )
+            .nullish()
+            .describe(
+                "Colors pinned to specific breakdown values across the dashboard's tiles. A list of entries, not an object keyed by breakdown value. Send an empty list to clear them."
+            ),
         data_color_theme_id: zod.number().nullish().describe('ID of the color theme used for chart visualizations.'),
         tags: zod.array(zod.string()).optional(),
         restriction_level: zod
@@ -3476,6 +3591,7 @@ export const DashboardsBulkUpdateTagsCreateBody = /* @__PURE__ */ zod.object({
 
 export const dashboardsCreateFromTemplateJsonCreateBodyNameMax = 400
 
+export const dashboardsCreateFromTemplateJsonCreateBodyBreakdownColorsItemColorTokenRegExp = new RegExp('^preset-\\d+$')
 export const dashboardsCreateFromTemplateJsonCreateBodyDeleteInsightsDefault = false
 
 export const DashboardsCreateFromTemplateJsonCreateBody = /* @__PURE__ */ zod
@@ -3485,7 +3601,44 @@ export const DashboardsCreateFromTemplateJsonCreateBody = /* @__PURE__ */ zod
         pinned: zod.boolean().optional(),
         last_accessed_at: zod.iso.datetime({ offset: true }).nullish(),
         deleted: zod.boolean().optional(),
-        breakdown_colors: zod.unknown().optional().describe('Custom color mapping for breakdown values.'),
+        breakdown_colors: zod
+            .array(
+                zod.object({
+                    breakdownValue: zod
+                        .string()
+                        .describe('The breakdown value this color applies to, as it appears in the chart legend.'),
+                    colorToken: zod
+                        .string()
+                        .regex(dashboardsCreateFromTemplateJsonCreateBodyBreakdownColorsItemColorTokenRegExp)
+                        .nullable()
+                        .describe(
+                            'Palette slot to color the value with, as `preset-1` upwards. Not a CSS color: a hex value is rejected. Null leaves the value on its default color.'
+                        ),
+                    breakdownType: zod
+                        .string()
+                        .nullish()
+                        .describe(
+                            'Breakdown type the value came from, such as `event`, `person`, `session`, or `cohort`.'
+                        ),
+                    breakdownProperty: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property.'
+                        ),
+                    source: zod
+                        .enum(['auto', 'manual'])
+                        .describe('\* `auto` - auto\n\* `manual` - manual')
+                        .optional()
+                        .describe(
+                            '`manual` for a color a person picked, `auto` for one the dashboard assigned.\n\n\* `auto` - auto\n\* `manual` - manual'
+                        ),
+                })
+            )
+            .nullish()
+            .describe(
+                "Colors pinned to specific breakdown values across the dashboard's tiles. A list of entries, not an object keyed by breakdown value. Send an empty list to clear them."
+            ),
         data_color_theme_id: zod.number().nullish().describe('ID of the color theme used for chart visualizations.'),
         tags: zod.array(zod.unknown()).optional(),
         restriction_level: zod
@@ -3535,6 +3688,9 @@ export const DashboardsCreateFromTemplateJsonCreateBody = /* @__PURE__ */ zod
  */
 export const dashboardsCreateUnlistedDashboardCreateBodyNameMax = 400
 
+export const dashboardsCreateUnlistedDashboardCreateBodyBreakdownColorsItemColorTokenRegExp = new RegExp(
+    '^preset-\\d+$'
+)
 export const dashboardsCreateUnlistedDashboardCreateBodyDeleteInsightsDefault = false
 
 export const DashboardsCreateUnlistedDashboardCreateBody = /* @__PURE__ */ zod
@@ -3544,7 +3700,44 @@ export const DashboardsCreateUnlistedDashboardCreateBody = /* @__PURE__ */ zod
         pinned: zod.boolean().optional(),
         last_accessed_at: zod.iso.datetime({ offset: true }).nullish(),
         deleted: zod.boolean().optional(),
-        breakdown_colors: zod.unknown().optional().describe('Custom color mapping for breakdown values.'),
+        breakdown_colors: zod
+            .array(
+                zod.object({
+                    breakdownValue: zod
+                        .string()
+                        .describe('The breakdown value this color applies to, as it appears in the chart legend.'),
+                    colorToken: zod
+                        .string()
+                        .regex(dashboardsCreateUnlistedDashboardCreateBodyBreakdownColorsItemColorTokenRegExp)
+                        .nullable()
+                        .describe(
+                            'Palette slot to color the value with, as `preset-1` upwards. Not a CSS color: a hex value is rejected. Null leaves the value on its default color.'
+                        ),
+                    breakdownType: zod
+                        .string()
+                        .nullish()
+                        .describe(
+                            'Breakdown type the value came from, such as `event`, `person`, `session`, or `cohort`.'
+                        ),
+                    breakdownProperty: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property.'
+                        ),
+                    source: zod
+                        .enum(['auto', 'manual'])
+                        .describe('\* `auto` - auto\n\* `manual` - manual')
+                        .optional()
+                        .describe(
+                            '`manual` for a color a person picked, `auto` for one the dashboard assigned.\n\n\* `auto` - auto\n\* `manual` - manual'
+                        ),
+                })
+            )
+            .nullish()
+            .describe(
+                "Colors pinned to specific breakdown values across the dashboard's tiles. A list of entries, not an object keyed by breakdown value. Send an empty list to clear them."
+            ),
         data_color_theme_id: zod.number().nullish().describe('ID of the color theme used for chart visualizations.'),
         tags: zod.array(zod.unknown()).optional(),
         restriction_level: zod

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -271,7 +271,7 @@ export const DashboardTemplatesCopyBetweenProjectsCreateBody = /* @__PURE__ */ z
 
 export const dashboardsCreateBodyNameMax = 400
 
-export const dashboardsCreateBodyBreakdownColorsItemColorTokenRegExp = new RegExp('^preset-\\d+$')
+export const dashboardsCreateBodyBreakdownColorsItemColorTokenRegExp = new RegExp('^preset-[1-9][0-9]\*$')
 export const dashboardsCreateBodyDeleteInsightsDefault = false
 
 export const DashboardsCreateBody = /* @__PURE__ */ zod
@@ -302,13 +302,15 @@ export const DashboardsCreateBody = /* @__PURE__ */ zod
                         ),
                     breakdownProperty: zod
                         .string()
-                        .optional()
+                        .nullish()
                         .describe(
                             'Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property.'
                         ),
                     source: zod
-                        .enum(['auto', 'manual'])
-                        .describe('\* `auto` - auto\n\* `manual` - manual')
+                        .union([
+                            zod.enum(['auto', 'manual']).describe('\* `auto` - auto\n\* `manual` - manual'),
+                            zod.null(),
+                        ])
                         .optional()
                         .describe(
                             '`manual` for a color a person picked, `auto` for one the dashboard assigned.\n\n\* `auto` - auto\n\* `manual` - manual'
@@ -372,7 +374,7 @@ export const DashboardsCollaboratorsCreateBody = /* @__PURE__ */ zod.object({
 
 export const dashboardsUpdateBodyNameMax = 400
 
-export const dashboardsUpdateBodyBreakdownColorsItemColorTokenRegExp = new RegExp('^preset-\\d+$')
+export const dashboardsUpdateBodyBreakdownColorsItemColorTokenRegExp = new RegExp('^preset-[1-9][0-9]\*$')
 export const dashboardsUpdateBodyDeleteInsightsDefault = false
 
 export const DashboardsUpdateBody = /* @__PURE__ */ zod
@@ -403,13 +405,15 @@ export const DashboardsUpdateBody = /* @__PURE__ */ zod
                         ),
                     breakdownProperty: zod
                         .string()
-                        .optional()
+                        .nullish()
                         .describe(
                             'Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property.'
                         ),
                     source: zod
-                        .enum(['auto', 'manual'])
-                        .describe('\* `auto` - auto\n\* `manual` - manual')
+                        .union([
+                            zod.enum(['auto', 'manual']).describe('\* `auto` - auto\n\* `manual` - manual'),
+                            zod.null(),
+                        ])
                         .optional()
                         .describe(
                             '`manual` for a color a person picked, `auto` for one the dashboard assigned.\n\n\* `auto` - auto\n\* `manual` - manual'
@@ -464,7 +468,7 @@ export const DashboardsUpdateBody = /* @__PURE__ */ zod
 
 export const dashboardsPartialUpdateBodyNameMax = 400
 
-export const dashboardsPartialUpdateBodyBreakdownColorsItemColorTokenRegExp = new RegExp('^preset-\\d+$')
+export const dashboardsPartialUpdateBodyBreakdownColorsItemColorTokenRegExp = new RegExp('^preset-[1-9][0-9]\*$')
 
 export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneOneLimitDefault = 25
 export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneOneLimitMax = 50
@@ -578,13 +582,15 @@ export const DashboardsPartialUpdateBody = /* @__PURE__ */ zod
                         ),
                     breakdownProperty: zod
                         .string()
-                        .optional()
+                        .nullish()
                         .describe(
                             'Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property.'
                         ),
                     source: zod
-                        .enum(['auto', 'manual'])
-                        .describe('\* `auto` - auto\n\* `manual` - manual')
+                        .union([
+                            zod.enum(['auto', 'manual']).describe('\* `auto` - auto\n\* `manual` - manual'),
+                            zod.null(),
+                        ])
                         .optional()
                         .describe(
                             '`manual` for a color a person picked, `auto` for one the dashboard assigned.\n\n\* `auto` - auto\n\* `manual` - manual'
@@ -3591,7 +3597,9 @@ export const DashboardsBulkUpdateTagsCreateBody = /* @__PURE__ */ zod.object({
 
 export const dashboardsCreateFromTemplateJsonCreateBodyNameMax = 400
 
-export const dashboardsCreateFromTemplateJsonCreateBodyBreakdownColorsItemColorTokenRegExp = new RegExp('^preset-\\d+$')
+export const dashboardsCreateFromTemplateJsonCreateBodyBreakdownColorsItemColorTokenRegExp = new RegExp(
+    '^preset-[1-9][0-9]\*$'
+)
 export const dashboardsCreateFromTemplateJsonCreateBodyDeleteInsightsDefault = false
 
 export const DashboardsCreateFromTemplateJsonCreateBody = /* @__PURE__ */ zod
@@ -3622,13 +3630,15 @@ export const DashboardsCreateFromTemplateJsonCreateBody = /* @__PURE__ */ zod
                         ),
                     breakdownProperty: zod
                         .string()
-                        .optional()
+                        .nullish()
                         .describe(
                             'Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property.'
                         ),
                     source: zod
-                        .enum(['auto', 'manual'])
-                        .describe('\* `auto` - auto\n\* `manual` - manual')
+                        .union([
+                            zod.enum(['auto', 'manual']).describe('\* `auto` - auto\n\* `manual` - manual'),
+                            zod.null(),
+                        ])
                         .optional()
                         .describe(
                             '`manual` for a color a person picked, `auto` for one the dashboard assigned.\n\n\* `auto` - auto\n\* `manual` - manual'
@@ -3689,7 +3699,7 @@ export const DashboardsCreateFromTemplateJsonCreateBody = /* @__PURE__ */ zod
 export const dashboardsCreateUnlistedDashboardCreateBodyNameMax = 400
 
 export const dashboardsCreateUnlistedDashboardCreateBodyBreakdownColorsItemColorTokenRegExp = new RegExp(
-    '^preset-\\d+$'
+    '^preset-[1-9][0-9]\*$'
 )
 export const dashboardsCreateUnlistedDashboardCreateBodyDeleteInsightsDefault = false
 
@@ -3721,13 +3731,15 @@ export const DashboardsCreateUnlistedDashboardCreateBody = /* @__PURE__ */ zod
                         ),
                     breakdownProperty: zod
                         .string()
-                        .optional()
+                        .nullish()
                         .describe(
                             'Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property.'
                         ),
                     source: zod
-                        .enum(['auto', 'manual'])
-                        .describe('\* `auto` - auto\n\* `manual` - manual')
+                        .union([
+                            zod.enum(['auto', 'manual']).describe('\* `auto` - auto\n\* `manual` - manual'),
+                            zod.null(),
+                        ])
                         .optional()
                         .describe(
                             '`manual` for a color a person picked, `auto` for one the dashboard assigned.\n\n\* `auto` - auto\n\* `manual` - manual'

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14185,7 +14185,7 @@ export namespace Schemas {
       /**
          * Palette slot to color the value with, as `preset-1` upwards. Not a CSS color: a hex value is rejected. Null leaves the value on its default color.
          * @nullable
-         * @pattern ^preset-\d+$
+         * @pattern ^preset-[1-9][0-9]*$
          */
       colorToken: string | null;
       /**
@@ -14193,13 +14193,16 @@ export namespace Schemas {
          * @nullable
          */
       breakdownType?: string | null;
-      /** Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property. */
-      breakdownProperty?: string;
+      /**
+         * Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property.
+         * @nullable
+         */
+      breakdownProperty?: string | null;
       /** `manual` for a color a person picked, `auto` for one the dashboard assigned.
        *
        * * `auto` - auto
        * * `manual` - manual */
-      source?: BreakdownColorConfigSourceEnum;
+      source?: BreakdownColorConfigSourceEnum | null;
     }
 
     export interface BreakdownItem {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14167,6 +14167,41 @@ export namespace Schemas {
       state: string | null;
     }
 
+    /**
+     * * `auto` - auto
+     * * `manual` - manual
+     */
+    export type BreakdownColorConfigSourceEnum = typeof BreakdownColorConfigSourceEnum[keyof typeof BreakdownColorConfigSourceEnum];
+
+
+    export const BreakdownColorConfigSourceEnum = {
+      Auto: 'auto',
+      Manual: 'manual',
+    } as const;
+
+    export interface BreakdownColorConfig {
+      /** The breakdown value this color applies to, as it appears in the chart legend. */
+      breakdownValue: string;
+      /**
+         * Palette slot to color the value with, as `preset-1` upwards. Not a CSS color: a hex value is rejected. Null leaves the value on its default color.
+         * @nullable
+         * @pattern ^preset-\d+$
+         */
+      colorToken: string | null;
+      /**
+         * Breakdown type the value came from, such as `event`, `person`, `session`, or `cohort`.
+         * @nullable
+         */
+      breakdownType?: string | null;
+      /** Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property. */
+      breakdownProperty?: string;
+      /** `manual` for a color a person picked, `auto` for one the dashboard assigned.
+       *
+       * * `auto` - auto
+       * * `manual` - manual */
+      source?: BreakdownColorConfigSourceEnum;
+    }
+
     export interface BreakdownItem {
       label: string;
       value: string | number;
@@ -21277,8 +21312,11 @@ export namespace Schemas {
       readonly filters: DashboardFilters;
       /** @nullable */
       readonly variables: DashboardVariables;
-      /** Custom color mapping for breakdown values. */
-      breakdown_colors?: unknown;
+      /**
+         * Colors pinned to specific breakdown values across the dashboard's tiles. A list of entries, not an object keyed by breakdown value. Send an empty list to clear them.
+         * @nullable
+         */
+      breakdown_colors?: BreakdownColorConfig[] | null;
       /**
          * ID of the color theme used for chart visualizations.
          * @nullable
@@ -66111,8 +66149,11 @@ export namespace Schemas {
       pinned?: boolean;
       /** Dashboard-level filters (date range and properties) applied across all tiles as the source of truth. */
       filters?: DashboardFiltersOpenApi;
-      /** Custom color mapping for breakdown values. */
-      breakdown_colors?: unknown;
+      /**
+         * Colors pinned to specific breakdown values across the dashboard's tiles. A list of entries, not an object keyed by breakdown value. Send an empty list to clear them.
+         * @nullable
+         */
+      breakdown_colors?: BreakdownColorConfig[] | null;
       /**
          * ID of the color theme used for chart visualizations.
          * @nullable

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -100,6 +100,7 @@ export const DashboardsCreateQueryParams = () => zod.object({
 
 export const dashboardsCreateBodyNameMax = 400
 
+export const dashboardsCreateBodyBreakdownColorsItemColorTokenRegExp = new RegExp('^preset-\\d+$')
 export const dashboardsCreateBodyDeleteInsightsDefault = false
 
 export const DashboardsCreateBody = () => zod
@@ -107,7 +108,44 @@ export const DashboardsCreateBody = () => zod
         name: zod.string().max(dashboardsCreateBodyNameMax).nullish(),
         description: zod.string().optional(),
         pinned: zod.boolean().optional(),
-        breakdown_colors: zod.unknown().optional().describe('Custom color mapping for breakdown values.'),
+        breakdown_colors: zod
+            .array(
+                zod.object({
+                    breakdownValue: zod
+                        .string()
+                        .describe('The breakdown value this color applies to, as it appears in the chart legend.'),
+                    colorToken: zod
+                        .string()
+                        .regex(dashboardsCreateBodyBreakdownColorsItemColorTokenRegExp)
+                        .nullable()
+                        .describe(
+                            'Palette slot to color the value with, as `preset-1` upwards. Not a CSS color: a hex value is rejected. Null leaves the value on its default color.'
+                        ),
+                    breakdownType: zod
+                        .string()
+                        .nullish()
+                        .describe(
+                            'Breakdown type the value came from, such as `event`, `person`, `session`, or `cohort`.'
+                        ),
+                    breakdownProperty: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property.'
+                        ),
+                    source: zod
+                        .enum(['auto', 'manual'])
+                        .describe('\* `auto` - auto\n\* `manual` - manual')
+                        .optional()
+                        .describe(
+                            '`manual` for a color a person picked, `auto` for one the dashboard assigned.\n\n\* `auto` - auto\n\* `manual` - manual'
+                        ),
+                })
+            )
+            .nullish()
+            .describe(
+                "Colors pinned to specific breakdown values across the dashboard's tiles. A list of entries, not an object keyed by breakdown value. Send an empty list to clear them."
+            ),
         data_color_theme_id: zod.number().nullish().describe('ID of the color theme used for chart visualizations.'),
         tags: zod.array(zod.unknown()).optional(),
         restriction_level: zod
@@ -200,6 +238,8 @@ export const DashboardsPartialUpdateQueryParams = () => zod.object({
 
 export const dashboardsPartialUpdateBodyNameMax = 400
 
+export const dashboardsPartialUpdateBodyBreakdownColorsItemColorTokenRegExp = new RegExp('^preset-\\d+$')
+
 export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneOneLimitDefault = 25
 export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneOneLimitMax = 50
 
@@ -289,7 +329,44 @@ export const DashboardsPartialUpdateBody = () => zod
             .describe(
                 'Dashboard-level filters (date range and properties) applied across all tiles as the source of truth.'
             ),
-        breakdown_colors: zod.unknown().optional().describe('Custom color mapping for breakdown values.'),
+        breakdown_colors: zod
+            .array(
+                zod.object({
+                    breakdownValue: zod
+                        .string()
+                        .describe('The breakdown value this color applies to, as it appears in the chart legend.'),
+                    colorToken: zod
+                        .string()
+                        .regex(dashboardsPartialUpdateBodyBreakdownColorsItemColorTokenRegExp)
+                        .nullable()
+                        .describe(
+                            'Palette slot to color the value with, as `preset-1` upwards. Not a CSS color: a hex value is rejected. Null leaves the value on its default color.'
+                        ),
+                    breakdownType: zod
+                        .string()
+                        .nullish()
+                        .describe(
+                            'Breakdown type the value came from, such as `event`, `person`, `session`, or `cohort`.'
+                        ),
+                    breakdownProperty: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property.'
+                        ),
+                    source: zod
+                        .enum(['auto', 'manual'])
+                        .describe('\* `auto` - auto\n\* `manual` - manual')
+                        .optional()
+                        .describe(
+                            '`manual` for a color a person picked, `auto` for one the dashboard assigned.\n\n\* `auto` - auto\n\* `manual` - manual'
+                        ),
+                })
+            )
+            .nullish()
+            .describe(
+                "Colors pinned to specific breakdown values across the dashboard's tiles. A list of entries, not an object keyed by breakdown value. Send an empty list to clear them."
+            ),
         data_color_theme_id: zod.number().nullish().describe('ID of the color theme used for chart visualizations.'),
         tags: zod.array(zod.string()).optional(),
         restriction_level: zod

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -100,7 +100,7 @@ export const DashboardsCreateQueryParams = () => zod.object({
 
 export const dashboardsCreateBodyNameMax = 400
 
-export const dashboardsCreateBodyBreakdownColorsItemColorTokenRegExp = new RegExp('^preset-\\d+$')
+export const dashboardsCreateBodyBreakdownColorsItemColorTokenRegExp = new RegExp('^preset-[1-9][0-9]\*$')
 export const dashboardsCreateBodyDeleteInsightsDefault = false
 
 export const DashboardsCreateBody = () => zod
@@ -129,13 +129,15 @@ export const DashboardsCreateBody = () => zod
                         ),
                     breakdownProperty: zod
                         .string()
-                        .optional()
+                        .nullish()
                         .describe(
                             'Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property.'
                         ),
                     source: zod
-                        .enum(['auto', 'manual'])
-                        .describe('\* `auto` - auto\n\* `manual` - manual')
+                        .union([
+                            zod.enum(['auto', 'manual']).describe('\* `auto` - auto\n\* `manual` - manual'),
+                            zod.null(),
+                        ])
                         .optional()
                         .describe(
                             '`manual` for a color a person picked, `auto` for one the dashboard assigned.\n\n\* `auto` - auto\n\* `manual` - manual'
@@ -238,7 +240,7 @@ export const DashboardsPartialUpdateQueryParams = () => zod.object({
 
 export const dashboardsPartialUpdateBodyNameMax = 400
 
-export const dashboardsPartialUpdateBodyBreakdownColorsItemColorTokenRegExp = new RegExp('^preset-\\d+$')
+export const dashboardsPartialUpdateBodyBreakdownColorsItemColorTokenRegExp = new RegExp('^preset-[1-9][0-9]\*$')
 
 export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneOneLimitDefault = 25
 export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneOneLimitMax = 50
@@ -350,13 +352,15 @@ export const DashboardsPartialUpdateBody = () => zod
                         ),
                     breakdownProperty: zod
                         .string()
-                        .optional()
+                        .nullish()
                         .describe(
                             'Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property.'
                         ),
                     source: zod
-                        .enum(['auto', 'manual'])
-                        .describe('\* `auto` - auto\n\* `manual` - manual')
+                        .union([
+                            zod.enum(['auto', 'manual']).describe('\* `auto` - auto\n\* `manual` - manual'),
+                            zod.null(),
+                        ])
                         .optional()
                         .describe(
                             '`manual` for a color a person picked, `auto` for one the dashboard assigned.\n\n\* `auto` - auto\n\* `manual` - manual'

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-create.json
@@ -2,7 +2,57 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "breakdown_colors": {
-            "description": "Custom color mapping for breakdown values."
+            "anyOf": [
+                {
+                    "items": {
+                        "properties": {
+                            "breakdownProperty": {
+                                "description": "Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property.",
+                                "type": "string"
+                            },
+                            "breakdownType": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "Breakdown type the value came from, such as `event`, `person`, `session`, or `cohort`."
+                            },
+                            "breakdownValue": {
+                                "description": "The breakdown value this color applies to, as it appears in the chart legend.",
+                                "type": "string"
+                            },
+                            "colorToken": {
+                                "anyOf": [
+                                    {
+                                        "pattern": "^preset-\\d+$",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "Palette slot to color the value with, as `preset-1` upwards. Not a CSS color: a hex value is rejected. Null leaves the value on its default color."
+                            },
+                            "source": {
+                                "description": "`manual` for a color a person picked, `auto` for one the dashboard assigned.\n\n* `auto` - auto\n* `manual` - manual",
+                                "enum": ["auto", "manual"],
+                                "type": "string"
+                            }
+                        },
+                        "required": ["breakdownValue", "colorToken"],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Colors pinned to specific breakdown values across the dashboard's tiles. A list of entries, not an object keyed by breakdown value. Send an empty list to clear them."
         },
         "data_color_theme_id": {
             "anyOf": [

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-create.json
@@ -7,8 +7,15 @@
                     "items": {
                         "properties": {
                             "breakdownProperty": {
-                                "description": "Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property.",
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property."
                             },
                             "breakdownType": {
                                 "anyOf": [
@@ -28,7 +35,7 @@
                             "colorToken": {
                                 "anyOf": [
                                     {
-                                        "pattern": "^preset-\\d+$",
+                                        "pattern": "^preset-[1-9][0-9]*$",
                                         "type": "string"
                                     },
                                     {
@@ -38,9 +45,17 @@
                                 "description": "Palette slot to color the value with, as `preset-1` upwards. Not a CSS color: a hex value is rejected. Null leaves the value on its default color."
                             },
                             "source": {
-                                "description": "`manual` for a color a person picked, `auto` for one the dashboard assigned.\n\n* `auto` - auto\n* `manual` - manual",
-                                "enum": ["auto", "manual"],
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "description": "* `auto` - auto\n* `manual` - manual",
+                                        "enum": ["auto", "manual"],
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "`manual` for a color a person picked, `auto` for one the dashboard assigned.\n\n* `auto` - auto\n* `manual` - manual"
                             }
                         },
                         "required": ["breakdownValue", "colorToken"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-update.json
@@ -2,7 +2,57 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "breakdown_colors": {
-            "description": "Custom color mapping for breakdown values."
+            "anyOf": [
+                {
+                    "items": {
+                        "properties": {
+                            "breakdownProperty": {
+                                "description": "Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property.",
+                                "type": "string"
+                            },
+                            "breakdownType": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "Breakdown type the value came from, such as `event`, `person`, `session`, or `cohort`."
+                            },
+                            "breakdownValue": {
+                                "description": "The breakdown value this color applies to, as it appears in the chart legend.",
+                                "type": "string"
+                            },
+                            "colorToken": {
+                                "anyOf": [
+                                    {
+                                        "pattern": "^preset-\\d+$",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "Palette slot to color the value with, as `preset-1` upwards. Not a CSS color: a hex value is rejected. Null leaves the value on its default color."
+                            },
+                            "source": {
+                                "description": "`manual` for a color a person picked, `auto` for one the dashboard assigned.\n\n* `auto` - auto\n* `manual` - manual",
+                                "enum": ["auto", "manual"],
+                                "type": "string"
+                            }
+                        },
+                        "required": ["breakdownValue", "colorToken"],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Colors pinned to specific breakdown values across the dashboard's tiles. A list of entries, not an object keyed by breakdown value. Send an empty list to clear them."
         },
         "data_color_theme_id": {
             "anyOf": [

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-update.json
@@ -7,8 +7,15 @@
                     "items": {
                         "properties": {
                             "breakdownProperty": {
-                                "description": "Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property.",
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "Breakdown property the color is scoped to, so the color applies only to tiles that break down by that property. Omit to apply it under every property."
                             },
                             "breakdownType": {
                                 "anyOf": [
@@ -28,7 +35,7 @@
                             "colorToken": {
                                 "anyOf": [
                                     {
-                                        "pattern": "^preset-\\d+$",
+                                        "pattern": "^preset-[1-9][0-9]*$",
                                         "type": "string"
                                     },
                                     {
@@ -38,9 +45,17 @@
                                 "description": "Palette slot to color the value with, as `preset-1` upwards. Not a CSS color: a hex value is rejected. Null leaves the value on its default color."
                             },
                             "source": {
-                                "description": "`manual` for a color a person picked, `auto` for one the dashboard assigned.\n\n* `auto` - auto\n* `manual` - manual",
-                                "enum": ["auto", "manual"],
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "description": "* `auto` - auto\n* `manual` - manual",
+                                        "enum": ["auto", "manual"],
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "`manual` for a color a person picked, `auto` for one the dashboard assigned.\n\n* `auto` - auto\n* `manual` - manual"
                             }
                         },
                         "required": ["breakdownValue", "colorToken"],

--- a/services/mcp/tests/unit/dashboard-update-schema.test.ts
+++ b/services/mcp/tests/unit/dashboard-update-schema.test.ts
@@ -50,6 +50,8 @@ describe('dashboard-update schema', () => {
         ['entries under other key names', [{ breakdown_value: 'good', color: '#36a854' }]],
         ['an entry without a color token', [{ breakdownValue: 'Chrome' }]],
         ['a hex value where a palette slot belongs', [{ breakdownValue: 'Chrome', colorToken: '#3fb950' }]],
+        // Also proves the generated schema carries the serializer's token pattern.
+        ['palette slot zero', [{ breakdownValue: 'Chrome', colorToken: 'preset-0' }]],
     ])('rejects breakdown_colors as %s', (_name, breakdownColors) => {
         const result = tool.schema.safeParse({ id: 1, breakdown_colors: breakdownColors })
 

--- a/services/mcp/tests/unit/dashboard-update-schema.test.ts
+++ b/services/mcp/tests/unit/dashboard-update-schema.test.ts
@@ -30,7 +30,7 @@ describe('dashboard-update schema', () => {
     it('accepts optional dashboard PATCH write params', () => {
         const result = tool.schema.safeParse({
             id: 1,
-            breakdown_colors: { series_a: '#ff0000' },
+            breakdown_colors: [{ breakdownValue: 'Chrome', breakdownType: 'event', colorToken: 'preset-1' }],
             data_color_theme_id: 2,
             quick_filter_ids: ['00000000-0000-4000-8000-000000000001'],
             use_template: '',
@@ -40,5 +40,19 @@ describe('dashboard-update schema', () => {
         })
 
         expect(result.success).toBe(true)
+    })
+
+    // The schema used to accept any JSON for this field, and its description read as a color
+    // mapping, so agents sent a dictionary of breakdown values to hex colors. The dashboard cannot
+    // read that shape.
+    it.each([
+        ['an object keyed by breakdown value', { series_a: '#ff0000' }],
+        ['entries under other key names', [{ breakdown_value: 'good', color: '#36a854' }]],
+        ['an entry without a color token', [{ breakdownValue: 'Chrome' }]],
+        ['a hex value where a palette slot belongs', [{ breakdownValue: 'Chrome', colorToken: '#3fb950' }]],
+    ])('rejects breakdown_colors as %s', (_name, breakdownColors) => {
+        const result = tool.schema.safeParse({ id: 1, breakdown_colors: breakdownColors })
+
+        expect(result.success).toBe(false)
     })
 })


### PR DESCRIPTION
## Problem

- The API accepted any JSON for `breakdown_colors`, so a caller could store a shape the dashboard cannot read. Two of those shapes crash the dashboard scene on every load; entries under other key names render as colors that silently never apply.
- The field's own description invited the bad writes. It read as "Custom color mapping for breakdown values" and constrained nothing, so a caller sends a dictionary of breakdown values to hex colors.
- A PATCH accepted an entry the dashboard cannot read, so the first revision of this PR did not close the hole on the path the dashboard and the MCP tool both use.
- The generated MCP schema was `zod.unknown()`, and the JSON Schema handed to an agent carried no `type` at all. This repo's own test asserted `{ series_a: '#ff0000' }` was valid input, so the misreading was ours too.

Closes #92891

## Changes

- A write of an entry that can never apply is rejected instead of stored and ignored. Both `breakdownValue` and `colorToken` are required.
- The description now states the shape: a list of entries, not an object keyed by breakdown value, and a hex value in `colorToken` is ignored.
- An agent asking for the tool schema gets the entry shape and its required keys, so it no longer has to guess from prose.

| Path | Before | After |
| --- | --- | --- |
| Write (serializers) | `JSONField`, any shape | `ListField` of typed entries, both keys required |
| `colorToken` | any string | must match `^preset-[1-9][0-9]*$`, or be null |
| Entry keys on a PATCH | skipped as not required | required, as on a PUT |
| `breakdownProperty`, `source` | null rejected | null accepted, same as omitted |
| MCP schema | `zod.unknown()`, no `type` | typed array, `required: [breakdownValue, colorToken]`, token pattern |
| Description | "Custom color mapping for breakdown values" | states the list shape and that hex is rejected |

- A write on a PATCH is now held to the same entry rules as a PUT. DRF resolves `required` against the root serializer's partial flag, and a dashboard update is partial, so the child skipped a missing key instead of failing it. Writes validate through an unbound list, whose own root carries no partial flag.
- A token naming palette slot zero, or written with another script's digits, is rejected. `getColorFromToken` wraps the index as `((N - 1) % slots) + 1`, and JavaScript keeps the sign of the dividend, so `preset-0` read `theme['preset-0']`. JavaScript `parseInt` reads `preset-١` as `NaN`.
- `breakdownProperty` and `source` accept null, which means the same as omitted for both. Rejecting an explicit null failed a client that sends one for an absent value, including one that saves back an entry it read.
- A token names a slot in the dashboard's color theme, not a color. `getColorFromToken` parses the N out of `preset-N` and indexes the theme with it, so any other string yields `theme['preset-NaN']`, which is undefined. The pattern rather than a fixed range, because a theme may carry more slots than the default palette and the token wraps past its end.
- Both directions validate entries through the child serializer and then store or return them as given. The child rewrites an entry rather than describing it: it drops a key it does not declare and adds a null for a declared key the entry omits. Since the dashboard saves the whole color list back, letting the child shape either direction would drop a key the frontend persists before this serializer learns about it, and the loss would only surface as colors disappearing after a later save.
- No defensive read path for the shapes this rejects. A read returns the stored value as given, so a dashboard that renders today still renders.
- The values already stored are cleared by a manual run of `clear_unusable_breakdown_colors` (#96309). That run is not tied to this deploy, so it can happen before or after this lands.
- `source` is also the name of a `Field` attribute on the `Serializer` base class, so mypy reads the declaration as a shadowed assignment. `SerializerMetaclass` pops every declared field out of the class namespace, which is why the entry key stays `source` and the base attribute survives.
- Nothing looks different in the app. This layer touches no frontend code; it changes what the API accepts and what the generated schemas say.
- Mechanical: regenerated OpenAPI types, zod schemas, and MCP tool-schema snapshots from the serializer change.

> [!WARNING]
> Until #96309's command runs, a dashboard whose stored entries carry a token the dashboard cannot resolve cannot be saved.
> The frontend sends those entries back, the API returns 400, and the whole save is lost, including its filters and layout.
> A team without the `dashboard-colors` flag hits this on any save of such a dashboard.
> A team with the flag hits it only on a save made while a tile still loads or has errored, because the frontend otherwise drops the unusable entry first.

## How did you test this code?

- A parameterized matrix on the serializer field, with no database. Every case runs against a partial serializer as well, because a rule proven on a non-partial one does not prove the endpoint's own path. It covers each rejected shape and, more importantly, the shapes that must keep saving: a minimal entry, every key, a null `colorToken`, a blank breakdown value, a null `breakdownProperty` and `source`, an empty list, and null.
- Reverting any one of the three fixes fails only its own cases: the partial fix fails five reject cases, the token pattern fails the two new token cases, and the nullable keys fail the two new null cases.
- Two cases pin the read and the write path. Reverting either to render through the child drops `somethingAddedLater` and adds an explicit null `breakdownProperty`, which is data loss on a valid entry.
- The endpoint wiring guard now also covers an entry-level rejection, not only a bad outer value. That case belongs at the endpoint because the update is a PATCH. An error inside an entry names the entry and the key, so the attr is `breakdown_colors__0__colorToken` rather than the bare field name.
- Not run locally: the database-backed cases, because this sandbox has no ClickHouse. The two attr values were read off the real serializer through the real exception handler instead, and CI runs the cases.
- The MCP schema test that asserted an object was valid input now asserts the valid list shape, plus four cases pinning the rejection at the zod layer, including palette slot zero.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented behavior changes.

## 🤖 Agent context

**Autonomy:** Supervised. A person chose to reject entries missing the required keys, to require the token to name a resolvable slot, to skip a DB check constraint, and to split this away from the data repair.

Written by PostHog Desktop (Claude). Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-code-comments`, `/stacking-prs`, `/writing-pr-descriptions`.

A second review round found three more holes, all verified against DRF and the frontend helpers before fixing: the partial-mode bypass, the two unresolvable token shapes, and the optional keys that rejected null. #96309 carries the matching token pattern, because a token it kept but this layer rejects would leave the next save failing with a 400 its owner cannot act on.

One review finding is fixed in #97322 rather than here: an entry with no `breakdownProperty` and no `breakdownType` is accepted but never matches a series, because `breakdownConfigMatches` defaults a missing type on the series side only, while `breakdownConfigIdentityMatches` defaults both. That fix makes colors that never applied start applying, so it carries its own review. Until it lands, the entry shape this schema calls complete still does nothing.

This PR left the stack it was opened in. Its first commit is the original one replayed onto master unchanged, so it no longer waits on #96309 to merge. #96309 stays open as the manually run repair.

This supersedes #92940, which combined this change with a repair-on-read path and frontend guards. Tracing the origin to the MCP write path, rather than to any frontend release, is what motivated fixing the description and requiring the entry keys. Review feedback on the first revision added the token pattern and the write-side passthrough.

Public artifact: nothing here carries material from the agent session. The test fixtures use invented breakdown values, and no counts from production data appear in this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*