### PR TITLE
feat(desktop): add copy link to sidebar item menus

### DIFF
--- a/products/desktop/docs/DEEP-LINKS.md
+++ b/products/desktop/docs/DEEP-LINKS.md
@@ -156,6 +156,10 @@ Use the link button in the canvas toolbar to copy this link without opening a
 menu. The button has a "Copy link to canvas" tooltip, like the session link
 button. "Copy link" also remains in the canvas options menu.
 
+In the left sidebar, right-click a session or canvas and select **Copy link**.
+Sessions copy the channel thread link. Canvases copy the canvas link.
+The row's options menu has the same action. Copying a link does not change access permissions.
+
 | Segment | Required | Description |
 |---|---|---|
 | `<channelId>` | Yes | Channel (folder) row id the canvas lives under. |

--- a/products/desktop/docs/DEEP-LINKS.md
+++ b/products/desktop/docs/DEEP-LINKS.md
@@ -156,10 +156,6 @@ Use the link button in the canvas toolbar to copy this link without opening a
 menu. The button has a "Copy link to canvas" tooltip, like the session link
 button. "Copy link" also remains in the canvas options menu.
 
-In the left sidebar, right-click a session or canvas and select **Copy link**.
-Sessions copy the channel thread link. Canvases copy the canvas link.
-The row's options menu has the same action. Copying a link does not change access permissions.
-
 | Segment | Required | Description |
 |---|---|---|
 | `<channelId>` | Yes | Channel (folder) row id the canvas lives under. |

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.test.tsx
@@ -4,6 +4,7 @@ import {
   DEFAULT_CHANNEL_ITEM_GROUPING,
   DEFAULT_CHANNEL_ITEM_SORT,
 } from "@posthog/core/canvas/channelItems";
+import { useAuthStore } from "@posthog/ui/features/auth/store";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { Theme } from "@radix-ui/themes";
 import { fireEvent, render, screen } from "@testing-library/react";
@@ -57,6 +58,15 @@ vi.mock("@posthog/ui/features/canvas/components/ChannelsFab", () => ({
 // the same reason.
 vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
   useChannels: () => ({ channels: [] }),
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useFileTaskToChannel", () => ({
+  useFileTaskToChannel: () => vi.fn(),
+}));
+vi.mock("@posthog/ui/features/browser-tabs/useOpenBrowserTab", () => ({
+  useOpenBrowserTab: () => vi.fn(),
+}));
+vi.mock("@posthog/ui/shell/analytics", () => ({
+  track: vi.fn(),
 }));
 vi.mock("@posthog/ui/features/auth/authClient", () => ({
   useOptionalAuthenticatedClient: () => null,
@@ -141,6 +151,43 @@ describe("ChannelSidebar", () => {
     mocks.pathname = "/spaces/channel-1";
     mocks.channelReportsFlag = false;
   });
+
+  it.each([
+    ["task", "Sessions", "/code/channel/channel-1/tasks/item-1"],
+    ["canvas", "Canvases", "/code/canvas/channel-1/item-1"],
+  ] as const)(
+    "copies the %s link from its context menu",
+    async (kind, tab, path) => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
+      const writeText = vi
+        .spyOn(navigator.clipboard, "writeText")
+        .mockResolvedValue();
+      const previousAuth = useAuthStore.getState().authState;
+      useAuthStore.setState({
+        authState: { ...previousAuth, cloudRegion: "us" },
+      });
+      mocks.items = [
+        item({
+          key: `${kind}:item-1`,
+          kind,
+          id: "item-1",
+          title: "Example item",
+        }),
+      ];
+      try {
+        renderSidebar();
+        await user.click(screen.getByRole("tab", { name: tab }));
+        fireEvent.contextMenu(screen.getByText("Example item"));
+        await user.click(
+          await screen.findByRole("menuitem", { name: "Copy link" }),
+        );
+        expect(writeText).toHaveBeenCalledWith(`https://us.posthog.com${path}`);
+      } finally {
+        useAuthStore.setState({ authState: previousAuth });
+        writeText.mockRestore();
+      }
+    },
+  );
 
   it.each([
     {

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
@@ -4,6 +4,7 @@ import {
   CaretRightIcon,
   DotsThreeIcon,
   FolderSimpleIcon,
+  LinkIcon,
   MagnifyingGlassIcon,
   PencilSimpleIcon,
   PushPinIcon,
@@ -34,6 +35,8 @@ import type { Task } from "@posthog/shared/domain-types";
 import { useOpenBrowserTab } from "@posthog/ui/features/browser-tabs/useOpenBrowserTab";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useFileTaskToChannel } from "@posthog/ui/features/canvas/hooks/useFileTaskToChannel";
+import { copyCanvasLink } from "@posthog/ui/features/canvas/utils/copyCanvasLink";
+import { copyChannelLink } from "@posthog/ui/features/canvas/utils/copyChannelLink";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useSidebarPeekStore } from "@posthog/ui/features/sidebar/sidebarPeekStore";
 import { useHoldSidebarPeek } from "@posthog/ui/features/sidebar/useHoldSidebarPeek";
@@ -181,6 +184,20 @@ function TaskRowMenuItems({
       >
         <ArrowSquareOutIcon size={14} />
         Open in new tab
+      </Item>
+      <Item
+        disabled={!menu.channelId}
+        onClick={() => {
+          if (!menu.channelId) return;
+          if (isTask) {
+            void copyChannelLink(menu.channelId, "sidebar", menu.id);
+          } else {
+            void copyCanvasLink(menu.channelId, menu.id, "sidebar");
+          }
+        }}
+      >
+        <LinkIcon size={14} />
+        Copy link
       </Item>
       <Item onClick={menu.onTogglePin}>
         {menu.isPinned ? (


### PR DESCRIPTION
## Problem

Desktop users cannot copy a session or canvas link from its sidebar menu.

**Why:** Users need to share an item without first opening it.

## Changes

- Add **Copy link** to session and canvas row menus, including the right-click menu.
- Reuse the existing link actions, success messages, and error messages. Access permissions stay unchanged.

Shared menu preview from Storybook:

![Sidebar copy link](https://raw.githubusercontent.com/PostHog/pr-assets/68466b3ec5bf2768f61ce51fe635db2eb446ec1d/2026/09/3adfd62e-1ea5-4ad3-9c77-06e7675e3d48.png)

## How did you test this code?

- Run the sidebar tests. New cases check the clipboard URL after a right-click on each item type.
- Run the UI type check, scoped Biome checks, and `hogli ci:preflight --fix`.
- Render the shared menu in Storybook with headless Chromium. No live-account Electron check.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Documentation changes are not needed for this menu action.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Codex used shell tools, Playwright, and signed Git tools. Skills: posthog-desktop, writing-ui-components, writing-tests, writing-pr-descriptions, and writing-simplified-technical-english.

The open PR search found no matching change. The screenshot uses an existing repository story, not customer data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

