### PR TITLE
chore(claude): fix web session setup for lint and test commands

### DIFF
--- a/.claude/hooks/install-tool-versions.sh
+++ b/.claude/hooks/install-tool-versions.sh
@@ -118,22 +118,31 @@ with urllib.request.urlopen('https://pypi.org/pypi/uv/json', timeout=20) as resp
 }
 
 # Replace the uv binary in place. 'uv self update' cannot cross a major.minor boundary.
+# The callers run this in an '|| true' list, which turns errexit off for the whole
+# body, so each step that must succeed is checked here. Otherwise a corrupt archive
+# reports the stale version as a fresh install.
 install_uv() {
     local target="$1"
-    local bin_dir tmp
+    local bin_dir tmp url rc=1
     bin_dir=$(dirname "$(command -v uv 2>/dev/null || echo "/root/.local/bin/uv")")
     tmp=$(mktemp -d)
-    if curl -fsSL "https://github.com/astral-sh/uv/releases/download/${target}/uv-${UV_ARCH}.tar.gz" -o "$tmp/uv.tar.gz"; then
-        tar -xzf "$tmp/uv.tar.gz" -C "$tmp"
-        cp "$tmp/uv-${UV_ARCH}/uv" "$bin_dir/uv"
+    url="https://github.com/astral-sh/uv/releases/download/${target}/uv-${UV_ARCH}.tar.gz"
+
+    if ! curl -fsSL "$url" -o "$tmp/uv.tar.gz"; then
+        echo "Warning: failed to download uv $target" >&2
+    elif ! tar -xzf "$tmp/uv.tar.gz" -C "$tmp"; then
+        echo "Warning: failed to unpack uv $target" >&2
+    elif ! cp "$tmp/uv-${UV_ARCH}/uv" "$bin_dir/uv"; then
+        echo "Warning: failed to install uv $target into $bin_dir" >&2
+    else
+        # uvx sits beside uv in the archive, and nothing in this repo needs it.
         cp "$tmp/uv-${UV_ARCH}/uvx" "$bin_dir/uvx" 2>/dev/null || true
-        rm -rf "$tmp"
         echo "uv is now $(uv --version 2>/dev/null)"
-        return 0
+        rc=0
     fi
+
     rm -rf "$tmp"
-    echo "Warning: failed to download uv $target" >&2
-    return 1
+    return "$rc"
 }
 
 # --- 1. Upgrade uv ---

--- a/.claude/hooks/install-tool-versions.sh
+++ b/.claude/hooks/install-tool-versions.sh
@@ -10,10 +10,25 @@ set -euo pipefail
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 ARCH="$(uname -m)"
+NODE_MAJOR=""
+
+case "$ARCH" in
+    x86_64)  UV_ARCH="x86_64-unknown-linux-gnu"; NODE_ARCH="x64" ;;
+    aarch64) UV_ARCH="aarch64-unknown-linux-gnu"; NODE_ARCH="arm64" ;;
+    *)       UV_ARCH="$ARCH-unknown-linux-gnu"; NODE_ARCH="$ARCH" ;;
+esac
 
 # --- Parse versions from config files using Python for reliable TOML/JSON parsing ---
