### PR TITLE
feat(dashboards): add three-column tile layout

### DIFF
--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -4120,6 +4120,31 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         self.assertEqual(tile1.layouts["xs"]["w"], 1)
         self.assertEqual(tile2.layouts["xs"]["w"], 1)
 
+    def test_reorder_tiles_preserve_legacy_string_layouts_use_defaults(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
+        legacy_tile = DashboardTile.objects.create(
+            dashboard=dashboard,
+            insight=Insight.objects.create(team=self.team, name="Legacy insight"),
+            layouts=json.dumps({"sm": {"x": 0, "y": 0, "w": 12, "h": 8}}),
+        )
+        default_tile = DashboardTile.objects.create(
+            dashboard=dashboard, insight=Insight.objects.create(team=self.team, name="Default insight")
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/reorder_tiles/",
+            {"tile_order": [legacy_tile.pk, default_tile.pk]},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        legacy_tile.refresh_from_db()
+        default_tile.refresh_from_db()
+        self.assertEqual(legacy_tile.layouts["sm"], {"x": 0, "y": 0, "w": 6, "h": 5})
+        self.assertEqual(default_tile.layouts["sm"], {"x": 6, "y": 0, "w": 6, "h": 5})
+        self.assertEqual(legacy_tile.layouts["xs"], {"x": 0, "y": 0, "w": 1, "h": 5})
+        self.assertEqual(default_tile.layouts["xs"], {"x": 0, "y": 5, "w": 1, "h": 5})
+
     def test_reorder_tiles_preserve_packs_mixed_widths(self):
         dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
         insight1 = Insight.objects.create(team=self.team, name="Insight 1")
@@ -4242,6 +4267,218 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         self.assertEqual(tile2.layouts["sm"], expected_second)
         self.assertEqual(tile1.layouts["xs"]["w"], 1)
         self.assertEqual(tile2.layouts["xs"]["w"], 1)
+
+    def test_reorder_tiles_three_column_keeps_legacy_string_layout_text_header_full_width(self) -> None:
+        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
+        header_tile = DashboardTile.objects.create(
+            dashboard=dashboard,
+            text=Text.objects.create(body="# Website health", team=self.team),
+            layouts=json.dumps({"sm": {"x": 0, "y": 0, "w": 6, "h": 1}}),
+        )
+        insight_tiles = [
+            DashboardTile.objects.create(
+                dashboard=dashboard, insight=Insight.objects.create(team=self.team, name=f"Insight {index}")
+            )
+            for index in range(3)
+        ]
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/reorder_tiles/",
+            {"tile_order": [header_tile.pk, *[tile.pk for tile in insight_tiles]], "layout": "three_column"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for tile in [header_tile, *insight_tiles]:
+            tile.refresh_from_db()
+        self.assertEqual(header_tile.layouts["sm"], {"x": 0, "y": 0, "w": 12, "h": 1})
+        self.assertEqual(header_tile.layouts["xs"], {"x": 0, "y": 0, "w": 1, "h": 1})
+        self.assertEqual(
+            [tile.layouts["sm"] for tile in insight_tiles],
+            [
+                {"x": 0, "y": 1, "w": 4, "h": 5},
+                {"x": 4, "y": 1, "w": 4, "h": 5},
+                {"x": 8, "y": 1, "w": 4, "h": 5},
+            ],
+        )
+        self.assertEqual(
+            [tile.layouts["xs"] for tile in insight_tiles],
+            [
+                {"x": 0, "y": 1, "w": 1, "h": 5},
+                {"x": 0, "y": 6, "w": 1, "h": 5},
+                {"x": 0, "y": 11, "w": 1, "h": 5},
+            ],
+        )
+
+    def test_reorder_tiles_three_column_uses_rendered_height_for_layoutless_text(self) -> None:
+        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
+        header_tile = DashboardTile.objects.create(
+            dashboard=dashboard, text=Text.objects.create(body="# Website health", team=self.team)
+        )
+        insight_tile = DashboardTile.objects.create(
+            dashboard=dashboard, insight=Insight.objects.create(team=self.team, name="Insight")
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/reorder_tiles/",
+            {"tile_order": [header_tile.pk, insight_tile.pk], "layout": "three_column"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        header_tile.refresh_from_db()
+        insight_tile.refresh_from_db()
+        self.assertEqual(header_tile.layouts["sm"], {"x": 0, "y": 0, "w": 12, "h": 2})
+        self.assertEqual(header_tile.layouts["xs"], {"x": 0, "y": 0, "w": 1, "h": 2})
+        self.assertEqual(insight_tile.layouts["sm"], {"x": 0, "y": 2, "w": 4, "h": 5})
+        self.assertEqual(insight_tile.layouts["xs"], {"x": 0, "y": 2, "w": 1, "h": 5})
+
+    def test_reorder_tiles_three_column_requires_every_visible_tile(self) -> None:
+        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
+        first_tile = DashboardTile.objects.create(
+            dashboard=dashboard, insight=Insight.objects.create(team=self.team, name="First insight")
+        )
+        missing_tile = DashboardTile.objects.create(
+            dashboard=dashboard, insight=Insight.objects.create(team=self.team, name="Missing insight")
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/reorder_tiles/",
+            {"tile_order": [first_tile.pk], "layout": "three_column"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json()["detail"],
+            "three_column layout requires tile_order to contain exactly the tile IDs returned by dashboard-get. "
+            f"Missing tile IDs: [{missing_tile.pk}]",
+        )
+
+    def test_reorder_tiles_three_column_ignores_deleted_insight_tiles_but_rejects_them_if_submitted(self) -> None:
+        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
+        visible_tile = DashboardTile.objects.create(
+            dashboard=dashboard, insight=Insight.objects.create(team=self.team, name="Visible insight")
+        )
+        deleted_insight = Insight.objects.create(team=self.team, name="Deleted insight")
+        hidden_tile = DashboardTile.objects.create(dashboard=dashboard, insight=deleted_insight)
+        Insight.objects.filter(pk=deleted_insight.pk).update(deleted=True)
+
+        visible_response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/reorder_tiles/",
+            {"tile_order": [visible_tile.pk], "layout": "three_column"},
+            content_type="application/json",
+        )
+        rejected_response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/reorder_tiles/",
+            {"tile_order": [visible_tile.pk, hidden_tile.pk], "layout": "three_column"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(visible_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(rejected_response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            rejected_response.json()["detail"],
+            "three_column layout requires tile_order to contain exactly the tile IDs returned by dashboard-get. "
+            f"Unexpected tile IDs: [{hidden_tile.pk}]",
+        )
+
+    def test_reorder_tiles_three_column_rejections_are_atomic(self) -> None:
+        for case in ("omitted", "hidden", "foreign", "duplicate"):
+            with self.subTest(case=case):
+                dashboard = Dashboard.objects.create(team=self.team, name=f"Dashboard {case}")
+                other_dashboard = Dashboard.objects.create(team=self.team, name=f"Other {case}")
+                first_tile = DashboardTile.objects.create(
+                    dashboard=dashboard,
+                    insight=Insight.objects.create(team=self.team, name=f"First {case}"),
+                    layouts={"sm": {"x": 7, "y": 11, "w": 2, "h": 3}, "xs": {"x": 0, "y": 4, "w": 1, "h": 3}},
+                )
+                second_tile = DashboardTile.objects.create(
+                    dashboard=dashboard,
+                    insight=Insight.objects.create(team=self.team, name=f"Second {case}"),
+                    layouts={"sm": {"x": 1, "y": 2, "w": 8, "h": 4}, "xs": {"x": 0, "y": 9, "w": 1, "h": 4}},
+                )
+                deleted_insight = Insight.objects.create(team=self.team, name=f"Deleted {case}", deleted=True)
+                hidden_tile = DashboardTile.objects.create(
+                    dashboard=dashboard,
+                    insight=deleted_insight,
+                    layouts={"sm": {"x": 3, "y": 6, "w": 6, "h": 2}},
+                )
+                foreign_tile = DashboardTile.objects.create(
+                    dashboard=other_dashboard,
+                    insight=Insight.objects.create(team=self.team, name=f"Foreign {case}"),
+                    layouts={"sm": {"x": 5, "y": 8, "w": 5, "h": 6}},
+                )
+                request_order = {
+                    "omitted": [second_tile.pk],
+                    "hidden": [second_tile.pk, first_tile.pk, hidden_tile.pk],
+                    "foreign": [second_tile.pk, first_tile.pk, foreign_tile.pk],
+                    "duplicate": [second_tile.pk, first_tile.pk, first_tile.pk],
+                }[case]
+                expected_status = {
+                    "omitted": status.HTTP_400_BAD_REQUEST,
+                    "hidden": status.HTTP_400_BAD_REQUEST,
+                    "foreign": status.HTTP_404_NOT_FOUND,
+                    "duplicate": status.HTTP_400_BAD_REQUEST,
+                }[case]
+                expected_layouts = {
+                    tile.pk: tile.layouts for tile in (first_tile, second_tile, hidden_tile, foreign_tile)
+                }
+
+                response = self.client.post(
+                    f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/reorder_tiles/",
+                    {"tile_order": request_order, "layout": "three_column"},
+                    content_type="application/json",
+                )
+
+                self.assertEqual(response.status_code, expected_status)
+                for tile in (first_tile, second_tile, hidden_tile, foreign_tile):
+                    tile.refresh_from_db()
+                    self.assertEqual(tile.layouts, expected_layouts[tile.pk])
+
+    def test_reorder_tiles_three_column_starts_new_rows_around_separator_after_partial_row(self) -> None:
+        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
+        tiles = [
+            DashboardTile.objects.create(
+                dashboard=dashboard, insight=Insight.objects.create(team=self.team, name=f"Insight {index}")
+            )
+            for index in range(6)
+        ]
+        separator = DashboardTile.objects.create(
+            dashboard=dashboard,
+            text=Text.objects.create(body="## Next section", team=self.team),
+            layouts={"sm": {"x": 0, "y": 0, "w": 12, "h": 1}},
+        )
+        ordered_tiles = [*tiles[:2], separator, *tiles[2:]]
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/reorder_tiles/",
+            {"tile_order": [tile.pk for tile in ordered_tiles], "layout": "three_column"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for tile in ordered_tiles:
+            tile.refresh_from_db()
+        self.assertEqual(tiles[0].layouts["sm"], {"x": 0, "y": 0, "w": 4, "h": 5})
+        self.assertEqual(tiles[1].layouts["sm"], {"x": 4, "y": 0, "w": 4, "h": 5})
+        self.assertEqual(separator.layouts["sm"], {"x": 0, "y": 5, "w": 12, "h": 1})
+        self.assertEqual(tiles[2].layouts["sm"], {"x": 0, "y": 6, "w": 4, "h": 5})
+        self.assertEqual(tiles[3].layouts["sm"], {"x": 4, "y": 6, "w": 4, "h": 5})
+        self.assertEqual(tiles[4].layouts["sm"], {"x": 8, "y": 6, "w": 4, "h": 5})
+        self.assertEqual(tiles[5].layouts["sm"], {"x": 0, "y": 11, "w": 4, "h": 5})
+        self.assertEqual(
+            [tile.layouts["xs"] for tile in ordered_tiles],
+            [
+                {"x": 0, "y": 0, "w": 1, "h": 5},
+                {"x": 0, "y": 5, "w": 1, "h": 5},
+                {"x": 0, "y": 10, "w": 1, "h": 1},
+                {"x": 0, "y": 11, "w": 1, "h": 5},
+                {"x": 0, "y": 16, "w": 1, "h": 5},
+                {"x": 0, "y": 21, "w": 1, "h": 5},
+                {"x": 0, "y": 26, "w": 1, "h": 5},
+            ],
+        )
 
     def test_reorder_tiles_invalid_layout_returns_400(self):
         dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -4333,6 +4333,41 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         self.assertEqual(insight_tile.layouts["sm"], {"x": 0, "y": 2, "w": 4, "h": 5})
         self.assertEqual(insight_tile.layouts["xs"], {"x": 0, "y": 2, "w": 1, "h": 5})
 
+    @parameterized.expand(
+        [
+            ("boolean", True),
+            ("string", "2"),
+            ("zero", 0),
+            ("negative", -1),
+        ]
+    )
+    def test_reorder_tiles_three_column_falls_back_for_invalid_saved_separator_height(
+        self, _case: str, saved_height: object
+    ) -> None:
+        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
+        header_tile = DashboardTile.objects.create(
+            dashboard=dashboard,
+            text=Text.objects.create(body="# Website health", team=self.team),
+            layouts={"sm": {"x": 0, "y": 0, "w": 12, "h": saved_height}},
+        )
+        insight_tile = DashboardTile.objects.create(
+            dashboard=dashboard, insight=Insight.objects.create(team=self.team, name="Insight")
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/dashboards/{dashboard.pk}/reorder_tiles/",
+            {"tile_order": [header_tile.pk, insight_tile.pk], "layout": "three_column"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        header_tile.refresh_from_db()
+        insight_tile.refresh_from_db()
+        self.assertEqual(header_tile.layouts["sm"], {"x": 0, "y": 0, "w": 12, "h": 2})
+        self.assertEqual(header_tile.layouts["xs"], {"x": 0, "y": 0, "w": 1, "h": 2})
+        self.assertEqual(insight_tile.layouts["sm"], {"x": 0, "y": 2, "w": 4, "h": 5})
+        self.assertEqual(insight_tile.layouts["xs"], {"x": 0, "y": 2, "w": 1, "h": 5})
+
     def test_reorder_tiles_three_column_requires_every_visible_tile(self) -> None:
         dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
         first_tile = DashboardTile.objects.create(

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -482,7 +482,7 @@ def _three_column_separator_height(tile: DashboardTile) -> int:
             layouts = None
     sm = layouts.get("sm") if isinstance(layouts, dict) else None
     height = sm.get("h") if isinstance(sm, dict) else None
-    return height if isinstance(height, int) and height > 0 else DEFAULT_TEXT_TILE_SIZE.height
+    return height if type(height) is int and height > 0 else DEFAULT_TEXT_TILE_SIZE.height
 
 
 def _apply_reorder_layout(

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -444,6 +444,7 @@ def serialize_tile_with_context(tile, order: int, context: dict) -> tuple[int, d
 class ReorderLayout(StrEnum):
     PRESERVE = "preserve"
     TWO_COLUMN = "two_column"
+    THREE_COLUMN = "three_column"
     FULL_WIDTH = "full_width"
 
 
@@ -458,6 +459,7 @@ class TileSize:
 
 
 DEFAULT_REORDER_TILE_SIZE = TileSize(width=DEFAULT_REORDER_TILE_WIDTH, height=DEFAULT_REORDER_TILE_HEIGHT)
+DEFAULT_TEXT_TILE_SIZE = TileSize(width=DASHBOARD_GRID_COLUMN_COUNT, height=2)
 
 
 def _existing_sm_size(tile: DashboardTile, defaults: TileSize) -> TileSize:
@@ -469,6 +471,18 @@ def _existing_sm_size(tile: DashboardTile, defaults: TileSize) -> TileSize:
         width=w if isinstance(w, int) and w > 0 else defaults.width,
         height=h if isinstance(h, int) and h > 0 else defaults.height,
     )
+
+
+def _three_column_separator_height(tile: DashboardTile) -> int:
+    layouts = tile.layouts
+    if isinstance(layouts, str):
+        try:
+            layouts = json.loads(layouts)
+        except (TypeError, ValueError):
+            layouts = None
+    sm = layouts.get("sm") if isinstance(layouts, dict) else None
+    height = sm.get("h") if isinstance(sm, dict) else None
+    return height if isinstance(height, int) and height > 0 else DEFAULT_TEXT_TILE_SIZE.height
 
 
 def _apply_reorder_layout(
@@ -490,6 +504,34 @@ def _apply_reorder_layout(
                 },
                 "xs": {"x": 0, "y": index * DEFAULT_REORDER_TILE_HEIGHT, "w": 1, "h": DEFAULT_REORDER_TILE_HEIGHT},
             }
+        return
+
+    if layout_mode == ReorderLayout.THREE_COLUMN:
+        sm_y = xs_y = column = 0
+        tile_width = DASHBOARD_GRID_COLUMN_COUNT // 3
+        for tile_id in tile_order:
+            tile = tile_map[tile_id]
+            if tile.text_id is not None:
+                if column:
+                    sm_y += DEFAULT_REORDER_TILE_HEIGHT
+                    column = 0
+                height = _three_column_separator_height(tile)
+                tile.layouts = {
+                    "sm": {"x": 0, "y": sm_y, "w": DASHBOARD_GRID_COLUMN_COUNT, "h": height},
+                    "xs": {"x": 0, "y": xs_y, "w": 1, "h": height},
+                }
+                sm_y += height
+                xs_y += height
+                continue
+            tile.layouts = {
+                "sm": {"x": column * tile_width, "y": sm_y, "w": tile_width, "h": DEFAULT_REORDER_TILE_HEIGHT},
+                "xs": {"x": 0, "y": xs_y, "w": 1, "h": DEFAULT_REORDER_TILE_HEIGHT},
+            }
+            column += 1
+            xs_y += DEFAULT_REORDER_TILE_HEIGHT
+            if column == 3:
+                sm_y += DEFAULT_REORDER_TILE_HEIGHT
+                column = 0
         return
 
     if layout_mode == ReorderLayout.FULL_WIDTH:
@@ -532,7 +574,10 @@ class ReorderTilesRequestSerializer(serializers.Serializer):
     tile_order = serializers.ListField(
         child=serializers.IntegerField(),
         min_length=1,
-        help_text="Array of tile IDs in the desired display order (top to bottom, left to right).",
+        help_text=(
+            "Array of tile IDs in the desired display order (top to bottom, left to right). The 'three_column' "
+            "layout requires exactly the tile IDs returned by dashboard-get."
+        ),
     )
     layout = serializers.ChoiceField(
         choices=[mode.value for mode in ReorderLayout],
@@ -541,7 +586,9 @@ class ReorderTilesRequestSerializer(serializers.Serializer):
         help_text=(
             "How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height "
             "and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per "
-            "row). 'full_width' forces each tile to span the full 12-column row at height 5."
+            "row). 'three_column' requires exactly the tile IDs returned by dashboard-get, packs regular tiles in "
+            "4-wide × 5-tall thirds, and keeps text and image tiles full-width as separators at their saved height "
+            "or height 2 when layoutless. 'full_width' forces each tile to span the full 12-column row at height 5."
         ),
     )
 
@@ -2978,16 +3025,31 @@ class DashboardsViewSet(
                 {"detail": "tile_order must contain unique tile IDs"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+        requested_tile_ids = set(tile_order)
 
         tiles = DashboardTile.objects.filter(dashboard=dashboard, id__in=tile_order)
         tile_map = {tile.id: tile for tile in tiles}
 
-        missing = set(tile_order) - set(tile_map.keys())
+        missing = requested_tile_ids - set(tile_map.keys())
         if missing:
             return Response(
                 {"detail": f"Tile IDs not found on this dashboard: {sorted(missing)}"},
                 status=status.HTTP_404_NOT_FOUND,
             )
+
+        if layout_mode == ReorderLayout.THREE_COLUMN:
+            visible_tile_ids = set(DashboardTile.dashboard_queryset(dashboard.tiles.all()).values_list("id", flat=True))
+            omitted_tile_ids = visible_tile_ids - requested_tile_ids
+            unexpected_tile_ids = requested_tile_ids - visible_tile_ids
+            if omitted_tile_ids or unexpected_tile_ids:
+                detail = (
+                    "three_column layout requires tile_order to contain exactly the tile IDs returned by dashboard-get."
+                )
+                if omitted_tile_ids:
+                    detail += f" Missing tile IDs: {sorted(omitted_tile_ids)}"
+                if unexpected_tile_ids:
+                    detail += f" Unexpected tile IDs: {sorted(unexpected_tile_ids)}"
+                return Response({"detail": detail}, status=status.HTTP_400_BAD_REQUEST)
 
         _apply_reorder_layout(tile_order, tile_map, layout_mode)
 

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -9473,6 +9473,7 @@ export interface PatchedMoveTileRequestApi {
 /**
  * * `preserve` - preserve
  * * `two_column` - two_column
+ * * `three_column` - three_column
  * * `full_width` - full_width
  */
 export type LayoutEnumApi = (typeof LayoutEnumApi)[keyof typeof LayoutEnumApi]
@@ -9480,19 +9481,21 @@ export type LayoutEnumApi = (typeof LayoutEnumApi)[keyof typeof LayoutEnumApi]
 export const LayoutEnumApi = {
     Preserve: 'preserve',
     TwoColumn: 'two_column',
+    ThreeColumn: 'three_column',
     FullWidth: 'full_width',
 } as const
 
 export interface ReorderTilesRequestApi {
     /**
-     * Array of tile IDs in the desired display order (top to bottom, left to right).
+     * Array of tile IDs in the desired display order (top to bottom, left to right). The 'three_column' layout requires exactly the tile IDs returned by dashboard-get.
      * @minItems 1
      */
     tile_order: number[]
-    /** How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'full_width' forces each tile to span the full 12-column row at height 5.
+    /** How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'three_column' requires exactly the tile IDs returned by dashboard-get, packs regular tiles in 4-wide × 5-tall thirds, and keeps text and image tiles full-width as separators at their saved height or height 2 when layoutless. 'full_width' forces each tile to span the full 12-column row at height 5.
      *
      * * `preserve` - preserve
      * * `two_column` - two_column
+     * * `three_column` - three_column
      * * `full_width` - full_width */
     layout?: LayoutEnumApi
 }

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -1338,13 +1338,17 @@ export const DashboardsReorderTilesCreateBody = /* @__PURE__ */ zod.object({
     tile_order: zod
         .array(zod.number())
         .min(1)
-        .describe('Array of tile IDs in the desired display order (top to bottom, left to right).'),
+        .describe(
+            "Array of tile IDs in the desired display order (top to bottom, left to right). The 'three_column' layout requires exactly the tile IDs returned by dashboard-get."
+        ),
     layout: zod
-        .enum(['preserve', 'two_column', 'full_width'])
-        .describe('\* `preserve` - preserve\n\* `two_column` - two_column\n\* `full_width` - full_width')
+        .enum(['preserve', 'two_column', 'three_column', 'full_width'])
+        .describe(
+            '\* `preserve` - preserve\n\* `two_column` - two_column\n\* `three_column` - three_column\n\* `full_width` - full_width'
+        )
         .default(dashboardsReorderTilesCreateBodyLayoutDefault)
         .describe(
-            "How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'full_width' forces each tile to span the full 12-column row at height 5.\n\n\* `preserve` - preserve\n\* `two_column` - two_column\n\* `full_width` - full_width"
+            "How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'three_column' requires exactly the tile IDs returned by dashboard-get, packs regular tiles in 4-wide × 5-tall thirds, and keeps text and image tiles full-width as separators at their saved height or height 2 when layoutless. 'full_width' forces each tile to span the full 12-column row at height 5.\n\n\* `preserve` - preserve\n\* `two_column` - two_column\n\* `three_column` - three_column\n\* `full_width` - full_width"
         ),
 })
 

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -245,7 +245,11 @@ tools:
         description: >
             Reorder tiles on a dashboard by providing an array of tile IDs in the desired display order. First, use
             dashboard-get to see current tile IDs. By default existing tile widths and heights are preserved; see the
-            layout parameter to force a 2-column or full-width grid instead.
+            layout parameter to force a two-column, three-column, or full-width grid instead. The three-column layout
+            is only for an explicitly requested three-column or equal-thirds layout and requires exactly the tile IDs
+            returned by dashboard-get. It keeps text and image tiles full-width as separators, preserving their saved
+            height or using rendered height 2 when layoutless, and packs each contiguous run of other tiles three per
+            row.
     dashboard-saved-views-create:
         operation: dashboard_saved_views_create
         enabled: false

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -245,8 +245,8 @@ tools:
         description: >
             Reorder tiles on a dashboard by providing an array of tile IDs in the desired display order. First, use
             dashboard-get to see current tile IDs. By default existing tile widths and heights are preserved; see the
-            layout parameter to force a two-column, three-column, or full-width grid instead. The three-column layout
-            is only for an explicitly requested three-column or equal-thirds layout and requires exactly the tile IDs
+            layout parameter to force a two-column, three-column, or full-width grid instead. The three-column layout is
+            only for an explicitly requested three-column or equal-thirds layout and requires exactly the tile IDs
             returned by dashboard-get. It keeps text and image tiles full-width as separators, preserving their saved
             height or using rendered height 2 when layoutless, and packs each contiguous run of other tiles three per
             row.

--- a/products/dashboards/skills/building-a-dashboard/SKILL.md
+++ b/products/dashboards/skills/building-a-dashboard/SKILL.md
@@ -54,7 +54,10 @@ Prefer reusing existing insights over recreating them.
 - Existing dashboard: `dashboard-update`. Adding, replacing, or removing insights means sending the full intended set of
   tiles — insights you omit are removed, so include the ones you want to keep.
 - Layout: by default preserve existing tile placement. Only reflow (`dashboard-reorder-tiles`) when the user explicitly
-  asks to rearrange, reorder, or move tiles.
+  asks to rearrange, reorder, or move tiles. Use `three_column` only when they explicitly ask for a three-column or
+  equal-thirds layout: first fetch `dashboard-get`, pass every returned tile ID exactly once, and fetch
+  `dashboard-get` again after reordering to verify the result. Text and image tiles remain full-width separators; other
+  tiles are packed three per row.
 - Verify with `dashboard-insights-run` to confirm the tiles return data, then summarize what you built and invite the
   user to refine it.
 

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -2405,7 +2405,7 @@
         }
     },
     "dashboard-reorder-tiles": {
-        "description": "Reorder tiles on a dashboard by providing an array of tile IDs in the desired display order. First, use dashboard-get to see current tile IDs. By default existing tile widths and heights are preserved; see the layout parameter to force a 2-column or full-width grid instead.",
+        "description": "Reorder tiles on a dashboard by providing an array of tile IDs in the desired display order. First, use dashboard-get to see current tile IDs. By default existing tile widths and heights are preserved; see the layout parameter to force a two-column, three-column, or full-width grid instead. The three-column layout is only for an explicitly requested three-column or equal-thirds layout and requires exactly the tile IDs returned by dashboard-get. It keeps text and image tiles full-width as separators, preserving their saved height or using rendered height 2 when layoutless, and packs each contiguous run of other tiles three per row.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Reorder dashboard tiles",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -2420,7 +2420,7 @@
         }
     },
     "dashboard-reorder-tiles": {
-        "description": "Reorder tiles on a dashboard by providing an array of tile IDs in the desired display order. First, use dashboard-get to see current tile IDs. By default existing tile widths and heights are preserved; see the layout parameter to force a 2-column or full-width grid instead.",
+        "description": "Reorder tiles on a dashboard by providing an array of tile IDs in the desired display order. First, use dashboard-get to see current tile IDs. By default existing tile widths and heights are preserved; see the layout parameter to force a two-column, three-column, or full-width grid instead. The three-column layout is only for an explicitly requested three-column or equal-thirds layout and requires exactly the tile IDs returned by dashboard-get. It keeps text and image tiles full-width as separators, preserving their saved height or using rendered height 2 when layoutless, and packs each contiguous run of other tiles three per row.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Reorder dashboard tiles",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -48655,6 +48655,7 @@ export namespace Schemas {
     /**
      * * `preserve` - preserve
      * * `two_column` - two_column
+     * * `three_column` - three_column
      * * `full_width` - full_width
      */
     export type LayoutEnum = typeof LayoutEnum[keyof typeof LayoutEnum];
@@ -48663,6 +48664,7 @@ export namespace Schemas {
     export const LayoutEnum = {
       Preserve: 'preserve',
       TwoColumn: 'two_column',
+      ThreeColumn: 'three_column',
       FullWidth: 'full_width',
     } as const;
 
@@ -75635,14 +75637,15 @@ export namespace Schemas {
 
     export interface ReorderTilesRequest {
       /**
-         * Array of tile IDs in the desired display order (top to bottom, left to right).
+         * Array of tile IDs in the desired display order (top to bottom, left to right). The 'three_column' layout requires exactly the tile IDs returned by dashboard-get.
          * @minItems 1
          */
       tile_order: number[];
-      /** How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'full_width' forces each tile to span the full 12-column row at height 5.
+      /** How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'three_column' requires exactly the tile IDs returned by dashboard-get, packs regular tiles in 4-wide × 5-tall thirds, and keeps text and image tiles full-width as separators at their saved height or height 2 when layoutless. 'full_width' forces each tile to span the full 12-column row at height 5.
        *
        * * `preserve` - preserve
        * * `two_column` - two_column
+       * * `three_column` - three_column
        * * `full_width` - full_width */
       layout?: LayoutEnum;
     }

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -1220,13 +1220,17 @@ export const DashboardsReorderTilesCreateBody = () => zod.object({
     tile_order: zod
         .array(zod.number())
         .min(1)
-        .describe('Array of tile IDs in the desired display order (top to bottom, left to right).'),
+        .describe(
+            "Array of tile IDs in the desired display order (top to bottom, left to right). The 'three_column' layout requires exactly the tile IDs returned by dashboard-get."
+        ),
     layout: zod
-        .enum(['preserve', 'two_column', 'full_width'])
-        .describe('\* `preserve` - preserve\n\* `two_column` - two_column\n\* `full_width` - full_width')
+        .enum(['preserve', 'two_column', 'three_column', 'full_width'])
+        .describe(
+            '\* `preserve` - preserve\n\* `two_column` - two_column\n\* `three_column` - three_column\n\* `full_width` - full_width'
+        )
         .default(dashboardsReorderTilesCreateBodyLayoutDefault)
         .describe(
-            "How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'full_width' forces each tile to span the full 12-column row at height 5.\n\n\* `preserve` - preserve\n\* `two_column` - two_column\n\* `full_width` - full_width"
+            "How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'three_column' requires exactly the tile IDs returned by dashboard-get, packs regular tiles in 4-wide × 5-tall thirds, and keeps text and image tiles full-width as separators at their saved height or height 2 when layoutless. 'full_width' forces each tile to span the full 12-column row at height 5.\n\n\* `preserve` - preserve\n\* `two_column` - two_column\n\* `three_column` - three_column\n\* `full_width` - full_width"
         ),
 })
 

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-reorder-tiles.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-reorder-tiles.json
@@ -7,12 +7,12 @@
         },
         "layout": {
             "default": "preserve",
-            "description": "How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'full_width' forces each tile to span the full 12-column row at height 5.\n\n* `preserve` - preserve\n* `two_column` - two_column\n* `full_width` - full_width",
-            "enum": ["preserve", "two_column", "full_width"],
+            "description": "How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'three_column' requires exactly the tile IDs returned by dashboard-get, packs regular tiles in 4-wide × 5-tall thirds, and keeps text and image tiles full-width as separators at their saved height or height 2 when layoutless. 'full_width' forces each tile to span the full 12-column row at height 5.\n\n* `preserve` - preserve\n* `two_column` - two_column\n* `three_column` - three_column\n* `full_width` - full_width",
+            "enum": ["preserve", "two_column", "three_column", "full_width"],
             "type": "string"
         },
         "tile_order": {
-            "description": "Array of tile IDs in the desired display order (top to bottom, left to right).",
+            "description": "Array of tile IDs in the desired display order (top to bottom, left to right). The 'three_column' layout requires exactly the tile IDs returned by dashboard-get.",
             "items": {
                 "type": "number"
             },


### PR DESCRIPTION
## Problem

Dashboard users cannot ask PostHog AI to place three insights in one row while keeping text and image tiles full-width.

Stack: [1/4 scene context](https://github.com/PostHog/posthog/pull/96398) · **2/4** · [3/4 mutation cards](https://github.com/PostHog/posthog/pull/96402) · [4/4 live apply-back](https://github.com/PostHog/posthog/pull/96404)

Depends on [1/4: dashboard scene context](https://github.com/PostHog/posthog/pull/96398).

## Changes

- The dashboard reorder API and MCP tool support a deterministic `three_column` layout.
- Regular tiles use a `4 × 5` desktop grid and stack on mobile.
- Text and image tiles remain full-width separators and preserve their saved height.
- Invalid, duplicate, hidden, omitted, or foreign tile identifiers leave every involved dashboard unchanged.
- Existing `preserve`, `two_column`, and `full_width` behavior remains unchanged.
- The dashboard-building skill and generated MCP contracts expose the new mode.

> [!NOTE]
> A dashboard screenshot remains pending because no dev stack ran for this isolated worktree.

## How did you test this code?

- Pre-rebase focused dashboard suite: 11 passed.
- Pre-rebase full `TestDashboard`: 210 passed; two unrelated sharing tests lacked `exporter.html`.
- Rebase range-diff is patch-identical across all three commits.
- Canonical OpenAPI generation passed and remained idempotent.
- Layer boundary remains exactly 11 files with `+377/-22`.
- Diff checks passed, and all three commits have valid YubiKey signatures.
- Fresh MCP package checks were inconclusive because package setup could not fetch; no source diagnostics were produced.
- Browser layout testing remains pending because no terminal-owned dev stack ran for this worktree.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- Updated the checked-in dashboard-building skill and generated MCP contracts.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: Codex.
- Skills: `/integrating-with-posthog-ai`, `/using-git-worktrees`, `/subagent-driven-development`, and `/test-driven-development`.
- Review: `/requesting-code-review`, `/verification-before-completion`, `/stacking-prs`, and `/writing-pr-descriptions`.
- Scoped adversarial re-review returned `ADDRESSED` after compatibility fixes.
