### PR TITLE
perf(logs): reapply the json sniff with a guard for body-less spans

### DIFF
--- a/nodejs/src/logs/log-body-parse.test.ts
+++ b/nodejs/src/logs/log-body-parse.test.ts
@@ -30,4 +30,31 @@ describe('log-body-parse', () => {
         const raw = 'not json {'
         expect(parseLogBodyForIngestion(raw)).toEqual({ kind: 'invalid_json', raw })
     })
+
+    // A body that cannot start a JSON document never reaches `parseJSON`. Each row here starts a
+    // valid document, so a narrower skip would misreport it as `invalid_json`.
+    it.each([
+        ['object', '{"a":1}', { kind: 'json_object_or_array', value: { a: 1 } }],
+        ['object behind leading whitespace', ' \r\n\t{"a":1}', { kind: 'json_object_or_array', value: { a: 1 } }],
+        ['array behind leading whitespace', '\n[1,2]', { kind: 'json_object_or_array', value: [1, 2] }],
+        ['string', '"hi"', { kind: 'json_string', value: 'hi' }],
+        ['negative number', '-7', { kind: 'json_primitive', parsed: -7 }],
+        ['true', 'true', { kind: 'json_primitive', parsed: true }],
+        ['false', 'false', { kind: 'json_primitive', parsed: false }],
+        ['null', 'null', { kind: 'json_primitive', parsed: null }],
+    ])('decodes a body that starts with %s', (_name, body, expected) => {
+        expect(parseLogBodyForIngestion(body)).toEqual(expected)
+    })
+
+    // The skip is a pre-filter, not a verdict. These bodies pass it and still fail the parse.
+    it.each([
+        ['null pointer at line 4'],
+        ['true and false both reported'],
+        ['-- person processing disabled'],
+        ['404 not found'],
+        ['   '],
+        [''],
+    ])('returns invalid_json for %p', (raw) => {
+        expect(parseLogBodyForIngestion(raw)).toEqual({ kind: 'invalid_json', raw })
+    })
 })

