### PR TITLE
fix(pi): test bundled agent model assignments

### DIFF
--- a/products/desktop/packages/harness/src/extensions/orchestration/agents.test.ts
+++ b/products/desktop/packages/harness/src/extensions/orchestration/agents.test.ts
@@ -34,19 +34,19 @@ describe("agents", () => {
     expect(general?.source).toBe("bundled");
   });
 
-  it("Explore is read-only and pinned to Sol", () => {
+  it("Explore is read-only and pinned to Luna", () => {
     const explore = findBundledAgent("Explore");
     expect(explore?.tools).toEqual(["read", "bash", "grep", "find", "ls"]);
-    expect(explore?.model).toBe("gpt-5.6-sol");
+    expect(explore?.model).toBe("gpt-5.6-luna");
   });
 
-  it("Plan is read-only and inherits the parent's model", () => {
+  it("Plan is read-only and pinned to Sol", () => {
     const plan = findBundledAgent("Plan");
     expect(plan?.tools).toEqual(["read", "bash", "grep", "find", "ls"]);
-    expect(plan?.model).toBeUndefined();
+    expect(plan?.model).toBe("gpt-5.6-sol");
   });
 
-  it("General is the only bundled agent with write access, and inherits the parent's model", () => {
+  it("General is the only bundled agent with write access and is pinned to Terra", () => {
     const general = findBundledAgent("General");
     expect(general?.tools).toEqual([
       "read",
@@ -57,7 +57,7 @@ describe("agents", () => {
       "find",
       "ls",
     ]);
-    expect(general?.model).toBeUndefined();
+    expect(general?.model).toBe("gpt-5.6-terra");
     for (const agent of loadBundledAgents()) {
       if (agent.name === "General") continue;
       expect(agent.tools).not.toContain("edit");

--- a/products/desktop/packages/harness/src/extensions/orchestration/tools/workflow-tool.test.ts
+++ b/products/desktop/packages/harness/src/extensions/orchestration/tools/workflow-tool.test.ts
@@ -294,7 +294,7 @@ return { count: inv.files.length }`,
       fakeCtx,
     );
     const passedAgent = runAgentMock.mock.calls[0][0].agent;
-    expect(passedAgent.model).toBe("gpt-5.6-sol");
+    expect(passedAgent.model).toBe("gpt-5.6-luna");
   });
 
   it("can dispatch to the General (read-write) persona by name", async () => {


### PR DESCRIPTION
## Problem

- Harness contributors could merge incorrect model assignments because the tests still asserted the assignments before #96406.

## Changes

- The tests now validate Luna for Explore, Sol for Plan, and Terra for General.
- Workflow coverage now validates that an unspecified Explore invocation retains its Luna assignment.
- This is a test-only follow-up to #96406. It does not change user-visible behavior.

## How did you test this code?

- `pnpm test src/extensions/orchestration/agents.test.ts src/extensions/orchestration/tools/workflow-tool.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `flox activate -- bash -c 'hogli ci:preflight --fix'`
- The full harness suite stops at an existing `buildAuthorizeUrl` `Invalid URL` failure outside this diff.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No docs update is needed. The change updates internal test coverage only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Used Pi with read, bash, and edit. No subagents or workflows were used.
- Invoked `/writing-tests`, `/posthog-desktop`, `/running-ci-preflight`, and `/writing-pr-descriptions`.
- Open-PR searches found no duplicate model-assignment test fix.
- The diff contains no customer data, support material, or other non-public context.
