### PR TITLE
feat(desktop): act on a task from its activity row

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/AGENTS.md
+++ b/products/desktop/packages/ui/src/features/canvas/AGENTS.md
@@ -236,6 +236,12 @@ changing breadcrumbs, canvas naming, or the canvas generation harness. The root
   filters into `/inbox/reports` before opening it.
   Picking a preview report stays on `/activity` and renders that already-loaded
   report beside the feed while its detail query refreshes in the background.
+- **An activity row acts on its task from the same menu the spaces surfaces use.** `useActivityTaskMenu` builds one `TaskRowMenuProps` per row and `ActivityRow` hangs it off a `TaskRowDropdownMenu`, beside the mark-read and copy-link buttons the row already reveals on hover, so pin, "Add to Command Center", "File to…" and Archive can't drift from the space lists.
+  Rename, hand off and analysis are the items the feed drops: the first needs an inline editor the feed has no row for, and the other two need the task itself, which an activity row does not carry.
+  The actions are built once for the feed and handed to the rows, the way `useSpaceTaskActions` serves the tree — one pin and one archive mutation for the page instead of one per row.
+  The hover actions overlay the row's right edge, because the row is a button and they cannot sit inside it, so the row reserves a trailing lane sized to how many it is showing.
+- **Activity drops archived tasks, the way a space's lists do.** Archive is local to the machine, so the server's activity read model still returns their rows; `deriveActivityFeedContent` filters them out of what it renders, which is also what makes archiving from a row legible.
+  Unreads stay whole, because "Mark all as read" acts on them and an archived task's unread update still counts against the badge.
 - **Which pane shows is view state, not a route.** `channelPaneStore` holds it,
   separately from the scoped channel (`currentChannelStore`): "back to channels"
   browses the list while the route, the main pane and the scoped channel stay

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityFeedList.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityFeedList.test.tsx
@@ -90,6 +90,9 @@ vi.mock("@posthog/quill", async (importOriginal) => ({
     </button>
   ),
 }));
+vi.mock("@posthog/ui/features/archive/useArchivedTaskIds", () => ({
+  useArchivedTaskIds: () => new Set<string>(),
+}));
 vi.mock("@posthog/ui/features/auth/authClient", () => ({
   useOptionalAuthenticatedClient: () => ({}),
 }));
@@ -202,6 +205,15 @@ vi.mock("@posthog/ui/features/canvas/components/InboxActivityRow", async () => {
     ),
   };
 });
+vi.mock("@posthog/ui/features/canvas/hooks/useActivityTaskMenu", () => ({
+  useActivityTaskMenu: () => (item: TaskActivityItem) => ({
+    kind: "task",
+    id: item.taskId,
+    title: item.taskTitle,
+    isPinned: false,
+    onTogglePin: vi.fn(),
+  }),
+}));
 vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
   useChannels: () => ({ channels: [] }),
 }));

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityFeedList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityFeedList.tsx
@@ -14,6 +14,7 @@ import {
 } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { SignalReport } from "@posthog/shared/types";
+import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { ActivityActionsMenu } from "@posthog/ui/features/canvas/components/ActivityActionsMenu";
@@ -23,6 +24,7 @@ import { InboxActivityOverflowRow } from "@posthog/ui/features/canvas/components
 import { InboxActivityRow } from "@posthog/ui/features/canvas/components/InboxActivityRow";
 import { openActivityItem } from "@posthog/ui/features/canvas/components/openActivityItem";
 import { SidebarSearchHeader } from "@posthog/ui/features/canvas/components/SidebarSearchHeader";
+import { useActivityTaskMenu } from "@posthog/ui/features/canvas/hooks/useActivityTaskMenu";
 import { useBlockedTaskIds } from "@posthog/ui/features/canvas/hooks/useBlockedSessionCount";
 import { useInboxActivityPreview } from "@posthog/ui/features/canvas/hooks/useInboxActivityPreview";
 import { useLocalDayStart } from "@posthog/ui/features/canvas/hooks/useLocalDayStart";
@@ -68,6 +70,7 @@ export function ActivityFeedList({
   });
   const taskActivity = useTaskActivity({ enabled: mentionsIncluded });
   const inboxActivity = useInboxActivityPreview();
