### PR TITLE
fix(signals): write unseen grade counts as int metadata

### DIFF
--- a/products/signals/dags/inbox_ranking/tests/test_training.py
+++ b/products/signals/dags/inbox_ranking/tests/test_training.py
@@ -21,6 +21,7 @@ from products.signals.dags.inbox_ranking.dataset.dag import LABELS_TABLE, STATE_
 from products.signals.dags.inbox_ranking.training.dag import (
     _delete_other_objects,
     champion_object_key,
+    grade_metadata,
     inbox_ranking_training_examples,
     load_snapshots,
     model_object_key,
@@ -524,6 +525,11 @@ def test_head_grades_report_counts_and_a_null_auc_on_a_single_class():
         graded_rows(_scores(["e"]), _labels(["e"], open_count=[0]), head), head, scoring_partition="2026-08-10"
     )
     assert (single_class.rows, single_class.positives, single_class.auc) == (1, 0, None)
+    # Counts are ints and the null AUC is dropped: the graded asset writes these as Dagster metadata.
+    metadata = grade_metadata([grade])
+    assert metadata["open_candidate_rows"] == dagster.MetadataValue.int(2)
+    assert metadata["open_candidate_auc"] == dagster.MetadataValue.float(1.0)
+    assert "open_candidate_auc" not in grade_metadata([single_class])
 
 
 @pytest.mark.parametrize(

--- a/products/signals/dags/inbox_ranking/training/dag.py
+++ b/products/signals/dags/inbox_ranking/training/dag.py
@@ -28,6 +28,7 @@ grades the model on reports it never saw, and the two are comparable because bot
 
 import json
 import datetime
+from collections.abc import Sequence
 from typing import Any
 
 import pandas as pd
@@ -546,6 +547,20 @@ def inbox_ranking_unseen_scores(context: dagster.AssetExecutionContext) -> None:
     )
 
 
+def grade_metadata(grades: Sequence[HeadGrade]) -> dict[str, dagster.MetadataValue]:
+    """One metadata entry per (head, model, metric). Counts stay ints: `MetadataValue.float` rejects them."""
+    metadata: dict[str, dagster.MetadataValue] = {}
+    for grade in grades:
+        for name, value in grade.metrics().items():
+            if value is None:
+                continue
+            key = f"{grade.head}_{grade.model_role}_{name}"
+            metadata[key] = (
+                dagster.MetadataValue.int(value) if isinstance(value, int) else dagster.MetadataValue.float(value)
+            )
+    return metadata
+
+
 @dagster.asset(
     name="inbox_ranking_unseen_graded",
     deps=[
@@ -597,17 +612,7 @@ def inbox_ranking_unseen_graded(context: dagster.AssetExecutionContext) -> None:
     for head_name, reason in skipped.items():
         context.log.info(f"{head_name}: not graded, {reason}")
 
-    context.add_output_metadata(
-        {
-            **{
-                f"{grade.head}_{grade.model_role}_{name}": dagster.MetadataValue.float(value)
-                for grade in grades
-                for name, value in grade.metrics().items()
-                if value is not None
-            },
-            "skipped_heads": dagster.MetadataValue.json(skipped),
-        }
-    )
+    context.add_output_metadata({**grade_metadata(grades), "skipped_heads": dagster.MetadataValue.json(skipped)})
     capture_training_events(
         context,
         partition_key,

--- a/products/signals/dags/inbox_ranking/training/unseen.py
+++ b/products/signals/dags/inbox_ranking/training/unseen.py
@@ -93,7 +93,7 @@ class HeadGrade:
     # nothing the inbox could not do by sorting on age.
     recency_auc: float | None
 
-    def metrics(self) -> dict[str, float | None]:
+    def metrics(self) -> dict[str, int | float | None]:
         return {
             "rows": self.rows,
             "positives": self.positives,


### PR DESCRIPTION
## Problem

- The inbox ranking training job fails every morning from now on, so no unseen-report grades, candidate promotion metadata, or Slack-visible green run for the self-driving team.
- The `inbox_ranking_unseen_graded` asset from #95239 crashed on its first real grade, the dt=2026-09-07 run ([run fc68e6c7](https://posthog.dagster.cloud/prod-us/runs/fc68e6c7-bb26-46f9-ab99-a1de9ed43402)).
- It wrote every grade metric through `MetadataValue.float`, and Dagster rejects the integer `rows` and `positives` counts.
- The crash happens before the graded events are captured, so the `inbox_ranking_unseen_head_graded` and `inbox_ranking_unseen_report_graded` events never reached project 2.
- Earlier runs passed because no head had reached its grading horizon yet, so the grade list was empty.

## Changes

- The training job completes again and the two graded events flow on every run that has a head at horizon.
- A small `grade_metadata` helper writes counts as int metadata and rates as float metadata. The asset calls it instead of the inline dict comprehension.
- The `HeadGrade.metrics` return type now admits ints, which it already returned. Mechanical.

Nothing user-visible changes.

## How did you test this code?

- Extended `test_head_grades_report_counts_and_a_null_auc_on_a_single_class` to build the Dagster metadata from a grade. It fails on master with the same `ParameterCheckError` the prod run raised.
- Not run: a prod re-run. The dt=2026-09-07 partition of `inbox_ranking_unseen_graded` needs a re-execution from failure after this deploys, or its `open` grade for the 2026-09-04 scores is skipped.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, directed by the assignee during an inbox ranking check-in. Found the failure through the Dagster Plus MCP run logs. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. Duplicate search on open PRs found nothing.

https://claude.ai/code/session_012j5eL6FXPPdmpg7kU3RzDJ