-read -r REQUIRED_UV REQUIRED_PYTHON REQUIRED_PNPM < <(python3 -c "
-import json, re, sys
+# One value per line, so a missing value cannot shift the others.
+REQUIRED_UV_SPEC=""
+REQUIRED_PYTHON=""
+REQUIRED_PNPM=""
+{
+    read -r REQUIRED_UV_SPEC || true
+    read -r REQUIRED_PYTHON || true
+    read -r REQUIRED_PNPM || true
+} < <(python3 -c "
+import json, re
 try:
     import tomllib
 except ImportError:
@@ -22,17 +37,16 @@ except ImportError:
     except ImportError:
         tomllib = None
 
-uv_ver = python_ver = pnpm_ver = ''
+uv_spec = python_ver = pnpm_ver = ''
 
 # Parse pyproject.toml
 if tomllib:
     try:
         with open('$PROJECT_DIR/pyproject.toml', 'rb') as f:
             data = tomllib.load(f)
-        # uv required-version: strip specifier prefix (~=, >=, ==, etc.)
-        raw = data.get('tool', {}).get('uv', {}).get('required-version', '')
-        uv_ver = re.sub(r'^[~><=!]+', '', raw)
-        # requires-python: strip specifier prefix
+        # Keep the comparison operator. It decides whether to track the newest uv
+        # release or stay inside one major.minor series.
+        uv_spec = data.get('tool', {}).get('uv', {}).get('required-version', '')
         raw = data.get('project', {}).get('requires-python', '')
         python_ver = re.sub(r'^[~><=!]+', '', raw)
     except Exception:
@@ -48,42 +62,88 @@ try:
 except Exception:
     pass
 
-print(uv_ver, python_ver, pnpm_ver)
-" 2>/dev/null || echo "")
+print(uv_spec)
+print(python_ver)
+print(pnpm_ver)
+" 2>/dev/null || true)
+
+# Print the uv version to install, or nothing when the current one already fits the
+# spec. Version discovery reads PyPI because the egress policy blocks api.github.com.
+resolve_uv_target() {
+    python3 -c "
+import json, re, sys, urllib.request
+
+spec, current = sys.argv[1], sys.argv[2]
+m = re.match(r'\s*([~><=!]*)\s*([0-9][0-9.]*)', spec)
+if not m:
+    sys.exit(0)
+op, floor = (m.group(1) or '=='), m.group(2)
+
+def parts(version):
+    return tuple(int(n) for n in re.findall(r'[0-9]+', version)[:3])
+
+def satisfies(version):
+    if parts(version) < parts(floor):
+        return False
+    # '>=' tracks the newest release. '~=' and '==' hold one major.minor series.
+    return op.startswith('>') or parts(version)[:2] == parts(floor)[:2]
+
+if current and satisfies(current):
+    sys.exit(0)
+
+try:
+    with urllib.request.urlopen('https://pypi.org/pypi/uv/json', timeout=20) as response:
+        releases = json.load(response)['releases']
+except Exception:
+    releases = {}
+
+best = ''
+for version in releases:
+    if re.fullmatch(r'[0-9]+\.[0-9]+\.[0-9]+', version) and satisfies(version):
+        if not best or parts(version) > parts(best):
+            best = version
+
+# Without an index, the floor is the only version known to fit the spec.
+print(best or floor)
+" "$1" "$2" 2>/dev/null || true
+}
+
+# Print the newest uv release on PyPI, or nothing when the index is unreachable.
+latest_uv() {
+    python3 -c "
+import json, urllib.request
+with urllib.request.urlopen('https://pypi.org/pypi/uv/json', timeout=20) as response:
+    print(json.load(response)['info']['version'])
+" 2>/dev/null || true
+}
+
+# Replace the uv binary in place. 'uv self update' cannot cross a major.minor boundary.
+install_uv() {
+    local target="$1"
+    local bin_dir tmp
+    bin_dir=$(dirname "$(command -v uv 2>/dev/null || echo "/root/.local/bin/uv")")
+    tmp=$(mktemp -d)
+    if curl -fsSL "https://github.com/astral-sh/uv/releases/download/${target}/uv-${UV_ARCH}.tar.gz" -o "$tmp/uv.tar.gz"; then
+        tar -xzf "$tmp/uv.tar.gz" -C "$tmp"
+        cp "$tmp/uv-${UV_ARCH}/uv" "$bin_dir/uv"
+        cp "$tmp/uv-${UV_ARCH}/uvx" "$bin_dir/uvx" 2>/dev/null || true
+        rm -rf "$tmp"
+        echo "uv is now $(uv --version 2>/dev/null)"
+        return 0
+    fi
+    rm -rf "$tmp"
+    echo "Warning: failed to download uv $target" >&2
+    return 1
+}
 
 # --- 1. Upgrade uv ---
-CURRENT_UV=$(uv --version 2>/dev/null | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' || echo "0.0.0")
+CURRENT_UV=$(uv --version 2>/dev/null | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' || echo "")
 
-if [ -n "$REQUIRED_UV" ]; then
-    # ~= means compatible release: ~=0.11.11 allows >=0.11.11, <0.12.0
-    REQ_MAJOR_MINOR=$(echo "$REQUIRED_UV" | cut -d. -f1,2)
-    CUR_MAJOR_MINOR=$(echo "$CURRENT_UV" | cut -d. -f1,2)
-    if [ "$CUR_MAJOR_MINOR" != "$REQ_MAJOR_MINOR" ] || [ "$(printf '%s\n' "$REQUIRED_UV" "$CURRENT_UV" | sort -V | head -1)" != "$REQUIRED_UV" ]; then
-        echo "Upgrading uv from $CURRENT_UV (need ~=$REQUIRED_UV)..."
-        # Find latest compatible patch version from GitHub releases
-        TARGET_UV=$(curl -fsSL "https://api.github.com/repos/astral-sh/uv/releases?per_page=30" 2>/dev/null \
-            | grep -oP '"tag_name": "\K[0-9.]+' \
-            | grep "^${REQ_MAJOR_MINOR}\." \
-            | head -1)
-        TARGET_UV="${TARGET_UV:-$REQUIRED_UV}"
-
-        # Download binary directly from GitHub (uv self update doesn't work across major.minor)
-        UV_BIN_DIR=$(dirname "$(command -v uv 2>/dev/null || echo "/root/.local/bin/uv")")
-        case "$ARCH" in
-            x86_64)  UV_ARCH="x86_64-unknown-linux-gnu" ;;
-            aarch64) UV_ARCH="aarch64-unknown-linux-gnu" ;;
-            *)       UV_ARCH="$ARCH-unknown-linux-gnu" ;;
-        esac
-        TMP_UV=$(mktemp -d)
-        if curl -fsSL "https://github.com/astral-sh/uv/releases/download/${TARGET_UV}/uv-${UV_ARCH}.tar.gz" -o "$TMP_UV/uv.tar.gz" 2>/dev/null; then
-            tar -xzf "$TMP_UV/uv.tar.gz" -C "$TMP_UV"
-            cp "$TMP_UV/uv-${UV_ARCH}/uv" "$UV_BIN_DIR/uv"
-            cp "$TMP_UV/uv-${UV_ARCH}/uvx" "$UV_BIN_DIR/uvx" 2>/dev/null || true
-            echo "uv upgraded to $(uv --version 2>/dev/null)"
-        else
-            echo "Warning: Failed to download uv $TARGET_UV" >&2
-        fi
-        rm -rf "$TMP_UV"
+if [ -n "$REQUIRED_UV_SPEC" ]; then
+    TARGET_UV=$(resolve_uv_target "$REQUIRED_UV_SPEC" "$CURRENT_UV")
+    if [ -n "$TARGET_UV" ]; then
+        echo "Installing uv $TARGET_UV (have ${CURRENT_UV:-none}, need $REQUIRED_UV_SPEC)..."
+        install_uv "$TARGET_UV" || true
     fi
 fi
 
@@ -91,14 +151,25 @@ fi
 if [ -n "$REQUIRED_PYTHON" ]; then
     if ! uv python find "$REQUIRED_PYTHON" >/dev/null 2>&1; then
         echo "Installing Python $REQUIRED_PYTHON via uv..."
-        uv python install "$REQUIRED_PYTHON" 2>/dev/null || true
+        if ! uv python install "$REQUIRED_PYTHON" 2>/dev/null; then
+            # uv only installs the interpreters its own build embeds, so a Python
+            # patch release newer than uv needs a newer uv first.
+            LATEST_UV=$(latest_uv)
+            CURRENT_UV=$(uv --version 2>/dev/null | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' || echo "")
+            if [ -n "$LATEST_UV" ] && [ "$LATEST_UV" != "$CURRENT_UV" ]; then
+                echo "Python $REQUIRED_PYTHON is unknown to this uv, trying uv $LATEST_UV..."
+                install_uv "$LATEST_UV" || true
+                uv python install "$REQUIRED_PYTHON" 2>/dev/null || \
+                    echo "Warning: failed to install Python $REQUIRED_PYTHON" >&2
+            fi
+        fi
     fi
 fi
 
 # --- 3. Install Node ---
 NODE_VERSION=""
 if [ -f "$PROJECT_DIR/.nvmrc" ]; then
-    NODE_VERSION=$(cat "$PROJECT_DIR/.nvmrc" | tr -d '[:space:]')
+    NODE_VERSION=$(tr -d '[:space:]' < "$PROJECT_DIR/.nvmrc")
     # Strip leading 'v' if present
     NODE_VERSION="${NODE_VERSION#v}"
 fi
@@ -112,24 +183,17 @@ if [ -n "$NODE_VERSION" ]; then
     if [ "$CURRENT_NODE" != "$NODE_VERSION" ]; then
         echo "Installing Node v${NODE_VERSION}..."
 
-        # Determine arch for download
-        case "$ARCH" in
-            x86_64)  NODE_ARCH="x64" ;;
-            aarch64) NODE_ARCH="arm64" ;;
-            *)       NODE_ARCH="$ARCH" ;;
-        esac
-
         TARBALL="node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz"
         URL="https://nodejs.org/dist/v${NODE_VERSION}/${TARBALL}"
         TMP_DIR=$(mktemp -d)
 
