### PR TITLE
chore(mcp): leave one way to report a missing capability

### DIFF
--- a/products/mcp_analytics/mcp/tools.yaml
+++ b/products/mcp_analytics/mcp/tools.yaml
@@ -136,26 +136,11 @@ tools:
     mcp-missing-capability-list:
         operation: mcp_analytics_missing_capabilities_list
         enabled: false
+    # Superseded by the analytics SDK's get_more_tools tool, which every connection is
+    # advertised rather than only the flagged teams this one reached. The endpoint stays.
     mcp-missing-capability-report:
         operation: mcp_analytics_missing_capabilities_create
-        enabled: true
-        scopes:
-            - mcp_analytics:write
-        annotations:
-            readOnly: false
-            destructive: false
-            idempotent: false
-        title: Report missing capability
-        description: >
-            Report that the current MCP tools are insufficient for the user's goal. Use this when a missing tool,
-            missing workflow support, or missing explanation blocks progress. Describe the gap without personal data or
-            sensitive query content. This records feedback for the PostHog team; continue with a fallback when possible.
-        include_params:
-            - goal
-            - missing_capability
-            - blocked
-            - attempted_tool
-        feature_flag: mcp-analytics
+        enabled: false
 wrappers:
     query-mcp-harness-breakdown:
         schema_ref: MCPHarnessBreakdownQuery

--- a/products/mcp_analytics/mcp/tools.yaml
+++ b/products/mcp_analytics/mcp/tools.yaml
@@ -136,8 +136,6 @@ tools:
     mcp-missing-capability-list:
         operation: mcp_analytics_missing_capabilities_list
         enabled: false
-    # Superseded by the analytics SDK's get_more_tools tool, which every connection is
-    # advertised rather than only the flagged teams this one reached. The endpoint stays.
     mcp-missing-capability-report:
         operation: mcp_analytics_missing_capabilities_create
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -7955,21 +7955,6 @@
         },
         "feature_flag": "mcp-analytics"
     },
-    "mcp-missing-capability-report": {
-        "description": "Report that the current MCP tools are insufficient for the user's goal. Use this when a missing tool, missing workflow support, or missing explanation blocks progress. Describe the gap without personal data or sensitive query content. This records feedback for the PostHog team; continue with a fallback when possible.",
-        "category": "MCP analytics",
-        "feature": "mcp_analytics",
-        "summary": "Report missing capability",
-        "title": "Report missing capability",
-        "required_scopes": ["mcp_analytics:write"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        },
-        "feature_flag": "mcp-analytics"
-    },
     "media-image-upload-complete": {
         "description": "Step 2 of the presigned upload flow. Verifies the file uploaded via media-image-upload-start, sniffs its real content type, and activates it — after this it appears in media-images-list and is publicly servable. Returns the permanent url; for emails, put it in the image block's values.src.url.",
         "category": "Core",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -8349,21 +8349,6 @@
         },
         "feature_flag": "mcp-analytics"
     },
