### PR TITLE
fix(posthog_ai): reset the debug logs preference to off for staff

### DIFF
--- a/products/posthog_ai/frontend/logics/debugLogsLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/debugLogsLogic.test.ts
@@ -41,7 +41,6 @@ describe('debugLogsLogic', () => {
     })
 
     it('ignores a value left under a superseded storage key', () => {
-        // A staff user who saw debug rows before they became opt-in must not inherit that state.
         localStorage.setItem('posthog_ai.debugLogsEnabled', 'true')
         setup({ user: { is_staff: true }, isDev: false })
         expect(logic.values.debugLogsEnabled).toBe(false)

--- a/products/posthog_ai/frontend/logics/debugLogsLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/debugLogsLogic.test.ts
@@ -40,6 +40,14 @@ describe('debugLogsLogic', () => {
         expect(logic.values.showDebugLogs).toBe(false)
     })
 
+    it('ignores a value left under a superseded storage key', () => {
+        // A staff user who saw debug rows before they became opt-in must not inherit that state.
+        localStorage.setItem('posthog_ai.debugLogsEnabled', 'true')
+        setup({ user: { is_staff: true }, isDev: false })
+        expect(logic.values.debugLogsEnabled).toBe(false)
+        expect(logic.values.showDebugLogs).toBe(false)
+    })
+
     it('offers no toggle to a staff user who is also impersonating, but still forces logs on', () => {
         // The toggle would be a no-op during impersonation (logs are force-shown), so it must not render.
         setup({ user: { is_staff: true, is_impersonated: true }, isDev: false })

--- a/products/posthog_ai/frontend/logics/debugLogsLogic.ts
+++ b/products/posthog_ai/frontend/logics/debugLogsLogic.ts
@@ -54,7 +54,9 @@ export const debugLogsLogic = kea<debugLogsLogicType>([
     reducers({
         debugLogsEnabled: [
             false,
-            { persist: true, storageKey: 'posthog_ai.debugLogsEnabled' },
+            // Keyed on the opt-in semantics, so a value stored while debug rows rendered for every
+            // staff user cannot switch them back on for someone who never asked for them.
+            { persist: true, storageKey: 'posthog_ai.debugLogsOptIn' },
             {
                 setDebugLogsEnabled: (_, { enabled }) => enabled,
             },

--- a/products/posthog_ai/frontend/logics/debugLogsLogic.ts
+++ b/products/posthog_ai/frontend/logics/debugLogsLogic.ts
@@ -54,8 +54,6 @@ export const debugLogsLogic = kea<debugLogsLogicType>([
     reducers({
         debugLogsEnabled: [
             false,
-            // Keyed on the opt-in semantics, so a value stored while debug rows rendered for every
-            // staff user cannot switch them back on for someone who never asked for them.
             { persist: true, storageKey: 'posthog_ai.debugLogsOptIn' },
             {
                 setDebugLogsEnabled: (_, { enabled }) => enabled,


### PR DESCRIPTION
## Problem

Staff users still see `_posthog/console` debug rows in PostHog AI run threads even though they never turned them on. The rows rendered for every staff user at one point, and the preference that state left in localStorage keeps the toggle on today. Staff have said they do not want them.

## Changes

- Staff and local dev users now start with debug rows hidden, and turn them on through the existing "Show debug logs" toggle in the staff menu, the scene panel, and the run overflow menu.
- The persisted preference moves to the `posthog_ai.debugLogsOptIn` localStorage key, so the old stored value cannot switch the rows back on.
- No change for impersonated sessions: debug rows stay force-on there, and no toggle renders.
- Nothing else changes. The toggle surfaces, the selectors, and the debug row rendering all stay as they are.

The toggle UI is unchanged, so there is nothing new to screenshot. What a staff user sees differently is a run thread without debug rows until they flip the toggle.

## How did you test this code?

- Ran `jest products/posthog_ai/frontend/logics/debugLogsLogic.test.ts` (9 passed).
- Added one case to `debugLogsLogic.test.ts`: a value under the superseded key leaves both `debugLogsEnabled` and `showDebugLogs` false for a staff user. It catches a revert of the key that would restore debug rows for staff who never opted in. No existing case seeded localStorage, so it needs its own setup.
- Not run: the wider frontend suite and Playwright, because this change touches one persisted key that the logic test covers directly.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The toggle is staff-only and undocumented.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack request to make the debug rows opt-in. Skills invoked: `/writing-tests` and `/writing-pr-descriptions`.

The product code already defaulted the toggle to off and already exposed it in three existing settings surfaces, so the only gap was the stale stored value. The change is therefore the key swap plus its regression guard, rather than new gating logic.

No duplicate: `gh pr list --state open --search "debug logs staff posthog_ai"` found no PR covering this.

Public artifact: the diff carries no material from the session. The Slack request named no customer, and the committed test seeds an invented boolean.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B29PTTLBU/p1788864261998509)*
