### PR TITLE
fix(tasks): restore older resource comments

### DIFF
--- a/docs/internal/task-comments.md
+++ b/docs/internal/task-comments.md
@@ -1,0 +1,19 @@
+# Task comments
+
+The desktop comments panel reads task, artifact, and canvas comments from
+`/api/projects/{project_id}/comments/`. Each request supplies `scope`, `item_id`,
+and `task_id`.
+
+## Older resource comments
+
+Older artifact and canvas comments can have no `taskId` in `item_context`.
+An authorized resource query includes these comments, including rows with a null
+context or a missing, null, or empty `taskId`. The API still checks task visibility
+and verifies that the resource belongs to the requested task. Comments with a
+stored non-empty `taskId` for another task remain excluded. Requests without an
+owning task do not return task-scoped comments.
+
+A reply keeps its root comment's target and context. If an older resource comment
+has no task ID, the reply can supply one. The API checks access to that task and
+resource before it saves the reply. A reply cannot replace a root's existing task
+ID. No stored comment is changed during a read.

--- a/posthog/api/comments.py
+++ b/posthog/api/comments.py
@@ -393,6 +393,13 @@ class CommentSerializer(serializers.ModelSerializer):
             # working, but a reply's own signal keys must survive the merge.
             data["item_context"] = {
                 **{key: value for key, value in root_context.items() if key != "threadState"},
+                **(
+                    {"taskId": reply_context["taskId"]}
+                    if root.scope in {"task_artifact", "desktop_canvas"}
+                    and not root_context.get("taskId")
+                    and reply_context.get("taskId")
+                    else {}
+                ),
                 **({"is_emoji": reply_context["is_emoji"]} if "is_emoji" in reply_context else {}),
                 **(
                     {"threadState": reply_context["threadState"]}
@@ -929,7 +936,13 @@ class CommentViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelV
                 ):
                     return queryset.none()
                 if scope != "task":
-                    queryset = queryset.filter(item_context__taskId=str(task_id))
+                    queryset = queryset.filter(
+                        Q(item_context__taskId=str(task_id))
+                        | Q(item_context__isnull=True)
+                        | ~Q(item_context__has_key="taskId")
+                        | Q(item_context__taskId=None)
+                        | Q(item_context__taskId="")
+                    )
         elif self.action in ("list", "count"):
             # Product-owned scopes require their own object-level access checks and must
             # never leak through an unscoped generic comments query.

--- a/posthog/api/test/test_comments.py
+++ b/posthog/api/test/test_comments.py
@@ -76,7 +76,17 @@ class TestComments(APIBaseTest, QueryMatchingTest):
         )
         return task
 
-    def test_task_artifact_comments_require_a_visible_owning_task(self) -> None:
+    @parameterized.expand(
+        [
+            ("null_context", None),
+            ("missing_task_id", {"anchor": {"kind": "document"}}),
+            ("null_task_id", {"taskId": None}),
+            ("empty_task_id", {"taskId": ""}),
+        ]
+    )
+    def test_task_artifact_comments_require_a_visible_owning_task(
+        self, _name: str, legacy_context: dict[str, object] | None
+    ) -> None:
         task = self._task_artifact_target()
         payload: dict[str, Any] = {
             "content": "Review this",
@@ -87,6 +97,23 @@ class TestComments(APIBaseTest, QueryMatchingTest):
 
         created = self.client.post(f"/api/projects/{self.team.id}/comments", payload)
         assert created.status_code == status.HTTP_201_CREATED
+        legacy = Comment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            scope="task_artifact",
+            item_id="artifact-1",
+            item_context=legacy_context,
+            content="Review the earlier output",
+        )
+        other_task = self._task_artifact_target()
+        Comment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            scope="task_artifact",
+            item_id="artifact-1",
+            item_context={"taskId": str(other_task.id)},
+            content="A different task's comment",
+        )
         without_task = self.client.get(f"/api/projects/{self.team.id}/comments?scope=task_artifact&item_id=artifact-1")
         assert without_task.json()["results"] == []
         unscoped = self.client.get(f"/api/projects/{self.team.id}/comments?item_id=artifact-1")
