### PR TITLE
feat(cdp): make destination input failures visible and rerunnable

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-data-warehouse-events.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-data-warehouse-events.consumer.ts
@@ -61,6 +61,7 @@ export class CdpDatawarehouseEventsConsumer extends CdpConsumerBase {
             hogWatcherMirror: this.hogWatcherMirror,
             hogMasker: this.hogMasker,
             hogFunctionMonitoringService: this.hogFunctionMonitoringService,
+            hogInvocationResultsService: this.invocationResultsService.invocationResultsRowsService,
             cdpUsageReporter: this.cdpUsageReporter,
             quotaLimiting: deps.quotaLimiting,
             redis: this.redis,

--- a/nodejs/src/cdp/consumers/cdp-events.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-events.consumer.ts
@@ -47,6 +47,7 @@ export class CdpEventsConsumer<
             hogWatcherMirror: this.hogWatcherMirror,
             hogMasker: this.hogMasker,
             hogFunctionMonitoringService: this.hogFunctionMonitoringService,
+            hogInvocationResultsService: this.invocationResultsService.invocationResultsRowsService,
             cdpUsageReporter: this.cdpUsageReporter,
             quotaLimiting: deps.quotaLimiting,
             redis: this.redis,

--- a/nodejs/src/cdp/consumers/cdp-internal-event.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-internal-event.consumer.ts
@@ -66,6 +66,7 @@ export class CdpInternalEventsConsumer extends CdpConsumerBase {
             hogWatcherMirror: this.hogWatcherMirror,
             hogMasker: this.hogMasker,
             hogFunctionMonitoringService: this.hogFunctionMonitoringService,
+            hogInvocationResultsService: this.invocationResultsService.invocationResultsRowsService,
             cdpUsageReporter: this.cdpUsageReporter,
             quotaLimiting: deps.quotaLimiting,
             redis: this.redis,

--- a/nodejs/src/cdp/consumers/cdp-person-updates-consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-person-updates-consumer.ts
@@ -38,6 +38,7 @@ export class CdpPersonUpdatesConsumer extends CdpConsumerBase {
             hogWatcherMirror: this.hogWatcherMirror,
             hogMasker: this.hogMasker,
             hogFunctionMonitoringService: this.hogFunctionMonitoringService,
+            hogInvocationResultsService: this.invocationResultsService.invocationResultsRowsService,
             cdpUsageReporter: this.cdpUsageReporter,
             quotaLimiting: deps.quotaLimiting,
             redis: this.redis,
@@ -72,6 +73,11 @@ export class CdpPersonUpdatesConsumer extends CdpConsumerBase {
                         logger.error('🔴', 'Error producing queued messages for monitoring', { err })
                     }
                 }),
+                // No other flush of the lifecycle rows runs in this consumer — without
+                // this one, the pipeline's `failed` rows accumulate in memory forever.
+                instrumentFn({ key: 'cdp.background_task.lifecycle_failed_flush', sendException: false }, () =>
+                    this.invocationResultsService.invocationResultsRowsService.flush()
+                ),
             ]),
             invocations: invocationsToBeQueued,
         }

--- a/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.test.ts
+++ b/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.test.ts
@@ -4,12 +4,15 @@ import { buildHogFunctionInvocations } from '../utils/invocation-utils'
 import { HogFunctionInvocationPipeline } from './hog-function-invocation-pipeline.service'
 import { HogFunctionManagerService } from './managers/hog-function-manager.service'
 import { HogFunctionMonitoringService } from './monitoring/hog-function-monitoring.service'
+import { HogInvocationResultsService } from './monitoring/hog-invocation-results.service'
 import { HogMaskerService } from './monitoring/hog-masker.service'
 import { HogWatcherService, HogWatcherState } from './monitoring/hog-watcher.service'
 
 jest.mock('../utils/invocation-utils', () => ({
     ...jest.requireActual('../utils/invocation-utils'),
-    buildHogFunctionInvocations: jest.fn().mockResolvedValue({ invocations: [], metrics: [], logs: [] }),
+    buildHogFunctionInvocations: jest
+        .fn()
+        .mockResolvedValue({ invocations: [], failedInvocations: [], metrics: [], logs: [] }),
 }))
 
 // Mock the rate limiter to give us deterministic control