-        if wget -q -O "$TMP_DIR/$TARBALL" "$URL" 2>/dev/null || curl -fsSL -o "$TMP_DIR/$TARBALL" "$URL" 2>/dev/null; then
+        if wget -q -O "$TMP_DIR/$TARBALL" "$URL" || curl -fsSL -o "$TMP_DIR/$TARBALL" "$URL"; then
             rm -rf "$NODE_DIR"
             mkdir -p "$NODE_DIR"
             tar -xJf "$TMP_DIR/$TARBALL" -C "$NODE_DIR" --strip-components=1
             echo "Node v${NODE_VERSION} installed to $NODE_DIR"
         else
-            echo "Warning: Failed to download Node v${NODE_VERSION}" >&2
+            echo "Warning: failed to download Node v${NODE_VERSION}" >&2
         fi
 
         rm -rf "$TMP_DIR"
@@ -140,7 +204,8 @@ if [ -n "$NODE_VERSION" ]; then
         CURRENT_PNPM=$("$NODE_DIR/bin/pnpm" --version 2>/dev/null || echo "")
         if [ "$CURRENT_PNPM" != "$REQUIRED_PNPM" ]; then
             echo "Installing pnpm@${REQUIRED_PNPM}..."
-            "$NODE_DIR/bin/npm" --prefix "$NODE_DIR" install -g "pnpm@${REQUIRED_PNPM}" 2>/dev/null || true
+            "$NODE_DIR/bin/npm" --prefix "$NODE_DIR" install -g "pnpm@${REQUIRED_PNPM}" 2>/dev/null || \
+                echo "Warning: failed to install pnpm@${REQUIRED_PNPM}" >&2
         fi
     fi
 
