### PR TITLE
perf(signals): lift repo slug onto the reports list

### DIFF
--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -551,6 +551,12 @@ class SignalReportSerializer(serializers.ModelSerializer):
     dismissal_note = serializers.SerializerMethodField(
         help_text="Free-form note captured alongside the dismissal reason (when present).",
     )
+    repo_slug = serializers.SerializerMethodField(
+        help_text=(
+            "`organization/repository` the report's work targets, from the latest repo-selection "
+            "artefact (when present). Lets list cards show repository context without a per-card fetch."
+        ),
+    )
     is_suggested_reviewer = serializers.BooleanField(read_only=True, default=False)
     source_products = serializers.SerializerMethodField(
         help_text="Distinct source products contributing signals to this report (from ClickHouse).",
@@ -609,6 +615,7 @@ class SignalReportSerializer(serializers.ModelSerializer):
             "already_addressed",
             "dismissal_reason",
             "dismissal_note",
+            "repo_slug",
             "is_suggested_reviewer",
             "source_products",
             "scout_name",
@@ -713,6 +720,31 @@ class SignalReportSerializer(serializers.ModelSerializer):
         if data is None:
             return None
         value = data.get("note")
+        return value if isinstance(value, str) and value else None
+
+    def _get_repo_selection_artefact_data(self, obj: SignalReport) -> dict | None:
+        prefetched = getattr(obj, "prefetched_repo_selection_artefacts", None)
+        if prefetched is not None:
+            art = prefetched[0] if prefetched else None
+        else:
+            art = (
+                obj.artefacts.filter(type=SignalReportArtefact.ArtefactType.REPO_SELECTION)
+                .order_by("-created_at")
+                .first()
+            )
+        if art is None:
+            return None
+        try:
+            data = json.loads(art.content)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return None
+        return data if isinstance(data, dict) else None
+
+    def get_repo_slug(self, obj: SignalReport) -> str | None:
+        data = self._get_repo_selection_artefact_data(obj)
+        if data is None:
+            return None
+        value = data.get("repository")
         return value if isinstance(value, str) and value else None
 
     def get_source_products(self, obj: SignalReport) -> list[str]:

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -1373,6 +1373,37 @@ class TestSignalReportListAPI(APIBaseTest):
         row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
         assert row["dismissal_reason"] == "analysis_wrong"
 
+    def _repo_selection_artefact(self, report: SignalReport, *, repository: str | None, created_at=None):
+        art = SignalReportArtefact(
+            team=self.team,
+            report=report,
+            type=SignalReportArtefact.ArtefactType.REPO_SELECTION,
+            content=json.dumps({"repository": repository, "reason": "pick"}),
+        )
+        art.save()
+        if created_at is not None:
+            SignalReportArtefact.objects.filter(pk=art.pk).update(created_at=created_at)
+        return art
+
+    def test_list_surfaces_latest_repo_slug(self):
+        report = self._create_report()
+        self._repo_selection_artefact(report, repository="acme/old", created_at=timezone.now() - timedelta(days=1))
+        self._repo_selection_artefact(report, repository="acme/new")
+
+        response = self.client.get(self._list_url())
+        assert response.status_code == status.HTTP_200_OK
+        row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
+        assert row["repo_slug"] == "acme/new"
+
+    def test_list_repo_slug_null_without_selection(self):
+        report = self._create_report()
+        self._repo_selection_artefact(report, repository=None)
+
+        response = self.client.get(self._list_url())
+        assert response.status_code == status.HTTP_200_OK
+        row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
+        assert row["repo_slug"] is None
+
 
 class TestAssociatedTaskRunsForReports(APIBaseTest):
     """`SignalReport.associated_task_runs_for_reports` — the batched, page-wide counterpart of

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from datetime import timedelta
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from urllib.parse import urlencode
@@ -56,6 +56,7 @@ from products.signals.backend.task_run_artefacts import (
 )
 from products.signals.backend.views import (
     PR_CI_STATUS_MAX_REPORTS,
+    SignalReportViewSet,
     classify_report_list_client,
     parse_pr_ci_status_report_ids,
 )
@@ -1373,7 +1374,9 @@ class TestSignalReportListAPI(APIBaseTest):
         row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
         assert row["dismissal_reason"] == "analysis_wrong"
 
-    def _repo_selection_artefact(self, report: SignalReport, *, repository: str | None, created_at=None):
+    def _repo_selection_artefact(
+        self, report: SignalReport, *, repository: str | None, created_at: datetime | None = None
+    ) -> SignalReportArtefact:
         art = SignalReportArtefact(
             team=self.team,
             report=report,
@@ -1394,6 +1397,17 @@ class TestSignalReportListAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
         assert row["repo_slug"] == "acme/new"
+
+    def test_list_prefetches_only_latest_repo_selection(self):
+        report = self._create_report()
+        self._repo_selection_artefact(report, repository="acme/old", created_at=timezone.now() - timedelta(days=1))
+        latest = self._repo_selection_artefact(report, repository="acme/new")
+
+        reports = list(
+            SignalReportViewSet()._prefetch_signal_report_priority_artefacts(SignalReport.objects.filter(pk=report.pk))
+        )
+
+        assert reports[0].prefetched_repo_selection_artefacts == [latest]
 
     def test_list_repo_slug_null_without_selection(self):
         report = self._create_report()

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -1541,6 +1541,13 @@ class SignalReportViewSet(
                 ),
                 to_attr="prefetched_dismissal_artefacts",
             ),
+            Prefetch(
+                "artefacts",
+                queryset=SignalReportArtefact.objects.filter(
+                    type=SignalReportArtefact.ArtefactType.REPO_SELECTION
+                ).order_by("-created_at"),
+                to_attr="prefetched_repo_selection_artefacts",
+            ),
         )
 
     def _annotate_is_suggested_reviewer(self, queryset):
@@ -2621,6 +2628,10 @@ class SignalReportViewSet(
                 )
                 if is_wrong_repo:
                     self._apply_wrong_repo_selection(report, corrected_repository)
+                    # The wrong-repo path just wrote a new repo_selection artefact; drop the
+                    # stale prefetch so a follow-up serializer reads the corrected/cleared slug.
+                    if hasattr(report, "prefetched_repo_selection_artefacts"):
+                        del report.prefetched_repo_selection_artefacts
                 # The dismissal prefetch may have been evaluated before this artefact
                 # existed; drop the stale cache so a follow-up serializer re-reads the
                 # just-written reason/note instead of the previous (or empty) dismissal.

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -1545,7 +1545,7 @@ class SignalReportViewSet(
                 "artefacts",
                 queryset=SignalReportArtefact.objects.filter(
                     type=SignalReportArtefact.ArtefactType.REPO_SELECTION
-                ).order_by("-created_at"),
+                ).order_by("-created_at")[:1],
                 to_attr="prefetched_repo_selection_artefacts",
             ),
         )

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -281,6 +281,11 @@ export interface SignalReportApi {
      * @nullable
      */
     readonly dismissal_note: string | null
+    /**
+     * `organization/repository` the report's work targets, from the latest repo-selection artefact (when present). Lets list cards show repository context without a per-card fetch.
+     * @nullable
+     */
+    readonly repo_slug: string | null
     readonly is_suggested_reviewer: boolean
     /** Distinct source products contributing signals to this report (from ClickHouse). */
     readonly source_products: readonly string[]

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -58027,6 +58027,11 @@ export namespace Schemas {
          * @nullable
          */
       readonly dismissal_note: string | null;
+      /**
+         * `organization/repository` the report's work targets, from the latest repo-selection artefact (when present). Lets list cards show repository context without a per-card fetch.
+         * @nullable
+         */
+      readonly repo_slug: string | null;
       readonly is_suggested_reviewer: boolean;
       /** Distinct source products contributing signals to this report (from ClickHouse). */
       readonly source_products: readonly string[];


### PR DESCRIPTION
## Problem

A person opening the Self-driving inbox waits while each report card fetches its own artefacts just to show one thing: the repository the report targets. The reports list does not carry that repository, so the desktop reads it from every report's full artefacts through a separate request per card. On a full inbox page that is one extra request per card, and the calls are not small.

This backend change adds the field so the client can drop that per-card fetch. The desktop change that stops fetching ships separately, because the desktop auto-updates on its own schedule and must not read a field before it is live.

## Changes

- The reports list response now carries `repo_slug`: the `organization/repository` the report targets, read from the latest repo-selection artefact, or null when there is none.
- The list query prefetches that artefact, so the new field keeps the list at one query instead of adding an N+1.
- A wrong-repo dismissal rewrites the selection in the same request; the stale prefetch is dropped afterward so a follow-up serialize reads the corrected or cleared slug.
- Mechanical: this mirrors the artefact lift the list already does for `priority`, `actionability`, and the dismissal reason.

No user-visible change ships in this PR on its own; it is the field the inbox will read.

## How did you test this code?

- Added two list cases in `TestSignalReportListAPI`: the newest repo-selection artefact wins over an older one, and a selection with no repository serializes as null. These guard the field reading the wrong artefact type, the wrong content key, or losing latest-wins ordering.
- Not run locally: the database-backed test suite and the OpenAPI type regeneration, because this machine has no Postgres. Both run in CI. The generated frontend types under `products/signals/frontend/generated/` still need the regeneration, so the generated-types check will flag this branch until it runs against a database.
- Python syntax, `ruff` lint, and `ruff format` pass on all three changed files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The inbox architecture guide already documents this artefact-lift pattern; the new field follows it and needs no doc change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Desktop). Invoked the `/improving-drf-endpoints` and `/writing-tests` skills. The N+1 was measured from an inbox-open HAR: 82 per-card `artefacts/` requests, about 3.6MB, fired on open. This PR is the first of a pair; the desktop follow-up removes the per-card fetch once the field is deployed.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
