### PR TITLE
feat(desktop): answer /usage in the agent from PostHog

### DIFF
--- a/products/desktop/packages/agent/src/adapters/acp-connection.ts
+++ b/products/desktop/packages/agent/src/adapters/acp-connection.ts
@@ -20,6 +20,7 @@ import type { GatewayEnv } from "./claude/session/options";
 import { nativeCodexBinaryPath } from "./codex-app-server/binary-path";
 import { CodexAppServerAgent } from "./codex-app-server/codex-app-server-agent";
 import type { CodexOptions } from "./codex-app-server/spawn";
+import type { UsageCommandConfig } from "./usage-command";
 
 export type AcpConnectionConfig = {
   adapter?: Adapter;
@@ -47,6 +48,7 @@ export type AcpConnectionConfig = {
   claudeMachineAuth?: MachineClaudeAuth;
   /** Per-session context wiki mount — prevents global process.env mutation. */
   contextWiki?: ContextWikiEnv;
+  usageCommand?: UsageCommandConfig;
 };
 
 export type AcpConnection = {
@@ -166,6 +168,7 @@ function createClaudeConnection(config: AcpConnectionConfig): AcpConnection {
       gatewayEnv: config.claudeGatewayEnv,
       machineAuth: config.claudeMachineAuth,
       contextWiki: config.contextWiki,
+      usageCommand: config.usageCommand,
     });
     return agent;
   }, agentStream);
@@ -254,6 +257,7 @@ function createCodexConnection(config: AcpConnectionConfig): AcpConnection {
       processCallbacks: config.processCallbacks,
       onStructuredOutput: config.onStructuredOutput,
       logger: config.logger?.child("CodexAppServerAgent"),
+      usageCommand: config.usageCommand,
     });
     return agent;
   }, agentStream);

--- a/products/desktop/packages/agent/src/adapters/base-acp-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/base-acp-agent.ts
@@ -37,6 +37,7 @@ import {
   pickAllowedModel,
 } from "../gateway-models";
 import { Logger } from "../utils/logger";
+import type { UsageCommandConfig } from "./usage-command";
 /**
  * Shared settings manager interface that Claude's SettingsManager
  * implements. BaseAcpAgent only calls dispose() on this; each adapter's
@@ -67,9 +68,14 @@ export abstract class BaseAcpAgent implements Agent {
   logger: Logger;
   fileContentCache: { [key: string]: string } = {};
   protected gatewayModels: GatewayModel[] = [];
+  protected usageCommandConfig?: UsageCommandConfig;
 
-  constructor(client: AgentSideConnection) {
+  constructor(
+    client: AgentSideConnection,
+    usageCommandConfig?: UsageCommandConfig,
+  ) {
     this.client = client;
+    this.usageCommandConfig = usageCommandConfig;
     this.logger = new Logger({ debug: true, prefix: "[BaseAcpAgent]" });
   }
 

--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
@@ -92,6 +92,7 @@ import {
   handleUsageCommand,
   isUsageCommand,
   type UsageCommandConfig,
+  withUsageCommand,
 } from "../usage-command";
 import {
   buildBreakdown,
@@ -1151,7 +1152,10 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
               session.knownSlashCommands = collectKnownSlashCommands(
                 message.commands,
               );
-              const available = getAvailableSlashCommands(message.commands);
+              const available = withUsageCommand(
+                getAvailableSlashCommands(message.commands),
+                this.usageCommandConfig,
+              );
               await this.client.sessionUpdate({
                 sessionId,
                 update: {
@@ -3499,7 +3503,10 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
   private async sendAvailableCommandsUpdate(): Promise<void> {
     const commands = await this.session.query.supportedCommands();
     this.session.knownSlashCommands = collectKnownSlashCommands(commands);
-    const available = getAvailableSlashCommands(commands);
+    const available = withUsageCommand(
+      getAvailableSlashCommands(commands),
+      this.usageCommandConfig,
+    );
     await this.client.sessionUpdate({
       sessionId: this.sessionId,
       update: {

--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
@@ -89,6 +89,11 @@ import {
   resolveTaskId,
 } from "../session-meta";
 import {
+  handleUsageCommand,
+  isUsageCommand,
+  type UsageCommandConfig,
+} from "../usage-command";
+import {
   buildBreakdown,
   emptyBaseline,
   estimateMcpTokens,
@@ -374,6 +379,7 @@ export interface ClaudeAcpAgentOptions {
   machineAuth?: MachineClaudeAuth;
   /** Per-session context wiki mount — avoids global process.env mutation across concurrent sessions. */
   contextWiki?: ContextWikiEnv;