@@ -62,6 +65,7 @@ describe('HogFunctionInvocationPipeline', () => {
     let hogWatcher: jest.Mocked<HogWatcherService>
     let hogMasker: jest.Mocked<HogMaskerService>
     let hogFunctionMonitoringService: jest.Mocked<HogFunctionMonitoringService>
+    let hogInvocationResultsService: jest.Mocked<HogInvocationResultsService>
     let quotaLimiting: jest.Mocked<QuotaLimiting>
     let pipeline: HogFunctionInvocationPipeline
     let rateLimitGroupedMock: jest.Mock
@@ -87,6 +91,10 @@ describe('HogFunctionInvocationPipeline', () => {
             queueLogs: jest.fn(),
         } as unknown as jest.Mocked<HogFunctionMonitoringService>
 
+        hogInvocationResultsService = {
+            queueLifecycleRow: jest.fn(),
+        } as unknown as jest.Mocked<HogInvocationResultsService>
+
         quotaLimiting = {
             isTeamQuotaLimited: jest.fn().mockResolvedValue(false),
         } as unknown as jest.Mocked<QuotaLimiting>
@@ -98,6 +106,7 @@ describe('HogFunctionInvocationPipeline', () => {
             hogWatcherMirror: hogWatcher,
             hogMasker,
             hogFunctionMonitoringService,
+            hogInvocationResultsService,
             quotaLimiting,
             redis: {} as any,
             valkeyShadow: { writer: {} as any, reader: {} as any },
@@ -126,7 +135,12 @@ describe('HogFunctionInvocationPipeline', () => {
     it('returns invocations for matching hog functions and queues triggered + billing metrics', async () => {
         const fn = makeHogFunction()
         const inv = makeInvocation(fn, 'evt-uuid-1')
-        jest.mocked(buildHogFunctionInvocations).mockResolvedValue({ invocations: [inv], metrics: [], logs: [] })
+        jest.mocked(buildHogFunctionInvocations).mockResolvedValue({
+            invocations: [inv],
+            failedInvocations: [],
+            metrics: [],
+            logs: [],
+        })
         hogWatcher.getEffectiveStates.mockResolvedValue({ [fn.id]: { state: HogWatcherState.healthy } } as any)
         rateLimitGroupedMock.mockResolvedValue([[null, { isRateLimited: false }]])
 
@@ -146,10 +160,38 @@ describe('HogFunctionInvocationPipeline', () => {
         expect(billingCall).toBeDefined()
     })
 
+    it('queues a terminal failed lifecycle row for invocations whose inputs failed to build', async () => {
+        const fn = makeHogFunction()
+        const inv = makeInvocation(fn)
+        const error = new Error('Could not execute bytecode for input field: url')
+        jest.mocked(buildHogFunctionInvocations).mockResolvedValue({
+            invocations: [],
+            failedInvocations: [{ invocation: inv, error }],
+            metrics: [],
+            logs: [],
+        })
+
+        const result = await pipeline.buildInvocations([makeGlobals()], {
+            hogTypes: ['destination'],
+            filterFn: () => true,
+        })
+
+        expect(result).toEqual([])
+        expect(hogInvocationResultsService.queueLifecycleRow).toHaveBeenCalledWith(inv, 'failed', {
+            error,
+            errorKind: 'inputs_failed',
+        })
+    })
+
     it('drops invocations in disabled watcher state', async () => {
         const fn = makeHogFunction()
         const inv = makeInvocation(fn)
-        jest.mocked(buildHogFunctionInvocations).mockResolvedValue({ invocations: [inv], metrics: [], logs: [] })
+        jest.mocked(buildHogFunctionInvocations).mockResolvedValue({
+            invocations: [inv],
+            failedInvocations: [],
+            metrics: [],
+            logs: [],
+        })
         hogWatcher.getEffectiveStates.mockResolvedValue({ [fn.id]: { state: HogWatcherState.disabled } } as any)
         rateLimitGroupedMock.mockResolvedValue([[null, { isRateLimited: false }]])
 
@@ -168,7 +210,12 @@ describe('HogFunctionInvocationPipeline', () => {
     it('routes degraded invocations to hogoverflow queue when overflow enabled', async () => {
         const fn = makeHogFunction()
         const inv = makeInvocation(fn)
-        jest.mocked(buildHogFunctionInvocations).mockResolvedValue({ invocations: [inv], metrics: [], logs: [] })
+        jest.mocked(buildHogFunctionInvocations).mockResolvedValue({
+            invocations: [inv],
+            failedInvocations: [],
+            metrics: [],
+            logs: [],
+        })
         hogWatcher.getEffectiveStates.mockResolvedValue({ [fn.id]: { state: HogWatcherState.degraded } } as any)
         rateLimitGroupedMock.mockResolvedValue([[null, { isRateLimited: false }]])
 
@@ -185,7 +232,12 @@ describe('HogFunctionInvocationPipeline', () => {
     it('drops quota-limited invocations', async () => {
         const fn = makeHogFunction()
         const inv = makeInvocation(fn)
-        jest.mocked(buildHogFunctionInvocations).mockResolvedValue({ invocations: [inv], metrics: [], logs: [] })
+        jest.mocked(buildHogFunctionInvocations).mockResolvedValue({
+            invocations: [inv],
+            failedInvocations: [],
+            metrics: [],
+            logs: [],
+        })
         hogWatcher.getEffectiveStates.mockResolvedValue({ [fn.id]: { state: HogWatcherState.healthy } } as any)
         rateLimitGroupedMock.mockResolvedValue([[null, { isRateLimited: false }]])
         quotaLimiting.isTeamQuotaLimited.mockResolvedValue(true)
@@ -201,7 +253,12 @@ describe('HogFunctionInvocationPipeline', () => {
     it('drops masked invocations', async () => {
         const fn = makeHogFunction()
         const inv = makeInvocation(fn)
-        jest.mocked(buildHogFunctionInvocations).mockResolvedValue({ invocations: [inv], metrics: [], logs: [] })
+        jest.mocked(buildHogFunctionInvocations).mockResolvedValue({
+            invocations: [inv],
+            failedInvocations: [],
+            metrics: [],
+            logs: [],
+        })
         hogWatcher.getEffectiveStates.mockResolvedValue({ [fn.id]: { state: HogWatcherState.healthy } } as any)
         rateLimitGroupedMock.mockResolvedValue([[null, { isRateLimited: false }]])
         hogMasker.filterByMasking.mockResolvedValue({ masked: [inv], notMasked: [], release: async () => {} })
@@ -223,7 +280,12 @@ describe('HogFunctionInvocationPipeline', () => {
         const fn2 = makeHogFunction({ id: 'fn-2' })
         const inv1 = makeInvocation(fn1, 'evt-same')
         const inv2 = makeInvocation(fn2, 'evt-same')
-        jest.mocked(buildHogFunctionInvocations).mockResolvedValue({ invocations: [inv1, inv2], metrics: [], logs: [] })
+        jest.mocked(buildHogFunctionInvocations).mockResolvedValue({
+            invocations: [inv1, inv2],
+            failedInvocations: [],
+            metrics: [],
+            logs: [],
+        })
         hogWatcher.getEffectiveStates.mockResolvedValue({
             [fn1.id]: { state: HogWatcherState.healthy },
             [fn2.id]: { state: HogWatcherState.healthy },
@@ -247,7 +309,12 @@ describe('HogFunctionInvocationPipeline', () => {
     it('does not drop rate-limited invocations (monitoring-only)', async () => {
         const fn = makeHogFunction()
         const inv = makeInvocation(fn)
-        jest.mocked(buildHogFunctionInvocations).mockResolvedValue({ invocations: [inv], metrics: [], logs: [] })
+        jest.mocked(buildHogFunctionInvocations).mockResolvedValue({
+            invocations: [inv],
+            failedInvocations: [],
+            metrics: [],
+            logs: [],
+        })
         hogWatcher.getEffectiveStates.mockResolvedValue({ [fn.id]: { state: HogWatcherState.healthy } } as any)
         rateLimitGroupedMock.mockResolvedValue([[null, { isRateLimited: true }]])
 

--- a/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.ts
+++ b/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.ts
@@ -20,6 +20,7 @@ import { buildHogFunctionInvocations } from '../utils/invocation-utils'
 import { HogInputsService } from './hog-inputs.service'
 import { HogFunctionManagerService } from './managers/hog-function-manager.service'
 import { HogFunctionMonitoringService } from './monitoring/hog-function-monitoring.service'
+import { HogInvocationResultsService } from './monitoring/hog-invocation-results.service'
 import { HogMaskerService } from './monitoring/hog-masker.service'
 import { HogWatcherService, HogWatcherState, sameWatcherStates } from './monitoring/hog-watcher.service'
 import { CdpUsageReporterService } from './usage/cdp-usage-reporter.service'
@@ -38,6 +39,7 @@ export interface HogFunctionInvocationPipelineDeps {
     hogWatcherMirror: HogWatcherService
     hogMasker: HogMaskerService
     hogFunctionMonitoringService: HogFunctionMonitoringService
+    hogInvocationResultsService: HogInvocationResultsService
     cdpUsageReporter?: CdpUsageReporterService
     quotaLimiting: QuotaLimiting
     redis: RedisV2
@@ -93,7 +95,7 @@ export class HogFunctionInvocationPipeline {
                         ? hogFunctionsByTeam[globals.project.id].filter((fn) => opts.invocationFilterFn!(fn, globals))
                         : hogFunctionsByTeam[globals.project.id]
 
-                    const { invocations, metrics, logs } = await buildHogFunctionInvocations(
+                    const { invocations, failedInvocations, metrics, logs } = await buildHogFunctionInvocations(
                         this.deps.hogInputsService,
                         teamHogFunctions,
                         globals
@@ -101,6 +103,13 @@ export class HogFunctionInvocationPipeline {
 
                     this.deps.hogFunctionMonitoringService.queueAppMetrics(metrics, 'hog_function')
                     this.deps.hogFunctionMonitoringService.queueLogs(logs, 'hog_function')
+
+                    for (const { invocation, error } of failedInvocations) {
+                        this.deps.hogInvocationResultsService.queueLifecycleRow(invocation, 'failed', {
+                            error,
+                            errorKind: 'inputs_failed',
+                        })
+                    }
 
                     return invocations
                 })

--- a/nodejs/src/cdp/utils/invocation-utils.test.ts
+++ b/nodejs/src/cdp/utils/invocation-utils.test.ts
@@ -253,6 +253,13 @@ describe('Invocation utils', () => {
                     message: expect.stringContaining('Error building inputs for event uuid:'),
                 },
             ])
+
+            expect(results.failedInvocations).toHaveLength(1)
+            const failed = results.failedInvocations[0]
+            expect(failed.invocation.functionId).toBe(broken.id)
+            expect(failed.invocation.state.globals.inputs).toEqual({})
+            expect(failed.error).toBeInstanceOf(Error)
+            expect(results.logs[0].instance_id).toBe(failed.invocation.id)
         })
     })
 

--- a/nodejs/src/cdp/utils/invocation-utils.ts
+++ b/nodejs/src/cdp/utils/invocation-utils.ts
@@ -36,9 +36,16 @@ export function createInvocation(
     }
 }
 
+export interface FailedHogFunctionInvocation {
+    invocation: CyclotronJobInvocationHogFunction
+    error: unknown
+}
+
 /**
  * Matches a batch of hog functions against one event's globals and builds an invocation per match,
  * resolving each one's inputs. Filter metrics/logs come back alongside for the caller to queue.
+ * Matches whose inputs could not be built come back as `failedInvocations` so the caller can
+ * record a terminal `failed` lifecycle row — they are never enqueued for execution.
  */
 export async function buildHogFunctionInvocations(
     hogInputsService: HogInputsService,
@@ -46,12 +53,14 @@ export async function buildHogFunctionInvocations(
     triggerGlobals: HogFunctionInvocationGlobals
 ): Promise<{
     invocations: CyclotronJobInvocationHogFunction[]
+    failedInvocations: FailedHogFunctionInvocation[]
     metrics: MinimalAppMetric[]
     logs: LogEntry[]
 }> {
     const metrics: MinimalAppMetric[] = []
     const logs: LogEntry[] = []
     const invocations: CyclotronJobInvocationHogFunction[] = []
+    const failedInvocations: FailedHogFunctionInvocation[] = []
 
     // TRICKY: The frontend generates filters matching the Clickhouse event type so we are converting back
     const filterGlobals = convertToHogFunctionFilterGlobal(triggerGlobals)
@@ -78,15 +87,15 @@ export async function buildHogFunctionInvocations(
         hogFunction: HogFunctionType,
         additionalInputs?: HogFunctionType['inputs']
     ): Promise<CyclotronJobInvocationHogFunction | null> => {
-        try {
-            const globalsWithSource = {
-                ...triggerGlobals,
-                source: {
-                    name: hogFunction.name ?? `Hog function: ${hogFunction.id}`,
-                    url: `${triggerGlobals.project.url}/functions/${hogFunction.id}/configuration/`,
-                },
-            }
+        const globalsWithSource = {
+            ...triggerGlobals,
+            source: {
+                name: hogFunction.name ?? `Hog function: ${hogFunction.id}`,
+                url: `${triggerGlobals.project.url}/functions/${hogFunction.id}/configuration/`,
+            },
+        }
 
+        try {
             const globalsWithInputs = await hogInputsService.buildInputsWithGlobals(
                 hogFunction,
                 globalsWithSource,
@@ -95,11 +104,17 @@ export async function buildHogFunctionInvocations(
 
             return createInvocation(globalsWithInputs, hogFunction)
         } catch (error) {
+            // Mint an invocation anyway so the terminal lifecycle row and the log entry
+            // can reference its id. The empty inputs never execute — a rerun rebuilds
+            // inputs from the current function config.
+            const failedInvocation = createInvocation({ ...globalsWithSource, inputs: {} }, hogFunction)
+            failedInvocations.push({ invocation: failedInvocation, error })
+
             logs.push({
                 team_id: hogFunction.team_id,
                 log_source: 'hog_function',
                 log_source_id: hogFunction.id,
-                instance_id: new UUIDT().toString(), // random UUID, like it would be for an invocation
+                instance_id: failedInvocation.id,
                 timestamp: DateTime.now(),
                 level: 'error',
                 message: `Error building inputs for event ${triggerGlobals.event.uuid}: ${error.message}`,
@@ -154,6 +169,7 @@ export async function buildHogFunctionInvocations(
 
     return {
         invocations,
+        failedInvocations,
         metrics,
         logs,
     }


### PR DESCRIPTION
## Problem

A destination whose input templates fail to resolve drops the event silently. The failure never appears in the Invocations tab, and the affected events cannot be re-run.

- The only traces are the aggregate "Input errors" tile on the Metrics tab and a log line with a random instance id that links to nothing.
- Input building fails before an invocation is created, so no row reaches `hog_invocation_results` - the table behind the Invocations tab and the rerun API.

## Changes

- The Invocations tab now lists input failures as failed runs with error kind `inputs_failed`, filterable like any other failure.
- These runs are now rerunnable: fix the input template, then use the existing re-run action. Rerun rebuilds inputs from the current function config, so the fixed template applies.
- The error log entry now carries the invocation id as its instance id, so the log links to the run.
- Mechanism: on an input-build failure, `buildHogFunctionInvocations` still mints the invocation (with empty inputs, which never execute) and the pipeline writes a terminal failed lifecycle row for it.
- No ClickHouse schema or frontend change: the existing status and error-kind filters pick the rows up.
- Mechanical: the four event consumers pass the lifecycle-row service into the shared pipeline. The person-updates consumer also gains the lifecycle-row flush it was missing.

## How did you test this code?

- Extended the existing input-failure test in `invocation-utils.test.ts`. It catches a regression where failures stop minting an invocation, or the log stops linking to its id.
- Added one pipeline test asserting the terminal failed row is queued with error kind `inputs_failed`. It catches the row wiring being dropped.
- Ran the changed unit suites and the events, data-warehouse, and person-updates consumer suites locally.
- Not run: `cdp-internal-events-consumer.test.ts` (needs a live Postgres, not available in this session) and any end-to-end rerun of an `inputs_failed` row. CI covers the former.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. The session first investigated why `inputs_failed` destinations are missing from the Invocations tab, then reused the lifecycle-row and rerun infrastructure instead of building an event-table replay path. Verified that the rerun paginator's globals schema accepts pre-input-build snapshots, so no rerun changes were needed. Skills invoked: /writing-tests, /writing-pr-descriptions.