### PR TITLE
feat(tasks): trace task workflow starts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -76,7 +76,7 @@
         "@posthog/brand": "catalog:",
         "@posthog/docs-onboarding": "workspace:*",
         "@posthog/esbuilder": "workspace:*",
-        "@posthog/hedgehog-mode": "^0.0.54",
+        "@posthog/hedgehog-mode": "^0.0.56",
         "@posthog/hogql-parser": "1.3.84",
         "@posthog/hogvm": "workspace:*",
         "@posthog/icons": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -621,8 +621,8 @@ importers:
         specifier: workspace:*
         version: link:../common/esbuilder
       '@posthog/hedgehog-mode':
-        specifier: ^0.0.54
-        version: 0.0.54(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^0.0.56
+        version: 0.0.56(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/hogql-parser':
         specifier: 1.3.84
         version: 1.3.84
@@ -10415,8 +10415,8 @@ packages:
   '@posthog/core@1.51.0':
     resolution: {integrity: sha512-LilmmtjcrjV1LgaVNQXrAUt4IXcWIYMrwEtx6VJUUFDeBBdmeI99jshKGtAWugYeB3Wkcp9xQIVCrxIYRpNiRA==}
 
-  '@posthog/hedgehog-mode@0.0.54':
-    resolution: {integrity: sha512-FBNsdZcqmSu++YkLXoGnWGEogWLKDIle8iMFDNbBKOdBoiNeKkiezwz5DnKvShZpKNLEvUVpoJh93vMOcuuLjQ==}
+  '@posthog/hedgehog-mode@0.0.56':
+    resolution: {integrity: sha512-I6PjNTR4BfVMXbgO3XQOPTirclJx8hHaR58j6ebB9ZXJohHVkS3eFUmLmJuc+q4baKs9ZU1kGn0K76pYhOUHFg==}
     engines: {node: '>=18'}
     peerDependencies:
       react: 18.3.1
@@ -29985,10 +29985,9 @@ snapshots:
     dependencies:
       '@posthog/types': 1.409.1
 
-  '@posthog/hedgehog-mode@0.0.54(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@posthog/hedgehog-mode@0.0.56(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       gsap: 3.14.2
-      lodash: 4.18.1
       matter-js: 0.20.0
       pixi.js: 8.19.0
       react: 18.3.1

--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -23,6 +23,7 @@ MODAL_NETWORK_ALLOWLIST_FEATURE_FLAG = "tasks-modal-network-allowlist"
 # Routes a plain default-template run onto the hogland (Firecracker) sandbox backend.
 HOGLAND_SANDBOX_FEATURE_FLAG = "tasks-hogland-sandbox"
 AGENT_RUN_OTEL_TELEMETRY_FEATURE_FLAG = "tasks-agent-run-otel-telemetry"
+TASK_START_TRACE_FEATURE_FLAG = "tasks-start-trace"
 PI_CLOUD_RUNTIME_FEATURE_FLAG = "pi-harness"
 # Gates agent-to-agent peer messaging between cloud runs. v1 additionally requires the Pi
 # runtime, so the effective audience is teams with both this flag and
@@ -39,6 +40,7 @@ TASK_ANALYSIS_ACTIVITIES_STATE_KEY = "task_analysis_activities"
 # Run-state key the telemetry flag decision is stamped under at dispatch (temporal/client.py).
 # Consumers read the stamp, so the decision stays stable for the run's whole lifetime.
 AGENT_OTEL_TELEMETRY_STATE_KEY = "agent_otel_telemetry_enabled"
+TASK_START_TRACE_STATE_KEY = "task_start_trace_enabled"
 PR_LOOP_ENABLED_STATE_KEY = "pr_loop_enabled"
 # The skills-store stubs the sandbox agent writes into its skill roots at session start.
 STORE_SKILLS_STATE_KEY = "store_skills"

--- a/products/tasks/backend/feature_flags.py
+++ b/products/tasks/backend/feature_flags.py
@@ -10,6 +10,8 @@ from products.tasks.backend.constants import (
     AGENT_OTEL_TELEMETRY_STATE_KEY,
     AGENT_RUN_OTEL_TELEMETRY_FEATURE_FLAG,
     DEV_STACK_IMAGE_BAKE_FEATURE_FLAG,
+    TASK_START_TRACE_FEATURE_FLAG,
+    TASK_START_TRACE_STATE_KEY,
     WORKFLOW_DISPATCH_ASYNC_FEATURE_FLAG,
     WORKFLOW_DISPATCH_RESTART_FEATURE_FLAG,
     WORKFLOW_DISPATCH_SHADOW_FEATURE_FLAG,
@@ -149,6 +151,23 @@ def is_agent_otel_telemetry_enabled(*, distinct_id: str, organization_id: str) -
         return False
 
 
+def is_task_start_trace_enabled(*, distinct_id: str, organization_id: str) -> bool:
+    try:
+        return bool(
+            posthoganalytics.feature_enabled(
+                TASK_START_TRACE_FEATURE_FLAG,
+                distinct_id=distinct_id,
+                groups={"organization": organization_id},
+                group_properties={"organization": {"id": organization_id}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception:
+        logger.exception("task_start_trace_flag_check_failed")
+        return False
+
+
 def get_model_access_error(model: str | None, *, distinct_id: str | None) -> str | None:
     """Reject a gated model the caller isn't entitled to; `None` when the selection is allowed.
 
@@ -191,3 +210,7 @@ def agent_otel_telemetry_enabled_for_state(state: dict | None) -> bool:
     if settings.DEBUG:
         return True
     return (state or {}).get(AGENT_OTEL_TELEMETRY_STATE_KEY) is True
+
+
+def task_start_trace_enabled_for_state(state: dict | None) -> bool:
+    return (state or {}).get(TASK_START_TRACE_STATE_KEY) is True

--- a/products/tasks/backend/temporal/client.py
+++ b/products/tasks/backend/temporal/client.py
@@ -1,6 +1,7 @@
 import uuid
 import asyncio
 import logging
+from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from django.conf import settings
@@ -9,6 +10,8 @@ from django.utils import timezone as django_timezone
 
 import posthoganalytics
 from asgiref.sync import sync_to_async
+from opentelemetry import trace
+from opentelemetry.trace import SpanKind
 from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 from temporalio.exceptions import WorkflowAlreadyStartedError
 
@@ -16,9 +19,18 @@ from posthog.models.team.team import Team
 from posthog.temporal.common.client import async_connect, sync_connect
 from posthog.temporal.oauth import PosthogMcpScopes
 
-from products.tasks.backend.constants import AGENT_OTEL_TELEMETRY_STATE_KEY, SANDBOX_EVENT_INGEST_FEATURE_FLAG
+from products.tasks.backend.constants import (
+    AGENT_OTEL_TELEMETRY_STATE_KEY,
+    SANDBOX_EVENT_INGEST_FEATURE_FLAG,
+    TASK_START_TRACE_STATE_KEY,
+)
 from products.tasks.backend.error_telemetry import truncate_error_message
-from products.tasks.backend.feature_flags import is_agent_otel_telemetry_enabled, is_native_steering_signals_enabled
+from products.tasks.backend.feature_flags import (
+    is_agent_otel_telemetry_enabled,
+    is_native_steering_signals_enabled,
+    is_task_start_trace_enabled,
+    task_start_trace_enabled_for_state,
+)
 from products.tasks.backend.logic.services.dev_stack_image import DEV_STACK_IMAGE_NAME
 from products.tasks.backend.metrics import AGENT_OTEL_TELEMETRY_STAMPED_TOTAL, observe_task_run_workflow_start
 from products.tasks.backend.models import Task, TaskRun
@@ -116,7 +128,7 @@ def _get_task_run_for_metrics(run_id: str) -> TaskRun | None:
         return None
 
 
-def _capture_run_feature_flags(run_id: str) -> None:
+def _capture_run_feature_flags(run_id: str) -> dict[str, Any] | None:
     """Evaluate per-run rollout flags once at dispatch and stamp them into run state.
 
     Idempotent per key, so retries and resumes keep the decision the run started with.
@@ -130,8 +142,9 @@ def _capture_run_feature_flags(run_id: str) -> None:
     state = task_run.state or {}
     need_event_ingest = not isinstance(state.get("sandbox_event_ingest_enabled"), bool)
     need_otel_telemetry = not isinstance(state.get(AGENT_OTEL_TELEMETRY_STATE_KEY), bool)
-    if not need_event_ingest and not need_otel_telemetry:
-        return
+    need_start_trace = not isinstance(state.get(TASK_START_TRACE_STATE_KEY), bool)
+    if not need_event_ingest and not need_otel_telemetry and not need_start_trace:
+        return state
 
     task = task_run.task
     organization_id = str(task.team.organization_id)
@@ -160,12 +173,17 @@ def _capture_run_feature_flags(run_id: str) -> None:
     otel_telemetry_enabled = need_otel_telemetry and is_agent_otel_telemetry_enabled(
         distinct_id=distinct_id, organization_id=organization_id
     )
+    start_trace_enabled = need_start_trace and is_task_start_trace_enabled(
+        distinct_id=distinct_id, organization_id=organization_id
+    )
 
     def _stamp_flags(latest_state: dict[str, Any]) -> None:
         if need_event_ingest and not isinstance(latest_state.get("sandbox_event_ingest_enabled"), bool):
             latest_state["sandbox_event_ingest_enabled"] = event_ingest_enabled
         if need_otel_telemetry and not isinstance(latest_state.get(AGENT_OTEL_TELEMETRY_STATE_KEY), bool):
             latest_state[AGENT_OTEL_TELEMETRY_STATE_KEY] = otel_telemetry_enabled
+        if need_start_trace and not isinstance(latest_state.get(TASK_START_TRACE_STATE_KEY), bool):
+            latest_state[TASK_START_TRACE_STATE_KEY] = start_trace_enabled
 
     captured_state = TaskRun.mutate_state_atomic(task_run.id, _stamp_flags)
     if need_otel_telemetry:
@@ -179,6 +197,23 @@ def _capture_run_feature_flags(run_id: str) -> None:
             "task_id": str(task.id),
             "sandbox_event_ingest_enabled": captured_state.get("sandbox_event_ingest_enabled"),
             "agent_otel_telemetry_enabled": captured_state.get(AGENT_OTEL_TELEMETRY_STATE_KEY),
+            "task_start_trace_enabled": captured_state.get(TASK_START_TRACE_STATE_KEY),
+        },
+    )
+    return captured_state
+
+
+def _task_start_trace(task_run: TaskRun | None):
+    if task_run is None or not task_start_trace_enabled_for_state(task_run.state):
+        return nullcontext()
+    return trace.get_tracer(__name__).start_as_current_span(
+        "tasks.run.trigger",
+        kind=SpanKind.PRODUCER,
+        attributes={
+            "task_id": str(task_run.task_id),
+            "task_run_id": str(task_run.id),
+            "task_origin_product": task_run.task.origin_product,
+            "task_run_environment": task_run.environment,
         },
     )
 
@@ -224,7 +259,9 @@ async def execute_task_processing_workflow_async(
         task_run_for_metrics = await _aget_task_run_for_metrics(run_id)
         observe_task_run_workflow_start(task_run_for_metrics, outcome="attempted", reason="requested")
         await Team.objects.select_related("organization").aget(id=team_id)
-        await sync_to_async(_capture_run_feature_flags)(run_id)
+        captured_state = await sync_to_async(_capture_run_feature_flags)(run_id)
+        if captured_state is not None and task_run_for_metrics is not None:
+            task_run_for_metrics.state = captured_state
 
         workflow_id = TaskRun.get_workflow_id(task_id, run_id, workflow_id_prefix)
         if workflow_id_prefix:
@@ -246,14 +283,15 @@ async def execute_task_processing_workflow_async(
         )
 
         client = await async_connect()
-        await client.start_workflow(
-            "process-task",
-            workflow_input,
-            id=workflow_id,
-            id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
-            task_queue=settings.TASKS_TASK_QUEUE,
-            retry_policy=RetryPolicy(maximum_attempts=3),
-        )
+        with _task_start_trace(task_run_for_metrics):
+            await client.start_workflow(
+                "process-task",
+                workflow_input,
+                id=workflow_id,
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+                task_queue=settings.TASKS_TASK_QUEUE,
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            )
 
         logger.info("task_processing_workflow_started", extra={"task_id": task_id, "run_id": run_id})
         observe_task_run_workflow_start(task_run_for_metrics, outcome="started", reason="accepted")
@@ -321,7 +359,9 @@ def execute_task_processing_workflow(
         )
 
         Team.objects.get(id=team_id)
-        _capture_run_feature_flags(run_id)
+        captured_state = _capture_run_feature_flags(run_id)
+        if captured_state is not None and task_run_for_metrics is not None:
+            task_run_for_metrics.state = captured_state
 
         workflow_id = TaskRun.get_workflow_id(task_id, run_id, workflow_id_prefix)
         if workflow_id_prefix:
@@ -349,16 +389,17 @@ def execute_task_processing_workflow(
             extra={"workflow_id": workflow_id, "task_id": task_id, "run_id": run_id},
         )
 
-        asyncio.run(
-            client.start_workflow(
-                "process-task",
-                workflow_input,
-                id=workflow_id,
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
-                task_queue=settings.TASKS_TASK_QUEUE,
-                retry_policy=RetryPolicy(maximum_attempts=3),
+        with _task_start_trace(task_run_for_metrics):
+            asyncio.run(
+                client.start_workflow(
+                    "process-task",
+                    workflow_input,
+                    id=workflow_id,
+                    id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+                    task_queue=settings.TASKS_TASK_QUEUE,
+                    retry_policy=RetryPolicy(maximum_attempts=3),
+                )
             )
-        )
 
         logger.info("task_processing_workflow_started", extra={"task_id": task_id, "run_id": run_id})
         observe_task_run_workflow_start(task_run_for_metrics, outcome="started", reason="accepted")

--- a/products/tasks/backend/tests/test_temporal_client.py
+++ b/products/tasks/backend/tests/test_temporal_client.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from django.test import SimpleTestCase, TestCase, override_settings
 
@@ -10,6 +10,7 @@ from temporalio.exceptions import WorkflowAlreadyStartedError
 from posthog.models import Organization, Team
 from posthog.models.user import User
 
+from products.tasks.backend.constants import TASK_START_TRACE_STATE_KEY
 from products.tasks.backend.models import Loop, Task, TaskRun
 from products.tasks.backend.temporal.client import (
     execute_task_processing_workflow,
@@ -230,10 +231,15 @@ class TestExecuteTaskProcessingWorkflow(TestCase):
         run.refresh_from_db()
         self.assertEqual(run.state["sandbox_event_ingest_enabled"], True)
         self.assertEqual(run.state["agent_otel_telemetry_enabled"], True)
+        self.assertEqual(run.state[TASK_START_TRACE_STATE_KEY], True)
         # Patching the shared posthoganalytics module attribute covers both evaluation
         # sites (event ingest in client.py, telemetry in feature_flags.py).
-        self.assertEqual(flag.call_count, 2)
-        for flag_key in ("tasks-cloud-runs-sandbox-event-ingest", "tasks-agent-run-otel-telemetry"):
+        self.assertEqual(flag.call_count, 3)
+        for flag_key in (
+            "tasks-cloud-runs-sandbox-event-ingest",
+            "tasks-agent-run-otel-telemetry",
+            "tasks-start-trace",
+        ):
             flag.assert_any_call(
                 flag_key,
                 distinct_id="process_task_workflow",
@@ -242,6 +248,48 @@ class TestExecuteTaskProcessingWorkflow(TestCase):
                 only_evaluate_locally=False,
                 send_feature_flag_events=False,
             )
+
+    @parameterized.expand([("enabled", True), ("disabled", False)])
+    def test_task_start_trace_wraps_workflow_start_only_when_enabled(self, _name: str, enabled: bool) -> None:
+        run = self._create_run()
+        run.state = {
+            "sandbox_event_ingest_enabled": False,
+            "agent_otel_telemetry_enabled": False,
+            TASK_START_TRACE_STATE_KEY: enabled,
+        }
+        run.save(update_fields=["state"])
+        client = Mock()
+        client.start_workflow = AsyncMock()
+        tracer = Mock()
+        tracer.start_as_current_span.return_value = MagicMock()
+
+        with (
+            patch("products.tasks.backend.temporal.client.sync_connect", return_value=client),
+            patch("products.tasks.backend.temporal.client.trace.get_tracer", return_value=tracer),
+        ):
+            execute_task_processing_workflow(
+                task_id=str(self.task.id),
+                run_id=str(run.id),
+                team_id=self.team.id,
+                user_id=self.user.id,
+            )
+
+        if not enabled:
+            tracer.start_as_current_span.assert_not_called()
+            return
+
+        tracer.start_as_current_span.assert_called_once()
+        args, kwargs = tracer.start_as_current_span.call_args
+        self.assertEqual(args, ("tasks.run.trigger",))
+        self.assertEqual(
+            kwargs["attributes"],
+            {
+                "task_id": str(self.task.id),
+                "task_run_id": str(run.id),
+                "task_origin_product": Task.OriginProduct.USER_CREATED,
+                "task_run_environment": run.environment,
+            },
+        )
 
     def test_captures_sandbox_event_ingest_flag_before_resuming_workflow(self) -> None:
         run = self._create_run()

--- a/products/tasks/docs/INSTRUMENTATION.md
+++ b/products/tasks/docs/INSTRUMENTATION.md
@@ -126,6 +126,12 @@ Source: `products/tasks/backend/temporal/process_task/workflow.py`
 
 These events are tracked via `_track_workflow_event()` which calls the `track_workflow_event` Temporal activity. All workflow events include `organization` and `project` group analytics and are enriched with Temporal context properties (see [Temporal Context](#temporal-context-enrichment)).
 
+## Distributed tracing
+
+When `tasks-start-trace` is enabled, a `tasks.run.trigger` producer span wraps the Temporal workflow start. Temporal propagates its trace context to the workflow and its activities, including sandbox provisioning and the first prompt dispatch.
+
+The span has `task_id`, `task_run_id`, `task_origin_product`, and `task_run_environment`. It does not include task text, prompt text, sandbox URLs, or credentials.
+
 ### `task_run_started`
 
 Tracked when the workflow begins execution.


### PR DESCRIPTION
## Problem

Task operators cannot see the full startup path in one trace.

**Why:** Existing worker spans have no Task trigger parent, so queue and sandbox wait are hard to connect to the prompt start.

## Changes

- Adds a flag-gated Task trigger span before the Temporal workflow starts.
- Propagates the trace context through Temporal to sandbox setup and prompt dispatch.
- Adds direct Task and run IDs as safe trace attributes.
- Keeps tracing off until `tasks-start-trace` rolls out.
- Updates @posthog/hedgehog-mode to release 0.0.56.

Before:

```mermaid
flowchart LR
    Trigger[Task trigger] --> Queue[Temporal queue]
    Queue --> Worker[Task worker]
    Worker --> Agent[Agent start]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class Trigger phYellow;
    class Queue,Worker,Agent phBlue;
```

After:

```mermaid
flowchart LR
    Trigger[Task trigger] --> Trace[Task start trace]
    Trace --> Queue[Temporal queue]
    Queue --> Worker[Task worker]
    Worker --> Agent[Agent start]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class Trigger phYellow;
    class Trace,Queue,Worker,Agent phBlue;
```

## How did you test this code?

- Ran `uv run ./bin/hogli test products/tasks/backend/tests/test_temporal_client.py`.
- Added flag-on and flag-off coverage for workflow-start trace creation.
- Validated the updated dependency lockfile and ran frontend formatting and lint checks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- Updated `products/tasks/docs/INSTRUMENTATION.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Slack app used `instrument-feature-flags`, `writing-tests`, `writing-user-facing-copy`, and `writing-pr-descriptions`.

The open-issue search found no matching Task tracing work.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/D03N18XLESG/p1788851894115009?thread_ts=1788851894.115009&cid=D03N18XLESG)*