+  const archivedTaskIds = useArchivedTaskIds();
   const {
     unreadItems,
     feedItems,
@@ -83,6 +86,7 @@ export function ActivityFeedList({
         mentionsIncluded,
         reportsIncluded: inboxActivity.isIncluded,
         unreadsOnly,
+        archivedTaskIds,
       }),
     [
       taskActivity.items,
@@ -91,6 +95,7 @@ export function ActivityFeedList({
       inboxActivity.isIncluded,
       mentionsIncluded,
       unreadsOnly,
+      archivedTaskIds,
     ],
   );
   const unreadCount = mentionsIncluded ? taskActivity.unreadCount : 0;
@@ -99,6 +104,8 @@ export function ActivityFeedList({
     (!unreadsOnly && inboxActivity.isLoading);
   // Selected once for the feed, not once per row.
   const blockedTaskIds = useBlockedTaskIds();
+  // One pin and one archive mutation for the feed, for the same reason.
+  const taskMenu = useActivityTaskMenu();
   const [scrollRoot, setScrollRoot] = useState<HTMLDivElement | null>(null);
   const [query, setQuery] = useState("");
   const [loadMoreRef, loadMoreInView] = useInView<HTMLDivElement>({
@@ -229,6 +236,7 @@ export function ActivityFeedList({
                       {item.kind === "task" ? (
                         <ActivityRow
                           item={item.task}
+                          menu={taskMenu(item.task)}
                           onMarkRead={markRead}
                           currentUser={currentUser}
                           blockedTaskIds={blockedTaskIds}

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityRow.test.tsx
@@ -1,5 +1,5 @@
 import type { TaskActivityItem } from "@posthog/core/canvas/taskActivity";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const navigation = vi.hoisted(() => ({
@@ -14,6 +14,20 @@ vi.mock("@posthog/ui/router/navigationBridge", () => ({
   navigateToTaskDetail: navigation.toTaskDetail,
 }));
 vi.mock("@posthog/ui/shell/analytics", () => ({ track: vi.fn() }));
+vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
+  useFeatureFlag: () => true,
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
+  useChannels: () => ({
+    channels: [{ id: "channel-1", name: "Personal space", starred: false }],
+  }),
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useFileTaskToChannel", () => ({
+  useFileTaskToChannel: () => vi.fn(),
+}));
+vi.mock("@posthog/ui/features/browser-tabs/useOpenBrowserTab", () => ({
+  useOpenBrowserTab: () => vi.fn(),
+}));
 
 import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
 import { ActivityRow } from "./ActivityRow";
@@ -39,14 +53,17 @@ function item(overrides: Partial<TaskActivityItem>): TaskActivityItem {
 
 const NO_BLOCKED_TASKS: ReadonlySet<string> = new Set();
 
-const MENU: TaskRowMenuProps = {
-  kind: "task",
-  id: "task-1",
-  title: "Say hello",
-  isPinned: false,
-  onTogglePin: vi.fn(),
-  onArchive: vi.fn(),
-};
+function taskMenu(overrides: Partial<TaskRowMenuProps> = {}): TaskRowMenuProps {
+  return {
+    kind: "task",
+    id: "task-1",
+    title: "Say hello",
+    isPinned: false,
+    onTogglePin: vi.fn(),
+    onArchive: vi.fn(),
+    ...overrides,
+  };
+}
 
 describe("ActivityRow", () => {
   beforeEach(() => {
@@ -68,7 +85,7 @@ describe("ActivityRow", () => {
   it("leads a completed activity row with the task title", () => {
     render(
       <ActivityRow
-        menu={MENU}
+        menu={taskMenu()}
         item={item({
           activityKind: "completed",
           taskTitle: "Tell me a joke",
@@ -111,7 +128,7 @@ describe("ActivityRow", () => {
       render(
         <ActivityRow
           item={item({ isUnread })}
-          menu={MENU}
+          menu={taskMenu()}
           onMarkRead={vi.fn()}
           onActivate={vi.fn()}
           blockedTaskIds={NO_BLOCKED_TASKS}
@@ -121,9 +138,48 @@ describe("ActivityRow", () => {
 
       const row = screen.getByText("Say hello").closest("button");
       expect(row).toHaveClass("py-1.5", laneClass);
-      expect(screen.getByLabelText("Options for Say hello")).toBeVisible();
+      expect(
+        screen.getByLabelText("Options for Say hello"),
+      ).toBeInTheDocument();
     },
   );
+
+  it("offers the row's task actions from its options menu", async () => {
+    // Real timers: the menu's open transition and `waitFor` both need a clock.
+    vi.useRealTimers();
+    const onArchive = vi.fn();
+    render(
+      <ActivityRow
+        item={item({})}
+        menu={taskMenu({ onArchive })}
+        onMarkRead={vi.fn()}
+        onActivate={vi.fn()}
+        blockedTaskIds={NO_BLOCKED_TASKS}
+      />,
+    );
+
+    fireEvent.mouseDown(screen.getByLabelText("Options for Say hello"), {
+      button: 0,
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText("Archive")).toBeInTheDocument(),
+    );
+    for (const label of [
+      "Open in new tab",
+      "Pin",
+      "Add to Command Center…",
+      "File to…",
+      "Archive",
+    ]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+    // A rename edits the row in place, and the feed has no inline editor.
+    expect(screen.queryByText("Rename")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Archive"));
+    expect(onArchive).toHaveBeenCalledOnce();
+  });
 
   it("opens an activity mention at its exact comment thread", () => {
     const activity = item({
@@ -142,7 +198,7 @@ describe("ActivityRow", () => {
     render(
       <ActivityRow
         item={activity}
-        menu={MENU}
+        menu={taskMenu()}
         onMarkRead={vi.fn()}
         onActivate={openActivityItem}
         blockedTaskIds={NO_BLOCKED_TASKS}

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityRow.test.tsx
@@ -18,6 +18,7 @@ vi.mock("@posthog/ui/shell/analytics", () => ({ track: vi.fn() }));
 import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
 import { ActivityRow } from "./ActivityRow";
 import { openActivityItem } from "./openActivityItem";
+import type { TaskRowMenuProps } from "./TaskRowMenu";
 
 function item(overrides: Partial<TaskActivityItem>): TaskActivityItem {
   return {
@@ -37,6 +38,15 @@ function item(overrides: Partial<TaskActivityItem>): TaskActivityItem {
 }
 
 const NO_BLOCKED_TASKS: ReadonlySet<string> = new Set();
+
+const MENU: TaskRowMenuProps = {
+  kind: "task",
+  id: "task-1",
+  title: "Say hello",
+  isPinned: false,
+  onTogglePin: vi.fn(),
+  onArchive: vi.fn(),
+};
 
 describe("ActivityRow", () => {
   beforeEach(() => {
@@ -58,6 +68,7 @@ describe("ActivityRow", () => {
   it("leads a completed activity row with the task title", () => {
     render(
       <ActivityRow
+        menu={MENU}
         item={item({
           activityKind: "completed",
           taskTitle: "Tell me a joke",
@@ -92,14 +103,15 @@ describe("ActivityRow", () => {
   });
 
   it.each([
-    { label: "unread", isUnread: true, hasActionPadding: true },
-    { label: "read", isUnread: false, hasActionPadding: false },
+    { label: "unread", isUnread: true, laneClass: "pr-14" },
+    { label: "read", isUnread: false, laneClass: "pr-8" },
   ])(
-    "reserves trailing room for a compact $label row only when it has a read action",
-    ({ isUnread, hasActionPadding }) => {
+    "reserves a compact $label row's trailing lane for the actions it shows",
+    ({ isUnread, laneClass }) => {
       render(
         <ActivityRow
           item={item({ isUnread })}
+          menu={MENU}
           onMarkRead={vi.fn()}
           onActivate={vi.fn()}
           blockedTaskIds={NO_BLOCKED_TASKS}
@@ -108,9 +120,8 @@ describe("ActivityRow", () => {
       );
 
       const row = screen.getByText("Say hello").closest("button");
-      expect(row).toHaveClass("py-1.5");
-      expect(row).not.toHaveClass("pr-10");
-      expect(row?.classList.contains("pr-8")).toBe(hasActionPadding);
+      expect(row).toHaveClass("py-1.5", laneClass);
+      expect(screen.getByLabelText("Options for Say hello")).toBeVisible();
     },
   );
 
@@ -131,6 +142,7 @@ describe("ActivityRow", () => {
     render(
       <ActivityRow
         item={activity}
+        menu={MENU}
         onMarkRead={vi.fn()}
         onActivate={openActivityItem}
         blockedTaskIds={NO_BLOCKED_TASKS}

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityRow.tsx
@@ -16,6 +16,10 @@ import {
   activityPresentation,
 } from "@posthog/ui/features/canvas/components/activityPresentation";
 import { MentionText } from "@posthog/ui/features/canvas/components/MentionText";
+import {
+  TaskRowDropdownMenu,
+  type TaskRowMenuProps,
+} from "@posthog/ui/features/canvas/components/TaskRowMenu";
 import { copyChannelLink } from "@posthog/ui/features/canvas/utils/copyChannelLink";
 import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
 import { track } from "@posthog/ui/shell/analytics";
@@ -42,8 +46,15 @@ function AgentActivityIcon({
   }
 }
 
+// How much of the row's right edge its actions take, by how many it is showing.
+// They overlay the row — it is a button, so they can't sit inside it — and the
+// title and metadata need a lane clear of them.
+const ACTION_LANE_CLASS = ["pr-8", "pr-14", "pr-20"];
+
 interface ActivityRowProps {
   item: TaskActivityItem;
+  /** The row's task actions, built once for the feed by `useActivityTaskMenu`. */
+  menu: TaskRowMenuProps;
   onMarkRead: (item: TaskActivityItem) => void;
   currentUser?: UserBasic | null;
   blockedTaskIds: ReadonlySet<string>;
@@ -57,6 +68,7 @@ interface ActivityRowProps {
 
 export function ActivityRow({
   item,
+  menu,
   onMarkRead,
   currentUser,
   blockedTaskIds,
@@ -78,6 +90,8 @@ export function ActivityRow({
     item.isUnread && !awaitsReply
       ? "bg-primary text-primary-foreground"
       : undefined;
+  const canCopyLink = channelId !== null && !compact;
+  const actionCount = 1 + (item.isUnread ? 1 : 0) + (canCopyLink ? 1 : 0);
   const openTask = (): void => {
     track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
       action_type: "open_task",
@@ -105,7 +119,7 @@ export function ActivityRow({
         left
         className={cn(
           compact ? "py-1.5" : "py-2",
-          compact && item.isUnread && "pr-8",
+          ACTION_LANE_CLASS[actionCount - 1],
           isSelected && "bg-fill-selected",
         )}
       >
@@ -162,31 +176,34 @@ export function ActivityRow({
           )}
         </span>
       </ActivityRowSurface>
-      {item.isUnread && (
-        <Button
-          variant="default"
-          size="icon-xs"
-          aria-label="Mark as read"
-          title="Mark as read"
-          className={`absolute opacity-0 transition-opacity group-hover:opacity-100 ${compact ? "top-2 right-2" : `top-2 ${channelId ? "right-9" : "right-2"}`}`}
-          onClick={() => onMarkRead(item)}
-        >
-          <CheckIcon size={14} />
-        </Button>
-      )}
-      {channelId && !compact && (
-        <Button
-          variant="default"
-          size="icon-xs"
-          aria-label="Copy thread link"
-          className="absolute top-2 right-2 opacity-0 transition-opacity group-hover:opacity-100"
-          onClick={() =>
-            void copyChannelLink(channelId, "activity", item.taskId)
-          }
-        >
-          <LinkIcon size={14} />
-        </Button>
-      )}
+      {/* An open menu keeps the cluster visible after the pointer has left the
+          row, which the trigger already states as data-popup-open. */}
+      <div className="absolute top-2 right-2 flex items-center gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 has-[[data-popup-open]]:opacity-100">
+        {item.isUnread && (
+          <Button
+            variant="default"
+            size="icon-xs"
+            aria-label="Mark as read"
+            title="Mark as read"
+            onClick={() => onMarkRead(item)}
+          >
+            <CheckIcon size={14} />
+          </Button>
+        )}
+        {canCopyLink && (
+          <Button
+            variant="default"
+            size="icon-xs"
+            aria-label="Copy thread link"
+            onClick={() =>
+              void copyChannelLink(channelId, "activity", item.taskId)
+            }
+          >
+            <LinkIcon size={14} />
+          </Button>
+        )}
+        <TaskRowDropdownMenu menu={menu} />
+      </div>
     </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
@@ -11,6 +11,7 @@ import {
   Spinner,
 } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { ActivityActionsMenu } from "@posthog/ui/features/canvas/components/ActivityActionsMenu";
@@ -19,6 +20,7 @@ import { ActivityUnreadsToggle } from "@posthog/ui/features/canvas/components/Ac
 import { InboxActivityOverflowRow } from "@posthog/ui/features/canvas/components/InboxActivityOverflowRow";
 import { InboxActivityRow } from "@posthog/ui/features/canvas/components/InboxActivityRow";
 import { openActivityItem } from "@posthog/ui/features/canvas/components/openActivityItem";
+import { useActivityTaskMenu } from "@posthog/ui/features/canvas/hooks/useActivityTaskMenu";
 import { useBlockedTaskIds } from "@posthog/ui/features/canvas/hooks/useBlockedSessionCount";
 import { useInboxActivityPreview } from "@posthog/ui/features/canvas/hooks/useInboxActivityPreview";
 import { useLocalDayStart } from "@posthog/ui/features/canvas/hooks/useLocalDayStart";
@@ -53,6 +55,7 @@ export function ActivityView() {
   });
   const taskActivity = useTaskActivity({ enabled: mentionsIncluded });
   const inboxActivity = useInboxActivityPreview();
+  const archivedTaskIds = useArchivedTaskIds();
   const {
     unreadItems,
     feedItems,
@@ -68,6 +71,7 @@ export function ActivityView() {
         mentionsIncluded,
         reportsIncluded: inboxActivity.isIncluded,
         unreadsOnly,
+        archivedTaskIds,
       }),
     [
       taskActivity.items,
@@ -76,6 +80,7 @@ export function ActivityView() {
       inboxActivity.isIncluded,
       mentionsIncluded,
       unreadsOnly,
+      archivedTaskIds,
     ],
   );
   const unreadCount = mentionsIncluded ? taskActivity.unreadCount : 0;
@@ -84,6 +89,8 @@ export function ActivityView() {
     (!unreadsOnly && inboxActivity.isLoading);
   // Selected once for the feed, not once per row.
   const blockedTaskIds = useBlockedTaskIds();
+  // One pin and one archive mutation for the feed, for the same reason.
+  const taskMenu = useActivityTaskMenu();
   const { mutate: markTasksRead, isPending: isMarkingRead } =
     useMarkTaskActivityRead();
   const dayStart = useLocalDayStart();
@@ -162,6 +169,7 @@ export function ActivityView() {
                   {item.kind === "task" ? (
                     <ActivityRow
                       item={item.task}
+                      menu={taskMenu(item.task)}
                       onMarkRead={markRead}
                       onActivate={openActivityItem}
                       currentUser={currentUser}

--- a/products/desktop/packages/ui/src/features/canvas/components/activityFeed.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/components/activityFeed.test.ts
@@ -87,6 +87,7 @@ describe("activityFeed", () => {
       mentionsIncluded: true,
       reportsIncluded: true,
       unreadsOnly: true,
+      archivedTaskIds: new Set(),
     });
 
     expect(content.feedItems).toEqual([]);
@@ -94,4 +95,33 @@ describe("activityFeed", () => {
     expect(content.remainingInboxReportCount).toBe(0);
     expect(content.selfDrivingIncluded).toBe(false);
   });
+
+  it.each([{ unreadsOnly: false }, { unreadsOnly: true }])(
+    "hides an archived task's activity but still lets it be marked read (unreadsOnly $unreadsOnly)",
+    ({ unreadsOnly }) => {
+      const activity = (id: string, taskId: string): TaskActivityItem =>
+        ({
+          id,
+          taskId,
+          isUnread: true,
+          activityAt: "2026-08-25T10:00:00Z",
+        }) as TaskActivityItem;
+
+      const content = deriveActivityFeedContent({
+        taskItems: [activity("live", "task-1"), activity("gone", "task-2")],
+        reports: [],
+        totalReportCount: 0,
+        mentionsIncluded: true,
+        reportsIncluded: false,
+        unreadsOnly,
+        archivedTaskIds: new Set(["task-2"]),
+      });
+
+      expect(content.feedItems.map((item) => item.id)).toEqual(["task:live"]);
+      expect(content.unreadItems.map((item) => item.id)).toEqual([
+        "live",
+        "gone",
+      ]);
+    },
+  );
 });

--- a/products/desktop/packages/ui/src/features/canvas/components/activityFeed.ts
+++ b/products/desktop/packages/ui/src/features/canvas/components/activityFeed.ts
@@ -55,17 +55,15 @@ export function deriveActivityFeedContent({
     (item) => !archivedTaskIds.has(item.taskId),
   );
   const visibleReports = unreadsOnly ? [] : reports;
+  const visibleTaskItems = mentionsIncluded
+    ? unreadsOnly
+      ? getUnreadActivityItems(shownItems)
+      : shownItems
+    : [];
 
   return {
     unreadItems,
-    feedItems: mergeActivityFeedItems(
-      mentionsIncluded
-        ? unreadsOnly
-          ? getUnreadActivityItems(shownItems)
-          : shownItems
-        : [],
-      visibleReports,
-    ),
+    feedItems: mergeActivityFeedItems(visibleTaskItems, visibleReports),
     lastShownReportId: visibleReports.at(-1)?.id ?? null,
     remainingInboxReportCount: Math.max(
       0,

--- a/products/desktop/packages/ui/src/features/canvas/components/activityFeed.ts
+++ b/products/desktop/packages/ui/src/features/canvas/components/activityFeed.ts
@@ -37,6 +37,7 @@ export function deriveActivityFeedContent({
   mentionsIncluded,
   reportsIncluded,
   unreadsOnly,
+  archivedTaskIds,
 }: {
   taskItems: TaskActivityItem[];
   reports: SignalReport[];
@@ -44,14 +45,25 @@ export function deriveActivityFeedContent({
   mentionsIncluded: boolean;
   reportsIncluded: boolean;
   unreadsOnly: boolean;
+  /** Archived tasks, which the feed drops the way a space's lists do. */
+  archivedTaskIds: ReadonlySet<string>;
 }): ActivityFeedContent {
+  // Unreads stay whole: this is also what "Mark all as read" acts on, and an
+  // archived task's unread update still counts against the badge.
   const unreadItems = getUnreadActivityItems(taskItems);
+  const shownItems = taskItems.filter(
+    (item) => !archivedTaskIds.has(item.taskId),
+  );
   const visibleReports = unreadsOnly ? [] : reports;
 
   return {
     unreadItems,
     feedItems: mergeActivityFeedItems(
-      mentionsIncluded ? (unreadsOnly ? unreadItems : taskItems) : [],
+      mentionsIncluded
+        ? unreadsOnly
+          ? getUnreadActivityItems(shownItems)
+          : shownItems
+        : [],
       visibleReports,
     ),
     lastShownReportId: visibleReports.at(-1)?.id ?? null,

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useActivityTaskMenu.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useActivityTaskMenu.ts
@@ -1,0 +1,59 @@
+import type { TaskActivityItem } from "@posthog/core/canvas/taskActivity";
+import { useArchiveTask } from "@posthog/ui/features/archive/useArchiveTask";
+import type { TaskRowMenuProps } from "@posthog/ui/features/canvas/components/TaskRowMenu";
+import { useCommandCenterStore } from "@posthog/ui/features/command-center/commandCenterStore";
+import { placeTaskInCommandCenter } from "@posthog/ui/features/command-center/placeTaskInCommandCenter";
+import { usePinnedTasks } from "@posthog/ui/features/sidebar/usePinnedTasks";
+import { toast } from "@posthog/ui/primitives/toast";
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * What an activity row can do to its task, from the definition the space's own
+ * lists and feed cards use, so the actions can't drift between them.
+ *
+ * Three items stay behind. Rename edits a row in place and the feed has no
+ * inline editor; hand off and analysis need the task itself, which an activity
+ * row doesn't carry — it holds one update about a task, not the task.
+ *
+ * Built once for the feed rather than per row: each hook here is a mutation or
+ * a store subscription, and the feed shows a page of rows at a time.
+ */
+export function useActivityTaskMenu(): (
+  item: TaskActivityItem,
+) => TaskRowMenuProps {
+  const { pinnedTaskIds, togglePin } = usePinnedTasks();
+  const { archiveTask } = useArchiveTask();
+  const cells = useCommandCenterStore((state) => state.cells);
+
+  // `archiveTask` is a new function every render, so it goes through a ref to
+  // keep the builder below stable while still calling the current one. The ref
+  // is written after the commit, not during the render, because a render can be
+  // thrown away and a row only reads this from an event handler.
+  const archiveRef = useRef(archiveTask);
+  useEffect(() => {
+    archiveRef.current = archiveTask;
+  });
+
+  return useCallback(
+    (item) => ({
+      kind: "task",
+      id: item.taskId,
+      title: item.taskTitle,
+      isPinned: pinnedTaskIds.has(item.taskId),
+      // Ticks the space the task is already filed to, inside "File to…".
+      channelId: item.channelId ?? undefined,
+      onAddToCommandCenter: cells.includes(item.taskId)
+        ? undefined
+        : () => placeTaskInCommandCenter(item.taskId, item.taskTitle),
+      onTogglePin: () => {
+        togglePin(item.taskId).catch(() => {
+          toast.error("Couldn't update pin");
+        });
+      },
+      onArchive: () => {
+        void archiveRef.current({ taskId: item.taskId });
+      },
+    }),
+    [cells, pinnedTaskIds, togglePin],
+  );
+}

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useActivityTaskMenu.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useActivityTaskMenu.ts
@@ -51,7 +51,9 @@ export function useActivityTaskMenu(): (
         });
       },
       onArchive: () => {
-        void archiveRef.current({ taskId: item.taskId });
+        archiveRef.current({ taskId: item.taskId }).catch(() => {
+          toast.error("Couldn't archive task");
+        });
       },
     }),
     [cells, pinnedTaskIds, togglePin],


### PR DESCRIPTION
## Problem

Reading Activity, you can open a task or mark it read, but you cannot archive it or file it to a space from the feed. Doing either means opening the task or hunting it down in a space list. Activity was the last task list without the row menu the spaces surfaces already carry.

## Changes

- An Activity row now reveals an options menu on hover, beside the mark-read and copy-link buttons it already showed. It offers pin, "Add to Command Center", "File to…" and Archive.
- Archiving from a row takes it out of the feed and shows the same undo toast the space lists show.
- Archived tasks no longer appear in Activity at all, which matches what a space's own lists do. Their unread updates still clear under "Mark all as read".
- Rename, hand off and "Run analysis" stay out of the menu. An activity row holds one update about a task rather than the task, and the feed has no inline editor.
- The menu comes from `TaskRowMenuProps`, the definition the space lists and feed cards use, so the actions cannot drift between the three surfaces.
- Mechanical: the row's hover buttons move into one cluster, and the row reserves a trailing lane sized to how many it shows.

No screenshot: this sandbox has no running desktop app, so the new menu was never rendered on screen. A reviewer should open Activity and check the cluster at the row's right edge, in the page and in the sidebar pane.

## How did you test this code?

- `packages/ui` unit tests for the touched files, plus a typecheck of the package.
- New coverage in `ActivityRow.test.tsx`: opening the row's options menu offers the five actions this surface wires, omits `Rename`, and clicking `Archive` calls the handler. Deleting `TaskRowDropdownMenu` from the row fails this test, which is the regression no existing test caught — `ChannelFeedView.test.tsx` covers the space feed card's menu, not an activity row's.
- New coverage in `activityFeed.test.ts`: an archived task's rows leave the feed while its unread activity stays markable. No existing test filtered archived tasks, in either the unreads-only view or the full one.
- `ActivityRow.test.tsx` also asserts the trailing lane tracks how many actions the row shows. It previously asserted a padding rule that only unread compact rows had.
- A hover-then-assert-visible test is deliberately absent. The reveal is a Tailwind `group-hover` rule, and jsdom loads no stylesheet, so `toBeVisible()` returns true for an `opacity-0` element and hovering changes nothing — such a test passes with the reveal deleted.
- Not run: the app itself, and the full `packages/ui` suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`packages/ui/src/features/canvas/AGENTS.md` records the row menu, the items the feed drops, and the archived-task filter.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by the PostHog Slack app from a Slack thread asking for archive and file from the Activity view.
- Skills invoked: `/writing-pr-descriptions`. Conventions read from `products/desktop/AGENTS.md` and the canvas feature guide.
- The row reuses `TaskRowDropdownMenu`, the ellipsis menu the space feed cards carry, rather than the spaces sidebar's hover preview card. That card needs a `ChannelItemModel` and its provider, and an activity row carries neither, so it would have opened mostly empty.
- Archived filtering was not in the request. Without it, Archive appeared to do nothing, because archive state is local to the machine and the server's activity read model keeps returning the rows.
- No duplicate: a search of open PRs for activity, archive and row-menu keywords found nothing covering this.
- Public artifact: nothing in this PR carries material from the session beyond the request itself.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1788854055595169?thread_ts=1788854055.595169&cid=C0ACRAMJUAG)*