--- a/nodejs/src/logs/log-body-parse.test.ts
+++ b/nodejs/src/logs/log-body-parse.test.ts
@@ -1,8 +1,9 @@
 import { parseLogBodyForIngestion } from './log-body-parse'
 
 describe('log-body-parse', () => {
-    it('returns empty for null body', () => {
-        expect(parseLogBodyForIngestion(null)).toEqual({ kind: 'empty' })
+    // Trace records have no body field, so the value arrives as `undefined` rather than `null`.
+    it.each([[null], [undefined]])('returns empty for %p body', (body) => {
+        expect(parseLogBodyForIngestion(body)).toEqual({ kind: 'empty' })
     })
 
     it('classifies JSON object', () => {

--- a/nodejs/src/logs/log-body-parse.ts
+++ b/nodejs/src/logs/log-body-parse.ts
@@ -41,13 +41,14 @@ function canStartJsonDocument(body: string): boolean {
     return false
 }
 
-export function parseLogBodyForIngestion(body: string | null): LogBodyParseResult {
-    if (body === null) {
+export function parseLogBodyForIngestion(body: string | null | undefined): LogBodyParseResult {
+    // Trace records carry no body field at all, so `undefined` reaches here as well as `null`.
+    if (body === null || body === undefined) {
         return { kind: 'empty' }
     }
     // Plaintext log lines are a large share of the traffic and every one of them makes `parseJSON`
     // build and throw an error. The scan reaches the same result without paying for the throw.
-    if (!canStartJsonDocument(body)) {
+    if (typeof body === 'string' && !canStartJsonDocument(body)) {
         return { kind: 'invalid_json', raw: body }
     }
     try {

--- a/nodejs/src/logs/log-body-parse.ts
+++ b/nodejs/src/logs/log-body-parse.ts
@@ -11,9 +11,44 @@ export type LogBodyParseResult =
     | { kind: 'json_string'; value: string }
     | { kind: 'json_primitive'; parsed: number | boolean | null }
 
+// JSON allows only these four characters between the start of the document and the value.
+const isJsonWhitespace = (code: number): boolean => code === 0x20 || code === 0x09 || code === 0x0a || code === 0x0d
+
+/**
+ * True when the first non-whitespace character is one a JSON document can begin with:
+ * `{`, `[`, `"`, `-`, a digit, or the first letter of `true`, `false`, or `null`.
+ *
+ * The set holds all eight starts on purpose. A `{`/`[` check would send top-level JSON strings
+ * and bare scalars down the `invalid_json` branch, which changes the pattern they produce.
+ */
+function canStartJsonDocument(body: string): boolean {
+    for (let index = 0; index < body.length; index++) {
+        const code = body.charCodeAt(index)
+        if (isJsonWhitespace(code)) {
+            continue
+        }
+        return (
+            code === 0x7b || // {
+            code === 0x5b || // [
+            code === 0x22 || // "
+            code === 0x2d || // -
+            (code >= 0x30 && code <= 0x39) || // 0-9
+            code === 0x74 || // t, for true
+            code === 0x66 || // f, for false
+            code === 0x6e // n, for null
+        )
+    }
+    return false
+}
+
 export function parseLogBodyForIngestion(body: string | null): LogBodyParseResult {
     if (body === null) {
         return { kind: 'empty' }
+    }
+    // Plaintext log lines are a large share of the traffic and every one of them makes `parseJSON`
+    // build and throw an error. The scan reaches the same result without paying for the throw.
+    if (!canStartJsonDocument(body)) {
+        return { kind: 'invalid_json', raw: body }
     }
     try {
         const parsed = parseJSON(body)

--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -248,6 +248,8 @@ describe('log-pattern-mask', () => {
             ['json string', '"quoted 7"', 'json_string', 'quoted <N>'],
             ['json number primitive', '42', 'primitive', '<N>'],
             ['prose body', 'plain text 3', 'plaintext', 'plain text <N>'],
+            ['json object behind leading whitespace', ' \n\t{"msg":"hi 9"}', 'json_object_or_array', 'hi <N>'],
+            ['prose body that opens like JSON', 'null pointer at line 4', 'plaintext', 'null pointer at line <N>'],
         ])('body kind %s', (_name, body, expectedKind, expectedPattern) => {
             const result = patternResult(body)
             expect(result.bodyKind).toEqual(expectedKind)

--- a/nodejs/src/logs/log-record-avro.test.ts
+++ b/nodejs/src/logs/log-record-avro.test.ts
@@ -406,6 +406,39 @@ describe('log-record-avro', () => {
     })
 
     describe('processLogMessageBuffer', () => {
+        // Trace records are written with a schema that has no `body` field, so the decoded record
+        // has no `body` key at all. The JSON stage must treat that like a null body, not throw.
+        it('passes a body-less trace record through with JSON parsing enabled', async () => {
+            const schemaJson = LOG_RECORD_SCHEMA.schema() as { fields: { name: string }[] }
+            const bodylessSchema = avro.parse({
+                ...schemaJson,
+                fields: schemaJson.fields.filter((field) => field.name !== 'body'),
+            })
+            const record = {
+                uuid: 'span-uuid',
+                trace_id: Buffer.from('0123456789abcdef'),
+                span_id: Buffer.from('01234567'),
+                trace_flags: null,
+                timestamp: null,
+                observed_timestamp: null,
+                severity_text: null,
+                severity_number: null,
+                service_name: 'api',
+                resource_attributes: null,
+                instrumentation_scope: null,
+                event_name: null,
+                attributes: { 'http.method': 'GET' },
+                bytes_uncompressed: null,
+            } as unknown as LogRecord
+
+            const inputBuffer = await encodeLogRecords(bodylessSchema, 'zstandard', [record])
+            const { value: outputBuffer } = await processLogMessageBuffer(inputBuffer, { json_parse_logs: true })
+            const [_, __, decoded] = await decodeLogRecords(outputBuffer!)
+
+            expect(decoded).toHaveLength(1)
+            expect(decoded[0]?.attributes).toEqual({ 'http.method': 'GET' })
+        })
+
         it('processes buffer with JSON parsing enabled', async () => {
             const records: LogRecord[] = [
                 {

--- a/nodejs/src/logs/log-record-avro.test.ts
+++ b/nodejs/src/logs/log-record-avro.test.ts
@@ -409,12 +409,12 @@ describe('log-record-avro', () => {
         // Trace records are written with a schema that has no `body` field, so the decoded record
         // has no `body` key at all. The JSON stage must treat that like a null body, not throw.
         it('passes a body-less trace record through with JSON parsing enabled', async () => {
-            const schemaJson = LOG_RECORD_SCHEMA.schema() as { fields: { name: string }[] }
-            const bodylessSchema = avro.parse({
+            const schemaJson = LOG_RECORD_SCHEMA.schema() as avro.schema.RecordType
+            const bodylessSchema = avro.Type.forSchema({
                 ...schemaJson,
                 fields: schemaJson.fields.filter((field) => field.name !== 'body'),
             })
-            const record = {
+            const record: LogRecord = {
                 uuid: 'span-uuid',
                 trace_id: Buffer.from('0123456789abcdef'),
                 span_id: Buffer.from('01234567'),
@@ -429,7 +429,7 @@ describe('log-record-avro', () => {
                 event_name: null,
                 attributes: { 'http.method': 'GET' },
                 bytes_uncompressed: null,
-            } as unknown as LogRecord
+            }
 
             const inputBuffer = await encodeLogRecords(bodylessSchema, 'zstandard', [record])
             const { value: outputBuffer } = await processLogMessageBuffer(inputBuffer, { json_parse_logs: true })

--- a/nodejs/src/logs/log-record-avro.ts
+++ b/nodejs/src/logs/log-record-avro.ts
@@ -41,7 +41,9 @@ export interface LogRecord {
     trace_flags: number | null
     timestamp: number | null
     observed_timestamp: number | null
-    body: string | null
+    /** Absent on trace spans, which are written with a schema that has no `body` field, so a decoded
+     * span has no key at all rather than `null`. Readers must accept `undefined`. */
+    body?: string | null
     severity_text: string | null
     severity_number: number | null
     service_name: string | null


### PR DESCRIPTION
## Problem

- Trace spans for teams with JSON parsing enabled stopped reaching ClickHouse after #92714 deployed. They landed on the dead-letter topic instead. #93996 reverted #92714.
- The traces consumer is a subclass of the logs consumer, so spans run through the same per-team JSON stage as log lines.
- Spans are written with a schema that has no `body` field. A decoded span has `body: undefined`, not `null`.
- The JSON start scan from #92714 guarded `null` only and read `body.length` before the `try`. Each span batch threw a `TypeError`.
- Before #92714, the same `undefined` threw inside the `try`, was reported as `invalid_json`, and the span went through.

## Changes

- Nobody sees a difference. Plaintext log lines skip the JSON parse again, and spans pass the JSON stage untouched.
- `parseLogBodyForIngestion` treats `undefined` like `null` and scans only string bodies. That is the fix from #93977, which this PR supersedes.
- `LogRecord.body` is now optional in the type. Code that reads `body.length` behind a `null` check fails the type check instead of failing in the traces consumer.
- The scan itself is the #92714 commit, cherry-picked unchanged. `PATTERN_VERSION` and the shape digests do not move. Mechanical.

## How did you test this code?

- `log-body-parse.test.ts` gains an `undefined` row on the null-body case. It catches a guard that checks `null` only.
- `log-record-avro.test.ts` gains a `processLogMessageBuffer` case that encodes a record with a schema without `body` and runs it with JSON parsing on. It catches a throw anywhere in the JSON stage for a span. No existing test used a body-less schema.
- With the guard removed and the scan kept, the span case fails with the `TypeError`. With the guard it passes.
- The scan's own cases from #92714 are unchanged.
- Ran the five logs suites that read `record.body`, plus the nodejs type check. Not run: the rest of the nodejs suite. Nothing ran against live traffic.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

- Open PR search: #93977 fixes the same throw, but its branch sits on the pre-revert master and conflicts. This PR carries that commit and replaces it.
- The optional `body` type was added after every other reader of `body` in the logs consumer was checked and already tolerated `undefined`.
- The body-less schema in the test now uses `avro.Type.forSchema`, because the `avro.parse` typing takes a string.
- Nothing in this PR carries material from the session that is not already public. The test records are invented.