@@ -150,10 +215,8 @@ if [ -n "$NODE_VERSION" ]; then
 fi
 
 # Write env updates to CLAUDE_ENV_FILE if available (SessionStart only)
-if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
-    {
-        [ -n "$NODE_VERSION" ] && echo "export PATH=\"/opt/node${NODE_MAJOR}/bin:\$PATH\""
-    } >> "$CLAUDE_ENV_FILE"
+if [ -n "${CLAUDE_ENV_FILE:-}" ] && [ -n "$NODE_MAJOR" ]; then
+    echo "export PATH=\"/opt/node${NODE_MAJOR}/bin:\$PATH\"" >> "$CLAUDE_ENV_FILE"
 fi
 
 exit 0

--- a/.claude/hooks/setup-cloud.sh
+++ b/.claude/hooks/setup-cloud.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
+# SessionStart hook: make lint and test commands runnable in Claude Code on the web.
 
 if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then
     exit 0
 fi
 
-cd "$CLAUDE_PROJECT_DIR"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+cd "$PROJECT_DIR" || exit 0
 
 # Install correct tool versions (uv, Python, Node, pnpm) if needed
 if [ -x .claude/hooks/install-tool-versions.sh ]; then
@@ -13,14 +15,31 @@ fi
 
 # install-tool-versions.sh runs in a subprocess so its PATH export doesn't propagate here;
 # re-apply it explicitly so pnpm below sees the right node.
-NODE_MAJOR=$(cat .nvmrc 2>/dev/null | tr -d 'v[:space:]' | cut -d. -f1)
+NODE_MAJOR=$(tr -d 'v[:space:]' < .nvmrc 2>/dev/null | cut -d. -f1)
 if [ -n "$NODE_MAJOR" ] && [ -d "/opt/node${NODE_MAJOR}/bin" ]; then
     export PATH="/opt/node${NODE_MAJOR}/bin:$PATH"
 fi
 
-# Sync Python dependencies (installs click, ruff, etc. from pyproject.toml)
-uv sync 2>/dev/null
-# Root-only install: linting tools + husky, skips full workspace
-pnpm install --frozen-lockfile --filter=. 2>/dev/null
+# Sync Python dependencies (installs django, pytest, ruff, etc. from pyproject.toml).
+# --quiet drops the per-package list, which is hundreds of lines on a cold container.
+# Errors stay visible: a failed sync leaves every Python test and linter unusable.
+uv sync --quiet || echo "Warning: uv sync failed, Python tests and linters are unavailable" >&2
+
+# '.' carries the shared JS tooling (oxlint, oxfmt, stylelint, tsgo) and husky.
+# '@posthog/frontend...' adds the frontend and the product packages it depends on,
+# which is what jest needs to collect and run the suite.
+# The nodejs/ (plugin-server) workspace stays out on purpose: it pulls uWebSockets.js
+# from codeload.github.com, which the sandbox egress policy blocks.
+pnpm install --frozen-lockfile --prefer-offline --filter=. --filter=@posthog/frontend... || \
+    echo "Warning: pnpm install failed, frontend tests and linters are unavailable" >&2
+
+# Put the project venv ahead of the sandbox's unrelated global python tools, so
+# 'pytest', 'ruff' and 'mypy' resolve to the versions pinned by pyproject.toml.
+if [ -n "${CLAUDE_ENV_FILE:-}" ] && [ -d "$PROJECT_DIR/.venv/bin" ]; then
+    {
+        echo "export VIRTUAL_ENV=\"$PROJECT_DIR/.venv\""
+        echo "export PATH=\"$PROJECT_DIR/.venv/bin:\$PATH\""
+    } >> "$CLAUDE_ENV_FILE"
+fi
 
 exit 0


