### PR TITLE
feat(posthog-ai): add dashboard mutation cards and tile reveal

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.highlight.test.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.highlight.test.tsx
@@ -1,0 +1,56 @@
+import '@testing-library/jest-dom'
+
+import { render } from '@testing-library/react'
+import React from 'react'
+
+import { NodeKind } from '~/queries/schema/schema-general'
+import { DashboardPlacement, QueryBasedInsightModel } from '~/types'
+
+import { InsightCard } from './InsightCard'
+
+jest.mock('kea', () => {
+    const React = jest.requireActual('react')
+    return {
+        ...jest.requireActual('kea'),
+        BindLogic: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+        useActions: () => ({ persistDisplayOptions: jest.fn() }),
+        useValues: () => ({ theme: null, insightLoading: false, insightDataLoading: false }),
+    }
+})
+
+jest.mock('@floating-ui/react', () => ({ useMergeRefs: () => jest.fn() }))
+jest.mock('react-intersection-observer', () => ({ useInView: () => ({ ref: jest.fn(), inView: true }) }))
+jest.mock('lib/hooks/usePageVisibility', () => ({ usePageVisibility: () => ({ isVisible: true }) }))
+jest.mock('scenes/insights/EmptyStates', () => ({
+    InsightErrorState: () => <div />,
+    InsightLoadingState: () => <div />,
+    InsightTimeoutState: () => <div />,
+    InsightValidationError: () => <div />,
+}))
+jest.mock('~/exporter/exporterViewLogic', () => ({ isSharedView: () => false }))
+jest.mock('~/layout/ErrorBoundary', () => ({
+    ErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+jest.mock('~/queries/Query/Query', () => ({ Query: () => <div data-testid="query" /> }))
+jest.mock('./InsightMeta', () => ({ InsightMeta: () => <div data-testid="insight-meta" /> }))
+
+const insight = {
+    id: 101,
+    short_id: 'target',
+    query: { kind: NodeKind.TrendsQuery },
+    result: [],
+} as unknown as QueryBasedInsightModel
+
+describe('InsightCard highlight class', () => {
+    it('removes the highlighted class when the highlight expires upstream', () => {
+        const { container, rerender } = render(
+            <InsightCard insight={insight} placement={DashboardPlacement.Dashboard} highlighted />
+        )
+
+        expect(container.querySelector('[data-attr="insight-card"]')).toHaveClass('InsightCard--highlighted')
+
+        rerender(<InsightCard insight={insight} placement={DashboardPlacement.Dashboard} highlighted={false} />)
+
+        expect(container.querySelector('[data-attr="insight-card"]')).not.toHaveClass('InsightCard--highlighted')
+    })
+})

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -207,6 +207,9 @@ export interface InsightCardProps extends Resizeable {
     dataColorThemeId?: number | null
     className?: string
     style?: React.CSSProperties
+    tabIndex?: React.HTMLAttributes<HTMLDivElement>['tabIndex']
+    'data-dashboard-tile-id'?: string
+    'data-dashboard-tile-highlighted'?: string
     children?: React.ReactNode
     tile?: DashboardTile<QueryBasedInsightModel>
     /** survey opportunity for this insight */

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1134,8 +1134,11 @@ export const productUrls = {
     warehouseProperties: (tab?: WarehousePropertiesSceneTab): string =>
         `/data-management/warehouse-properties${tab ? `/${tab}` : ''}`,
     dashboards: (): string => '/dashboard',
-    dashboard: (id: string | number, highlightInsightId?: string): string =>
-        combineUrl(`/dashboard/${id}`, highlightInsightId ? { highlightInsightId } : {}).url,
+    dashboard: (id: string | number, highlightInsightId?: string, highlightTileId?: string | number): string =>
+        combineUrl(`/dashboard/${id}`, {
+            ...(highlightInsightId ? { highlightInsightId } : {}),
+            ...(highlightTileId ? { highlightTileId } : {}),
+        }).url,
     dashboardTile: (id: string | number, tileId: string | number): string => `${urls.dashboard(id)}/tiles/${tileId}`,
     dashboardSharing: (id: string | number): string => `/dashboard/${id}/sharing`,
     dashboardSubscriptions: (id: string | number): string => `/dashboard/${id}/subscriptions`,

--- a/frontend/src/scenes/dashboard/DashboardItems.scss
+++ b/frontend/src/scenes/dashboard/DashboardItems.scss
@@ -11,6 +11,28 @@
     }
 }
 
+@keyframes DashboardItems__aiTileHighlight {
+    from {
+        outline-offset: 6px;
+    }
+
+    to {
+        outline-offset: 2px;
+    }
+}
+
+.dashboard-items-wrapper [data-dashboard-tile-highlighted='true'] {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+    animation: DashboardItems__aiTileHighlight 3s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .dashboard-items-wrapper [data-dashboard-tile-highlighted='true'] {
+        animation: none;
+    }
+}
+
 .react-grid-layout {
     position: relative;
     transition: height 100ms ease;

--- a/frontend/src/scenes/dashboard/DashboardItems.test.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.test.tsx
@@ -98,6 +98,7 @@ jest.mock('lib/components/Cards/InsightCard', () => ({
             data?: { queryId?: string }
         }
         refresh?: () => void
+        highlighted?: boolean
         'data-dashboard-tile-id'?: string
         'data-dashboard-tile-highlighted'?: string
         tabIndex?: number
@@ -247,6 +248,8 @@ let mockHighlightedInsightId: string | null = null
 let mockHasHighlightTileIdParam = false
 let mockHighlightTileIdParam: unknown
 let mockHighlightedTileId: number | null = null
+let mockDashboardLoading = false
+let mockDashboardFailedToLoad = false
 
 type DashboardTileFixture = {
     id: number
@@ -278,7 +281,8 @@ function installDashboardValues(getTiles: () => DashboardTileFixture[]): void {
                 highlightedTileId: mockHighlightedTileId,
                 refreshStatus: {},
                 dashboardStreaming: false,
-                dashboardLoading: false,
+                dashboardLoading: mockDashboardLoading,
+                dashboardFailedToLoad: mockDashboardFailedToLoad,
                 effectiveEditBarFilters: {},
                 effectiveDashboardVariableOverrides: {},
                 effectiveBreakdownColors: [],
@@ -343,6 +347,8 @@ describe('DashboardItems', () => {
         mockHasHighlightTileIdParam = false
         mockHighlightTileIdParam = undefined
         mockHighlightedTileId = null
+        mockDashboardLoading = false
+        mockDashboardFailedToLoad = false
         installAnimationFrameMocks()
         Object.defineProperty(window, 'matchMedia', {
             configurable: true,
@@ -544,6 +550,76 @@ describe('DashboardItems', () => {
         expect(target.focus).toHaveBeenCalledTimes(1)
     })
 
+    it('reloads an already-open dashboard once before revealing a newly created tile', () => {
+        let tiles: DashboardTileFixture[] = [
+            { id: 41, insight: { id: 101, short_id: 'existing', query: { kind: 'InsightVizNode' } } },
+        ]
+        installDashboardValues(() => tiles)
+
+        const { container, rerender } = render(<DashboardItems />)
+
+        mockHasHighlightTileIdParam = true
+        mockHighlightTileIdParam = '42'
+        mockHighlightedTileId = 42
+        rerender(<DashboardItems />)
+
+        expect(mockTriggerDashboardRefresh).toHaveBeenCalledTimes(1)
+        expect(requestAnimationFrameCallbacks.size).toBe(0)
+
+        mockDashboardLoading = true
+        rerender(<DashboardItems />)
+        tiles = [...tiles, { id: 42, insight: { id: 102, short_id: 'created', query: { kind: 'InsightVizNode' } } }]
+        mockDashboardLoading = false
+        rerender(<DashboardItems />)
+
+        const target = container.querySelector('[data-tile-id="42"]') as HTMLElement
+        target.scrollIntoView = jest.fn()
+        target.focus = jest.fn()
+        act(flushAllAnimationFrames)
+
+        expect(mockTriggerDashboardRefresh).toHaveBeenCalledTimes(1)
+        expect(target.scrollIntoView).toHaveBeenCalledTimes(1)
+        expect(target.focus).toHaveBeenCalledTimes(1)
+    })
+
+    it('reloads an already-open dashboard once before revealing a stale updated tile', () => {
+        let tiles: DashboardTileFixture[] = [
+            { id: 41, insight: { id: 101, short_id: 'before-update', query: { kind: 'InsightVizNode' } } },
+        ]
+        installDashboardValues(() => tiles)
+
+        const { container, rerender } = render(<DashboardItems />)
+        const staleTarget = container.querySelector('[data-tile-id="41"]') as HTMLElement
+        staleTarget.scrollIntoView = jest.fn()
+        staleTarget.focus = jest.fn()
+
+        mockHasHighlightTileIdParam = true
+        mockHighlightTileIdParam = '41'
+        mockHighlightedTileId = 41
+        rerender(<DashboardItems />)
+
+        expect(mockTriggerDashboardRefresh).toHaveBeenCalledTimes(1)
+        act(flushAllAnimationFrames)
+        expect(staleTarget.scrollIntoView).not.toHaveBeenCalled()
+        expect(staleTarget.focus).not.toHaveBeenCalled()
+
+        mockDashboardLoading = true
+        rerender(<DashboardItems />)
+        tiles = [{ id: 41, insight: { id: 101, short_id: 'after-update', query: { kind: 'InsightVizNode' } } }]
+        mockDashboardLoading = false
+        rerender(<DashboardItems />)
+
+        const refreshedTarget = container.querySelector('[data-tile-id="41"]') as HTMLElement
+        refreshedTarget.scrollIntoView = jest.fn()
+        refreshedTarget.focus = jest.fn()
+        act(flushAllAnimationFrames)
+        rerender(<DashboardItems />)
+
+        expect(mockTriggerDashboardRefresh).toHaveBeenCalledTimes(1)
+        expect(refreshedTarget.scrollIntoView).toHaveBeenCalledTimes(1)
+        expect(refreshedTarget.focus).toHaveBeenCalledTimes(1)
+    })
+
     it('cancels a stale reveal between animation frames when the target changes', () => {
         const tiles: DashboardTileFixture[] = [
             { id: 41, insight: { id: 101, short_id: 'first', query: { kind: 'InsightVizNode' } } },
@@ -567,6 +643,15 @@ describe('DashboardItems', () => {
         mockHighlightTileIdParam = '42'
         mockHighlightedTileId = 42
         rerender(<DashboardItems />)
+
+        expect(mockTriggerDashboardRefresh).toHaveBeenCalledTimes(1)
+        expect(firstTarget.scrollIntoView).not.toHaveBeenCalled()
+        expect(secondTarget.scrollIntoView).not.toHaveBeenCalled()
+
+        mockDashboardLoading = true
+        rerender(<DashboardItems />)
+        mockDashboardLoading = false
+        rerender(<DashboardItems />)
         act(flushAllAnimationFrames)
 
         expect(cancelAnimationFrame).toHaveBeenCalledWith(firstFrameId)
@@ -575,6 +660,51 @@ describe('DashboardItems', () => {
         expect(firstTarget.focus).not.toHaveBeenCalled()
         expect(secondTarget.scrollIntoView).toHaveBeenCalledTimes(1)
         expect(secondTarget.focus).toHaveBeenCalledTimes(1)
+    })
+
+    it('uses an active dashboard load instead of starting a duplicate reveal refresh', () => {
+        const tiles: DashboardTileFixture[] = [
+            { id: 41, insight: { id: 101, short_id: 'target', query: { kind: 'InsightVizNode' } } },
+        ]
+        mockDashboardLoading = true
+        installDashboardValues(() => tiles)
+
+        const { container, rerender } = render(<DashboardItems />)
+        mockHasHighlightTileIdParam = true
+        mockHighlightTileIdParam = '41'
+        mockHighlightedTileId = 41
+        rerender(<DashboardItems />)
+
+        expect(mockTriggerDashboardRefresh).not.toHaveBeenCalled()
+        expect(requestAnimationFrameCallbacks.size).toBe(0)
+
+        mockDashboardLoading = false
+        rerender(<DashboardItems />)
+        const target = container.querySelector('[data-tile-id="41"]') as HTMLElement
+        target.scrollIntoView = jest.fn()
+        target.focus = jest.fn()
+        act(flushAllAnimationFrames)
+
+        expect(mockTriggerDashboardRefresh).not.toHaveBeenCalled()
+        expect(target.scrollIntoView).toHaveBeenCalledTimes(1)
+        expect(target.focus).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not reload for an invalid explicit tile target', () => {
+        const tiles: DashboardTileFixture[] = [
+            { id: 41, insight: { id: 101, short_id: 'legacy-target', query: { kind: 'InsightVizNode' } } },
+        ]
+        installDashboardValues(() => tiles)
+
+        const { rerender } = render(<DashboardItems />)
+        mockHasHighlightTileIdParam = true
+        mockHighlightTileIdParam = 'invalid'
+        mockHighlightedTileId = null
+        mockHighlightedInsightId = 'legacy-target'
+        rerender(<DashboardItems />)
+
+        expect(mockTriggerDashboardRefresh).not.toHaveBeenCalled()
+        expect(requestAnimationFrameCallbacks.size).toBe(0)
     })
 
     it('cancels both reveal frames when the dashboard unmounts', () => {
@@ -699,6 +829,22 @@ describe('DashboardItems', () => {
         expect(target).toHaveAttribute('data-dashboard-tile-highlighted', 'true')
         act(() => jest.advanceTimersByTime(1))
         expect(target).not.toHaveAttribute('data-dashboard-tile-highlighted')
+    })
+
+    it('expires the legacy insight card highlight after 3000ms', () => {
+        jest.useFakeTimers()
+        installAnimationFrameMocks()
+        mockHighlightedInsightId = 'target'
+        installDashboardValues(() => [
+            { id: 41, insight: { id: 101, short_id: 'target', query: { kind: 'InsightVizNode' } } },
+        ])
+
+        render(<DashboardItems />)
+        act(flushAllAnimationFrames)
+
+        expect(mockInsightCard).toHaveBeenLastCalledWith(expect.objectContaining({ highlighted: true }))
+        act(() => jest.advanceTimersByTime(3000))
+        expect(mockInsightCard).toHaveBeenLastCalledWith(expect.objectContaining({ highlighted: false }))
     })
 
     it.each([

--- a/frontend/src/scenes/dashboard/DashboardItems.test.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.test.tsx
@@ -249,7 +249,7 @@ let mockHasHighlightTileIdParam = false
 let mockHighlightTileIdParam: unknown
 let mockHighlightedTileId: number | null = null
 let mockDashboardLoading = false
-let mockDashboardFailedToLoad = false
+let mockDashboardRevealReadyKey: string | null = null
 
 type DashboardTileFixture = {
     id: number
@@ -282,7 +282,7 @@ function installDashboardValues(getTiles: () => DashboardTileFixture[]): void {
                 refreshStatus: {},
                 dashboardStreaming: false,
                 dashboardLoading: mockDashboardLoading,
-                dashboardFailedToLoad: mockDashboardFailedToLoad,
+                dashboardRevealReadyKey: mockDashboardRevealReadyKey,
                 effectiveEditBarFilters: {},
                 effectiveDashboardVariableOverrides: {},
                 effectiveBreakdownColors: [],
@@ -348,7 +348,7 @@ describe('DashboardItems', () => {
         mockHighlightTileIdParam = undefined
         mockHighlightedTileId = null
         mockDashboardLoading = false
-        mockDashboardFailedToLoad = false
+        mockDashboardRevealReadyKey = null
         installAnimationFrameMocks()
         Object.defineProperty(window, 'matchMedia', {
             configurable: true,
@@ -467,6 +467,7 @@ describe('DashboardItems', () => {
         mockHasHighlightTileIdParam = true
         mockHighlightTileIdParam = '42'
         mockHighlightedTileId = 42
+        mockDashboardRevealReadyKey = '5:tile:42'
         installDashboardValues(() => tiles)
 
         const { container } = render(<DashboardItems />)
@@ -512,6 +513,7 @@ describe('DashboardItems', () => {
             { id: 41, insight: { id: 101, short_id: 'legacy-target', query: { kind: 'InsightVizNode' } } },
         ]
         mockHighlightedInsightId = 'legacy-target'
+        mockDashboardRevealReadyKey = '5:insight:legacy-target'
         installDashboardValues(() => tiles)
 
         const { container } = render(<DashboardItems />)
@@ -534,6 +536,7 @@ describe('DashboardItems', () => {
         mockHasHighlightTileIdParam = true
         mockHighlightTileIdParam = '42'
         mockHighlightedTileId = 42
+        mockDashboardRevealReadyKey = '5:tile:42'
         installDashboardValues(() => tiles)
 
         const { container, rerender } = render(<DashboardItems />)
@@ -550,39 +553,7 @@ describe('DashboardItems', () => {
         expect(target.focus).toHaveBeenCalledTimes(1)
     })
 
-    it('reloads an already-open dashboard once before revealing a newly created tile', () => {
-        let tiles: DashboardTileFixture[] = [
-            { id: 41, insight: { id: 101, short_id: 'existing', query: { kind: 'InsightVizNode' } } },
-        ]
-        installDashboardValues(() => tiles)
-
-        const { container, rerender } = render(<DashboardItems />)
-
-        mockHasHighlightTileIdParam = true
-        mockHighlightTileIdParam = '42'
-        mockHighlightedTileId = 42
-        rerender(<DashboardItems />)
-
-        expect(mockTriggerDashboardRefresh).toHaveBeenCalledTimes(1)
-        expect(requestAnimationFrameCallbacks.size).toBe(0)
-
-        mockDashboardLoading = true
-        rerender(<DashboardItems />)
-        tiles = [...tiles, { id: 42, insight: { id: 102, short_id: 'created', query: { kind: 'InsightVizNode' } } }]
-        mockDashboardLoading = false
-        rerender(<DashboardItems />)
-
-        const target = container.querySelector('[data-tile-id="42"]') as HTMLElement
-        target.scrollIntoView = jest.fn()
-        target.focus = jest.fn()
-        act(flushAllAnimationFrames)
-
-        expect(mockTriggerDashboardRefresh).toHaveBeenCalledTimes(1)
-        expect(target.scrollIntoView).toHaveBeenCalledTimes(1)
-        expect(target.focus).toHaveBeenCalledTimes(1)
-    })
-
-    it('reloads an already-open dashboard once before revealing a stale updated tile', () => {
+    it('waits for the dashboard refresh before revealing an existing tile', () => {
         let tiles: DashboardTileFixture[] = [
             { id: 41, insight: { id: 101, short_id: 'before-update', query: { kind: 'InsightVizNode' } } },
         ]
@@ -598,15 +569,12 @@ describe('DashboardItems', () => {
         mockHighlightedTileId = 41
         rerender(<DashboardItems />)
 
-        expect(mockTriggerDashboardRefresh).toHaveBeenCalledTimes(1)
         act(flushAllAnimationFrames)
         expect(staleTarget.scrollIntoView).not.toHaveBeenCalled()
         expect(staleTarget.focus).not.toHaveBeenCalled()
 
-        mockDashboardLoading = true
-        rerender(<DashboardItems />)
         tiles = [{ id: 41, insight: { id: 101, short_id: 'after-update', query: { kind: 'InsightVizNode' } } }]
-        mockDashboardLoading = false
+        mockDashboardRevealReadyKey = '5:tile:41'
         rerender(<DashboardItems />)
 
         const refreshedTarget = container.querySelector('[data-tile-id="41"]') as HTMLElement
@@ -615,7 +583,6 @@ describe('DashboardItems', () => {
         act(flushAllAnimationFrames)
         rerender(<DashboardItems />)
 
-        expect(mockTriggerDashboardRefresh).toHaveBeenCalledTimes(1)
         expect(refreshedTarget.scrollIntoView).toHaveBeenCalledTimes(1)
         expect(refreshedTarget.focus).toHaveBeenCalledTimes(1)
     })
@@ -628,6 +595,7 @@ describe('DashboardItems', () => {
         mockHasHighlightTileIdParam = true
         mockHighlightTileIdParam = '41'
         mockHighlightedTileId = 41
+        mockDashboardRevealReadyKey = '5:tile:41'
         installDashboardValues(() => tiles)
 
         const { container, rerender } = render(<DashboardItems />)
@@ -642,16 +610,11 @@ describe('DashboardItems', () => {
 
         mockHighlightTileIdParam = '42'
         mockHighlightedTileId = 42
+        mockDashboardRevealReadyKey = '5:tile:42'
         rerender(<DashboardItems />)
 
-        expect(mockTriggerDashboardRefresh).toHaveBeenCalledTimes(1)
         expect(firstTarget.scrollIntoView).not.toHaveBeenCalled()
         expect(secondTarget.scrollIntoView).not.toHaveBeenCalled()
-
-        mockDashboardLoading = true
-        rerender(<DashboardItems />)
-        mockDashboardLoading = false
-        rerender(<DashboardItems />)
         act(flushAllAnimationFrames)
 
         expect(cancelAnimationFrame).toHaveBeenCalledWith(firstFrameId)
@@ -662,35 +625,7 @@ describe('DashboardItems', () => {
         expect(secondTarget.focus).toHaveBeenCalledTimes(1)
     })
 
-    it('uses an active dashboard load instead of starting a duplicate reveal refresh', () => {
-        const tiles: DashboardTileFixture[] = [
-            { id: 41, insight: { id: 101, short_id: 'target', query: { kind: 'InsightVizNode' } } },
-        ]
-        mockDashboardLoading = true
-        installDashboardValues(() => tiles)
-
-        const { container, rerender } = render(<DashboardItems />)
-        mockHasHighlightTileIdParam = true
-        mockHighlightTileIdParam = '41'
-        mockHighlightedTileId = 41
-        rerender(<DashboardItems />)
-
-        expect(mockTriggerDashboardRefresh).not.toHaveBeenCalled()
-        expect(requestAnimationFrameCallbacks.size).toBe(0)
-
-        mockDashboardLoading = false
-        rerender(<DashboardItems />)
-        const target = container.querySelector('[data-tile-id="41"]') as HTMLElement
-        target.scrollIntoView = jest.fn()
-        target.focus = jest.fn()
-        act(flushAllAnimationFrames)
-
-        expect(mockTriggerDashboardRefresh).not.toHaveBeenCalled()
-        expect(target.scrollIntoView).toHaveBeenCalledTimes(1)
-        expect(target.focus).toHaveBeenCalledTimes(1)
-    })
-
-    it('does not reload for an invalid explicit tile target', () => {
+    it('does not reveal for an invalid explicit tile target', () => {
         const tiles: DashboardTileFixture[] = [
             { id: 41, insight: { id: 101, short_id: 'legacy-target', query: { kind: 'InsightVizNode' } } },
         ]
@@ -703,7 +638,6 @@ describe('DashboardItems', () => {
         mockHighlightedInsightId = 'legacy-target'
         rerender(<DashboardItems />)
 
-        expect(mockTriggerDashboardRefresh).not.toHaveBeenCalled()
         expect(requestAnimationFrameCallbacks.size).toBe(0)
     })
 
@@ -714,6 +648,7 @@ describe('DashboardItems', () => {
         mockHasHighlightTileIdParam = true
         mockHighlightTileIdParam = '41'
         mockHighlightedTileId = 41
+        mockDashboardRevealReadyKey = '5:tile:41'
         installDashboardValues(() => tiles)
 
         const { container, unmount } = render(<DashboardItems />)
@@ -739,6 +674,7 @@ describe('DashboardItems', () => {
         mockHasHighlightTileIdParam = true
         mockHighlightTileIdParam = '41'
         mockHighlightedTileId = 41
+        mockDashboardRevealReadyKey = '5:tile:41'
         installDashboardValues(() => tiles)
 
         const { container, rerender } = render(<DashboardItems />)
@@ -765,6 +701,7 @@ describe('DashboardItems', () => {
         mockHasHighlightTileIdParam = true
         mockHighlightTileIdParam = '41'
         mockHighlightedTileId = 41
+        mockDashboardRevealReadyKey = '5:tile:41'
         installDashboardValues(() => tiles)
         jest.mocked(window.matchMedia).mockReturnValue({ matches: true } as MediaQueryList)
 
@@ -790,6 +727,7 @@ describe('DashboardItems', () => {
         mockHasHighlightTileIdParam = true
         mockHighlightTileIdParam = '41'
         mockHighlightedTileId = 41
+        mockDashboardRevealReadyKey = '5:tile:41'
         installDashboardValues(() => [tile])
 
         const { container } = render(<DashboardItems />)
@@ -814,6 +752,7 @@ describe('DashboardItems', () => {
         mockHasHighlightTileIdParam = true
         mockHighlightTileIdParam = '41'
         mockHighlightedTileId = 41
+        mockDashboardRevealReadyKey = '5:tile:41'
         installDashboardValues(() => [
             { id: 41, insight: { id: 101, short_id: 'target', query: { kind: 'InsightVizNode' } } },
         ])
@@ -835,6 +774,7 @@ describe('DashboardItems', () => {
         jest.useFakeTimers()
         installAnimationFrameMocks()
         mockHighlightedInsightId = 'target'
+        mockDashboardRevealReadyKey = '5:insight:target'
         installDashboardValues(() => [
             { id: 41, insight: { id: 101, short_id: 'target', query: { kind: 'InsightVizNode' } } },
         ])

--- a/frontend/src/scenes/dashboard/DashboardItems.test.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.test.tsx
@@ -458,14 +458,14 @@ describe('DashboardItems', () => {
         expect(urls.dashboard(7, undefined, 41)).toBe('/dashboard/7?highlightTileId=41')
     })
 
-    it('prefers an explicit tile target over the legacy insight target', () => {
+    it.each([42, '42'])('prefers an explicit tile target of %p over the legacy insight target', (rawTarget) => {
         const tiles: DashboardTileFixture[] = [
             { id: 41, insight: { id: 101, short_id: 'legacy-target', query: { kind: 'InsightVizNode' } } },
             { id: 42, text: { id: 102, body: 'Explicit target' } },
         ]
         mockHighlightedInsightId = 'legacy-target'
         mockHasHighlightTileIdParam = true
-        mockHighlightTileIdParam = '42'
+        mockHighlightTileIdParam = rawTarget
         mockHighlightedTileId = 42
         mockDashboardRevealReadyKey = '5:tile:42'
         installDashboardValues(() => tiles)

--- a/frontend/src/scenes/dashboard/DashboardItems.test.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.test.tsx
@@ -1,11 +1,12 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent, render } from '@testing-library/react'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
 import { useActions, useAsyncActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import { urls } from 'scenes/urls'
 
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { insightsModel } from '~/models/insightsModel'
@@ -97,6 +98,9 @@ jest.mock('lib/components/Cards/InsightCard', () => ({
             data?: { queryId?: string }
         }
         refresh?: () => void
+        'data-dashboard-tile-id'?: string
+        'data-dashboard-tile-highlighted'?: string
+        tabIndex?: number
     }): JSX.Element => {
         mockInsightCard(props)
         const { tile, showResizeHandles, apiErrored, apiError } = props
@@ -109,27 +113,69 @@ jest.mock('lib/components/Cards/InsightCard', () => ({
                 data-api-error-status={apiError?.status}
                 data-api-error-detail={apiError?.detail ?? undefined}
                 data-api-error-code={apiError?.code ?? undefined}
+                data-dashboard-tile-id={props['data-dashboard-tile-id']}
+                data-dashboard-tile-highlighted={props['data-dashboard-tile-highlighted']}
+                tabIndex={props.tabIndex}
             />
         )
     },
 }))
 
 jest.mock('products/dashboards/frontend/components/DashboardTextItem/DashboardTextItem', () => ({
-    DashboardTextItem: ({ tile, showResizeHandles }: { tile: { id: number }; showResizeHandles: boolean }) => (
+    DashboardTextItem: ({
+        tile,
+        showResizeHandles,
+        'data-dashboard-tile-id': dashboardTileId,
+        'data-dashboard-tile-highlighted': dashboardTileHighlighted,
+        tabIndex,
+    }: {
+        tile: { id: number }
+        showResizeHandles: boolean
+        'data-dashboard-tile-id'?: string
+        'data-dashboard-tile-highlighted'?: string
+        tabIndex?: number
+    }) => (
         <div
             data-attr="text-card"
             data-tile-id={String(tile.id)}
             data-show-resize-handles={String(showResizeHandles)}
+            data-dashboard-tile-id={dashboardTileId}
+            data-dashboard-tile-highlighted={dashboardTileHighlighted}
+            tabIndex={tabIndex}
+        />
+    ),
+}))
+
+jest.mock('./items/DashboardButtonTileItem', () => ({
+    DashboardButtonTileItem: ({
+        tile,
+        'data-dashboard-tile-id': dashboardTileId,
+        'data-dashboard-tile-highlighted': dashboardTileHighlighted,
+        tabIndex,
+    }: {
+        tile: { id: number }
+        'data-dashboard-tile-id'?: string
+        'data-dashboard-tile-highlighted'?: string
+        tabIndex?: number
+    }) => (
+        <div
+            data-attr="button-tile-card"
+            data-tile-id={String(tile.id)}
+            data-dashboard-tile-id={dashboardTileId}
+            data-dashboard-tile-highlighted={dashboardTileHighlighted}
+            tabIndex={tabIndex}
         />
     ),
 }))
 
 jest.mock('react-grid-layout', () => {
+    const containerRef = { current: null }
+
     return {
         cloneLayoutItem: (item: Record<string, unknown>) => ({ ...item }),
         useContainerWidth: () => ({
             width: 1200,
-            containerRef: { current: null },
+            containerRef,
             mounted: true,
         }),
         verticalCompactor: {
@@ -173,7 +219,20 @@ jest.mock('react-grid-layout/extras', () => ({
 }))
 
 jest.mock('@posthog/products-dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem', () => ({
-    DashboardWidgetItem: () => <div data-attr="widget-card" />,
+    DashboardWidgetItem: (props: {
+        tile: { id: number }
+        'data-dashboard-tile-id'?: string
+        'data-dashboard-tile-highlighted'?: string
+        tabIndex?: number
+    }) => (
+        <div
+            data-attr="widget-card"
+            data-tile-id={String(props.tile.id)}
+            data-dashboard-tile-id={props['data-dashboard-tile-id']}
+            data-dashboard-tile-highlighted={props['data-dashboard-tile-highlighted']}
+            tabIndex={props.tabIndex}
+        />
+    ),
 }))
 
 const mockedUseValues = useValues as jest.Mock
@@ -182,11 +241,113 @@ const mockedUseAsyncActions = useAsyncActions as jest.Mock
 const mockRemoveTile = jest.fn()
 const mockTriggerDashboardRefresh = jest.fn()
 const mockInsightCard = jest.fn()
+const requestAnimationFrameCallbacks = new Map<number, FrameRequestCallback>()
+let requestAnimationFrameId = 0
+let mockHighlightedInsightId: string | null = null
+let mockHasHighlightTileIdParam = false
+let mockHighlightTileIdParam: unknown
+let mockHighlightedTileId: number | null = null
+
+type DashboardTileFixture = {
+    id: number
+    insight?: { id: number; short_id: string; query: { kind: string } }
+    text?: { id: number; body: string }
+    button_tile?: { id: number; text: string; url: string; style: 'primary' }
+    widget?: { id: number; widget_type: string; config: Record<string, never> }
+    error?: { type: string; message: string }
+}
+
+function installDashboardValues(getTiles: () => DashboardTileFixture[]): void {
+    mockedUseValues.mockImplementation((logic) => {
+        if (logic === dashboardLogic) {
+            const tiles = getTiles()
+            return {
+                dashboard: { id: 5 },
+                tiles,
+                layouts: {
+                    sm: tiles.map((tile, index) => ({ i: String(tile.id), x: index * 2, y: 0, w: 2, h: 5 })),
+                },
+                dashboardMode: DashboardMode.Edit,
+                layoutEditMode: true,
+                placement: DashboardPlacement.Dashboard,
+                isRefreshingQueued: () => false,
+                isRefreshing: () => false,
+                highlightedInsightId: mockHighlightedInsightId,
+                hasHighlightTileIdParam: mockHasHighlightTileIdParam,
+                highlightTileIdParam: mockHighlightTileIdParam,
+                highlightedTileId: mockHighlightedTileId,
+                refreshStatus: {},
+                dashboardStreaming: false,
+                dashboardLoading: false,
+                effectiveEditBarFilters: {},
+                effectiveDashboardVariableOverrides: {},
+                effectiveBreakdownColors: [],
+                dataColorThemeId: null,
+                canEditDashboard: true,
+                dashboardWidgetsEnabled: true,
+                widgetResultsByTileId: {},
+                widgetRefreshStatus: {},
+                scrollToBottomSignal: 0,
+                layoutZoom: 1,
+            }
+        }
+
+        if (logic === dashboardsModel) {
+            return { nameSortedDashboards: [] }
+        }
+
+        return {}
+    })
+}
+
+function flushNextAnimationFrame(): number {
+    const entry = requestAnimationFrameCallbacks.entries().next().value as [number, FrameRequestCallback] | undefined
+    if (!entry) {
+        throw new Error('No animation frame is scheduled')
+    }
+    const [id, callback] = entry
+    requestAnimationFrameCallbacks.delete(id)
+    callback(0)
+    return id
+}
+
+function flushAllAnimationFrames(): void {
+    while (requestAnimationFrameCallbacks.size > 0) {
+        flushNextAnimationFrame()
+    }
+}
+
+function installAnimationFrameMocks(): void {
+    global.requestAnimationFrame = jest.fn((callback: FrameRequestCallback): number => {
+        const id = ++requestAnimationFrameId
+        requestAnimationFrameCallbacks.set(id, callback)
+        return id
+    })
+    global.cancelAnimationFrame = jest.fn((id: number): void => {
+        requestAnimationFrameCallbacks.delete(id)
+    })
+}
 
 describe('DashboardItems', () => {
+    afterEach(() => {
+        cleanup()
+        jest.useRealTimers()
+    })
+
     beforeEach(() => {
         mockInsightCard.mockClear()
         jest.clearAllMocks()
+        requestAnimationFrameCallbacks.clear()
+        requestAnimationFrameId = 0
+        mockHighlightedInsightId = null
+        mockHasHighlightTileIdParam = false
+        mockHighlightTileIdParam = undefined
+        mockHighlightedTileId = null
+        installAnimationFrameMocks()
+        Object.defineProperty(window, 'matchMedia', {
+            configurable: true,
+            value: jest.fn().mockReturnValue({ matches: false }),
+        })
 
         mockedUseValues.mockImplementation((logic) => {
             if (logic === dashboardLogic) {
@@ -206,7 +367,10 @@ describe('DashboardItems', () => {
                     placement: DashboardPlacement.Dashboard,
                     isRefreshingQueued: () => false,
                     isRefreshing: () => false,
-                    highlightedInsightId: null,
+                    highlightedInsightId: mockHighlightedInsightId,
+                    hasHighlightTileIdParam: mockHasHighlightTileIdParam,
+                    highlightTileIdParam: mockHighlightTileIdParam,
+                    highlightedTileId: mockHighlightedTileId,
                     refreshStatus: {},
                     itemsLoading: false,
                     dashboardStreaming: false,
@@ -282,6 +446,259 @@ describe('DashboardItems', () => {
     it('matches snapshot in edit mode with layout zoom enabled', () => {
         const { container } = render(<DashboardItems />)
         expect(container.firstChild).toMatchSnapshot()
+    })
+
+    it('builds an explicit dashboard tile reveal URL', () => {
+        expect(urls.dashboard(7, undefined, 41)).toBe('/dashboard/7?highlightTileId=41')
+    })
+
+    it('prefers an explicit tile target over the legacy insight target', () => {
+        const tiles: DashboardTileFixture[] = [
+            { id: 41, insight: { id: 101, short_id: 'legacy-target', query: { kind: 'InsightVizNode' } } },
+            { id: 42, text: { id: 102, body: 'Explicit target' } },
+        ]
+        mockHighlightedInsightId = 'legacy-target'
+        mockHasHighlightTileIdParam = true
+        mockHighlightTileIdParam = '42'
+        mockHighlightedTileId = 42
+        installDashboardValues(() => tiles)
+
+        const { container } = render(<DashboardItems />)
+        const legacyTarget = container.querySelector('[data-tile-id="41"]') as HTMLElement
+        const explicitTarget = container.querySelector('[data-tile-id="42"]') as HTMLElement
+        legacyTarget.scrollIntoView = jest.fn()
+        explicitTarget.scrollIntoView = jest.fn()
+        explicitTarget.focus = jest.fn()
+
+        act(flushAllAnimationFrames)
+
+        expect(legacyTarget.scrollIntoView).not.toHaveBeenCalled()
+        expect(explicitTarget.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' })
+        expect(explicitTarget.focus).toHaveBeenCalledWith({ preventScroll: true })
+    })
+
+    it.each(['invalid', '0', '-1', '1.5', String(Number.MAX_SAFE_INTEGER + 1)])(
+        'does not fall back to an insight when the explicit tile target is %s',
+        (rawTarget) => {
+            const tiles: DashboardTileFixture[] = [
+                { id: 41, insight: { id: 101, short_id: 'legacy-target', query: { kind: 'InsightVizNode' } } },
+            ]
+            mockHighlightedInsightId = 'legacy-target'
+            mockHasHighlightTileIdParam = true
+            mockHighlightTileIdParam = rawTarget
+            mockHighlightedTileId = null
+            installDashboardValues(() => tiles)
+
+            const { container } = render(<DashboardItems />)
+            const legacyTarget = container.querySelector('[data-tile-id="41"]') as HTMLElement
+            legacyTarget.scrollIntoView = jest.fn()
+            legacyTarget.focus = jest.fn()
+
+            act(flushAllAnimationFrames)
+
+            expect(legacyTarget.scrollIntoView).not.toHaveBeenCalled()
+            expect(legacyTarget.focus).not.toHaveBeenCalled()
+        }
+    )
+
+    it('uses the legacy insight target only when the tile parameter is absent', () => {
+        const tiles: DashboardTileFixture[] = [
+            { id: 41, insight: { id: 101, short_id: 'legacy-target', query: { kind: 'InsightVizNode' } } },
+        ]
+        mockHighlightedInsightId = 'legacy-target'
+        installDashboardValues(() => tiles)
+
+        const { container } = render(<DashboardItems />)
+        const target = container.querySelector('[data-tile-id="41"]') as HTMLElement
+        target.scrollIntoView = jest.fn()
+        target.focus = jest.fn()
+
+        act(flushAllAnimationFrames)
+
+        expect(target.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' })
+        expect(target.focus).toHaveBeenCalledWith({ preventScroll: true })
+    })
+
+    it('reveals a requested tile after it arrives in dashboard state', () => {
+        const tile: DashboardTileFixture = {
+            id: 42,
+            insight: { id: 101, short_id: 'tile-target', query: { kind: 'InsightVizNode' } },
+        }
+        let tiles: DashboardTileFixture[] = []
+        mockHasHighlightTileIdParam = true
+        mockHighlightTileIdParam = '42'
+        mockHighlightedTileId = 42
+        installDashboardValues(() => tiles)
+
+        const { container, rerender } = render(<DashboardItems />)
+        expect(requestAnimationFrameCallbacks.size).toBe(0)
+
+        tiles = [tile]
+        rerender(<DashboardItems />)
+        const target = container.querySelector('[data-tile-id="42"]') as HTMLElement
+        target.scrollIntoView = jest.fn()
+        target.focus = jest.fn()
+        act(flushAllAnimationFrames)
+
+        expect(target.scrollIntoView).toHaveBeenCalledTimes(1)
+        expect(target.focus).toHaveBeenCalledTimes(1)
+    })
+
+    it('cancels a stale reveal between animation frames when the target changes', () => {
+        const tiles: DashboardTileFixture[] = [
+            { id: 41, insight: { id: 101, short_id: 'first', query: { kind: 'InsightVizNode' } } },
+            { id: 42, insight: { id: 102, short_id: 'second', query: { kind: 'InsightVizNode' } } },
+        ]
+        mockHasHighlightTileIdParam = true
+        mockHighlightTileIdParam = '41'
+        mockHighlightedTileId = 41
+        installDashboardValues(() => tiles)
+
+        const { container, rerender } = render(<DashboardItems />)
+        const firstTarget = container.querySelector('[data-tile-id="41"]') as HTMLElement
+        const secondTarget = container.querySelector('[data-tile-id="42"]') as HTMLElement
+        firstTarget.scrollIntoView = jest.fn()
+        firstTarget.focus = jest.fn()
+        secondTarget.scrollIntoView = jest.fn()
+        secondTarget.focus = jest.fn()
+        const firstFrameId = flushNextAnimationFrame()
+        const secondFrameId = requestAnimationFrameId
+
+        mockHighlightTileIdParam = '42'
+        mockHighlightedTileId = 42
+        rerender(<DashboardItems />)
+        act(flushAllAnimationFrames)
+
+        expect(cancelAnimationFrame).toHaveBeenCalledWith(firstFrameId)
+        expect(cancelAnimationFrame).toHaveBeenCalledWith(secondFrameId)
+        expect(firstTarget.scrollIntoView).not.toHaveBeenCalled()
+        expect(firstTarget.focus).not.toHaveBeenCalled()
+        expect(secondTarget.scrollIntoView).toHaveBeenCalledTimes(1)
+        expect(secondTarget.focus).toHaveBeenCalledTimes(1)
+    })
+
+    it('cancels both reveal frames when the dashboard unmounts', () => {
+        const tiles: DashboardTileFixture[] = [
+            { id: 41, insight: { id: 101, short_id: 'target', query: { kind: 'InsightVizNode' } } },
+        ]
+        mockHasHighlightTileIdParam = true
+        mockHighlightTileIdParam = '41'
+        mockHighlightedTileId = 41
+        installDashboardValues(() => tiles)
+
+        const { container, unmount } = render(<DashboardItems />)
+        const target = container.querySelector('[data-tile-id="41"]') as HTMLElement
+        target.scrollIntoView = jest.fn()
+        target.focus = jest.fn()
+        const firstFrameId = flushNextAnimationFrame()
+        const secondFrameId = requestAnimationFrameId
+
+        unmount()
+        act(flushAllAnimationFrames)
+
+        expect(cancelAnimationFrame).toHaveBeenCalledWith(firstFrameId)
+        expect(cancelAnimationFrame).toHaveBeenCalledWith(secondFrameId)
+        expect(target.scrollIntoView).not.toHaveBeenCalled()
+        expect(target.focus).not.toHaveBeenCalled()
+    })
+
+    it('does not reveal a consumed target again after dashboard tiles reload', () => {
+        let tiles: DashboardTileFixture[] = [
+            { id: 41, insight: { id: 101, short_id: 'target', query: { kind: 'InsightVizNode' } } },
+        ]
+        mockHasHighlightTileIdParam = true
+        mockHighlightTileIdParam = '41'
+        mockHighlightedTileId = 41
+        installDashboardValues(() => tiles)
+
+        const { container, rerender } = render(<DashboardItems />)
+        const target = container.querySelector('[data-tile-id="41"]') as HTMLElement
+        target.scrollIntoView = jest.fn()
+        target.focus = jest.fn()
+        act(flushAllAnimationFrames)
+
+        tiles = []
+        rerender(<DashboardItems />)
+        tiles = [{ id: 41, insight: { id: 101, short_id: 'target', query: { kind: 'InsightVizNode' } } }]
+        rerender(<DashboardItems />)
+        expect(requestAnimationFrameCallbacks.size).toBe(0)
+        act(flushAllAnimationFrames)
+
+        expect(target.scrollIntoView).toHaveBeenCalledTimes(1)
+        expect(target.focus).toHaveBeenCalledTimes(1)
+    })
+
+    it('uses non-animated scrolling when reduced motion is requested', () => {
+        const tiles: DashboardTileFixture[] = [
+            { id: 41, insight: { id: 101, short_id: 'target', query: { kind: 'InsightVizNode' } } },
+        ]
+        mockHasHighlightTileIdParam = true
+        mockHighlightTileIdParam = '41'
+        mockHighlightedTileId = 41
+        installDashboardValues(() => tiles)
+        jest.mocked(window.matchMedia).mockReturnValue({ matches: true } as MediaQueryList)
+
+        const { container } = render(<DashboardItems />)
+        const target = container.querySelector('[data-tile-id="41"]') as HTMLElement
+        target.scrollIntoView = jest.fn()
+        target.focus = jest.fn()
+        act(flushAllAnimationFrames)
+
+        expect(target.scrollIntoView).toHaveBeenCalledWith({ behavior: 'auto', block: 'center' })
+    })
+
+    it.each([
+        ['insight', { id: 41, insight: { id: 101, short_id: 'target', query: { kind: 'InsightVizNode' } } }],
+        ['text', { id: 41, text: { id: 102, body: 'Text' } }],
+        ['image', { id: 41, text: { id: 102, body: '![Image](https://example.test/image.png)' } }],
+        ['button', { id: 41, button_tile: { id: 103, text: 'Open', url: '/', style: 'primary' } }],
+        ['widget', { id: 41, widget: { id: 104, widget_type: 'error_tracking_list', config: {} } }],
+        ['error', { id: 41, error: { type: 'ValidationError', message: 'Invalid filters' } }],
+    ] as const)('applies the common focus and visual contract to a highlighted %s tile', (_kind, tile) => {
+        jest.useFakeTimers()
+        installAnimationFrameMocks()
+        mockHasHighlightTileIdParam = true
+        mockHighlightTileIdParam = '41'
+        mockHighlightedTileId = 41
+        installDashboardValues(() => [tile])
+
+        const { container } = render(<DashboardItems />)
+        const target = container.querySelector('[data-tile-id="41"], [data-attr="dashboard-tile-error"]') as HTMLElement
+        target.scrollIntoView = jest.fn()
+        target.focus = jest.fn()
+        act(flushAllAnimationFrames)
+
+        expect(target).toHaveAttribute('data-dashboard-tile-id', '41')
+        expect(target).toHaveAttribute('tabindex', '-1')
+        expect(target).toHaveAttribute('data-dashboard-tile-highlighted', 'true')
+
+        act(() => jest.advanceTimersByTime(2999))
+        expect(target).toHaveAttribute('data-dashboard-tile-highlighted', 'true')
+        act(() => jest.advanceTimersByTime(1))
+        expect(target).not.toHaveAttribute('data-dashboard-tile-highlighted')
+    })
+
+    it('keeps the visual highlight for 3000ms when reduced motion is requested', () => {
+        jest.useFakeTimers()
+        installAnimationFrameMocks()
+        mockHasHighlightTileIdParam = true
+        mockHighlightTileIdParam = '41'
+        mockHighlightedTileId = 41
+        installDashboardValues(() => [
+            { id: 41, insight: { id: 101, short_id: 'target', query: { kind: 'InsightVizNode' } } },
+        ])
+        jest.mocked(window.matchMedia).mockReturnValue({ matches: true } as MediaQueryList)
+
+        const { container } = render(<DashboardItems />)
+        const target = container.querySelector('[data-tile-id="41"]') as HTMLElement
+        target.scrollIntoView = jest.fn()
+        target.focus = jest.fn()
+        act(flushAllAnimationFrames)
+
+        act(() => jest.advanceTimersByTime(2999))
+        expect(target).toHaveAttribute('data-dashboard-tile-highlighted', 'true')
+        act(() => jest.advanceTimersByTime(1))
+        expect(target).not.toHaveAttribute('data-dashboard-tile-highlighted')
     })
 
     it.each([

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -50,6 +50,7 @@ const DRAG_AUTO_SCROLL_SPEED = 50
 const BASE_ROW_HEIGHT = 80
 const BASE_MARGIN: [number, number] = [16, 16]
 const CONTAINER_PADDING: [number, number] = [0, 0]
+const TILE_HIGHLIGHT_DURATION_MS = 3000
 
 interface DashboardItemsProps {
     showCreateAnomalyAlertButton?: boolean
@@ -89,7 +90,10 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         placement,
         isRefreshingQueued,
         isRefreshing,
+        hasHighlightTileIdParam,
         highlightedInsightId,
+        highlightTileIdParam,
+        highlightedTileId,
         refreshStatus,
         dashboardStreaming,
         dashboardLoading,
@@ -145,6 +149,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
     // redraw on every frame as the tile's dimensions change — the dominant cost that makes resizing feel laggy.
     const [resizingTileId, setResizingTileId] = useState<string | null>(null)
     const [containerHeight, setContainerHeight] = useState<number | undefined>(undefined)
+    const [visuallyHighlightedTileId, setVisuallyHighlightedTileId] = useState<number | null>(null)
 
     // cannot click links when dragging and 250ms after
     const isDragging = useRef(false)
@@ -156,6 +161,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
     const scrollContainerRef = useRef<HTMLElement | null>(null)
     const scrollContainerRectRef = useRef<DOMRect | null>(null)
     const lastScrollSignalRef = useRef(scrollToBottomSignal)
+    const consumedRevealKeyRef = useRef<string | null>(null)
 
     useEffect(() => {
         return () => {
@@ -201,6 +207,73 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
     })
 
     const { width, containerRef, mounted } = useContainerWidth()
+    const revealTargetKind = hasHighlightTileIdParam
+        ? 'tile'
+        : typeof highlightedInsightId === 'string' && highlightedInsightId
+          ? 'insight'
+          : null
+    const rawRevealTarget = hasHighlightTileIdParam
+        ? typeof highlightTileIdParam === 'string'
+            ? highlightTileIdParam
+            : null
+        : typeof highlightedInsightId === 'string' && highlightedInsightId
+          ? highlightedInsightId
+          : null
+    const revealTileId = hasHighlightTileIdParam
+        ? highlightedTileId !== null
+            ? (tiles.find((tile) => tile.id === highlightedTileId)?.id ?? null)
+            : null
+        : (tiles.find((tile) => tile.insight?.short_id === highlightedInsightId)?.id ?? null)
+    const revealKey =
+        dashboard && revealTargetKind && rawRevealTarget
+            ? `${dashboard.id}:${revealTargetKind}:${rawRevealTarget}`
+            : null
+
+    useEffect(() => {
+        if (consumedRevealKeyRef.current !== revealKey) {
+            consumedRevealKeyRef.current = null
+        }
+    }, [revealKey])
+
+    useEffect(() => {
+        setVisuallyHighlightedTileId(null)
+        if (!mounted || !revealKey || !revealTileId || consumedRevealKeyRef.current === revealKey) {
+            return
+        }
+
+        let secondFrame: number | null = null
+        let highlightTimer: number | null = null
+        const firstFrame = requestAnimationFrame(() => {
+            secondFrame = requestAnimationFrame(() => {
+                const target = containerRef.current?.querySelector<HTMLElement>(
+                    `[data-dashboard-tile-id="${revealTileId}"]`
+                )
+                if (!target) {
+                    return
+                }
+
+                target.scrollIntoView({
+                    behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
+                    block: 'center',
+                })
+                target.focus({ preventScroll: true })
+                consumedRevealKeyRef.current = revealKey
+                setVisuallyHighlightedTileId(revealTileId)
+                highlightTimer = window.setTimeout(() => setVisuallyHighlightedTileId(null), TILE_HIGHLIGHT_DURATION_MS)
+            })
+        })
+
+        return () => {
+            cancelAnimationFrame(firstFrame)
+            if (secondFrame !== null) {
+                cancelAnimationFrame(secondFrame)
+            }
+            if (highlightTimer !== null) {
+                window.clearTimeout(highlightTimer)
+            }
+        }
+    }, [mounted, revealKey, revealTileId])
+
     const { gridCompactor, handleLayoutChange, interactionInProgress, startInteraction, finishInteraction } =
         useDashboardLayoutInteraction({
             layoutEditMode,
@@ -553,6 +626,12 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                                 },
                                 removeFromDashboard: () => removeTile(tile),
                             }
+                            const revealProps = {
+                                'data-dashboard-tile-id': String(tile.id),
+                                'data-dashboard-tile-highlighted':
+                                    visuallyHighlightedTileId === tile.id ? 'true' : undefined,
+                                tabIndex: -1,
+                            }
 
                             if (tile.error && !insight) {
                                 return (
@@ -568,6 +647,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                                         onEnterEditModeFromEdge={onEnterEditModeFromEdge}
                                         onDragHandleMouseDown={onDragHandleMouseDown}
                                         showEditingControls={showEditingControls}
+                                        {...revealProps}
                                     />
                                 )
                             }
@@ -598,7 +678,11 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                                         apiErrored={apiErrored}
                                         apiError={apiError}
                                         queryId={insight.query_status?.id}
-                                        highlighted={highlightedInsightId && insight.short_id === highlightedInsightId}
+                                        highlighted={
+                                            !hasHighlightTileIdParam &&
+                                            highlightedInsightId &&
+                                            insight.short_id === highlightedInsightId
+                                        }
                                         updateColor={(color) => updateTileColor(tile.id, color)}
                                         toggleShowDescription={() => toggleTileDescription(tile.id)}
                                         ribbonColor={tile.color}
@@ -620,6 +704,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                                         surveyOpportunity={tile.id === bestSurveyOpportunityFunnel?.id}
                                         showCreateAnomalyAlertButton={showCreateAnomalyAlertButton}
                                         {...commonTileProps}
+                                        {...revealProps}
                                     />
                                 )
                             }
@@ -645,6 +730,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                                         canEnterEditModeFromEdge={commonTileProps.canEnterEditModeFromEdge}
                                         onEnterEditModeFromEdge={commonTileProps.onEnterEditModeFromEdge}
                                         onDragHandleMouseDown={commonTileProps.onDragHandleMouseDown}
+                                        {...revealProps}
                                     />
                                 )
                             }
@@ -670,6 +756,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                                         canEnterEditModeFromEdge={commonTileProps.canEnterEditModeFromEdge}
                                         onEnterEditModeFromEdge={commonTileProps.onEnterEditModeFromEdge}
                                         onDragHandleMouseDown={commonTileProps.onDragHandleMouseDown}
+                                        {...revealProps}
                                     />
                                 )
                             }
@@ -717,6 +804,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                                         canEnterEditModeFromEdge={commonTileProps.canEnterEditModeFromEdge}
                                         onEnterEditModeFromEdge={commonTileProps.onEnterEditModeFromEdge}
                                         onDragHandleMouseDown={commonTileProps.onDragHandleMouseDown}
+                                        {...revealProps}
                                     />
                                 )
                             }

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -214,8 +214,8 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
           ? 'insight'
           : null
     const rawRevealTarget = hasHighlightTileIdParam
-        ? typeof highlightTileIdParam === 'string'
-            ? highlightTileIdParam
+        ? typeof highlightTileIdParam === 'string' || typeof highlightTileIdParam === 'number'
+            ? String(highlightTileIdParam)
             : null
         : typeof highlightedInsightId === 'string' && highlightedInsightId
           ? highlightedInsightId

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -97,7 +97,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         refreshStatus,
         dashboardStreaming,
         dashboardLoading,
-        dashboardFailedToLoad,
+        dashboardRevealReadyKey,
         effectiveEditBarFilters,
         effectiveDashboardVariableOverrides,
         effectiveBreakdownColors,
@@ -229,56 +229,21 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         dashboard && revealTargetKind && rawRevealTarget && (revealTargetKind !== 'tile' || highlightedTileId !== null)
             ? `${dashboard.id}:${revealTargetKind}:${rawRevealTarget}`
             : null
-    const previousRevealKeyRef = useRef(revealKey)
-    const revealRefreshRequiredKeyRef = useRef<string | null>(null)
-    const revealRefreshObservedLoadingKeyRef = useRef<string | null>(null)
-    const revealRefreshReadyKeyRef = useRef(revealKey)
 
     useEffect(() => {
-        if (previousRevealKeyRef.current === revealKey) {
-            return
-        }
-
-        previousRevealKeyRef.current = revealKey
-        consumedRevealKeyRef.current = null
-        revealRefreshRequiredKeyRef.current = null
-        revealRefreshObservedLoadingKeyRef.current = null
-        revealRefreshReadyKeyRef.current = null
         setVisuallyHighlightedTileId(null)
-
-        if (!revealKey) {
-            return
+        if (consumedRevealKeyRef.current !== revealKey) {
+            consumedRevealKeyRef.current = null
         }
-
-        if (dashboardLoading) {
-            // A load already in flight is the freshness boundary for this newly selected target.
-            revealRefreshReadyKeyRef.current = revealKey
-            return
-        }
-
-        revealRefreshRequiredKeyRef.current = revealKey
-        loadDashboard({ action: DashboardLoadAction.Update })
-    }, [dashboardLoading, loadDashboard, revealKey])
-
-    useEffect(() => {
-        if (revealRefreshRequiredKeyRef.current !== revealKey) {
-            return
-        }
-        if (dashboardLoading) {
-            revealRefreshObservedLoadingKeyRef.current = revealKey
-        } else if (revealRefreshObservedLoadingKeyRef.current === revealKey && !dashboardFailedToLoad) {
-            revealRefreshReadyKeyRef.current = revealKey
-        }
-    }, [dashboardFailedToLoad, dashboardLoading, revealKey])
+    }, [revealKey])
 
     useEffect(() => {
         setVisuallyHighlightedTileId(null)
         if (
             !mounted ||
             dashboardLoading ||
-            dashboardFailedToLoad ||
             !revealKey ||
-            revealRefreshReadyKeyRef.current !== revealKey ||
+            dashboardRevealReadyKey !== revealKey ||
             !revealTileId ||
             consumedRevealKeyRef.current === revealKey
         ) {
@@ -316,7 +281,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                 window.clearTimeout(highlightTimer)
             }
         }
-    }, [dashboardFailedToLoad, dashboardLoading, mounted, revealKey, revealTileId])
+    }, [dashboardLoading, dashboardRevealReadyKey, mounted, revealKey, revealTileId])
 
     const { gridCompactor, handleLayoutChange, interactionInProgress, startInteraction, finishInteraction } =
         useDashboardLayoutInteraction({

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -97,6 +97,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         refreshStatus,
         dashboardStreaming,
         dashboardLoading,
+        dashboardFailedToLoad,
         effectiveEditBarFilters,
         effectiveDashboardVariableOverrides,
         effectiveBreakdownColors,
@@ -225,19 +226,62 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
             : null
         : (tiles.find((tile) => tile.insight?.short_id === highlightedInsightId)?.id ?? null)
     const revealKey =
-        dashboard && revealTargetKind && rawRevealTarget
+        dashboard && revealTargetKind && rawRevealTarget && (revealTargetKind !== 'tile' || highlightedTileId !== null)
             ? `${dashboard.id}:${revealTargetKind}:${rawRevealTarget}`
             : null
+    const previousRevealKeyRef = useRef(revealKey)
+    const revealRefreshRequiredKeyRef = useRef<string | null>(null)
+    const revealRefreshObservedLoadingKeyRef = useRef<string | null>(null)
+    const revealRefreshReadyKeyRef = useRef(revealKey)
 
     useEffect(() => {
-        if (consumedRevealKeyRef.current !== revealKey) {
-            consumedRevealKeyRef.current = null
+        if (previousRevealKeyRef.current === revealKey) {
+            return
         }
-    }, [revealKey])
+
+        previousRevealKeyRef.current = revealKey
+        consumedRevealKeyRef.current = null
+        revealRefreshRequiredKeyRef.current = null
+        revealRefreshObservedLoadingKeyRef.current = null
+        revealRefreshReadyKeyRef.current = null
+        setVisuallyHighlightedTileId(null)
+
+        if (!revealKey) {
+            return
+        }
+
+        if (dashboardLoading) {
+            // A load already in flight is the freshness boundary for this newly selected target.
+            revealRefreshReadyKeyRef.current = revealKey
+            return
+        }
+
+        revealRefreshRequiredKeyRef.current = revealKey
+        loadDashboard({ action: DashboardLoadAction.Update })
+    }, [dashboardLoading, loadDashboard, revealKey])
+
+    useEffect(() => {
+        if (revealRefreshRequiredKeyRef.current !== revealKey) {
+            return
+        }
+        if (dashboardLoading) {
+            revealRefreshObservedLoadingKeyRef.current = revealKey
+        } else if (revealRefreshObservedLoadingKeyRef.current === revealKey && !dashboardFailedToLoad) {
+            revealRefreshReadyKeyRef.current = revealKey
+        }
+    }, [dashboardFailedToLoad, dashboardLoading, revealKey])
 
     useEffect(() => {
         setVisuallyHighlightedTileId(null)
-        if (!mounted || !revealKey || !revealTileId || consumedRevealKeyRef.current === revealKey) {
+        if (
+            !mounted ||
+            dashboardLoading ||
+            dashboardFailedToLoad ||
+            !revealKey ||
+            revealRefreshReadyKeyRef.current !== revealKey ||
+            !revealTileId ||
+            consumedRevealKeyRef.current === revealKey
+        ) {
             return
         }
 
@@ -272,7 +316,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                 window.clearTimeout(highlightTimer)
             }
         }
-    }, [mounted, revealKey, revealTileId])
+    }, [dashboardFailedToLoad, dashboardLoading, mounted, revealKey, revealTileId])
 
     const { gridCompactor, handleLayoutChange, interactionInProgress, startInteraction, finishInteraction } =
         useDashboardLayoutInteraction({
@@ -678,11 +722,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                                         apiErrored={apiErrored}
                                         apiError={apiError}
                                         queryId={insight.query_status?.id}
-                                        highlighted={
-                                            !hasHighlightTileIdParam &&
-                                            highlightedInsightId &&
-                                            insight.short_id === highlightedInsightId
-                                        }
+                                        highlighted={visuallyHighlightedTileId === tile.id}
                                         updateColor={(color) => updateTileColor(tile.id, color)}
                                         toggleShowDescription={() => toggleTileDescription(tile.id)}
                                         ribbonColor={tile.color}

--- a/frontend/src/scenes/dashboard/__snapshots__/DashboardItems.test.tsx.snap
+++ b/frontend/src/scenes/dashboard/__snapshots__/DashboardItems.test.tsx.snap
@@ -22,8 +22,10 @@ exports[`DashboardItems matches snapshot in edit mode with layout zoom enabled 1
     >
       <div
         data-attr="insight-card"
+        data-dashboard-tile-id="1"
         data-show-resize-handles="false"
         data-tile-id="1"
+        tabindex="-1"
       />
     </div>
     <div

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -22,6 +22,7 @@ import { DashboardLoadAction, dashboardLogic } from 'scenes/dashboard/dashboardL
 import * as dashboardUtils from 'scenes/dashboard/dashboardUtils'
 import * as widgetFetchUtils from 'scenes/dashboard/widgetFetchUtils'
 import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
 
 import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
@@ -432,6 +433,17 @@ describe('dashboardLogic', () => {
 
             expect(loadDashboardSpy).not.toHaveBeenCalled()
             expect(logic.values.dashboardRevealReadyKey).toBeNull()
+        })
+
+        it('reveals a tile when the parameter arrives in the pushed URL', async () => {
+            router.actions.push(urls.dashboard(5, undefined, TEXT_TILE.id))
+            logic = dashboardLogic({ id: 5 })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.highlightTileIdParam).toBe(TEXT_TILE.id)
+            expect(logic.values.highlightedTileId).toBe(TEXT_TILE.id)
+            expect(logic.values.dashboardRevealReadyKey).toBe(`5:tile:${TEXT_TILE.id}`)
         })
 
         it('keeps parameter presence separate from a valid positive safe integer', () => {

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -358,6 +358,42 @@ describe('dashboardLogic', () => {
         })
     })
 
+    describe('dashboard tile reveal query', () => {
+        it('keeps parameter presence separate from a valid positive safe integer', () => {
+            router.actions.push('/dashboard/5', { highlightTileId: '42', highlightInsightId: 'legacy-target' })
+            logic = dashboardLogic({ id: 5 })
+            logic.mount()
+
+            expect(logic.values.hasHighlightTileIdParam).toBe(true)
+            expect(logic.values.highlightTileIdParam).toBe('42')
+            expect(logic.values.highlightedTileId).toBe(42)
+        })
+
+        it.each(['invalid', '0', '-1', '1.5', String(Number.MAX_SAFE_INTEGER + 1)])(
+            'preserves explicit parameter presence but rejects %s',
+            (highlightTileId) => {
+                router.actions.push('/dashboard/5', { highlightTileId, highlightInsightId: 'legacy-target' })
+                logic = dashboardLogic({ id: 5 })
+                logic.mount()
+
+                expect(logic.values.hasHighlightTileIdParam).toBe(true)
+                expect(logic.values.highlightTileIdParam).toBe(highlightTileId)
+                expect(logic.values.highlightedTileId).toBeNull()
+            }
+        )
+
+        it('reports an absent tile parameter without hiding the legacy insight target', () => {
+            router.actions.push('/dashboard/5', { highlightInsightId: 'legacy-target' })
+            logic = dashboardLogic({ id: 5 })
+            logic.mount()
+
+            expect(logic.values.hasHighlightTileIdParam).toBe(false)
+            expect(logic.values.highlightTileIdParam).toBeUndefined()
+            expect(logic.values.highlightedTileId).toBeNull()
+            expect(logic.values.highlightedInsightId).toBe('legacy-target')
+        })
+    })
+
     describe('tile layouts', () => {
         beforeEach(() => {
             logic = dashboardLogic({ id: 5 })

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -359,6 +359,81 @@ describe('dashboardLogic', () => {
     })
 
     describe('dashboard tile reveal query', () => {
+        it('reloads an empty dashboard when a reveal targets its first created tile', async () => {
+            router.actions.push('/dashboard/12')
+            logic = dashboardLogic({ id: 12 })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+            expect(logic.values.tiles).toEqual([])
+
+            dashboards[12].tiles.push({ ...TEXT_TILE, id: 42 })
+            const loadDashboardSpy = jest.spyOn(logic.actions, 'loadDashboard')
+
+            await expectLogic(logic, () => {
+                router.actions.push('/dashboard/12', { highlightTileId: '42' })
+            })
+                .toFinishAllListeners()
+                .toMatchValues({
+                    tiles: [expect.objectContaining({ id: 42 })],
+                })
+
+            expect(loadDashboardSpy).toHaveBeenCalledTimes(1)
+
+            await expectLogic(logic, () => {
+                router.actions.push('/dashboard/12', { highlightTileId: '42', unrelated: 'change' })
+            }).toFinishAllListeners()
+            expect(loadDashboardSpy).toHaveBeenCalledTimes(1)
+            expect(logic.values.dashboardRevealReadyKey).toBe('12:tile:42')
+        })
+
+        it('uses an active dashboard load as the reveal freshness boundary', async () => {
+            router.actions.push('/dashboard/5')
+            logic = dashboardLogic({ id: 5 })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+
+            const loadDashboardSpy = jest.spyOn(logic.actions, 'loadDashboard')
+            logic.actions.loadDashboard({ action: DashboardLoadAction.Update })
+            expect(logic.values.dashboardLoading).toBe(true)
+
+            router.actions.push('/dashboard/5', { highlightTileId: String(TEXT_TILE.id) })
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(loadDashboardSpy).toHaveBeenCalledTimes(1)
+            expect(logic.values.dashboardRevealReadyKey).toBe(`5:tile:${TEXT_TILE.id}`)
+        })
+
+        it('uses the cross-dashboard initial load as the reveal freshness boundary', async () => {
+            router.actions.push('/dashboard/5', { highlightTileId: String(TEXT_TILE.id) })
+            logic = dashboardLogic({ id: 5 })
+            const loadDashboardSpy = jest.spyOn(logic.actions, 'loadDashboard')
+
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(loadDashboardSpy).toHaveBeenCalledTimes(1)
+            expect(loadDashboardSpy).toHaveBeenCalledWith({ action: DashboardLoadAction.InitialLoad })
+            expect(logic.values.dashboardRevealReadyKey).toBe(`5:tile:${TEXT_TILE.id}`)
+        })
+
+        it('does not refresh or fall back for an invalid explicit tile target', async () => {
+            router.actions.push('/dashboard/5')
+            logic = dashboardLogic({ id: 5 })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+            const loadDashboardSpy = jest.spyOn(logic.actions, 'loadDashboard')
+
+            await expectLogic(logic, () => {
+                router.actions.push('/dashboard/5', {
+                    highlightTileId: 'invalid',
+                    highlightInsightId: '172',
+                })
+            }).toFinishAllListeners()
+
+            expect(loadDashboardSpy).not.toHaveBeenCalled()
+            expect(logic.values.dashboardRevealReadyKey).toBeNull()
+        })
+
         it('keeps parameter presence separate from a valid positive safe integer', () => {
             router.actions.push('/dashboard/5', { highlightTileId: '42', highlightInsightId: 'legacy-target' })
             logic = dashboardLogic({ id: 5 })

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -321,13 +321,16 @@ export interface dashboardLogicValues {
     error404: boolean
     externalFilters: DashboardFilter
     filtersOverrideForLoad: DashboardFilter
+    hasHighlightTileIdParam: boolean
     hasIntermittentFilters: boolean
     hasInvalidDashboardId: boolean
     hasUnsavedColorChanges: boolean
     hasUnsavedLayoutChanges: boolean
     hasUrlFilters: boolean
     hasVariables: boolean
+    highlightTileIdParam: unknown
     highlightedInsightId: any
+    highlightedTileId: number | null
     initialVariablesLoaded: boolean
     insightTiles: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>[]
     intermittentFilters: DashboardFilter
@@ -1131,7 +1134,10 @@ export interface dashboardLogicMeta {
         ) => boolean
         isRefreshingQueued: (refreshStatus: Record<string, RefreshStatus>) => (id: string) => boolean
         isRefreshing: (refreshStatus: Record<string, RefreshStatus>) => (id: string) => boolean
+        hasHighlightTileIdParam: (searchParams: Record<string, any>) => boolean
         highlightedInsightId: (searchParams: Record<string, any>) => any
+        highlightTileIdParam: (searchParams: Record<string, any>) => unknown
+        highlightedTileId: (searchParams: Record<string, any>) => number | null
         sortedDates: (insightTiles: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>[]) => Dayjs[]
         oldestRefreshed: (sortedDates: Dayjs[], pageVisibility: boolean) => Dayjs | null
         effectiveLastRefresh: (lastDashboardRefresh: Dayjs | null, oldestRefreshed: Dayjs | null) => Dayjs | null
@@ -2909,9 +2915,26 @@ export const dashboardLogic = kea<dashboardLogicType>([
             (s) => [s.refreshStatus],
             (refreshStatus: Record<string, RefreshStatus>) => (id: string) => !!refreshStatus[id]?.loading,
         ],
+        hasHighlightTileIdParam: [
+            () => [router.selectors.searchParams],
+            (searchParams: Record<string, unknown>): boolean =>
+                Object.prototype.hasOwnProperty.call(searchParams, 'highlightTileId'),
+        ],
         highlightedInsightId: [
             () => [router.selectors.searchParams],
             (searchParams: Record<string, any>) => searchParams.highlightInsightId,
+        ],
+        highlightTileIdParam: [
+            () => [router.selectors.searchParams],
+            (searchParams: Record<string, unknown>): unknown => searchParams.highlightTileId,
+        ],
+        highlightedTileId: [
+            () => [router.selectors.searchParams],
+            (searchParams: Record<string, unknown>): number | null => {
+                const value = searchParams.highlightTileId
+                const parsed = typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : null
+                return parsed !== null && Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null
+            },
         ],
         sortedDates: [
             (s) => [s.insightTiles],

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -218,6 +218,19 @@ function parseDashboardTileId(tileId: string | undefined): DashboardTileIdOrNew 
     return Number.isNaN(parsedTileId) ? null : parsedTileId
 }
 
+function dashboardRevealKeyFromSearchParams(dashboardId: number, searchParams: Record<string, unknown>): string | null {
+    if (Object.prototype.hasOwnProperty.call(searchParams, 'highlightTileId')) {
+        const value = searchParams.highlightTileId
+        const parsed = typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : null
+        return parsed !== null && Number.isSafeInteger(parsed) && parsed > 0 ? `${dashboardId}:tile:${value}` : null
+    }
+
+    const highlightedInsightId = searchParams.highlightInsightId
+    return typeof highlightedInsightId === 'string' && highlightedInsightId
+        ? `${dashboardId}:insight:${highlightedInsightId}`
+        : null
+}
+
 const tileLayoutsFromDashboard = (
     dashboard: DashboardType<QueryBasedInsightModel> | null | undefined
 ): Record<number, DashboardTile['layouts']> => {
@@ -302,6 +315,7 @@ export interface dashboardLogicValues {
     }
     dashboardLoading: boolean
     dashboardMode: DashboardMode | null
+    dashboardRevealReadyKey: string | null
     dashboardStreaming: boolean
     dashboardTileSpacingSaving: boolean
     dashboardWidgetsEnabled: boolean
@@ -630,6 +644,9 @@ export interface dashboardLogicActions {
         value: any
         variableId: string
     }
+    prepareDashboardReveal: (revealKey: string | null) => {
+        revealKey: string | null
+    }
     receiveTileFromStream: (data: { order: number; tile: any }) => {
         order: number
         tile: any
@@ -786,6 +803,9 @@ export interface dashboardLogicActions {
             mode: DashboardMode | null
             source: DashboardEventSource
         }
+    }
+    setDashboardRevealReadyKey: (revealKey: string | null) => {
+        revealKey: string | null
     }
     setDashboardStreamFailed: () => {
         value: true
@@ -1022,6 +1042,15 @@ export interface dashboardLogicMeta {
             previousState: any
         ) => void | Promise<void>
         handleDashboardLoadComplete: (
+            payload: any,
+            breakpoint: BreakPointFunction,
+            action: {
+                type: string
+                payload: any
+            },
+            previousState: any
+        ) => void | Promise<void>
+        markDashboardRevealReady: (
             payload: any,
             breakpoint: BreakPointFunction,
             action: {
@@ -1279,6 +1308,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
         setInitialLoadResponseBytes: (responseBytes: number) => ({ responseBytes }),
         /** Manually refresh the entire dashboard. */
         triggerDashboardRefresh: true,
+        prepareDashboardReveal: (revealKey: string | null) => ({ revealKey }),
+        setDashboardRevealReadyKey: (revealKey: string | null) => ({ revealKey }),
         /**
          * If the latest tile data is older than SHARED_DASHBOARD_AUTO_FORCE_IF_STALE_MINUTES,
          * queue a single force-blocking refresh on the next microtask. Reads
@@ -1854,6 +1885,12 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 loadDashboard: () => true,
                 loadDashboardSuccess: () => false,
                 loadDashboardFailure: () => false,
+            },
+        ],
+        dashboardRevealReadyKey: [
+            null as string | null,
+            {
+                setDashboardRevealReadyKey: (_, { revealKey }) => revealKey,
             },
         ],
         dashboardStreaming: [
@@ -3304,7 +3341,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             cache.tileIdsBeforeInsertion = undefined
         },
     })),
-    sharedListeners(({ values, props, actions }) => ({
+    sharedListeners(({ values, props, actions, cache }) => ({
         reportRefreshTiming: ({ shortId }) => {
             const refreshStatus = values.refreshStatus[shortId]
 
@@ -3331,6 +3368,16 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 actions.reportDashboardViewed()
             }
         },
+        markDashboardRevealReady: () => {
+            if (
+                values.dashboard &&
+                cache.pendingDashboardRevealKey &&
+                cache.pendingDashboardRevealKey === cache.activeDashboardRevealKey
+            ) {
+                actions.setDashboardRevealReadyKey(cache.pendingDashboardRevealKey)
+                cache.pendingDashboardRevealKey = null
+            }
+        },
     })),
     listeners(({ actions, values, cache, props, sharedListeners }) => ({
         scheduleRefreshDashboardWidgets: ({ tileId }: { tileId: number }) => {
@@ -3345,6 +3392,21 @@ export const dashboardLogic = kea<dashboardLogicType>([
             if (open) {
                 actions.clearAddWidgetSelectedTypes()
             }
+        },
+        prepareDashboardReveal: ({ revealKey }) => {
+            if (cache.activeDashboardRevealKey === revealKey) {
+                return
+            }
+
+            cache.activeDashboardRevealKey = revealKey
+            cache.pendingDashboardRevealKey = revealKey
+            actions.setDashboardRevealReadyKey(null)
+
+            if (!revealKey || values.dashboardLoading || values.dashboardStreaming || !values.dashboard) {
+                return
+            }
+
+            actions.loadDashboard({ action: DashboardLoadAction.Update })
         },
         togglePinned: () => {
             if (values.dashboard) {
@@ -3404,6 +3466,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             }
         },
         loadDashboardFailure: () => {
+            cache.pendingDashboardRevealKey = null
             const { action, dashboardQueryId, startTime } = values.dashboardLoadData
 
             eventUsageLogic.actions.reportTimeToSeeData({
@@ -3417,6 +3480,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             })
         },
         tileStreamingFailure: ({ error }) => {
+            cache.pendingDashboardRevealKey = null
             // Only a genuine 404 response means the dashboard is missing. Stream errors can contain
             // "404" in their message even when the dashboard still exists.
             if (error?.status === 404) {
@@ -4595,6 +4659,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         },
         loadDashboardSuccess: [
             sharedListeners.reportLoadTiming,
+            sharedListeners.markDashboardRevealReady,
             () => {
                 if (!values.dashboard) {
                     actions.dashboardNotFound()
@@ -4611,7 +4676,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 return // We hit a 404
             }
         },
-        tileStreamingComplete: sharedListeners.handleDashboardLoadComplete,
+        tileStreamingComplete: [sharedListeners.markDashboardRevealReady, sharedListeners.handleDashboardLoadComplete],
         reportInsightsViewed: ({ insights }: { insights: QueryBasedInsightModel[] }) => {
             const insightIds = insights
                 .map((insight: QueryBasedInsightModel) => insight?.id)
@@ -5049,7 +5114,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         },
     })),
 
-    urlToAction(({ values, actions }) => ({
+    urlToAction(({ values, actions, props }) => ({
         '/dashboard/:id/subscriptions(/:subscriptionId)': ({ subscriptionId }) => {
             const id = subscriptionId
                 ? subscriptionId == 'new'
@@ -5063,6 +5128,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         },
 
         '/dashboard/:id': (_params, searchParams) => {
+            actions.prepareDashboardReveal(dashboardRevealKeyFromSearchParams(props.id, searchParams))
             actions.setSubscriptionMode(false, undefined)
             actions.setTextTileId(null)
             actions.setButtonTileId(null)

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -218,11 +218,18 @@ function parseDashboardTileId(tileId: string | undefined): DashboardTileIdOrNew 
     return Number.isNaN(parsedTileId) ? null : parsedTileId
 }
 
+// kea-router decodes a numeric query value to a number, so a clicked link supplies 41 while a
+// params-object push supplies '41'. Both forms must resolve to the same tile.
+function parseHighlightTileId(value: unknown): number | null {
+    const parsed =
+        typeof value === 'number' ? value : typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : null
+    return parsed !== null && Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null
+}
+
 function dashboardRevealKeyFromSearchParams(dashboardId: number, searchParams: Record<string, unknown>): string | null {
     if (Object.prototype.hasOwnProperty.call(searchParams, 'highlightTileId')) {
         const value = searchParams.highlightTileId
-        const parsed = typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : null
-        return parsed !== null && Number.isSafeInteger(parsed) && parsed > 0 ? `${dashboardId}:tile:${value}` : null
+        return parseHighlightTileId(value) !== null ? `${dashboardId}:tile:${String(value)}` : null
     }
 
     const highlightedInsightId = searchParams.highlightInsightId
@@ -2967,11 +2974,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
         ],
         highlightedTileId: [
             () => [router.selectors.searchParams],
-            (searchParams: Record<string, unknown>): number | null => {
-                const value = searchParams.highlightTileId
-                const parsed = typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : null
-                return parsed !== null && Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null
-            },
+            (searchParams: Record<string, unknown>): number | null =>
+                parseHighlightTileId(searchParams.highlightTileId),
         ],
         sortedDates: [
             (s) => [s.insightTiles],

--- a/products/dashboards/manifest.tsx
+++ b/products/dashboards/manifest.tsx
@@ -10,8 +10,11 @@ export const manifest: ProductManifest = {
     name: 'Dashboards',
     urls: {
         dashboards: (): string => '/dashboard',
-        dashboard: (id: string | number, highlightInsightId?: string): string =>
-            combineUrl(`/dashboard/${id}`, highlightInsightId ? { highlightInsightId } : {}).url,
+        dashboard: (id: string | number, highlightInsightId?: string, highlightTileId?: string | number): string =>
+            combineUrl(`/dashboard/${id}`, {
+                ...(highlightInsightId ? { highlightInsightId } : {}),
+                ...(highlightTileId ? { highlightTileId } : {}),
+            }).url,
         dashboardTile: (id: string | number, tileId: string | number): string =>
             `${urls.dashboard(id)}/tiles/${tileId}`,
         dashboardSharing: (id: string | number): string => `/dashboard/${id}/sharing`,

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -245,8 +245,8 @@ tools:
         description: >
             Reorder tiles on a dashboard by providing an array of tile IDs in the desired display order. First, use
             dashboard-get to see current tile IDs. By default existing tile widths and heights are preserved; see the
-            layout parameter to force a two-column, three-column, or full-width grid instead. The three-column layout
-            is only for an explicitly requested three-column or equal-thirds layout and requires exactly the tile IDs
+            layout parameter to force a two-column, three-column, or full-width grid instead. The three-column layout is
+            only for an explicitly requested three-column or equal-thirds layout and requires exactly the tile IDs
             returned by dashboard-get. It keeps text and image tiles full-width as separators, preserving their saved
             height or using rendered height 2 when layoutless, and packs each contiguous run of other tiles three per
             row.

--- a/products/posthog_ai/frontend/api/logics.ts
+++ b/products/posthog_ai/frontend/api/logics.ts
@@ -55,6 +55,7 @@ export type { ToolStreamSubscription } from '../logics/toolStreamEventsLogic'
 export { useToolStreamListener } from '../hooks/useToolStream'
 export type { UseToolStreamListenerOptions } from '../hooks/useToolStream'
 export { resolveToolCall } from '../utils/toolResolver'
+export { parseToolOutputRecord } from '../utils/toolOutput'
 
 // --- Foreground stream registry + MCP tool apply-back (headless) ---
 // `foregroundStreamLogic` marks the single stream rendered in the side panel the user is watching; a

--- a/products/posthog_ai/frontend/components/tool/posthogExecDisplay.ts
+++ b/products/posthog_ai/frontend/components/tool/posthogExecDisplay.ts
@@ -2,85 +2,11 @@
  * Shared display helpers for the PostHog single-exec MCP tool. The `posthog` MCP server exposes one
  * outer `exec` tool whose `command` string carries the real intent (`tools` / `search` / `info` /
  * `schema` / `call <sub-tool>`). Both the thread tool-card renderer and the permission card need the
- * same human-friendly label + input preview, so the parsing lives here — one source of truth.
+ * same human-friendly label + input preview. Tokenization stays in the headless `utils/posthogExec`
+ * utility so non-display consumers do not import this component module.
  */
 
-/** Matches the PostHog single-exec MCP tool (`mcp__posthog__exec`, plus plugin/regional variants). */
-export const POSTHOG_EXEC_TOOL_RE = /^mcp__(?:plugin_)?posthog(?:_[^_]+)*__exec$/
-
-export function isPostHogExecTool(toolName: string): boolean {
-    return POSTHOG_EXEC_TOOL_RE.test(toolName)
-}
-
-/** The verbs the single-exec tool accepts. `call` runs a sub-tool; the rest are read-only. */
-export type PostHogExecVerb = 'tools' | 'search' | 'info' | 'schema' | 'call'
-const POSTHOG_EXEC_VERBS = new Set<PostHogExecVerb>(['tools', 'search', 'info', 'schema', 'call'])
-
-/**
- * Splits the leading whitespace-delimited token off a command and returns it plus the trimmed
- * remainder. Mirrors the backend exec `parseCommand` (`services/mcp/src/tools/exec.ts`)
- * token-for-token — single-space split, trimmed remainder — so the client tokenizes a command
- * exactly the way the server that runs it does. This is a security boundary: any divergence lets a
- * crafted command resolve to a different (safer-looking) inner tool here than the backend executes.
- */
-export function splitFirstToken(input: string): { head: string; rest: string } {
-    const trimmed = input.trim()
-    const idx = trimmed.indexOf(' ')
-    if (idx === -1) {
-        return { head: trimmed, rest: '' }
-    }
-    return { head: trimmed.slice(0, idx), rest: trimmed.slice(idx + 1).trim() }
-}
-
-/**
- * Parses an exec `command` into its verb and remainder. `verb` is null when the leading token isn't
- * a recognized verb (the backend rejects such a command as `Unknown command`).
- */
-export function parseExecCommand(command: string): { verb: PostHogExecVerb | null; rest: string } {
-    const { head, rest } = splitFirstToken(command)
-    return POSTHOG_EXEC_VERBS.has(head as PostHogExecVerb)
-        ? { verb: head as PostHogExecVerb, rest }
-        : { verb: null, rest }
-}
-
-/**
- * Parses the body of a `call` command (everything after the `call` verb) into its inner sub-tool,
- * its remaining args, and the boolean flags. Strips leading `--json` / `--confirm` flags in any
- * order, mirroring the backend `parseCallFlags`, then takes the next token as the sub-tool.
- * `subTool` is null when no sub-tool remains, or when the next token still looks like a flag — a real
- * sub-tool name never starts with `-`. The permission gate keys destructive-tool detection off
- * `subTool`, so this MUST match the server's flag grammar: what the server strips, we strip; what it
- * can't resolve, we fail closed on.
- */
-export function parseExecCall(callBody: string): {
-    subTool: string | null
-    args: string
-    forceJson: boolean
-    confirmed: boolean
-} {
-    let rest = callBody.trim()
-    let forceJson = false
-    let confirmed = false
-    while (rest) {
-        const { head, rest: next } = splitFirstToken(rest)
-        if (head === '--json') {
-            forceJson = true
-            rest = next
-            continue
-        }
-        if (head === '--confirm') {
-            confirmed = true
-            rest = next
-            continue
-        }
-        break
-    }
-    const { head: subTool, rest: args } = splitFirstToken(rest)
-    if (!subTool || subTool.startsWith('-')) {
-        return { subTool: null, args, forceJson, confirmed }
-    }
-    return { subTool, args, forceJson, confirmed }
-}
+import { parseExecCall, parseExecCommand, splitFirstToken } from '../../utils/posthogExec'
 
 export interface PostHogExecDisplay {
     label: string

--- a/products/posthog_ai/frontend/components/tool/widgets/CreateInsightWidget.test.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/CreateInsightWidget.test.tsx
@@ -3,28 +3,13 @@ import '@testing-library/jest-dom'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import posthog from 'posthog-js'
 
+import { initKeaTests } from '~/test/init'
+
 import type { ToolCallMessage } from 'products/posthog_ai/frontend/types/toolTypes'
 
 import { CreateInsightWidget } from './CreateInsightWidget'
 
 jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
-jest.mock('@posthog/lemon-ui', () => ({
-    LemonButton: ({
-        children,
-        onClick,
-        targetBlank,
-        to,
-    }: {
-        children: React.ReactNode
-        onClick?: () => void
-        targetBlank?: boolean
-        to: string
-    }) => (
-        <button role="link" href={to} target={targetBlank ? '_blank' : undefined} onClick={onClick}>
-            {children}
-        </button>
-    ),
-}))
 jest.mock('scenes/urls', () => ({
     urls: {
         dashboard: (id: number): string => `/dashboard/${id}`,
@@ -68,6 +53,10 @@ function message(overrides: Partial<ToolCallMessage> = {}): ToolCallMessage {
 }
 
 describe('CreateInsightWidget', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
     afterEach(() => {
         cleanup()
         jest.mocked(posthog.capture).mockClear()
@@ -89,7 +78,7 @@ describe('CreateInsightWidget', () => {
         render(<CreateInsightWidget isLastInGroup message={message()} />)
 
         const action = screen.getByRole('link', { name: 'Show on dashboard' })
-        expect(action).toHaveAttribute('href', '/dashboard/7?highlightTileId=41')
+        expect(action).toHaveAttribute('href', '/project/997/dashboard/7?highlightTileId=41')
         expect(action).not.toHaveAttribute('target', '_blank')
 
         fireEvent.click(action)
@@ -99,15 +88,50 @@ describe('CreateInsightWidget', () => {
         })
     })
 
-    it('retains the visualization but omits the reveal action for mismatched dashboard membership', () => {
+    it.each([
+        ['mismatched dashboard membership', { dashboards: [7] }, [{ id: 41, dashboard_id: 8, deleted: false }]],
+        [
+            'ambiguous dashboard membership',
+            { dashboards: [7] },
+            [
+                { id: 41, dashboard_id: 7, deleted: false },
+                { id: 42, dashboard_id: 7, deleted: false },
+            ],
+        ],
+        [
+            'unsafe dashboard membership',
+            { dashboards: [7] },
+            [{ id: Number.MAX_SAFE_INTEGER + 1, dashboard_id: 7, deleted: false }],
+        ],
+    ])('falls back for %s', (_case, innerInput, dashboardTiles) => {
         render(
             <CreateInsightWidget
                 isLastInGroup
                 message={message({
+                    innerInput,
                     rawOutput: {
                         short_id: 'abc12345',
                         query: { kind: 'TrendsQuery' },
-                        dashboard_tiles: [{ id: 41, dashboard_id: 8, deleted: false }],
+                        dashboard_tiles: dashboardTiles,
+                    },
+                })}
+            />
+        )
+
+        expect(screen.getByTestId('generic-mcp-tool-renderer')).toBeInTheDocument()
+        expect(screen.queryByTestId('visualization-widget')).not.toBeInTheDocument()
+    })
+
+    it('keeps the visualization for a valid insight that did not request dashboard placement', () => {
+        render(
+            <CreateInsightWidget
+                isLastInGroup
+                message={message({
+                    innerInput: { dashboards: [] },
+                    rawOutput: {
+                        short_id: 'abc12345',
+                        query: { kind: 'TrendsQuery' },
+                        dashboard_tiles: [],
                     },
                 })}
             />

--- a/products/posthog_ai/frontend/components/tool/widgets/CreateInsightWidget.test.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/CreateInsightWidget.test.tsx
@@ -12,7 +12,8 @@ import { CreateInsightWidget } from './CreateInsightWidget'
 jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
 jest.mock('scenes/urls', () => ({
     urls: {
-        dashboard: (id: number): string => `/dashboard/${id}`,
+        dashboard: (id: number, _highlightInsightId?: string, highlightTileId?: number): string =>
+            `/dashboard/${id}${highlightTileId ? `?highlightTileId=${highlightTileId}` : ''}`,
         insightView: (id: string): string => `/insight/${id}`,
         insightNew: (): string => '/insights/new',
     },

--- a/products/posthog_ai/frontend/components/tool/widgets/CreateInsightWidget.test.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/CreateInsightWidget.test.tsx
@@ -1,0 +1,119 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import posthog from 'posthog-js'
+
+import type { ToolCallMessage } from 'products/posthog_ai/frontend/types/toolTypes'
+
+import { CreateInsightWidget } from './CreateInsightWidget'
+
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
+jest.mock('@posthog/lemon-ui', () => ({
+    LemonButton: ({
+        children,
+        onClick,
+        targetBlank,
+        to,
+    }: {
+        children: React.ReactNode
+        onClick?: () => void
+        targetBlank?: boolean
+        to: string
+    }) => (
+        <button role="link" href={to} target={targetBlank ? '_blank' : undefined} onClick={onClick}>
+            {children}
+        </button>
+    ),
+}))
+jest.mock('scenes/urls', () => ({
+    urls: {
+        dashboard: (id: number): string => `/dashboard/${id}`,
+        insightView: (id: string): string => `/insight/${id}`,
+        insightNew: (): string => '/insights/new',
+    },
+}))
+jest.mock('../DataToolRow', () => ({
+    DataToolRow: ({ children }: { children: React.ReactNode }) => <div data-attr="data-tool-row">{children}</div>,
+}))
+jest.mock('../GenericMcpToolRenderer', () => ({
+    GenericMcpToolRenderer: () => <div data-attr="generic-mcp-tool-renderer" />,
+}))
+jest.mock('./VisualizationWidget', () => ({
+    VisualizationWidget: ({ extraActions }: { extraActions?: React.ReactNode }) => (
+        <div data-attr="visualization-widget">{extraActions}</div>
+    ),
+    getArtifactOpenTarget: (): { url: string; tooltip: string } => ({
+        url: '/insight/abc12345',
+        tooltip: 'Open insight',
+    }),
+}))
+
+function message(overrides: Partial<ToolCallMessage> = {}): ToolCallMessage {
+    return {
+        id: 'call-1',
+        resolvedKey: 'insight-create',
+        rawServerName: 'posthog',
+        rawToolName: 'exec',
+        rawInput: { command: 'call insight-create {}' },
+        innerInput: { dashboards: [7] },
+        rawOutput: {
+            short_id: 'abc12345',
+            query: { kind: 'TrendsQuery' },
+            dashboard_tiles: [{ id: 41, dashboard_id: 7, deleted: false }],
+        },
+        content: [],
+        status: 'completed',
+        ...overrides,
+    }
+}
+
+describe('CreateInsightWidget', () => {
+    afterEach(() => {
+        cleanup()
+        jest.mocked(posthog.capture).mockClear()
+    })
+
+    it.each(['pending', 'in_progress', 'failed'] as const)('falls back while the tool is %s', (status) => {
+        render(<CreateInsightWidget isLastInGroup message={message({ status })} />)
+
+        expect(screen.getByTestId('generic-mcp-tool-renderer')).toBeInTheDocument()
+    })
+
+    it('falls back for malformed insight output', () => {
+        render(<CreateInsightWidget isLastInGroup message={message({ rawOutput: { short_id: 'abc12345' } })} />)
+
+        expect(screen.getByTestId('generic-mcp-tool-renderer')).toBeInTheDocument()
+    })
+
+    it('renders a same-tab dashboard action only for validated dashboard membership', () => {
+        render(<CreateInsightWidget isLastInGroup message={message()} />)
+
+        const action = screen.getByRole('link', { name: 'Show on dashboard' })
+        expect(action).toHaveAttribute('href', '/dashboard/7?highlightTileId=41')
+        expect(action).not.toHaveAttribute('target', '_blank')
+
+        fireEvent.click(action)
+        expect(posthog.capture).toHaveBeenCalledWith('posthog ai dashboard reveal clicked', {
+            source: 'tool_card',
+            target_kind: 'tile',
+        })
+    })
+
+    it('retains the visualization but omits the reveal action for mismatched dashboard membership', () => {
+        render(
+            <CreateInsightWidget
+                isLastInGroup
+                message={message({
+                    rawOutput: {
+                        short_id: 'abc12345',
+                        query: { kind: 'TrendsQuery' },
+                        dashboard_tiles: [{ id: 41, dashboard_id: 8, deleted: false }],
+                    },
+                })}
+            />
+        )
+
+        expect(screen.getByTestId('visualization-widget')).toBeInTheDocument()
+        expect(screen.queryByRole('link', { name: 'Show on dashboard' })).not.toBeInTheDocument()
+    })
+})

--- a/products/posthog_ai/frontend/components/tool/widgets/CreateInsightWidget.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/CreateInsightWidget.tsx
@@ -8,7 +8,11 @@ import { urls } from 'scenes/urls'
 import { DataToolRow } from '../DataToolRow'
 import { GenericMcpToolRenderer } from '../GenericMcpToolRenderer'
 import type { ToolRendererProps } from '../toolRegistry'
-import { extractInsightDashboardRevealTarget, extractVisualizationArtifact } from './extractors'
+import {
+    extractInsightDashboardRevealTarget,
+    extractVisualizationArtifact,
+    insightRequestIncludesDashboardTarget,
+} from './extractors'
 import { VisualizationWidget, getArtifactOpenTarget } from './VisualizationWidget'
 
 /**
@@ -19,13 +23,13 @@ import { VisualizationWidget, getArtifactOpenTarget } from './VisualizationWidge
 export function CreateInsightWidget(props: ToolRendererProps): JSX.Element {
     const { message } = props
     const artifact = message.status === 'completed' ? extractVisualizationArtifact(message) : null
+    const dashboardTarget = extractInsightDashboardRevealTarget(message)
 
-    if (!artifact) {
+    if (!artifact || (insightRequestIncludesDashboardTarget(message) && !dashboardTarget)) {
         return <GenericMcpToolRenderer {...props} />
     }
 
     const target = getArtifactOpenTarget(artifact.envelope, artifact.content)
-    const dashboardTarget = extractInsightDashboardRevealTarget(message)
     const dashboardAction = dashboardTarget ? (
         <LemonButton
             to={

--- a/products/posthog_ai/frontend/components/tool/widgets/CreateInsightWidget.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/CreateInsightWidget.tsx
@@ -1,7 +1,14 @@
+import { combineUrl } from 'kea-router'
+import posthog from 'posthog-js'
+
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { urls } from 'scenes/urls'
+
 import { DataToolRow } from '../DataToolRow'
 import { GenericMcpToolRenderer } from '../GenericMcpToolRenderer'
 import type { ToolRendererProps } from '../toolRegistry'
-import { extractVisualizationArtifact } from './extractors'
+import { extractInsightDashboardRevealTarget, extractVisualizationArtifact } from './extractors'
 import { VisualizationWidget, getArtifactOpenTarget } from './VisualizationWidget'
 
 /**
@@ -18,10 +25,32 @@ export function CreateInsightWidget(props: ToolRendererProps): JSX.Element {
     }
 
     const target = getArtifactOpenTarget(artifact.envelope, artifact.content)
+    const dashboardTarget = extractInsightDashboardRevealTarget(message)
+    const dashboardAction = dashboardTarget ? (
+        <LemonButton
+            to={
+                combineUrl(urls.dashboard(dashboardTarget.dashboardId), { highlightTileId: dashboardTarget.tileId }).url
+            }
+            size="xsmall"
+            onClick={() =>
+                posthog.capture('posthog ai dashboard reveal clicked', {
+                    source: 'tool_card',
+                    target_kind: 'tile',
+                })
+            }
+        >
+            Show on dashboard
+        </LemonButton>
+    ) : null
 
     return (
         <DataToolRow {...props}>
-            <VisualizationWidget content={artifact.content} openUrl={target.url} openTooltip={target.tooltip} />
+            <VisualizationWidget
+                content={artifact.content}
+                openUrl={target.url}
+                openTooltip={target.tooltip}
+                extraActions={dashboardAction}
+            />
         </DataToolRow>
     )
 }

--- a/products/posthog_ai/frontend/components/tool/widgets/CreateInsightWidget.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/CreateInsightWidget.tsx
@@ -1,4 +1,3 @@
-import { combineUrl } from 'kea-router'
 import posthog from 'posthog-js'
 
 import { LemonButton } from '@posthog/lemon-ui'
@@ -32,9 +31,7 @@ export function CreateInsightWidget(props: ToolRendererProps): JSX.Element {
     const target = getArtifactOpenTarget(artifact.envelope, artifact.content)
     const dashboardAction = dashboardTarget ? (
         <LemonButton
-            to={
-                combineUrl(urls.dashboard(dashboardTarget.dashboardId), { highlightTileId: dashboardTarget.tileId }).url
-            }
+            to={urls.dashboard(dashboardTarget.dashboardId, undefined, dashboardTarget.tileId)}
             size="xsmall"
             onClick={() =>
                 posthog.capture('posthog ai dashboard reveal clicked', {

--- a/products/posthog_ai/frontend/components/tool/widgets/CreateNotebookWidget.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/CreateNotebookWidget.tsx
@@ -5,10 +5,10 @@ import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { urls } from 'scenes/urls'
 
 import { MessageTemplate } from '../../../messages/MessageTemplate'
+import { parseToolOutputRecord } from '../../../utils/toolOutput'
 import { DataToolRow } from '../DataToolRow'
 import { GenericMcpToolRenderer } from '../GenericMcpToolRenderer'
 import type { ToolRendererProps } from '../toolRegistry'
-import { parseToolOutputRecord } from './extractors'
 
 /** The notebook fields the widget renders, pulled from the REST payload. */
 export interface NotebookExtraction {
@@ -25,7 +25,7 @@ export interface NotebookExtraction {
  * the generic card.
  */
 export function extractNotebook(message: ToolRendererProps['message']): NotebookExtraction | null {
-    const output = parseToolOutputRecord(message)
+    const output = parseToolOutputRecord(message.rawOutput, message.rawInput)
     if (!output) {
         return null
     }

--- a/products/posthog_ai/frontend/components/tool/widgets/DashboardTileMutationWidget.test.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/DashboardTileMutationWidget.test.tsx
@@ -1,0 +1,124 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import posthog from 'posthog-js'
+
+import type { ToolCallMessage } from 'products/posthog_ai/frontend/types/toolTypes'
+
+import { DashboardTileMutationWidget } from './DashboardTileMutationWidget'
+
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
+jest.mock('@posthog/lemon-ui', () => ({
+    LemonButton: ({
+        children,
+        onClick,
+        targetBlank,
+        to,
+    }: {
+        children: React.ReactNode
+        onClick?: () => void
+        targetBlank?: boolean
+        to: string
+    }) => (
+        <button role="link" href={to} target={targetBlank ? '_blank' : undefined} onClick={onClick}>
+            {children}
+        </button>
+    ),
+}))
+jest.mock('scenes/urls', () => ({ urls: { dashboard: (id: number): string => `/dashboard/${id}` } }))
+jest.mock('../DataToolRow', () => ({
+    DataToolRow: ({ children }: { children: React.ReactNode }) => <div data-attr="data-tool-row">{children}</div>,
+}))
+jest.mock('../GenericMcpToolRenderer', () => ({
+    GenericMcpToolRenderer: () => <div data-attr="generic-mcp-tool-renderer" />,
+}))
+
+function message(overrides: Partial<ToolCallMessage> = {}): ToolCallMessage {
+    return {
+        id: 'call-1',
+        resolvedKey: 'dashboard-create-tile',
+        rawServerName: 'posthog',
+        rawToolName: 'exec',
+        rawInput: { command: 'call dashboard-create-tile {}' },
+        innerInput: { dashboard_id: 7 },
+        rawOutput: { id: 41, dashboard_id: 7 },
+        content: [],
+        status: 'completed',
+        ...overrides,
+    }
+}
+
+describe('DashboardTileMutationWidget', () => {
+    afterEach(() => {
+        cleanup()
+        jest.mocked(posthog.capture).mockClear()
+    })
+
+    it.each(['pending', 'in_progress', 'failed'] as const)('falls back while the tool is %s', (status) => {
+        render(<DashboardTileMutationWidget isLastInGroup message={message({ status })} />)
+
+        expect(screen.getByTestId('generic-mcp-tool-renderer')).toBeInTheDocument()
+    })
+
+    it.each([
+        ['malformed output', 'not a result', { dashboard_id: 7 }],
+        ['mismatched dashboard', { id: 41, dashboard_id: 8 }, { dashboard_id: 7 }],
+        [
+            'ambiguous batch',
+            {
+                tiles: [
+                    { id: 41, dashboard_id: 7 },
+                    { id: 42, dashboard_id: 7 },
+                ],
+                dashboard_id: 7,
+            },
+            { dashboard_id: 7, widgets: [{}] },
+        ],
+    ])('falls back for %s', (_case, rawOutput, innerInput) => {
+        render(<DashboardTileMutationWidget isLastInGroup message={message({ rawOutput, innerInput })} />)
+
+        expect(screen.getByTestId('generic-mcp-tool-renderer')).toBeInTheDocument()
+    })
+
+    it('shows a validated single tile on its dashboard in the current tab', () => {
+        const { container } = render(<DashboardTileMutationWidget isLastInGroup message={message()} />)
+
+        const action = screen.getByRole('link', { name: 'Show on dashboard' })
+        expect(action).toHaveAttribute('href', '/dashboard/7?highlightTileId=41')
+        expect(action).not.toHaveAttribute('target', '_blank')
+        expect(container.querySelector('.flex-wrap')).toBeInTheDocument()
+        expect(container.querySelector('.min-w-0')).toBeInTheDocument()
+        expect(container.querySelector('.truncate')).toBeInTheDocument()
+
+        fireEvent.click(action)
+        expect(posthog.capture).toHaveBeenCalledWith('posthog ai dashboard reveal clicked', {
+            source: 'tool_card',
+            target_kind: 'tile',
+        })
+    })
+
+    it('opens a validated dashboard-only mutation in a new tab without exposing output data in telemetry', () => {
+        render(
+            <DashboardTileMutationWidget
+                isLastInGroup
+                message={message({
+                    resolvedKey: 'dashboard-reorder-tiles',
+                    rawInput: { command: 'call dashboard-reorder-tiles {}' },
+                    innerInput: { dashboard_id: 7 },
+                    rawOutput: { id: 7, name: 'Sensitive dashboard name' },
+                })}
+            />
+        )
+
+        const action = screen.getByRole('link', { name: 'View dashboard' })
+        expect(action).toHaveAttribute('href', '/dashboard/7')
+        expect(action).toHaveAttribute('target', '_blank')
+
+        fireEvent.click(action)
+        expect(posthog.capture).toHaveBeenCalledWith('posthog ai dashboard reveal clicked', {
+            source: 'tool_card',
+            target_kind: 'dashboard',
+        })
+        expect(JSON.stringify(jest.mocked(posthog.capture).mock.calls)).not.toContain('Sensitive dashboard name')
+    })
+})

--- a/products/posthog_ai/frontend/components/tool/widgets/DashboardTileMutationWidget.test.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/DashboardTileMutationWidget.test.tsx
@@ -3,28 +3,13 @@ import '@testing-library/jest-dom'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import posthog from 'posthog-js'
 
+import { initKeaTests } from '~/test/init'
+
 import type { ToolCallMessage } from 'products/posthog_ai/frontend/types/toolTypes'
 
 import { DashboardTileMutationWidget } from './DashboardTileMutationWidget'
 
 jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
-jest.mock('@posthog/lemon-ui', () => ({
-    LemonButton: ({
-        children,
-        onClick,
-        targetBlank,
-        to,
-    }: {
-        children: React.ReactNode
-        onClick?: () => void
-        targetBlank?: boolean
-        to: string
-    }) => (
-        <button role="link" href={to} target={targetBlank ? '_blank' : undefined} onClick={onClick}>
-            {children}
-        </button>
-    ),
-}))
 jest.mock('scenes/urls', () => ({ urls: { dashboard: (id: number): string => `/dashboard/${id}` } }))
 jest.mock('../DataToolRow', () => ({
     DataToolRow: ({ children }: { children: React.ReactNode }) => <div data-attr="data-tool-row">{children}</div>,
@@ -49,6 +34,10 @@ function message(overrides: Partial<ToolCallMessage> = {}): ToolCallMessage {
 }
 
 describe('DashboardTileMutationWidget', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
     afterEach(() => {
         cleanup()
         jest.mocked(posthog.capture).mockClear()
@@ -84,7 +73,7 @@ describe('DashboardTileMutationWidget', () => {
         const { container } = render(<DashboardTileMutationWidget isLastInGroup message={message()} />)
 
         const action = screen.getByRole('link', { name: 'Show on dashboard' })
-        expect(action).toHaveAttribute('href', '/dashboard/7?highlightTileId=41')
+        expect(action).toHaveAttribute('href', '/project/997/dashboard/7?highlightTileId=41')
         expect(action).not.toHaveAttribute('target', '_blank')
         expect(container.querySelector('.flex-wrap')).toBeInTheDocument()
         expect(container.querySelector('.min-w-0')).toBeInTheDocument()
@@ -111,7 +100,7 @@ describe('DashboardTileMutationWidget', () => {
         )
 
         const action = screen.getByRole('link', { name: 'View dashboard' })
-        expect(action).toHaveAttribute('href', '/dashboard/7')
+        expect(action).toHaveAttribute('href', '/project/997/dashboard/7')
         expect(action).toHaveAttribute('target', '_blank')
 
         fireEvent.click(action)
@@ -120,5 +109,18 @@ describe('DashboardTileMutationWidget', () => {
             target_kind: 'dashboard',
         })
         expect(JSON.stringify(jest.mocked(posthog.capture).mock.calls)).not.toContain('Sensitive dashboard name')
+    })
+
+    it('keeps its label and action responsive in a 520px container', () => {
+        const { container } = render(
+            <div data-attr="narrow-container" style={{ width: 520 }}>
+                <DashboardTileMutationWidget isLastInGroup message={message()} />
+            </div>
+        )
+
+        expect(screen.getByTestId('narrow-container')).toHaveStyle({ width: '520px' })
+        expect(container.querySelector('.flex-wrap')).toBeInTheDocument()
+        expect(screen.getByText('Dashboard updated')).toHaveClass('min-w-0', 'truncate')
+        expect(screen.getByRole('link', { name: 'Show on dashboard' })).toHaveClass('shrink-0')
     })
 })

--- a/products/posthog_ai/frontend/components/tool/widgets/DashboardTileMutationWidget.test.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/DashboardTileMutationWidget.test.tsx
@@ -10,7 +10,12 @@ import type { ToolCallMessage } from 'products/posthog_ai/frontend/types/toolTyp
 import { DashboardTileMutationWidget } from './DashboardTileMutationWidget'
 
 jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
-jest.mock('scenes/urls', () => ({ urls: { dashboard: (id: number): string => `/dashboard/${id}` } }))
+jest.mock('scenes/urls', () => ({
+    urls: {
+        dashboard: (id: number, _highlightInsightId?: string, highlightTileId?: number): string =>
+            `/dashboard/${id}${highlightTileId ? `?highlightTileId=${highlightTileId}` : ''}`,
+    },
+}))
 jest.mock('../DataToolRow', () => ({
     DataToolRow: ({ children }: { children: React.ReactNode }) => <div data-attr="data-tool-row">{children}</div>,
 }))

--- a/products/posthog_ai/frontend/components/tool/widgets/DashboardTileMutationWidget.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/DashboardTileMutationWidget.tsx
@@ -43,7 +43,13 @@ export function DashboardTileMutationWidget(props: ToolRendererProps): JSX.Eleme
                         <IconDashboard className="text-base" />
                         <span className="min-w-0 truncate font-medium">Dashboard updated</span>
                     </div>
-                    <LemonButton to={to} targetBlank={!revealsTile} size="xsmall" onClick={captureReveal}>
+                    <LemonButton
+                        className="shrink-0"
+                        to={to}
+                        targetBlank={!revealsTile}
+                        size="xsmall"
+                        onClick={captureReveal}
+                    >
                         {revealsTile ? 'Show on dashboard' : 'View dashboard'}
                     </LemonButton>
                 </div>

--- a/products/posthog_ai/frontend/components/tool/widgets/DashboardTileMutationWidget.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/DashboardTileMutationWidget.tsx
@@ -1,4 +1,3 @@
-import { combineUrl } from 'kea-router'
 import posthog from 'posthog-js'
 
 import { IconDashboard } from '@posthog/icons'
@@ -25,9 +24,7 @@ export function DashboardTileMutationWidget(props: ToolRendererProps): JSX.Eleme
     }
 
     const revealsTile = target.tileId !== undefined
-    const to = revealsTile
-        ? combineUrl(urls.dashboard(target.dashboardId), { highlightTileId: target.tileId }).url
-        : urls.dashboard(target.dashboardId)
+    const to = urls.dashboard(target.dashboardId, undefined, target.tileId)
     const captureReveal = (): void => {
         posthog.capture('posthog ai dashboard reveal clicked', {
             source: 'tool_card',

--- a/products/posthog_ai/frontend/components/tool/widgets/DashboardTileMutationWidget.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/DashboardTileMutationWidget.tsx
@@ -1,0 +1,53 @@
+import { combineUrl } from 'kea-router'
+import posthog from 'posthog-js'
+
+import { IconDashboard } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { urls } from 'scenes/urls'
+
+import { MessageTemplate } from '../../../messages/MessageTemplate'
+import { DataToolRow } from '../DataToolRow'
+import { GenericMcpToolRenderer } from '../GenericMcpToolRenderer'
+import type { ToolRendererProps } from '../toolRegistry'
+import { extractDashboardMutationRevealTarget } from './extractors'
+
+/**
+ * Displays an authoritative dashboard mutation with a direct route to its affected tile or dashboard.
+ * Any incomplete or ambiguous result stays on the generic card to avoid suggesting a false target.
+ */
+export function DashboardTileMutationWidget(props: ToolRendererProps): JSX.Element {
+    const { message } = props
+    const target = extractDashboardMutationRevealTarget(message)
+
+    if (!target) {
+        return <GenericMcpToolRenderer {...props} />
+    }
+
+    const revealsTile = target.tileId !== undefined
+    const to = revealsTile
+        ? combineUrl(urls.dashboard(target.dashboardId), { highlightTileId: target.tileId }).url
+        : urls.dashboard(target.dashboardId)
+    const captureReveal = (): void => {
+        posthog.capture('posthog ai dashboard reveal clicked', {
+            source: 'tool_card',
+            target_kind: revealsTile ? 'tile' : 'dashboard',
+        })
+    }
+
+    return (
+        <DataToolRow {...props}>
+            <MessageTemplate type="ai" wrapperClassName="w-full">
+                <div className="flex min-w-0 flex-wrap items-center justify-between gap-2">
+                    <div className="flex min-w-0 items-center gap-1.5">
+                        <IconDashboard className="text-base" />
+                        <span className="min-w-0 truncate font-medium">Dashboard updated</span>
+                    </div>
+                    <LemonButton to={to} targetBlank={!revealsTile} size="xsmall" onClick={captureReveal}>
+                        {revealsTile ? 'Show on dashboard' : 'View dashboard'}
+                    </LemonButton>
+                </div>
+            </MessageTemplate>
+        </DataToolRow>
+    )
+}

--- a/products/posthog_ai/frontend/components/tool/widgets/UpsertDashboardWidget.test.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/UpsertDashboardWidget.test.tsx
@@ -3,28 +3,13 @@ import '@testing-library/jest-dom'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import posthog from 'posthog-js'
 
+import { initKeaTests } from '~/test/init'
+
 import type { ToolCallMessage } from 'products/posthog_ai/frontend/types/toolTypes'
 
 import { UpsertDashboardWidget } from './UpsertDashboardWidget'
 
 jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
-jest.mock('@posthog/lemon-ui', () => ({
-    LemonButton: ({
-        children,
-        onClick,
-        targetBlank,
-        to,
-    }: {
-        children: React.ReactNode
-        onClick?: () => void
-        targetBlank?: boolean
-        to: string
-    }) => (
-        <button role="link" href={to} target={targetBlank ? '_blank' : undefined} onClick={onClick}>
-            {children}
-        </button>
-    ),
-}))
 jest.mock('scenes/urls', () => ({ urls: { dashboard: (id: number): string => `/dashboard/${id}` } }))
 jest.mock('../DataToolRow', () => ({
     DataToolRow: ({ children }: { children: React.ReactNode }) => <div data-attr="data-tool-row">{children}</div>,
@@ -49,6 +34,10 @@ function message(overrides: Partial<ToolCallMessage> = {}): ToolCallMessage {
 }
 
 describe('UpsertDashboardWidget', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
     afterEach(() => {
         cleanup()
         jest.mocked(posthog.capture).mockClear()
@@ -73,7 +62,7 @@ describe('UpsertDashboardWidget', () => {
         const { container } = render(<UpsertDashboardWidget isLastInGroup message={message()} />)
 
         const action = screen.getByRole('link', { name: 'View dashboard' })
-        expect(action).toHaveAttribute('href', '/dashboard/7')
+        expect(action).toHaveAttribute('href', '/project/997/dashboard/7')
         expect(action).toHaveAttribute('target', '_blank')
         expect(container.querySelector('.flex-wrap')).toBeInTheDocument()
         expect(container.querySelector('.min-w-0')).toBeInTheDocument()
@@ -96,5 +85,47 @@ describe('UpsertDashboardWidget', () => {
         )
 
         expect(screen.getByRole('link', { name: 'View dashboard' })).toHaveAttribute('target', '_blank')
+    })
+
+    it.each([
+        ['an empty object', {}],
+        ['zero', { id: 0 }],
+        ['a negative number', { id: -1 }],
+        ['a decimal', { id: 1.5 }],
+        ['an unsafe integer', { id: Number.MAX_SAFE_INTEGER + 1 }],
+        ['a string', { id: '7' }],
+        ['an arbitrary object', { name: 'Dashboard', url: '/dashboard/7' }],
+        ['unstructured text', 'created dashboard 7'],
+    ])('falls back when dashboard-create returns %s', (_case, rawOutput) => {
+        render(
+            <UpsertDashboardWidget
+                isLastInGroup
+                message={message({ resolvedKey: 'dashboard-create', innerInput: { name: 'New dashboard' }, rawOutput })}
+            />
+        )
+
+        expect(screen.getByTestId('generic-mcp-tool-renderer')).toBeInTheDocument()
+        expect(screen.queryByRole('link', { name: 'View dashboard' })).not.toBeInTheDocument()
+    })
+
+    it('keeps its label and action responsive in a 520px container', () => {
+        const { container } = render(
+            <div data-attr="narrow-container" style={{ width: 520 }}>
+                <UpsertDashboardWidget
+                    isLastInGroup
+                    message={message({
+                        rawOutput: {
+                            id: 7,
+                            name: 'A dashboard name that is intentionally long enough to require truncation',
+                        },
+                    })}
+                />
+            </div>
+        )
+
+        expect(screen.getByTestId('narrow-container')).toHaveStyle({ width: '520px' })
+        expect(container.querySelector('.flex-wrap')).toBeInTheDocument()
+        expect(screen.getByText(/intentionally long/)).toHaveClass('min-w-0', 'truncate')
+        expect(screen.getByRole('link', { name: 'View dashboard' })).toHaveClass('shrink-0')
     })
 })

--- a/products/posthog_ai/frontend/components/tool/widgets/UpsertDashboardWidget.test.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/UpsertDashboardWidget.test.tsx
@@ -10,7 +10,12 @@ import type { ToolCallMessage } from 'products/posthog_ai/frontend/types/toolTyp
 import { UpsertDashboardWidget } from './UpsertDashboardWidget'
 
 jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
-jest.mock('scenes/urls', () => ({ urls: { dashboard: (id: number): string => `/dashboard/${id}` } }))
+jest.mock('scenes/urls', () => ({
+    urls: {
+        dashboard: (id: number, _highlightInsightId?: string, highlightTileId?: number): string =>
+            `/dashboard/${id}${highlightTileId ? `?highlightTileId=${highlightTileId}` : ''}`,
+    },
+}))
 jest.mock('../DataToolRow', () => ({
     DataToolRow: ({ children }: { children: React.ReactNode }) => <div data-attr="data-tool-row">{children}</div>,
 }))

--- a/products/posthog_ai/frontend/components/tool/widgets/UpsertDashboardWidget.test.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/UpsertDashboardWidget.test.tsx
@@ -1,0 +1,100 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import posthog from 'posthog-js'
+
+import type { ToolCallMessage } from 'products/posthog_ai/frontend/types/toolTypes'
+
+import { UpsertDashboardWidget } from './UpsertDashboardWidget'
+
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
+jest.mock('@posthog/lemon-ui', () => ({
+    LemonButton: ({
+        children,
+        onClick,
+        targetBlank,
+        to,
+    }: {
+        children: React.ReactNode
+        onClick?: () => void
+        targetBlank?: boolean
+        to: string
+    }) => (
+        <button role="link" href={to} target={targetBlank ? '_blank' : undefined} onClick={onClick}>
+            {children}
+        </button>
+    ),
+}))
+jest.mock('scenes/urls', () => ({ urls: { dashboard: (id: number): string => `/dashboard/${id}` } }))
+jest.mock('../DataToolRow', () => ({
+    DataToolRow: ({ children }: { children: React.ReactNode }) => <div data-attr="data-tool-row">{children}</div>,
+}))
+jest.mock('../GenericMcpToolRenderer', () => ({
+    GenericMcpToolRenderer: () => <div data-attr="generic-mcp-tool-renderer" />,
+}))
+
+function message(overrides: Partial<ToolCallMessage> = {}): ToolCallMessage {
+    return {
+        id: 'call-1',
+        resolvedKey: 'dashboard-update',
+        rawServerName: 'posthog',
+        rawToolName: 'exec',
+        rawInput: { command: 'call dashboard-update {}' },
+        innerInput: { id: 7 },
+        rawOutput: { id: 7, name: 'Sensitive dashboard name' },
+        content: [],
+        status: 'completed',
+        ...overrides,
+    }
+}
+
+describe('UpsertDashboardWidget', () => {
+    afterEach(() => {
+        cleanup()
+        jest.mocked(posthog.capture).mockClear()
+    })
+
+    it.each(['pending', 'in_progress', 'failed'] as const)('falls back while the tool is %s', (status) => {
+        render(<UpsertDashboardWidget isLastInGroup message={message({ status })} />)
+
+        expect(screen.getByTestId('generic-mcp-tool-renderer')).toBeInTheDocument()
+    })
+
+    it.each([
+        ['malformed output', 'not a result'],
+        ['mismatched response id', { id: 8, name: 'Sensitive dashboard name' }],
+    ])('falls back for %s', (_case, rawOutput) => {
+        render(<UpsertDashboardWidget isLastInGroup message={message({ rawOutput })} />)
+
+        expect(screen.getByTestId('generic-mcp-tool-renderer')).toBeInTheDocument()
+    })
+
+    it('shows a validated update as a dashboard link in a new tab with private telemetry', () => {
+        const { container } = render(<UpsertDashboardWidget isLastInGroup message={message()} />)
+
+        const action = screen.getByRole('link', { name: 'View dashboard' })
+        expect(action).toHaveAttribute('href', '/dashboard/7')
+        expect(action).toHaveAttribute('target', '_blank')
+        expect(container.querySelector('.flex-wrap')).toBeInTheDocument()
+        expect(container.querySelector('.min-w-0')).toBeInTheDocument()
+        expect(container.querySelector('.truncate')).toBeInTheDocument()
+
+        fireEvent.click(action)
+        expect(posthog.capture).toHaveBeenCalledWith('posthog ai dashboard reveal clicked', {
+            source: 'tool_card',
+            target_kind: 'dashboard',
+        })
+        expect(JSON.stringify(jest.mocked(posthog.capture).mock.calls)).not.toContain('Sensitive dashboard name')
+    })
+
+    it('keeps dashboard-create links opening in a new tab', () => {
+        render(
+            <UpsertDashboardWidget
+                isLastInGroup
+                message={message({ resolvedKey: 'dashboard-create', innerInput: { name: 'New dashboard' } })}
+            />
+        )
+
+        expect(screen.getByRole('link', { name: 'View dashboard' })).toHaveAttribute('target', '_blank')
+    })
+})

--- a/products/posthog_ai/frontend/components/tool/widgets/UpsertDashboardWidget.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/UpsertDashboardWidget.tsx
@@ -9,7 +9,11 @@ import { MessageTemplate } from '../../../messages/MessageTemplate'
 import { DataToolRow } from '../DataToolRow'
 import { GenericMcpToolRenderer } from '../GenericMcpToolRenderer'
 import type { ToolRendererProps } from '../toolRegistry'
-import { extractDashboard, extractDashboardMutationRevealTarget } from './extractors'
+import {
+    extractDashboard,
+    extractDashboardCreateRevealTarget,
+    extractDashboardMutationRevealTarget,
+} from './extractors'
 
 /**
  * Dashboard create / update tool calls. v1 is a status line + "View dashboard" CTA (a full
@@ -20,9 +24,13 @@ export function UpsertDashboardWidget(props: ToolRendererProps): JSX.Element {
     const { message } = props
     const dashboard = message.status === 'completed' ? extractDashboard(message) : null
     const dashboardTarget =
-        message.resolvedKey === 'dashboard-update' ? extractDashboardMutationRevealTarget(message) : null
+        message.resolvedKey === 'dashboard-update'
+            ? extractDashboardMutationRevealTarget(message)
+            : extractDashboardCreateRevealTarget(message)
+    const requiresStrictTarget =
+        message.resolvedKey === 'dashboard-update' || message.resolvedKey === 'dashboard-create'
 
-    if (!dashboard || (message.resolvedKey === 'dashboard-update' && !dashboardTarget)) {
+    if (!dashboard || (requiresStrictTarget && !dashboardTarget)) {
         return <GenericMcpToolRenderer {...props} />
     }
 
@@ -47,7 +55,14 @@ export function UpsertDashboardWidget(props: ToolRendererProps): JSX.Element {
                         <span className="min-w-0 truncate font-medium">{dashboard.name || 'Dashboard ready'}</span>
                     </div>
                     {to && (
-                        <LemonButton to={to} targetBlank size="xsmall" tooltip="Open dashboard" onClick={captureReveal}>
+                        <LemonButton
+                            className="shrink-0"
+                            to={to}
+                            targetBlank
+                            size="xsmall"
+                            tooltip="Open dashboard"
+                            onClick={captureReveal}
+                        >
                             View dashboard
                         </LemonButton>
                     )}

--- a/products/posthog_ai/frontend/components/tool/widgets/UpsertDashboardWidget.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/UpsertDashboardWidget.tsx
@@ -1,14 +1,15 @@
+import posthog from 'posthog-js'
+
 import { IconDashboard } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
-import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { urls } from 'scenes/urls'
 
 import { MessageTemplate } from '../../../messages/MessageTemplate'
 import { DataToolRow } from '../DataToolRow'
 import { GenericMcpToolRenderer } from '../GenericMcpToolRenderer'
 import type { ToolRendererProps } from '../toolRegistry'
-import { extractDashboard } from './extractors'
+import { extractDashboard, extractDashboardMutationRevealTarget } from './extractors'
 
 /**
  * Dashboard create / update tool calls. v1 is a status line + "View dashboard" CTA (a full
@@ -18,29 +19,35 @@ import { extractDashboard } from './extractors'
 export function UpsertDashboardWidget(props: ToolRendererProps): JSX.Element {
     const { message } = props
     const dashboard = message.status === 'completed' ? extractDashboard(message) : null
+    const dashboardTarget =
+        message.resolvedKey === 'dashboard-update' ? extractDashboardMutationRevealTarget(message) : null
 
-    if (!dashboard) {
+    if (!dashboard || (message.resolvedKey === 'dashboard-update' && !dashboardTarget)) {
         return <GenericMcpToolRenderer {...props} />
     }
 
-    const to = dashboard.url ?? (dashboard.id !== undefined ? urls.dashboard(dashboard.id) : undefined)
+    const to = dashboardTarget
+        ? urls.dashboard(dashboardTarget.dashboardId)
+        : dashboard.id !== undefined
+          ? urls.dashboard(dashboard.id)
+          : dashboard.url
+    const captureReveal = (): void => {
+        posthog.capture('posthog ai dashboard reveal clicked', {
+            source: 'tool_card',
+            target_kind: 'dashboard',
+        })
+    }
 
     return (
         <DataToolRow {...props}>
             <MessageTemplate type="ai" wrapperClassName="w-full">
-                <div className="flex items-center justify-between gap-2">
-                    <div className="flex items-center gap-1.5">
+                <div className="flex min-w-0 flex-wrap items-center justify-between gap-2">
+                    <div className="flex min-w-0 items-center gap-1.5">
                         <IconDashboard className="text-base" />
-                        <span className="font-medium">{dashboard.name || 'Dashboard ready'}</span>
+                        <span className="min-w-0 truncate font-medium">{dashboard.name || 'Dashboard ready'}</span>
                     </div>
                     {to && (
-                        <LemonButton
-                            to={to}
-                            targetBlank
-                            icon={<IconOpenInNew />}
-                            size="xsmall"
-                            tooltip="Open dashboard"
-                        >
+                        <LemonButton to={to} targetBlank size="xsmall" tooltip="Open dashboard" onClick={captureReveal}>
                             View dashboard
                         </LemonButton>
                     )}

--- a/products/posthog_ai/frontend/components/tool/widgets/UpsertDashboardWidget.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/UpsertDashboardWidget.tsx
@@ -35,7 +35,7 @@ export function UpsertDashboardWidget(props: ToolRendererProps): JSX.Element {
     }
 
     const to = dashboardTarget
-        ? urls.dashboard(dashboardTarget.dashboardId)
+        ? urls.dashboard(dashboardTarget.dashboardId, undefined, dashboardTarget.tileId)
         : dashboard.id !== undefined
           ? urls.dashboard(dashboard.id)
           : dashboard.url

--- a/products/posthog_ai/frontend/components/tool/widgets/VisualizationWidget.test.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/VisualizationWidget.test.tsx
@@ -1,0 +1,51 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { ArtifactContentType } from '~/queries/schema/schema-assistant-messages'
+import { NodeKind } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+
+import { VisualizationWidget } from './VisualizationWidget'
+
+jest.mock('~/queries/Query/Query', () => ({
+    Query: () => <div data-attr="visualization-query" />,
+}))
+
+describe('VisualizationWidget', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('wraps the real action row in a 520px container', () => {
+        const { container } = render(
+            <div data-attr="narrow-container" style={{ width: 520 }}>
+                <VisualizationWidget
+                    content={{
+                        content_type: ArtifactContentType.Visualization,
+                        query: { kind: NodeKind.HogQLQuery, query: 'SELECT 1' },
+                    }}
+                    extraActions={<LemonButton size="xsmall">Show on dashboard</LemonButton>}
+                    openUrl="/insight/example"
+                />
+            </div>
+        )
+
+        expect(screen.getByTestId('narrow-container')).toHaveStyle({ width: '520px' })
+
+        const actionRow = container.querySelector('[data-attr="visualization-widget-action-row"]')
+        expect(actionRow).toHaveClass('min-w-0', 'flex-wrap')
+        expect(container.querySelector('[data-attr="visualization-widget-heading"]')).toHaveClass('min-w-0', 'truncate')
+        expect(container.querySelector('[data-attr="visualization-widget-actions"]')).toHaveClass(
+            'shrink-0',
+            'flex-wrap'
+        )
+        expect(screen.getByRole('button', { name: 'Show on dashboard' })).toBeInTheDocument()
+    })
+})

--- a/products/posthog_ai/frontend/components/tool/widgets/VisualizationWidget.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/VisualizationWidget.tsx
@@ -105,27 +105,32 @@ export const VisualizationWidget = React.memo(function VisualizationWidget({
                     <Query query={query} readOnly embedded context={QUERY_CONTEXT_POSTHOG_AI} />
                 </div>
             )}
-            <div className={clsx('flex items-center justify-between', !isCollapsed && 'mt-2')}>
-                {isInsightVizNode(query) ? (
-                    <div className="flex items-center gap-1.5">
-                        <LemonButton
-                            sideIcon={isSummaryShown ? <IconCollapse /> : <IconExpand />}
-                            onClick={() => setIsSummaryShown(!isSummaryShown)}
-                            size="xsmall"
-                            className="-m-1 shrink"
-                            tooltip={isSummaryShown ? 'Hide definition' : 'Show definition'}
-                        >
-                            <h5 className="m-0 leading-none">
-                                <TopHeading query={query} />
-                            </h5>
-                        </LemonButton>
-                    </div>
-                ) : (
-                    <h5 className="m-0 leading-none">
-                        <TopHeading query={query} />
-                    </h5>
-                )}
-                <div className="flex items-center gap-1.5">
+            <div
+                className={clsx('flex min-w-0 flex-wrap items-center justify-between gap-2', !isCollapsed && 'mt-2')}
+                data-attr="visualization-widget-action-row"
+            >
+                <div className="min-w-0 flex-1 truncate" data-attr="visualization-widget-heading">
+                    {isInsightVizNode(query) ? (
+                        <div className="flex min-w-0 items-center gap-1.5">
+                            <LemonButton
+                                sideIcon={isSummaryShown ? <IconCollapse /> : <IconExpand />}
+                                onClick={() => setIsSummaryShown(!isSummaryShown)}
+                                size="xsmall"
+                                className="-m-1 min-w-0 max-w-full shrink"
+                                tooltip={isSummaryShown ? 'Hide definition' : 'Show definition'}
+                            >
+                                <h5 className="m-0 truncate leading-none">
+                                    <TopHeading query={query} />
+                                </h5>
+                            </LemonButton>
+                        </div>
+                    ) : (
+                        <h5 className="m-0 truncate leading-none">
+                            <TopHeading query={query} />
+                        </h5>
+                    )}
+                </div>
+                <div className="flex shrink-0 flex-wrap items-center gap-1.5" data-attr="visualization-widget-actions">
                     {extraActions}
                     {openUrl && (
                         <LemonButton

--- a/products/posthog_ai/frontend/components/tool/widgets/extractors.test.ts
+++ b/products/posthog_ai/frontend/components/tool/widgets/extractors.test.ts
@@ -371,10 +371,34 @@ describe('mcp tool adapter extractors', () => {
         })
 
         it.each([
+            ['a local deployment', 'http://localhost:8010/project/1/dashboard/7'],
+            ['a self-hosted deployment', 'https://posthog.example.test/project/42/dashboard/7'],
+            [
+                'a custom domain with query and hash',
+                'https://analytics.customer.test/project/1/dashboard/7?source=mcp#highlight',
+            ],
+        ])('accepts a 204 tile delete from %s', (_case, url) => {
+            expect(
+                extractDashboardMutationRevealTarget(
+                    toolMessage({ _posthogUrl: url }, { id: 7, tile_id: 41 }, 'dashboard-delete-tile')
+                )
+            ).toEqual({ dashboardId: 7 })
+        })
+
+        it.each([
             [undefined, 'missing enrichment'],
-            [{ _posthogUrl: 'https://example.com/project/1/dashboard/7' }, 'a third-party URL'],
-            [{ _posthogUrl: 'https://us.posthog.com/project/1/dashboard/8' }, 'a URL for a different dashboard'],
-            [{ _posthogUrl: '/dashboard/7' }, 'a relative URL'],
+            [{ _posthogUrl: 'https://analytics.customer.test/project/0/dashboard/7' }, 'a zero project ID'],
+            [
+                { _posthogUrl: 'https://analytics.customer.test/project/9007199254740992/dashboard/7' },
+                'an unsafe project ID',
+            ],
+            [
+                { _posthogUrl: 'https://analytics.customer.test/project/1/dashboard/8' },
+                'a URL for a different dashboard',
+            ],
+            [{ _posthogUrl: 'https://analytics.customer.test/project/1/dashboard/7/tiles' }, 'a nested route'],
+            [{ _posthogUrl: 'ftp://analytics.customer.test/project/1/dashboard/7' }, 'a non-HTTP URL'],
+            [{ _posthogUrl: '/project/1/dashboard/7' }, 'a relative URL'],
         ])('rejects a 204 tile delete with %s', (rawOutput, _case) => {
             expect(
                 extractDashboardMutationRevealTarget(
@@ -393,6 +417,25 @@ describe('mcp tool adapter extractors', () => {
         it.each(['insight-create', 'insight-update'])('extracts an authoritative tile after %s', (resolvedKey) => {
             expect(
                 extractInsightDashboardRevealTarget(toolMessage(matchingOutput, { dashboards: [7] }, resolvedKey))
+            ).toEqual({
+                dashboardId: 7,
+                tileId: 41,
+                insightShortId: 'abc12345',
+            })
+        })
+
+        it('accepts an active API dashboard tile whose deleted field is null', () => {
+            expect(
+                extractInsightDashboardRevealTarget(
+                    toolMessage(
+                        {
+                            short_id: 'abc12345',
+                            dashboard_tiles: [{ id: 41, dashboard_id: 7, deleted: null }],
+                        },
+                        { dashboards: [7] },
+                        'insight-update'
+                    )
+                )
             ).toEqual({
                 dashboardId: 7,
                 tileId: 41,

--- a/products/posthog_ai/frontend/components/tool/widgets/extractors.test.ts
+++ b/products/posthog_ai/frontend/components/tool/widgets/extractors.test.ts
@@ -4,12 +4,14 @@ import type { ToolCallMessage } from 'products/posthog_ai/frontend/types/toolTyp
 
 import {
     extractDashboard,
+    extractDashboardCreateRevealTarget,
     extractDashboardMutationRevealTarget,
     extractErrorTrackingResponse,
     extractInsightDashboardRevealTarget,
     extractQueryResult,
     extractRecordingFilters,
     extractVisualizationArtifact,
+    insightRequestIncludesDashboardTarget,
 } from './extractors'
 
 function toolMessage(
@@ -94,6 +96,46 @@ describe('mcp tool adapter extractors', () => {
                 rawInput: { command: 'call dashboard-create {}' },
             })
             expect(dashboard).toBeNull()
+        })
+    })
+
+    describe('extractDashboardCreateRevealTarget', () => {
+        it('accepts a completed dashboard-create response with a positive safe numeric id', () => {
+            expect(extractDashboardCreateRevealTarget(toolMessage({ id: 7 }, {}, 'dashboard-create'))).toEqual({
+                dashboardId: 7,
+            })
+        })
+
+        it.each([{}, { id: 0 }, { id: -1 }, { id: 1.5 }, { id: Number.MAX_SAFE_INTEGER + 1 }, { id: '7' }])(
+            'rejects malformed dashboard-create response %p',
+            (rawOutput) => {
+                expect(extractDashboardCreateRevealTarget(toolMessage(rawOutput, {}, 'dashboard-create'))).toBeNull()
+            }
+        )
+
+        it('rejects other tool keys and unfinished calls', () => {
+            expect(extractDashboardCreateRevealTarget(toolMessage({ id: 7 }, {}, 'dashboard-update'))).toBeNull()
+            expect(
+                extractDashboardCreateRevealTarget({
+                    ...toolMessage({ id: 7 }, {}, 'dashboard-create'),
+                    status: 'pending',
+                })
+            ).toBeNull()
+        })
+    })
+
+    describe('insightRequestIncludesDashboardTarget', () => {
+        it.each([
+            [{ dashboards: [7] }, true],
+            [{ dashboards: [0] }, true],
+            [{ dashboards: [7, 8] }, true],
+            [{ dashboards: '7' }, true],
+            [{ dashboards: [] }, false],
+            [{ dashboards: null }, false],
+            [{}, false],
+            [undefined, false],
+        ])('reports whether %p asks for dashboard placement', (innerInput, expected) => {
+            expect(insightRequestIncludesDashboardTarget(toolMessage({}, innerInput, 'insight-create'))).toBe(expected)
         })
     })
 

--- a/products/posthog_ai/frontend/components/tool/widgets/extractors.test.ts
+++ b/products/posthog_ai/frontend/components/tool/widgets/extractors.test.ts
@@ -337,18 +337,18 @@ describe('mcp tool adapter extractors', () => {
                 { dashboardId: 7, tileId: 41 },
             ],
             [
-                'moves a tile while retaining the authoritative source dashboard response',
+                'moves a tile onto the destination dashboard it now lives on',
                 'dashboards-move-tile-create',
                 { id: 7, to_dashboard: 8, tile: { id: 41 } },
                 { id: 7 },
-                { dashboardId: 7 },
+                { dashboardId: 8, tileId: 41 },
             ],
             [
                 'moves a tile through the live partial-update key',
                 'dashboards-move-tile-partial-update',
                 { id: 7, to_dashboard: 8, tile: { id: 41 } },
                 { id: 7 },
-                { dashboardId: 7 },
+                { dashboardId: 8, tileId: 41 },
             ],
         ])('strictly extracts a target when it %s', (_case, resolvedKey, innerInput, rawOutput, expected) => {
             expect(extractDashboardMutationRevealTarget(toolMessage(rawOutput, innerInput, resolvedKey))).toEqual(
@@ -456,6 +456,36 @@ describe('mcp tool adapter extractors', () => {
                 'dashboard-widgets-batch-update',
                 'not a structured response',
                 { id: 7, widgets: [{ tile_id: 41 }] },
+            ],
+            [
+                'a move whose response describes a different source dashboard',
+                'dashboards-move-tile-partial-update',
+                { id: 8 },
+                { id: 7, to_dashboard: 8, tile: { id: 41 } },
+            ],
+            [
+                'a move without a destination dashboard',
+                'dashboards-move-tile-partial-update',
+                { id: 7 },
+                { id: 7, tile: { id: 41 } },
+            ],
+            [
+                'a move with an invalid destination dashboard',
+                'dashboards-move-tile-partial-update',
+                { id: 7 },
+                { id: 7, to_dashboard: 0, tile: { id: 41 } },
+            ],
+            [
+                'a move without an identified tile',
+                'dashboards-move-tile-partial-update',
+                { id: 7 },
+                { id: 7, to_dashboard: 8 },
+            ],
+            [
+                'a move with an invalid tile ID',
+                'dashboards-move-tile-partial-update',
+                { id: 7 },
+                { id: 7, to_dashboard: 8, tile: { id: -1 } },
             ],
         ])('rejects %s', (_case, resolvedKey, rawOutput, innerInput) => {
             expect(extractDashboardMutationRevealTarget(toolMessage(rawOutput, innerInput, resolvedKey))).toBeNull()

--- a/products/posthog_ai/frontend/components/tool/widgets/extractors.test.ts
+++ b/products/posthog_ai/frontend/components/tool/widgets/extractors.test.ts
@@ -263,21 +263,21 @@ describe('mcp tool adapter extractors', () => {
                 'creates a text tile',
                 'dashboard-create-tile',
                 { id: 7, body: '## Launch' },
-                { id: 41 },
+                { id: 41, _posthogUrl: dashboardUrl },
                 { dashboardId: 7, tileId: 41 },
             ],
             [
                 'keeps the replay alias for text-tile creation',
                 'dashboard-create-text-tile',
                 { id: '7', body: '## Launch' },
-                { id: '41' },
+                { id: '41', _posthogUrl: dashboardUrl },
                 { dashboardId: 7, tileId: 41 },
             ],
             [
                 'updates one text tile',
                 'dashboard-update-text-tile',
                 { id: 7, tile_id: 41, body: 'Updated' },
-                { id: 41 },
+                { id: 41, _posthogUrl: dashboardUrl },
                 { dashboardId: 7, tileId: 41 },
             ],
             [
@@ -312,28 +312,28 @@ describe('mcp tool adapter extractors', () => {
                 'reveals one newly added widget',
                 'dashboard-widgets-batch-add',
                 { id: 7, widgets: [{ widget_type: 'session_replay_list' }] },
-                { tiles: [{ id: 41 }] },
+                { tiles: [{ id: 41 }], _posthogUrl: dashboardUrl },
                 { dashboardId: 7, tileId: 41 },
             ],
             [
                 'returns dashboard-only for multiple added widgets',
                 'dashboard-widgets-batch-add',
                 { id: 7, widgets: [{ widget_type: 'session_replay_list' }, { widget_type: 'error_tracking_list' }] },
-                { tiles: [{ id: 41 }, { id: 42 }] },
+                { tiles: [{ id: 41 }, { id: 42 }], _posthogUrl: dashboardUrl },
                 { dashboardId: 7 },
             ],
             [
                 'reveals one updated widget after its returned ID matches the request',
                 'dashboard-widgets-batch-update',
                 { id: 7, widgets: [{ tile_id: 41, name: 'New name' }] },
-                { tiles: [{ id: 41 }] },
+                { tiles: [{ id: 41 }], _posthogUrl: dashboardUrl },
                 { dashboardId: 7, tileId: 41 },
             ],
             [
                 'keeps the batch-create replay alias',
                 'dashboards-widgets-batch-create',
                 { id: 7, widgets: [{ widget_type: 'session_replay_list' }] },
-                { tiles: [{ id: 41 }] },
+                { tiles: [{ id: 41 }], _posthogUrl: dashboardUrl },
                 { dashboardId: 7, tileId: 41 },
             ],
             [
@@ -365,6 +365,55 @@ describe('mcp tool adapter extractors', () => {
             expect(
                 extractDashboardMutationRevealTarget(
                     toolMessage({ id: 8, name: 'Growth' }, { id: 7 }, 'dashboard-update')
+                )
+            ).toBeNull()
+        })
+
+        it('accepts an ID-only tile response when its absolute dashboard URL corroborates ownership', () => {
+            expect(
+                extractDashboardMutationRevealTarget(
+                    toolMessage(
+                        { id: 41, _posthogUrl: 'http://localhost:8010/project/3/dashboard/7' },
+                        { id: 7, body: '## Launch' },
+                        'dashboard-create-tile'
+                    )
+                )
+            ).toEqual({ dashboardId: 7, tileId: 41 })
+        })
+
+        it.each([
+            [
+                'a tile URL that contradicts the requested dashboard',
+                'dashboard-create-tile',
+                { id: 41, dashboard_id: 7, _posthogUrl: 'https://app.example.test/project/1/dashboard/8' },
+                { id: 7, body: '## Launch' },
+            ],
+            [
+                'a nested tile dashboard that contradicts the requested dashboard',
+                'dashboard-create-tile',
+                { id: 41, dashboard: { id: 8 }, _posthogUrl: dashboardUrl },
+                { id: 7, body: '## Launch' },
+            ],
+            [
+                'an enclosing batch dashboard that contradicts its requested dashboard',
+                'dashboard-widgets-batch-add',
+                { dashboard_id: 8, tiles: [{ id: 41, dashboard_id: 7 }], _posthogUrl: dashboardUrl },
+                { id: 7, widgets: [{ widget_type: 'session_replay_list' }] },
+            ],
+            [
+                'a dashboard response field that contradicts its response id',
+                'dashboard-update',
+                { id: 7, dashboard_id: 8, _posthogUrl: dashboardUrl },
+                { id: 7, name: 'Growth' },
+            ],
+        ])('rejects %s', (_case, resolvedKey, rawOutput, innerInput) => {
+            expect(extractDashboardMutationRevealTarget(toolMessage(rawOutput, innerInput, resolvedKey))).toBeNull()
+        })
+
+        it('rejects an ID-only tile response without response ownership', () => {
+            expect(
+                extractDashboardMutationRevealTarget(
+                    toolMessage({ id: 41 }, { id: 7, body: '## Launch' }, 'dashboard-create-tile')
                 )
             ).toBeNull()
         })

--- a/products/posthog_ai/frontend/components/tool/widgets/extractors.test.ts
+++ b/products/posthog_ai/frontend/components/tool/widgets/extractors.test.ts
@@ -4,7 +4,9 @@ import type { ToolCallMessage } from 'products/posthog_ai/frontend/types/toolTyp
 
 import {
     extractDashboard,
+    extractDashboardMutationRevealTarget,
     extractErrorTrackingResponse,
+    extractInsightDashboardRevealTarget,
     extractQueryResult,
     extractRecordingFilters,
     extractVisualizationArtifact,
@@ -208,6 +210,234 @@ describe('mcp tool adapter extractors', () => {
             expect(extractQueryResult(toolMessage({ results: [] }))).toBeNull()
             expect(extractQueryResult(toolMessage({ query: 'not-an-object' }))).toBeNull()
             expect(extractQueryResult(toolMessage(undefined))).toBeNull()
+        })
+    })
+
+    describe('extractDashboardMutationRevealTarget', () => {
+        const dashboardUrl = 'https://us.posthog.com/project/1/dashboard/7'
+
+        it.each([
+            [
+                'creates a text tile',
+                'dashboard-create-tile',
+                { id: 7, body: '## Launch' },
+                { id: 41 },
+                { dashboardId: 7, tileId: 41 },
+            ],
+            [
+                'keeps the replay alias for text-tile creation',
+                'dashboard-create-text-tile',
+                { id: '7', body: '## Launch' },
+                { id: '41' },
+                { dashboardId: 7, tileId: 41 },
+            ],
+            [
+                'updates one text tile',
+                'dashboard-update-text-tile',
+                { id: 7, tile_id: 41, body: 'Updated' },
+                { id: 41 },
+                { dashboardId: 7, tileId: 41 },
+            ],
+            [
+                'deletes a tile after the 204 response is enriched with a dashboard URL',
+                'dashboard-delete-tile',
+                { id: 7, tile_id: 41 },
+                { _posthogUrl: dashboardUrl },
+                { dashboardId: 7 },
+            ],
+            [
+                'reorders tiles from an authoritative dashboard response',
+                'dashboard-reorder-tiles',
+                { id: 7, tile_order: [41, 42] },
+                { id: 7, tiles: [{ id: 41 }, { id: 42 }] },
+                { dashboardId: 7 },
+            ],
+            [
+                'copies a tile without selecting one from the returned dashboard',
+                'dashboard-tile-copy',
+                { id: 7, fromDashboardId: 6, tileId: 41 },
+                { id: 7, tiles: [{ id: 88 }] },
+                { dashboardId: 7 },
+            ],
+            [
+                'keeps the copy replay alias',
+                'dashboards-copy-tile-create',
+                { id: 7, fromDashboardId: 6, tileId: 41 },
+                { id: 7, tiles: [{ id: 88 }] },
+                { dashboardId: 7 },
+            ],
+            [
+                'reveals one newly added widget',
+                'dashboard-widgets-batch-add',
+                { id: 7, widgets: [{ widget_type: 'session_replay_list' }] },
+                { tiles: [{ id: 41 }] },
+                { dashboardId: 7, tileId: 41 },
+            ],
+            [
+                'returns dashboard-only for multiple added widgets',
+                'dashboard-widgets-batch-add',
+                { id: 7, widgets: [{ widget_type: 'session_replay_list' }, { widget_type: 'error_tracking_list' }] },
+                { tiles: [{ id: 41 }, { id: 42 }] },
+                { dashboardId: 7 },
+            ],
+            [
+                'reveals one updated widget after its returned ID matches the request',
+                'dashboard-widgets-batch-update',
+                { id: 7, widgets: [{ tile_id: 41, name: 'New name' }] },
+                { tiles: [{ id: 41 }] },
+                { dashboardId: 7, tileId: 41 },
+            ],
+            [
+                'keeps the batch-create replay alias',
+                'dashboards-widgets-batch-create',
+                { id: 7, widgets: [{ widget_type: 'session_replay_list' }] },
+                { tiles: [{ id: 41 }] },
+                { dashboardId: 7, tileId: 41 },
+            ],
+            [
+                'moves a tile while retaining the authoritative source dashboard response',
+                'dashboards-move-tile-create',
+                { id: 7, to_dashboard: 8, tile: { id: 41 } },
+                { id: 7 },
+                { dashboardId: 7 },
+            ],
+            [
+                'moves a tile through the live partial-update key',
+                'dashboards-move-tile-partial-update',
+                { id: 7, to_dashboard: 8, tile: { id: 41 } },
+                { id: 7 },
+                { dashboardId: 7 },
+            ],
+        ])('strictly extracts a target when it %s', (_case, resolvedKey, innerInput, rawOutput, expected) => {
+            expect(extractDashboardMutationRevealTarget(toolMessage(rawOutput, innerInput, resolvedKey))).toEqual(
+                expected
+            )
+        })
+
+        it('accepts dashboard-update only when its response confirms the requested dashboard', () => {
+            expect(
+                extractDashboardMutationRevealTarget(
+                    toolMessage({ id: 7, name: 'Growth' }, { id: 7 }, 'dashboard-update')
+                )
+            ).toEqual({ dashboardId: 7 })
+            expect(
+                extractDashboardMutationRevealTarget(
+                    toolMessage({ id: 8, name: 'Growth' }, { id: 7 }, 'dashboard-update')
+                )
+            ).toBeNull()
+        })
+
+        it.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '1.2', 'not-an-id'])(
+            'rejects unsafe dashboard id %p',
+            (id) => {
+                expect(extractDashboardMutationRevealTarget(toolMessage({ id }, { id }, 'dashboard-update'))).toBeNull()
+            }
+        )
+
+        it.each([
+            [
+                'a response tile with a conflicting dashboard_id',
+                'dashboard-create-tile',
+                { id: 41, dashboard_id: 8 },
+                { id: 7 },
+            ],
+            [
+                'a text update whose response tile disagrees with tile_id',
+                'dashboard-update-text-tile',
+                { id: 42 },
+                { id: 7, tile_id: 41 },
+            ],
+            ['an empty widget batch', 'dashboard-widgets-batch-update', { tiles: [] }, { id: 7, widgets: [] }],
+            [
+                'a widget batch with mismatched cardinality',
+                'dashboard-widgets-batch-update',
+                { tiles: [{ id: 41 }] },
+                { id: 7, widgets: [{ widget_type: 'session_replay_list' }, { widget_type: 'error_tracking_list' }] },
+            ],
+            [
+                'a widget-update batch whose returned IDs do not match in order',
+                'dashboard-widgets-batch-update',
+                { tiles: [{ id: 42 }, { id: 41 }] },
+                { id: 7, widgets: [{ tile_id: 41 }, { tile_id: 42 }] },
+            ],
+            [
+                'malformed output',
+                'dashboard-widgets-batch-update',
+                'not a structured response',
+                { id: 7, widgets: [{ tile_id: 41 }] },
+            ],
+        ])('rejects %s', (_case, resolvedKey, rawOutput, innerInput) => {
+            expect(extractDashboardMutationRevealTarget(toolMessage(rawOutput, innerInput, resolvedKey))).toBeNull()
+        })
+
+        it.each([
+            [undefined, 'missing enrichment'],
+            [{ _posthogUrl: 'https://example.com/project/1/dashboard/7' }, 'a third-party URL'],
+            [{ _posthogUrl: 'https://us.posthog.com/project/1/dashboard/8' }, 'a URL for a different dashboard'],
+            [{ _posthogUrl: '/dashboard/7' }, 'a relative URL'],
+        ])('rejects a 204 tile delete with %s', (rawOutput, _case) => {
+            expect(
+                extractDashboardMutationRevealTarget(
+                    toolMessage(rawOutput, { id: 7, tile_id: 41 }, 'dashboard-delete-tile')
+                )
+            ).toBeNull()
+        })
+    })
+
+    describe('extractInsightDashboardRevealTarget', () => {
+        const matchingOutput = {
+            short_id: 'abc12345',
+            dashboard_tiles: [{ id: 41, dashboard_id: 7, deleted: false }],
+        }
+
+        it.each(['insight-create', 'insight-update'])('extracts an authoritative tile after %s', (resolvedKey) => {
+            expect(
+                extractInsightDashboardRevealTarget(toolMessage(matchingOutput, { dashboards: [7] }, resolvedKey))
+            ).toEqual({
+                dashboardId: 7,
+                tileId: 41,
+                insightShortId: 'abc12345',
+            })
+        })
+
+        it.each([
+            ['missing requested dashboards', matchingOutput, {}],
+            ['multiple requested dashboards', matchingOutput, { dashboards: [7, 8] }],
+            ['an unsafe requested dashboard', matchingOutput, { dashboards: [0] }],
+            ['a blank response short ID', { ...matchingOutput, short_id: ' ' }, { dashboards: [7] }],
+            ['no response membership', { short_id: 'abc12345', dashboard_tiles: [] }, { dashboards: [7] }],
+            [
+                'a response membership for another dashboard',
+                { ...matchingOutput, dashboard_tiles: [{ id: 41, dashboard_id: 8, deleted: false }] },
+                { dashboards: [7] },
+            ],
+            [
+                'multiple matching response tiles',
+                {
+                    ...matchingOutput,
+                    dashboard_tiles: [
+                        { id: 41, dashboard_id: 7, deleted: false },
+                        { id: 42, dashboard_id: 7, deleted: false },
+                    ],
+                },
+                { dashboards: [7] },
+            ],
+            [
+                'a deleted matching response tile',
+                { ...matchingOutput, dashboard_tiles: [{ id: 41, dashboard_id: 7, deleted: true }] },
+                { dashboards: [7] },
+            ],
+            [
+                'an unsafe returned tile ID',
+                {
+                    ...matchingOutput,
+                    dashboard_tiles: [{ id: Number.MAX_SAFE_INTEGER + 1, dashboard_id: 7, deleted: false }],
+                },
+                { dashboards: [7] },
+            ],
+            ['malformed output', 'not a structured response', { dashboards: [7] }],
+        ])('rejects %s', (_case, rawOutput, innerInput) => {
+            expect(extractInsightDashboardRevealTarget(toolMessage(rawOutput, innerInput, 'insight-create'))).toBeNull()
         })
     })
 })

--- a/products/posthog_ai/frontend/components/tool/widgets/extractors.ts
+++ b/products/posthog_ai/frontend/components/tool/widgets/extractors.ts
@@ -1,5 +1,3 @@
-import { decode } from '@toon-format/toon'
-
 import { recordingsQueryToUniversalFilters } from 'scenes/session-recordings/filters/recordingsQueryConversions'
 
 import { MaxErrorTrackingSearchResponse } from '~/queries/schema/schema-assistant-error-tracking'
@@ -16,7 +14,7 @@ import { RecordingUniversalFilters } from '~/types'
 
 import type { ToolCallMessage } from 'products/posthog_ai/frontend/types/toolTypes'
 
-import { parseExecCall, parseExecCommand } from '../posthogExecDisplay'
+import { parseToolOutputRecord } from '../../../utils/toolOutput'
 
 /**
  * Shared shape extractors for the sandbox MCP tool renderer widgets. Each turns a flattened
@@ -26,59 +24,6 @@ import { parseExecCall, parseExecCommand } from '../posthogExecDisplay'
 
 function asRecord(value: unknown): Record<string, unknown> | null {
     return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null
-}
-
-function parseJsonRecord(text: string): Record<string, unknown> | null {
-    try {
-        return asRecord(JSON.parse(text))
-    } catch {
-        return null
-    }
-}
-
-function parseToonRecord(text: string): Record<string, unknown> | null {
-    // TOON decode is lenient — JSON text doesn't throw, it mangles into a garbage record — so
-    // anything that reads as JSON syntax must never reach it.
-    if (/^[[{]/.test(text)) {
-        return null
-    }
-    try {
-        return asRecord(decode(text))
-    } catch {
-        return null
-    }
-}
-
-/**
- * Best-effort record from a tool call's `rawOutput`. Objects pass through; strings are parsed per the
- * exec `call` output contract: `--json` means the server responded with `JSON.stringify`, otherwise
- * TOON (`services/mcp/src/lib/response.ts`). The off-order format is still tried as a fallback, and
- * anything unparseable (or empty) resolves to null so the widget falls back to the generic card.
- */
-export function parseToolOutputRecord(message: ToolCallMessage): Record<string, unknown> | null {
-    const direct = asRecord(message.rawOutput)
-    if (direct) {
-        return direct
-    }
-    if (typeof message.rawOutput !== 'string') {
-        return null
-    }
-    const text = message.rawOutput.trim()
-    if (!text) {
-        return null
-    }
-    const command = typeof message.rawInput.command === 'string' ? message.rawInput.command : ''
-    const { verb, rest } = parseExecCommand(command)
-    const forceJson = verb === 'call' && parseExecCall(rest).forceJson
-    const attempts = forceJson ? [parseJsonRecord, parseToonRecord] : [parseToonRecord, parseJsonRecord]
-    for (const attempt of attempts) {
-        const record = attempt(text)
-        // decode('') and JSON '{}' both yield {}, which carries nothing a widget can render.
-        if (record && Object.keys(record).length > 0) {
-            return record
-        }
-    }
-    return null
 }
 
 function asString(value: unknown): string | undefined {
@@ -129,7 +74,7 @@ export interface VisualizationArtifactExtraction {
  * query-only outputs carry neither and render inline as ephemeral visualizations.
  */
 export function extractVisualizationArtifact(message: ToolCallMessage): VisualizationArtifactExtraction | null {
-    const output = parseToolOutputRecord(message)
+    const output = parseToolOutputRecord(message.rawOutput, message.rawInput)
     if (!output) {
         return null
     }
@@ -175,7 +120,7 @@ export interface QueryResultExtraction {
  * renderer (e.g. a single LLM trace) return null and fall back to the generic card.
  */
 export function extractQueryResult(message: ToolCallMessage): QueryResultExtraction | null {
-    const output = parseToolOutputRecord(message)
+    const output = parseToolOutputRecord(message.rawOutput, message.rawInput)
     const query = (output ? asRecord(output.query) : null) ?? queryFromToolInput(message)
     if (!query || typeof query.kind !== 'string') {
         return null
@@ -218,7 +163,7 @@ export interface DashboardExtraction {
 }
 
 export function extractDashboard(message: ToolCallMessage): DashboardExtraction | null {
-    const output = parseToolOutputRecord(message)
+    const output = parseToolOutputRecord(message.rawOutput, message.rawInput)
     if (!output) {
         return null
     }
@@ -237,7 +182,7 @@ export function extractDashboard(message: ToolCallMessage): DashboardExtraction 
  * falls back to the generic card rather than feeding the playlist a shape it can't use.
  */
 export function extractRecordingFilters(message: ToolCallMessage): RecordingUniversalFilters | null {
-    const output = parseToolOutputRecord(message)
+    const output = parseToolOutputRecord(message.rawOutput, message.rawInput)
     if (!output) {
         return null
     }
@@ -280,7 +225,7 @@ const ERROR_TRACKING_RESPONSE_KEYS: readonly (keyof MaxErrorTrackingSearchRespon
  * REST issues list — fall back to the generic card instead of rendering empty filter chips.
  */
 export function extractErrorTrackingResponse(message: ToolCallMessage): MaxErrorTrackingSearchResponse | null {
-    const output = parseToolOutputRecord(message)
+    const output = parseToolOutputRecord(message.rawOutput, message.rawInput)
     if (!output || !ERROR_TRACKING_RESPONSE_KEYS.some((key) => key in output)) {
         return null
     }

--- a/products/posthog_ai/frontend/components/tool/widgets/extractors.ts
+++ b/products/posthog_ai/frontend/components/tool/widgets/extractors.ts
@@ -30,6 +30,218 @@ function asString(value: unknown): string | undefined {
     return typeof value === 'string' ? value : undefined
 }
 
+function asPositiveSafeInteger(value: unknown): number | null {
+    const parsed =
+        typeof value === 'number' ? value : typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : null
+    return parsed !== null && Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+function asRecordArray(value: unknown): Record<string, unknown>[] | null {
+    if (!Array.isArray(value)) {
+        return null
+    }
+    const records = value.map(asRecord)
+    return records.every((record): record is Record<string, unknown> => record !== null) ? records : null
+}
+
+function getAgreedPositiveSafeInteger(
+    record: Record<string, unknown>,
+    keys: readonly string[]
+): number | null | undefined {
+    const values = keys.filter((key) => key in record).map((key) => asPositiveSafeInteger(record[key]))
+    if (values.length === 0) {
+        return undefined
+    }
+    if (values.some((value) => value === null)) {
+        return null
+    }
+    return values.every((value) => value === values[0]) ? values[0]! : null
+}
+
+function getRequestDashboardId(input: Record<string, unknown>): number | null {
+    return getAgreedPositiveSafeInteger(input, ['id', 'dashboard_id', 'dashboardId']) ?? null
+}
+
+function responseAgreesWithDashboard(output: Record<string, unknown>, dashboardId: number): boolean {
+    const directDashboardId = getAgreedPositiveSafeInteger(output, ['dashboard_id', 'dashboardId'])
+    if (directDashboardId === null || (directDashboardId !== undefined && directDashboardId !== dashboardId)) {
+        return false
+    }
+
+    const nestedDashboard = asRecord(output.dashboard)
+    if (!nestedDashboard) {
+        return true
+    }
+    return getAgreedPositiveSafeInteger(nestedDashboard, ['id']) === dashboardId
+}
+
+function getResponseTileId(output: Record<string, unknown>, dashboardId: number): number | null {
+    if (!responseAgreesWithDashboard(output, dashboardId)) {
+        return null
+    }
+    return getAgreedPositiveSafeInteger(output, ['id', 'tile_id']) ?? null
+}
+
+function getDashboardIdFromPostHogUrl(value: unknown): number | null {
+    if (typeof value !== 'string') {
+        return null
+    }
+    try {
+        const url = new URL(value)
+        if (url.protocol !== 'https:' || (url.hostname !== 'posthog.com' && !url.hostname.endsWith('.posthog.com'))) {
+            return null
+        }
+        const match = /^\/project\/[^/]+\/dashboard\/(\d+)\/?$/.exec(url.pathname)
+        return match ? asPositiveSafeInteger(match[1]) : null
+    } catch {
+        return null
+    }
+}
+
+export interface DashboardRevealTarget {
+    dashboardId: number
+    tileId?: number
+    insightShortId?: string
+}
+
+const DASHBOARD_TILE_CREATE_KEYS = new Set(['dashboard-create-tile', 'dashboard-create-text-tile'])
+const DASHBOARD_TILE_UPDATE_KEYS = new Set(['dashboard-update-text-tile'])
+const DASHBOARD_BATCH_ADD_KEYS = new Set(['dashboard-widgets-batch-add', 'dashboards-widgets-batch-create'])
+const DASHBOARD_BATCH_UPDATE_KEYS = new Set(['dashboard-widgets-batch-update'])
+const DASHBOARD_RESPONSE_KEYS = new Set([
+    'dashboard-update',
+    'dashboard-reorder-tiles',
+    'dashboard-tile-copy',
+    'dashboards-copy-tile-create',
+    'dashboards-move-tile-create',
+    'dashboards-move-tile-partial-update',
+])
+
+function extractDashboardBatchRevealTarget(
+    input: Record<string, unknown>,
+    output: Record<string, unknown>,
+    dashboardId: number,
+    requireExistingTileIds: boolean
+): DashboardRevealTarget | null {
+    const requestedWidgets = asRecordArray(input.widgets)
+    const returnedTiles = asRecordArray(output.tiles)
+    if (
+        !requestedWidgets ||
+        !returnedTiles ||
+        requestedWidgets.length === 0 ||
+        requestedWidgets.length !== returnedTiles.length
+    ) {
+        return null
+    }
+
+    const tileIds = returnedTiles.map((tile) => getResponseTileId(tile, dashboardId))
+    if (tileIds.some((tileId) => tileId === null)) {
+        return null
+    }
+
+    if (requireExistingTileIds) {
+        const requestedTileIds = requestedWidgets.map((widget) => getAgreedPositiveSafeInteger(widget, ['tile_id']))
+        if (
+            requestedTileIds.some((tileId) => tileId === null || tileId === undefined) ||
+            requestedTileIds.some((tileId, index) => tileId !== tileIds[index])
+        ) {
+            return null
+        }
+    }
+
+    return tileIds.length === 1 ? { dashboardId, tileId: tileIds[0]! } : { dashboardId }
+}
+
+/**
+ * Produces a navigation target only when the completed mutation response corroborates the request.
+ * Ambiguous batches and response/request disagreements intentionally fall back to the generic card.
+ */
+export function extractDashboardMutationRevealTarget(message: ToolCallMessage): DashboardRevealTarget | null {
+    if (message.status !== 'completed') {
+        return null
+    }
+    const input = asRecord(message.innerInput)
+    const output = parseToolOutputRecord(message.rawOutput, message.rawInput)
+    if (!input || !output) {
+        return null
+    }
+    const dashboardId = getRequestDashboardId(input)
+    if (dashboardId === null) {
+        return null
+    }
+
+    if (DASHBOARD_TILE_CREATE_KEYS.has(message.resolvedKey)) {
+        const tileId = getResponseTileId(output, dashboardId)
+        return tileId === null ? null : { dashboardId, tileId }
+    }
+
+    if (DASHBOARD_TILE_UPDATE_KEYS.has(message.resolvedKey)) {
+        const requestedTileId = getAgreedPositiveSafeInteger(input, ['tile_id'])
+        const responseTileId = getResponseTileId(output, dashboardId)
+        return requestedTileId === null || requestedTileId === undefined || requestedTileId !== responseTileId
+            ? null
+            : { dashboardId, tileId: responseTileId }
+    }
+
+    if (DASHBOARD_BATCH_ADD_KEYS.has(message.resolvedKey)) {
+        return extractDashboardBatchRevealTarget(input, output, dashboardId, false)
+    }
+
+    if (DASHBOARD_BATCH_UPDATE_KEYS.has(message.resolvedKey)) {
+        return extractDashboardBatchRevealTarget(input, output, dashboardId, true)
+    }
+
+    if (message.resolvedKey === 'dashboard-delete-tile') {
+        return getDashboardIdFromPostHogUrl(output._posthogUrl) === dashboardId ? { dashboardId } : null
+    }
+
+    if (DASHBOARD_RESPONSE_KEYS.has(message.resolvedKey)) {
+        return getAgreedPositiveSafeInteger(output, ['id']) === dashboardId ? { dashboardId } : null
+    }
+
+    return null
+}
+
+/**
+ * Intersects a requested dashboard with the saved insight's authoritative, non-deleted tile response.
+ * Request-side dashboard IDs alone never establish a reveal target.
+ */
+export function extractInsightDashboardRevealTarget(message: ToolCallMessage): DashboardRevealTarget | null {
+    if (
+        message.status !== 'completed' ||
+        (message.resolvedKey !== 'insight-create' && message.resolvedKey !== 'insight-update')
+    ) {
+        return null
+    }
+    const input = asRecord(message.innerInput)
+    const output = parseToolOutputRecord(message.rawOutput, message.rawInput)
+    const requestedDashboards = input && Array.isArray(input.dashboards) ? input.dashboards : null
+    const shortId = asString(output?.short_id)
+    const dashboardTiles = asRecordArray(output?.dashboard_tiles)
+    if (
+        !requestedDashboards ||
+        requestedDashboards.length !== 1 ||
+        !shortId?.trim() ||
+        !dashboardTiles ||
+        dashboardTiles.length === 0
+    ) {
+        return null
+    }
+
+    const dashboardId = asPositiveSafeInteger(requestedDashboards[0])
+    if (dashboardId === null) {
+        return null
+    }
+    const matchingTiles = dashboardTiles.filter(
+        (tile) => asPositiveSafeInteger(tile.dashboard_id) === dashboardId && tile.deleted === false
+    )
+    if (matchingTiles.length !== 1) {
+        return null
+    }
+    const tileId = asPositiveSafeInteger(matchingTiles[0].id)
+    return tileId === null ? null : { dashboardId, tileId, insightShortId: shortId }
+}
+
 const QUERY_WRAPPER_KIND_BY_TOOL_KEY: Record<string, NodeKind> = {
     'query-trends': NodeKind.TrendsQuery,
     'query-funnel': NodeKind.FunnelsQuery,

--- a/products/posthog_ai/frontend/components/tool/widgets/extractors.ts
+++ b/products/posthog_ai/frontend/components/tool/widgets/extractors.ts
@@ -88,11 +88,14 @@ function getDashboardIdFromPostHogUrl(value: unknown): number | null {
     }
     try {
         const url = new URL(value)
-        if (url.protocol !== 'https:' || (url.hostname !== 'posthog.com' && !url.hostname.endsWith('.posthog.com'))) {
+        if ((url.protocol !== 'http:' && url.protocol !== 'https:') || !url.hostname) {
             return null
         }
-        const match = /^\/project\/[^/]+\/dashboard\/(\d+)\/?$/.exec(url.pathname)
-        return match ? asPositiveSafeInteger(match[1]) : null
+        const match = /^\/project\/(\d+)\/dashboard\/(\d+)\/?$/.exec(url.pathname)
+        if (!match || asPositiveSafeInteger(match[1]) === null) {
+            return null
+        }
+        return asPositiveSafeInteger(match[2])
     } catch {
         return null
     }
@@ -233,7 +236,9 @@ export function extractInsightDashboardRevealTarget(message: ToolCallMessage): D
         return null
     }
     const matchingTiles = dashboardTiles.filter(
-        (tile) => asPositiveSafeInteger(tile.dashboard_id) === dashboardId && tile.deleted === false
+        (tile) =>
+            asPositiveSafeInteger(tile.dashboard_id) === dashboardId &&
+            (tile.deleted === false || tile.deleted === null)
     )
     if (matchingTiles.length !== 1) {
         return null

--- a/products/posthog_ai/frontend/components/tool/widgets/extractors.ts
+++ b/products/posthog_ai/frontend/components/tool/widgets/extractors.ts
@@ -194,13 +194,12 @@ const DASHBOARD_TILE_CREATE_KEYS = new Set(['dashboard-create-tile', 'dashboard-
 const DASHBOARD_TILE_UPDATE_KEYS = new Set(['dashboard-update-text-tile'])
 const DASHBOARD_BATCH_ADD_KEYS = new Set(['dashboard-widgets-batch-add', 'dashboards-widgets-batch-create'])
 const DASHBOARD_BATCH_UPDATE_KEYS = new Set(['dashboard-widgets-batch-update'])
+const DASHBOARD_MOVE_TILE_KEYS = new Set(['dashboards-move-tile-create', 'dashboards-move-tile-partial-update'])
 const DASHBOARD_RESPONSE_KEYS = new Set([
     'dashboard-update',
     'dashboard-reorder-tiles',
     'dashboard-tile-copy',
     'dashboards-copy-tile-create',
-    'dashboards-move-tile-create',
-    'dashboards-move-tile-partial-update',
 ])
 
 function extractDashboardBatchRevealTarget(
@@ -278,6 +277,21 @@ export function extractDashboardMutationRevealTarget(message: ToolCallMessage): 
 
     if (DASHBOARD_BATCH_UPDATE_KEYS.has(message.resolvedKey)) {
         return extractDashboardBatchRevealTarget(input, output, dashboardId, true)
+    }
+
+    if (DASHBOARD_MOVE_TILE_KEYS.has(message.resolvedKey)) {
+        // A move answers with the source dashboard the tile left, so the response corroborates the
+        // request while the tile keeps its ID on the destination it was asked to move to.
+        const toDashboardId = getAgreedPositiveSafeInteger(input, ['to_dashboard'])
+        const requestedTile = asRecord(input.tile)
+        const requestedTileId = requestedTile ? getAgreedPositiveSafeInteger(requestedTile, ['id']) : null
+        return responseDashboardAgreesWithRequest(output, dashboardId) &&
+            toDashboardId !== null &&
+            toDashboardId !== undefined &&
+            requestedTileId !== null &&
+            requestedTileId !== undefined
+            ? { dashboardId: toDashboardId, tileId: requestedTileId }
+            : null
     }
 
     if (message.resolvedKey === 'dashboard-delete-tile') {

--- a/products/posthog_ai/frontend/components/tool/widgets/extractors.ts
+++ b/products/posthog_ai/frontend/components/tool/widgets/extractors.ts
@@ -36,6 +36,10 @@ function asPositiveSafeInteger(value: unknown): number | null {
     return parsed !== null && Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null
 }
 
+function asPositiveSafeIntegerNumber(value: unknown): number | null {
+    return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? value : null
+}
+
 function asRecordArray(value: unknown): Record<string, unknown>[] | null {
     if (!Array.isArray(value)) {
         return null
@@ -105,6 +109,26 @@ export interface DashboardRevealTarget {
     dashboardId: number
     tileId?: number
     insightShortId?: string
+}
+
+/** Dashboard creation routes require the numeric ID returned by the completed first-party tool. */
+export function extractDashboardCreateRevealTarget(message: ToolCallMessage): DashboardRevealTarget | null {
+    if (message.status !== 'completed' || message.resolvedKey !== 'dashboard-create') {
+        return null
+    }
+    const output = parseToolOutputRecord(message.rawOutput, message.rawInput)
+    const dashboardId = asPositiveSafeIntegerNumber(output?.id)
+    return dashboardId === null ? null : { dashboardId }
+}
+
+/** Distinguishes an ordinary insight result from one that requested dashboard placement. */
+export function insightRequestIncludesDashboardTarget(message: ToolCallMessage): boolean {
+    const input = asRecord(message.innerInput)
+    if (!input || !Object.prototype.hasOwnProperty.call(input, 'dashboards')) {
+        return false
+    }
+    const dashboards = input.dashboards
+    return dashboards !== null && dashboards !== undefined && (!Array.isArray(dashboards) || dashboards.length > 0)
 }
 
 const DASHBOARD_TILE_CREATE_KEYS = new Set(['dashboard-create-tile', 'dashboard-create-text-tile'])

--- a/products/posthog_ai/frontend/components/tool/widgets/extractors.ts
+++ b/products/posthog_ai/frontend/components/tool/widgets/extractors.ts
@@ -66,26 +66,6 @@ function getRequestDashboardId(input: Record<string, unknown>): number | null {
     return getAgreedPositiveSafeInteger(input, ['id', 'dashboard_id', 'dashboardId']) ?? null
 }
 
-function responseAgreesWithDashboard(output: Record<string, unknown>, dashboardId: number): boolean {
-    const directDashboardId = getAgreedPositiveSafeInteger(output, ['dashboard_id', 'dashboardId'])
-    if (directDashboardId === null || (directDashboardId !== undefined && directDashboardId !== dashboardId)) {
-        return false
-    }
-
-    const nestedDashboard = asRecord(output.dashboard)
-    if (!nestedDashboard) {
-        return true
-    }
-    return getAgreedPositiveSafeInteger(nestedDashboard, ['id']) === dashboardId
-}
-
-function getResponseTileId(output: Record<string, unknown>, dashboardId: number): number | null {
-    if (!responseAgreesWithDashboard(output, dashboardId)) {
-        return null
-    }
-    return getAgreedPositiveSafeInteger(output, ['id', 'tile_id']) ?? null
-}
-
 function getDashboardIdFromPostHogUrl(value: unknown): number | null {
     if (typeof value !== 'string') {
         return null
@@ -105,6 +85,83 @@ function getDashboardIdFromPostHogUrl(value: unknown): number | null {
     }
 }
 
+interface DashboardOwnershipCheck {
+    agrees: boolean
+    hasEvidence: boolean
+}
+
+function checkDashboardOwnership(
+    output: Record<string, unknown>,
+    dashboardId: number,
+    responseIdIsDashboardId = false
+): DashboardOwnershipCheck {
+    const ownershipIds: number[] = []
+
+    const directKeys = responseIdIsDashboardId ? ['id', 'dashboard_id', 'dashboardId'] : ['dashboard_id', 'dashboardId']
+    const directDashboardId = getAgreedPositiveSafeInteger(output, directKeys)
+    if (directDashboardId === null) {
+        return { agrees: false, hasEvidence: true }
+    }
+    if (directDashboardId !== undefined) {
+        ownershipIds.push(directDashboardId)
+    }
+
+    if (Object.prototype.hasOwnProperty.call(output, 'dashboard')) {
+        const nestedDashboard = asRecord(output.dashboard)
+        const nestedDashboardId = nestedDashboard
+            ? getAgreedPositiveSafeInteger(nestedDashboard, ['id', 'dashboard_id', 'dashboardId'])
+            : asPositiveSafeInteger(output.dashboard)
+        if (nestedDashboardId === null || nestedDashboardId === undefined) {
+            return { agrees: false, hasEvidence: true }
+        }
+        ownershipIds.push(nestedDashboardId)
+    }
+
+    if (Object.prototype.hasOwnProperty.call(output, '_posthogUrl')) {
+        const dashboardIdFromUrl = getDashboardIdFromPostHogUrl(output._posthogUrl)
+        if (dashboardIdFromUrl === null) {
+            return { agrees: false, hasEvidence: true }
+        }
+        ownershipIds.push(dashboardIdFromUrl)
+    }
+
+    return {
+        agrees: ownershipIds.every((ownershipId) => ownershipId === dashboardId),
+        hasEvidence: ownershipIds.length > 0,
+    }
+}
+
+function getResponseTileId(
+    output: Record<string, unknown>,
+    dashboardId: number,
+    requireDashboardOwnership: boolean
+): number | null {
+    const ownership = checkDashboardOwnership(output, dashboardId)
+    if (!ownership.agrees || (requireDashboardOwnership && !ownership.hasEvidence)) {
+        return null
+    }
+    return getAgreedPositiveSafeInteger(output, ['id', 'tile_id']) ?? null
+}
+
+function responseDashboardAgreesWithRequest(output: Record<string, unknown>, dashboardId: number): boolean {
+    const ownership = checkDashboardOwnership(output, dashboardId, true)
+    if (!ownership.agrees || !ownership.hasEvidence) {
+        return false
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(output, 'tiles')) {
+        return true
+    }
+    const tiles = asRecordArray(output.tiles)
+    return (
+        tiles !== null &&
+        tiles.every((tile) => {
+            const tileOwnership = checkDashboardOwnership(tile, dashboardId)
+            return tileOwnership.agrees
+        })
+    )
+}
+
 export interface DashboardRevealTarget {
     dashboardId: number
     tileId?: number
@@ -118,7 +175,9 @@ export function extractDashboardCreateRevealTarget(message: ToolCallMessage): Da
     }
     const output = parseToolOutputRecord(message.rawOutput, message.rawInput)
     const dashboardId = asPositiveSafeIntegerNumber(output?.id)
-    return dashboardId === null ? null : { dashboardId }
+    return dashboardId === null || !output || !responseDashboardAgreesWithRequest(output, dashboardId)
+        ? null
+        : { dashboardId }
 }
 
 /** Distinguishes an ordinary insight result from one that requested dashboard placement. */
@@ -150,9 +209,12 @@ function extractDashboardBatchRevealTarget(
     dashboardId: number,
     requireExistingTileIds: boolean
 ): DashboardRevealTarget | null {
+    const outputOwnership = checkDashboardOwnership(output, dashboardId)
     const requestedWidgets = asRecordArray(input.widgets)
     const returnedTiles = asRecordArray(output.tiles)
     if (
+        !outputOwnership.agrees ||
+        !outputOwnership.hasEvidence ||
         !requestedWidgets ||
         !returnedTiles ||
         requestedWidgets.length === 0 ||
@@ -161,7 +223,7 @@ function extractDashboardBatchRevealTarget(
         return null
     }
 
-    const tileIds = returnedTiles.map((tile) => getResponseTileId(tile, dashboardId))
+    const tileIds = returnedTiles.map((tile) => getResponseTileId(tile, dashboardId, false))
     if (tileIds.some((tileId) => tileId === null)) {
         return null
     }
@@ -198,13 +260,13 @@ export function extractDashboardMutationRevealTarget(message: ToolCallMessage): 
     }
 
     if (DASHBOARD_TILE_CREATE_KEYS.has(message.resolvedKey)) {
-        const tileId = getResponseTileId(output, dashboardId)
+        const tileId = getResponseTileId(output, dashboardId, true)
         return tileId === null ? null : { dashboardId, tileId }
     }
 
     if (DASHBOARD_TILE_UPDATE_KEYS.has(message.resolvedKey)) {
         const requestedTileId = getAgreedPositiveSafeInteger(input, ['tile_id'])
-        const responseTileId = getResponseTileId(output, dashboardId)
+        const responseTileId = getResponseTileId(output, dashboardId, true)
         return requestedTileId === null || requestedTileId === undefined || requestedTileId !== responseTileId
             ? null
             : { dashboardId, tileId: responseTileId }
@@ -219,11 +281,12 @@ export function extractDashboardMutationRevealTarget(message: ToolCallMessage): 
     }
 
     if (message.resolvedKey === 'dashboard-delete-tile') {
-        return getDashboardIdFromPostHogUrl(output._posthogUrl) === dashboardId ? { dashboardId } : null
+        const ownership = checkDashboardOwnership(output, dashboardId)
+        return ownership.agrees && ownership.hasEvidence ? { dashboardId } : null
     }
 
     if (DASHBOARD_RESPONSE_KEYS.has(message.resolvedKey)) {
-        return getAgreedPositiveSafeInteger(output, ['id']) === dashboardId ? { dashboardId } : null
+        return responseDashboardAgreesWithRequest(output, dashboardId) ? { dashboardId } : null
     }
 
     return null

--- a/products/posthog_ai/frontend/components/tool/widgets/registerDataToolRenderers.test.ts
+++ b/products/posthog_ai/frontend/components/tool/widgets/registerDataToolRenderers.test.ts
@@ -12,7 +12,20 @@ describe('registerDataToolRenderers', () => {
         ['insight-get', 'Insight'],
         ['create_insight', 'Insight'],
         ['dashboard-create', 'Dashboard'],
+        ['dashboard-update', 'Dashboard'],
         ['upsert_dashboard', 'Dashboard'],
+        ['dashboard-create-tile', 'Dashboard update'],
+        ['dashboard-create-text-tile', 'Dashboard update'],
+        ['dashboard-update-text-tile', 'Dashboard update'],
+        ['dashboard-delete-tile', 'Dashboard update'],
+        ['dashboard-reorder-tiles', 'Dashboard update'],
+        ['dashboard-tile-copy', 'Dashboard update'],
+        ['dashboard-widgets-batch-add', 'Dashboard update'],
+        ['dashboard-widgets-batch-update', 'Dashboard update'],
+        ['dashboards-widgets-batch-create', 'Dashboard update'],
+        ['dashboards-copy-tile-create', 'Dashboard update'],
+        ['dashboards-move-tile-create', 'Dashboard update'],
+        ['dashboards-move-tile-partial-update', 'Dashboard update'],
         ['query-session-recordings-list', 'Session recordings'],
         ['search_session_recordings', 'Session recordings'],
         ['query-error-tracking-issues-list', 'Error tracking'],
@@ -25,5 +38,6 @@ describe('registerDataToolRenderers', () => {
         const entry = toolRegistry.lookup(key)
         expect(entry).not.toBeNull()
         expect(entry?.displayName).toEqual(displayName)
+        expect(entry?.requiresPostHogOrigin).toBe(true)
     })
 })

--- a/products/posthog_ai/frontend/components/tool/widgets/registerDataToolRenderers.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/registerDataToolRenderers.tsx
@@ -33,6 +33,9 @@ const InsightRenderer = lazyWithRetry(() =>
 const DashboardRenderer = lazyWithRetry(() =>
     import('./UpsertDashboardWidget').then((m) => ({ default: m.UpsertDashboardWidget }))
 )
+const DashboardTileMutationRenderer = lazyWithRetry(() =>
+    import('./DashboardTileMutationWidget').then((m) => ({ default: m.DashboardTileMutationWidget }))
+)
 const SessionRecordingsRenderer = lazyWithRetry(() =>
     import('./SearchSessionRecordingsWidget').then((m) => ({ default: m.SearchSessionRecordingsWidget }))
 )
@@ -76,6 +79,28 @@ register(
     'Dashboard',
     <IconDashboard />,
     DashboardRenderer
+)
+
+// Dashboard tile mutations share one explicit target card. The text-tile create alias remains so
+// replayed threads keep their card after the live command moved to `dashboard-create-tile`.
+register(
+    [
+        'dashboard-create-tile',
+        'dashboard-create-text-tile',
+        'dashboard-update-text-tile',
+        'dashboard-delete-tile',
+        'dashboard-reorder-tiles',
+        'dashboard-tile-copy',
+        'dashboard-widgets-batch-add',
+        'dashboard-widgets-batch-update',
+        'dashboards-widgets-batch-create',
+        'dashboards-copy-tile-create',
+        'dashboards-move-tile-create',
+        'dashboards-move-tile-partial-update',
+    ],
+    'Dashboard update',
+    <IconDashboard />,
+    DashboardTileMutationRenderer
 )
 
 // --- Data tools: session recordings ---

--- a/products/posthog_ai/frontend/policy/permissionDisplayUtils.ts
+++ b/products/posthog_ai/frontend/policy/permissionDisplayUtils.ts
@@ -1,9 +1,6 @@
-import {
-    POSTHOG_EXEC_TOOL_RE,
-    formatPostHogExecBody,
-    getPostHogExecDisplay,
-} from '../components/tool/posthogExecDisplay'
+import { formatPostHogExecBody, getPostHogExecDisplay } from '../components/tool/posthogExecDisplay'
 import type { PermissionRequestRecord } from '../types/streamTypes'
+import { POSTHOG_EXEC_TOOL_RE } from '../utils/posthogExec'
 import { resolveToolCall } from '../utils/toolResolver'
 
 // Re-exported so existing importers (and tests) keep resolving the exec display from here.

--- a/products/posthog_ai/frontend/policy/toolPolicy.test.ts
+++ b/products/posthog_ai/frontend/policy/toolPolicy.test.ts
@@ -1,7 +1,8 @@
 import type { PermissionRequestRecord, ToolInvocation } from '../types/streamTypes'
 import type { PermissionOption } from '../types/wireTypes'
+import { isPostHogExecTool } from '../utils/posthogExec'
 import type { AgentQuestion } from './questionUtils'
-import { defaultPermissionDecision, findAllowOptionId, isPostHogExecTool, type PermissionDecision } from './toolPolicy'
+import { defaultPermissionDecision, findAllowOptionId, type PermissionDecision } from './toolPolicy'
 
 function makeRecord(
     overrides: {

--- a/products/posthog_ai/frontend/policy/toolPolicy.ts
+++ b/products/posthog_ai/frontend/policy/toolPolicy.ts
@@ -1,9 +1,6 @@
-import { isPostHogExecTool } from '../components/tool/posthogExecDisplay'
 import type { PermissionRequestRecord } from '../types/streamTypes'
+import { isPostHogExecTool } from '../utils/posthogExec'
 import { resolveToolCall } from '../utils/toolResolver'
-
-// Re-exported so existing importers (and tests) keep resolving the exec-tool check from here.
-export { isPostHogExecTool } from '../components/tool/posthogExecDisplay'
 
 /**
  * Client-side sandbox tool-permission policy.

--- a/products/posthog_ai/frontend/utils/posthogExec.ts
+++ b/products/posthog_ai/frontend/utils/posthogExec.ts
@@ -1,0 +1,76 @@
+/** Matches the PostHog single-exec MCP tool (`mcp__posthog__exec`, plus plugin/regional variants). */
+export const POSTHOG_EXEC_TOOL_RE = /^mcp__(?:plugin_)?posthog(?:_[^_]+)*__exec$/
+
+export function isPostHogExecTool(toolName: string): boolean {
+    return POSTHOG_EXEC_TOOL_RE.test(toolName)
+}
+
+/** The verbs the single-exec tool accepts. `call` runs a sub-tool; the rest are read-only. */
+export type PostHogExecVerb = 'tools' | 'search' | 'info' | 'schema' | 'call'
+const POSTHOG_EXEC_VERBS = new Set<PostHogExecVerb>(['tools', 'search', 'info', 'schema', 'call'])
+
+/**
+ * Splits the leading whitespace-delimited token off a command and returns it plus the trimmed
+ * remainder. Mirrors the backend exec `parseCommand` (`services/mcp/src/tools/exec.ts`)
+ * token-for-token — single-space split, trimmed remainder — so the client tokenizes a command
+ * exactly the way the server that runs it does. This is a security boundary: any divergence lets a
+ * crafted command resolve to a different (safer-looking) inner tool here than the backend executes.
+ */
+export function splitFirstToken(input: string): { head: string; rest: string } {
+    const trimmed = input.trim()
+    const idx = trimmed.indexOf(' ')
+    if (idx === -1) {
+        return { head: trimmed, rest: '' }
+    }
+    return { head: trimmed.slice(0, idx), rest: trimmed.slice(idx + 1).trim() }
+}
+
+/**
+ * Parses an exec `command` into its verb and remainder. `verb` is null when the leading token isn't
+ * a recognized verb (the backend rejects such a command as `Unknown command`).
+ */
+export function parseExecCommand(command: string): { verb: PostHogExecVerb | null; rest: string } {
+    const { head, rest } = splitFirstToken(command)
+    return POSTHOG_EXEC_VERBS.has(head as PostHogExecVerb)
+        ? { verb: head as PostHogExecVerb, rest }
+        : { verb: null, rest }
+}
+
+/**
+ * Parses the body of a `call` command (everything after the `call` verb) into its inner sub-tool,
+ * its remaining args, and the boolean flags. Strips leading `--json` / `--confirm` flags in any
+ * order, mirroring the backend `parseCallFlags`, then takes the next token as the sub-tool.
+ * `subTool` is null when no sub-tool remains, or when the next token still looks like a flag — a real
+ * sub-tool name never starts with `-`. The permission gate keys destructive-tool detection off
+ * `subTool`, so this MUST match the server's flag grammar: what the server strips, we strip; what it
+ * can't resolve, we fail closed on.
+ */
+export function parseExecCall(callBody: string): {
+    subTool: string | null
+    args: string
+    forceJson: boolean
+    confirmed: boolean
+} {
+    let rest = callBody.trim()
+    let forceJson = false
+    let confirmed = false
+    while (rest) {
+        const { head, rest: next } = splitFirstToken(rest)
+        if (head === '--json') {
+            forceJson = true
+            rest = next
+            continue
+        }
+        if (head === '--confirm') {
+            confirmed = true
+            rest = next
+            continue
+        }
+        break
+    }
+    const { head: subTool, rest: args } = splitFirstToken(rest)
+    if (!subTool || subTool.startsWith('-')) {
+        return { subTool: null, args, forceJson, confirmed }
+    }
+    return { subTool, args, forceJson, confirmed }
+}

--- a/products/posthog_ai/frontend/utils/toolOutput.test.ts
+++ b/products/posthog_ai/frontend/utils/toolOutput.test.ts
@@ -1,0 +1,35 @@
+import { parseToolOutputRecord } from './toolOutput'
+
+describe('parseToolOutputRecord', () => {
+    it.each([
+        ['object', { id: 7 }, {}, { id: 7 }],
+        ['empty object', {}, {}, null],
+        ['JSON with flag', '{"id":7}', { command: 'call --json dashboard-update {"id":7}' }, { id: 7 }],
+        [
+            'TOON without flag',
+            'id: 7\nname: Growth',
+            { command: 'call dashboard-update {"id":7}' },
+            { id: 7, name: 'Growth' },
+        ],
+        ['JSON fallback', '{"id":7}', { command: 'call dashboard-update {"id":7}' }, { id: 7 }],
+        [
+            'TOON fallback after JSON flag',
+            'id: 7\nname: Growth',
+            { command: 'call --json dashboard-update' },
+            { id: 7, name: 'Growth' },
+        ],
+    ])('parses %s', (_case, rawOutput, rawInput, expected) => {
+        expect(parseToolOutputRecord(rawOutput, rawInput)).toEqual(expected)
+    })
+
+    it.each([undefined, null, '', '[]', '{}', 'not a structured response', 7, ['id']])(
+        'returns null for %p',
+        (rawOutput) => {
+            expect(parseToolOutputRecord(rawOutput, {})).toBeNull()
+        }
+    )
+
+    it('does not reinterpret JSON-looking malformed output as TOON', () => {
+        expect(parseToolOutputRecord('{"id":', { command: 'call dashboard-update' })).toBeNull()
+    })
+})

--- a/products/posthog_ai/frontend/utils/toolOutput.ts
+++ b/products/posthog_ai/frontend/utils/toolOutput.ts
@@ -1,0 +1,57 @@
+import { decode } from '@toon-format/toon'
+
+import { parseExecCall, parseExecCommand } from './posthogExec'
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null
+}
+
+function parseJsonRecord(text: string): Record<string, unknown> | null {
+    try {
+        return asRecord(JSON.parse(text))
+    } catch {
+        return null
+    }
+}
+
+function parseToonRecord(text: string): Record<string, unknown> | null {
+    // TOON decode is lenient — JSON text doesn't throw, it mangles into a garbage record — so
+    // anything that reads as JSON syntax must never reach it.
+    if (/^[[{]/.test(text)) {
+        return null
+    }
+    try {
+        return asRecord(decode(text))
+    } catch {
+        return null
+    }
+}
+
+/**
+ * Best-effort record from an MCP tool call's `rawOutput`. Objects pass through; strings are parsed
+ * per the exec `call` output contract: `--json` means JSON, otherwise TOON. The off-order format is
+ * still tried as a fallback, and anything unparseable (or empty) resolves to null.
+ */
+export function parseToolOutputRecord(
+    rawOutput: unknown,
+    rawInput: Record<string, unknown>
+): Record<string, unknown> | null {
+    const direct = asRecord(rawOutput)
+    if (direct && Object.keys(direct).length > 0) {
+        return direct
+    }
+    if (typeof rawOutput !== 'string' || !rawOutput.trim()) {
+        return null
+    }
+    const command = typeof rawInput.command === 'string' ? rawInput.command : ''
+    const { verb, rest } = parseExecCommand(command)
+    const forceJson = verb === 'call' && parseExecCall(rest).forceJson
+    const attempts = forceJson ? [parseJsonRecord, parseToonRecord] : [parseToonRecord, parseJsonRecord]
+    for (const attempt of attempts) {
+        const record = attempt(rawOutput.trim())
+        if (record && Object.keys(record).length > 0) {
+            return record
+        }
+    }
+    return null
+}

--- a/products/posthog_ai/frontend/utils/toolResolver.ts
+++ b/products/posthog_ai/frontend/utils/toolResolver.ts
@@ -1,5 +1,5 @@
-import { parseExecCall, parseExecCommand, POSTHOG_EXEC_TOOL_RE } from '../components/tool/posthogExecDisplay'
 import type { PermissionRequestRecord } from '../types/streamTypes'
+import { parseExecCall, parseExecCommand, POSTHOG_EXEC_TOOL_RE } from './posthogExec'
 
 export interface ResolvedToolKey {
     resolvedKey: string


### PR DESCRIPTION
## Problem

PostHog AI users see generic dashboard tool output and cannot jump directly to the dashboard tile that changed.

Stack: [1/4 scene context](https://github.com/PostHog/posthog/pull/96398) · [2/4 three-column layout](https://github.com/PostHog/posthog/pull/96401) · **3/4** · [4/4 live apply-back](https://github.com/PostHog/posthog/pull/96404)

Depends on [2/4: three-column layout](https://github.com/PostHog/posthog/pull/96401).

## Changes

- Validated dashboard mutations render dedicated completion cards.
- `Show on dashboard` opens and reveals the affected tile.
- `View dashboard` opens mutations without a single authoritative tile.
- Same-dashboard reveals reload committed data before scrolling, focusing, and highlighting the tile.
- The three-second highlight supports reduced motion and every dashboard tile type.
- Ambiguous or contradictory tool output retains the generic renderer.
- Empty dashboards can reveal their first AI-created tile after the committed reload.
- Master’s same-project auto-approval and connected-project prompt behavior remain intact.

```mermaid
flowchart LR
    A{{Validated tool completion}} --> B[Dashboard mutation card]
    B --> C[Show on dashboard]
    C --> D[Reload committed dashboard]
    D --> E[Scroll, focus, and highlight tile]
```

> [!NOTE]
> Card and tile-reveal screenshots remain pending because no dev stack ran for this isolated worktree.

## How did you test this code?

- Focused matrix: 14 suites, 407 passed, one pre-existing skip, and one passing snapshot.
- Frontend TypeScript, Oxlint, Oxfmt, preflight, and diff checks passed.
- Product generation passed twice and remained idempotent.
- Rebase preserved exactly nine signed commits over PR2.
- Independent review confirmed the newer permission model survived conflict resolution.
- Browser card-state and tile-reveal testing remains pending because no terminal-owned dev stack ran for this worktree.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No public docs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: Codex.
- Skills: `/integrating-with-posthog-ai`, `/using-git-worktrees`, `/subagent-driven-development`, and `/test-driven-development`.
- Review: `/requesting-code-review`, `/verification-before-completion`, `/stacking-prs`, and `/writing-pr-descriptions`.
- Adversarial review strengthened response ownership, URL validation, highlight expiry, and first-tile reveal behavior.
