### PR TITLE
feat(cyclotron): add durable workflow resume inbox

### DIFF
--- a/rust/cyclotron-node-migrations/20260908000001_add_pending_step_resumes.sql
+++ b/rust/cyclotron-node-migrations/20260908000001_add_pending_step_resumes.sql
@@ -1,0 +1,29 @@
+ALTER TABLE cyclotron_jobs ADD COLUMN IF NOT EXISTS pending_step_resumes JSONB;
+
+CREATE OR REPLACE FUNCTION apply_pending_workflow_step_resume()
+RETURNS TRIGGER AS $$
+DECLARE
+    invocation JSONB;
+    wait_key TEXT;
+    resume JSONB;
+BEGIN
+    invocation := convert_from(NEW.state, 'UTF8')::jsonb;
+    wait_key := invocation #>> '{state,currentAction,awaitingResume,key}';
+    resume := NEW.pending_step_resumes -> wait_key;
+    IF resume IS NOT NULL THEN
+        IF invocation #>> '{state,currentAction,resumeResult,key}' IS DISTINCT FROM wait_key THEN
+            invocation := jsonb_set(invocation, '{state,currentAction,resumeResult}', resume);
+            NEW.state := convert_to(invocation::text, 'UTF8');
+            NEW.scheduled := LEAST(NEW.scheduled, NOW());
+        END IF;
+        NEW.pending_step_resumes := NULLIF(NEW.pending_step_resumes - wait_key, '{}'::jsonb);
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER apply_pending_workflow_step_resume
+BEFORE UPDATE OF state, status, pending_step_resumes ON cyclotron_jobs
+FOR EACH ROW
+WHEN (NEW.status = 'available' AND NEW.state IS NOT NULL AND NEW.pending_step_resumes IS NOT NULL)
+EXECUTE FUNCTION apply_pending_workflow_step_resume();


### PR DESCRIPTION
## Problem

Early completion events can arrive before a workflow saves its wait.

**Why:** The database schema must deploy before the consumer in [#94051](https://github.com/PostHog/posthog/pull/94051) can safely retain those events.

## Changes

- Add a nullable inbox column and a trigger that applies a matching result when the worker saves its wait.
- Existing jobs remain unchanged until a consumer writes to the inbox.

> [!IMPORTANT]
> Merge and deploy this migration before merging [#94051](https://github.com/PostHog/posthog/pull/94051). Do not deploy both changes together.

## How did you test this code?

The unchanged migration passed local PostgreSQL tests with the service changes. Tests cover early results, running jobs, dispatch retries, and stale rerun keys. The extracted file is byte-identical to that tested migration.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The service PR documents the deployment order.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used PostHog Desktop and GitHub CLI to extract the migration without behavior changes. Skill: `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