### PR DESCRIPTION
## Problem

Claude Code on the web cannot run a single linter or test in this repo. Every web session starts with no Python virtualenv and no frontend workspace.

Two silent failures cause it:

- `install-tool-versions.sh` exits about three lines in. It reads the uv release list from `api.github.com`, which the sandbox egress policy rejects with 403. Under `set -euo pipefail` that failed pipeline sits in a bare assignment, so the shell exits before it installs uv, Python, Node or pnpm. Node stays on v22 while `.nvmrc` asks for v24.
- `setup-cloud.sh` sends `uv sync` and `pnpm install` to `/dev/null`. The preinstalled uv 0.8.17 cannot parse `exclude-newer = "7 days"`, so the sync fails and leaves no `.venv`, with nothing on screen.

The version logic is wrong too. The script holds uv to one major.minor series, but `pyproject.toml` asks for `>=0.10.2`, and uv installs only the interpreters its own build embeds. No 0.10.x uv provides the pinned Python 3.13.13.

## Changes

- `ruff`, `pytest`, `oxlint` and `jest` all run in a web session now.
- Version discovery reads PyPI, which the sandbox allows.
- The specifier operator picks the target. `>=` tracks the newest release, `~=` and `==` hold the series.
- Every fallible step warns and names what became unavailable, instead of ending the run or hiding the error.
- The pnpm install adds the frontend and the product packages jest collects, not just the repo root.
- The virtualenv goes on `PATH` ahead of the sandbox's unrelated global `ruff`, `pytest` and `mypy`, so those match `pyproject.toml`.
- `nodejs/` stays out of the install. It fetches uWebSockets.js from `codeload.github.com`, which the egress policy also blocks, so plugin-server tests need that host allowlisted first.
- Mechanical: three shell bugs where an unset value shifted a positional read, left `NODE_MAJOR` unbound, or failed the last command under `set -e`.

Nothing in the product changes, so no screenshot applies.

## How did you test this code?

CI does not exercise `.claude/hooks/`, so this is manual verification against `origin/master`.

- The hook completes with exit 0 and writes both `PATH` entries. A warm run takes 8 to 10 seconds. A re-run takes 0.45 seconds and downloads nothing.
- Each command runs: `ruff check` and `ruff format --check`, `hogli test posthog/test/test_datetime.py`, `pnpm lint:js`, and jest over a frontend, a product and a quill suite.
- oxlint reports real findings, checked against a file holding a deliberate `no-debugger` and `no-const-assign`.
- The version resolver returns the right target for a fresh container, an already-satisfied uv, a `~=` series pin, and unparseable input.
- Not run: Python tests that need Postgres, ClickHouse or Redis. The sandbox has none of them and no Docker daemon.
- Not run: the `nodejs/` workspace, blocked by egress, and the full-repo `typescript:check`, which the OOM killer stops at an 8 GB heap.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: Claude Code on the web. Skills invoked: `/session-start-hook`, `/writing-pr-descriptions`.
- The hooks stay synchronous, so dependencies finish installing before a session starts. Async mode would cut startup latency and let the agent race the install.
- The `*Type.ts` files kea-typegen writes are legacy. Logic types are inline `MakeLogicType<...>` declarations now, so `typescript:check` needs no typegen step and the hook does not run one.
- The commit first landed on `posthog/pa-move-trends-narrow` and reached [#96095](https://github.com/PostHog/posthog/pull/96095). It moved here on request. That branch reset to its previous tip, and no PR in its stack changed.
- Public artifact: nothing here comes from the agent session. The diff is two repository shell scripts.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDyL8qPBKPMUJbY8sM6HiN


---
_Generated by [Claude Code](https://claude.ai/code/session_01QDyL8qPBKPMUJbY8sM6HiN)_