+  usageCommand?: UsageCommandConfig;
 }
 
 export class ClaudeAcpAgent extends BaseAcpAgent {
@@ -401,7 +407,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
   private sideQuestionAbort: AbortController | null = null;
 
   constructor(client: AgentSideConnection, options?: ClaudeAcpAgentOptions) {
-    super(client);
+    super(client, options?.usageCommand);
     this.options = options;
     this.toolUseCache = {};
     this.emittedToolCalls = new Set();
@@ -606,6 +612,22 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       return this.clearConversation(params);
     }
 
+    const hasInFlightTurns =
+      this.session.activeTurn !== null || this.session.turnQueue.length > 0;
+    if (
+      this.usageCommandConfig &&
+      !hasInFlightTurns &&
+      !isSteerMeta(params._meta) &&
+      isUsageCommand(params)
+    ) {
+      return handleUsageCommand({
+        client: this.client,
+        sessionId: this.sessionId,
+        params,
+        config: this.usageCommandConfig,
+      });
+    }
+
     const userMessage = promptToClaude(params);
     const promptUuid = randomUUID();
     userMessage.uuid = promptUuid;
@@ -628,9 +650,6 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     if (this.session.queryClosed) {
       throw RequestError.internalError(undefined, SESSION_ENDED_MESSAGE);
     }
-
-    const hasInFlightTurns =
-      this.session.activeTurn !== null || this.session.turnQueue.length > 0;
 
     const isSteer = isSteerMeta(params._meta);
     if (hasInFlightTurns && isSteer && !this.session.compacting) {

--- a/products/desktop/packages/agent/src/adapters/claude/session/options.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/options.ts
@@ -80,6 +80,8 @@ export type GatewayEnv = {
   openaiCustomHeaders?: Record<string, string>;
   /** PostHog project ID used to build the gateway project-scope header. */
   posthogProjectId?: string;
+  /** The `ai_product` the gateway stamps onto this session's generations. */
+  aiProduct?: string;
 };
 
 export interface BuildOptionsParams {

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
@@ -3663,6 +3663,36 @@ describe("CodexAppServerAgent", () => {
     ).toBe("turn_2");
   });
 
+  it("advertises /usage only when the session can answer it", async () => {
+    // A command menu built from this list must offer only what the adapter can honor.
+    const withUsage = async (usageCommand?: {
+      loadUsageMessage: () => Promise<string>;
+    }) => {
+      const stub = makeStubRpc({
+        "thread/start": { thread: { id: "t" } },
+        "skills/list": { data: [] },
+      });
+      const { client, sessionUpdates } = makeFakeClient();
+      const agent = new CodexAppServerAgent(client, {
+        processOptions: { binaryPath: "/x/codex" },
+        rpcFactory: stub.factory,
+        usageCommand,
+      });
+      await agent.newSession({ cwd: "/r" } as unknown as NewSessionRequest);
+      const cmds = (
+        sessionUpdates.find(
+          (u: any) => u.update?.sessionUpdate === "available_commands_update",
+        ) as any
+      )?.update?.availableCommands;
+      return (cmds ?? []).map((c: { name: string }) => c.name);
+    };
+
+    expect(
+      await withUsage({ loadUsageMessage: () => Promise.resolve("report") }),
+    ).toContain("usage");
+    expect(await withUsage(undefined)).not.toContain("usage");
+  });
+
   it("omits disabled skills from available_commands_update", async () => {
     const stub = makeStubRpc({
       "thread/start": { thread: { id: "t" } },

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -65,6 +65,11 @@ import { LOCAL_TOOLS_MCP_NAME } from "../local-tools";
 import { visiblePromptBlocks } from "../prompt-blocks";
 import { resolveSpokenNarration } from "../session-meta";
 import {
+  handleUsageCommand,
+  isUsageCommand,
+  type UsageCommandConfig,
+} from "../usage-command";
+import {
   AppServerClient,
   type AppServerClientHandlers,
   type AppServerRpc,
@@ -281,6 +286,7 @@ export interface CodexAppServerAgentOptions {
   onStructuredOutput?: (output: Record<string, unknown>) => Promise<void>;
   /** Test seam: build the JSON-RPC client (defaults to spawning the process). */
   rpcFactory?: (handlers: AppServerClientHandlers) => AppServerRpc;
+  usageCommand?: UsageCommandConfig;
 }
 
 /**
@@ -353,7 +359,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     client: AgentSideConnection,
     options: CodexAppServerAgentOptions,
   ) {
-    super(client);
+    super(client, options.usageCommand);
     this.logger =
       options.logger ??
       new Logger({ debug: true, prefix: "[CodexAppServerAgent]" });
@@ -877,6 +883,20 @@ export class CodexAppServerAgent extends BaseAcpAgent {
       return isSteer
         ? { stopReason: "end_turn", _meta: { steer: true } }
         : { stopReason: "end_turn" };
+    }
+    if (
+      this.usageCommandConfig &&
+      !isSteer &&
+      !this.turns.isRunning &&
+      !this.turns.isPending &&
+      isUsageCommand(params)
+    ) {
+      return handleUsageCommand({
+        client: this.client,
+        sessionId: this.sessionId,
+        params,
+        config: this.usageCommandConfig,
+      });
     }
     this.cancelNextGoalTurn = false;
     // Reopen the notification gate (a prior interrupt may have left session.cancelled set).

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -68,6 +68,7 @@ import {
   handleUsageCommand,
   isUsageCommand,
   type UsageCommandConfig,
+  withUsageCommand,
 } from "../usage-command";
 import {
   AppServerClient,
@@ -861,7 +862,10 @@ export class CodexAppServerAgent extends BaseAcpAgent {
         sessionId: this.sessionId,
         update: {
           sessionUpdate: "available_commands_update",
-          availableCommands: commands,
+          availableCommands: withUsageCommand(
+            commands,
+            this.usageCommandConfig,
+          ),
         },
       } as unknown as Parameters<AgentSideConnection["sessionUpdate"]>[0])
       .catch(() => undefined);

--- a/products/desktop/packages/agent/src/adapters/usage-command.test.ts
+++ b/products/desktop/packages/agent/src/adapters/usage-command.test.ts
@@ -1,0 +1,92 @@
+import type {
+  AgentSideConnection,
+  PromptRequest,
+} from "@agentclientprotocol/sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handleUsageCommand, isUsageCommand } from "./usage-command";
+
+describe("usage command", () => {
+  const sessionUpdate = vi.fn().mockResolvedValue(undefined);
+  const client = { sessionUpdate } as unknown as AgentSideConnection;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function promptOf(...texts: string[]): PromptRequest {
+    return {
+      sessionId: "session-1",
+      prompt: texts.map((text) => ({ type: "text", text })),
+    } as PromptRequest;
+  }
+
+  it("answers with the report instead of sending the prompt to a model", async () => {
+    const params = {
+      sessionId: "session-1",
+      prompt: [
+        {
+          type: "text",
+          text: "resume context",
+          _meta: { ui: { hidden: true } },
+        },
+        { type: "text", text: " /usage " },
+      ],
+    } as PromptRequest;
+
+    expect(isUsageCommand(params)).toBe(true);
+    await expect(
+      handleUsageCommand({
+        client,
+        sessionId: "session-1",
+        params,
+        config: {
+          loadUsageMessage: () =>
+            Promise.resolve(
+              "## PostHog AI usage\n\n**Current conversation**: 12 credits",
+            ),
+        },
+      }),
+    ).resolves.toEqual({ stopReason: "end_turn" });
+
+    expect(sessionUpdate).toHaveBeenCalledTimes(2);
+    expect(sessionUpdate.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          sessionUpdate: "agent_message_chunk",
+          content: expect.objectContaining({
+            text: expect.stringContaining(
+              "**Current conversation**: 12 credits",
+            ),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("keeps the session alive when the report cannot be loaded", async () => {
+    await expect(
+      handleUsageCommand({
+        client,
+        sessionId: "session-1",
+        params: promptOf("/usage"),
+        config: {
+          loadUsageMessage: () => Promise.reject(new Error("gateway down")),
+        },
+      }),
+    ).resolves.toEqual({ stopReason: "end_turn" });
+
+    expect(sessionUpdate.mock.calls.at(-1)?.[0]).toEqual(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          content: expect.objectContaining({
+            text: "Couldn't load PostHog AI usage. Try again in a moment.",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("does not claim prompts that include another visible block", () => {
+    expect(isUsageCommand(promptOf("/usage", "for this task"))).toBe(false);
+  });
+});

--- a/products/desktop/packages/agent/src/adapters/usage-command.test.ts
+++ b/products/desktop/packages/agent/src/adapters/usage-command.test.ts
@@ -89,4 +89,19 @@ describe("usage command", () => {
   it("does not claim prompts that include another visible block", () => {
     expect(isUsageCommand(promptOf("/usage", "for this task"))).toBe(false);
   });
+
+  // The PostHog AI composer sends the resources a person is looking at ahead of what they typed.
+  it.each([
+    ["<posthog_context>\ndashboard 3\n</posthog_context>\n\n/usage", true],
+    [
+      "<posthog_trusted_context>\ninsight 7\n</posthog_trusted_context>\n<posthog_untrusted_context>\nrows\n</posthog_untrusted_context>\n\n/usage",
+      true,
+    ],
+    [
+      "<posthog_context>\ndashboard 3\n</posthog_context>\n\nwhat did I spend",
+      false,
+    ],
+  ])("reads the command after attached context: %s", (text, claimed) => {
+    expect(isUsageCommand(promptOf(text))).toBe(claimed);
+  });
 });

--- a/products/desktop/packages/agent/src/adapters/usage-command.ts
+++ b/products/desktop/packages/agent/src/adapters/usage-command.ts
@@ -1,0 +1,86 @@
+import type {
+  AgentSideConnection,
+  PromptRequest,
+  PromptResponse,
+} from "@agentclientprotocol/sdk";
+import { visiblePromptBlocks } from "./prompt-blocks";
+
+export interface UsageCommandConfig {
+  /** PostHog renders the report, so no surface holds a second wording of it. */
+  loadUsageMessage: () => Promise<string>;
+}
+
+export interface UsageSource {
+  getAiUsageMessage(args: {
+    conversationId?: string;
+    conversationStartedAt?: string;
+    product?: string;
+  }): Promise<string>;
+}
+
+/** The desktop app's own runs are billed as PostHog Desktop. */
+const LOCAL_AI_PRODUCT = "posthog_code";
+
+export function usageCommandConfig(
+  source: UsageSource | undefined,
+  conversationId: string | undefined,
+  conversationStartedAt: string | undefined,
+  product: string = LOCAL_AI_PRODUCT,
+): UsageCommandConfig | undefined {
+  if (!source) return undefined;
+  return {
+    loadUsageMessage: () =>
+      source.getAiUsageMessage({
+        conversationId,
+        conversationStartedAt,
+        product,
+      }),
+  };
+}
+
+export function isUsageCommand(params: PromptRequest): boolean {
+  const visible = visiblePromptBlocks(params.prompt);
+  return (
+    visible.length === 1 &&
+    visible[0]?.type === "text" &&
+    visible[0].text.trim().toLowerCase() === "/usage"
+  );
+}
+
+export async function handleUsageCommand({
+  client,
+  sessionId,
+  params,
+  config,
+}: {
+  client: AgentSideConnection;
+  sessionId: string;
+  params: PromptRequest;
+  config: UsageCommandConfig;
+}): Promise<PromptResponse> {
+  for (const block of visiblePromptBlocks(params.prompt)) {
+    if (block.type !== "text" && block.type !== "image") continue;
+    await client.sessionUpdate({
+      sessionId,
+      update: {
+        sessionUpdate: "user_message_chunk",
+        content: block,
+      },
+    });
+  }
+
+  let message: string;
+  try {
+    message = await config.loadUsageMessage();
+  } catch {
+    message = "Couldn't load PostHog AI usage. Try again in a moment.";
+  }
+  await client.sessionUpdate({
+    sessionId,
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: message },
+    },
+  });
+  return { stopReason: "end_turn" };
+}

--- a/products/desktop/packages/agent/src/adapters/usage-command.ts
+++ b/products/desktop/packages/agent/src/adapters/usage-command.ts
@@ -38,12 +38,29 @@ export function usageCommandConfig(
   };
 }
 
+/**
+ * One `<posthog_context>` / `<posthog_trusted_context>` / `<posthog_untrusted_context>` block.
+ * The PostHog AI composer prefixes the resources a person is looking at as these blocks, so the
+ * command they typed sits after them and an exact match on the whole text would miss it.
+ */
+const CONTEXT_BLOCK =
+  /^\s*<posthog_(trusted_|untrusted_)?context>[\s\S]*?<\/posthog_\1context>\s*/;
+
+function typedCommand(text: string): string {
+  let rest = text;
+  for (let stripped = rest.replace(CONTEXT_BLOCK, ""); stripped !== rest; ) {
+    rest = stripped;
+    stripped = rest.replace(CONTEXT_BLOCK, "");
+  }
+  return rest.trim().toLowerCase();
+}
+
 export function isUsageCommand(params: PromptRequest): boolean {
   const visible = visiblePromptBlocks(params.prompt);
   return (
     visible.length === 1 &&
     visible[0]?.type === "text" &&
-    visible[0].text.trim().toLowerCase() === "/usage"
+    typedCommand(visible[0].text) === "/usage"
   );
 }
 

--- a/products/desktop/packages/agent/src/adapters/usage-command.ts
+++ b/products/desktop/packages/agent/src/adapters/usage-command.ts
@@ -1,9 +1,32 @@
 import type {
   AgentSideConnection,
+  AvailableCommand,
   PromptRequest,
   PromptResponse,
 } from "@agentclientprotocol/sdk";
 import { visiblePromptBlocks } from "./prompt-blocks";
+
+/**
+ * What a session advertises for this command, so a client's command menu offers only what the
+ * agent can honor. The adapter answers it rather than the model, like `/clear`, so no model
+ * lists it and it has to be added to the declaration by hand.
+ */
+export const USAGE_AVAILABLE_COMMAND: AvailableCommand = {
+  name: "usage",
+  description:
+    "Show PostHog AI credits for this conversation and billing period",
+  input: null,
+};
+
+export function withUsageCommand<T extends { name: string }>(
+  commands: T[],
+  config: UsageCommandConfig | undefined,
+): (T | AvailableCommand)[] {
+  if (!config || commands.some((command) => command.name === "usage")) {
+    return commands;
+  }
+  return [...commands, USAGE_AVAILABLE_COMMAND];
+}
 
 export interface UsageCommandConfig {
   /** PostHog renders the report, so no surface holds a second wording of it. */

--- a/products/desktop/packages/agent/src/agent.test.ts
+++ b/products/desktop/packages/agent/src/agent.test.ts
@@ -128,6 +128,8 @@ describe("Agent", () => {
         anthropicAuthToken: "token",
       }),
     );
+    // Without this the `/usage` command falls through to the model.
+    expect(config.usageCommand?.loadUsageMessage).toBeInstanceOf(Function);
   });
 
   it("stops before starting Codex without authentication", async () => {

--- a/products/desktop/packages/agent/src/agent.ts
+++ b/products/desktop/packages/agent/src/agent.ts
@@ -16,6 +16,7 @@ import {
 } from "./adapters/acp-connection";
 import { machineClaudeAuth } from "./adapters/claude/machine-auth";
 import type { GatewayEnv } from "./adapters/claude/session/options";
+import { usageCommandConfig } from "./adapters/usage-command";
 import {
   DEFAULT_CODEX_MODEL,
   DEFAULT_GATEWAY_MODEL,
@@ -245,6 +246,11 @@ export class Agent {
       claudeGatewayEnv,
       claudeMachineAuth: claudeSubscription ? machineClaudeAuth() : undefined,
       contextWiki: options.contextWiki,
+      usageCommand: usageCommandConfig(
+        this.posthogAPI,
+        taskId,
+        task?.created_at,
+      ),
       codexOptions:
         options.adapter === "codex" && (codexSubscription || gatewayConfig)
           ? {

--- a/products/desktop/packages/agent/src/posthog-api.ts
+++ b/products/desktop/packages/agent/src/posthog-api.ts
@@ -222,6 +222,28 @@ export class PostHogAPIClient {
     return getLlmGatewayUrl(this.baseUrl);
   }
 
+  /** The conversation is the `$ai_session_id`, which for an agent run is the task. */
+  async getAiUsageMessage({
+    conversationId,
+    conversationStartedAt,
+    product,
+  }: {
+    conversationId?: string;
+    conversationStartedAt?: string;
+    product?: string;
+  } = {}): Promise<string> {
+    const query = new URLSearchParams();
+    if (conversationId) query.set("conversation_id", conversationId);
+    if (conversationStartedAt)
+      query.set("conversation_started_at", conversationStartedAt);
+    if (product) query.set("product", product);
+    const search = query.size > 0 ? `?${query}` : "";
+    const usage = await this.apiRequest<{ message: string }>(
+      `/api/projects/${this.getTeamId()}/ai_usage/${search}`,
+    );
+    return usage.message;
+  }
+
   /**
    * The gateway user node for the signed-in person, or null when the credential
    * resolves to no user (a task-scoped token). This is the distinct id, not the

--- a/products/desktop/packages/agent/src/server/agent-server.configure-environment.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.configure-environment.test.ts
@@ -341,6 +341,7 @@ describe("AgentServer.configureEnvironment", () => {
     expect(env.openaiBaseUrl).toBe(
       "https://gateway.us.posthog.com/slack_app/v1",
     );
+    expect(env.aiProduct).toBe("slack_app");
   });
 
   it("prefers slack_app over background_agents when both signals are present", () => {

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -1856,6 +1856,19 @@ export class AgentServer {
       onWireMessage: (message, eventId) =>
         this.handleAcpTransportMessage(message, eventId),
       logger: this.logger,
+      usageCommand: {
+        // Fetched per command rather than per session: `/usage` is rare, and the
+        // task's start time only bounds this one search.
+        loadUsageMessage: async () =>
+          posthogAPI.getAiUsageMessage({
+            conversationId: payload.task_id,
+            conversationStartedAt: await posthogAPI
+              .getTask(payload.task_id)
+              .then((task) => task.created_at)
+              .catch(() => undefined),
+            product: gatewayEnv.aiProduct,
+          }),
+      },
       claudeGatewayEnv: runtimeAdapter !== "codex" ? gatewayEnv : undefined,
       codexOptions:
         runtimeAdapter === "codex"
@@ -4769,6 +4782,7 @@ ${commonInstructions}
       anthropicCustomHeaders: customHeaders,
       openaiCustomHeaders,
       posthogProjectId: String(projectId),
+      aiProduct,
     };
   }
 


### PR DESCRIPTION
## Problem

Someone working in a cloud agent or in the desktop app cannot see what the conversation has cost without leaving it.

- Asking the model costs credits to answer a question about credits, and the model has no reliable source for the number.
- The Max chat has answered `/usage` since it shipped. The agent had no equivalent.
- The backend half is [#94298](https://github.com/PostHog/posthog/pull/94298). It adds the shared report and the `ai_usage` endpoint this PR calls. That PR must deploy first.

## Changes

- Typing `/usage` in an agent session prints credits for this conversation, for the product the session is billed as, and for PostHog AI as a whole.
- The agent recognizes the command before the prompt reaches a model, so asking costs no credits.
- PostHog renders the report and the agent prints it as it arrives, so the agent, Slack and the Max chat cannot drift into three wordings.
- A failed load ends the turn with one line rather than leaving the session waiting.
- The PostHog AI view is covered by the same interception. Its sandbox conversations reach the agent through this prompt path, so `/usage` there is answered without a model call too.
- The session declares `/usage` in `available_commands_update`, so a client's command menu offers it. A session that cannot reach PostHog does not declare it, so the menu promises only what the agent can honor.
- The command is read after the `<posthog_context>` blocks the composer prefixes, so attached page context no longer sends the question to a model. A prompt with any other visible block still goes to the model as before.

> [!IMPORTANT]
> This is the top layer of stack #96453. Land it bottom-first: enqueueing this PR would merge [#94298](https://github.com/PostHog/posthog/pull/94298) with it, and desktop auto-updates, so this must merge only once that endpoint is deployed. Until then `/usage` answers that usage could not be loaded.

Both adapters (Claude and Codex) route the command through the same handler, and neither claims it while a turn is in flight or while the prompt is a steer.

Nothing looks different in the app: the change produces text in the agent's own conversation.

## How did you test this code?

- `usage-command.test.ts` covers the three behaviors that break the feature silently: the command is answered without reaching a model, a failed load still ends the turn, and a prompt carrying another visible block is not claimed.
- The codex adapter test asserts the command is declared when the session can answer it and absent when it cannot. A menu built from a list that over-promises is the failure this catches.
- `agent.test.ts` asserts the desktop path wires a loader. Without it the command falls through to the model, which is the regression that has no other symptom.
- `usage-command.test.ts` covers a prompt carrying attached context, in both the legacy and the trusted/untrusted block form. That is the shape the PostHog AI composer sends, and the exact match missed it.
- `agent-server.configure-environment.test.ts` gains one assertion that the session carries its `ai_product`, which is what attributes the product row.
- Not run: no live agent session against a deployed `ai_usage` endpoint, since the endpoint ships in the other PR.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [x] Publish to changelog?

## Docs update

None. The command is discoverable in the agent's own command list.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) split this out of [#94298](https://github.com/PostHog/posthog/pull/94298), which held both halves and failed the desktop/backend coupling gate. The first version of this code called the LLM gateway's quota endpoint and formatted the answer in TypeScript; the interception survives, the formatting does not.

Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-pr-descriptions`.

Nothing in this PR carries material from the session that is not already in this repository.
