### PR TITLE
fix(desktop): left-align the saved search title

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/SavedSearchSwitcher.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/SavedSearchSwitcher.tsx
@@ -31,6 +31,7 @@ export function SavedSearchSwitcher({
             type="button"
             variant="default"
             size="sm"
+            left
             aria-label="Switch saved search"
             className={cn("-ml-1.5 min-w-0 shrink gap-1 px-1.5", className)}
           >


### PR DESCRIPTION
## Problem

In PostHog Desktop, the saved search title in the task list header showed in the middle of the row. It moved as the title got longer, and it did not align with the query line and the search box below it.

## Changes

- The saved search title and its caret now stay at the left edge of the header row.
- The same title in the feed home header aligns the same way, because both use one component.
- Mechanical: the switcher trigger button gets the `left` variant, which sets `justify-start`.

## How did you test this code?

- `pnpm exec vitest run src/features/canvas/components/SavedSearchSwitcher.test.tsx` in `products/desktop/packages/ui` passes.

## 🤖 Agent context

The trigger is a Quill `Button`, which centers its content. The header gives the trigger `flex-1`, so the label got centered in the free space. The fix uses the same `left` prop that the query bar button below it already uses.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
