### PR TITLE
fix(desktop): focus comments from the full input area

### DIFF
--- a/products/desktop/docs/TESTING.md
+++ b/products/desktop/docs/TESTING.md
@@ -35,6 +35,19 @@ E2E-test:
 
 Rule: if Electron is not required, write a unit test.
 
+## Comment Input Focus
+
+In the right-panel comment input, click an empty area below the placeholder or
+beside the send button. The editor must receive focus so you can type. Clicking
+existing text must keep the selected caret position. Send and cancel buttons must
+keep their own actions.
+
+Run the focus and submission checks with:
+
+```bash
+pnpm --filter @posthog/ui test src/features/sessions/components/CommentComposer.integration.test.tsx
+```
+
 ## File Location
 
 - Unit tests colocate with source as `.test.ts` or `.test.tsx`.

--- a/products/desktop/packages/ui/src/features/canvas/components/MentionComposer.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/MentionComposer.tsx
@@ -296,7 +296,17 @@ export function MentionComposer({
           </div>
         </div>
       )}
-      <InputGroup className="h-auto cursor-text bg-card">
+      <InputGroup
+        className="h-auto cursor-text bg-card"
+        onClick={(event) => {
+          if (
+            event.target instanceof Element &&
+            !event.target.closest("button, [contenteditable]")
+          ) {
+            editor?.commands.focus("end");
+          }
+        }}
+      >
         <div
           data-slot="input-group-control"
           className={`quill-input-group__control mention-composer w-full overflow-y-auto p-0 ${inputClassName ?? ""}`}

--- a/products/desktop/packages/ui/src/features/sessions/components/CommentComposer.integration.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/CommentComposer.integration.test.tsx
@@ -1,8 +1,57 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { CommentComposer } from "./CommentComposer";
 
-describe("CommentComposer submission", () => {
+describe("CommentComposer", () => {
+  it.each(["input-group", "input-group-control", "input-group-addon"])(
+    "focuses the editor when clicking the empty %s area",
+    async (slot) => {
+      const { container } = render(
+        <CommentComposer
+          value=""
+          onValueChange={vi.fn()}
+          onSubmit={vi.fn()}
+          members={[]}
+          placeholder="Comment"
+        />,
+      );
+
+      const area = container.querySelector(`[data-slot="${slot}"]`);
+      expect(area).not.toBeNull();
+      fireEvent.click(area as Element);
+
+      await waitFor(() =>
+        expect(container.querySelector(".ProseMirror")).toHaveFocus(),
+      );
+    },
+  );
+
+  it.each(["Comment", "Cancel"])(
+    "keeps focus on the %s button when clicked",
+    async (label) => {
+      const onSubmit = vi.fn();
+      const onCancel = vi.fn();
+      render(
+        <CommentComposer
+          value="Check this"
+          onValueChange={vi.fn()}
+          onSubmit={onSubmit}
+          onCancel={onCancel}
+          members={[]}
+          placeholder="Comment"
+        />,
+      );
+
+      const button = screen.getByRole("button", { name: label });
+      button.focus();
+      fireEvent.click(button.querySelector("svg") as SVGElement);
+      await new Promise(requestAnimationFrame);
+
+      expect(button).toHaveFocus();
+      expect(label === "Comment" ? onSubmit : onCancel).toHaveBeenCalledOnce();
+    },
+  );
+
   it.each(["enter", "send"] as const)(
     "submits the current comment with %s",
     (input) => {

--- a/products/desktop/packages/ui/src/features/sessions/components/CommentComposer.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/CommentComposer.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { CommentComposer } from "./CommentComposer";
+
+const meta = {
+  title: "Sessions/CommentComposer",
+  component: CommentComposer,
+  parameters: { layout: "centered" },
+  args: {
+    value: "",
+    members: [],
+    placeholder: "Add a comment…",
+    onValueChange: () => {},
+    onSubmit: () => {},
+  },
+  render: function Composer(args) {
+    const [value, setValue] = useState(args.value);
+    return (
+      <div className="w-80">
+        <CommentComposer
+          {...args}
+          value={value}
+          onValueChange={setValue}
+          onSubmit={() => setValue("")}
+        />
+      </div>
+    );
+  },
+} satisfies Meta<typeof CommentComposer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {};
+export const WithText: Story = { args: { value: "Check the updated layout." } };


### PR DESCRIPTION
## Problem

Empty areas in the right-panel comment input do not accept focus.

**Why:** Users must be able to click the visible input area and start typing without aiming at the placeholder.

## Changes

- Clicking empty space in the comment input now focuses the editor.
- Text clicks keep their caret position. Send and cancel buttons keep their actions.
- Regression tests, Storybook examples, and test instructions support the fix.

Before: a click beside the send button does not focus the editor.

![Before](https://raw.githubusercontent.com/PostHog/pr-assets/599b63fa97c7955959884415865bf1dffb9f07c8/2026/09/9bb2733b-89d8-4667-a5f9-8082312d9b04.png)

After: the same click lets the user type.

![After](https://raw.githubusercontent.com/PostHog/pr-assets/76f65724637f295b1c17d94dbcec39d823104942/2026/09/d7ce62d2-50a0-45f1-8250-7eb732ca0ef2.png)

## How did you test this code?

- New focus tests failed before the fix and passed after it. Existing comment tests also passed.
- Chromium checks in Storybook confirmed empty-area focus, typing, caret preservation, and submission.
- Biome and preflight passed. Preflight skipped root TypeScript complexity and Markdown checks because root dependencies are absent.
- The full Electron app was not tested.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated `products/desktop/docs/TESTING.md` with the expected behavior and regression command.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

No matching open issue or duplicate pull request was found. Tests and screenshots use invented text, with no customer data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
