### PR TITLE
fix(devex): forget squash addons rows when restoring a schema dump

### DIFF
--- a/tools/hogli-commands/hogli_commands/db_schema.py
+++ b/tools/hogli-commands/hogli_commands/db_schema.py
@@ -35,6 +35,7 @@ DOCKER_COMPOSE = ["docker", "compose", "-f", "docker-compose.dev.yml"]
 DB_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,62}$")
 PRODUCT_DB_ROUTING_PATH = Path("products/db_routing.yaml")
 APP_LABEL_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+SQUASH_SCHEMA_ADDONS_NAME_PATTERN = r"%\_squash\_%\_schema\_addons"
 
 T = TypeVar("T")
 
@@ -198,6 +199,11 @@ def _forget_product_app_migrations(target_db: str) -> None:
     environment that configures no product database then applies their NEXT migration for real
     and dies on the missing table. Clearing the rows lets each consumer replay them under its own
     routing: a no-op where the app is routed away, real tables where it isn't.
+
+    The squash schema-addons migrations go with them. Each one depends on the leaf squash of every
+    squashed app, the product-routed apps included, so a database that keeps an addons row while
+    its dependency row is gone fails Django's consistency check before `migrate` does anything.
+    Replay is cheap: the addons operations probe the schema and skip what is already there.
     """
     app_labels = _product_routed_app_labels()
     if not app_labels:
@@ -217,7 +223,8 @@ def _forget_product_app_migrations(target_db: str) -> None:
             "posthog",
             target_db,
             "-c",
-            f"DELETE FROM django_migrations WHERE app IN ({in_list});",
+            f"DELETE FROM django_migrations WHERE app IN ({in_list}) "
+            f"OR name LIKE '{SQUASH_SCHEMA_ADDONS_NAME_PATTERN}';",
         ]
     )
 

--- a/tools/hogli-commands/hogli_commands/tests/test_db_schema.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_db_schema.py
@@ -307,7 +307,9 @@ def test_restore_schema_dump_recreate_drops_and_creates(tmp_path: Path, monkeypa
 def test_restore_schema_dump_forgets_product_app_migrations(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # The dump comes from a database that routes product apps elsewhere, so it records their
     # migrations as applied without ever creating their tables. Left in place, the next product
-    # migration is applied for real here and fails on the missing table.
+    # migration is applied for real here and fails on the missing table. The squash schema-addons
+    # rows must go too: they depend on the product apps' leaf squashes, so keeping them while the
+    # product rows are gone fails Django's migration consistency check.
     schema_path = tmp_path / "schema.sql.gz"
     _write_schema(schema_path)
     commands: list[list[str]] = []
@@ -324,6 +326,7 @@ def test_restore_schema_dump_forgets_product_app_migrations(tmp_path: Path, monk
     assert app_labels, "expected products/db_routing.yaml to route at least one app"
     for app_label in app_labels:
         assert f"'{app_label}'" in deletes[0]
+    assert r"name LIKE '%\_squash\_%\_schema\_addons'" in deletes[0]
 
 
 def test_restore_schema_dump_recreate_cleans_up_after_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem

- Every Playwright E2E job fails since the migration squash merged (#91646), on master ([run](https://github.com/PostHog/posthog/actions/runs/34206267216)) and on every PR, and `hogli db:restore-schema` breaks a developer's database the same way.
- `migrate` stops before it applies anything: `InconsistentMigrationHistory: Migration ai_observability.0045_squash_2026_09_07_schema_addons is applied before its dependency stamphog.0001_squash_2026_09_07_initial`.
- The dump itself is consistent. `hogli db:restore-schema-fresh` then deletes the `django_migrations` rows of the product-routed apps (stamphog, visual_review, warehouse_sources_queue), so a consumer without product databases replays them under its own routing.
- Since the squash, every generated `schema_addons` migration depends on the leaf squash of every squashed app, the product-routed ones included. Keeping those rows while their dependency rows are gone is what the check rejects.

## Changes

- The restore now forgets the `*_squash_*_schema_addons` rows together with the product-app rows. The next `migrate` replays the product apps and then the addons in dependency order; the addons only probe the schema and skip, so the replay costs seconds.
- Mechanical: one DELETE clause, one docstring paragraph, one assertion in the existing restore test.

## How did you test this code?

- Restored master's `migrated-schema` artifact into a scratch database, ran the exact DELETE the command now issues, then `migrate`: 30 migrations replay in about 30 s, a second `migrate` is a no-op. Without the addons clause the same restore reproduces the CI error.
- The extended `test_restore_schema_dump_forgets_product_app_migrations` fails if the addons clause is dropped again.
- The Playwright E2E job on this PR primes from today's dump, so it is the live check.
- Not checked: a consumer that routes the product apps to their own databases; there the rows come back as no-op records on `default`, the same as before this PR.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: no doc describes the row forgetting.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code in a session driven by the assignee: [session](https://claude.ai/code/session_01LxRjtiprtqWdH9VNi4JMub). Diagnosis from the failing master job, the cached dump artifact, and a local reproduction; the change was written by an Opus subagent from that diagnosis.
- Skills invoked: `/writing-pr-descriptions`, `/writing-tests`.
- No duplicate: `gh pr list --search` for restore-schema / schema_addons / InconsistentMigrationHistory found no open PR.
- Follow-up in the squash tool, not this PR: `schema_addons` files do not need dependencies on apps that live in another database; removing those edges makes this clause unnecessary.