-    "mcp-missing-capability-report": {
-        "description": "Report that the current MCP tools are insufficient for the user's goal. Use this when a missing tool, missing workflow support, or missing explanation blocks progress. Describe the gap without personal data or sensitive query content. This records feedback for the PostHog team; continue with a fallback when possible.",
-        "category": "MCP analytics",
-        "feature": "mcp_analytics",
-        "summary": "Report missing capability",
-        "title": "Report missing capability",
-        "required_scopes": ["mcp_analytics:write"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        },
-        "feature_flag": "mcp-analytics"
-    },
     "media-image-upload-complete": {
         "description": "Step 2 of the presigned upload flow. Verifies the file uploaded via media-image-upload-start, sniffs its real content type, and activates it — after this it appears in media-images-list and is publicly servable. Returns the permanent url; for emails, put it in the image block's values.src.url.",
         "category": "Core",

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -550,7 +550,7 @@
                     "type": "string"
                 },
                 "category": {
-                    "description": "For MCP feedback (`feedback_type: \"mcp\"`) only: the single category that best describes the dominant theme. Pick \"missing_tool\" if a capability was absent, \"tool_description\" if the tool docs were unclear, \"tool_input_schema\" if input args were confusing, \"tool_output_format\" if the response was hard to consume, \"instructions_clarity\" if these MCP instructions were unclear, \"tool_correctness\" if a tool returned wrong data, \"error_message\" if an error was unhelpful, \"performance\" if latency was the issue. Omit for product, docs, or other feedback.",
+                    "description": "For MCP feedback (`feedback_type: \"mcp\"`) only: the single category that best describes the dominant theme. Pick \"tool_description\" if the tool docs were unclear, \"tool_input_schema\" if input args were confusing, \"tool_output_format\" if the response was hard to consume, \"instructions_clarity\" if these MCP instructions were unclear, \"tool_correctness\" if a tool returned wrong data, \"error_message\" if an error was unhelpful, \"performance\" if latency was the issue. Report a capability that does not exist with `get_more_tools` instead; pick \"missing_tool\" only when the gap is a side note to feedback about a tool that does exist. Omit for product, docs, or other feedback.",
                     "type": "string",
                     "enum": [
                         "tool_correctness",

--- a/services/mcp/src/generated/mcp_analytics/api.ts
+++ b/services/mcp/src/generated/mcp_analytics/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 7 enabled ops
+ * PostHog API - MCP 6 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -130,94 +130,6 @@ export const McpAnalyticsIntentClustersRecomputeParams = () => zod.object({
         .describe(
             "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
         ),
-})
-
-/**
- * Create a new missing capability report for the current project.
- */
-export const McpAnalyticsMissingCapabilitiesCreateParams = () => zod.object({
-    project_id: zod
-        .string()
-        .describe(
-            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
-        ),
-})
-
-export const mcpAnalyticsMissingCapabilitiesCreateBodyAttemptedToolDefault = ``
-export const mcpAnalyticsMissingCapabilitiesCreateBodyAttemptedToolMax = 200
-
-export const mcpAnalyticsMissingCapabilitiesCreateBodyMcpClientNameDefault = ``
-export const mcpAnalyticsMissingCapabilitiesCreateBodyMcpClientNameMax = 200
-
-export const mcpAnalyticsMissingCapabilitiesCreateBodyMcpClientVersionDefault = ``
-export const mcpAnalyticsMissingCapabilitiesCreateBodyMcpClientVersionMax = 100
-
-export const mcpAnalyticsMissingCapabilitiesCreateBodyMcpProtocolVersionDefault = ``
-export const mcpAnalyticsMissingCapabilitiesCreateBodyMcpProtocolVersionMax = 50
-
-export const mcpAnalyticsMissingCapabilitiesCreateBodyMcpTransportDefault = ``
-export const mcpAnalyticsMissingCapabilitiesCreateBodyMcpTransportMax = 50
-
-export const mcpAnalyticsMissingCapabilitiesCreateBodyMcpSessionIdDefault = ``
-export const mcpAnalyticsMissingCapabilitiesCreateBodyMcpSessionIdMax = 200
-
-export const mcpAnalyticsMissingCapabilitiesCreateBodyMcpTraceIdDefault = ``
-export const mcpAnalyticsMissingCapabilitiesCreateBodyMcpTraceIdMax = 200
-
-export const mcpAnalyticsMissingCapabilitiesCreateBodyGoalMax = 500
-
-export const mcpAnalyticsMissingCapabilitiesCreateBodyMissingCapabilityMax = 5000
-
-export const mcpAnalyticsMissingCapabilitiesCreateBodyBlockedDefault = true
-
-export const McpAnalyticsMissingCapabilitiesCreateBody = () => zod.object({
-    attempted_tool: zod
-        .string()
-        .max(mcpAnalyticsMissingCapabilitiesCreateBodyAttemptedToolMax)
-        .default(mcpAnalyticsMissingCapabilitiesCreateBodyAttemptedToolDefault)
-        .describe('The tool the user tried before leaving feedback, if known.'),
-    mcp_client_name: zod
-        .string()
-        .max(mcpAnalyticsMissingCapabilitiesCreateBodyMcpClientNameMax)
-        .default(mcpAnalyticsMissingCapabilitiesCreateBodyMcpClientNameDefault)
-        .describe('MCP client name, for example Claude Desktop or Cursor.'),
-    mcp_client_version: zod
-        .string()
-        .max(mcpAnalyticsMissingCapabilitiesCreateBodyMcpClientVersionMax)
-        .default(mcpAnalyticsMissingCapabilitiesCreateBodyMcpClientVersionDefault)
-        .describe('Version string for the MCP client when available.'),
-    mcp_protocol_version: zod
-        .string()
-        .max(mcpAnalyticsMissingCapabilitiesCreateBodyMcpProtocolVersionMax)
-        .default(mcpAnalyticsMissingCapabilitiesCreateBodyMcpProtocolVersionDefault)
-        .describe('MCP protocol version negotiated for the session when available.'),
-    mcp_transport: zod
-        .string()
-        .max(mcpAnalyticsMissingCapabilitiesCreateBodyMcpTransportMax)
-        .default(mcpAnalyticsMissingCapabilitiesCreateBodyMcpTransportDefault)
-        .describe('Transport used for the MCP session, for example streamable_http or sse.'),
-    mcp_session_id: zod
-        .string()
-        .max(mcpAnalyticsMissingCapabilitiesCreateBodyMcpSessionIdMax)
-        .default(mcpAnalyticsMissingCapabilitiesCreateBodyMcpSessionIdDefault)
-        .describe('Stable MCP session identifier when available.'),
-    mcp_trace_id: zod
-        .string()
-        .max(mcpAnalyticsMissingCapabilitiesCreateBodyMcpTraceIdMax)
-        .default(mcpAnalyticsMissingCapabilitiesCreateBodyMcpTraceIdDefault)
-        .describe('Trace identifier for the surrounding MCP workflow when available.'),
-    goal: zod
-        .string()
-        .max(mcpAnalyticsMissingCapabilitiesCreateBodyGoalMax)
-        .describe("The user's intended outcome when using MCP."),
-    missing_capability: zod
-        .string()
-        .max(mcpAnalyticsMissingCapabilitiesCreateBodyMissingCapabilityMax)
-        .describe('Capability, tool, or workflow support that is currently missing.'),
-    blocked: zod
-        .boolean()
-        .default(mcpAnalyticsMissingCapabilitiesCreateBodyBlockedDefault)
-        .describe("Whether the missing capability blocked the user's progress."),
 })
 
 /**

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -282,7 +282,7 @@ export const FeedbackSubmitSchema = z
             ])
             .optional()
             .describe(
-                'For MCP feedback (`feedback_type: "mcp"`) only: the single category that best describes the dominant theme. Pick "missing_tool" if a capability was absent, "tool_description" if the tool docs were unclear, "tool_input_schema" if input args were confusing, "tool_output_format" if the response was hard to consume, "instructions_clarity" if these MCP instructions were unclear, "tool_correctness" if a tool returned wrong data, "error_message" if an error was unhelpful, "performance" if latency was the issue. Omit for product, docs, or other feedback.'
+                'For MCP feedback (`feedback_type: "mcp"`) only: the single category that best describes the dominant theme. Pick "tool_description" if the tool docs were unclear, "tool_input_schema" if input args were confusing, "tool_output_format" if the response was hard to consume, "instructions_clarity" if these MCP instructions were unclear, "tool_correctness" if a tool returned wrong data, "error_message" if an error was unhelpful, "performance" if latency was the issue. Report a capability that does not exist with `get_more_tools` instead; pick "missing_tool" only when the gap is a side note to feedback about a tool that does exist. Omit for product, docs, or other feedback.'
             ),
         scout_skill_name: z
             .string()

--- a/services/mcp/src/templates/sections/agent-feedback.md
+++ b/services/mcp/src/templates/sections/agent-feedback.md
@@ -1,16 +1,18 @@
 ### Sharing feedback on PostHog
 
-The `agent-feedback` tool is a direct channel to the PostHog team for feedback about **anything PostHog** — a product or feature you (or the user) hit a rough edge with, this MCP server itself, the docs, or a capability that's missing. Use it whenever you or the user run into something worth telling the PostHog team, on any surface.
+The `agent-feedback` tool is a direct channel to the PostHog team for feedback about **anything PostHog** — a product or feature you (or the user) hit a rough edge with, this MCP server itself, or the docs. Use it whenever you or the user run into something worth telling the PostHog team, on any surface.
+
+When the tool you need does not exist at all, report the gap with `get_more_tools` instead of here.
 
 Set `feedback_type` to route it:
 
 - `product` — any PostHog product or feature: insights, session replay, feature flags, the data warehouse, web analytics, error tracking, experiments, etc. Put the area in `product_area` (e.g. "session replay").
-- `mcp` — this MCP server itself: an unclear tool description, a confusing input schema, a hard-to-consume response, wrong results, an unhelpful error, a missing tool, or these instructions. Set `category` for MCP feedback.
+- `mcp` — this MCP server itself: an unclear tool description, a confusing input schema, a hard-to-consume response, wrong results, an unhelpful error, or these instructions. Set `category` for MCP feedback.
 - `docs` — PostHog documentation.
 - `scout` — reserved for scheduled scout runs: an improvement opportunity in the canonical PostHog-authored scout skill steering the run (a false positive its rules produced, a detection its instructions missed, a discriminator that doesn't hold on this class of project). Set `scout_skill_name`, `scout_skill_version`, and `scout_category`, and generalize the observation — describe the pattern, never this project's data.
 - `other` — anything that doesn't fit the above.
 
-**All sentiments are welcome** — set `sentiment` to `positive`, `neutral`, `negative`, or `mixed`. Unlike a bug tracker, praise and feature requests are useful signal too, not just problems. Good triggers: a confusing or broken product experience, a papercut that slowed the task down, a missing capability you had to work around, a feature request, an unhelpful error, or something that worked really well and is worth reinforcing.
+**All sentiments are welcome** — set `sentiment` to `positive`, `neutral`, `negative`, or `mixed`. Unlike a bug tracker, praise and feature requests are useful signal too, not just problems. Good triggers: a confusing or broken product experience, a papercut that slowed the task down, a feature request, an unhelpful error, or something that worked really well and is worth reinforcing.
 
 Keep it short and actionable: a one-sentence `summary`, then the detail fields (`friction_points`, `suggested_improvement`, `details`) as clear, concise bullet points, quoting the exact product surface, tool name, parameter, or error text where you can. Include a concrete `suggested_improvement` whenever you can name one — for negative or mixed feedback that's the most valuable part. Use `task_completed: false` when you couldn't finish the user's request. Do not include user PII or sensitive query content in any field.
 

--- a/services/mcp/src/tools/generated/mcp_analytics.ts
+++ b/services/mcp/src/tools/generated/mcp_analytics.ts
@@ -176,48 +176,6 @@ const mcpFeedbackSubmit = (): ToolBase<ReturnType<typeof McpFeedbackSubmitSchema
     },
 })
 
-const McpMissingCapabilityReportSchema = () => {
-    const McpAnalyticsMissingCapabilitiesCreateBody = orvalSchemas.McpAnalyticsMissingCapabilitiesCreateBody()
-    return McpAnalyticsMissingCapabilitiesCreateBody.omit({
-        mcp_client_name: true,
-        mcp_client_version: true,
-        mcp_protocol_version: true,
-        mcp_transport: true,
-        mcp_session_id: true,
-        mcp_trace_id: true,
-    })
-}
-
-const mcpMissingCapabilityReport = (): ToolBase<
-    ReturnType<typeof McpMissingCapabilityReportSchema>,
-    Schemas.MCPAnalyticsSubmission
-> => ({
-    name: 'mcp-missing-capability-report',
-    schema: McpMissingCapabilityReportSchema(),
-    handler: async (context: Context, params: z.infer<ReturnType<typeof McpMissingCapabilityReportSchema>>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const body: Record<string, unknown> = {}
-        if (params.attempted_tool !== undefined) {
-            body['attempted_tool'] = params.attempted_tool
-        }
-        if (params.goal !== undefined) {
-            body['goal'] = params.goal
-        }
-        if (params.missing_capability !== undefined) {
-            body['missing_capability'] = params.missing_capability
-        }
-        if (params.blocked !== undefined) {
-            body['blocked'] = params.blocked
-        }
-        const result = await context.api.request<Schemas.MCPAnalyticsSubmission>({
-            method: 'POST',
-            path: `/api/projects/${encodeURIComponent(String(projectId))}/mcp_analytics/missing_capabilities/`,
-            body,
-        })
-        return result
-    },
-})
-
 // --- Query wrapper schemas from schema.json ---
 
 const DateRange = z.object({
@@ -706,7 +664,6 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'mcp-analytics-sessions-list': mcpAnalyticsSessionsList,
     'mcp-analytics-sessions-tool-calls': mcpAnalyticsSessionsToolCalls,
     'mcp-feedback-submit': mcpFeedbackSubmit,
-    'mcp-missing-capability-report': mcpMissingCapabilityReport,
     'query-mcp-harness-breakdown': createQueryWrapper({
         name: 'query-mcp-harness-breakdown',
         schema: MCPHarnessBreakdownQuery,

--- a/services/mcp/tests/unit/__snapshots__/instructions/exec-command-reference-full.txt
+++ b/services/mcp/tests/unit/__snapshots__/instructions/exec-command-reference-full.txt
@@ -280,17 +280,19 @@ Choose the link source in this order:
 
 ### Sharing feedback on PostHog
 
-The `agent-feedback` tool is a direct channel to the PostHog team for feedback about **anything PostHog** — a product or feature you (or the user) hit a rough edge with, this MCP server itself, the docs, or a capability that's missing. Use it whenever you or the user run into something worth telling the PostHog team, on any surface.
+The `agent-feedback` tool is a direct channel to the PostHog team for feedback about **anything PostHog** — a product or feature you (or the user) hit a rough edge with, this MCP server itself, or the docs. Use it whenever you or the user run into something worth telling the PostHog team, on any surface.
+
+When the tool you need does not exist at all, report the gap with `get_more_tools` instead of here.
 
 Set `feedback_type` to route it:
 
 - `product` — any PostHog product or feature: insights, session replay, feature flags, the data warehouse, web analytics, error tracking, experiments, etc. Put the area in `product_area` (e.g. "session replay").
-- `mcp` — this MCP server itself: an unclear tool description, a confusing input schema, a hard-to-consume response, wrong results, an unhelpful error, a missing tool, or these instructions. Set `category` for MCP feedback.
+- `mcp` — this MCP server itself: an unclear tool description, a confusing input schema, a hard-to-consume response, wrong results, an unhelpful error, or these instructions. Set `category` for MCP feedback.
 - `docs` — PostHog documentation.
 - `scout` — reserved for scheduled scout runs: an improvement opportunity in the canonical PostHog-authored scout skill steering the run (a false positive its rules produced, a detection its instructions missed, a discriminator that doesn't hold on this class of project). Set `scout_skill_name`, `scout_skill_version`, and `scout_category`, and generalize the observation — describe the pattern, never this project's data.
 - `other` — anything that doesn't fit the above.
 
-**All sentiments are welcome** — set `sentiment` to `positive`, `neutral`, `negative`, or `mixed`. Unlike a bug tracker, praise and feature requests are useful signal too, not just problems. Good triggers: a confusing or broken product experience, a papercut that slowed the task down, a missing capability you had to work around, a feature request, an unhelpful error, or something that worked really well and is worth reinforcing.
+**All sentiments are welcome** — set `sentiment` to `positive`, `neutral`, `negative`, or `mixed`. Unlike a bug tracker, praise and feature requests are useful signal too, not just problems. Good triggers: a confusing or broken product experience, a papercut that slowed the task down, a feature request, an unhelpful error, or something that worked really well and is worth reinforcing.
 
 Keep it short and actionable: a one-sentence `summary`, then the detail fields (`friction_points`, `suggested_improvement`, `details`) as clear, concise bullet points, quoting the exact product surface, tool name, parameter, or error text where you can. Include a concrete `suggested_improvement` whenever you can name one — for negative or mixed feedback that's the most valuable part. Use `task_completed: false` when you couldn't finish the user's request. Do not include user PII or sensitive query content in any field.
 

--- a/services/mcp/tests/unit/__snapshots__/instructions/tools-instructions.txt
+++ b/services/mcp/tests/unit/__snapshots__/instructions/tools-instructions.txt
@@ -166,17 +166,19 @@ Choose the link source in this order:
 
 ### Sharing feedback on PostHog
 
-The `agent-feedback` tool is a direct channel to the PostHog team for feedback about **anything PostHog** — a product or feature you (or the user) hit a rough edge with, this MCP server itself, the docs, or a capability that's missing. Use it whenever you or the user run into something worth telling the PostHog team, on any surface.
+The `agent-feedback` tool is a direct channel to the PostHog team for feedback about **anything PostHog** — a product or feature you (or the user) hit a rough edge with, this MCP server itself, or the docs. Use it whenever you or the user run into something worth telling the PostHog team, on any surface.
+
+When the tool you need does not exist at all, report the gap with `get_more_tools` instead of here.
 
 Set `feedback_type` to route it:
 
 - `product` — any PostHog product or feature: insights, session replay, feature flags, the data warehouse, web analytics, error tracking, experiments, etc. Put the area in `product_area` (e.g. "session replay").
-- `mcp` — this MCP server itself: an unclear tool description, a confusing input schema, a hard-to-consume response, wrong results, an unhelpful error, a missing tool, or these instructions. Set `category` for MCP feedback.
+- `mcp` — this MCP server itself: an unclear tool description, a confusing input schema, a hard-to-consume response, wrong results, an unhelpful error, or these instructions. Set `category` for MCP feedback.
 - `docs` — PostHog documentation.
 - `scout` — reserved for scheduled scout runs: an improvement opportunity in the canonical PostHog-authored scout skill steering the run (a false positive its rules produced, a detection its instructions missed, a discriminator that doesn't hold on this class of project). Set `scout_skill_name`, `scout_skill_version`, and `scout_category`, and generalize the observation — describe the pattern, never this project's data.
 - `other` — anything that doesn't fit the above.
 
-**All sentiments are welcome** — set `sentiment` to `positive`, `neutral`, `negative`, or `mixed`. Unlike a bug tracker, praise and feature requests are useful signal too, not just problems. Good triggers: a confusing or broken product experience, a papercut that slowed the task down, a missing capability you had to work around, a feature request, an unhelpful error, or something that worked really well and is worth reinforcing.
+**All sentiments are welcome** — set `sentiment` to `positive`, `neutral`, `negative`, or `mixed`. Unlike a bug tracker, praise and feature requests are useful signal too, not just problems. Good triggers: a confusing or broken product experience, a papercut that slowed the task down, a feature request, an unhelpful error, or something that worked really well and is worth reinforcing.
 
 Keep it short and actionable: a one-sentence `summary`, then the detail fields (`friction_points`, `suggested_improvement`, `details`) as clear, concise bullet points, quoting the exact product surface, tool name, parameter, or error text where you can. Include a concrete `suggested_improvement` whenever you can name one — for negative or mixed feedback that's the most valuable part. Use `task_completed: false` when you couldn't finish the user's request. Do not include user PII or sensitive query content in any field.
 

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/agent-feedback.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/agent-feedback.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "category": {
-            "description": "For MCP feedback (`feedback_type: \"mcp\"`) only: the single category that best describes the dominant theme. Pick \"missing_tool\" if a capability was absent, \"tool_description\" if the tool docs were unclear, \"tool_input_schema\" if input args were confusing, \"tool_output_format\" if the response was hard to consume, \"instructions_clarity\" if these MCP instructions were unclear, \"tool_correctness\" if a tool returned wrong data, \"error_message\" if an error was unhelpful, \"performance\" if latency was the issue. Omit for product, docs, or other feedback.",
+            "description": "For MCP feedback (`feedback_type: \"mcp\"`) only: the single category that best describes the dominant theme. Pick \"tool_description\" if the tool docs were unclear, \"tool_input_schema\" if input args were confusing, \"tool_output_format\" if the response was hard to consume, \"instructions_clarity\" if these MCP instructions were unclear, \"tool_correctness\" if a tool returned wrong data, \"error_message\" if an error was unhelpful, \"performance\" if latency was the issue. Report a capability that does not exist with `get_more_tools` instead; pick \"missing_tool\" only when the gap is a side note to feedback about a tool that does exist. Omit for product, docs, or other feedback.",
             "enum": [
                 "tool_correctness",
                 "tool_description",


### PR DESCRIPTION
## Problem

An agent on PostHog's MCP server was offered three ways to say "there is no tool for this", and the one most likely to be picked produced a report nobody could read.

- `mcp-missing-capability-report` writes a row to `posthog_mcp_analytics_submission` and captures `$mcp_missing_capability` into the *reporting team's* project without the description, so the Missing capabilities feed renders it as an empty row. It reaches only teams holding the `mcp-analytics` flag and the `mcp_analytics:write` scope.
- `agent-feedback` names the same trigger three times in its instructions, and its `category` field tells the model to pick `missing_tool` when a capability was absent. That lands on `mcp feedback submitted`, which the feed does not read.
- #96072 added `get_more_tools`, which every connection sees and which puts the description on `$mcp_intent`, the one field the feed renders.

Stacked on #96072, because the prose added here points at a tool that PR registers. Part of #95834.

CLI discovery is no longer part of this PR. #96072 now wires the `tools`, `info` and `schema` verbs to the SDK descriptor directly, which covers `posthog-cli` as well.

## Changes

- An agent now has one route for a missing capability. `get_more_tools` keeps it; the other two stop asking.
- `mcp-missing-capability-report` is `enabled: false`. The endpoint, the viewset, the model and all existing rows are untouched. That tool was its only caller, so no new rows arrive.
- `agent-feedback` drops the three "capability that's missing" triggers and points at `get_more_tools` instead.
- The `category` field description stops routing an absent capability to `missing_tool`. This is the load-bearing half: it instructs the model directly, so prose alone would not have changed behavior.
- The `missing_tool` value stays valid. Removing a value from a live input schema fails validation for a session holding the old schema, and on a feedback tool that loses the report rather than misrouting it.

Mechanical: removing the retired tool from the two generated definition JSONs and its generated handler, mirroring one description line into `tool-inputs.json`, and three snapshots. `tests-posthog[bot]` regenerated the OpenAPI client for the retired operation in its own commit.

The generated files were edited by hand, scoped to this one tool. A full `generate-tools` run in this sandbox drops about 150 unrelated tools against a stale local OpenAPI spec, and `generate-tool-schema` rewrites roughly 3600 lines the same way.

`products/mcp_analytics/backend/facade/api.py` still stamps `$mcp_tool_name: "mcp-missing-capability-report"`. Left alone on purpose: the endpoint still emits that event, so the value still names the write path, and changing it would break continuity with the events already recorded.

## How did you test this code?

No new tests. Nothing here adds behavior; it removes a tool and rewords instructions, and the existing suites already pin both.

- `pnpm lint-tool-names` passes, which is the check that catches a description naming a tool that no longer exists.
- Three snapshots refreshed, and their diff is only the reworded text: two instruction files and the `agent-feedback` tool schema.
- Ran locally: `vitest run tests/unit`, `pnpm test:hono`, `pnpm fix`, `tsc --noEmit`, `hogli ci:preflight`. Not run: the Python suites. The one Python file this touches is unchanged, and no Python code reads the MCP tool config.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No published doc describes either retired trigger.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in Claude Code, directed by the assignee. Skills invoked: `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-pr-descriptions`.

- Retiring the REST tool was checked against production before proposing it, not assumed. Its reports are real and recent, and the case rests on the replacement reaching every connection rather than the flagged subset, and on producing rows the feed can render.
- The endpoint was checked for other callers before deciding to leave it: the generated MCP handler is the only one. The frontend's generated client functions are never imported, and no admin, task, workflow or command touches the viewset. A 410 was considered and dropped, because it defends against a caller that does not exist and would churn two test files.
- `mcp-feedback-submit` writes the same table and duplicates `agent-feedback`. It is deliberately untouched, because feedback capture is moving into the SDKs in its own story.
- Public artifact: the diff carries no material from the agent session. Every string in it is written for this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