@@ -94,7 +121,15 @@ class TestComments(APIBaseTest, QueryMatchingTest):
         with_task = self.client.get(
             f"/api/projects/{self.team.id}/comments?scope=task_artifact&item_id=artifact-1&task_id={task.id}"
         )
-        assert [row["id"] for row in with_task.json()["results"]] == [created.json()["id"]]
+        assert {row["id"] for row in with_task.json()["results"]} == {created.json()["id"], str(legacy.id)}
+
+        reply = self.client.post(
+            f"/api/projects/{self.team.id}/comments",
+            {**payload, "source_comment": str(legacy.id), "content": "Updated the earlier output"},
+        )
+        assert reply.status_code == status.HTTP_201_CREATED
+        assert reply.json()["source_comment"] == str(legacy.id)
+        assert reply.json()["item_context"] == {**(legacy_context or {}), "taskId": str(task.id)}
 
     @mock.patch("posthog.api.comments.send_mention_notifications")
     @mock.patch("posthog.api.comments.produce_discussion_mention_events")
@@ -509,6 +544,21 @@ class TestComments(APIBaseTest, QueryMatchingTest):
             "item_context": {"anchor": {"kind": "document"}, "taskId": str(task.id)},
         }
         assert self.client.post(f"/api/projects/{self.team.id}/comments", payload).status_code == 403
+        legacy = Comment.objects.create(
+            team=self.team,
+            created_by=other,
+            scope="task_artifact",
+            item_id="artifact-1",
+            content="Earlier private comment",
+        )
+        query = f"/api/projects/{self.team.id}/comments?scope=task_artifact&item_id=artifact-1&task_id={task.id}"
+        assert self.client.get(query).json()["results"] == []
+        assert (
+            self.client.post(
+                f"/api/projects/{self.team.id}/comments", {**payload, "source_comment": str(legacy.id)}
+            ).status_code
+            == 403
+        )
 
         visible_task = self._task_artifact_target()
         payload["item_context"]["taskId"] = str(visible_task.id)
@@ -570,10 +620,18 @@ class TestComments(APIBaseTest, QueryMatchingTest):
         created = self.client.post(f"/api/projects/{self.team.id}/comments", payload)
 
         assert created.status_code == status.HTTP_201_CREATED
+        legacy = Comment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            scope="desktop_canvas",
+            item_id=str(canvas.id),
+            item_context={"anchor": {"kind": "document"}},
+            content="Review the earlier canvas",
+        )
         with_task = self.client.get(
             f"/api/projects/{self.team.id}/comments?scope=desktop_canvas&item_id={canvas.id}&task_id={task.id}"
         )
-        assert [row["id"] for row in with_task.json()["results"]] == [created.json()["id"]]
+        assert {row["id"] for row in with_task.json()["results"]} == {created.json()["id"], str(legacy.id)}
         task_activity_model = apps.get_model("tasks", "TaskCommentActivity")
         assert (
             task_activity_model.objects.unscoped()


### PR DESCRIPTION
## Problem

Older artifact and canvas comments do not appear in the desktop comments panel.

**Why:** Users need to read and reply to earlier feedback when they reopen a task.

## Changes

- Show older resource comments after the existing task and resource access checks pass.
- Allow replies to supply a missing task ID without replacing a root comment's existing task ID.
- The remaining changes add regression coverage and document the API behavior.

## How did you test this code?

- Reproduced the failure before the fix with four stored-context variants.
- Extended existing tests for older comments, replies, canvas ownership, and denied access.
- Ran `hogli test posthog/api/test/test_comments.py -k 'task or canvas or reply'` and `hogli ci:preflight --fix` successfully.
- No desktop UI test or full mypy run. API schemas and generated types remain unchanged.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Added `docs/internal/task-comments.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex used shell, GitHub CLI, and signed-commit tools. Searches found no matching open PR or issue.
- Skills: `/posthog-desktop`, `/writing-tests`, `/improving-drf-endpoints`, `/maintaining-python-tests`, `/hogli`, `/running-ci-preflight`, `/writing-user-facing-copy`, `/announcing-behavior-changes`, and `/writing-pr-descriptions`.
- Diagnosis used repository code and synthetic test data. No customer data appears in this change.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
