### PR TITLE
feat(dashboards): synchronize posthog ai mutations

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.highlight.test.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.highlight.test.tsx
@@ -42,6 +42,25 @@ const insight = {
 } as unknown as QueryBasedInsightModel
 
 describe('InsightCard highlight class', () => {
+    it('forwards the dashboard reveal contract to the card root', () => {
+        const { container } = render(
+            <InsightCard
+                insight={insight}
+                placement={DashboardPlacement.Dashboard}
+                className="ai-highlight-test"
+                data-dashboard-tile-id="41"
+                data-dashboard-tile-highlighted="true"
+                tabIndex={-1}
+            />
+        )
+
+        const card = container.querySelector('[data-attr="insight-card"]')
+        expect(card).toHaveClass('DashboardTileCard', 'InsightCard', 'ai-highlight-test')
+        expect(card).toHaveAttribute('data-dashboard-tile-id', '41')
+        expect(card).toHaveAttribute('data-dashboard-tile-highlighted', 'true')
+        expect(card).toHaveAttribute('tabindex', '-1')
+    })
+
     it('removes the highlighted class when the highlight expires upstream', () => {
         const { container, rerender } = render(
             <InsightCard insight={insight} placement={DashboardPlacement.Dashboard} highlighted />

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -1,7 +1,7 @@
 import './Dashboard.scss'
 
 import { BindLogic, useActions, useMountedLogic, useValues } from 'kea'
-import { useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import { AccessDenied } from 'lib/components/AccessDenied'
 import { dashboardTileScreenshotKey } from 'lib/components/Cards/InsightCard/insightCardImageCapture'
@@ -16,6 +16,7 @@ import { DashboardItems } from 'scenes/dashboard/DashboardItems'
 import { DashboardLoadAction, DashboardLogicProps, dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { dataThemeLogic } from 'scenes/dataThemeLogic'
 import { InsightErrorState } from 'scenes/insights/EmptyStates'
+import { sceneAgentPanelLogic } from 'scenes/max/sceneAgentPanelLogic'
 import { useSceneAgentPanel } from 'scenes/max/useSceneAgentPanel'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
@@ -121,6 +122,26 @@ function DashboardScene({
     const { currentTeamId } = useValues(teamLogic)
     const { reportDashboardViewed, abortAnyRunningQuery, loadDashboard, setLayoutZoom } = useActions(dashboardLogic)
     const { addInsightToDashboardModalVisible } = useValues(addInsightToDashboardLogic)
+    const { sceneIntegrationEnabled } = useValues(sceneAgentPanelLogic)
+    const [transientHighlightedTileIds, setTransientHighlightedTileIds] = useState<number[]>([])
+    const updateTransientHighlightedTileIds = useCallback((tileIds: number[]) => {
+        setTransientHighlightedTileIds((currentTileIds) =>
+            currentTileIds.length === tileIds.length &&
+            currentTileIds.every((currentTileId, index) => currentTileId === tileIds[index])
+                ? currentTileIds
+                : tileIds
+        )
+    }, [])
+
+    const dashboardAiSyncEnabled = Boolean(
+        placement === DashboardPlacement.Dashboard &&
+        dashboard?.id &&
+        canEditDashboard &&
+        sceneIntegrationEnabled &&
+        !dashboardFailedToLoad &&
+        !accessDeniedToDashboard &&
+        !error404
+    )
 
     const agentContextItems = useMemo(
         () => dashboardAgentContextForPlacement(dashboard ?? null, placement),
@@ -173,12 +194,12 @@ function DashboardScene({
             {placement == DashboardPlacement.Dashboard && (
                 <DashboardHeader loading={!dashboard && !dashboardFailedToLoad} />
             )}
-            {placement === DashboardPlacement.Dashboard &&
-                dashboard?.id &&
-                canEditDashboard &&
-                !dashboardFailedToLoad &&
-                !accessDeniedToDashboard &&
-                !error404 && <DashboardAiSync dashboardId={dashboard.id} />}
+            {dashboardAiSyncEnabled && dashboard?.id && (
+                <DashboardAiSync
+                    dashboardId={dashboard.id}
+                    onTransientHighlightedTileIdsChange={updateTransientHighlightedTileIds}
+                />
+            )}
             {placement == DashboardPlacement.Dashboard && !!dashboard?.id && (
                 <DashboardSubscribeNudgeTrigger dashboardId={dashboard.id} />
             )}
@@ -224,7 +245,10 @@ function DashboardScene({
                             )}
                     </SceneStickyBar>
 
-                    <DashboardItems showCreateAnomalyAlertButton={showCreateAnomalyAlertButton} />
+                    <DashboardItems
+                        showCreateAnomalyAlertButton={showCreateAnomalyAlertButton}
+                        transientHighlightedTileIds={transientHighlightedTileIds}
+                    />
                 </div>
             )}
         </SceneContent>

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -33,6 +33,7 @@ import {
 import { teamLogic } from '../teamLogic'
 import { AddInsightToDashboardModal } from './addInsightToDashboardModal/AddInsightToDashboardModal'
 import { addInsightToDashboardLogic } from './addInsightToDashboardModalLogic'
+import { DashboardAiSync } from './DashboardAiSync'
 import { DashboardHeader } from './DashboardHeader'
 import { DashboardOverridesBanner } from './DashboardOverridesBanner'
 import { DashboardPublicAccessBanner } from './DashboardPublicAccessBanner'
@@ -172,6 +173,12 @@ function DashboardScene({
             {placement == DashboardPlacement.Dashboard && (
                 <DashboardHeader loading={!dashboard && !dashboardFailedToLoad} />
             )}
+            {placement === DashboardPlacement.Dashboard &&
+                dashboard?.id &&
+                canEditDashboard &&
+                !dashboardFailedToLoad &&
+                !accessDeniedToDashboard &&
+                !error404 && <DashboardAiSync dashboardId={dashboard.id} />}
             {placement == DashboardPlacement.Dashboard && !!dashboard?.id && (
                 <DashboardSubscribeNudgeTrigger dashboardId={dashboard.id} />
             )}

--- a/frontend/src/scenes/dashboard/DashboardAiSync.test.tsx
+++ b/frontend/src/scenes/dashboard/DashboardAiSync.test.tsx
@@ -1,0 +1,193 @@
+import { cleanup, render } from '@testing-library/react'
+import { BindLogic } from 'kea'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { AccessControlLevel, DashboardPlacement } from '~/types'
+
+import { useMcpToolApplyBack } from 'products/posthog_ai/frontend/api/logics'
+import type { ToolStreamEvent } from 'products/posthog_ai/frontend/types/streamTypes'
+
+import { maxMocks } from '../max/testUtils'
+import { Dashboard } from './Dashboard'
+import { DashboardAiSync } from './DashboardAiSync'
+import { DASHBOARD_AI_MUTATION_TOOLS, dashboardAiSyncLogic } from './dashboardAiSyncLogic'
+import { dashboardLogic } from './dashboardLogic'
+import { dashboardResult } from './dashboardLogic.testHelpers'
+
+jest.mock('products/posthog_ai/frontend/api/logics', () => ({
+    useAttachedContext: jest.fn(),
+    useMcpToolApplyBack: jest.fn(),
+    useWelcomeOverride: jest.fn(),
+}))
+
+describe('DashboardAiSync', () => {
+    beforeEach(() => {
+        localStorage.clear()
+        useMocks(maxMocks)
+        initKeaTests()
+        featureFlagLogic.actions.setFeatureFlags(
+            [FEATURE_FLAGS.PHAI_SCENE_AUTO_OPEN, FEATURE_FLAGS.PHAI_SANDBOX_MODE],
+            {
+                [FEATURE_FLAGS.PHAI_SCENE_AUTO_OPEN]: true,
+                [FEATURE_FLAGS.PHAI_SANDBOX_MODE]: true,
+            }
+        )
+    })
+
+    afterEach(() => {
+        cleanup()
+        jest.clearAllMocks()
+    })
+
+    const setFlags = (flags: string[]): void => {
+        featureFlagLogic.actions.setFeatureFlags(flags, Object.fromEntries(flags.map((flag) => [flag, true])))
+    }
+
+    const allFlags = [FEATURE_FLAGS.PHAI_SCENE_AUTO_OPEN, FEATURE_FLAGS.PHAI_SANDBOX_MODE]
+    const editableDashboard = (): ReturnType<typeof dashboardResult> => ({
+        ...dashboardResult(7, []),
+        user_access_level: AccessControlLevel.Editor,
+    })
+
+    it('registers the exact dashboard mutation tools for completed calls', () => {
+        render(<DashboardAiSync dashboardId={7} />)
+
+        expect(useMcpToolApplyBack).toHaveBeenCalledWith({
+            tools: DASHBOARD_AI_MUTATION_TOOLS,
+            targetKey: 'dashboard:7',
+            applyOn: 'tool_call_completed',
+            active: true,
+            onApply: expect.any(Function),
+        })
+    })
+
+    it('forwards the completed event and resolved inner input to the dashboard sync logic', () => {
+        const dashboard = dashboardResult(7, [])
+        const dashboardSceneLogic = dashboardLogic({ id: 7, dashboard })
+        const syncLogic = dashboardAiSyncLogic({ dashboardId: 7 })
+        dashboardSceneLogic.mount()
+        syncLogic.mount()
+        const applyToolCompletion = jest.spyOn(syncLogic.actions, 'applyToolCompletion')
+
+        render(<DashboardAiSync dashboardId={7} />)
+
+        const options = jest.mocked(useMcpToolApplyBack).mock.calls[0][0]
+        const event = { toolName: 'dashboard-update' } as ToolStreamEvent
+        const innerInput = { id: 7 }
+        options.onApply(event, { innerInput })
+
+        expect(applyToolCompletion).toHaveBeenCalledWith(event, innerInput)
+        syncLogic.unmount()
+        dashboardSceneLogic.unmount()
+    })
+
+    it.each([
+        {
+            name: 'the scene rollout flag is off',
+            flags: [FEATURE_FLAGS.PHAI_SANDBOX_MODE],
+            view: 'new' as const,
+            preflight: { cloud: true },
+            expected: false,
+        },
+        {
+            name: 'the legacy runtime is selected',
+            flags: allFlags,
+            view: 'legacy' as const,
+            preflight: { cloud: true },
+            expected: false,
+        },
+        {
+            name: 'PostHog AI is unavailable',
+            flags: allFlags,
+            view: 'new' as const,
+            preflight: { cloud: false, is_debug: false, anthropic_available: false },
+            expected: false,
+        },
+        {
+            name: 'the sandbox runtime and all gates are enabled',
+            flags: allFlags,
+            view: 'new' as const,
+            preflight: { cloud: true },
+            expected: true,
+        },
+    ])('sets the apply-back registration active=$expected when $name', ({ flags, view, preflight, expected }) => {
+        const maxLogic = maxGlobalLogic()
+        maxLogic.mount()
+        setFlags(flags)
+        maxLogic.actions.setPhaiViewMode(view)
+        preflightLogic.actions.loadPreflightSuccess(preflight as any)
+
+        render(<DashboardAiSync dashboardId={7} />)
+
+        expect(jest.mocked(useMcpToolApplyBack).mock.calls[0][0].active).toBe(expected)
+        maxLogic.unmount()
+    })
+
+    it('mounts exactly one bridge for a loaded editable standard dashboard', () => {
+        const dashboard = editableDashboard()
+
+        render(<Dashboard id="7" dashboard={dashboard} placement={DashboardPlacement.Dashboard} />)
+
+        expect(useMcpToolApplyBack).toHaveBeenCalledTimes(1)
+        expect(useMcpToolApplyBack).toHaveBeenCalledWith(
+            expect.objectContaining({ tools: DASHBOARD_AI_MUTATION_TOOLS, targetKey: 'dashboard:7' })
+        )
+    })
+
+    it.each([
+        { name: 'public placement', placement: DashboardPlacement.Public },
+        { name: 'export placement', placement: DashboardPlacement.Export },
+        { name: 'project homepage placement', placement: DashboardPlacement.ProjectHomepage },
+    ])('does not mount the bridge for $name', ({ placement }) => {
+        const dashboard = editableDashboard()
+
+        render(<Dashboard id="7" dashboard={dashboard} placement={placement} />)
+
+        expect(useMcpToolApplyBack).not.toHaveBeenCalled()
+    })
+
+    it('does not mount the bridge for a read-only dashboard', () => {
+        const dashboard = { ...editableDashboard(), user_access_level: AccessControlLevel.Viewer }
+
+        render(<Dashboard id="7" dashboard={dashboard} placement={DashboardPlacement.Dashboard} />)
+
+        expect(useMcpToolApplyBack).not.toHaveBeenCalled()
+    })
+
+    it('does not mount the bridge before the dashboard loads', () => {
+        render(<Dashboard id="7" placement={DashboardPlacement.Dashboard} />)
+
+        expect(useMcpToolApplyBack).not.toHaveBeenCalled()
+    })
+
+    it.each([
+        {
+            name: 'access is denied',
+            setup: (logic: ReturnType<typeof dashboardLogic.build>) => logic.actions.setAccessDeniedToDashboard(),
+        },
+        {
+            name: 'loading has failed',
+            setup: (logic: ReturnType<typeof dashboardLogic.build>) => logic.actions.setDashboardFailedToLoad(),
+        },
+    ])('does not mount the bridge when $name', ({ setup }) => {
+        const dashboard = editableDashboard()
+        const logic = dashboardLogic({ id: 7, dashboard, placement: DashboardPlacement.Dashboard })
+        logic.mount()
+        setup(logic)
+
+        render(
+            <BindLogic logic={dashboardLogic} props={{ id: 7, dashboard, placement: DashboardPlacement.Dashboard }}>
+                <Dashboard id="7" dashboard={dashboard} placement={DashboardPlacement.Dashboard} />
+            </BindLogic>
+        )
+
+        expect(useMcpToolApplyBack).not.toHaveBeenCalled()
+        logic.unmount()
+    })
+})

--- a/frontend/src/scenes/dashboard/DashboardAiSync.test.tsx
+++ b/frontend/src/scenes/dashboard/DashboardAiSync.test.tsx
@@ -1,5 +1,6 @@
-import { cleanup, render } from '@testing-library/react'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
 import { BindLogic } from 'kea'
+import posthog from 'posthog-js'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -53,6 +54,17 @@ describe('DashboardAiSync', () => {
     const editableDashboard = (): ReturnType<typeof dashboardResult> => ({
         ...dashboardResult(7, []),
         user_access_level: AccessControlLevel.Editor,
+    })
+    const editableDashboardWithTile = (): ReturnType<typeof dashboardResult> => ({
+        ...editableDashboard(),
+        tiles: [
+            {
+                id: 41,
+                layouts: {},
+                color: null,
+                text: { id: 91, body: 'Dashboard status', last_modified_at: '2026-01-01T00:00:00Z' },
+            },
+        ],
     })
 
     it('registers the exact dashboard mutation tools for completed calls', () => {
@@ -116,16 +128,18 @@ describe('DashboardAiSync', () => {
             preflight: { cloud: true },
             expected: true,
         },
-    ])('sets the apply-back registration active=$expected when $name', ({ flags, view, preflight, expected }) => {
+    ])('mounts the apply-back owner=$expected when $name', ({ flags, view, preflight, expected }) => {
         const maxLogic = maxGlobalLogic()
         maxLogic.mount()
         setFlags(flags)
         maxLogic.actions.setPhaiViewMode(view)
         preflightLogic.actions.loadPreflightSuccess(preflight as any)
+        const dashboard = editableDashboardWithTile()
 
-        render(<DashboardAiSync dashboardId={7} />)
+        render(<Dashboard id="7" dashboard={dashboard} placement={DashboardPlacement.Dashboard} />)
 
-        expect(jest.mocked(useMcpToolApplyBack).mock.calls[0][0].active).toBe(expected)
+        expect(useMcpToolApplyBack).toHaveBeenCalledTimes(expected ? 1 : 0)
+        expect(dashboardAiSyncLogic({ dashboardId: 7 }).isMounted()).toBe(expected)
         maxLogic.unmount()
     })
 
@@ -145,19 +159,60 @@ describe('DashboardAiSync', () => {
         { name: 'export placement', placement: DashboardPlacement.Export },
         { name: 'project homepage placement', placement: DashboardPlacement.ProjectHomepage },
     ])('does not mount the bridge for $name', ({ placement }) => {
-        const dashboard = editableDashboard()
+        const dashboard = editableDashboardWithTile()
 
         render(<Dashboard id="7" dashboard={dashboard} placement={placement} />)
 
         expect(useMcpToolApplyBack).not.toHaveBeenCalled()
+        expect(dashboardAiSyncLogic({ dashboardId: 7 }).isMounted()).toBe(false)
     })
 
     it('does not mount the bridge for a read-only dashboard', () => {
-        const dashboard = { ...editableDashboard(), user_access_level: AccessControlLevel.Viewer }
+        const dashboard = { ...editableDashboardWithTile(), user_access_level: AccessControlLevel.Viewer }
 
         render(<Dashboard id="7" dashboard={dashboard} placement={DashboardPlacement.Dashboard} />)
 
         expect(useMcpToolApplyBack).not.toHaveBeenCalled()
+        expect(dashboardAiSyncLogic({ dashboardId: 7 }).isMounted()).toBe(false)
+    })
+
+    it('disposes pending synchronization without telemetry when the scene gate turns off', async () => {
+        const dashboard = editableDashboardWithTile()
+        const sceneLogic = dashboardLogic({ id: 7, dashboard, placement: DashboardPlacement.Dashboard })
+        let resolveDashboardReload!: () => void
+        const pendingReload = new Promise<void>((resolve) => {
+            resolveDashboardReload = resolve
+        })
+        const loadDashboard = jest.spyOn(sceneLogic.asyncActions, 'loadDashboard').mockReturnValue(pendingReload)
+        jest.mocked(posthog.capture).mockClear()
+        const maxLogic = maxGlobalLogic()
+        maxLogic.mount()
+        maxLogic.actions.setPhaiViewMode('new')
+        const { rerender } = render(<Dashboard id="7" dashboard={dashboard} placement={DashboardPlacement.Dashboard} />)
+        const syncLogic = dashboardAiSyncLogic({ dashboardId: 7 })
+
+        act(() =>
+            syncLogic.actions.queueDashboardSync({
+                family: 'dashboard',
+                dashboardId: 7,
+                tileIds: [],
+                insightIds: [],
+                deletesDashboard: false,
+            })
+        )
+        expect(loadDashboard).toHaveBeenCalledTimes(1)
+
+        act(() => setFlags([FEATURE_FLAGS.PHAI_SANDBOX_MODE]))
+        rerender(<Dashboard id="7" dashboard={dashboard} placement={DashboardPlacement.Dashboard} />)
+        resolveDashboardReload()
+        await pendingReload
+        await Promise.resolve()
+        await Promise.resolve()
+
+        await waitFor(() => expect(dashboardAiSyncLogic({ dashboardId: 7 }).isMounted()).toBe(false))
+        expect(posthog.capture).not.toHaveBeenCalledWith('dashboard ai sync completed', expect.anything())
+        loadDashboard.mockRestore()
+        maxLogic.unmount()
     })
 
     it('does not mount the bridge before the dashboard loads', () => {

--- a/frontend/src/scenes/dashboard/DashboardAiSync.tsx
+++ b/frontend/src/scenes/dashboard/DashboardAiSync.tsx
@@ -1,0 +1,22 @@
+import { useActions, useValues } from 'kea'
+
+import { sceneAgentPanelLogic } from 'scenes/max/sceneAgentPanelLogic'
+
+import { useMcpToolApplyBack } from 'products/posthog_ai/frontend/api/logics'
+
+import { DASHBOARD_AI_MUTATION_TOOLS, dashboardAiSyncLogic } from './dashboardAiSyncLogic'
+
+export function DashboardAiSync({ dashboardId }: { dashboardId: number }): null {
+    const { applyToolCompletion } = useActions(dashboardAiSyncLogic({ dashboardId }))
+    const { sceneIntegrationEnabled } = useValues(sceneAgentPanelLogic)
+
+    useMcpToolApplyBack({
+        tools: [...DASHBOARD_AI_MUTATION_TOOLS],
+        targetKey: `dashboard:${dashboardId}`,
+        applyOn: 'tool_call_completed',
+        active: sceneIntegrationEnabled,
+        onApply: (event, { innerInput }) => applyToolCompletion(event, innerInput),
+    })
+
+    return null
+}

--- a/frontend/src/scenes/dashboard/DashboardAiSync.tsx
+++ b/frontend/src/scenes/dashboard/DashboardAiSync.tsx
@@ -1,20 +1,35 @@
 import { useActions, useValues } from 'kea'
-
-import { sceneAgentPanelLogic } from 'scenes/max/sceneAgentPanelLogic'
+import { useEffect } from 'react'
 
 import { useMcpToolApplyBack } from 'products/posthog_ai/frontend/api/logics'
 
 import { DASHBOARD_AI_MUTATION_TOOLS, dashboardAiSyncLogic } from './dashboardAiSyncLogic'
 
-export function DashboardAiSync({ dashboardId }: { dashboardId: number }): null {
+interface DashboardAiSyncProps {
+    dashboardId: number
+    onTransientHighlightedTileIdsChange?: (tileIds: number[]) => void
+}
+
+export function DashboardAiSync({ dashboardId, onTransientHighlightedTileIdsChange }: DashboardAiSyncProps): null {
     const { applyToolCompletion } = useActions(dashboardAiSyncLogic({ dashboardId }))
-    const { sceneIntegrationEnabled } = useValues(sceneAgentPanelLogic)
+    const { transientHighlightedTileIds } = useValues(dashboardAiSyncLogic({ dashboardId }))
+
+    useEffect(() => {
+        onTransientHighlightedTileIdsChange?.(transientHighlightedTileIds)
+    }, [onTransientHighlightedTileIdsChange, transientHighlightedTileIds])
+
+    useEffect(
+        () => () => {
+            onTransientHighlightedTileIdsChange?.([])
+        },
+        [onTransientHighlightedTileIdsChange]
+    )
 
     useMcpToolApplyBack({
         tools: [...DASHBOARD_AI_MUTATION_TOOLS],
         targetKey: `dashboard:${dashboardId}`,
         applyOn: 'tool_call_completed',
-        active: sceneIntegrationEnabled,
+        active: true,
         onApply: (event, { innerInput }) => applyToolCompletion(event, innerInput),
     })
 

--- a/frontend/src/scenes/dashboard/DashboardHeader.test.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.test.tsx
@@ -11,21 +11,14 @@ import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { AccessControlLevel, DashboardMode, DashboardType, QueryBasedInsightModel } from '~/types'
 
-import { useMcpToolApplyBack } from 'products/posthog_ai/frontend/api/logics'
-import type { ToolStreamEvent } from 'products/posthog_ai/frontend/types/streamTypes'
-
-import { DashboardHeader, insightIsAddedToDashboard } from './DashboardHeader'
-import { DashboardLoadAction, dashboardLogic } from './dashboardLogic'
+import { DashboardHeader } from './DashboardHeader'
+import { dashboardLogic } from './dashboardLogic'
 
 jest.mock('lib/components/FullScreen', () => ({
     FullScreen: () => null,
 }))
 jest.mock('scenes/max/MaxTool', () => ({
     MaxTool: ({ children }: any) => <>{children}</>,
-}))
-
-jest.mock('products/posthog_ai/frontend/api/logics', () => ({
-    useMcpToolApplyBack: jest.fn(),
 }))
 
 const MOCK_DASHBOARD: DashboardType<QueryBasedInsightModel> = {
@@ -88,8 +81,7 @@ describe('DashboardHeader', () => {
         dashboardMode?: DashboardMode | null
         dashboardModeSource?: DashboardEventSource
         loading?: boolean
-        spyOnLoadDashboard?: boolean
-    }): { logic: ReturnType<typeof dashboardLogic.build>; loadDashboard?: jest.SpyInstance } {
+    }): { logic: ReturnType<typeof dashboardLogic.build> } {
         const {
             dashboard = MOCK_DASHBOARD,
             dashboardMode = null,
@@ -99,9 +91,6 @@ describe('DashboardHeader', () => {
 
         const logic = dashboardLogic({ id: dashboard?.id ?? MOCK_DASHBOARD.id, dashboard: dashboard ?? undefined })
         logic.mount()
-        const loadDashboard = opts.spyOnLoadDashboard
-            ? jest.spyOn(logic.actions, 'loadDashboard').mockImplementation()
-            : undefined
 
         if (dashboardMode) {
             logic.actions.setDashboardMode(dashboardMode, dashboardModeSource)
@@ -116,7 +105,7 @@ describe('DashboardHeader', () => {
             </BindLogic>
         )
 
-        return { logic, loadDashboard }
+        return { logic }
     }
 
     it('keeps the scene header visible while the dashboard is loading', () => {
@@ -124,25 +113,6 @@ describe('DashboardHeader', () => {
 
         expect(document.querySelector('.scene-title-section')).toBeInTheDocument()
 
-        logic.unmount()
-    })
-
-    it('recognizes sandbox insight calls that add to the open dashboard', () => {
-        expect(insightIsAddedToDashboard({ dashboards: ['5', 8] }, 5)).toBe(true)
-        expect(insightIsAddedToDashboard({ dashboards: [8] }, 5)).toBe(false)
-        expect(insightIsAddedToDashboard({ dashboards: '5' }, 5)).toBe(false)
-    })
-
-    it('reloads the open dashboard when sandbox AI adds an insight to it', () => {
-        const { logic, loadDashboard } = renderHeader({ dashboard: MOCK_DASHBOARD, spyOnLoadDashboard: true })
-        const applyBackOptions = jest
-            .mocked(useMcpToolApplyBack)
-            .mock.calls.map(([options]) => options)
-            .find((options) => options.targetKey === `dashboard:${MOCK_DASHBOARD.id}`)
-
-        applyBackOptions?.onApply({} as ToolStreamEvent, { innerInput: { dashboards: [MOCK_DASHBOARD.id] } })
-
-        expect(loadDashboard).toHaveBeenCalledWith({ action: DashboardLoadAction.Update })
         logic.unmount()
     })
 

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -10,8 +10,6 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { DashboardMode } from '~/types'
 
-import { useMcpToolApplyBack } from 'products/posthog_ai/frontend/api/logics'
-
 import { EditModeActions, FullscreenModeActions, ViewModeActions } from './DashboardHeaderActions'
 import { DashboardLoadAction, dashboardLogic } from './dashboardLogic'
 import { DashboardModals } from './DashboardModals'
@@ -21,29 +19,12 @@ import { DashboardScenePanel } from './DashboardScenePanel'
 export const DASHBOARD_CANNOT_EDIT_MESSAGE =
     "You don't have edit permissions for this dashboard. Ask a dashboard collaborator with edit access to add you."
 
-export function insightIsAddedToDashboard(input: Record<string, unknown> | null, dashboardId: number): boolean {
-    return Array.isArray(input?.dashboards) && input.dashboards.some((id) => Number(id) === dashboardId)
-}
-
 export function DashboardHeader({ loading = false }: { loading?: boolean }): JSX.Element | null {
     const { dashboard, dashboardLoading, dashboardMode, canEditDashboard } = useValues(dashboardLogic)
     const { setDashboardMode, loadDashboard } = useActions(dashboardLogic)
     const { updateDashboard } = useActions(dashboardsModel)
 
     const isLoading = !dashboard && (loading || dashboardLoading)
-
-    // Sandbox PostHog AI adds insights through insight-create/insight-update, rather than the legacy
-    // upsert_dashboard tool. Reload only when that tool explicitly targets the dashboard being viewed.
-    useMcpToolApplyBack({
-        tools: ['insight-create', 'insight-update'],
-        targetKey: `dashboard:${dashboard?.id ?? 'unloaded'}`,
-        active: !!dashboard && canEditDashboard,
-        onApply: (_event, { innerInput }) => {
-            if (dashboard && insightIsAddedToDashboard(innerInput, dashboard.id)) {
-                loadDashboard({ action: DashboardLoadAction.Update })
-            }
-        },
-    })
 
     if (!dashboard && !isLoading) {
         return null

--- a/frontend/src/scenes/dashboard/DashboardItems.test.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.test.tsx
@@ -14,6 +14,13 @@ import { DashboardMode, DashboardPlacement } from '~/types'
 
 import { DashboardItems } from './DashboardItems'
 
+jest.mock('./dashboardAiSyncLogic', () => ({
+    dashboardAiSyncLogic: jest.fn((props: { dashboardId: number }) => ({
+        __mock: 'dashboardAiSyncLogic',
+        props,
+    })),
+}))
+
 jest.mock('kea', () => ({
     ...jest.requireActual('kea'),
     useValues: jest.fn(),
@@ -250,6 +257,7 @@ let mockHighlightTileIdParam: unknown
 let mockHighlightedTileId: number | null = null
 let mockDashboardLoading = false
 let mockDashboardRevealReadyKey: string | null = null
+let mockTransientHighlightedTileIds: number[] = []
 
 type DashboardTileFixture = {
     id: number
@@ -298,6 +306,10 @@ function installDashboardValues(getTiles: () => DashboardTileFixture[]): void {
 
         if (logic === dashboardsModel) {
             return { nameSortedDashboards: [] }
+        }
+
+        if (logic?.__mock === 'dashboardAiSyncLogic') {
+            return { transientHighlightedTileIds: mockTransientHighlightedTileIds }
         }
 
         return {}
@@ -349,6 +361,7 @@ describe('DashboardItems', () => {
         mockHighlightedTileId = null
         mockDashboardLoading = false
         mockDashboardRevealReadyKey = null
+        mockTransientHighlightedTileIds = []
         installAnimationFrameMocks()
         Object.defineProperty(window, 'matchMedia', {
             configurable: true,
@@ -393,6 +406,10 @@ describe('DashboardItems', () => {
                 return {
                     nameSortedDashboards: [{ id: 6, name: 'Other dashboard' }],
                 }
+            }
+
+            if (logic?.__mock === 'dashboardAiSyncLogic') {
+                return { transientHighlightedTileIds: mockTransientHighlightedTileIds }
             }
 
             return {}
@@ -744,6 +761,32 @@ describe('DashboardItems', () => {
         expect(target).toHaveAttribute('data-dashboard-tile-highlighted', 'true')
         act(() => jest.advanceTimersByTime(1))
         expect(target).not.toHaveAttribute('data-dashboard-tile-highlighted')
+    })
+
+    it.each([
+        ['insight', { id: 41, insight: { id: 101, short_id: 'target', query: { kind: 'InsightVizNode' } } }],
+        ['text', { id: 41, text: { id: 102, body: 'Text' } }],
+        ['image', { id: 41, text: { id: 102, body: '![Image](https://example.test/image.png)' } }],
+        ['button', { id: 41, button_tile: { id: 103, text: 'Open', url: '/', style: 'primary' } }],
+        ['widget', { id: 41, widget: { id: 104, widget_type: 'error_tracking_list', config: {} } }],
+        ['error', { id: 41, error: { type: 'ValidationError', message: 'Invalid filters' } }],
+    ] as const)('renders a transient highlight without scrolling for a %s tile', (_kind, tile) => {
+        mockTransientHighlightedTileIds = [41]
+        installDashboardValues(() => [tile])
+        const scrollIntoView = jest.fn()
+        const scrollTo = jest.fn()
+        Object.defineProperty(Element.prototype, 'scrollIntoView', { configurable: true, value: scrollIntoView })
+        Object.defineProperty(window, 'scrollTo', { configurable: true, value: scrollTo })
+
+        const { container } = render(<DashboardItems />)
+        const target = container.querySelector('[data-dashboard-tile-id="41"]') as HTMLElement
+        act(flushAllAnimationFrames)
+
+        expect(target).toHaveAttribute('data-dashboard-tile-highlighted', 'true')
+        expect(target).toHaveAttribute('tabindex', '-1')
+        expect(scrollIntoView).not.toHaveBeenCalled()
+        expect(scrollTo).not.toHaveBeenCalled()
+        expect(requestAnimationFrameCallbacks.size).toBe(0)
     })
 
     it('keeps the visual highlight for 3000ms when reduced motion is requested', () => {

--- a/frontend/src/scenes/dashboard/DashboardItems.test.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.test.tsx
@@ -14,13 +14,6 @@ import { DashboardMode, DashboardPlacement } from '~/types'
 
 import { DashboardItems } from './DashboardItems'
 
-jest.mock('./dashboardAiSyncLogic', () => ({
-    dashboardAiSyncLogic: jest.fn((props: { dashboardId: number }) => ({
-        __mock: 'dashboardAiSyncLogic',
-        props,
-    })),
-}))
-
 jest.mock('kea', () => ({
     ...jest.requireActual('kea'),
     useValues: jest.fn(),
@@ -257,7 +250,6 @@ let mockHighlightTileIdParam: unknown
 let mockHighlightedTileId: number | null = null
 let mockDashboardLoading = false
 let mockDashboardRevealReadyKey: string | null = null
-let mockTransientHighlightedTileIds: number[] = []
 
 type DashboardTileFixture = {
     id: number
@@ -306,10 +298,6 @@ function installDashboardValues(getTiles: () => DashboardTileFixture[]): void {
 
         if (logic === dashboardsModel) {
             return { nameSortedDashboards: [] }
-        }
-
-        if (logic?.__mock === 'dashboardAiSyncLogic') {
-            return { transientHighlightedTileIds: mockTransientHighlightedTileIds }
         }
 
         return {}
@@ -361,7 +349,6 @@ describe('DashboardItems', () => {
         mockHighlightedTileId = null
         mockDashboardLoading = false
         mockDashboardRevealReadyKey = null
-        mockTransientHighlightedTileIds = []
         installAnimationFrameMocks()
         Object.defineProperty(window, 'matchMedia', {
             configurable: true,
@@ -406,10 +393,6 @@ describe('DashboardItems', () => {
                 return {
                     nameSortedDashboards: [{ id: 6, name: 'Other dashboard' }],
                 }
-            }
-
-            if (logic?.__mock === 'dashboardAiSyncLogic') {
-                return { transientHighlightedTileIds: mockTransientHighlightedTileIds }
             }
 
             return {}
@@ -771,14 +754,13 @@ describe('DashboardItems', () => {
         ['widget', { id: 41, widget: { id: 104, widget_type: 'error_tracking_list', config: {} } }],
         ['error', { id: 41, error: { type: 'ValidationError', message: 'Invalid filters' } }],
     ] as const)('renders a transient highlight without scrolling for a %s tile', (_kind, tile) => {
-        mockTransientHighlightedTileIds = [41]
         installDashboardValues(() => [tile])
         const scrollIntoView = jest.fn()
         const scrollTo = jest.fn()
         Object.defineProperty(Element.prototype, 'scrollIntoView', { configurable: true, value: scrollIntoView })
         Object.defineProperty(window, 'scrollTo', { configurable: true, value: scrollTo })
 
-        const { container } = render(<DashboardItems />)
+        const { container } = render(<DashboardItems transientHighlightedTileIds={[41]} />)
         const target = container.querySelector('[data-dashboard-tile-id="41"]') as HTMLElement
         act(flushAllAnimationFrames)
 

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -41,7 +41,6 @@ import { DashboardLayoutSize, DashboardMode, DashboardPlacement, DashboardType }
 import { DashboardTextItem } from 'products/dashboards/frontend/components/DashboardTextItem/DashboardTextItem'
 import { getDashboardTileSpacingGap } from 'products/dashboards/frontend/dashboardCustomization'
 
-import { dashboardAiSyncLogic } from './dashboardAiSyncLogic'
 import { DashboardButtonTileItem } from './items/DashboardButtonTileItem'
 import { DashboardErrorTileItem } from './items/DashboardErrorTileItem'
 
@@ -55,6 +54,7 @@ const TILE_HIGHLIGHT_DURATION_MS = 3000
 
 interface DashboardItemsProps {
     showCreateAnomalyAlertButton?: boolean
+    transientHighlightedTileIds?: number[]
 }
 
 /**
@@ -81,7 +81,10 @@ const MemoizedDashboardButtonTileItem = memo(
 const MemoizedDashboardErrorTileItem = memo(DashboardErrorTileItem, gridTilePropsEqual) as typeof DashboardErrorTileItem
 const MemoizedDashboardWidgetItem = memo(DashboardWidgetItem, gridTilePropsEqual) as typeof DashboardWidgetItem
 
-export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsProps = {}): JSX.Element {
+export function DashboardItems({
+    showCreateAnomalyAlertButton,
+    transientHighlightedTileIds = [],
+}: DashboardItemsProps = {}): JSX.Element {
     const {
         dashboard,
         tiles,
@@ -109,7 +112,6 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         widgetRefreshStatus,
         scrollToBottomSignal,
     } = useValues(dashboardLogic)
-    const { transientHighlightedTileIds = [] } = useValues(dashboardAiSyncLogic({ dashboardId: dashboard?.id ?? 0 }))
     const { layoutZoom = 1 } = useValues(dashboardLogic)
     const {
         updateLayouts,

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -41,6 +41,7 @@ import { DashboardLayoutSize, DashboardMode, DashboardPlacement, DashboardType }
 import { DashboardTextItem } from 'products/dashboards/frontend/components/DashboardTextItem/DashboardTextItem'
 import { getDashboardTileSpacingGap } from 'products/dashboards/frontend/dashboardCustomization'
 
+import { dashboardAiSyncLogic } from './dashboardAiSyncLogic'
 import { DashboardButtonTileItem } from './items/DashboardButtonTileItem'
 import { DashboardErrorTileItem } from './items/DashboardErrorTileItem'
 
@@ -108,6 +109,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         widgetRefreshStatus,
         scrollToBottomSignal,
     } = useValues(dashboardLogic)
+    const { transientHighlightedTileIds = [] } = useValues(dashboardAiSyncLogic({ dashboardId: dashboard?.id ?? 0 }))
     const { layoutZoom = 1 } = useValues(dashboardLogic)
     const {
         updateLayouts,
@@ -616,6 +618,8 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                     >
                         {tiles?.map((tile) => {
                             const { insight, text, button_tile, widget } = tile
+                            const isTileHighlighted =
+                                visuallyHighlightedTileId === tile.id || transientHighlightedTileIds.includes(tile.id)
                             const smLayout = layouts['sm']?.find((l) => {
                                 return l.i == tile.id.toString()
                             })
@@ -637,8 +641,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                             }
                             const revealProps = {
                                 'data-dashboard-tile-id': String(tile.id),
-                                'data-dashboard-tile-highlighted':
-                                    visuallyHighlightedTileId === tile.id ? 'true' : undefined,
+                                'data-dashboard-tile-highlighted': isTileHighlighted ? 'true' : undefined,
                                 tabIndex: -1,
                             }
 
@@ -687,7 +690,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                                         apiErrored={apiErrored}
                                         apiError={apiError}
                                         queryId={insight.query_status?.id}
-                                        highlighted={visuallyHighlightedTileId === tile.id}
+                                        highlighted={isTileHighlighted}
                                         updateColor={(color) => updateTileColor(tile.id, color)}
                                         toggleShowDescription={() => toggleTileDescription(tile.id)}
                                         ribbonColor={tile.color}

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
@@ -809,12 +809,18 @@ describe('resolveDashboardAiMutation candidate classification', () => {
         ).toBeNull()
     })
 
-    it('learns an alert on an insight in the open dashboard', () => {
-        const result = resolveFor(
-            'alert-create',
-            { insight: '101' },
-            { id: 'alert-new', insight: 101, insight_short_id: 'alpha' }
-        )
+    it.each([
+        ['a bare insight ID', { id: 'alert-new', insight: 101, insight_short_id: 'alpha' }],
+        [
+            'the serialized insight object the alert API returns',
+            {
+                id: 'alert-new',
+                insight: { id: 101, short_id: 'alpha', name: 'Weekly signups' },
+                insight_short_id: 'alpha',
+            },
+        ],
+    ])('learns an alert on an insight in the open dashboard from %s', (_case, output) => {
+        const result = resolveFor('alert-create', { insight: '101' }, output)
 
         expect(result.candidate).toEqual({
             family: 'alert',
@@ -964,6 +970,10 @@ describe('resolveDashboardAiMutation candidate classification', () => {
         ['an insight outside this dashboard', { id: 'alert-new', insight: 999 }],
         ['a mismatched numeric insight ID', { id: 'alert-new', insight: 202, insight_short_id: 'alpha' }],
         ['a mismatched insight short ID', { id: 'alert-new', insight: 101, insight_short_id: 'beta' }],
+        [
+            'a serialized insight object that contradicts the top-level short ID',
+            { id: 'alert-new', insight: { id: 101, short_id: 'alpha' }, insight_short_id: 'beta' },
+        ],
     ])('rejects an alert candidate with %s', (_case, output) => {
         expect(resolveFor('alert-create', { insight: 101 }, output).candidate).toBeNull()
     })

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
@@ -33,6 +33,7 @@ import {
 
 let mockCommittedDashboard: DashboardType<QueryBasedInsightModel> | null = null
 const mockLoadDashboard = jest.fn<Promise<void>, [unknown]>()
+const mockRefreshDashboardWidgets = jest.fn<void, [unknown]>()
 
 jest.mock('scenes/dashboard/dashboardLogic', () => ({
     ...jest.requireActual('scenes/dashboard/dashboardLogic'),
@@ -41,6 +42,9 @@ jest.mock('scenes/dashboard/dashboardLogic', () => ({
             get dashboard(): DashboardType<QueryBasedInsightModel> | null {
                 return mockCommittedDashboard
             },
+        },
+        actions: {
+            refreshDashboardWidgets: (payload: unknown): void => mockRefreshDashboardWidgets(payload),
         },
         asyncActions: {
             loadDashboard: (payload: unknown): Promise<void> => mockLoadDashboard(payload),
@@ -178,6 +182,19 @@ function dashboardWithInsight(
                 id: tileId,
                 color: InsightColor.White,
                 insight: committedInsight(insightId, shortId, alertIds),
+            },
+        ],
+    }
+}
+
+function dashboardWithWidget(config: Record<string, unknown>): DashboardType<QueryBasedInsightModel> {
+    return {
+        ...committedDashboard(),
+        tiles: [
+            {
+                id: 71,
+                color: InsightColor.White,
+                widget: { id: 'widget-1', widget_type: 'session_replay_list', config },
             },
         ],
     }
@@ -1435,6 +1452,39 @@ describe('resolveDashboardAiMutation candidate classification', () => {
             logic.unmount()
             timeoutSpy.mockRestore()
             jest.useRealTimers()
+        })
+
+        it.each([
+            [
+                'refreshes a widget whose configuration the reload changed',
+                { rows: 20 },
+                [[{ tileIds: [71], forceRefresh: true }]],
+            ],
+            ['leaves an unchanged widget result in place', { rows: 10 }, []],
+        ])('%s', async (_case, reloadedConfig, expectedCalls) => {
+            initKeaTests()
+            mockCommittedDashboard = dashboardWithWidget({ rows: 10 })
+            const reload = deferred<void>()
+            mockLoadDashboard.mockReset().mockReturnValue(reload.promise)
+            mockRefreshDashboardWidgets.mockReset()
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+
+            const innerInput = { id: dashboardId, widgets: [{ tile_id: 71, config: reloadedConfig }] }
+            logic.actions.applyToolCompletion(
+                eventFor('dashboard-widgets-batch-update', innerInput, {
+                    dashboard_id: dashboardId,
+                    tiles: [{ id: 71, dashboard_id: dashboardId }],
+                }),
+                innerInput
+            )
+            mockCommittedDashboard = dashboardWithWidget(reloadedConfig)
+            reload.resolve()
+            await waitFor(() => expect(logic.values.activeBatch).toBeNull())
+
+            expect(mockRefreshDashboardWidgets.mock.calls).toEqual(expectedCalls)
+
+            logic.unmount()
         })
 
         it('does not highlight a requested tile missing from the committed dashboard', async () => {

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
@@ -288,17 +288,31 @@ const dashboardStructureCases: DashboardStructureCase[] = [
         label: 'copies a tile',
         toolName: 'dashboard-tile-copy',
         input: (id) => ({ id, fromDashboardId: 6, tileId: 41 }),
-        output: (id) => ({ id }),
-        candidate: dashboardCandidate(),
-        contradictoryOutput: { id: 8 },
+        output: (id) => ({
+            id,
+            tiles: [
+                { id: 41, dashboard_id: id },
+                { id: 42, dashboard_id: id },
+                { id: '61', dashboard_id: id },
+            ],
+        }),
+        candidate: dashboardCandidate({ tileIds: [61] }),
+        contradictoryOutput: { id: 8, tiles: [{ id: 61, dashboard_id: 8 }] },
     },
     {
         label: 'keeps the generated tile copy alias',
         toolName: 'dashboards-copy-tile-create',
         input: (id) => ({ id, fromDashboardId: 6, tileId: 41 }),
-        output: (id) => ({ id }),
-        candidate: dashboardCandidate(),
-        contradictoryOutput: { id: 8 },
+        output: (id) => ({
+            id,
+            tiles: [
+                { id: 41, dashboard_id: id },
+                { id: 42, dashboard_id: id },
+                { id: '61', dashboard_id: id },
+            ],
+        }),
+        candidate: dashboardCandidate({ tileIds: [61] }),
+        contradictoryOutput: { id: 8, tiles: [{ id: 61, dashboard_id: 8 }] },
     },
     {
         label: 'adds dashboard widgets',
@@ -405,6 +419,25 @@ describe('resolveDashboardAiMutation candidate classification', () => {
             expect(resolveFor(toolName, input(7), contradictoryOutput).candidate).toBeNull()
         }
     )
+
+    it.each([
+        ['no tile list', { id: 7 }],
+        [
+            'more than one tile the committed dashboard is missing',
+            {
+                id: 7,
+                tiles: [
+                    { id: 41, dashboard_id: 7 },
+                    { id: 61, dashboard_id: 7 },
+                    { id: 62, dashboard_id: 7 },
+                ],
+            },
+        ],
+    ])('reloads without a highlight when a tile copy response has %s', (_case, output) => {
+        expect(resolveFor('dashboard-tile-copy', { id: 7, fromDashboardId: 6, tileId: 41 }, output).candidate).toEqual(
+            dashboardCandidate()
+        )
+    })
 
     it.each(['dashboards-move-tile-create', 'dashboards-move-tile-partial-update'])(
         'recognizes the destination dashboard for %s',

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
@@ -591,6 +591,62 @@ describe('resolveDashboardAiMutation candidate classification', () => {
         ).toBeNull()
     })
 
+    it.each([
+        ['another dashboard', [8], [{ id: 61, dashboard_id: 8, deleted: false }], { 101: [8], alpha: [8] }],
+        ['no dashboards', [], [], { 101: [], alpha: [] }],
+    ])(
+        'reloads the prior open owner when an insight update replaces membership with %s',
+        (_case, dashboards, dashboardTiles, expectedOwnership) => {
+            const ownership: DashboardAiKnownOwnership = {
+                ...emptyOwnership(),
+                insightDashboardsById: { 101: [7], alpha: [7] },
+            }
+            const result = resolveFor(
+                'insight-update',
+                { id: 'alpha', dashboards },
+                { id: 101, short_id: 'alpha', dashboard_tiles: dashboardTiles },
+                ownership
+            )
+
+            expect(result.candidate).toEqual({
+                family: 'insight',
+                dashboardId,
+                tileIds: [],
+                insightIds: [101, 'alpha'],
+                deletesDashboard: false,
+            })
+            expect(result.ownership.insightDashboardsById).toEqual(expectedOwnership)
+        }
+    )
+
+    it.each([
+        ['the request retains the open dashboard but the response removes it', [7], []],
+        [
+            'the request removes the open dashboard but the response retains it',
+            [8],
+            [{ id: 41, dashboard_id: 7, deleted: false }],
+        ],
+        [
+            'the replacement memberships disagree outside the open dashboard',
+            [8],
+            [{ id: 61, dashboard_id: 9, deleted: false }],
+        ],
+    ])('rejects an insight update when %s', (_case, dashboards, dashboardTiles) => {
+        const ownership: DashboardAiKnownOwnership = {
+            ...emptyOwnership(),
+            insightDashboardsById: { 101: [7], alpha: [7] },
+        }
+
+        const result = resolveFor(
+            'insight-update',
+            { id: 'alpha', dashboards },
+            { id: 101, short_id: 'alpha', dashboard_tiles: dashboardTiles },
+            ownership
+        )
+
+        expect(result).toEqual({ candidate: null, ownership })
+    })
+
     it('deletes an insight owned by a current tile and removes both identifier forms immutably', () => {
         const ownership: DashboardAiKnownOwnership = {
             ...emptyOwnership(),
@@ -699,6 +755,39 @@ describe('resolveDashboardAiMutation candidate classification', () => {
         expect(learned.subscriptionDashboardById).toEqual({ 51: 7 })
     })
 
+    it('refreshes the prior open owner when a subscription moves to an agreed new dashboard', () => {
+        const ownership: DashboardAiKnownOwnership = {
+            ...emptyOwnership(),
+            subscriptionDashboardById: { 51: 7 },
+        }
+
+        const result = resolveFor(
+            'subscriptions-partial-update',
+            { id: 51, dashboard: 8 },
+            { id: 51, dashboard: 8 },
+            ownership
+        )
+
+        expect(result.candidate).toMatchObject({ family: 'subscription', dashboardId: 7 })
+        expect(result.ownership.subscriptionDashboardById).toEqual({ 51: 8 })
+    })
+
+    it('rejects a subscription move when request and response owners disagree', () => {
+        const ownership: DashboardAiKnownOwnership = {
+            ...emptyOwnership(),
+            subscriptionDashboardById: { 51: 7 },
+        }
+
+        const result = resolveFor(
+            'subscriptions-partial-update',
+            { id: 51, dashboard: 8 },
+            { id: 51, dashboard: 9 },
+            ownership
+        )
+
+        expect(result).toEqual({ candidate: null, ownership })
+    })
+
     it('rejects learned subscription ownership for another dashboard and unsafe IDs', () => {
         const ownership: DashboardAiKnownOwnership = {
             ...emptyOwnership(),
@@ -762,6 +851,45 @@ describe('resolveDashboardAiMutation candidate classification', () => {
             insightIds: [101, 'alpha'],
             deletesDashboard: false,
         })
+    })
+
+    it('refreshes the prior open insight when an alert moves to an agreed new insight', () => {
+        const ownership: DashboardAiKnownOwnership = {
+            ...emptyOwnership(),
+            alertInsightById: { 'alert-new': '101' },
+        }
+
+        const result = resolveFor(
+            'alert-update',
+            { id: 'alert-new', insight: 999 },
+            { id: 'alert-new', insight: 999 },
+            ownership
+        )
+
+        expect(result.candidate).toEqual({
+            family: 'alert',
+            dashboardId,
+            tileIds: [41],
+            insightIds: [101, 'alpha'],
+            deletesDashboard: false,
+        })
+        expect(result.ownership.alertInsightById).toEqual({ 'alert-new': '999' })
+    })
+
+    it('rejects an alert move when request and response owners disagree', () => {
+        const ownership: DashboardAiKnownOwnership = {
+            ...emptyOwnership(),
+            alertInsightById: { 'alert-new': '101' },
+        }
+
+        const result = resolveFor(
+            'alert-update',
+            { id: 'alert-new', insight: 999 },
+            { id: 'alert-new', insight: 888 },
+            ownership
+        )
+
+        expect(result).toEqual({ candidate: null, ownership })
     })
 
     it('resolves a cold ID-only alert delete from committed tile alert IDs and removes that ownership', () => {
@@ -1038,6 +1166,36 @@ describe('resolveDashboardAiMutation candidate classification', () => {
             listSpy.mockRestore()
         })
 
+        it('refreshes the mounted prior subscription owner before replacing learned ownership', async () => {
+            initKeaTests()
+            mockCommittedDashboard = committedDashboard()
+            mockLoadDashboard.mockReset()
+            const listSpy = jest.spyOn(api.subscriptions, 'list').mockResolvedValue({ results: [] })
+            const mountedSubscriptions = subscriptionsLogic({ dashboardId })
+            mountedSubscriptions.mount()
+            await waitFor(() => expect(mountedSubscriptions.values.subscriptionsLoading).toBe(false))
+            listSpy.mockClear()
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+            logic.actions.setKnownOwnership({
+                ...emptyOwnership(),
+                subscriptionDashboardById: { 71: dashboardId },
+            })
+
+            logic.actions.applyToolCompletion(
+                eventFor('subscriptions-partial-update', { id: 71, dashboard: 8 }, { id: 71, dashboard: 8 }),
+                { id: 71, dashboard: 8 }
+            )
+
+            await waitFor(() => expect(listSpy).toHaveBeenCalledWith({ dashboardId }))
+            expect(logic.values.knownOwnership.subscriptionDashboardById).toEqual({ 71: 8 })
+            expect(mockLoadDashboard).not.toHaveBeenCalled()
+
+            logic.unmount()
+            mountedSubscriptions.unmount()
+            listSpy.mockRestore()
+        })
+
         it('reloads an authoritative insight create and highlights its exact committed tile', async () => {
             initKeaTests()
             mockCommittedDashboard = committedDashboard()
@@ -1070,6 +1228,37 @@ describe('resolveDashboardAiMutation candidate classification', () => {
                 { dashboards: [7] }
             )
             expect(mockLoadDashboard).toHaveBeenCalledTimes(1)
+            logic.unmount()
+        })
+
+        it('reloads an insight removed from the open dashboard without highlighting a tile', async () => {
+            initKeaTests()
+            mockCommittedDashboard = dashboardWithInsight(41, 101, 'alpha')
+            const reload = deferred<void>()
+            mockLoadDashboard.mockReset().mockReturnValue(reload.promise)
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+            logic.actions.setKnownOwnership({
+                ...emptyOwnership(),
+                insightDashboardsById: { 101: [dashboardId], alpha: [dashboardId] },
+            })
+
+            logic.actions.applyToolCompletion(
+                eventFor(
+                    'insight-update',
+                    { id: 'alpha', dashboards: [] },
+                    { id: 101, short_id: 'alpha', dashboard_tiles: [] }
+                ),
+                { id: 'alpha', dashboards: [] }
+            )
+            expect(mockLoadDashboard).toHaveBeenCalledTimes(1)
+
+            mockCommittedDashboard = { ...committedDashboard(), tiles: [] }
+            reload.resolve()
+            await waitFor(() => expect(logic.values.activeBatch).toBeNull())
+
+            expect(logic.values.transientHighlightedTileIds).toEqual([])
+            expect(logic.values.knownOwnership.insightDashboardsById).toEqual({ 101: [], alpha: [] })
             logic.unmount()
         })
 
@@ -1349,6 +1538,39 @@ describe('resolveDashboardAiMutation candidate classification', () => {
                 { insight: 999 }
             )
             expect(alertListSpy).toHaveBeenCalledTimes(1)
+            expect(mockLoadDashboard).not.toHaveBeenCalled()
+
+            logic.unmount()
+            mountedAlerts.unmount()
+            alertListSpy.mockRestore()
+        })
+
+        it('refreshes the mounted prior alert owner before replacing learned ownership', async () => {
+            initKeaTests()
+            mockCommittedDashboard = dashboardWithInsight(41, 101, 'alpha')
+            mockLoadDashboard.mockReset()
+            const alertListSpy = jest.spyOn(api.alerts, 'list').mockResolvedValue({ results: [], count: 0 })
+            const insightLogicProps = insightLogicPropsForDashboard(mockCommittedDashboard)!
+            const mountedAlerts = insightAlertsLogic({
+                insightId: 101,
+                insightLogicProps,
+                deferInitialAlertsLoad: true,
+            })
+            mountedAlerts.mount()
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+            logic.actions.setKnownOwnership({
+                ...emptyOwnership(),
+                alertInsightById: { 'alert-new': '101' },
+            })
+
+            logic.actions.applyToolCompletion(
+                eventFor('alert-update', { id: 'alert-new', insight: 999 }, { id: 'alert-new', insight: 999 }),
+                { id: 'alert-new', insight: 999 }
+            )
+
+            await waitFor(() => expect(alertListSpy).toHaveBeenCalledWith(101))
+            expect(logic.values.knownOwnership.alertInsightById).toEqual({ 'alert-new': '999' })
             expect(mockLoadDashboard).not.toHaveBeenCalled()
 
             logic.unmount()

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
@@ -1153,6 +1153,58 @@ describe('resolveDashboardAiMutation candidate classification', () => {
             jest.useRealTimers()
         })
 
+        it('does not let a replaced highlight timer clear a newer highlight', async () => {
+            jest.useFakeTimers()
+            initKeaTests()
+            mockCommittedDashboard = dashboardWithInsight(42, 202, 'beta')
+            const firstReload = deferred<void>()
+            const secondReload = deferred<void>()
+            mockLoadDashboard
+                .mockReset()
+                .mockReturnValueOnce(firstReload.promise)
+                .mockReturnValueOnce(secondReload.promise)
+            const timeoutSpy = jest.spyOn(window, 'setTimeout')
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+
+            logic.actions.applyToolCompletion(
+                eventFor(
+                    'dashboard-update-text-tile',
+                    { id: dashboardId, tile_id: 42 },
+                    { id: 42, dashboard_id: dashboardId }
+                ),
+                { id: dashboardId, tile_id: 42 }
+            )
+            firstReload.resolve()
+            await waitFor(() => expect(logic.values.transientHighlightedTileIds).toEqual([42]))
+            const firstExpiry = timeoutSpy.mock.calls.find((call: unknown[]) => call[1] === 3000)?.[0] as
+                | (() => void)
+                | undefined
+            expect(firstExpiry).not.toBeUndefined()
+
+            mockCommittedDashboard = {
+                ...committedDashboard(),
+                tiles: [committedDashboard().tiles[0], dashboardWithInsight(42, 202, 'beta').tiles[0]],
+            }
+            logic.actions.applyToolCompletion(
+                eventFor(
+                    'dashboard-update-text-tile',
+                    { id: dashboardId, tile_id: 41 },
+                    { id: 41, dashboard_id: dashboardId }
+                ),
+                { id: dashboardId, tile_id: 41 }
+            )
+            secondReload.resolve()
+            await waitFor(() => expect(logic.values.transientHighlightedTileIds).toEqual([41, 42]))
+
+            firstExpiry?.()
+
+            expect(logic.values.transientHighlightedTileIds).toEqual([41, 42])
+            logic.unmount()
+            timeoutSpy.mockRestore()
+            jest.useRealTimers()
+        })
+
         it('does not highlight a requested tile missing from the committed dashboard', async () => {
             jest.useFakeTimers()
             initKeaTests()
@@ -1204,6 +1256,66 @@ describe('resolveDashboardAiMutation candidate classification', () => {
 
             expect(setHighlightSpy).not.toHaveBeenCalled()
             jest.useRealTimers()
+        })
+
+        it('abandons an active reload and its queued successor after the keyed logic remounts', async () => {
+            initKeaTests()
+            mockCommittedDashboard = committedDashboard()
+            const activeReload = deferred<void>()
+            const successorReload = deferred<void>()
+            mockLoadDashboard
+                .mockReset()
+                .mockReturnValueOnce(activeReload.promise)
+                .mockReturnValueOnce(successorReload.promise)
+            const timeoutSpy = jest.spyOn(window, 'setTimeout')
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+
+            logic.actions.applyToolCompletion(
+                eventFor('dashboard-create-tile', { id: dashboardId }, { id: 61, dashboard_id: dashboardId }),
+                { id: dashboardId }
+            )
+            logic.actions.applyToolCompletion(
+                eventFor(
+                    'dashboard-update-text-tile',
+                    { id: dashboardId, tile_id: 41 },
+                    { id: 41, dashboard_id: dashboardId }
+                ),
+                { id: dashboardId, tile_id: 41 }
+            )
+            expect(logic.values.queuedBatch?.tileIds).toEqual([41])
+
+            const setActiveBatchSpy = jest.spyOn(logic.actions, 'setActiveBatch')
+            const setQueuedBatchSpy = jest.spyOn(logic.actions, 'setQueuedBatch')
+            const setHighlightSpy = jest.spyOn(logic.actions, 'setTransientHighlightedTileIds')
+            const setKnownOwnershipSpy = jest.spyOn(logic.actions, 'setKnownOwnership')
+            const syncDashboardSpy = jest.spyOn(logic.actions, 'syncDashboard')
+            setActiveBatchSpy.mockClear()
+            setQueuedBatchSpy.mockClear()
+            setHighlightSpy.mockClear()
+            setKnownOwnershipSpy.mockClear()
+            syncDashboardSpy.mockClear()
+            timeoutSpy.mockClear()
+
+            logic.unmount()
+            const remountedLogic = dashboardAiSyncLogic({ dashboardId })
+            remountedLogic.mount()
+            mockCommittedDashboard = dashboardWithInsight(61, 303, 'gamma')
+            activeReload.resolve()
+            await activeReload.promise
+            await Promise.resolve()
+            await Promise.resolve()
+
+            expect(setActiveBatchSpy).not.toHaveBeenCalled()
+            expect(setQueuedBatchSpy).not.toHaveBeenCalled()
+            expect(setHighlightSpy).not.toHaveBeenCalled()
+            expect(setKnownOwnershipSpy).not.toHaveBeenCalled()
+            expect(syncDashboardSpy).not.toHaveBeenCalled()
+            expect(mockLoadDashboard).toHaveBeenCalledTimes(1)
+            expect(timeoutSpy.mock.calls.some((call: unknown[]) => call[1] === 3000)).toBe(false)
+
+            remountedLogic.unmount()
+            timeoutSpy.mockRestore()
         })
 
         it('refreshes only the mounted alert logic for the exact dashboard insight', async () => {

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
@@ -636,6 +636,19 @@ describe('resolveDashboardAiMutation candidate classification', () => {
         expect(result.ownership.alertInsightById).toEqual({ 501: '101' })
     })
 
+    it.each(['{}', '  { }\n'])('accepts an empty JSON object string from call --json alert-delete: %p', (output) => {
+        const result = resolveFor('alert-delete', { id: 'alert-1' }, output)
+
+        expect(result.candidate).toEqual({
+            family: 'alert',
+            dashboardId,
+            tileIds: [41],
+            insightIds: [101, 'alpha'],
+            deletesDashboard: false,
+        })
+        expect(result.ownership.alertInsightById).toEqual({ 501: '101' })
+    })
+
     it.each([
         ['an array', []],
         ['a non-empty malformed object', { unexpected: true }],
@@ -650,6 +663,21 @@ describe('resolveDashboardAiMutation candidate classification', () => {
     it('rejects malformed alert deletion output instead of treating it as an empty 204 response', () => {
         const ownership = emptyOwnership()
         const result = resolveFor('alert-delete', { id: 'alert-1' }, 'not a structured response', ownership)
+
+        expect(result).toEqual({ candidate: null, ownership })
+        expect(result.ownership).toBe(ownership)
+    })
+
+    it.each([
+        ['a JSON array', '[]'],
+        ['a non-empty JSON object', '{"id":"alert-1"}'],
+        ['JSON null', 'null'],
+        ['a JSON scalar', '7'],
+        ['malformed JSON', '{'],
+        ['TOON-like non-empty content', 'id: alert-1'],
+    ])('rejects alert deletion string output shaped as %s', (_case, output) => {
+        const ownership = emptyOwnership()
+        const result = resolveFor('alert-delete', { id: 'alert-1' }, output, ownership)
 
         expect(result).toEqual({ candidate: null, ownership })
         expect(result.ownership).toBe(ownership)

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
@@ -281,6 +281,60 @@ describe('resolveDashboardAiMutation candidate classification', () => {
         }
     )
 
+    it('classifies a partial preserve reorder from the full dashboard response', () => {
+        expect(
+            resolveFor(
+                'dashboard-reorder-tiles',
+                { id: 7, tile_order: [42, 41], layout: 'preserve' },
+                {
+                    id: 7,
+                    tiles: [
+                        { id: 41, dashboard_id: 7 },
+                        { id: 42, dashboard_id: 7 },
+                        { id: 61, dashboard_id: 7 },
+                    ],
+                }
+            ).candidate
+        ).toEqual(dashboardCandidate({ tileIds: [41, 42] }))
+    })
+
+    it('classifies a complete three-column reorder when the full dashboard response contains every requested tile', () => {
+        expect(
+            resolveFor(
+                'dashboard-reorder-tiles',
+                { id: 7, tile_order: [42, 41], layout: 'three_column' },
+                {
+                    id: 7,
+                    tiles: [
+                        { id: 42, dashboard_id: 7 },
+                        { id: 41, dashboard_id: 7 },
+                    ],
+                }
+            ).candidate
+        ).toEqual(dashboardCandidate({ tileIds: [41, 42] }))
+    })
+
+    it.each([
+        ['a missing requested tile', [42], [{ id: 41, dashboard_id: 7 }]],
+        [
+            'duplicate requested tile IDs',
+            [42, 42],
+            [
+                { id: 42, dashboard_id: 7 },
+                { id: 42, dashboard_id: 7 },
+            ],
+        ],
+        [
+            'an unsafe requested tile ID',
+            [Number.MAX_SAFE_INTEGER + 1],
+            [{ id: Number.MAX_SAFE_INTEGER + 1, dashboard_id: 7 }],
+        ],
+    ])('rejects a reorder with %s', (_case, tileOrder, tiles) => {
+        expect(
+            resolveFor('dashboard-reorder-tiles', { id: 7, tile_order: tileOrder }, { id: 7, tiles }).candidate
+        ).toBeNull()
+    })
+
     it('rejects a direct third-party MCP event with the same dashboard tool name before changing ownership', () => {
         const ownership = emptyOwnership()
         const directInvocation = {
@@ -570,7 +624,7 @@ describe('resolveDashboardAiMutation candidate classification', () => {
     })
 
     it('resolves a cold ID-only alert delete from committed tile alert IDs and removes that ownership', () => {
-        const result = resolveFor('alert-delete', { id: 'alert-1' }, undefined)
+        const result = resolveFor('alert-delete', { id: 'alert-1' }, {})
 
         expect(result.candidate).toEqual({
             family: 'alert',
@@ -580,6 +634,17 @@ describe('resolveDashboardAiMutation candidate classification', () => {
             deletesDashboard: false,
         })
         expect(result.ownership.alertInsightById).toEqual({ 501: '101' })
+    })
+
+    it.each([
+        ['an array', []],
+        ['a non-empty malformed object', { unexpected: true }],
+    ])('rejects alert deletion output shaped as %s', (_case, output) => {
+        const ownership = emptyOwnership()
+        const result = resolveFor('alert-delete', { id: 'alert-1' }, output, ownership)
+
+        expect(result).toEqual({ candidate: null, ownership })
+        expect(result.ownership).toBe(ownership)
     })
 
     it('rejects malformed alert deletion output instead of treating it as an empty 204 response', () => {

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
@@ -1404,7 +1404,116 @@ describe('resolveDashboardAiMutation candidate classification', () => {
             routerPushSpy.mockRestore()
         })
 
-        it('continues with a queued successor after the active dashboard reload fails', async () => {
+        it('emits exact privacy-safe telemetry for an active batch and its merged successor', async () => {
+            initKeaTests()
+            mockCommittedDashboard = committedDashboard()
+            const firstReload = deferred<void>()
+            const successorReload = deferred<void>()
+            mockLoadDashboard
+                .mockReset()
+                .mockReturnValueOnce(firstReload.promise)
+                .mockReturnValueOnce(successorReload.promise)
+            jest.mocked(posthog.capture).mockClear()
+            let now = 1_000
+            const dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now)
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+
+            logic.actions.applyToolCompletion(
+                eventFor(
+                    'dashboard-update',
+                    { id: dashboardId, name: 'private-dashboard-title@example.com' },
+                    { id: dashboardId, name: 'private-dashboard-title@example.com' }
+                ),
+                { id: dashboardId, name: 'private-dashboard-title@example.com' }
+            )
+
+            now = 1_100
+            logic.actions.applyToolCompletion(
+                eventFor(
+                    'dashboard-update-text-tile',
+                    { id: dashboardId, tile_id: 42, body: 'private tile copy' },
+                    { id: 42, dashboard_id: dashboardId, body: 'private tile copy' }
+                ),
+                { id: dashboardId, tile_id: 42, body: 'private tile copy' }
+            )
+            logic.actions.applyToolCompletion(
+                eventFor(
+                    'dashboard-update',
+                    { id: dashboardId, recipient: 'test@example.com' },
+                    { id: dashboardId, recipient: 'test@example.com' }
+                ),
+                { id: dashboardId, recipient: 'test@example.com' }
+            )
+            logic.actions.applyToolCompletion(
+                eventFor(
+                    'insight-create',
+                    { dashboards: [dashboardId], name: 'private insight name' },
+                    {
+                        id: 303,
+                        short_id: 'private-insight-short-id',
+                        name: 'private insight name',
+                        dashboard_tiles: [{ id: 61, dashboard_id: dashboardId, deleted: false }],
+                    }
+                ),
+                { dashboards: [dashboardId], name: 'private insight name' }
+            )
+
+            now = 1_200
+            firstReload.resolve()
+            await waitFor(() => expect(mockLoadDashboard).toHaveBeenCalledTimes(2))
+
+            mockCommittedDashboard = {
+                ...committedDashboard(),
+                tiles: [
+                    committedDashboard().tiles[0],
+                    dashboardWithInsight(42, 202, 'beta').tiles[0],
+                    dashboardWithInsight(61, 303, 'private-insight-short-id').tiles[0],
+                ],
+            }
+            now = 1_350
+            successorReload.resolve()
+            await waitFor(() => expect(logic.values.activeBatch).toBeNull())
+
+            expect(jest.mocked(posthog.capture).mock.calls).toEqual([
+                [
+                    'dashboard ai sync completed',
+                    {
+                        tool_families: ['dashboard'],
+                        queued_event_count: 1,
+                        highlighted_tile_count: 0,
+                        duration_ms: 200,
+                        success: true,
+                    },
+                ],
+                [
+                    'dashboard ai sync completed',
+                    {
+                        tool_families: ['dashboard', 'insight'],
+                        queued_event_count: 3,
+                        highlighted_tile_count: 2,
+                        duration_ms: 250,
+                        success: true,
+                    },
+                ],
+            ])
+            const serializedCalls = JSON.stringify(jest.mocked(posthog.capture).mock.calls)
+            for (const privateValue of [
+                'private-dashboard-title@example.com',
+                'private tile copy',
+                'test@example.com',
+                'dashboard-update-text-tile',
+                'private insight name',
+                'private-insight-short-id',
+            ]) {
+                expect(serializedCalls).not.toContain(privateValue)
+            }
+
+            logic.unmount()
+            dateNowSpy.mockRestore()
+        })
+
+        it('continues with a queued successor and emits failure telemetry after the active dashboard reload fails', async () => {
             initKeaTests()
             const committed = committedDashboard()
             mockCommittedDashboard = committed
@@ -1414,23 +1523,139 @@ describe('resolveDashboardAiMutation candidate classification', () => {
                 .mockReset()
                 .mockReturnValueOnce(firstReload.promise)
                 .mockReturnValueOnce(successorReload.promise)
+            jest.mocked(posthog.capture).mockClear()
+            let now = 2_000
+            const dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now)
             const logic = dashboardAiSyncLogic({ dashboardId })
             logic.mount()
 
             logic.actions.applyToolCompletion(eventFor('dashboard-update', { id: 7 }, { id: 7 }), { id: 7 })
+            now = 2_050
             logic.actions.applyToolCompletion(
                 eventFor('dashboard-update-text-tile', { id: 7, tile_id: 41 }, { id: 41, dashboard_id: 7 }),
                 { id: 7, tile_id: 41 }
             )
+            now = 2_125
             firstReload.reject(new Error('reload failed'))
 
             await waitFor(() => expect(mockLoadDashboard).toHaveBeenCalledTimes(2))
             expect(mockCommittedDashboard).toBe(committed)
             expect(logic.values.activeBatch?.tileIds).toEqual([41])
+            expect(jest.mocked(posthog.capture).mock.calls).toEqual([
+                [
+                    'dashboard ai sync completed',
+                    {
+                        tool_families: ['dashboard'],
+                        queued_event_count: 1,
+                        highlighted_tile_count: 0,
+                        duration_ms: 125,
+                        success: false,
+                    },
+                ],
+            ])
+            now = 2_300
             successorReload.resolve()
             await waitFor(() => expect(logic.values.activeBatch).toBeNull())
             expect(logic.values.queuedBatch).toBeNull()
+            expect(jest.mocked(posthog.capture).mock.calls).toEqual([
+                [
+                    'dashboard ai sync completed',
+                    {
+                        tool_families: ['dashboard'],
+                        queued_event_count: 1,
+                        highlighted_tile_count: 0,
+                        duration_ms: 125,
+                        success: false,
+                    },
+                ],
+                [
+                    'dashboard ai sync completed',
+                    {
+                        tool_families: ['dashboard'],
+                        queued_event_count: 1,
+                        highlighted_tile_count: 1,
+                        duration_ms: 250,
+                        success: true,
+                    },
+                ],
+            ])
             logic.unmount()
+            dateNowSpy.mockRestore()
+        })
+
+        it('clamps a backwards-clock telemetry duration to zero', async () => {
+            initKeaTests()
+            mockCommittedDashboard = committedDashboard()
+            const reload = deferred<void>()
+            mockLoadDashboard.mockReset().mockReturnValue(reload.promise)
+            jest.mocked(posthog.capture).mockClear()
+            let now = 3_000
+            const dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now)
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+
+            logic.actions.applyToolCompletion(eventFor('dashboard-update', { id: dashboardId }, { id: dashboardId }), {
+                id: dashboardId,
+            })
+            now = 2_999
+            reload.resolve()
+            await waitFor(() => expect(logic.values.activeBatch).toBeNull())
+
+            expect(jest.mocked(posthog.capture).mock.calls).toEqual([
+                [
+                    'dashboard ai sync completed',
+                    {
+                        tool_families: ['dashboard'],
+                        queued_event_count: 1,
+                        highlighted_tile_count: 0,
+                        duration_ms: 0,
+                        success: true,
+                    },
+                ],
+            ])
+            logic.unmount()
+            dateNowSpy.mockRestore()
+        })
+
+        it('does not emit telemetry for an invalid candidate, a third-party origin, or disposed work', async () => {
+            initKeaTests()
+            mockCommittedDashboard = committedDashboard()
+            const reload = deferred<void>()
+            mockLoadDashboard.mockReset().mockReturnValue(reload.promise)
+            jest.mocked(posthog.capture).mockClear()
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+
+            logic.actions.applyToolCompletion(eventFor('dashboard-update', { id: 8 }, { id: 8 }), { id: 8 })
+            const directInvocation = {
+                ...eventFor('dashboard-update', { id: dashboardId }, { id: dashboardId }).invocation,
+                rawServerName: 'third_party',
+                rawToolName: 'dashboard-update',
+                input: { id: dashboardId },
+            }
+            logic.actions.applyToolCompletion(
+                eventFor(
+                    'dashboard-update',
+                    { id: dashboardId },
+                    { id: dashboardId },
+                    { rawToolName: 'dashboard-update', invocation: directInvocation }
+                ),
+                { id: dashboardId }
+            )
+            expect(mockLoadDashboard).not.toHaveBeenCalled()
+            expect(posthog.capture).not.toHaveBeenCalled()
+
+            logic.actions.applyToolCompletion(eventFor('dashboard-update', { id: dashboardId }, { id: dashboardId }), {
+                id: dashboardId,
+            })
+            expect(mockLoadDashboard).toHaveBeenCalledTimes(1)
+            logic.unmount()
+            reload.resolve()
+            await reload.promise
+            await Promise.resolve()
+            await Promise.resolve()
+
+            expect(posthog.capture).not.toHaveBeenCalled()
         })
 
         it('ignores a direct third-party same-name event without any side effect', () => {

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
@@ -1073,6 +1073,139 @@ describe('resolveDashboardAiMutation candidate classification', () => {
             logic.unmount()
         })
 
+        it('highlights only confirmed tiles for 3000ms after the dashboard reload commits', async () => {
+            jest.useFakeTimers()
+            initKeaTests()
+            mockCommittedDashboard = committedDashboard()
+            const reload = deferred<void>()
+            mockLoadDashboard.mockReset().mockReturnValue(reload.promise)
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+
+            logic.actions.applyToolCompletion(
+                eventFor('dashboard-create-tile', { id: dashboardId }, { id: 61, dashboard_id: dashboardId }),
+                { id: dashboardId }
+            )
+            expect(logic.values.transientHighlightedTileIds).toEqual([])
+
+            mockCommittedDashboard = dashboardWithInsight(61, 303, 'gamma')
+            reload.resolve()
+            await waitFor(() => expect(logic.values.activeBatch).toBeNull())
+            expect(logic.values.transientHighlightedTileIds).toEqual([61])
+
+            jest.advanceTimersByTime(2999)
+            expect(logic.values.transientHighlightedTileIds).toEqual([61])
+            jest.advanceTimersByTime(1)
+            expect(logic.values.transientHighlightedTileIds).toEqual([])
+
+            logic.unmount()
+            jest.useRealTimers()
+        })
+
+        it('restarts one highlight timer for the sorted union from a later committed reload', async () => {
+            jest.useFakeTimers()
+            initKeaTests()
+            mockCommittedDashboard = dashboardWithInsight(42, 202, 'beta')
+            const firstReload = deferred<void>()
+            const secondReload = deferred<void>()
+            mockLoadDashboard
+                .mockReset()
+                .mockReturnValueOnce(firstReload.promise)
+                .mockReturnValueOnce(secondReload.promise)
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+
+            logic.actions.applyToolCompletion(
+                eventFor(
+                    'dashboard-update-text-tile',
+                    { id: dashboardId, tile_id: 42 },
+                    { id: 42, dashboard_id: dashboardId }
+                ),
+                { id: dashboardId, tile_id: 42 }
+            )
+            firstReload.resolve()
+            await waitFor(() => expect(logic.values.activeBatch).toBeNull())
+            expect(logic.values.transientHighlightedTileIds).toEqual([42])
+
+            jest.advanceTimersByTime(2000)
+            mockCommittedDashboard = {
+                ...committedDashboard(),
+                tiles: [committedDashboard().tiles[0], dashboardWithInsight(42, 202, 'beta').tiles[0]],
+            }
+            logic.actions.applyToolCompletion(
+                eventFor(
+                    'dashboard-update-text-tile',
+                    { id: dashboardId, tile_id: 41 },
+                    { id: 41, dashboard_id: dashboardId }
+                ),
+                { id: dashboardId, tile_id: 41 }
+            )
+            secondReload.resolve()
+            await waitFor(() => expect(logic.values.activeBatch).toBeNull())
+            expect(logic.values.transientHighlightedTileIds).toEqual([41, 42])
+
+            jest.advanceTimersByTime(2999)
+            expect(logic.values.transientHighlightedTileIds).toEqual([41, 42])
+            jest.advanceTimersByTime(1)
+            expect(logic.values.transientHighlightedTileIds).toEqual([])
+
+            logic.unmount()
+            jest.useRealTimers()
+        })
+
+        it('does not highlight a requested tile missing from the committed dashboard', async () => {
+            jest.useFakeTimers()
+            initKeaTests()
+            mockCommittedDashboard = committedDashboard()
+            const reload = deferred<void>()
+            mockLoadDashboard.mockReset().mockReturnValue(reload.promise)
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+
+            logic.actions.applyToolCompletion(
+                eventFor('dashboard-create-tile', { id: dashboardId }, { id: 61, dashboard_id: dashboardId }),
+                { id: dashboardId }
+            )
+            reload.resolve()
+            await waitFor(() => expect(logic.values.activeBatch).toBeNull())
+
+            expect(logic.values.transientHighlightedTileIds).toEqual([])
+            jest.advanceTimersByTime(3000)
+            expect(logic.values.transientHighlightedTileIds).toEqual([])
+
+            logic.unmount()
+            jest.useRealTimers()
+        })
+
+        it('cancels the transient highlight expiry when the keyed logic unmounts', async () => {
+            jest.useFakeTimers()
+            initKeaTests()
+            mockCommittedDashboard = committedDashboard()
+            const reload = deferred<void>()
+            mockLoadDashboard.mockReset().mockReturnValue(reload.promise)
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+
+            logic.actions.applyToolCompletion(
+                eventFor(
+                    'dashboard-update-text-tile',
+                    { id: dashboardId, tile_id: 41 },
+                    { id: 41, dashboard_id: dashboardId }
+                ),
+                { id: dashboardId, tile_id: 41 }
+            )
+            reload.resolve()
+            await waitFor(() => expect(logic.values.transientHighlightedTileIds).toEqual([41]))
+            const setHighlightSpy = jest.spyOn(logic.actions, 'setTransientHighlightedTileIds')
+            setHighlightSpy.mockClear()
+
+            logic.unmount()
+            jest.advanceTimersByTime(3000)
+
+            expect(setHighlightSpy).not.toHaveBeenCalled()
+            jest.useRealTimers()
+        })
+
         it('refreshes only the mounted alert logic for the exact dashboard insight', async () => {
             initKeaTests()
             mockCommittedDashboard = dashboardWithInsight(41, 101, 'alpha')

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
@@ -1,0 +1,647 @@
+import type { ToolStreamEvent } from 'products/posthog_ai/frontend/types/streamTypes'
+
+import {
+    DASHBOARD_AI_MUTATION_TOOLS,
+    DashboardAiKnownOwnership,
+    DashboardAiMutationResolution,
+    DashboardAiSyncCandidate,
+    DashboardAiSyncTarget,
+    resolveDashboardAiMutation,
+} from './dashboardAiSyncLogic'
+
+const dashboardId = 7
+const target: DashboardAiSyncTarget = {
+    dashboardId,
+    tiles: [
+        { tileId: 41, insightId: 101, insightShortId: 'alpha', alertIds: ['alert-1', 501] },
+        { tileId: 42, insightId: 202, insightShortId: 'beta', alertIds: ['alert-2'] },
+    ],
+}
+
+const emptyOwnership = (): DashboardAiKnownOwnership => ({
+    subscriptionDashboardById: {},
+    insightDashboardsById: {},
+    alertInsightById: {},
+})
+
+function eventFor(
+    toolName: string,
+    innerInput: Record<string, unknown>,
+    output: unknown,
+    overrides: Partial<ToolStreamEvent> = {}
+): ToolStreamEvent {
+    return {
+        streamKey: 'stream-1',
+        toolCallId: 'call-1',
+        toolName,
+        rawToolName: 'exec',
+        phase: 'completed',
+        source: 'live',
+        invocation: {
+            toolCallId: 'call-1',
+            rawServerName: 'posthog',
+            rawToolName: 'exec',
+            input: { command: `call --json ${toolName} ${JSON.stringify(innerInput)}` },
+            output,
+            status: 'completed',
+            contentBlocks: [],
+        },
+        ...overrides,
+    }
+}
+
+function resolveFor(
+    toolName: string,
+    innerInput: Record<string, unknown>,
+    output: unknown,
+    ownership: DashboardAiKnownOwnership = emptyOwnership(),
+    syncTarget: DashboardAiSyncTarget = target,
+    overrides: Partial<ToolStreamEvent> = {}
+): DashboardAiMutationResolution {
+    return resolveDashboardAiMutation(
+        syncTarget,
+        ownership,
+        eventFor(toolName, innerInput, output, overrides),
+        innerInput
+    )
+}
+
+function dashboardCandidate(overrides: Partial<DashboardAiSyncCandidate> = {}): DashboardAiSyncCandidate {
+    return {
+        family: 'dashboard',
+        dashboardId,
+        tileIds: [],
+        insightIds: [],
+        deletesDashboard: false,
+        ...overrides,
+    }
+}
+
+interface DashboardStructureCase {
+    label: string
+    toolName: string
+    input: (id: unknown) => Record<string, unknown>
+    output: (id: unknown) => unknown
+    candidate: DashboardAiSyncCandidate
+    contradictoryOutput: unknown
+}
+
+const dashboardStructureCases: DashboardStructureCase[] = [
+    {
+        label: 'updates dashboard metadata',
+        toolName: 'dashboard-update',
+        input: (id) => ({ id }),
+        output: (id) => ({ id }),
+        candidate: dashboardCandidate(),
+        contradictoryOutput: { id: 8 },
+    },
+    {
+        label: 'keeps the generated dashboard update alias',
+        toolName: 'dashboards-update',
+        input: (id) => ({ id }),
+        output: (id) => ({ id }),
+        candidate: dashboardCandidate(),
+        contradictoryOutput: { id: 8 },
+    },
+    {
+        label: 'creates a text tile',
+        toolName: 'dashboard-create-tile',
+        input: (id) => ({ id, body: '## Status' }),
+        output: (id) => ({ id: '61', dashboard_id: id }),
+        candidate: dashboardCandidate({ tileIds: [61] }),
+        contradictoryOutput: { id: 61, dashboard_id: 8 },
+    },
+    {
+        label: 'keeps the text tile replay alias',
+        toolName: 'dashboard-create-text-tile',
+        input: (id) => ({ id, body: '## Status' }),
+        output: (id) => ({ id: '61', dashboard_id: id }),
+        candidate: dashboardCandidate({ tileIds: [61] }),
+        contradictoryOutput: { id: 61, dashboard_id: 8 },
+    },
+    {
+        label: 'updates a text tile',
+        toolName: 'dashboard-update-text-tile',
+        input: (id) => ({ id, tile_id: '41', body: 'Updated' }),
+        output: (id) => ({ id: '41', dashboard_id: id }),
+        candidate: dashboardCandidate({ tileIds: [41] }),
+        contradictoryOutput: { id: 42, dashboard_id: 7 },
+    },
+    {
+        label: 'deletes a tile from a 204 response URL',
+        toolName: 'dashboard-delete-tile',
+        input: (id) => ({ id, tile_id: '41' }),
+        output: (id) => ({ _posthogUrl: `https://app.example.test/project/1/dashboard/${id}` }),
+        candidate: dashboardCandidate({ tileIds: [41] }),
+        contradictoryOutput: { _posthogUrl: 'https://app.example.test/project/1/dashboard/8' },
+    },
+    {
+        label: 'reorders dashboard tiles',
+        toolName: 'dashboard-reorder-tiles',
+        input: (id) => ({ id, tile_order: ['42', '41'] }),
+        output: (id) => ({ id, tiles: [{ id: 42 }, { id: 41 }] }),
+        candidate: dashboardCandidate({ tileIds: [41, 42] }),
+        contradictoryOutput: { id: 8, tiles: [{ id: 42 }, { id: 41 }] },
+    },
+    {
+        label: 'copies a tile',
+        toolName: 'dashboard-tile-copy',
+        input: (id) => ({ id, fromDashboardId: 6, tileId: 41 }),
+        output: (id) => ({ id }),
+        candidate: dashboardCandidate(),
+        contradictoryOutput: { id: 8 },
+    },
+    {
+        label: 'keeps the generated tile copy alias',
+        toolName: 'dashboards-copy-tile-create',
+        input: (id) => ({ id, fromDashboardId: 6, tileId: 41 }),
+        output: (id) => ({ id }),
+        candidate: dashboardCandidate(),
+        contradictoryOutput: { id: 8 },
+    },
+    {
+        label: 'adds dashboard widgets',
+        toolName: 'dashboard-widgets-batch-add',
+        input: (id) => ({ id, widgets: [{ widget_type: 'session_replay_list' }] }),
+        output: (id) => ({ dashboard_id: id, tiles: [{ id: '61', dashboard_id: id }] }),
+        candidate: dashboardCandidate({ tileIds: [61] }),
+        contradictoryOutput: { dashboard_id: 8, tiles: [{ id: 61, dashboard_id: 7 }] },
+    },
+    {
+        label: 'keeps the generated widget batch create alias',
+        toolName: 'dashboards-widgets-batch-create',
+        input: (id) => ({ id, widgets: [{ widget_type: 'session_replay_list' }] }),
+        output: (id) => ({ dashboard_id: id, tiles: [{ id: '61', dashboard_id: id }] }),
+        candidate: dashboardCandidate({ tileIds: [61] }),
+        contradictoryOutput: { dashboard_id: 8, tiles: [{ id: 61, dashboard_id: 7 }] },
+    },
+    {
+        label: 'updates dashboard widgets',
+        toolName: 'dashboard-widgets-batch-update',
+        input: (id) => ({ id, widgets: [{ tile_id: '41', name: 'Updated' }] }),
+        output: (id) => ({ dashboard_id: id, tiles: [{ id: '41', dashboard_id: id }] }),
+        candidate: dashboardCandidate({ tileIds: [41] }),
+        contradictoryOutput: { dashboard_id: 7, tiles: [{ id: 42, dashboard_id: 7 }] },
+    },
+    {
+        label: 'moves a tile through the create alias',
+        toolName: 'dashboards-move-tile-create',
+        input: (id) => ({ id, to_dashboard: 8, tile: { id: '41' } }),
+        output: (id) => ({ id }),
+        candidate: dashboardCandidate({ tileIds: [41] }),
+        contradictoryOutput: { id: 9 },
+    },
+    {
+        label: 'moves a tile through the partial update alias',
+        toolName: 'dashboards-move-tile-partial-update',
+        input: (id) => ({ id, to_dashboard: 8, tile: { id: '41' } }),
+        output: (id) => ({ id }),
+        candidate: dashboardCandidate({ tileIds: [41] }),
+        contradictoryOutput: { id: 9 },
+    },
+    {
+        label: 'deletes the dashboard',
+        toolName: 'dashboard-delete',
+        input: (id) => ({ id }),
+        output: (id) => ({ id, deleted: true }),
+        candidate: dashboardCandidate({ deletesDashboard: true }),
+        contradictoryOutput: { id: 8, deleted: true },
+    },
+]
+
+describe('resolveDashboardAiMutation candidate classification', () => {
+    it('publishes the complete dashboard, insight, subscription, and alert mutation key set', () => {
+        expect(DASHBOARD_AI_MUTATION_TOOLS).toEqual([
+            'alert-create',
+            'alert-delete',
+            'alert-update',
+            'dashboard-create-text-tile',
+            'dashboard-create-tile',
+            'dashboard-delete',
+            'dashboard-delete-tile',
+            'dashboard-reorder-tiles',
+            'dashboard-tile-copy',
+            'dashboard-update',
+            'dashboard-update-text-tile',
+            'dashboard-widgets-batch-add',
+            'dashboard-widgets-batch-update',
+            'dashboards-copy-tile-create',
+            'dashboards-move-tile-create',
+            'dashboards-move-tile-partial-update',
+            'dashboards-update',
+            'dashboards-widgets-batch-create',
+            'insight-create',
+            'insight-delete',
+            'insight-update',
+            'subscriptions-create',
+            'subscriptions-delete',
+            'subscriptions-partial-update',
+        ])
+    })
+
+    it.each(dashboardStructureCases)(
+        '$label from numeric string schema IDs',
+        ({ toolName, input, output, candidate }) => {
+            expect(resolveFor(toolName, input('7'), output('7')).candidate).toEqual(candidate)
+        }
+    )
+
+    it.each(dashboardStructureCases)('rejects unsafe dashboard IDs for $label', ({ toolName, input, output }) => {
+        expect(resolveFor(toolName, input(Number.MAX_SAFE_INTEGER + 1), output(7)).candidate).toBeNull()
+    })
+
+    it.each(dashboardStructureCases)('rejects malformed output for $label', ({ toolName, input }) => {
+        expect(resolveFor(toolName, input(7), 'not a structured response').candidate).toBeNull()
+    })
+
+    it.each(dashboardStructureCases)('ignores another dashboard for $label', ({ toolName, input, output }) => {
+        expect(resolveFor(toolName, input(8), output(8)).candidate).toBeNull()
+    })
+
+    it.each(dashboardStructureCases)(
+        'rejects request and response disagreement for $label',
+        ({ toolName, input, contradictoryOutput }) => {
+            expect(resolveFor(toolName, input(7), contradictoryOutput).candidate).toBeNull()
+        }
+    )
+
+    it.each(['dashboards-move-tile-create', 'dashboards-move-tile-partial-update'])(
+        'recognizes the destination dashboard for %s',
+        (toolName) => {
+            const destinationTarget = { ...target, dashboardId: 8 }
+            expect(
+                resolveFor(
+                    toolName,
+                    { id: 7, to_dashboard: '8', tile: { id: '41' } },
+                    { id: 7 },
+                    emptyOwnership(),
+                    destinationTarget
+                ).candidate
+            ).toEqual({ ...dashboardCandidate({ tileIds: [41] }), dashboardId: 8 })
+        }
+    )
+
+    it('rejects a direct third-party MCP event with the same dashboard tool name before changing ownership', () => {
+        const ownership = emptyOwnership()
+        const directInvocation = {
+            ...eventFor('dashboard-update', { id: 7 }, { id: 7 }).invocation,
+            rawServerName: 'third_party',
+            rawToolName: 'dashboard-update',
+            input: { id: 7 },
+        }
+        const result = resolveFor('dashboard-update', { id: 7 }, { id: 7 }, ownership, target, {
+            rawToolName: 'dashboard-update',
+            invocation: directInvocation,
+        })
+
+        expect(result).toEqual({ candidate: null, ownership })
+        expect(result.ownership).toBe(ownership)
+    })
+
+    it('classifies an insight create from one authoritative open-dashboard tile and learns every returned membership', () => {
+        const result = resolveFor(
+            'insight-create',
+            { dashboards: [8, '7'] },
+            {
+                id: 303,
+                short_id: 'gamma',
+                dashboard_tiles: [
+                    { id: 61, dashboard_id: '7', deleted: false },
+                    { id: 62, dashboard_id: 8, deleted: null },
+                ],
+            }
+        )
+
+        expect(result.candidate).toEqual({
+            family: 'insight',
+            dashboardId,
+            tileIds: [61],
+            insightIds: [303, 'gamma'],
+            deletesDashboard: false,
+        })
+        expect(result.ownership.insightDashboardsById).toEqual({ 303: [7, 8], gamma: [7, 8] })
+    })
+
+    it.each(['insight-create', 'insight-update'])(
+        'accepts %s without request membership when the response and identifiers are authoritative',
+        (toolName) => {
+            const input = toolName === 'insight-update' ? { id: 'alpha' } : { name: 'Existing query' }
+            expect(
+                resolveFor(toolName, input, {
+                    id: 101,
+                    short_id: 'alpha',
+                    dashboard_tiles: [{ id: 41, dashboard_id: 7, deleted: false }],
+                }).candidate
+            ).toEqual({
+                family: 'insight',
+                dashboardId,
+                tileIds: [41],
+                insightIds: [101, 'alpha'],
+                deletesDashboard: false,
+            })
+        }
+    )
+
+    it.each([
+        [
+            'request membership excludes the open dashboard',
+            { dashboards: [8] },
+            { id: 303, short_id: 'gamma', dashboard_tiles: [{ id: 61, dashboard_id: 7, deleted: false }] },
+        ],
+        ['request-only membership', { dashboards: [7] }, { id: 303, short_id: 'gamma' }],
+        [
+            'response membership excludes the open dashboard',
+            { dashboards: [7] },
+            { id: 303, short_id: 'gamma', dashboard_tiles: [{ id: 61, dashboard_id: 8, deleted: false }] },
+        ],
+        [
+            'ambiguous response membership',
+            { dashboards: [7] },
+            {
+                id: 303,
+                short_id: 'gamma',
+                dashboard_tiles: [
+                    { id: 61, dashboard_id: 7, deleted: false },
+                    { id: 62, dashboard_id: 7, deleted: false },
+                ],
+            },
+        ],
+        [
+            'deleted response tile',
+            { dashboards: [7] },
+            { id: 303, short_id: 'gamma', dashboard_tiles: [{ id: 61, dashboard_id: 7, deleted: true }] },
+        ],
+        [
+            'unsafe response tile ID',
+            { dashboards: [7] },
+            {
+                id: 303,
+                short_id: 'gamma',
+                dashboard_tiles: [{ id: Number.MAX_SAFE_INTEGER + 1, dashboard_id: 7, deleted: false }],
+            },
+        ],
+    ])('rejects an insight candidate with %s', (_case, input, output) => {
+        expect(resolveFor('insight-create', input, output).candidate).toBeNull()
+    })
+
+    it.each([
+        ['numeric ID mismatch', { id: 101 }, { id: 102, short_id: 'alpha' }],
+        ['short ID mismatch', { id: 'alpha' }, { id: 101, short_id: 'beta' }],
+    ])('rejects an insight update with %s', (_case, input, identifiers) => {
+        expect(
+            resolveFor('insight-update', input, {
+                ...identifiers,
+                dashboard_tiles: [{ id: 41, dashboard_id: 7, deleted: false }],
+            }).candidate
+        ).toBeNull()
+    })
+
+    it('deletes an insight owned by a current tile and removes both identifier forms immutably', () => {
+        const ownership: DashboardAiKnownOwnership = {
+            ...emptyOwnership(),
+            insightDashboardsById: { 101: [7, 8], alpha: [7, 8], untouched: [8] },
+        }
+        const result = resolveFor(
+            'insight-delete',
+            { id: 'alpha' },
+            { id: 101, short_id: 'alpha', deleted: true },
+            ownership
+        )
+
+        expect(result.candidate).toEqual({
+            family: 'insight',
+            dashboardId,
+            tileIds: [41],
+            insightIds: [101, 'alpha'],
+            deletesDashboard: false,
+        })
+        expect(result.ownership.insightDashboardsById).toEqual({ untouched: [8] })
+        expect(ownership.insightDashboardsById).toEqual({ 101: [7, 8], alpha: [7, 8], untouched: [8] })
+    })
+
+    it('deletes an insight from learned ownership even when it is no longer in the committed tiles', () => {
+        const ownership: DashboardAiKnownOwnership = {
+            ...emptyOwnership(),
+            insightDashboardsById: { 303: [7], gamma: [7] },
+        }
+        const result = resolveFor(
+            'insight-delete',
+            { id: 'gamma' },
+            { id: 303, short_id: 'gamma', deleted: true },
+            ownership,
+            { dashboardId, tiles: [] }
+        )
+
+        expect(result.candidate).toEqual({
+            family: 'insight',
+            dashboardId,
+            tileIds: [],
+            insightIds: [303, 'gamma'],
+            deletesDashboard: false,
+        })
+        expect(result.ownership.insightDashboardsById).toEqual({})
+    })
+
+    it('does not invent insight deletion ownership from a dashboards input', () => {
+        expect(
+            resolveFor('insight-delete', { id: 'unknown', dashboards: [7] }, { short_id: 'unknown', deleted: true })
+                .candidate
+        ).toBeNull()
+    })
+
+    it('rejects an insight deletion response that says the insight remains active', () => {
+        expect(
+            resolveFor('insight-delete', { id: 'alpha' }, { id: 101, short_id: 'alpha', deleted: false }).candidate
+        ).toBeNull()
+    })
+
+    it('learns a dashboard subscription from a corroborated create response', () => {
+        const result = resolveFor('subscriptions-create', { dashboard: '7' }, { id: '51', dashboard: 7 })
+
+        expect(result.candidate).toEqual({
+            family: 'subscription',
+            dashboardId,
+            tileIds: [],
+            insightIds: [],
+            deletesDashboard: false,
+        })
+        expect(result.ownership.subscriptionDashboardById).toEqual({ 51: 7 })
+    })
+
+    it.each(['subscriptions-create', 'subscriptions-partial-update'])(
+        'rejects a %s response for another or contradictory dashboard',
+        (toolName) => {
+            expect(resolveFor(toolName, { id: 51, dashboard: 7 }, { id: 51, dashboard: 8 }).candidate).toBeNull()
+        }
+    )
+
+    it('classifies a subscription update from its validated full response', () => {
+        expect(
+            resolveFor('subscriptions-partial-update', { id: 51 }, { id: 51, dashboard: 7 }).candidate
+        ).toMatchObject({
+            family: 'subscription',
+            dashboardId,
+        })
+    })
+
+    it('uses learned subscription ownership for an ID-only update and 204 delete, then removes it', () => {
+        const learned: DashboardAiKnownOwnership = {
+            ...emptyOwnership(),
+            subscriptionDashboardById: { 51: 7 },
+        }
+        const updated = resolveFor('subscriptions-partial-update', { id: '51' }, { id: '51' }, learned)
+        expect(updated.candidate).toMatchObject({ family: 'subscription', dashboardId })
+        expect(updated.ownership.subscriptionDashboardById).toEqual({ 51: 7 })
+
+        const deleted = resolveFor(
+            'subscriptions-delete',
+            { id: '51' },
+            { _posthogUrl: '/subscriptions' },
+            updated.ownership
+        )
+        expect(deleted.candidate).toMatchObject({ family: 'subscription', dashboardId })
+        expect(deleted.ownership.subscriptionDashboardById).toEqual({})
+        expect(learned.subscriptionDashboardById).toEqual({ 51: 7 })
+    })
+
+    it('rejects learned subscription ownership for another dashboard and unsafe IDs', () => {
+        const ownership: DashboardAiKnownOwnership = {
+            ...emptyOwnership(),
+            subscriptionDashboardById: { 51: 8 },
+        }
+        expect(resolveFor('subscriptions-delete', { id: 51 }, { id: 51 }, ownership).candidate).toBeNull()
+        expect(
+            resolveFor('subscriptions-delete', { id: Number.MAX_SAFE_INTEGER + 1 }, { id: 51 }, ownership).candidate
+        ).toBeNull()
+    })
+
+    it('rejects a subscription deletion response that says the subscription remains active', () => {
+        const ownership: DashboardAiKnownOwnership = {
+            ...emptyOwnership(),
+            subscriptionDashboardById: { 51: 7 },
+        }
+        expect(
+            resolveFor('subscriptions-delete', { id: 51 }, { id: 51, deleted: false }, ownership).candidate
+        ).toBeNull()
+    })
+
+    it('learns an alert on an insight in the open dashboard', () => {
+        const result = resolveFor(
+            'alert-create',
+            { insight: '101' },
+            { id: 'alert-new', insight: 101, insight_short_id: 'alpha' }
+        )
+
+        expect(result.candidate).toEqual({
+            family: 'alert',
+            dashboardId,
+            tileIds: [41],
+            insightIds: [101, 'alpha'],
+            deletesDashboard: false,
+        })
+        expect(result.ownership.alertInsightById).toEqual({ 'alert-new': '101' })
+    })
+
+    it('classifies an alert update from a validated response without prior ownership', () => {
+        expect(
+            resolveFor('alert-update', { id: 'alert-new' }, { id: 'alert-new', insight: 202, insight_short_id: 'beta' })
+                .candidate
+        ).toEqual({
+            family: 'alert',
+            dashboardId,
+            tileIds: [42],
+            insightIds: [202, 'beta'],
+            deletesDashboard: false,
+        })
+    })
+
+    it('uses learned alert ownership for an ID-only update', () => {
+        const ownership: DashboardAiKnownOwnership = {
+            ...emptyOwnership(),
+            alertInsightById: { 'alert-new': '101' },
+        }
+        expect(resolveFor('alert-update', { id: 'alert-new' }, { id: 'alert-new' }, ownership).candidate).toEqual({
+            family: 'alert',
+            dashboardId,
+            tileIds: [41],
+            insightIds: [101, 'alpha'],
+            deletesDashboard: false,
+        })
+    })
+
+    it('resolves a cold ID-only alert delete from committed tile alert IDs and removes that ownership', () => {
+        const result = resolveFor('alert-delete', { id: 'alert-1' }, undefined)
+
+        expect(result.candidate).toEqual({
+            family: 'alert',
+            dashboardId,
+            tileIds: [41],
+            insightIds: [101, 'alpha'],
+            deletesDashboard: false,
+        })
+        expect(result.ownership.alertInsightById).toEqual({ 501: '101' })
+    })
+
+    it('rejects malformed alert deletion output instead of treating it as an empty 204 response', () => {
+        const ownership = emptyOwnership()
+        const result = resolveFor('alert-delete', { id: 'alert-1' }, 'not a structured response', ownership)
+
+        expect(result).toEqual({ candidate: null, ownership })
+        expect(result.ownership).toBe(ownership)
+    })
+
+    it('rejects an alert deletion response that says the alert remains active', () => {
+        expect(resolveFor('alert-delete', { id: 'alert-1' }, { id: 'alert-1', deleted: false }).candidate).toBeNull()
+    })
+
+    it('rejects a dashboard deletion response that says the dashboard remains active', () => {
+        expect(resolveFor('dashboard-delete', { id: 7 }, { id: 7, deleted: false }).candidate).toBeNull()
+    })
+
+    it.each([
+        ['an insight outside this dashboard', { id: 'alert-new', insight: 999 }],
+        ['a mismatched numeric insight ID', { id: 'alert-new', insight: 202, insight_short_id: 'alpha' }],
+        ['a mismatched insight short ID', { id: 'alert-new', insight: 101, insight_short_id: 'beta' }],
+    ])('rejects an alert candidate with %s', (_case, output) => {
+        expect(resolveFor('alert-create', { insight: 101 }, output).candidate).toBeNull()
+    })
+
+    it('rejects an alert response that contradicts learned ownership', () => {
+        const ownership: DashboardAiKnownOwnership = {
+            ...emptyOwnership(),
+            alertInsightById: { 'alert-new': '101' },
+        }
+        const result = resolveFor(
+            'alert-update',
+            { id: 'alert-new' },
+            { id: 'alert-new', insight: 202, insight_short_id: 'beta' },
+            ownership
+        )
+
+        expect(result).toEqual({ candidate: null, ownership })
+    })
+
+    it('fails closed for incomplete, failed, unknown, or unparseable mutations without changing ownership', () => {
+        const ownership = emptyOwnership()
+        const cases: Array<[string, ToolStreamEvent, Record<string, unknown> | null]> = [
+            ['missing input', eventFor('dashboard-update', { id: 7 }, { id: 7 }), null],
+            ['failed event', eventFor('dashboard-update', { id: 7 }, { id: 7 }, { phase: 'failed' }), { id: 7 }],
+            [
+                'incomplete invocation',
+                {
+                    ...eventFor('dashboard-update', { id: 7 }, { id: 7 }),
+                    invocation: { ...eventFor('dashboard-update', { id: 7 }, { id: 7 }).invocation, status: 'failed' },
+                },
+                { id: 7 },
+            ],
+            ['unknown tool', eventFor('dashboard-get', { id: 7 }, { id: 7 }), { id: 7 }],
+            ['unparseable output', eventFor('dashboard-update', { id: 7 }, ''), { id: 7 }],
+        ]
+
+        for (const [_case, event, input] of cases) {
+            const result = resolveDashboardAiMutation(target, ownership, event, input)
+            expect(result).toEqual({ candidate: null, ownership })
+            expect(result.ownership).toBe(ownership)
+        }
+    })
+})

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
@@ -1,13 +1,52 @@
+import { waitFor } from '@testing-library/react'
+import { router } from 'kea-router'
+import posthog from 'posthog-js'
+
+import api from 'lib/api'
+import { urls } from 'scenes/urls'
+
+import { initKeaTests } from '~/test/init'
+import {
+    AccessControlLevel,
+    DashboardType,
+    InsightColor,
+    InsightLogicProps,
+    InsightShortId,
+    QueryBasedInsightModel,
+    SubscriptionType,
+} from '~/types'
+
+import { insightAlertsLogic } from 'products/alerts/frontend/logic/insightAlertsLogic'
 import type { ToolStreamEvent } from 'products/posthog_ai/frontend/types/streamTypes'
+import { subscriptionsLogic } from 'products/subscriptions/frontend/components/Subscriptions/subscriptionsLogic'
 
 import {
     DASHBOARD_AI_MUTATION_TOOLS,
     DashboardAiKnownOwnership,
     DashboardAiMutationResolution,
+    DashboardAiSyncBatch,
     DashboardAiSyncCandidate,
     DashboardAiSyncTarget,
+    dashboardAiSyncLogic,
     resolveDashboardAiMutation,
 } from './dashboardAiSyncLogic'
+
+let mockCommittedDashboard: DashboardType<QueryBasedInsightModel> | null = null
+const mockLoadDashboard = jest.fn<Promise<void>, [unknown]>()
+
+jest.mock('scenes/dashboard/dashboardLogic', () => ({
+    ...jest.requireActual('scenes/dashboard/dashboardLogic'),
+    dashboardLogic: jest.fn(() => ({
+        values: {
+            get dashboard(): DashboardType<QueryBasedInsightModel> | null {
+                return mockCommittedDashboard
+            },
+        },
+        asyncActions: {
+            loadDashboard: (payload: unknown): Promise<void> => mockLoadDashboard(payload),
+        },
+    })),
+}))
 
 const dashboardId = 7
 const target: DashboardAiSyncTarget = {
@@ -75,6 +114,108 @@ function dashboardCandidate(overrides: Partial<DashboardAiSyncCandidate> = {}): 
         deletesDashboard: false,
         ...overrides,
     }
+}
+
+function committedInsight(id: number, shortId: string, alertIds: string[] = []): QueryBasedInsightModel {
+    return {
+        id,
+        short_id: shortId as InsightShortId,
+        name: shortId,
+        query: null,
+        order: null,
+        result: null,
+        deleted: false,
+        saved: true,
+        created_at: '2026-01-01T00:00:00Z',
+        created_by: null,
+        is_sample: false,
+        dashboards: [dashboardId],
+        dashboard_tiles: [],
+        updated_at: '2026-01-01T00:00:00Z',
+        last_modified_at: '2026-01-01T00:00:00Z',
+        last_modified_by: null,
+        last_refresh: null,
+        user_access_level: AccessControlLevel.Editor,
+        alerts: alertIds.map((alertId) => ({ id: alertId })) as QueryBasedInsightModel['alerts'],
+    }
+}
+
+function committedDashboard(): DashboardType<QueryBasedInsightModel> {
+    return {
+        id: dashboardId,
+        name: 'AI dashboard',
+        description: '',
+        pinned: false,
+        created_at: '2026-01-01T00:00:00Z',
+        created_by: null,
+        last_accessed_at: null,
+        is_shared: false,
+        deleted: false,
+        creation_mode: 'default',
+        user_access_level: AccessControlLevel.Editor,
+        filters: {},
+        tiles: [
+            {
+                id: 41,
+                color: InsightColor.White,
+                insight: committedInsight(101, 'alpha'),
+            },
+        ],
+    }
+}
+
+function dashboardWithInsight(
+    tileId: number,
+    insightId: number,
+    shortId: string,
+    alertIds: string[] = []
+): DashboardType<QueryBasedInsightModel> {
+    const dashboard = committedDashboard()
+    return {
+        ...dashboard,
+        tiles: [
+            {
+                id: tileId,
+                color: InsightColor.White,
+                insight: committedInsight(insightId, shortId, alertIds),
+            },
+        ],
+    }
+}
+
+function insightLogicPropsForDashboard(dashboard: DashboardType<QueryBasedInsightModel>): InsightLogicProps | null {
+    const insight = dashboard.tiles[0]?.insight
+    return insight
+        ? {
+              dashboardItemId: insight.short_id,
+              dashboardId: dashboard.id,
+              cachedInsight: insight,
+          }
+        : null
+}
+
+function deferred<T>(): {
+    promise: Promise<T>
+    resolve: (value: T) => void
+    reject: (error: unknown) => void
+} {
+    let resolve!: (value: T) => void
+    let reject!: (error: unknown) => void
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise
+        reject = rejectPromise
+    })
+    return { promise, resolve, reject }
+}
+
+function subscription(id: number, title: string): SubscriptionType {
+    return {
+        id,
+        title,
+        target_type: 'email',
+        target_value: 'demo@example.com',
+        frequency: 'weekly',
+    } as SubscriptionType
 }
 
 interface DashboardStructureCase {
@@ -736,5 +877,358 @@ describe('resolveDashboardAiMutation candidate classification', () => {
             expect(result).toEqual({ candidate: null, ownership })
             expect(result.ownership).toBe(ownership)
         }
+    })
+
+    describe('dashboard synchronization', () => {
+        it('stores immutable sorted and deduplicated synchronization batches', () => {
+            initKeaTests()
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+            const batch: DashboardAiSyncBatch = {
+                families: ['insight', 'dashboard', 'insight'],
+                tileIds: [9, 3, 9],
+                insightIds: ['zeta', 2, 'alpha', 2],
+                queuedEventCount: 3,
+                startedAt: 123,
+            }
+
+            logic.actions.setActiveBatch(batch)
+
+            expect(logic.values.activeBatch).toEqual({
+                families: ['dashboard', 'insight'],
+                tileIds: [3, 9],
+                insightIds: [2, 'alpha', 'zeta'],
+                queuedEventCount: 3,
+                startedAt: 123,
+            })
+            batch.tileIds.push(1)
+            batch.insightIds.push('mutated')
+            expect(logic.values.activeBatch?.tileIds).toEqual([3, 9])
+            expect(logic.values.activeBatch?.insightIds).toEqual([2, 'alpha', 'zeta'])
+
+            const ownership: DashboardAiKnownOwnership = {
+                subscriptionDashboardById: { 71: dashboardId },
+                insightDashboardsById: { 101: [dashboardId] },
+                alertInsightById: { 501: '101' },
+            }
+            logic.actions.setKnownOwnership(ownership)
+            ownership.subscriptionDashboardById[71] = 8
+            ownership.insightDashboardsById[101]!.push(8)
+            ownership.alertInsightById[501] = '202'
+            expect(logic.values.knownOwnership).toEqual({
+                subscriptionDashboardById: { 71: dashboardId },
+                insightDashboardsById: { 101: [dashboardId] },
+                alertInsightById: { 501: '101' },
+            })
+            logic.unmount()
+        })
+
+        it('serializes structural reloads into one active and one merged successor batch', async () => {
+            initKeaTests()
+            mockCommittedDashboard = committedDashboard()
+            const firstReload = deferred<void>()
+            const secondReload = deferred<void>()
+            mockLoadDashboard
+                .mockReset()
+                .mockReturnValueOnce(firstReload.promise)
+                .mockReturnValueOnce(secondReload.promise)
+
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+
+            logic.actions.applyToolCompletion(
+                eventFor('dashboard-create-tile', { id: 7 }, { id: 63, dashboard_id: 7 }),
+                { id: 7 }
+            )
+            logic.actions.applyToolCompletion(
+                eventFor('dashboard-update-text-tile', { id: 7, tile_id: 42 }, { id: 42, dashboard_id: 7 }),
+                { id: 7, tile_id: 42 }
+            )
+            logic.actions.applyToolCompletion(
+                eventFor(
+                    'dashboard-reorder-tiles',
+                    { id: 7, tile_order: [42, 41] },
+                    { id: 7, tiles: [{ id: 42 }, { id: 41 }] }
+                ),
+                { id: 7, tile_order: [42, 41] }
+            )
+
+            expect(mockLoadDashboard).toHaveBeenCalledTimes(1)
+            expect(logic.values.activeBatch).toMatchObject({
+                families: ['dashboard'],
+                tileIds: [63],
+                insightIds: [],
+                queuedEventCount: 1,
+                startedAt: expect.any(Number),
+            })
+            expect(logic.values.queuedBatch).toMatchObject({
+                families: ['dashboard'],
+                tileIds: [41, 42],
+                insightIds: [],
+                queuedEventCount: 2,
+                startedAt: expect.any(Number),
+            })
+
+            firstReload.resolve()
+            await waitFor(() => expect(mockLoadDashboard).toHaveBeenCalledTimes(2))
+
+            secondReload.resolve()
+            await waitFor(() => expect(logic.values.activeBatch).toBeNull())
+            logic.unmount()
+        })
+
+        it('refreshes a mounted subscription list through a create, ID-only update, and 204 delete chain', async () => {
+            initKeaTests()
+            mockCommittedDashboard = committedDashboard()
+            mockLoadDashboard.mockReset()
+
+            const initialResponse = { results: [], count: 0 }
+            const listSpy = jest.spyOn(api.subscriptions, 'list').mockResolvedValue(initialResponse)
+            const mountedSubscriptions = subscriptionsLogic({ dashboardId })
+            mountedSubscriptions.mount()
+            await waitFor(() => expect(mountedSubscriptions.values.subscriptionsLoading).toBe(false))
+
+            const created = deferred<{ results: SubscriptionType[]; count: number }>()
+            const updated = deferred<{ results: SubscriptionType[]; count: number }>()
+            const deleted = deferred<{ results: SubscriptionType[]; count: number }>()
+            const directResponses = [created, updated, deleted]
+            let directRequestIndex = 0
+            listSpy.mockReset().mockImplementation(({ dashboardId: requestedDashboardId, dashboardTiles }) => {
+                if (dashboardTiles) {
+                    return Promise.resolve(initialResponse)
+                }
+                expect(requestedDashboardId).toBe(dashboardId)
+                return directResponses[directRequestIndex++]!.promise
+            })
+
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+            logic.actions.applyToolCompletion(
+                eventFor('subscriptions-create', { dashboard: 7 }, { id: 71, dashboard: 7 }),
+                { dashboard: 7 }
+            )
+            await waitFor(() => expect(directRequestIndex).toBe(1))
+            logic.actions.applyToolCompletion(eventFor('subscriptions-partial-update', { id: 71 }, { id: 71 }), {
+                id: 71,
+            })
+            await waitFor(() => expect(directRequestIndex).toBe(2))
+            logic.actions.applyToolCompletion(
+                eventFor('subscriptions-delete', { id: 71 }, { _posthogUrl: '/subscriptions' }),
+                { id: 71 }
+            )
+
+            await waitFor(() => expect(directRequestIndex).toBe(3))
+            expect(logic.values.knownOwnership.subscriptionDashboardById).toEqual({})
+
+            deleted.resolve({ results: [], count: 0 })
+            await waitFor(() => expect(mountedSubscriptions.values.subscriptionsLoading).toBe(false))
+            updated.resolve({ results: [subscription(71, 'Updated')], count: 1 })
+            created.resolve({ results: [subscription(71, 'Created')], count: 1 })
+            await waitFor(() => expect(mountedSubscriptions.values.subscriptions).toEqual([]))
+
+            logic.actions.applyToolCompletion(
+                eventFor('subscriptions-create', { dashboard: 8 }, { id: 72, dashboard: 8 }),
+                { dashboard: 8 }
+            )
+            expect(directRequestIndex).toBe(3)
+            expect(mockLoadDashboard).not.toHaveBeenCalled()
+
+            logic.unmount()
+            mountedSubscriptions.unmount()
+            listSpy.mockRestore()
+        })
+
+        it('reloads an authoritative insight create and highlights its exact committed tile', async () => {
+            initKeaTests()
+            mockCommittedDashboard = committedDashboard()
+            const reload = deferred<void>()
+            mockLoadDashboard.mockReset().mockReturnValue(reload.promise)
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+
+            logic.actions.applyToolCompletion(
+                eventFor(
+                    'insight-create',
+                    { dashboards: [7] },
+                    {
+                        id: 303,
+                        short_id: 'gamma',
+                        dashboard_tiles: [{ id: 61, dashboard_id: 7, deleted: false }],
+                    }
+                ),
+                { dashboards: [7] }
+            )
+            expect(mockLoadDashboard).toHaveBeenCalledTimes(1)
+
+            mockCommittedDashboard = dashboardWithInsight(61, 303, 'gamma')
+            reload.resolve()
+            await waitFor(() => expect(logic.values.activeBatch).toBeNull())
+            expect(logic.values.transientHighlightedTileIds).toEqual([61])
+
+            logic.actions.applyToolCompletion(
+                eventFor('insight-create', { dashboards: [7] }, { id: 404, short_id: 'request-only' }),
+                { dashboards: [7] }
+            )
+            expect(mockLoadDashboard).toHaveBeenCalledTimes(1)
+            logic.unmount()
+        })
+
+        it('refreshes only the mounted alert logic for the exact dashboard insight', async () => {
+            initKeaTests()
+            mockCommittedDashboard = dashboardWithInsight(41, 101, 'alpha')
+            mockLoadDashboard.mockReset()
+            const alertListSpy = jest.spyOn(api.alerts, 'list').mockResolvedValue({ results: [], count: 0 })
+            const insightLogicProps = insightLogicPropsForDashboard(mockCommittedDashboard)!
+            const mountedAlerts = insightAlertsLogic({
+                insightId: 101,
+                insightLogicProps,
+                deferInitialAlertsLoad: true,
+            })
+            mountedAlerts.mount()
+            alertListSpy.mockClear()
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+
+            logic.actions.applyToolCompletion(
+                eventFor(
+                    'alert-create',
+                    { insight: 101 },
+                    { id: 'alert-new', insight: 101, insight_short_id: 'alpha' }
+                ),
+                { insight: 101 }
+            )
+            await waitFor(() => expect(alertListSpy).toHaveBeenCalledWith(101))
+
+            logic.actions.applyToolCompletion(
+                eventFor('alert-create', { insight: 999 }, { id: 'other', insight: 999, insight_short_id: 'other' }),
+                { insight: 999 }
+            )
+            expect(alertListSpy).toHaveBeenCalledTimes(1)
+            expect(mockLoadDashboard).not.toHaveBeenCalled()
+
+            logic.unmount()
+            mountedAlerts.unmount()
+            alertListSpy.mockRestore()
+        })
+
+        it('refreshes a cold ID-only alert delete from committed tile alert ownership', async () => {
+            initKeaTests()
+            mockCommittedDashboard = dashboardWithInsight(41, 101, 'alpha', ['alert-cold'])
+            mockLoadDashboard.mockReset()
+            const alertListSpy = jest.spyOn(api.alerts, 'list').mockResolvedValue({ results: [], count: 0 })
+            const insightLogicProps = insightLogicPropsForDashboard(mockCommittedDashboard)!
+            const mountedAlerts = insightAlertsLogic({
+                insightId: 101,
+                insightLogicProps,
+                deferInitialAlertsLoad: true,
+            })
+            mountedAlerts.mount()
+            alertListSpy.mockClear()
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+
+            logic.actions.applyToolCompletion(eventFor('alert-delete', { id: 'alert-cold' }, ''), {
+                id: 'alert-cold',
+            })
+
+            await waitFor(() => expect(alertListSpy).toHaveBeenCalledWith(101))
+            expect(logic.values.knownOwnership.alertInsightById).toEqual({})
+
+            logic.unmount()
+            mountedAlerts.unmount()
+            alertListSpy.mockRestore()
+        })
+
+        it('routes an open-dashboard deletion to the dashboard list without reloading', () => {
+            initKeaTests()
+            router.actions.push(urls.dashboard(dashboardId))
+            mockCommittedDashboard = committedDashboard()
+            mockLoadDashboard.mockReset()
+            const routerPushSpy = jest.spyOn(router.actions, 'push')
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+
+            logic.actions.applyToolCompletion(
+                eventFor('dashboard-delete', { id: dashboardId }, { id: dashboardId, deleted: true }),
+                { id: dashboardId }
+            )
+
+            expect(routerPushSpy).toHaveBeenCalledWith(urls.dashboards())
+            expect(mockLoadDashboard).not.toHaveBeenCalled()
+            logic.unmount()
+            routerPushSpy.mockRestore()
+        })
+
+        it('continues with a queued successor after the active dashboard reload fails', async () => {
+            initKeaTests()
+            const committed = committedDashboard()
+            mockCommittedDashboard = committed
+            const firstReload = deferred<void>()
+            const successorReload = deferred<void>()
+            mockLoadDashboard
+                .mockReset()
+                .mockReturnValueOnce(firstReload.promise)
+                .mockReturnValueOnce(successorReload.promise)
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+
+            logic.actions.applyToolCompletion(eventFor('dashboard-update', { id: 7 }, { id: 7 }), { id: 7 })
+            logic.actions.applyToolCompletion(
+                eventFor('dashboard-update-text-tile', { id: 7, tile_id: 41 }, { id: 41, dashboard_id: 7 }),
+                { id: 7, tile_id: 41 }
+            )
+            firstReload.reject(new Error('reload failed'))
+
+            await waitFor(() => expect(mockLoadDashboard).toHaveBeenCalledTimes(2))
+            expect(mockCommittedDashboard).toBe(committed)
+            expect(logic.values.activeBatch?.tileIds).toEqual([41])
+            successorReload.resolve()
+            await waitFor(() => expect(logic.values.activeBatch).toBeNull())
+            expect(logic.values.queuedBatch).toBeNull()
+            logic.unmount()
+        })
+
+        it('ignores a direct third-party same-name event without any side effect', () => {
+            initKeaTests()
+            router.actions.push(urls.dashboard(dashboardId))
+            const startingPath = router.values.location.pathname
+            mockCommittedDashboard = committedDashboard()
+            mockLoadDashboard.mockReset()
+            jest.mocked(posthog.capture).mockClear()
+            const subscriptionFindMountedSpy = jest.spyOn(subscriptionsLogic, 'findMounted')
+            const alertFindMountedSpy = jest.spyOn(insightAlertsLogic, 'findMounted')
+            const logic = dashboardAiSyncLogic({ dashboardId })
+            logic.mount()
+            const directInvocation = {
+                ...eventFor('dashboard-update', { id: 7 }, { id: 7 }).invocation,
+                rawServerName: 'third_party',
+                rawToolName: 'dashboard-update',
+                input: { id: 7 },
+            }
+
+            logic.actions.applyToolCompletion(
+                eventFor(
+                    'dashboard-update',
+                    { id: 7 },
+                    { id: 7 },
+                    {
+                        rawToolName: 'dashboard-update',
+                        invocation: directInvocation,
+                    }
+                ),
+                { id: 7 }
+            )
+
+            expect(mockLoadDashboard).not.toHaveBeenCalled()
+            expect(router.values.location.pathname).toBe(startingPath)
+            expect(logic.values.transientHighlightedTileIds).toEqual([])
+            expect(logic.values.knownOwnership).toEqual(emptyOwnership())
+            expect(subscriptionFindMountedSpy).not.toHaveBeenCalled()
+            expect(alertFindMountedSpy).not.toHaveBeenCalled()
+            expect(posthog.capture).not.toHaveBeenCalled()
+            logic.unmount()
+            subscriptionFindMountedSpy.mockRestore()
+            alertFindMountedSpy.mockRestore()
+        })
     })
 })

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.test.ts
@@ -932,6 +932,35 @@ describe('resolveDashboardAiMutation candidate classification', () => {
         expect(result.ownership.alertInsightById).toEqual({ 'alert-new': '999' })
     })
 
+    it.each([
+        [
+            'a new insight on this dashboard',
+            { id: 'alert-1', insight: 202 },
+            { id: 'alert-1', insight: 202, insight_short_id: 'beta' },
+            { tileIds: [41, 42], insightIds: [101, 202, 'alpha', 'beta'], ownerKey: '202' },
+        ],
+        [
+            'an insight outside this dashboard',
+            { id: 'alert-1', insight: 999 },
+            { id: 'alert-1', insight: 999 },
+            { tileIds: [41], insightIds: [101, 'alpha'], ownerKey: '999' },
+        ],
+    ])(
+        'refreshes the committed alert owner when an alert with no learned ownership moves to %s',
+        (_case, input, output, expected) => {
+            const result = resolveFor('alert-update', input, output)
+
+            expect(result.candidate).toEqual({
+                family: 'alert',
+                dashboardId,
+                tileIds: expected.tileIds,
+                insightIds: expected.insightIds,
+                deletesDashboard: false,
+            })
+            expect(result.ownership.alertInsightById).toEqual({ 'alert-1': expected.ownerKey })
+        }
+    )
+
     it('rejects an alert move when request and response owners disagree', () => {
         const ownership: DashboardAiKnownOwnership = {
             ...emptyOwnership(),

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
@@ -1,4 +1,4 @@
-import { LogicWrapper, MakeLogicType, actions, kea, key, listeners, path, props, reducers } from 'kea'
+import { LogicWrapper, MakeLogicType, actions, beforeUnmount, kea, key, listeners, path, props, reducers } from 'kea'
 import { router } from 'kea-router'
 
 import { urls } from 'scenes/urls'
@@ -11,6 +11,8 @@ import type { ToolStreamEvent } from 'products/posthog_ai/frontend/types/streamT
 import { subscriptionsLogic } from 'products/subscriptions/frontend/components/Subscriptions/subscriptionsLogic'
 
 import { DashboardLoadAction, dashboardLogic } from './dashboardLogic'
+
+const TRANSIENT_HIGHLIGHT_DURATION_MS = 3000
 
 export const DASHBOARD_AI_MUTATION_TOOLS = [
     'alert-create',
@@ -1040,7 +1042,7 @@ export const dashboardAiSyncLogic: LogicWrapper<dashboardAiSyncLogicType> = kea<
             { setTransientHighlightedTileIds: (_, { tileIds }) => [...tileIds] },
         ],
     }),
-    listeners(({ actions, props, values }) => ({
+    listeners(({ actions, cache, props, values }) => ({
         applyToolCompletion: ({ event, innerInput }) => {
             const dashboard = dashboardLogic({ id: props.dashboardId }).values.dashboard
             const target = targetFromCommittedDashboard(props.dashboardId, dashboard)
@@ -1081,7 +1083,19 @@ export const dashboardAiSyncLogic: LogicWrapper<dashboardAiSyncLogicType> = kea<
                 })
 
                 const committedDashboard = dashboardLogic({ id: props.dashboardId }).values.dashboard
-                actions.setTransientHighlightedTileIds(confirmedHighlightTileIds(batch, committedDashboard))
+                const confirmedTileIds = confirmedHighlightTileIds(batch, committedDashboard)
+                if (confirmedTileIds.length > 0) {
+                    actions.setTransientHighlightedTileIds(
+                        sortedUniqueNumbers([...values.transientHighlightedTileIds, ...confirmedTileIds])
+                    )
+                    if (cache.transientHighlightTimer !== undefined) {
+                        window.clearTimeout(cache.transientHighlightTimer)
+                    }
+                    cache.transientHighlightTimer = window.setTimeout(() => {
+                        actions.setTransientHighlightedTileIds([])
+                        cache.transientHighlightTimer = undefined
+                    }, TRANSIENT_HIGHLIGHT_DURATION_MS)
+                }
             } catch {
                 // The dashboard loader keeps the last committed dashboard visible on failure.
             } finally {
@@ -1095,4 +1109,10 @@ export const dashboardAiSyncLogic: LogicWrapper<dashboardAiSyncLogicType> = kea<
             }
         },
     })),
+    beforeUnmount(({ cache }) => {
+        if (cache.transientHighlightTimer !== undefined) {
+            window.clearTimeout(cache.transientHighlightTimer)
+            cache.transientHighlightTimer = undefined
+        }
+    }),
 ])

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
@@ -119,6 +119,11 @@ function asRecordArray(value: unknown): Record<string, unknown>[] | null {
     return records.every((record): record is Record<string, unknown> => record !== null) ? records : null
 }
 
+function isEmptyRecord(value: unknown): boolean {
+    const record = asRecord(value)
+    return record !== null && Object.keys(record).length === 0
+}
+
 function asPositiveSafeInteger(value: unknown): number | null {
     const parsed = typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : value
     return typeof parsed === 'number' && Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null
@@ -362,15 +367,18 @@ function resolveDashboardMutation(
         }
         const requestedTileIds = input.tile_order.map(asPositiveSafeInteger)
         const returned = parseDashboardTileIds(output, requestedDashboardId)
+        const validRequestedTileIds = requestedTileIds.filter((id): id is number => id !== null)
+        const returnedTileIds = new Set(returned.tileIds)
         if (
-            requestedTileIds.some((id) => id === null) ||
+            validRequestedTileIds.length !== requestedTileIds.length ||
+            new Set(validRequestedTileIds).size !== validRequestedTileIds.length ||
             !returned.valid ||
-            requestedTileIds.length !== returned.tileIds.length ||
-            requestedTileIds.some((id, index) => id !== returned.tileIds[index])
+            returnedTileIds.size !== returned.tileIds.length ||
+            validRequestedTileIds.some((id) => !returnedTileIds.has(id))
         ) {
             return null
         }
-        return candidate('dashboard', target.dashboardId, requestedTileIds as number[])
+        return candidate('dashboard', target.dashboardId, validRequestedTileIds)
     }
 
     if (BATCH_ADD_TOOLS.has(toolName) || toolName === 'dashboard-widgets-batch-update') {
@@ -700,6 +708,9 @@ function resolveAlertMutation(
     if (requestInsightId === null || responseIdentity === null) {
         return { candidate: null, ownership: knownOwnership }
     }
+    if (toolName === 'alert-delete' && Object.keys(output).length > 0 && outputAlertId === undefined) {
+        return { candidate: null, ownership: knownOwnership }
+    }
 
     const learnedInsightKey = knownOwnership.alertInsightById[alertId]
     const evidence: InsightIdentifier[] = [
@@ -761,6 +772,7 @@ export function resolveDashboardAiMutation(
         event.toolName === 'alert-delete' &&
         (event.invocation.output === null ||
             event.invocation.output === undefined ||
+            isEmptyRecord(event.invocation.output) ||
             (typeof event.invocation.output === 'string' && !event.invocation.output.trim()))
     if (!parsedOutput && !hasEmptyAlertDeleteOutput) {
         return { candidate: null, ownership: knownOwnership }

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
@@ -745,17 +745,34 @@ function targetInsightForAlertId(target: DashboardAiSyncTarget, alertId: string)
     return { tileId: tile.tileId, numericId: tile.insightId, shortId: tile.insightShortId }
 }
 
+function parseAlertInsightField(value: unknown): InsightIdentity | null {
+    const nested = asRecord(value)
+    if (nested !== null) {
+        return parseOutputInsightIdentity(nested)
+    }
+    const numericId = asPositiveSafeInteger(value)
+    return numericId === null ? null : { numericId, shortId: null, identifiers: [numericId] }
+}
+
 function alertInsightIdentity(output: Record<string, unknown>): InsightIdentity | null | undefined {
-    const hasNumericId = Object.prototype.hasOwnProperty.call(output, 'insight')
+    const hasInsight = Object.prototype.hasOwnProperty.call(output, 'insight')
     const hasShortId = Object.prototype.hasOwnProperty.call(output, 'insight_short_id')
-    if (!hasNumericId && !hasShortId) {
+    if (!hasInsight && !hasShortId) {
         return undefined
     }
-    const numericId = hasNumericId ? asPositiveSafeInteger(output.insight) : null
-    const shortId = hasShortId ? asNonEmptyString(output.insight_short_id) : null
-    if ((hasNumericId && numericId === null) || (hasShortId && shortId === null)) {
+    // The alert serializer replaces `insight` with the full insight object in every response, so
+    // the identity arrives nested even though the generated type declares a bare ID.
+    const insight = hasInsight ? parseAlertInsightField(output.insight) : null
+    const topShortId = hasShortId ? asNonEmptyString(output.insight_short_id) : null
+    if ((hasInsight && insight === null) || (hasShortId && topShortId === null)) {
         return null
     }
+    const numericId = insight?.numericId ?? null
+    const nestedShortId = insight?.shortId ?? null
+    if (nestedShortId !== null && topShortId !== null && nestedShortId !== topShortId) {
+        return null
+    }
+    const shortId = nestedShortId ?? topShortId
     return {
         numericId,
         shortId,

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
@@ -124,6 +124,24 @@ function isEmptyRecord(value: unknown): boolean {
     return record !== null && Object.keys(record).length === 0
 }
 
+function isEmptyAlertDeleteOutput(value: unknown): boolean {
+    if (value === null || value === undefined || isEmptyRecord(value)) {
+        return true
+    }
+    if (typeof value !== 'string') {
+        return false
+    }
+    const trimmed = value.trim()
+    if (!trimmed) {
+        return true
+    }
+    try {
+        return isEmptyRecord(JSON.parse(trimmed))
+    } catch {
+        return false
+    }
+}
+
 function asPositiveSafeInteger(value: unknown): number | null {
     const parsed = typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : value
     return typeof parsed === 'number' && Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null
@@ -767,13 +785,12 @@ export function resolveDashboardAiMutation(
     if (resolved.innerToolName !== event.toolName) {
         return { candidate: null, ownership: knownOwnership }
     }
-    const parsedOutput = parseToolOutputRecord(event.invocation.output, event.invocation.input)
-    const hasEmptyAlertDeleteOutput =
-        event.toolName === 'alert-delete' &&
-        (event.invocation.output === null ||
-            event.invocation.output === undefined ||
-            isEmptyRecord(event.invocation.output) ||
-            (typeof event.invocation.output === 'string' && !event.invocation.output.trim()))
+    const rawOutput = event.invocation.output
+    const parsedOutput = parseToolOutputRecord(rawOutput, event.invocation.input)
+    const hasEmptyAlertDeleteOutput = event.toolName === 'alert-delete' && isEmptyAlertDeleteOutput(rawOutput)
+    if (event.toolName === 'alert-delete' && typeof rawOutput === 'string' && !hasEmptyAlertDeleteOutput) {
+        return { candidate: null, ownership: knownOwnership }
+    }
     if (!parsedOutput && !hasEmptyAlertDeleteOutput) {
         return { candidate: null, ownership: knownOwnership }
     }

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
@@ -1,4 +1,4 @@
-import { LogicWrapper, MakeLogicType, actions, beforeUnmount, kea, key, listeners, path, props, reducers } from 'kea'
+import { LogicWrapper, MakeLogicType, actions, kea, key, listeners, path, props, reducers } from 'kea'
 import { router } from 'kea-router'
 
 import { urls } from 'scenes/urls'
@@ -1077,42 +1077,49 @@ export const dashboardAiSyncLogic: LogicWrapper<dashboardAiSyncLogicType> = kea<
             actions.syncDashboard(batch)
         },
         syncDashboard: async ({ batch }) => {
+            const disposables = cache.disposables
             try {
                 await dashboardLogic({ id: props.dashboardId }).asyncActions.loadDashboard({
                     action: DashboardLoadAction.BackgroundUpdate,
                 })
 
+                if (disposables.isDisposed) {
+                    return
+                }
                 const committedDashboard = dashboardLogic({ id: props.dashboardId }).values.dashboard
                 const confirmedTileIds = confirmedHighlightTileIds(batch, committedDashboard)
                 if (confirmedTileIds.length > 0) {
                     actions.setTransientHighlightedTileIds(
                         sortedUniqueNumbers([...values.transientHighlightedTileIds, ...confirmedTileIds])
                     )
-                    if (cache.transientHighlightTimer !== undefined) {
-                        window.clearTimeout(cache.transientHighlightTimer)
-                    }
-                    cache.transientHighlightTimer = window.setTimeout(() => {
-                        actions.setTransientHighlightedTileIds([])
-                        cache.transientHighlightTimer = undefined
-                    }, TRANSIENT_HIGHLIGHT_DURATION_MS)
+                    cache.disposables.add(() => {
+                        let active = true
+                        const timer = window.setTimeout(() => {
+                            if (!active) {
+                                return
+                            }
+                            active = false
+                            actions.setTransientHighlightedTileIds([])
+                        }, TRANSIENT_HIGHLIGHT_DURATION_MS)
+                        return () => {
+                            active = false
+                            window.clearTimeout(timer)
+                        }
+                    }, 'transientHighlightExpiry')
                 }
             } catch {
                 // The dashboard loader keeps the last committed dashboard visible on failure.
             } finally {
-                const successor = values.queuedBatch
-                actions.setActiveBatch(null)
-                if (successor) {
-                    actions.setQueuedBatch(null)
-                    actions.setActiveBatch(successor)
-                    actions.syncDashboard(successor)
+                if (!disposables.isDisposed) {
+                    const successor = values.queuedBatch
+                    actions.setActiveBatch(null)
+                    if (successor) {
+                        actions.setQueuedBatch(null)
+                        actions.setActiveBatch(successor)
+                        actions.syncDashboard(successor)
+                    }
                 }
             }
         },
     })),
-    beforeUnmount(({ cache }) => {
-        if (cache.transientHighlightTimer !== undefined) {
-            window.clearTimeout(cache.transientHighlightTimer)
-            cache.transientHighlightTimer = undefined
-        }
-    }),
 ])

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
@@ -2,6 +2,7 @@ import { LogicWrapper, MakeLogicType, actions, kea, key, listeners, path, props,
 import { router } from 'kea-router'
 import posthog from 'posthog-js'
 
+import { objectsEqual } from 'lib/utils/objects'
 import { urls } from 'scenes/urls'
 
 import { DashboardType, QueryBasedInsightModel } from '~/types'
@@ -1101,6 +1102,19 @@ function captureDashboardAiSyncCompleted(
     }
 }
 
+function widgetTileIdsWithChangedConfig(
+    before: DashboardType<QueryBasedInsightModel> | null,
+    after: DashboardType<QueryBasedInsightModel> | null
+): number[] {
+    const widgetsBefore = new Map((before?.tiles ?? []).map((tile) => [tile.id, tile.widget]))
+    return (after?.tiles ?? [])
+        .filter((tile) => {
+            const widgetBefore = widgetsBefore.get(tile.id)
+            return !!tile.widget && !!widgetBefore && !objectsEqual(widgetBefore.config, tile.widget.config)
+        })
+        .map((tile) => tile.id)
+}
+
 function refreshMountedInsightAlerts(
     dashboardId: number,
     dashboard: DashboardType<QueryBasedInsightModel> | null,
@@ -1244,6 +1258,7 @@ export const dashboardAiSyncLogic: LogicWrapper<dashboardAiSyncLogicType> = kea<
             const disposables = cache.disposables
             let confirmedTileIds: number[] = []
             let success = false
+            const previousDashboard = dashboardLogic({ id: props.dashboardId }).values.dashboard
             try {
                 await dashboardLogic({ id: props.dashboardId }).asyncActions.loadDashboard({
                     action: DashboardLoadAction.BackgroundUpdate,
@@ -1253,6 +1268,16 @@ export const dashboardAiSyncLogic: LogicWrapper<dashboardAiSyncLogicType> = kea<
                     return
                 }
                 const committedDashboard = dashboardLogic({ id: props.dashboardId }).values.dashboard
+                // A widget keeps its cached result across the reload, and the refresh that follows a
+                // load is not forced, so a reconfigured widget would show its old result for the rest
+                // of the client TTL. Invalidate the ones whose configuration actually changed.
+                const reconfiguredWidgetTileIds = widgetTileIdsWithChangedConfig(previousDashboard, committedDashboard)
+                if (reconfiguredWidgetTileIds.length > 0) {
+                    dashboardLogic({ id: props.dashboardId }).actions.refreshDashboardWidgets({
+                        tileIds: reconfiguredWidgetTileIds,
+                        forceRefresh: true,
+                    })
+                }
                 confirmedTileIds = confirmedHighlightTileIds(batch, committedDashboard)
                 success = true
                 if (confirmedTileIds.length > 0) {

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
@@ -1,5 +1,16 @@
+import { LogicWrapper, MakeLogicType, actions, kea, key, listeners, path, props, reducers } from 'kea'
+import { router } from 'kea-router'
+
+import { urls } from 'scenes/urls'
+
+import { DashboardType, QueryBasedInsightModel } from '~/types'
+
+import { insightAlertsLogic } from 'products/alerts/frontend/logic/insightAlertsLogic'
 import { parseToolOutputRecord, resolveToolCall } from 'products/posthog_ai/frontend/api/logics'
 import type { ToolStreamEvent } from 'products/posthog_ai/frontend/types/streamTypes'
+import { subscriptionsLogic } from 'products/subscriptions/frontend/components/Subscriptions/subscriptionsLogic'
+
+import { DashboardLoadAction, dashboardLogic } from './dashboardLogic'
 
 export const DASHBOARD_AI_MUTATION_TOOLS = [
     'alert-create',
@@ -57,6 +68,18 @@ export interface DashboardAiKnownOwnership {
 export interface DashboardAiMutationResolution {
     candidate: DashboardAiSyncCandidate | null
     ownership: DashboardAiKnownOwnership
+}
+
+export interface DashboardAiSyncBatch {
+    families: DashboardAiToolFamily[]
+    tileIds: number[]
+    insightIds: Array<number | string>
+    queuedEventCount: number
+    startedAt: number
+}
+
+export interface DashboardAiSyncLogicProps {
+    dashboardId: number
 }
 
 type InsightIdentifier = number | string
@@ -828,3 +851,248 @@ export function resolveDashboardAiMutation(
     }
     return { candidate: null, ownership: knownOwnership }
 }
+
+function emptyKnownOwnership(): DashboardAiKnownOwnership {
+    return {
+        subscriptionDashboardById: {},
+        insightDashboardsById: {},
+        alertInsightById: {},
+    }
+}
+
+function targetFromCommittedDashboard(
+    dashboardId: number,
+    dashboard: DashboardType<QueryBasedInsightModel> | null
+): DashboardAiSyncTarget {
+    return {
+        dashboardId,
+        tiles: (dashboard?.tiles ?? []).map((tile) => ({
+            tileId: tile.id,
+            insightId: tile.insight?.id ?? null,
+            insightShortId: tile.insight?.short_id ?? null,
+            alertIds: tile.insight?.alerts?.map((alert) => alert.id) ?? [],
+        })),
+    }
+}
+
+function batchFromCandidate(candidate: DashboardAiSyncCandidate): DashboardAiSyncBatch {
+    return {
+        families: [candidate.family],
+        tileIds: [...candidate.tileIds],
+        insightIds: [...candidate.insightIds],
+        queuedEventCount: 1,
+        startedAt: Date.now(),
+    }
+}
+
+function mergeBatches(left: DashboardAiSyncBatch, right: DashboardAiSyncBatch): DashboardAiSyncBatch {
+    return {
+        families: [...new Set([...left.families, ...right.families])].sort(),
+        tileIds: sortedUniqueNumbers([...left.tileIds, ...right.tileIds]),
+        insightIds: sortedUniqueInsightIds([...left.insightIds, ...right.insightIds]),
+        queuedEventCount: left.queuedEventCount + right.queuedEventCount,
+        startedAt: Math.min(left.startedAt, right.startedAt),
+    }
+}
+
+function copyBatch(batch: DashboardAiSyncBatch): DashboardAiSyncBatch {
+    return {
+        families: [...new Set(batch.families)].sort(),
+        tileIds: sortedUniqueNumbers(batch.tileIds),
+        insightIds: sortedUniqueInsightIds(batch.insightIds),
+        queuedEventCount: batch.queuedEventCount,
+        startedAt: batch.startedAt,
+    }
+}
+
+function copyKnownOwnership(ownership: DashboardAiKnownOwnership): DashboardAiKnownOwnership {
+    return {
+        subscriptionDashboardById: { ...ownership.subscriptionDashboardById },
+        insightDashboardsById: Object.fromEntries(
+            Object.entries(ownership.insightDashboardsById).map(([insightId, dashboardIds]) => [
+                insightId,
+                [...dashboardIds],
+            ])
+        ),
+        alertInsightById: { ...ownership.alertInsightById },
+    }
+}
+
+function confirmedHighlightTileIds(
+    batch: DashboardAiSyncBatch,
+    dashboard: DashboardType<QueryBasedInsightModel> | null
+): number[] {
+    return sortedUniqueNumbers(
+        (dashboard?.tiles ?? [])
+            .filter((tile) => {
+                if (batch.tileIds.includes(tile.id)) {
+                    return true
+                }
+                const insightId = tile.insight?.id
+                const insightShortId = tile.insight?.short_id
+                return (
+                    (insightId !== undefined && batch.insightIds.includes(insightId)) ||
+                    (insightShortId !== undefined && batch.insightIds.includes(insightShortId))
+                )
+            })
+            .map((tile) => tile.id)
+    )
+}
+
+function refreshMountedInsightAlerts(
+    dashboardId: number,
+    dashboard: DashboardType<QueryBasedInsightModel> | null,
+    candidate: DashboardAiSyncCandidate
+): void {
+    const insight = dashboard?.tiles.find((tile) => candidate.tileIds.includes(tile.id))?.insight
+    if (!insight?.id) {
+        return
+    }
+
+    const insightLogicProps = {
+        dashboardItemId: insight.short_id,
+        dashboardId,
+        cachedInsight: insight,
+    }
+    insightAlertsLogic.findMounted({ insightId: insight.id, insightLogicProps })?.actions.loadAlerts()
+}
+
+// Generated by kea-typegen. Update if you're an agent, ignore if you're human.
+export interface dashboardAiSyncLogicValues {
+    activeBatch: DashboardAiSyncBatch | null
+    knownOwnership: DashboardAiKnownOwnership
+    queuedBatch: DashboardAiSyncBatch | null
+    transientHighlightedTileIds: number[]
+}
+
+// Generated by kea-typegen. Update if you're an agent, ignore if you're human.
+export interface dashboardAiSyncLogicActions {
+    applyToolCompletion: (
+        event: ToolStreamEvent,
+        innerInput: Record<string, unknown> | null
+    ) => {
+        event: ToolStreamEvent
+        innerInput: Record<string, unknown> | null
+    }
+    queueDashboardSync: (candidate: DashboardAiSyncCandidate) => {
+        candidate: DashboardAiSyncCandidate
+    }
+    setActiveBatch: (batch: DashboardAiSyncBatch | null) => {
+        batch: DashboardAiSyncBatch | null
+    }
+    setKnownOwnership: (ownership: DashboardAiKnownOwnership) => {
+        ownership: DashboardAiKnownOwnership
+    }
+    setQueuedBatch: (batch: DashboardAiSyncBatch | null) => {
+        batch: DashboardAiSyncBatch | null
+    }
+    setTransientHighlightedTileIds: (tileIds: number[]) => {
+        tileIds: number[]
+    }
+    syncDashboard: (batch: DashboardAiSyncBatch) => {
+        batch: DashboardAiSyncBatch
+    }
+}
+
+// Generated by kea-typegen. Update if you're an agent, ignore if you're human.
+export interface dashboardAiSyncLogicMeta {
+    key: number
+}
+
+export type dashboardAiSyncLogicType = MakeLogicType<
+    dashboardAiSyncLogicValues,
+    dashboardAiSyncLogicActions,
+    DashboardAiSyncLogicProps,
+    dashboardAiSyncLogicMeta
+>
+
+export const dashboardAiSyncLogic: LogicWrapper<dashboardAiSyncLogicType> = kea<dashboardAiSyncLogicType>([
+    props({} as DashboardAiSyncLogicProps),
+    key((props) => props.dashboardId),
+    path((key) => ['scenes', 'dashboard', 'dashboardAiSyncLogic', key]),
+    actions({
+        applyToolCompletion: (event: ToolStreamEvent, innerInput: Record<string, unknown> | null) => ({
+            event,
+            innerInput,
+        }),
+        queueDashboardSync: (candidate: DashboardAiSyncCandidate) => ({ candidate }),
+        setActiveBatch: (batch: DashboardAiSyncBatch | null) => ({ batch }),
+        setQueuedBatch: (batch: DashboardAiSyncBatch | null) => ({ batch }),
+        setKnownOwnership: (ownership: DashboardAiKnownOwnership) => ({ ownership }),
+        setTransientHighlightedTileIds: (tileIds: number[]) => ({ tileIds }),
+        syncDashboard: (batch: DashboardAiSyncBatch) => ({ batch }),
+    }),
+    reducers({
+        activeBatch: [
+            null as DashboardAiSyncBatch | null,
+            { setActiveBatch: (_, { batch }) => (batch ? copyBatch(batch) : null) },
+        ],
+        queuedBatch: [
+            null as DashboardAiSyncBatch | null,
+            { setQueuedBatch: (_, { batch }) => (batch ? copyBatch(batch) : null) },
+        ],
+        knownOwnership: [
+            emptyKnownOwnership(),
+            { setKnownOwnership: (_, { ownership }) => copyKnownOwnership(ownership) },
+        ],
+        transientHighlightedTileIds: [
+            [] as number[],
+            { setTransientHighlightedTileIds: (_, { tileIds }) => [...tileIds] },
+        ],
+    }),
+    listeners(({ actions, props, values }) => ({
+        applyToolCompletion: ({ event, innerInput }) => {
+            const dashboard = dashboardLogic({ id: props.dashboardId }).values.dashboard
+            const target = targetFromCommittedDashboard(props.dashboardId, dashboard)
+            const resolution = resolveDashboardAiMutation(target, values.knownOwnership, event, innerInput)
+            if (!resolution.candidate) {
+                return
+            }
+
+            actions.setKnownOwnership(resolution.ownership)
+            const candidate = resolution.candidate
+            if (candidate.deletesDashboard) {
+                router.actions.push(urls.dashboards())
+                return
+            }
+            if (candidate.family === 'subscription') {
+                subscriptionsLogic.findMounted({ dashboardId: props.dashboardId })?.actions.loadAllSubscriptions()
+                return
+            }
+            if (candidate.family === 'alert') {
+                refreshMountedInsightAlerts(props.dashboardId, dashboard, candidate)
+                return
+            }
+            actions.queueDashboardSync(candidate)
+        },
+        queueDashboardSync: ({ candidate }) => {
+            const batch = batchFromCandidate(candidate)
+            if (values.activeBatch) {
+                actions.setQueuedBatch(values.queuedBatch ? mergeBatches(values.queuedBatch, batch) : batch)
+                return
+            }
+            actions.setActiveBatch(batch)
+            actions.syncDashboard(batch)
+        },
+        syncDashboard: async ({ batch }) => {
+            try {
+                await dashboardLogic({ id: props.dashboardId }).asyncActions.loadDashboard({
+                    action: DashboardLoadAction.Update,
+                })
+
+                const committedDashboard = dashboardLogic({ id: props.dashboardId }).values.dashboard
+                actions.setTransientHighlightedTileIds(confirmedHighlightTileIds(batch, committedDashboard))
+            } catch {
+                // The dashboard loader keeps the last committed dashboard visible on failure.
+            } finally {
+                const successor = values.queuedBatch
+                actions.setActiveBatch(null)
+                if (successor) {
+                    actions.setQueuedBatch(null)
+                    actions.setActiveBatch(successor)
+                    actions.syncDashboard(successor)
+                }
+            }
+        },
+    })),
+])

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
@@ -1,5 +1,6 @@
 import { LogicWrapper, MakeLogicType, actions, kea, key, listeners, path, props, reducers } from 'kea'
 import { router } from 'kea-router'
+import posthog from 'posthog-js'
 
 import { urls } from 'scenes/urls'
 
@@ -941,6 +942,24 @@ function confirmedHighlightTileIds(
     )
 }
 
+function captureDashboardAiSyncCompleted(
+    batch: DashboardAiSyncBatch,
+    highlightedTileCount: number,
+    success: boolean
+): void {
+    try {
+        posthog.capture('dashboard ai sync completed', {
+            tool_families: [...new Set(batch.families)].sort(),
+            queued_event_count: batch.queuedEventCount,
+            highlighted_tile_count: highlightedTileCount,
+            duration_ms: Math.max(0, Date.now() - batch.startedAt),
+            success,
+        })
+    } catch {
+        // Telemetry must not interrupt dashboard synchronization or a queued successor.
+    }
+}
+
 function refreshMountedInsightAlerts(
     dashboardId: number,
     dashboard: DashboardType<QueryBasedInsightModel> | null,
@@ -1078,6 +1097,8 @@ export const dashboardAiSyncLogic: LogicWrapper<dashboardAiSyncLogicType> = kea<
         },
         syncDashboard: async ({ batch }) => {
             const disposables = cache.disposables
+            let confirmedTileIds: number[] = []
+            let success = false
             try {
                 await dashboardLogic({ id: props.dashboardId }).asyncActions.loadDashboard({
                     action: DashboardLoadAction.BackgroundUpdate,
@@ -1087,7 +1108,8 @@ export const dashboardAiSyncLogic: LogicWrapper<dashboardAiSyncLogicType> = kea<
                     return
                 }
                 const committedDashboard = dashboardLogic({ id: props.dashboardId }).values.dashboard
-                const confirmedTileIds = confirmedHighlightTileIds(batch, committedDashboard)
+                confirmedTileIds = confirmedHighlightTileIds(batch, committedDashboard)
+                success = true
                 if (confirmedTileIds.length > 0) {
                     actions.setTransientHighlightedTileIds(
                         sortedUniqueNumbers([...values.transientHighlightedTileIds, ...confirmedTileIds])
@@ -1111,6 +1133,7 @@ export const dashboardAiSyncLogic: LogicWrapper<dashboardAiSyncLogicType> = kea<
                 // The dashboard loader keeps the last committed dashboard visible on failure.
             } finally {
                 if (!disposables.isDisposed) {
+                    captureDashboardAiSyncCompleted(batch, confirmedTileIds.length, success)
                     const successor = values.queuedBatch
                     actions.setActiveBatch(null)
                     if (successor) {

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
@@ -529,7 +529,7 @@ function parseAuthoritativeDashboardTiles(
     output: Record<string, unknown>
 ): Array<{ tileId: number; dashboardId: number }> | null {
     const records = asRecordArray(output.dashboard_tiles)
-    if (!records || records.length === 0) {
+    if (!records) {
         return null
     }
     const activeTiles: Array<{ tileId: number; dashboardId: number }> = []
@@ -576,6 +576,10 @@ function learnInsightOwnership(
     return { ...knownOwnership, insightDashboardsById }
 }
 
+function sameDashboardMembership(left: number[], right: number[]): boolean {
+    return left.length === right.length && left.every((dashboardId, index) => dashboardId === right[index])
+}
+
 function resolveInsightMutation(
     target: DashboardAiSyncTarget,
     knownOwnership: DashboardAiKnownOwnership,
@@ -604,20 +608,36 @@ function resolveInsightMutation(
         }
         const requestedDashboards = requestDashboardMembership(input)
         const responseTiles = parseAuthoritativeDashboardTiles(output)
-        if (
-            requestedDashboards === null ||
-            (requestedDashboards !== undefined && !requestedDashboards.includes(target.dashboardId)) ||
-            !responseTiles
-        ) {
-            return { candidate: null, ownership: knownOwnership }
-        }
-        const matchingTiles = responseTiles.filter((tile) => tile.dashboardId === target.dashboardId)
-        if (matchingTiles.length !== 1) {
+        if (requestedDashboards === null || !responseTiles) {
             return { candidate: null, ownership: knownOwnership }
         }
         const dashboardIds = sortedUniqueNumbers(responseTiles.map((tile) => tile.dashboardId))
+        if (requestedDashboards !== undefined && !sameDashboardMembership(requestedDashboards, dashboardIds)) {
+            return { candidate: null, ownership: knownOwnership }
+        }
+        const matchingTiles = responseTiles.filter((tile) => tile.dashboardId === target.dashboardId)
+        if (matchingTiles.length > 1) {
+            return { candidate: null, ownership: knownOwnership }
+        }
+        const currentTarget = resolveTargetInsight(target, identity.identifiers)
+        const wasKnownOnTarget = identity.identifiers.some((identifier) =>
+            knownOwnership.insightDashboardsById[String(identifier)]?.includes(target.dashboardId)
+        )
+        if (
+            matchingTiles.length === 0 &&
+            (toolName !== 'insight-update' ||
+                requestedDashboards === undefined ||
+                (!currentTarget && !wasKnownOnTarget))
+        ) {
+            return { candidate: null, ownership: knownOwnership }
+        }
         return {
-            candidate: candidate('insight', target.dashboardId, [matchingTiles[0].tileId], identity.identifiers),
+            candidate: candidate(
+                'insight',
+                target.dashboardId,
+                matchingTiles.length === 1 ? [matchingTiles[0].tileId] : [],
+                identity.identifiers
+            ),
             ownership: learnInsightOwnership(knownOwnership, identity, dashboardIds),
         }
     }
@@ -674,24 +694,42 @@ function resolveSubscriptionMutation(
         return { candidate: null, ownership: knownOwnership }
     }
     const knownDashboardId = knownOwnership.subscriptionDashboardById[subscriptionId]
-    if (knownDashboardId !== undefined && outputDashboardId !== undefined && knownDashboardId !== outputDashboardId) {
+    const subscriptionDashboardById = { ...knownOwnership.subscriptionDashboardById }
+    if (toolName === 'subscriptions-delete') {
+        if (
+            knownDashboardId !== undefined &&
+            ((requestDashboardId !== undefined && requestDashboardId !== knownDashboardId) ||
+                (outputDashboardId !== undefined && outputDashboardId !== knownDashboardId))
+        ) {
+            return { candidate: null, ownership: knownOwnership }
+        }
+        const priorDashboardId = knownDashboardId ?? outputDashboardId ?? requestDashboardId
+        if (priorDashboardId !== target.dashboardId) {
+            return { candidate: null, ownership: knownOwnership }
+        }
+        delete subscriptionDashboardById[subscriptionId]
+        return {
+            candidate: candidate('subscription', target.dashboardId),
+            ownership: { ...knownOwnership, subscriptionDashboardById },
+        }
+    }
+
+    const movesFromKnownOwner =
+        knownDashboardId !== undefined &&
+        ((requestDashboardId !== undefined && requestDashboardId !== knownDashboardId) ||
+            (outputDashboardId !== undefined && outputDashboardId !== knownDashboardId))
+    if (movesFromKnownOwner && (requestDashboardId === undefined || outputDashboardId === undefined)) {
         return { candidate: null, ownership: knownOwnership }
     }
-    const ownedDashboardId = outputDashboardId ?? knownDashboardId
+    const postDashboardId = outputDashboardId ?? knownDashboardId
     if (
-        ownedDashboardId === undefined ||
-        ownedDashboardId !== target.dashboardId ||
-        (toolName === 'subscriptions-create' && requestDashboardId !== ownedDashboardId)
+        postDashboardId === undefined ||
+        (knownDashboardId !== target.dashboardId && postDashboardId !== target.dashboardId) ||
+        (toolName === 'subscriptions-create' && requestDashboardId !== postDashboardId)
     ) {
         return { candidate: null, ownership: knownOwnership }
     }
-
-    const subscriptionDashboardById = { ...knownOwnership.subscriptionDashboardById }
-    if (toolName === 'subscriptions-delete') {
-        delete subscriptionDashboardById[subscriptionId]
-    } else {
-        subscriptionDashboardById[subscriptionId] = ownedDashboardId
-    }
+    subscriptionDashboardById[subscriptionId] = postDashboardId
     return {
         candidate: candidate('subscription', target.dashboardId),
         ownership: { ...knownOwnership, subscriptionDashboardById },
@@ -728,6 +766,26 @@ function alertInsightIdentity(output: Record<string, unknown>): InsightIdentity 
     }
 }
 
+function insightIdentifiersAgree(
+    target: DashboardAiSyncTarget,
+    left: InsightIdentifier,
+    right: InsightIdentifier
+): boolean {
+    if (left === right) {
+        return true
+    }
+    const leftTarget = resolveTargetInsight(target, [left])
+    const rightTarget = resolveTargetInsight(target, [right])
+    return leftTarget !== null && rightTarget !== null && leftTarget.tileId === rightTarget.tileId
+}
+
+function canonicalInsightKey(identity: InsightIdentity | undefined, fallback?: InsightIdentifier): string | null {
+    if (identity?.numericId !== null && identity?.numericId !== undefined) {
+        return String(identity.numericId)
+    }
+    return identity?.shortId ?? (fallback === undefined ? null : String(fallback))
+}
+
 function resolveAlertMutation(
     target: DashboardAiSyncTarget,
     knownOwnership: DashboardAiKnownOwnership,
@@ -756,43 +814,96 @@ function resolveAlertMutation(
         return { candidate: null, ownership: knownOwnership }
     }
 
-    const learnedInsightKey = knownOwnership.alertInsightById[alertId]
-    const evidence: InsightIdentifier[] = [
-        ...(requestInsightId === undefined ? [] : [requestInsightId]),
-        ...(responseIdentity === undefined ? [] : responseIdentity.identifiers),
-        ...(learnedInsightKey === undefined ? [] : [asInsightIdentifier(learnedInsightKey)!]),
-    ]
-    let ownedInsight = resolveTargetInsight(target, evidence)
-    if (!ownedInsight && toolName === 'alert-delete' && evidence.length === 0) {
-        ownedInsight = targetInsightForAlertId(target, alertId)
-    }
-    if (!ownedInsight) {
+    if (responseIdentity !== undefined && !identitiesAgreeWithTarget(target, responseIdentity, requestInsightId)) {
         return { candidate: null, ownership: knownOwnership }
     }
 
-    const alertInsightById = { ...knownOwnership.alertInsightById }
-    const canonicalInsightKey = ownedInsight.numericId === null ? ownedInsight.shortId : String(ownedInsight.numericId)
-    if (!canonicalInsightKey) {
-        return { candidate: null, ownership: knownOwnership }
+    const learnedInsightKey = knownOwnership.alertInsightById[alertId]
+    let learnedInsightId: InsightIdentifier | undefined
+    if (learnedInsightKey !== undefined) {
+        const parsedLearnedInsightId = asInsightIdentifier(learnedInsightKey)
+        if (parsedLearnedInsightId === null) {
+            return { candidate: null, ownership: knownOwnership }
+        }
+        learnedInsightId = parsedLearnedInsightId
     }
+    const alertInsightById = { ...knownOwnership.alertInsightById }
     if (toolName === 'alert-delete') {
+        if (
+            learnedInsightId !== undefined &&
+            ((requestInsightId !== undefined && !insightIdentifiersAgree(target, requestInsightId, learnedInsightId)) ||
+                (responseIdentity !== undefined &&
+                    !identitiesAgreeWithTarget(target, responseIdentity, learnedInsightId)))
+        ) {
+            return { candidate: null, ownership: knownOwnership }
+        }
+        let ownedInsight = learnedInsightId ? resolveTargetInsight(target, [learnedInsightId]) : null
+        if (learnedInsightId !== undefined && !ownedInsight) {
+            return { candidate: null, ownership: knownOwnership }
+        }
+        ownedInsight ??= requestInsightId === undefined ? null : resolveTargetInsight(target, [requestInsightId])
+        ownedInsight ??= responseIdentity ? resolveTargetInsight(target, responseIdentity.identifiers) : null
+        ownedInsight ??= targetInsightForAlertId(target, alertId)
+        if (!ownedInsight) {
+            return { candidate: null, ownership: knownOwnership }
+        }
+        const ownedInsightKey = ownedInsight.numericId === null ? ownedInsight.shortId : String(ownedInsight.numericId)
+        if (!ownedInsightKey) {
+            return { candidate: null, ownership: knownOwnership }
+        }
         const owningTile = target.tiles.find((tile) => tile.tileId === ownedInsight!.tileId)
         for (const currentAlertId of owningTile?.alertIds ?? []) {
             const currentAlertKey = asResourceKey(currentAlertId)
             if (currentAlertKey) {
-                alertInsightById[currentAlertKey] = canonicalInsightKey
+                alertInsightById[currentAlertKey] = ownedInsightKey
             }
         }
         delete alertInsightById[alertId]
-    } else {
-        alertInsightById[alertId] = canonicalInsightKey
+        return {
+            candidate: candidate(
+                'alert',
+                target.dashboardId,
+                [ownedInsight.tileId],
+                identifiersForTargetInsight(ownedInsight)
+            ),
+            ownership: { ...knownOwnership, alertInsightById },
+        }
     }
+
+    if (learnedInsightId !== undefined) {
+        const requestMovesOwner =
+            requestInsightId !== undefined && !insightIdentifiersAgree(target, requestInsightId, learnedInsightId)
+        const responseMovesOwner =
+            responseIdentity !== undefined && !identitiesAgreeWithTarget(target, responseIdentity, learnedInsightId)
+        if (
+            (requestMovesOwner || responseMovesOwner) &&
+            (requestInsightId === undefined || responseIdentity === undefined)
+        ) {
+            return { candidate: null, ownership: knownOwnership }
+        }
+    }
+
+    const priorInsight = learnedInsightId ? resolveTargetInsight(target, [learnedInsightId]) : null
+    const postInsight = responseIdentity
+        ? resolveTargetInsight(target, responseIdentity.identifiers)
+        : requestInsightId === undefined
+          ? priorInsight
+          : resolveTargetInsight(target, [requestInsightId])
+    if (!priorInsight && !postInsight) {
+        return { candidate: null, ownership: knownOwnership }
+    }
+    const postInsightKey = canonicalInsightKey(responseIdentity, requestInsightId ?? learnedInsightId)
+    if (!postInsightKey) {
+        return { candidate: null, ownership: knownOwnership }
+    }
+    alertInsightById[alertId] = postInsightKey
+    const affectedInsights = [priorInsight, postInsight].filter((insight): insight is TargetInsight => insight !== null)
     return {
         candidate: candidate(
             'alert',
             target.dashboardId,
-            [ownedInsight.tileId],
-            identifiersForTargetInsight(ownedInsight)
+            affectedInsights.map((insight) => insight.tileId),
+            affectedInsights.flatMap(identifiersForTargetInsight)
         ),
         ownership: { ...knownOwnership, alertInsightById },
     }
@@ -965,17 +1076,18 @@ function refreshMountedInsightAlerts(
     dashboard: DashboardType<QueryBasedInsightModel> | null,
     candidate: DashboardAiSyncCandidate
 ): void {
-    const insight = dashboard?.tiles.find((tile) => candidate.tileIds.includes(tile.id))?.insight
-    if (!insight?.id) {
-        return
+    for (const tile of dashboard?.tiles ?? []) {
+        const insight = tile.insight
+        if (!candidate.tileIds.includes(tile.id) || !insight?.id) {
+            continue
+        }
+        const insightLogicProps = {
+            dashboardItemId: insight.short_id,
+            dashboardId,
+            cachedInsight: insight,
+        }
+        insightAlertsLogic.findMounted({ insightId: insight.id, insightLogicProps })?.actions.loadAlerts()
     }
-
-    const insightLogicProps = {
-        dashboardItemId: insight.short_id,
-        dashboardId,
-        cachedInsight: insight,
-    }
-    insightAlertsLogic.findMounted({ insightId: insight.id, insightLogicProps })?.actions.loadAlerts()
 }
 
 // Generated by kea-typegen. Update if you're an agent, ignore if you're human.
@@ -1070,21 +1182,24 @@ export const dashboardAiSyncLogic: LogicWrapper<dashboardAiSyncLogicType> = kea<
                 return
             }
 
-            actions.setKnownOwnership(resolution.ownership)
             const candidate = resolution.candidate
             if (candidate.deletesDashboard) {
+                actions.setKnownOwnership(resolution.ownership)
                 router.actions.push(urls.dashboards())
                 return
             }
             if (candidate.family === 'subscription') {
                 subscriptionsLogic.findMounted({ dashboardId: props.dashboardId })?.actions.loadAllSubscriptions()
+                actions.setKnownOwnership(resolution.ownership)
                 return
             }
             if (candidate.family === 'alert') {
                 refreshMountedInsightAlerts(props.dashboardId, dashboard, candidate)
+                actions.setKnownOwnership(resolution.ownership)
                 return
             }
             actions.queueDashboardSync(candidate)
+            actions.setKnownOwnership(resolution.ownership)
         },
         queueDashboardSync: ({ candidate }) => {
             const batch = batchFromCandidate(candidate)

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
@@ -1077,7 +1077,7 @@ export const dashboardAiSyncLogic: LogicWrapper<dashboardAiSyncLogicType> = kea<
         syncDashboard: async ({ batch }) => {
             try {
                 await dashboardLogic({ id: props.dashboardId }).asyncActions.loadDashboard({
-                    action: DashboardLoadAction.Update,
+                    action: DashboardLoadAction.BackgroundUpdate,
                 })
 
                 const committedDashboard = dashboardLogic({ id: props.dashboardId }).values.dashboard

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
@@ -914,7 +914,11 @@ function resolveAlertMutation(
         }
     }
 
-    const priorInsight = learnedInsightId ? resolveTargetInsight(target, [learnedInsightId]) : null
+    // With no learned owner, the committed tiles still say which insight holds this alert, so a move
+    // away can refresh the insight losing it. The delete branch reads the same evidence.
+    const priorInsight = learnedInsightId
+        ? resolveTargetInsight(target, [learnedInsightId])
+        : targetInsightForAlertId(target, alertId)
     const postInsight = responseIdentity
         ? resolveTargetInsight(target, responseIdentity.identifiers)
         : requestInsightId === undefined

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
@@ -132,6 +132,7 @@ const DASHBOARD_RESPONSE_TOOLS = new Set([
 ])
 const TILE_CREATE_TOOLS = new Set(['dashboard-create-tile', 'dashboard-create-text-tile'])
 const BATCH_ADD_TOOLS = new Set(['dashboard-widgets-batch-add', 'dashboards-widgets-batch-create'])
+const COPY_TILE_TOOLS = new Set(['dashboard-tile-copy', 'dashboards-copy-tile-create'])
 
 function asRecord(value: unknown): Record<string, unknown> | null {
     return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null
@@ -448,6 +449,18 @@ function resolveDashboardMutation(
             }
         }
         return candidate('dashboard', target.dashboardId, returned.tileIds)
+    }
+
+    if (COPY_TILE_TOOLS.has(toolName)) {
+        // The copy response carries the whole destination dashboard, so the copied tile is the one
+        // tile the committed dashboard does not hold yet. A stale or reduced response can leave
+        // that ambiguous, and then the reload still runs but no tile is highlighted.
+        const returned = parseDashboardTileIds(output, requestedDashboardId)
+        const committedTileIds = new Set(target.tiles.map((tile) => tile.tileId))
+        const addedTileIds = returned.tileIds.filter((tileId) => !committedTileIds.has(tileId))
+        return returned.valid && addedTileIds.length === 1
+            ? candidate('dashboard', target.dashboardId, addedTileIds)
+            : candidate('dashboard', target.dashboardId)
     }
 
     if (toolName === 'dashboard-delete') {

--- a/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardAiSyncLogic.ts
@@ -1,0 +1,801 @@
+import { parseToolOutputRecord, resolveToolCall } from 'products/posthog_ai/frontend/api/logics'
+import type { ToolStreamEvent } from 'products/posthog_ai/frontend/types/streamTypes'
+
+export const DASHBOARD_AI_MUTATION_TOOLS = [
+    'alert-create',
+    'alert-delete',
+    'alert-update',
+    'dashboard-create-text-tile',
+    'dashboard-create-tile',
+    'dashboard-delete',
+    'dashboard-delete-tile',
+    'dashboard-reorder-tiles',
+    'dashboard-tile-copy',
+    'dashboard-update',
+    'dashboard-update-text-tile',
+    'dashboard-widgets-batch-add',
+    'dashboard-widgets-batch-update',
+    'dashboards-copy-tile-create',
+    'dashboards-move-tile-create',
+    'dashboards-move-tile-partial-update',
+    'dashboards-update',
+    'dashboards-widgets-batch-create',
+    'insight-create',
+    'insight-delete',
+    'insight-update',
+    'subscriptions-create',
+    'subscriptions-delete',
+    'subscriptions-partial-update',
+] as const
+
+export type DashboardAiToolFamily = 'dashboard' | 'insight' | 'subscription' | 'alert'
+
+export interface DashboardAiSyncCandidate {
+    family: DashboardAiToolFamily
+    dashboardId: number
+    tileIds: number[]
+    insightIds: Array<number | string>
+    deletesDashboard: boolean
+}
+
+export interface DashboardAiSyncTarget {
+    dashboardId: number
+    tiles: Array<{
+        tileId: number
+        insightId: number | null
+        insightShortId: string | null
+        alertIds: Array<number | string>
+    }>
+}
+
+export interface DashboardAiKnownOwnership {
+    subscriptionDashboardById: Record<number, number>
+    insightDashboardsById: Record<string, number[]>
+    alertInsightById: Record<string, string>
+}
+
+export interface DashboardAiMutationResolution {
+    candidate: DashboardAiSyncCandidate | null
+    ownership: DashboardAiKnownOwnership
+}
+
+type InsightIdentifier = number | string
+
+interface DashboardEvidence {
+    valid: boolean
+    dashboardId: number | null
+}
+
+interface InsightIdentity {
+    numericId: number | null
+    shortId: string | null
+    identifiers: InsightIdentifier[]
+}
+
+interface TargetInsight {
+    tileId: number
+    numericId: number | null
+    shortId: string | null
+}
+
+const DASHBOARD_TOOLS = new Set<string>([
+    'dashboard-update',
+    'dashboard-create-tile',
+    'dashboard-create-text-tile',
+    'dashboard-update-text-tile',
+    'dashboard-delete-tile',
+    'dashboard-reorder-tiles',
+    'dashboard-tile-copy',
+    'dashboard-widgets-batch-add',
+    'dashboard-widgets-batch-update',
+    'dashboards-widgets-batch-create',
+    'dashboards-copy-tile-create',
+    'dashboards-move-tile-create',
+    'dashboards-move-tile-partial-update',
+    'dashboards-update',
+    'dashboard-delete',
+])
+const MOVE_TOOLS = new Set(['dashboards-move-tile-create', 'dashboards-move-tile-partial-update'])
+const DASHBOARD_RESPONSE_TOOLS = new Set([
+    'dashboard-update',
+    'dashboards-update',
+    'dashboard-reorder-tiles',
+    'dashboard-tile-copy',
+    'dashboards-copy-tile-create',
+    'dashboard-delete',
+])
+const TILE_CREATE_TOOLS = new Set(['dashboard-create-tile', 'dashboard-create-text-tile'])
+const BATCH_ADD_TOOLS = new Set(['dashboard-widgets-batch-add', 'dashboards-widgets-batch-create'])
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null
+}
+
+function asRecordArray(value: unknown): Record<string, unknown>[] | null {
+    if (!Array.isArray(value)) {
+        return null
+    }
+    const records = value.map(asRecord)
+    return records.every((record): record is Record<string, unknown> => record !== null) ? records : null
+}
+
+function asPositiveSafeInteger(value: unknown): number | null {
+    const parsed = typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : value
+    return typeof parsed === 'number' && Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+function asNonEmptyString(value: unknown): string | null {
+    return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function asResourceKey(value: unknown): string | null {
+    const numericId = asPositiveSafeInteger(value)
+    if (numericId !== null) {
+        return String(numericId)
+    }
+    return asNonEmptyString(value)
+}
+
+function asInsightIdentifier(value: unknown): InsightIdentifier | null {
+    const numericId = asPositiveSafeInteger(value)
+    return numericId ?? asNonEmptyString(value)
+}
+
+function getAgreedPositiveSafeInteger(
+    record: Record<string, unknown>,
+    keys: readonly string[]
+): number | null | undefined {
+    const present = keys.filter((key) => Object.prototype.hasOwnProperty.call(record, key))
+    if (present.length === 0) {
+        return undefined
+    }
+    const values = present.map((key) => asPositiveSafeInteger(record[key]))
+    if (values.some((value) => value === null)) {
+        return null
+    }
+    return values.every((value) => value === values[0]) ? values[0]! : null
+}
+
+function getAgreedResourceKey(record: Record<string, unknown>, keys: readonly string[]): string | null | undefined {
+    const present = keys.filter((key) => Object.prototype.hasOwnProperty.call(record, key))
+    if (present.length === 0) {
+        return undefined
+    }
+    const values = present.map((key) => asResourceKey(record[key]))
+    if (values.some((value) => value === null)) {
+        return null
+    }
+    return values.every((value) => value === values[0]) ? values[0]! : null
+}
+
+function getAgreedInsightIdentifier(
+    record: Record<string, unknown>,
+    keys: readonly string[]
+): InsightIdentifier | null | undefined {
+    const present = keys.filter((key) => Object.prototype.hasOwnProperty.call(record, key))
+    if (present.length === 0) {
+        return undefined
+    }
+    const values = present.map((key) => asInsightIdentifier(record[key]))
+    if (values.some((value) => value === null)) {
+        return null
+    }
+    return values.every((value) => value === values[0]) ? values[0]! : null
+}
+
+function sortedUniqueNumbers(values: number[]): number[] {
+    return [...new Set(values)].sort((a, b) => a - b)
+}
+
+function sortedUniqueInsightIds(values: InsightIdentifier[]): InsightIdentifier[] {
+    return [...new Set(values)].sort((a, b) => {
+        if (typeof a === 'number' && typeof b === 'string') {
+            return -1
+        }
+        if (typeof a === 'string' && typeof b === 'number') {
+            return 1
+        }
+        return typeof a === 'number' && typeof b === 'number' ? a - b : String(a).localeCompare(String(b))
+    })
+}
+
+function candidate(
+    family: DashboardAiToolFamily,
+    dashboardId: number,
+    tileIds: number[] = [],
+    insightIds: InsightIdentifier[] = [],
+    deletesDashboard = false
+): DashboardAiSyncCandidate {
+    return {
+        family,
+        dashboardId,
+        tileIds: sortedUniqueNumbers(tileIds),
+        insightIds: sortedUniqueInsightIds(insightIds),
+        deletesDashboard,
+    }
+}
+
+function dashboardIdFromUrl(value: unknown): number | null {
+    if (typeof value !== 'string') {
+        return null
+    }
+    try {
+        const url = new URL(value)
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+            return null
+        }
+        const match = /^\/project\/(\d+)\/dashboard\/(\d+)\/?$/.exec(url.pathname)
+        if (!match || asPositiveSafeInteger(match[1]) === null) {
+            return null
+        }
+        return asPositiveSafeInteger(match[2])
+    } catch {
+        return null
+    }
+}
+
+function collectDashboardEvidence(
+    output: Record<string, unknown>,
+    responseIdIsDashboardId: boolean
+): DashboardEvidence {
+    const evidence: number[] = []
+    const directKeys = responseIdIsDashboardId ? ['id', 'dashboard_id', 'dashboardId'] : ['dashboard_id', 'dashboardId']
+    const direct = getAgreedPositiveSafeInteger(output, directKeys)
+    if (direct === null) {
+        return { valid: false, dashboardId: null }
+    }
+    if (direct !== undefined) {
+        evidence.push(direct)
+    }
+
+    if (Object.prototype.hasOwnProperty.call(output, 'dashboard')) {
+        const nested = asRecord(output.dashboard)
+        const nestedId = nested ? getAgreedPositiveSafeInteger(nested, ['id']) : asPositiveSafeInteger(output.dashboard)
+        if (nestedId === null || nestedId === undefined) {
+            return { valid: false, dashboardId: null }
+        }
+        evidence.push(nestedId)
+    }
+
+    if (Object.prototype.hasOwnProperty.call(output, '_posthogUrl')) {
+        const urlId = dashboardIdFromUrl(output._posthogUrl)
+        if (urlId === null) {
+            return { valid: false, dashboardId: null }
+        }
+        evidence.push(urlId)
+    }
+
+    if (evidence.length === 0 || !evidence.every((id) => id === evidence[0])) {
+        return { valid: false, dashboardId: null }
+    }
+    return { valid: true, dashboardId: evidence[0]! }
+}
+
+function parseDashboardTileIds(
+    output: Record<string, unknown>,
+    expectedDashboardId: number
+): { valid: boolean; tileIds: number[] } {
+    const tiles = asRecordArray(output.tiles)
+    if (!tiles) {
+        return { valid: false, tileIds: [] }
+    }
+    const tileIds: number[] = []
+    for (const tile of tiles) {
+        const tileId = getAgreedPositiveSafeInteger(tile, ['id', 'tile_id', 'tileId'])
+        const tileDashboardId = getAgreedPositiveSafeInteger(tile, ['dashboard_id', 'dashboardId'])
+        if (tileId === null || tileId === undefined || tileDashboardId === null) {
+            return { valid: false, tileIds: [] }
+        }
+        if (tileDashboardId !== undefined && tileDashboardId !== expectedDashboardId) {
+            return { valid: false, tileIds: [] }
+        }
+        tileIds.push(tileId)
+    }
+    return { valid: true, tileIds }
+}
+
+function resolveDashboardMutation(
+    target: DashboardAiSyncTarget,
+    toolName: string,
+    input: Record<string, unknown>,
+    output: Record<string, unknown>
+): DashboardAiSyncCandidate | null {
+    const requestedDashboardId = getAgreedPositiveSafeInteger(input, ['id', 'dashboard_id', 'dashboardId'])
+    if (requestedDashboardId === null || requestedDashboardId === undefined) {
+        return null
+    }
+
+    if (MOVE_TOOLS.has(toolName)) {
+        const destinationDashboardId = getAgreedPositiveSafeInteger(input, ['to_dashboard', 'toDashboard'])
+        const tile = asRecord(input.tile)
+        const tileId = tile ? getAgreedPositiveSafeInteger(tile, ['id', 'tile_id', 'tileId']) : null
+        const evidence = collectDashboardEvidence(output, true)
+        if (
+            destinationDashboardId === null ||
+            destinationDashboardId === undefined ||
+            tileId === null ||
+            tileId === undefined ||
+            !evidence.valid ||
+            ![requestedDashboardId, destinationDashboardId].includes(evidence.dashboardId!) ||
+            ![requestedDashboardId, destinationDashboardId].includes(target.dashboardId)
+        ) {
+            return null
+        }
+        return candidate('dashboard', target.dashboardId, [tileId])
+    }
+
+    if (requestedDashboardId !== target.dashboardId) {
+        return null
+    }
+
+    const responseIdIsDashboardId = DASHBOARD_RESPONSE_TOOLS.has(toolName)
+    const evidence = collectDashboardEvidence(output, responseIdIsDashboardId)
+    if (!evidence.valid || evidence.dashboardId !== requestedDashboardId) {
+        return null
+    }
+
+    if (TILE_CREATE_TOOLS.has(toolName)) {
+        const tileId = getAgreedPositiveSafeInteger(output, ['id', 'tile_id', 'tileId'])
+        return tileId === null || tileId === undefined ? null : candidate('dashboard', target.dashboardId, [tileId])
+    }
+
+    if (toolName === 'dashboard-update-text-tile') {
+        const requestedTileId = getAgreedPositiveSafeInteger(input, ['tile_id', 'tileId'])
+        const responseTileId = getAgreedPositiveSafeInteger(output, ['id', 'tile_id', 'tileId'])
+        return requestedTileId === null ||
+            requestedTileId === undefined ||
+            responseTileId === null ||
+            responseTileId === undefined ||
+            requestedTileId !== responseTileId
+            ? null
+            : candidate('dashboard', target.dashboardId, [responseTileId])
+    }
+
+    if (toolName === 'dashboard-delete-tile') {
+        const tileId = getAgreedPositiveSafeInteger(input, ['tile_id', 'tileId'])
+        return tileId === null || tileId === undefined ? null : candidate('dashboard', target.dashboardId, [tileId])
+    }
+
+    if (toolName === 'dashboard-reorder-tiles') {
+        if (!Array.isArray(input.tile_order) || input.tile_order.length === 0) {
+            return null
+        }
+        const requestedTileIds = input.tile_order.map(asPositiveSafeInteger)
+        const returned = parseDashboardTileIds(output, requestedDashboardId)
+        if (
+            requestedTileIds.some((id) => id === null) ||
+            !returned.valid ||
+            requestedTileIds.length !== returned.tileIds.length ||
+            requestedTileIds.some((id, index) => id !== returned.tileIds[index])
+        ) {
+            return null
+        }
+        return candidate('dashboard', target.dashboardId, requestedTileIds as number[])
+    }
+
+    if (BATCH_ADD_TOOLS.has(toolName) || toolName === 'dashboard-widgets-batch-update') {
+        const requestedWidgets = asRecordArray(input.widgets)
+        const returned = parseDashboardTileIds(output, requestedDashboardId)
+        if (
+            !requestedWidgets ||
+            requestedWidgets.length === 0 ||
+            !returned.valid ||
+            requestedWidgets.length !== returned.tileIds.length
+        ) {
+            return null
+        }
+        if (toolName === 'dashboard-widgets-batch-update') {
+            const requestedTileIds = requestedWidgets.map((widget) =>
+                getAgreedPositiveSafeInteger(widget, ['tile_id', 'tileId'])
+            )
+            if (
+                requestedTileIds.some((id) => id === null || id === undefined) ||
+                requestedTileIds.some((id, index) => id !== returned.tileIds[index])
+            ) {
+                return null
+            }
+        }
+        return candidate('dashboard', target.dashboardId, returned.tileIds)
+    }
+
+    if (toolName === 'dashboard-delete') {
+        return candidate('dashboard', target.dashboardId, [], [], true)
+    }
+
+    return candidate('dashboard', target.dashboardId)
+}
+
+function parseOutputInsightIdentity(output: Record<string, unknown>): InsightIdentity | null {
+    const hasNumericId = Object.prototype.hasOwnProperty.call(output, 'id')
+    const hasShortId = Object.prototype.hasOwnProperty.call(output, 'short_id')
+    const numericId = hasNumericId ? asPositiveSafeInteger(output.id) : null
+    const shortId = hasShortId ? asNonEmptyString(output.short_id) : null
+    if ((hasNumericId && numericId === null) || (hasShortId && shortId === null) || (!hasNumericId && !hasShortId)) {
+        return null
+    }
+    return {
+        numericId,
+        shortId,
+        identifiers: sortedUniqueInsightIds([
+            ...(numericId === null ? [] : [numericId]),
+            ...(shortId === null ? [] : [shortId]),
+        ]),
+    }
+}
+
+function tileMatchesIdentifier(tile: DashboardAiSyncTarget['tiles'][number], identifier: InsightIdentifier): boolean {
+    return typeof identifier === 'number' ? tile.insightId === identifier : tile.insightShortId === identifier
+}
+
+function resolveTargetInsight(target: DashboardAiSyncTarget, identifiers: InsightIdentifier[]): TargetInsight | null {
+    if (identifiers.length === 0) {
+        return null
+    }
+    let matchedTile: DashboardAiSyncTarget['tiles'][number] | null = null
+    for (const identifier of identifiers) {
+        const matches = target.tiles.filter((tile) => tileMatchesIdentifier(tile, identifier))
+        if (matches.length !== 1 || (matchedTile && matchedTile.tileId !== matches[0].tileId)) {
+            return null
+        }
+        matchedTile = matches[0]
+    }
+    return matchedTile
+        ? { tileId: matchedTile.tileId, numericId: matchedTile.insightId, shortId: matchedTile.insightShortId }
+        : null
+}
+
+function identifiersForTargetInsight(insight: TargetInsight): InsightIdentifier[] {
+    return sortedUniqueInsightIds([
+        ...(insight.numericId === null ? [] : [insight.numericId]),
+        ...(insight.shortId === null ? [] : [insight.shortId]),
+    ])
+}
+
+function identitiesAgreeWithTarget(
+    target: DashboardAiSyncTarget,
+    identity: InsightIdentity,
+    requestIdentifier?: InsightIdentifier
+): boolean {
+    const outputMatches = identity.identifiers.flatMap((identifier) =>
+        target.tiles.filter((tile) => tileMatchesIdentifier(tile, identifier))
+    )
+    if (outputMatches.length > 0 && !resolveTargetInsight(target, identity.identifiers)) {
+        return false
+    }
+    if (requestIdentifier === undefined) {
+        return true
+    }
+    if (identity.identifiers.includes(requestIdentifier)) {
+        return true
+    }
+    const requestTarget = resolveTargetInsight(target, [requestIdentifier])
+    const responseTarget = resolveTargetInsight(target, identity.identifiers)
+    return requestTarget !== null && responseTarget !== null && requestTarget.tileId === responseTarget.tileId
+}
+
+function parseAuthoritativeDashboardTiles(
+    output: Record<string, unknown>
+): Array<{ tileId: number; dashboardId: number }> | null {
+    const records = asRecordArray(output.dashboard_tiles)
+    if (!records || records.length === 0) {
+        return null
+    }
+    const activeTiles: Array<{ tileId: number; dashboardId: number }> = []
+    for (const record of records) {
+        const tileId = getAgreedPositiveSafeInteger(record, ['id'])
+        const dashboardId = getAgreedPositiveSafeInteger(record, ['dashboard_id', 'dashboardId'])
+        if (
+            tileId === null ||
+            tileId === undefined ||
+            dashboardId === null ||
+            dashboardId === undefined ||
+            !Object.prototype.hasOwnProperty.call(record, 'deleted') ||
+            ![true, false, null].includes(record.deleted as boolean | null)
+        ) {
+            return null
+        }
+        if (record.deleted === false || record.deleted === null) {
+            activeTiles.push({ tileId, dashboardId })
+        }
+    }
+    return activeTiles
+}
+
+function requestDashboardMembership(input: Record<string, unknown>): number[] | null | undefined {
+    if (!Object.prototype.hasOwnProperty.call(input, 'dashboards')) {
+        return undefined
+    }
+    if (!Array.isArray(input.dashboards)) {
+        return null
+    }
+    const ids = input.dashboards.map(asPositiveSafeInteger)
+    return ids.some((id) => id === null) ? null : sortedUniqueNumbers(ids as number[])
+}
+
+function learnInsightOwnership(
+    knownOwnership: DashboardAiKnownOwnership,
+    identity: InsightIdentity,
+    dashboardIds: number[]
+): DashboardAiKnownOwnership {
+    const insightDashboardsById = { ...knownOwnership.insightDashboardsById }
+    for (const identifier of identity.identifiers) {
+        insightDashboardsById[String(identifier)] = sortedUniqueNumbers(dashboardIds)
+    }
+    return { ...knownOwnership, insightDashboardsById }
+}
+
+function resolveInsightMutation(
+    target: DashboardAiSyncTarget,
+    knownOwnership: DashboardAiKnownOwnership,
+    toolName: string,
+    input: Record<string, unknown>,
+    output: Record<string, unknown>
+): DashboardAiMutationResolution {
+    const identity = parseOutputInsightIdentity(output)
+    if (!identity) {
+        return { candidate: null, ownership: knownOwnership }
+    }
+    const requestIdentifier = getAgreedInsightIdentifier(input, [
+        'id',
+        'insight_id',
+        'insightId',
+        'short_id',
+        'shortId',
+    ])
+    if (requestIdentifier === null || !identitiesAgreeWithTarget(target, identity, requestIdentifier)) {
+        return { candidate: null, ownership: knownOwnership }
+    }
+
+    if (toolName === 'insight-create' || toolName === 'insight-update') {
+        if (toolName === 'insight-update' && requestIdentifier === undefined) {
+            return { candidate: null, ownership: knownOwnership }
+        }
+        const requestedDashboards = requestDashboardMembership(input)
+        const responseTiles = parseAuthoritativeDashboardTiles(output)
+        if (
+            requestedDashboards === null ||
+            (requestedDashboards !== undefined && !requestedDashboards.includes(target.dashboardId)) ||
+            !responseTiles
+        ) {
+            return { candidate: null, ownership: knownOwnership }
+        }
+        const matchingTiles = responseTiles.filter((tile) => tile.dashboardId === target.dashboardId)
+        if (matchingTiles.length !== 1) {
+            return { candidate: null, ownership: knownOwnership }
+        }
+        const dashboardIds = sortedUniqueNumbers(responseTiles.map((tile) => tile.dashboardId))
+        return {
+            candidate: candidate('insight', target.dashboardId, [matchingTiles[0].tileId], identity.identifiers),
+            ownership: learnInsightOwnership(knownOwnership, identity, dashboardIds),
+        }
+    }
+
+    if (requestIdentifier === undefined) {
+        return { candidate: null, ownership: knownOwnership }
+    }
+    const currentTarget = resolveTargetInsight(target, identity.identifiers)
+    const identifiers = currentTarget ? identifiersForTargetInsight(currentTarget) : identity.identifiers
+    const isKnownOnDashboard = identifiers.some((identifier) =>
+        knownOwnership.insightDashboardsById[String(identifier)]?.includes(target.dashboardId)
+    )
+    if (!currentTarget && !isKnownOnDashboard) {
+        return { candidate: null, ownership: knownOwnership }
+    }
+    const insightDashboardsById = { ...knownOwnership.insightDashboardsById }
+    for (const identifier of identifiers) {
+        delete insightDashboardsById[String(identifier)]
+    }
+    return {
+        candidate: candidate('insight', target.dashboardId, currentTarget ? [currentTarget.tileId] : [], identifiers),
+        ownership: { ...knownOwnership, insightDashboardsById },
+    }
+}
+
+function resolveSubscriptionMutation(
+    target: DashboardAiSyncTarget,
+    knownOwnership: DashboardAiKnownOwnership,
+    toolName: string,
+    input: Record<string, unknown>,
+    output: Record<string, unknown>
+): DashboardAiMutationResolution {
+    const requestId = getAgreedPositiveSafeInteger(input, ['id', 'subscription_id', 'subscriptionId'])
+    const outputId = getAgreedPositiveSafeInteger(output, ['id', 'subscription_id', 'subscriptionId'])
+    const subscriptionId = toolName === 'subscriptions-create' ? outputId : requestId
+    if (
+        subscriptionId === null ||
+        subscriptionId === undefined ||
+        outputId === null ||
+        (outputId !== undefined && outputId !== subscriptionId)
+    ) {
+        return { candidate: null, ownership: knownOwnership }
+    }
+
+    const requestDashboardId = getAgreedPositiveSafeInteger(input, ['dashboard', 'dashboard_id', 'dashboardId'])
+    const outputDashboardId = getAgreedPositiveSafeInteger(output, ['dashboard', 'dashboard_id', 'dashboardId'])
+    if (
+        requestDashboardId === null ||
+        outputDashboardId === null ||
+        (requestDashboardId !== undefined &&
+            outputDashboardId !== undefined &&
+            requestDashboardId !== outputDashboardId)
+    ) {
+        return { candidate: null, ownership: knownOwnership }
+    }
+    const knownDashboardId = knownOwnership.subscriptionDashboardById[subscriptionId]
+    if (knownDashboardId !== undefined && outputDashboardId !== undefined && knownDashboardId !== outputDashboardId) {
+        return { candidate: null, ownership: knownOwnership }
+    }
+    const ownedDashboardId = outputDashboardId ?? knownDashboardId
+    if (
+        ownedDashboardId === undefined ||
+        ownedDashboardId !== target.dashboardId ||
+        (toolName === 'subscriptions-create' && requestDashboardId !== ownedDashboardId)
+    ) {
+        return { candidate: null, ownership: knownOwnership }
+    }
+
+    const subscriptionDashboardById = { ...knownOwnership.subscriptionDashboardById }
+    if (toolName === 'subscriptions-delete') {
+        delete subscriptionDashboardById[subscriptionId]
+    } else {
+        subscriptionDashboardById[subscriptionId] = ownedDashboardId
+    }
+    return {
+        candidate: candidate('subscription', target.dashboardId),
+        ownership: { ...knownOwnership, subscriptionDashboardById },
+    }
+}
+
+function targetInsightForAlertId(target: DashboardAiSyncTarget, alertId: string): TargetInsight | null {
+    const matchingTiles = target.tiles.filter((tile) => tile.alertIds.some((id) => asResourceKey(id) === alertId))
+    if (matchingTiles.length !== 1) {
+        return null
+    }
+    const tile = matchingTiles[0]
+    return { tileId: tile.tileId, numericId: tile.insightId, shortId: tile.insightShortId }
+}
+
+function alertInsightIdentity(output: Record<string, unknown>): InsightIdentity | null | undefined {
+    const hasNumericId = Object.prototype.hasOwnProperty.call(output, 'insight')
+    const hasShortId = Object.prototype.hasOwnProperty.call(output, 'insight_short_id')
+    if (!hasNumericId && !hasShortId) {
+        return undefined
+    }
+    const numericId = hasNumericId ? asPositiveSafeInteger(output.insight) : null
+    const shortId = hasShortId ? asNonEmptyString(output.insight_short_id) : null
+    if ((hasNumericId && numericId === null) || (hasShortId && shortId === null)) {
+        return null
+    }
+    return {
+        numericId,
+        shortId,
+        identifiers: sortedUniqueInsightIds([
+            ...(numericId === null ? [] : [numericId]),
+            ...(shortId === null ? [] : [shortId]),
+        ]),
+    }
+}
+
+function resolveAlertMutation(
+    target: DashboardAiSyncTarget,
+    knownOwnership: DashboardAiKnownOwnership,
+    toolName: string,
+    input: Record<string, unknown>,
+    output: Record<string, unknown>
+): DashboardAiMutationResolution {
+    const requestAlertId = getAgreedResourceKey(input, ['id', 'alert_id', 'alertId'])
+    const outputAlertId = getAgreedResourceKey(output, ['id', 'alert_id', 'alertId'])
+    const alertId = toolName === 'alert-create' ? outputAlertId : requestAlertId
+    if (
+        alertId === null ||
+        alertId === undefined ||
+        outputAlertId === null ||
+        (outputAlertId !== undefined && outputAlertId !== alertId)
+    ) {
+        return { candidate: null, ownership: knownOwnership }
+    }
+
+    const requestInsightId = getAgreedInsightIdentifier(input, ['insight', 'insight_id', 'insightId'])
+    const responseIdentity = alertInsightIdentity(output)
+    if (requestInsightId === null || responseIdentity === null) {
+        return { candidate: null, ownership: knownOwnership }
+    }
+
+    const learnedInsightKey = knownOwnership.alertInsightById[alertId]
+    const evidence: InsightIdentifier[] = [
+        ...(requestInsightId === undefined ? [] : [requestInsightId]),
+        ...(responseIdentity === undefined ? [] : responseIdentity.identifiers),
+        ...(learnedInsightKey === undefined ? [] : [asInsightIdentifier(learnedInsightKey)!]),
+    ]
+    let ownedInsight = resolveTargetInsight(target, evidence)
+    if (!ownedInsight && toolName === 'alert-delete' && evidence.length === 0) {
+        ownedInsight = targetInsightForAlertId(target, alertId)
+    }
+    if (!ownedInsight) {
+        return { candidate: null, ownership: knownOwnership }
+    }
+
+    const alertInsightById = { ...knownOwnership.alertInsightById }
+    const canonicalInsightKey = ownedInsight.numericId === null ? ownedInsight.shortId : String(ownedInsight.numericId)
+    if (!canonicalInsightKey) {
+        return { candidate: null, ownership: knownOwnership }
+    }
+    if (toolName === 'alert-delete') {
+        const owningTile = target.tiles.find((tile) => tile.tileId === ownedInsight!.tileId)
+        for (const currentAlertId of owningTile?.alertIds ?? []) {
+            const currentAlertKey = asResourceKey(currentAlertId)
+            if (currentAlertKey) {
+                alertInsightById[currentAlertKey] = canonicalInsightKey
+            }
+        }
+        delete alertInsightById[alertId]
+    } else {
+        alertInsightById[alertId] = canonicalInsightKey
+    }
+    return {
+        candidate: candidate(
+            'alert',
+            target.dashboardId,
+            [ownedInsight.tileId],
+            identifiersForTargetInsight(ownedInsight)
+        ),
+        ownership: { ...knownOwnership, alertInsightById },
+    }
+}
+
+export function resolveDashboardAiMutation(
+    target: DashboardAiSyncTarget,
+    knownOwnership: DashboardAiKnownOwnership,
+    event: ToolStreamEvent,
+    innerInput: Record<string, unknown> | null
+): DashboardAiMutationResolution {
+    if (event.phase !== 'completed' || event.invocation.status !== 'completed' || !innerInput) {
+        return { candidate: null, ownership: knownOwnership }
+    }
+    const resolved = resolveToolCall(event.invocation)
+    if (resolved.innerToolName !== event.toolName) {
+        return { candidate: null, ownership: knownOwnership }
+    }
+    const parsedOutput = parseToolOutputRecord(event.invocation.output, event.invocation.input)
+    const hasEmptyAlertDeleteOutput =
+        event.toolName === 'alert-delete' &&
+        (event.invocation.output === null ||
+            event.invocation.output === undefined ||
+            (typeof event.invocation.output === 'string' && !event.invocation.output.trim()))
+    if (!parsedOutput && !hasEmptyAlertDeleteOutput) {
+        return { candidate: null, ownership: knownOwnership }
+    }
+    const output = parsedOutput ?? {}
+    if (
+        ['dashboard-delete', 'insight-delete', 'subscriptions-delete', 'alert-delete'].includes(event.toolName) &&
+        Object.prototype.hasOwnProperty.call(output, 'deleted') &&
+        output.deleted !== true
+    ) {
+        return { candidate: null, ownership: knownOwnership }
+    }
+
+    if (DASHBOARD_TOOLS.has(event.toolName)) {
+        return {
+            candidate: resolveDashboardMutation(target, event.toolName, innerInput, output),
+            ownership: knownOwnership,
+        }
+    }
+    if (
+        event.toolName === 'insight-create' ||
+        event.toolName === 'insight-update' ||
+        event.toolName === 'insight-delete'
+    ) {
+        return resolveInsightMutation(target, knownOwnership, event.toolName, innerInput, output)
+    }
+    if (
+        event.toolName === 'subscriptions-create' ||
+        event.toolName === 'subscriptions-partial-update' ||
+        event.toolName === 'subscriptions-delete'
+    ) {
+        return resolveSubscriptionMutation(target, knownOwnership, event.toolName, innerInput, output)
+    }
+    if (event.toolName === 'alert-create' || event.toolName === 'alert-update' || event.toolName === 'alert-delete') {
+        return resolveAlertMutation(target, knownOwnership, event.toolName, innerInput, output)
+    }
+    return { candidate: null, ownership: knownOwnership }
+}

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -2,6 +2,7 @@
 import { MOCK_TEAM_ID } from 'lib/api.mock'
 
 import { waitFor } from '@testing-library/react'
+import { getContext } from 'kea'
 import { router } from 'kea-router'
 import { expectLogic, truth } from 'kea-test-utils'
 
@@ -43,7 +44,9 @@ import {
 } from '~/types'
 
 import { DashboardGridCompaction } from 'products/dashboards/frontend/dashboardCustomization'
+import type { ToolStreamEvent } from 'products/posthog_ai/frontend/types/streamTypes'
 
+import { dashboardAiSyncLogic } from './dashboardAiSyncLogic'
 import { dashboardResult, insightOnDashboard, tileFromInsight } from './dashboardLogic.testHelpers'
 
 const TEXT_TILE: DashboardTile<QueryBasedInsightModel> = {
@@ -89,6 +92,24 @@ function deferred<T>(): {
 
 const responseFor = (dashboard: DashboardType<QueryBasedInsightModel>): Response =>
     new Response(JSON.stringify(dashboard), { status: 200, headers: { 'Content-Type': 'application/json' } })
+
+const dashboardToolEvent = (toolName: string, input: Record<string, unknown>, output: unknown): ToolStreamEvent => ({
+    streamKey: 'dashboard-load-test',
+    toolCallId: 'dashboard-load-test-call',
+    toolName,
+    rawToolName: 'exec',
+    phase: 'completed',
+    source: 'live',
+    invocation: {
+        toolCallId: 'dashboard-load-test-call',
+        rawServerName: 'posthog',
+        rawToolName: 'exec',
+        input: { command: `call --json ${toolName} ${JSON.stringify(input)}` },
+        output,
+        status: 'completed',
+        contentBlocks: [],
+    },
+})
 
 export const boxToId = (param: string | readonly string[]): number => {
     //path params from msw can be a string or an array
@@ -3008,6 +3029,85 @@ describe('dashboardLogic', () => {
             expect(logic.values.accessDeniedToDashboard).toBe(false)
             expect(logic.values.error404).toBe(false)
             expect(logic.values.dashboardFailedToLoad).toBe(false)
+        })
+
+        it('preserves the committed dashboard when an AI background reload fails', async () => {
+            logic = dashboardLogic({ id: 12, dashboard: dashboards[12] })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+            const committedDashboard = logic.values.dashboard
+            getResponseSpy.mockClear()
+            getResponseSpy.mockRejectedValueOnce(new Error('AI background reload failed'))
+            const syncLogic = dashboardAiSyncLogic({ dashboardId: 12 })
+            syncLogic.mount()
+            const failureStates: boolean[] = []
+            const unsubscribe = getContext().store.subscribe(() => {
+                failureStates.push(logic.values.dashboardFailedToLoad)
+            })
+
+            syncLogic.actions.applyToolCompletion(dashboardToolEvent('dashboard-update', { id: 12 }, { id: 12 }), {
+                id: 12,
+            })
+            await expectLogic(syncLogic).toFinishAllListeners()
+
+            expect(logic.values.dashboard).toBe(committedDashboard)
+            expect(logic.values.dashboardFailedToLoad).toBe(false)
+            expect(failureStates).not.toContain(true)
+            unsubscribe()
+            syncLogic.unmount()
+        })
+
+        it('preserves the committed dashboard while a queued AI reload follows a failure', async () => {
+            logic = dashboardLogic({ id: 12, dashboard: dashboards[12] })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+            const committedDashboard = logic.values.dashboard
+            getResponseSpy.mockClear()
+            const firstReload = deferred<Response>()
+            const successorReload = deferred<Response>()
+            getResponseSpy.mockReturnValueOnce(firstReload.promise).mockReturnValueOnce(successorReload.promise)
+            const syncLogic = dashboardAiSyncLogic({ dashboardId: 12 })
+            syncLogic.mount()
+            const failureStates: boolean[] = []
+            const unsubscribe = getContext().store.subscribe(() => {
+                failureStates.push(logic.values.dashboardFailedToLoad)
+            })
+
+            syncLogic.actions.applyToolCompletion(dashboardToolEvent('dashboard-update', { id: 12 }, { id: 12 }), {
+                id: 12,
+            })
+            await waitFor(() => expect(getResponseSpy).toHaveBeenCalledTimes(1))
+            syncLogic.actions.applyToolCompletion(dashboardToolEvent('dashboard-update', { id: 12 }, { id: 12 }), {
+                id: 12,
+            })
+            firstReload.reject(new Error('AI background reload failed'))
+
+            await waitFor(() => expect(getResponseSpy).toHaveBeenCalledTimes(2))
+            expect(logic.values.dashboard).toBe(committedDashboard)
+            expect(logic.values.dashboardFailedToLoad).toBe(false)
+
+            successorReload.resolve(responseFor({ ...dashboards[12], name: 'successor' }))
+            await waitFor(() => expect(syncLogic.values.activeBatch).toBeNull())
+            expect(logic.values.dashboard?.name).toBe('successor')
+            expect(logic.values.dashboardFailedToLoad).toBe(false)
+            expect(failureStates).not.toContain(true)
+            unsubscribe()
+            syncLogic.unmount()
+        })
+
+        it('still surfaces a failed ordinary update over a committed dashboard', async () => {
+            logic = dashboardLogic({ id: 12, dashboard: dashboards[12] })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+            const committedDashboard = logic.values.dashboard
+            getResponseSpy.mockClear()
+            getResponseSpy.mockRejectedValueOnce(new Error('ordinary reload failed'))
+
+            logic.actions.loadDashboard({ action: DashboardLoadAction.Update })
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.dashboard).toBe(committedDashboard)
+            expect(logic.values.dashboardFailedToLoad).toBe(true)
         })
     })
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -1,6 +1,7 @@
 // let tiles assert an insight is present in tests i.e. `tile!.insight` when it must be present for tests to pass
 import { MOCK_TEAM_ID } from 'lib/api.mock'
 
+import { waitFor } from '@testing-library/react'
 import { router } from 'kea-router'
 import { expectLogic, truth } from 'kea-test-utils'
 
@@ -71,6 +72,23 @@ const uncached = (insight: QueryBasedInsightModel): QueryBasedInsightModel => ({
     result: null,
     last_refresh: null,
 })
+
+function deferred<T>(): {
+    promise: Promise<T>
+    resolve: (value: T) => void
+    reject: (reason: unknown) => void
+} {
+    let resolve!: (value: T) => void
+    let reject!: (reason: unknown) => void
+    const promise = new Promise<T>((promiseResolve, promiseReject) => {
+        resolve = promiseResolve
+        reject = promiseReject
+    })
+    return { promise, resolve, reject }
+}
+
+const responseFor = (dashboard: DashboardType<QueryBasedInsightModel>): Response =>
+    new Response(JSON.stringify(dashboard), { status: 200, headers: { 'Content-Type': 'application/json' } })
 
 export const boxToId = (param: string | readonly string[]): number => {
     //path params from msw can be a string or an array
@@ -2920,6 +2938,76 @@ describe('dashboardLogic', () => {
                 })
             }).toFinishAllListeners()
             expect(loadDashboardSpy).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('loadDashboard request ownership', () => {
+        let getResponseSpy: jest.SpiedFunction<typeof api.getResponse>
+
+        beforeEach(() => {
+            silenceKeaLoadersErrors()
+            getResponseSpy = jest.spyOn(api, 'getResponse')
+        })
+        afterEach(() => {
+            getResponseSpy.mockRestore()
+            resumeKeaLoadersErrors()
+        })
+
+        it('ignores a superseded successful response', async () => {
+            logic = dashboardLogic({ id: 12, dashboard: dashboards[12] })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+            getResponseSpy.mockClear()
+
+            const first = deferred<Response>()
+            const second = deferred<Response>()
+            getResponseSpy.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+
+            logic.actions.loadDashboard({ action: DashboardLoadAction.Update })
+            await waitFor(() => expect(getResponseSpy).toHaveBeenCalledTimes(1))
+
+            logic.actions.loadDashboard({ action: DashboardLoadAction.Update })
+            await waitFor(() => expect(getResponseSpy).toHaveBeenCalledTimes(2))
+
+            second.resolve(responseFor({ ...dashboards[12], name: 'new' }))
+            await waitFor(() => expect(logic.values.dashboard?.name).toBe('new'))
+
+            first.resolve(responseFor({ ...dashboards[12], name: 'old' }))
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.dashboard?.name).toBe('new')
+        })
+
+        it.each([403, 404])('ignores a superseded %i response', async (status) => {
+            logic = dashboardLogic({ id: 12, dashboard: dashboards[12] })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+            getResponseSpy.mockClear()
+
+            const first = deferred<Response>()
+            const second = deferred<Response>()
+            getResponseSpy.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+
+            logic.actions.loadDashboard({ action: DashboardLoadAction.Update })
+            await waitFor(() => expect(getResponseSpy).toHaveBeenCalledTimes(1))
+
+            logic.actions.loadDashboard({ action: DashboardLoadAction.Update })
+            await waitFor(() => expect(getResponseSpy).toHaveBeenCalledTimes(2))
+
+            second.resolve(responseFor({ ...dashboards[12], name: 'new' }))
+            await waitFor(() => expect(logic.values.dashboard?.name).toBe('new'))
+
+            first.reject(
+                new ApiError('Stale dashboard response', status, undefined, {
+                    code: status === 403 ? 'permission_denied' : undefined,
+                })
+            )
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.dashboard?.name).toBe('new')
+            expect(logic.values.accessDeniedToDashboard).toBe(false)
+            expect(logic.values.error404).toBe(false)
+            expect(logic.values.dashboardFailedToLoad).toBe(false)
         })
     })
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -93,6 +93,11 @@ function deferred<T>(): {
 const responseFor = (dashboard: DashboardType<QueryBasedInsightModel>): Response =>
     new Response(JSON.stringify(dashboard), { status: 200, headers: { 'Content-Type': 'application/json' } })
 
+const dashboardHttpError = (status: 403 | 404): ApiError =>
+    new ApiError(`Dashboard request failed with ${status}`, status, undefined, {
+        code: status === 403 ? 'permission_denied' : undefined,
+    })
+
 const dashboardToolEvent = (toolName: string, input: Record<string, unknown>, output: unknown): ToolStreamEvent => ({
     streamKey: 'dashboard-load-test',
     toolCallId: 'dashboard-load-test-call',
@@ -3031,7 +3036,55 @@ describe('dashboardLogic', () => {
             expect(logic.values.dashboardFailedToLoad).toBe(false)
         })
 
-        it('preserves the committed dashboard when an AI background reload fails', async () => {
+        it.each([403, 404] as const)(
+            'preserves the committed dashboard when an AI background reload returns %i',
+            async (status) => {
+                logic = dashboardLogic({ id: 12, dashboard: dashboards[12] })
+                logic.mount()
+                await expectLogic(logic).toFinishAllListeners()
+                const committedDashboard = logic.values.dashboard
+                getResponseSpy.mockClear()
+                getResponseSpy.mockRejectedValueOnce(dashboardHttpError(status))
+                const dashboardNotFoundSpy = jest.spyOn(logic.actions, 'dashboardNotFound')
+                const observedStates: Array<{
+                    dashboard: DashboardType<QueryBasedInsightModel> | null
+                    accessDenied: boolean
+                    error404: boolean
+                    failed: boolean
+                }> = []
+                const unsubscribe = getContext().store.subscribe(() => {
+                    observedStates.push({
+                        dashboard: logic.values.dashboard,
+                        accessDenied: logic.values.accessDeniedToDashboard,
+                        error404: logic.values.error404,
+                        failed: logic.values.dashboardFailedToLoad,
+                    })
+                })
+
+                logic.actions.loadDashboard({ action: DashboardLoadAction.BackgroundUpdate })
+                await expectLogic(logic).toFinishAllListeners()
+
+                expect(logic.values.dashboard).toBe(committedDashboard)
+                expect(logic.values.accessDeniedToDashboard).toBe(false)
+                expect(logic.values.error404).toBe(false)
+                expect(logic.values.dashboardFailedToLoad).toBe(false)
+                expect(dashboardNotFoundSpy).not.toHaveBeenCalled()
+                expect(observedStates).not.toHaveLength(0)
+                expect(
+                    observedStates.every(
+                        (state) =>
+                            state.dashboard === committedDashboard &&
+                            !state.accessDenied &&
+                            !state.error404 &&
+                            !state.failed
+                    )
+                ).toBe(true)
+                unsubscribe()
+                dashboardNotFoundSpy.mockRestore()
+            }
+        )
+
+        it('preserves the committed dashboard when an AI background reload fails without an HTTP status', async () => {
             logic = dashboardLogic({ id: 12, dashboard: dashboards[12] })
             logic.mount()
             await expectLogic(logic).toFinishAllListeners()
@@ -3057,43 +3110,72 @@ describe('dashboardLogic', () => {
             syncLogic.unmount()
         })
 
-        it('preserves the committed dashboard while a queued AI reload follows a failure', async () => {
-            logic = dashboardLogic({ id: 12, dashboard: dashboards[12] })
-            logic.mount()
-            await expectLogic(logic).toFinishAllListeners()
-            const committedDashboard = logic.values.dashboard
-            getResponseSpy.mockClear()
-            const firstReload = deferred<Response>()
-            const successorReload = deferred<Response>()
-            getResponseSpy.mockReturnValueOnce(firstReload.promise).mockReturnValueOnce(successorReload.promise)
-            const syncLogic = dashboardAiSyncLogic({ dashboardId: 12 })
-            syncLogic.mount()
-            const failureStates: boolean[] = []
-            const unsubscribe = getContext().store.subscribe(() => {
-                failureStates.push(logic.values.dashboardFailedToLoad)
-            })
+        it.each([403, 404] as const)(
+            'preserves the committed dashboard while a queued AI reload follows a %i',
+            async (status) => {
+                logic = dashboardLogic({ id: 12, dashboard: dashboards[12] })
+                logic.mount()
+                await expectLogic(logic).toFinishAllListeners()
+                const committedDashboard = logic.values.dashboard
+                getResponseSpy.mockClear()
+                const firstReload = deferred<Response>()
+                const successorReload = deferred<Response>()
+                getResponseSpy.mockReturnValueOnce(firstReload.promise).mockReturnValueOnce(successorReload.promise)
+                const syncLogic = dashboardAiSyncLogic({ dashboardId: 12 })
+                syncLogic.mount()
+                const dashboardNotFoundSpy = jest.spyOn(logic.actions, 'dashboardNotFound')
+                const destructiveStates: Array<{
+                    dashboard: DashboardType<QueryBasedInsightModel> | null
+                    accessDenied: boolean
+                    error404: boolean
+                    failed: boolean
+                }> = []
+                const unsubscribe = getContext().store.subscribe(() => {
+                    destructiveStates.push({
+                        dashboard: logic.values.dashboard,
+                        accessDenied: logic.values.accessDeniedToDashboard,
+                        error404: logic.values.error404,
+                        failed: logic.values.dashboardFailedToLoad,
+                    })
+                })
 
-            syncLogic.actions.applyToolCompletion(dashboardToolEvent('dashboard-update', { id: 12 }, { id: 12 }), {
-                id: 12,
-            })
-            await waitFor(() => expect(getResponseSpy).toHaveBeenCalledTimes(1))
-            syncLogic.actions.applyToolCompletion(dashboardToolEvent('dashboard-update', { id: 12 }, { id: 12 }), {
-                id: 12,
-            })
-            firstReload.reject(new Error('AI background reload failed'))
+                syncLogic.actions.applyToolCompletion(dashboardToolEvent('dashboard-update', { id: 12 }, { id: 12 }), {
+                    id: 12,
+                })
+                await waitFor(() => expect(getResponseSpy).toHaveBeenCalledTimes(1))
+                syncLogic.actions.applyToolCompletion(dashboardToolEvent('dashboard-update', { id: 12 }, { id: 12 }), {
+                    id: 12,
+                })
+                firstReload.reject(dashboardHttpError(status))
 
-            await waitFor(() => expect(getResponseSpy).toHaveBeenCalledTimes(2))
-            expect(logic.values.dashboard).toBe(committedDashboard)
-            expect(logic.values.dashboardFailedToLoad).toBe(false)
+                await waitFor(() => expect(getResponseSpy).toHaveBeenCalledTimes(2))
+                expect(logic.values.dashboard).toBe(committedDashboard)
+                expect(logic.values.accessDeniedToDashboard).toBe(false)
+                expect(logic.values.error404).toBe(false)
+                expect(logic.values.dashboardFailedToLoad).toBe(false)
+                expect(dashboardNotFoundSpy).not.toHaveBeenCalled()
+                expect(destructiveStates).not.toHaveLength(0)
+                expect(
+                    destructiveStates.every(
+                        (state) =>
+                            state.dashboard === committedDashboard &&
+                            !state.accessDenied &&
+                            !state.error404 &&
+                            !state.failed
+                    )
+                ).toBe(true)
 
-            successorReload.resolve(responseFor({ ...dashboards[12], name: 'successor' }))
-            await waitFor(() => expect(syncLogic.values.activeBatch).toBeNull())
-            expect(logic.values.dashboard?.name).toBe('successor')
-            expect(logic.values.dashboardFailedToLoad).toBe(false)
-            expect(failureStates).not.toContain(true)
-            unsubscribe()
-            syncLogic.unmount()
-        })
+                successorReload.resolve(responseFor({ ...dashboards[12], name: 'successor' }))
+                await waitFor(() => expect(syncLogic.values.activeBatch).toBeNull())
+                expect(logic.values.dashboard?.name).toBe('successor')
+                expect(logic.values.accessDeniedToDashboard).toBe(false)
+                expect(logic.values.error404).toBe(false)
+                expect(logic.values.dashboardFailedToLoad).toBe(false)
+                unsubscribe()
+                dashboardNotFoundSpy.mockRestore()
+                syncLogic.unmount()
+            }
+        )
 
         it('still surfaces a failed ordinary update over a committed dashboard', async () => {
             logic = dashboardLogic({ id: 12, dashboard: dashboards[12] })
@@ -3109,6 +3191,29 @@ describe('dashboardLogic', () => {
             expect(logic.values.dashboard).toBe(committedDashboard)
             expect(logic.values.dashboardFailedToLoad).toBe(true)
         })
+
+        it.each([
+            { status: 403 as const, accessDenied: true, error404: false, failed: true, clearsDashboard: true },
+            { status: 404 as const, accessDenied: false, error404: true, failed: false, clearsDashboard: true },
+        ])(
+            'preserves ordinary Update handling for $status responses',
+            async ({ status, accessDenied, error404, failed, clearsDashboard }) => {
+                logic = dashboardLogic({ id: 12, dashboard: dashboards[12] })
+                logic.mount()
+                await expectLogic(logic).toFinishAllListeners()
+                const committedDashboard = logic.values.dashboard
+                getResponseSpy.mockClear()
+                getResponseSpy.mockRejectedValueOnce(dashboardHttpError(status))
+
+                logic.actions.loadDashboard({ action: DashboardLoadAction.Update })
+                await expectLogic(logic).toFinishAllListeners()
+
+                expect(logic.values.dashboard).toBe(clearsDashboard ? null : committedDashboard)
+                expect(logic.values.accessDeniedToDashboard).toBe(accessDenied)
+                expect(logic.values.error404).toBe(error404)
+                expect(logic.values.dashboardFailedToLoad).toBe(failed)
+            }
+        )
     })
 
     describe('text tiles', () => {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -194,6 +194,8 @@ export enum DashboardLoadAction {
     InitialLoadWithVariables = 'initial_load_with_variables',
     /** Get a fresh copy of the dashboard after it was updated (e.g. a tile was duplicated or removed). */
     Update = 'update',
+    /** Refresh a committed dashboard in the background without replacing it with a transient load error. */
+    BackgroundUpdate = 'background_update',
 }
 
 export enum RefreshDashboardItemsAction {
@@ -545,6 +547,9 @@ export interface dashboardLogicActions {
     }
     loadDashboardMetadataSuccess: (dashboard: DashboardType<QueryBasedInsightModel> | null) => {
         dashboard: DashboardType<QueryBasedInsightModel<Node<Record<string, any>>>> | null
+    }
+    setDashboardFailedToLoad: () => {
+        value: true
     }
     loadDashboardStreaming: (payload: { action: DashboardLoadAction; manualDashboardRefresh?: boolean }) => {
         action: DashboardLoadAction
@@ -1294,6 +1299,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
         loadDashboardStreaming: (payload: { action: DashboardLoadAction; manualDashboardRefresh?: boolean }) => payload,
         /** Dashboard metadata loaded successfully. */
         loadDashboardMetadataSuccess: (dashboard: DashboardType<QueryBasedInsightModel> | null) => ({ dashboard }),
+        /** Mark an ordinary dashboard load as failed. */
+        setDashboardFailedToLoad: true,
         /** Single tile received from stream. */
         receiveTileFromStream: (data: { tile: any; order: number }) => data,
         /** Tile streaming completed. */
@@ -1960,7 +1967,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 loadDashboardMetadataSuccess: () => false,
                 dashboardNotFound: () => false,
                 setAccessDeniedToDashboard: () => false,
-                loadDashboardFailure: () => true,
+                setDashboardFailedToLoad: () => true,
                 setDashboardStreamFailed: () => true,
             },
         ],
@@ -3471,6 +3478,10 @@ export const dashboardLogic = kea<dashboardLogicType>([
             cache.pendingDashboardRevealKey = null
             const { action, dashboardQueryId, startTime } = values.dashboardLoadData
 
+            if (action !== DashboardLoadAction.BackgroundUpdate) {
+                actions.setDashboardFailedToLoad()
+            }
+
             eventUsageLogic.actions.reportTimeToSeeData({
                 team_id: values.currentTeamId,
                 type: 'dashboard_load',
@@ -4118,7 +4129,10 @@ export const dashboardLogic = kea<dashboardLogicType>([
             const dashboardRefreshStartTime = performance.now()
             const isInitialLoad =
                 action === DashboardLoadAction.InitialLoad || action === DashboardLoadAction.InitialLoadWithVariables
-            const isInitialLoadOrUpdate = isInitialLoad || action === DashboardLoadAction.Update
+            const isInitialLoadOrUpdate =
+                isInitialLoad ||
+                action === DashboardLoadAction.Update ||
+                action === DashboardLoadAction.BackgroundUpdate
 
             const dashboardId: number = props.id
             const allInsightTiles = values.insightTiles || []

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1529,6 +1529,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         return getQueryBasedDashboard(dashboard)
                     } catch (error: any) {
                         breakpoint()
+                        if (action === DashboardLoadAction.BackgroundUpdate) {
+                            throw error
+                        }
                         if (error.status === 404) {
                             return null
                         }

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1511,6 +1511,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         const apiUrl = values.apiUrl('force_cache', values.filtersOverrideForLoad, values.urlVariables)
                         const dashboardResponse: Response = await api.getResponse(apiUrl)
                         const dashboard: DashboardType<InsightModel> | null = await getJSONOrNull(dashboardResponse)
+                        breakpoint()
 
                         actions.setInitialLoadResponseBytes(getResponseBytes(dashboardResponse))
 
@@ -1520,6 +1521,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
                         return getQueryBasedDashboard(dashboard)
                     } catch (error: any) {
+                        breakpoint()
                         if (error.status === 404) {
                             return null
                         }

--- a/frontend/src/scenes/dashboard/items/DashboardTileRevealProps.test.tsx
+++ b/frontend/src/scenes/dashboard/items/DashboardTileRevealProps.test.tsx
@@ -1,0 +1,89 @@
+import '@testing-library/jest-dom'
+
+import { render } from '@testing-library/react'
+
+import { DashboardPlacement, DashboardTile, QueryBasedInsightModel } from '~/types'
+
+import { DashboardTextItem } from 'products/dashboards/frontend/components/DashboardTextItem/DashboardTextItem'
+
+import { DashboardButtonTileItem } from './DashboardButtonTileItem'
+import { DashboardErrorTileItem } from './DashboardErrorTileItem'
+
+jest.mock('kea', () => ({
+    ...jest.requireActual('kea'),
+    useActions: () => ({ push: jest.fn() }),
+    useValues: () => ({ copyToDestinations: [] }),
+}))
+jest.mock('lib/components/RichContentEditor', () => ({ useRichContentEditor: () => null }))
+jest.mock('scenes/insights/EmptyStates', () => ({ InsightErrorState: () => <div data-testid="error-state" /> }))
+
+const commonProps = {
+    className: 'ai-highlight-test',
+    'data-dashboard-tile-id': '41',
+    'data-dashboard-tile-highlighted': 'true',
+    tabIndex: -1,
+}
+
+function assertRevealContract(element: Element, rendererClass: string): void {
+    expect(element).toHaveClass('DashboardTileCard', rendererClass, 'ai-highlight-test')
+    expect(element).toHaveAttribute('data-dashboard-tile-id', '41')
+    expect(element).toHaveAttribute('data-dashboard-tile-highlighted', 'true')
+    expect(element).toHaveAttribute('tabindex', '-1')
+}
+
+function tile(overrides: Partial<DashboardTile<QueryBasedInsightModel>>): DashboardTile<QueryBasedInsightModel> {
+    return { id: 41, ...overrides } as DashboardTile<QueryBasedInsightModel>
+}
+
+describe('dashboard tile reveal props', () => {
+    it.each([
+        ['text', 'Plain text', 'text-card', 'TextCard'],
+        ['image', '![Chart](https://example.test/chart.png)', 'image-tile', 'DashboardImageTile'],
+    ] as const)('forwards the contract through the %s tile renderer', (_kind, body, dataAttr, rendererClass) => {
+        const { container } = render(
+            <DashboardTextItem
+                tile={tile({ text: { id: 11, body } as DashboardTile<QueryBasedInsightModel>['text'] })}
+                placement={DashboardPlacement.Dashboard}
+                onEdit={jest.fn()}
+                onDuplicate={jest.fn()}
+                {...commonProps}
+            />
+        )
+
+        const card = container.querySelector(`[data-attr="${dataAttr}"]`)
+        expect(card).not.toBeNull()
+        assertRevealContract(card!, rendererClass)
+    })
+
+    it('forwards the contract through the button tile renderer', () => {
+        const { container } = render(
+            <DashboardButtonTileItem
+                tile={tile({
+                    button_tile: { id: 12, text: 'Open', url: '/', style: 'primary' },
+                } as Partial<DashboardTile<QueryBasedInsightModel>>)}
+                placement={DashboardPlacement.Dashboard}
+                onEdit={jest.fn()}
+                onDuplicate={jest.fn()}
+                {...commonProps}
+            />
+        )
+
+        const card = container.querySelector('[data-attr="button-tile-card"]')
+        expect(card).not.toBeNull()
+        assertRevealContract(card!, 'ButtonTileCard')
+    })
+
+    it('forwards the contract through the error tile renderer', () => {
+        const { container } = render(
+            <DashboardErrorTileItem
+                tile={tile({ error: { type: 'ValidationError', message: 'Invalid filters' } })}
+                placement={DashboardPlacement.Dashboard}
+                {...commonProps}
+            />
+        )
+
+        const card = container.querySelector('[data-attr="dashboard-tile-error"]')
+        expect(card).not.toBeNull()
+        assertRevealContract(card!, 'InsightCard')
+    })
+})

--- a/products/alerts/frontend/logic/insightAlertsLogic.test.ts
+++ b/products/alerts/frontend/logic/insightAlertsLogic.test.ts
@@ -186,6 +186,52 @@ describe('insightAlertsLogic', () => {
         alertsLogic.unmount()
     })
 
+    it('ignores an older alert request that fails after a newer one succeeded', async () => {
+        let rejectOlder!: (error: Error) => void
+        let resolveNewer!: (response: { results: AlertType[]; count: number }) => void
+        const olderResponse = new Promise<{ results: AlertType[]; count: number }>((_resolve, reject) => {
+            rejectOlder = reject
+        })
+        const newerResponse = new Promise<{ results: AlertType[]; count: number }>((resolve) => {
+            resolveNewer = resolve
+        })
+        listSpy.mockReset().mockReturnValueOnce(olderResponse).mockReturnValueOnce(newerResponse)
+        const insightLogicProps: InsightLogicProps = {
+            dashboardItemId: Insight42,
+            dashboardId: 1,
+            cachedInsight: {
+                ...createEmptyInsight(Insight42),
+                id: 42,
+                query: API_QUERY,
+                alerts: [],
+            },
+        }
+        mountInsightStack(insightLogicProps)
+        const alertsLogic = insightAlertsLogic({
+            insightId: 42,
+            insightLogicProps,
+            deferInitialAlertsLoad: true,
+        })
+        alertsLogic.mount()
+
+        alertsLogic.actions.loadAlerts()
+        alertsLogic.actions.loadAlerts()
+        expect(listSpy).toHaveBeenCalledTimes(2)
+
+        const newer = [{ id: 'alert-a', name: 'Newer' }] as AlertType[]
+        resolveNewer({ results: newer, count: 1 })
+        await waitFor(() => expect(alertsLogic.values.alerts).toEqual(newer))
+
+        rejectOlder(new Error('Alerts request failed'))
+        await olderResponse.catch(() => {})
+        await Promise.resolve()
+        await Promise.resolve()
+
+        await expectLogic(alertsLogic).toNotHaveDispatchedActions(['loadAlertsFailure'])
+        expect(alertsLogic.values.alerts).toEqual(newer)
+        alertsLogic.unmount()
+    })
+
     it('dispatches loadAlerts on mount when not deferred and cached insight has no alerts field', async () => {
         const insightLogicProps: InsightLogicProps = {
             dashboardItemId: Insight42,

--- a/products/alerts/frontend/logic/insightAlertsLogic.test.ts
+++ b/products/alerts/frontend/logic/insightAlertsLogic.test.ts
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/react'
 import { expectLogic } from 'kea-test-utils'
 
 import api from 'lib/api'
@@ -138,6 +139,51 @@ describe('insightAlertsLogic', () => {
         }).toFinishAllListeners()
 
         expect(listSpy).toHaveBeenCalledWith(42)
+    })
+
+    it('keeps the newest alert list when an older request resolves last', async () => {
+        let resolveOlder!: (response: { results: AlertType[]; count: number }) => void
+        let resolveNewer!: (response: { results: AlertType[]; count: number }) => void
+        const olderResponse = new Promise<{ results: AlertType[]; count: number }>((resolve) => {
+            resolveOlder = resolve
+        })
+        const newerResponse = new Promise<{ results: AlertType[]; count: number }>((resolve) => {
+            resolveNewer = resolve
+        })
+        listSpy.mockReset().mockReturnValueOnce(olderResponse).mockReturnValueOnce(newerResponse)
+        const insightLogicProps: InsightLogicProps = {
+            dashboardItemId: Insight42,
+            dashboardId: 1,
+            cachedInsight: {
+                ...createEmptyInsight(Insight42),
+                id: 42,
+                query: API_QUERY,
+                alerts: [],
+            },
+        }
+        mountInsightStack(insightLogicProps)
+        const alertsLogic = insightAlertsLogic({
+            insightId: 42,
+            insightLogicProps,
+            deferInitialAlertsLoad: true,
+        })
+        alertsLogic.mount()
+
+        alertsLogic.actions.loadAlerts()
+        alertsLogic.actions.loadAlerts()
+        expect(listSpy).toHaveBeenCalledTimes(2)
+
+        const newer = [{ id: 'alert-a', name: 'Newer' }] as AlertType[]
+        resolveNewer({ results: newer, count: 1 })
+        await waitFor(() => expect(alertsLogic.values.alerts).toEqual(newer))
+
+        resolveOlder({ results: [{ id: 'alert-a', name: 'Older' }] as AlertType[], count: 1 })
+        await olderResponse
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(alertsLogic.values.alerts).toEqual(newer)
+        alertsLogic.unmount()
     })
 
     it('dispatches loadAlerts on mount when not deferred and cached insight has no alerts field', async () => {

--- a/products/alerts/frontend/logic/insightAlertsLogic.ts
+++ b/products/alerts/frontend/logic/insightAlertsLogic.ts
@@ -1,4 +1,17 @@
-import { MakeLogicType, actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import {
+    BreakPointFunction,
+    MakeLogicType,
+    actions,
+    afterMount,
+    connect,
+    kea,
+    key,
+    listeners,
+    path,
+    props,
+    reducers,
+    selectors,
+} from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
@@ -256,8 +269,10 @@ export const insightAlertsLogic = kea<insightAlertsLogicType>([
     loaders(({ props }) => ({
         alerts: {
             __default: [] as AlertType[],
-            loadAlerts: async () => {
+            loadAlerts: async (_?: unknown, breakpoint?: BreakPointFunction) => {
+                breakpoint?.()
                 const response = await api.alerts.list(props.insightId)
+                breakpoint?.()
                 return response.results
             },
         },

--- a/products/alerts/frontend/logic/insightAlertsLogic.ts
+++ b/products/alerts/frontend/logic/insightAlertsLogic.ts
@@ -271,9 +271,17 @@ export const insightAlertsLogic = kea<insightAlertsLogicType>([
             __default: [] as AlertType[],
             loadAlerts: async (_?: unknown, breakpoint?: BreakPointFunction) => {
                 breakpoint?.()
-                const response = await api.alerts.list(props.insightId)
-                breakpoint?.()
-                return response.results
+                try {
+                    const response = await api.alerts.list(props.insightId)
+                    breakpoint?.()
+                    return response.results
+                } catch (error) {
+                    // Bail if a newer request superseded this one. Without this the obsolete
+                    // failure toasts, gets reported, and clears the loading state while the newer
+                    // request is still in flight.
+                    breakpoint?.()
+                    throw error
+                }
             },
         },
         alertDestinationCounts: [

--- a/products/dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem.test.tsx
+++ b/products/dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem.test.tsx
@@ -148,6 +148,29 @@ describe('DashboardWidgetItem', () => {
         }).unmount()
     })
 
+    it('forwards the dashboard reveal contract to the widget card root', () => {
+        const { container } = render(
+            <DashboardWidgetItem
+                tile={tile}
+                placement={DashboardPlacement.Dashboard}
+                dashboardId={99}
+                result={null}
+                loading={false}
+                onRefresh={jest.fn()}
+                className="ai-highlight-test"
+                data-dashboard-tile-id="41"
+                data-dashboard-tile-highlighted="true"
+                tabIndex={-1}
+            />
+        )
+
+        const card = container.querySelector('[data-slot="widget-card"]')
+        expect(card).toHaveClass('DashboardTileCard', 'WidgetCard', 'ai-highlight-test')
+        expect(card).toHaveAttribute('data-dashboard-tile-id', '41')
+        expect(card).toHaveAttribute('data-dashboard-tile-highlighted', 'true')
+        expect(card).toHaveAttribute('tabindex', '-1')
+    })
+
     it('does not render tile filters without product access', () => {
         jest.mocked(userHasDashboardWidgetProductAccess).mockReturnValue(false)
 


### PR DESCRIPTION
## Problem

Dashboard users cannot see completed agent mutations until they refresh, and mounted subscription or alert views can remain stale.

Stack: [1/4 scene context](https://github.com/PostHog/posthog/pull/96398) · [2/4 three-column layout](https://github.com/PostHog/posthog/pull/96401) · [3/4 mutation cards](https://github.com/PostHog/posthog/pull/96402) · **4/4**

Depends on [3/4: dashboard mutation cards and tile reveal](https://github.com/PostHog/posthog/pull/96402).

## Changes

- Editable standard dashboards synchronize validated PostHog AI tool completions automatically.
- The classifier accepts only first-party PostHog exec completions with authoritative dashboard ownership.
- Structural mutations use one active reload and one merged successor.
- Subscription and alert mutations refresh only their exact mounted views.
- Move-away and deletion mutations refresh both affected ownership states.
- Failed background reloads preserve the last committed dashboard.
- Confirmed tiles receive a three-second highlight without automatic scrolling.
- Dashboard deletion returns users to the dashboard list.
- Synchronization telemetry contains only five aggregate fields.

```mermaid
flowchart TD
    A{{Tool completion}} --> B[Rollout-gated dashboard bridge]
    B --> C[First-party ownership validation]
    C --> D[Serialized dashboard reload]
    C --> E[Mounted subscription refresh]
    C --> F[Mounted alert refresh]
    C --> G[Dashboard deletion navigation]
    D --> H[Confirmed tile highlight]
    D --> I[Aggregate outcome telemetry]
```

> [!NOTE]
> Apply-back and highlight screenshots remain pending because no dev stack ran for this isolated worktree.

## How did you test this code?

- Rebased matrix: 10 suites, 416 passed, one pre-existing skip, and one passing snapshot.
- Full frontend TypeScript, targeted Oxlint/Oxfmt, strict preflight, and diff checks passed.
- Range-diff is patch-identical across all 12 PR4 commits.
- All 12 commits have valid YubiKey signatures.
- Independent adversarial review covered trust boundaries, ownership transitions, request races, and lifecycle disposal.
- Browser apply-back testing remains pending because no terminal-owned dev stack ran for this worktree.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No public docs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: Codex.
- Skills: `/integrating-with-posthog-ai`, `/using-git-worktrees`, `/subagent-driven-development`, and `/test-driven-development`.
- Review: `/requesting-code-review`, `/verification-before-completion`, `/stacking-prs`, and `/writing-pr-descriptions`.
- Adversarial review strengthened ownership transitions, request races, lifecycle disposal, and bridge gating.
