### PR TITLE
chore(notebooks): report which legacy content migrations still run

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/migrations/migrate.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/migrations/migrate.test.ts
@@ -1073,8 +1073,6 @@ describe('migrate()', () => {
         await expect(migrate(prevNotebook)).resolves.toEqual(nextNotebook)
     })
 
-    // `migrate` runs on every notebook load, so a report on a load that repaired nothing, or one
-    // naming the wrong converter, would keep a dead converter alive or delete a load bearing one.
     const legacyMigrationReports: [string, JSONContent[], NotebookLegacyMigration[] | null][] = [
         ['nothing for content that holds no legacy shape', [{ type: 'paragraph' }], null],
         [

--- a/frontend/src/scenes/notebooks/Notebook/migrations/migrate.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/migrations/migrate.test.ts
@@ -1,3 +1,5 @@
+import posthog from 'posthog-js'
+
 import { JSONContent } from 'lib/components/RichContentEditor/types'
 import { NotebookType } from 'scenes/notebooks/types'
 
@@ -8,7 +10,7 @@ import { initKeaTests } from '~/test/init'
 import { AccessControlLevel } from '~/types'
 
 import mockNotebook from '../__mocks__/notebook-12345.json'
-import { migrate } from './migrate'
+import { migrate, NotebookLegacyMigration } from './migrate'
 
 describe('migrate()', () => {
     beforeEach(() => {
@@ -1069,5 +1071,59 @@ describe('migrate()', () => {
         }
 
         await expect(migrate(prevNotebook)).resolves.toEqual(nextNotebook)
+    })
+
+    // `migrate` runs on every notebook load, so a report on a load that repaired nothing, or one
+    // naming the wrong converter, would keep a dead converter alive or delete a load bearing one.
+    const legacyMigrationReports: [string, JSONContent[], NotebookLegacyMigration[] | null][] = [
+        ['nothing for content that holds no legacy shape', [{ type: 'paragraph' }], null],
+        [
+            'the trends converter for a legacy trends filter',
+            [
+                {
+                    type: 'ph-query',
+                    attrs: {
+                        query: {
+                            kind: NodeKind.InsightVizNode,
+                            source: {
+                                kind: NodeKind.TrendsQuery,
+                                series: [],
+                                trendsFilter: { compare: true, show_values_on_series: true },
+                            },
+                        },
+                    },
+                },
+            ],
+            ['trends_filter'],
+        ],
+        [
+            'both converters for a stringified query that holds a legacy breakdown',
+            [
+                {
+                    type: 'ph-query',
+                    attrs: {
+                        query: '{"kind":"InsightVizNode","source":{"kind":"TrendsQuery","series":[],"breakdown":{"breakdown_type":"event","breakdown":"$browser"}}}',
+                    },
+                },
+            ],
+            ['breakdown_filter', 'query_string_to_object'],
+        ],
+    ]
+
+    it.each(legacyMigrationReports)('reports %s', async (_name, content, expectedMigrations) => {
+        const captureSpy = jest.spyOn(posthog, 'capture').mockReturnValue(undefined as any)
+
+        const notebook: NotebookType = {
+            ...mockNotebook,
+            user_access_level: AccessControlLevel.Editor,
+            content: { type: 'doc', content },
+        }
+
+        await migrate(notebook, { skipApiUpgrade: true })
+
+        const reported = captureSpy.mock.calls
+            .filter(([event]) => event === 'notebook_legacy_migration_applied')
+            .map(([, properties]) => (properties as any).migrations)
+        expect(reported).toEqual(expectedMigrations ? [expectedMigrations] : [])
     })
 })

--- a/frontend/src/scenes/notebooks/Notebook/migrations/migrate.ts
+++ b/frontend/src/scenes/notebooks/Notebook/migrations/migrate.ts
@@ -1,4 +1,5 @@
 import { JSONContent } from '@tiptap/core'
+import posthog from 'posthog-js'
 
 import api from 'lib/api'
 import { isEmptyObject } from 'lib/utils/guards'
@@ -47,6 +48,21 @@ import { convertMarkdownTablesInContent } from './convertMarkdownTablesInContent
 // is filtered through the migrate function below that ensures integrity
 export const NOTEBOOKS_VERSION = '3'
 
+// The names `migrate` reports in `notebook_legacy_migration_applied`. A name that never gets
+// reported marks a converter, and a `filtersToQueryNode` export, that no stored notebook needs.
+export type NotebookLegacyMigration =
+    | 'insight_to_query_node'
+    | 'query_string_to_object'
+    | 'playlist_filters_to_universal_filters'
+    | 'trends_filter'
+    | 'funnels_filter'
+    | 'funnels_exclusion'
+    | 'retention_filter'
+    | 'paths_filter'
+    | 'stickiness_filter'
+    | 'lifecycle_filter'
+    | 'breakdown_filter'
+
 export interface MigrateOptions {
     /**
      * Skips the query migrate step which issues a POST request to the backend which will result
@@ -62,11 +78,22 @@ export async function migrate(notebook: NotebookType, options: MigrateOptions = 
         return notebook
     }
 
-    content = convertInsightToQueryNode(content)
-    content = convertInsightQueryStringsToObjects(content)
-    content = convertInsightQueriesToNewSchema(content)
-    content = convertPlaylistFiltersToUniversalFilters(content)
+    const applied = new Set<NotebookLegacyMigration>()
+
+    content = convertInsightToQueryNode(content, applied)
+    content = convertInsightQueryStringsToObjects(content, applied)
+    content = convertInsightQueriesToNewSchema(content, applied)
+    content = convertPlaylistFiltersToUniversalFilters(content, applied)
     content = convertMarkdownTablesInContent(content)
+
+    // Report before the upgrade request, so a failing request does not lose the measurement.
+    if (applied.size > 0) {
+        posthog.capture('notebook_legacy_migration_applied', {
+            migrations: Array.from(applied).sort(),
+            short_id: notebook.short_id,
+        })
+    }
+
     if (!options.skipApiUpgrade) {
         content = await upgradeQueryNode(content)
     }
@@ -74,7 +101,10 @@ export async function migrate(notebook: NotebookType, options: MigrateOptions = 
     return { ...notebook, content: { type: 'doc', content: content } }
 }
 
-function convertPlaylistFiltersToUniversalFilters(content: JSONContent[]): JSONContent[] {
+function convertPlaylistFiltersToUniversalFilters(
+    content: JSONContent[],
+    applied: Set<NotebookLegacyMigration>
+): JSONContent[] {
     return content.map((node) => {
         if (node.type != NotebookNodeType.RecordingPlaylist) {
             return node
@@ -89,6 +119,8 @@ function convertPlaylistFiltersToUniversalFilters(content: JSONContent[]): JSONC
         if (universalFilters) {
             return node
         }
+
+        applied.add('playlist_filters_to_universal_filters')
 
         const jsonFilters = typeof filters === 'string' ? JSON.parse(filters) : filters
         const jsonSimpleFilters = typeof simpleFilters === 'string' ? JSON.parse(simpleFilters) : simpleFilters
@@ -105,11 +137,13 @@ function convertPlaylistFiltersToUniversalFilters(content: JSONContent[]): JSONC
     })
 }
 
-function convertInsightToQueryNode(content: JSONContent[]): JSONContent[] {
+function convertInsightToQueryNode(content: JSONContent[], applied: Set<NotebookLegacyMigration>): JSONContent[] {
     return content.map((node) => {
         if (node.type != 'ph-insight') {
             return node
         }
+
+        applied.add('insight_to_query_node')
 
         return {
             ...node,
@@ -122,7 +156,10 @@ function convertInsightToQueryNode(content: JSONContent[]): JSONContent[] {
     })
 }
 
-function convertInsightQueryStringsToObjects(content: JSONContent[]): JSONContent[] {
+function convertInsightQueryStringsToObjects(
+    content: JSONContent[],
+    applied: Set<NotebookLegacyMigration>
+): JSONContent[] {
     return content.map((node) => {
         if (
             !(
@@ -134,6 +171,8 @@ function convertInsightQueryStringsToObjects(content: JSONContent[]): JSONConten
         ) {
             return node
         }
+
+        applied.add('query_string_to_object')
 
         let query
 
@@ -162,7 +201,10 @@ function convertInsightQueryStringsToObjects(content: JSONContent[]): JSONConten
     })
 }
 
-function convertInsightQueriesToNewSchema(content: JSONContent[]): JSONContent[] {
+function convertInsightQueriesToNewSchema(
+    content: JSONContent[],
+    applied: Set<NotebookLegacyMigration>
+): JSONContent[] {
     return content.map((node) => {
         if (
             !(
@@ -183,6 +225,8 @@ function convertInsightQueriesToNewSchema(content: JSONContent[]): JSONContent[]
          * Insight filters
          */
         if (query.kind === NodeKind.TrendsQuery && isLegacyTrendsFilter(query.trendsFilter as any)) {
+            applied.add('trends_filter')
+
             const compareFilter = compareFilterToQuery(query.trendsFilter as any)
             if (!isEmptyObject(compareFilter)) {
                 query.compareFilter = compareFilter
@@ -200,8 +244,10 @@ function convertInsightQueriesToNewSchema(content: JSONContent[]): JSONContent[]
 
         if (query.kind === NodeKind.FunnelsQuery) {
             if (isLegacyFunnelsFilter(query.funnelsFilter as any)) {
+                applied.add('funnels_filter')
                 query.funnelsFilter = funnelsFilterToQuery(query.funnelsFilter as any)
             } else if (isLegacyFunnelsExclusion(query.funnelsFilter as any)) {
+                applied.add('funnels_exclusion')
                 query.funnelsFilter = {
                     ...query.funnelsFilter,
                     exclusions: query.funnelsFilter!.exclusions!.map((entity) =>
@@ -212,14 +258,18 @@ function convertInsightQueriesToNewSchema(content: JSONContent[]): JSONContent[]
         }
 
         if (query.kind === NodeKind.RetentionQuery && isLegacyRetentionFilter(query.retentionFilter as any)) {
+            applied.add('retention_filter')
             query.retentionFilter = retentionFilterToQuery(query.retentionFilter as any)
         }
 
         if (query.kind === NodeKind.PathsQuery && isLegacyPathsFilter(query.pathsFilter as any)) {
+            applied.add('paths_filter')
             query.pathsFilter = pathsFilterToQuery(query.pathsFilter as any)
         }
 
         if (query.kind === NodeKind.StickinessQuery && isLegacyStickinessFilter(query.stickinessFilter as any)) {
+            applied.add('stickiness_filter')
+
             const compareFilter = compareFilterToQuery(query.stickinessFilter as any)
             if (!isEmptyObject(compareFilter)) {
                 query.compareFilter = compareFilter
@@ -236,6 +286,7 @@ function convertInsightQueriesToNewSchema(content: JSONContent[]): JSONContent[]
         }
 
         if (query.kind === NodeKind.LifecycleQuery && isLegacyLifecycleFilter(query.lifecycleFilter as any)) {
+            applied.add('lifecycle_filter')
             query.lifecycleFilter = lifecycleFilterToQuery(query.lifecycleFilter as any)
         }
 
@@ -243,6 +294,7 @@ function convertInsightQueriesToNewSchema(content: JSONContent[]): JSONContent[]
          * Breakdown
          */
         if ((query.kind === NodeKind.TrendsQuery || query.kind === NodeKind.FunnelsQuery) && 'breakdown' in query) {
+            applied.add('breakdown_filter')
             query.breakdownFilter = breakdownFilterToQuery(query.breakdown as any, query.kind === NodeKind.TrendsQuery)
             delete query.breakdown
         }

--- a/frontend/src/scenes/notebooks/Notebook/migrations/migrate.ts
+++ b/frontend/src/scenes/notebooks/Notebook/migrations/migrate.ts
@@ -48,8 +48,7 @@ import { convertMarkdownTablesInContent } from './convertMarkdownTablesInContent
 // is filtered through the migrate function below that ensures integrity
 export const NOTEBOOKS_VERSION = '3'
 
-// The names `migrate` reports in `notebook_legacy_migration_applied`. A name that never gets
-// reported marks a converter, and a `filtersToQueryNode` export, that no stored notebook needs.
+// The names reported in `notebook_legacy_migration_applied`. A name nothing reports marks a dead converter.
 export type NotebookLegacyMigration =
     | 'insight_to_query_node'
     | 'query_string_to_object'


### PR DESCRIPTION
## Problem

Removing the legacy insight filters is stuck on nine converter exports that nobody can show are dead.

- `frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts` exports nine sub-converters whose only consumer outside that file is notebook `migrate.ts`.
- `migrate` repairs four legacy content shapes on every notebook load, and no event recorded whether any of them fired.
- `legacy_filters_to_query_node_called` does not cover this path. It fires from the top level `filtersToQueryNode`, which notebooks never call.
- The data warehouse holds no mirror of `posthog_notebook`, so nothing outside the browser answered the question either.

## Changes

- Nothing looks different in a notebook. The migration output is unchanged, so there is no screenshot to show.
- `migrate` now reports `notebook_legacy_migration_applied` once per load, with a `migrations` array and the notebook `short_id`.
- A load that repairs nothing reports nothing. The event count therefore follows stored legacy content rather than notebook traffic.
- The report goes out before the `query/upgrade` request, so a failed request cannot lose it.
- The `migrations` array holds eleven possible names, one per legacy shape, which separates the three content converters from the eight filter branches.
- Moving the nine converters into the notebooks folder would not free `filtersToQueryNode.ts`. Sixteen other non-test files import non-legacy helpers from it, `actionsAndEventsToSeries` alone in thirteen.
- Threading an `applied` set through the four converter signatures is mechanical.

## How did you test this code?

- Extended `migrate.test.ts` with three cases over the reported set: content with no legacy shape, an object query with a legacy trends filter, and a stringified query with a legacy breakdown.
- The regression each catches: a report on a load that repaired nothing would make the event track notebook traffic, and a wrong name would retire a converter that is still load bearing. No existing case asserted anything about the event.
- Not checked: a clean repo-wide typecheck. `tsgo --noEmit` in this sandbox fails on the unbuilt `@posthog/quill` and `@posthog/hogvm` workspaces, with no error in either changed file.
- Not checked: the event reaching a real project. Nothing here ran in a browser.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior, API, or config changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code, in a Claude Code on the web session, linked below. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- No duplicate: a search of open PRs for notebook migration and `filtersToQueryNode` work found nothing covering this.
- The session also ran a census of stored notebook content in PostHog's own project, which found none of the eleven shapes. That is evidence for dropping the converters, not proof for other projects, which is why this PR measures rather than deletes.
- The eleven names started as one flag per converter file. They ended up one per legacy shape so the eight filter branches report separately, since each maps to a different `filtersToQueryNode` export.
- Public artifact: the test fixtures come from the key lists in `frontend/src/queries/nodes/InsightQuery/utils/legacy.ts`. Nothing in the diff comes from a customer conversation, ticket, or log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014J1g84MbsNVgQfMVuhuVtt

---
_Generated by [Claude Code](https://claude.ai/code/session_014J1g84MbsNVgQfMVuhuVtt)_