### PR TITLE
fix(logs): skip the json parse stage for trace spans

### DIFF
--- a/nodejs/src/logs/log-record-avro.test.ts
+++ b/nodejs/src/logs/log-record-avro.test.ts
@@ -428,7 +428,10 @@ describe('log-record-avro', () => {
             ]
 
             const inputBuffer = await encodeLogRecords(LOG_RECORD_SCHEMA, 'zstandard', records)
-            const { value: outputBuffer, pii } = await processLogMessageBuffer(inputBuffer, { json_parse_logs: true })
+            const { value: outputBuffer, pii } = await processLogMessageBuffer(inputBuffer, {
+                jsonParse: true,
+                piiScrub: false,
+            })
             expect(pii).toEqual({ piiReplacements: 0 })
             const [_, __, decoded] = await decodeLogRecords(outputBuffer!)
 
@@ -477,7 +480,10 @@ describe('log-record-avro', () => {
             ]
 
             const inputBuffer = await encodeLogRecords(LOG_RECORD_SCHEMA, 'zstandard', records)
-            const { value: outputBuffer, pii } = await processLogMessageBuffer(inputBuffer, { json_parse_logs: true })
+            const { value: outputBuffer, pii } = await processLogMessageBuffer(inputBuffer, {
+                jsonParse: true,
+                piiScrub: false,
+            })
             expect(pii).toEqual({ piiReplacements: 0 })
             const [_, __, decoded] = await decodeLogRecords(outputBuffer!)
 
@@ -515,8 +521,8 @@ describe('log-record-avro', () => {
 
             const inputBuffer = await encodeLogRecords(LOG_RECORD_SCHEMA, 'zstandard', records)
             const { value: out, pii } = await processLogMessageBuffer(inputBuffer, {
-                json_parse_logs: false,
-                pii_scrub_logs: false,
+                jsonParse: false,
+                piiScrub: false,
             })
 
             expect(out).toBe(inputBuffer)
@@ -548,7 +554,7 @@ describe('log-record-avro', () => {
             const onRecordsDecoded = jest.fn()
             const { value: out } = await processLogMessageBuffer(
                 inputBuffer,
-                { json_parse_logs: false, pii_scrub_logs: false },
+                { jsonParse: false, piiScrub: false },
                 { onRecordsDecoded }
             )
 
@@ -560,14 +566,14 @@ describe('log-record-avro', () => {
         })
 
         it.each([
-            ['everything off', {}, 0, false, 'passthrough'],
-            ['json parse on', { json_parse_logs: true }, 0, false, 'decode_and_reencode'],
-            ['pii scrub on', { pii_scrub_logs: true }, 0, false, 'decode_and_reencode'],
-            ['a stage present', {}, 1, false, 'decode_and_reencode'],
-            ['a decoded-records visitor present', {}, 0, true, 'decode_only'],
-            ['a visitor and a stage', {}, 1, true, 'decode_and_reencode'],
-        ])('bufferProcessingMode: %s', (_name, settings, stageCount, hasVisitor, expected) => {
-            expect(bufferProcessingMode(settings, stageCount, hasVisitor)).toEqual(expected)
+            ['everything off', { jsonParse: false, piiScrub: false }, 0, false, 'passthrough'],
+            ['json parse on', { jsonParse: true, piiScrub: false }, 0, false, 'decode_and_reencode'],
+            ['pii scrub on', { jsonParse: false, piiScrub: true }, 0, false, 'decode_and_reencode'],
+            ['a stage present', { jsonParse: false, piiScrub: false }, 1, false, 'decode_and_reencode'],
+            ['a decoded-records visitor present', { jsonParse: false, piiScrub: false }, 0, true, 'decode_only'],
+            ['a visitor and a stage', { jsonParse: false, piiScrub: false }, 1, true, 'decode_and_reencode'],
+        ])('bufferProcessingMode: %s', (_name, transforms, stageCount, hasVisitor, expected) => {
+            expect(bufferProcessingMode(transforms, stageCount, hasVisitor)).toEqual(expected)
         })
 
         it('decodes and scrubs only when PII scrub is on without JSON parse', async () => {
@@ -593,8 +599,8 @@ describe('log-record-avro', () => {
 
             const inputBuffer = await encodeLogRecords(LOG_RECORD_SCHEMA, 'zstandard', records)
             const { value: outputBuffer, pii } = await processLogMessageBuffer(inputBuffer, {
-                json_parse_logs: false,
-                pii_scrub_logs: true,
+                jsonParse: false,
+                piiScrub: true,
             })
             expect(outputBuffer).not.toBe(inputBuffer)
             expect(pii.piiReplacements).toBeGreaterThanOrEqual(1)
@@ -629,8 +635,8 @@ describe('log-record-avro', () => {
 
             const inputBuffer = await encodeLogRecords(LOG_RECORD_SCHEMA, 'zstandard', records)
             const { value: outputBuffer, pii } = await processLogMessageBuffer(inputBuffer, {
-                json_parse_logs: false,
-                pii_scrub_logs: true,
+                jsonParse: false,
+                piiScrub: true,
             })
             expect(pii.piiReplacements).toBe(1)
             const [_, __, decoded] = await decodeLogRecords(outputBuffer!)
@@ -661,8 +667,8 @@ describe('log-record-avro', () => {
 
             const inputBuffer = await encodeLogRecords(LOG_RECORD_SCHEMA, 'zstandard', records)
             const { value: outputBuffer, pii } = await processLogMessageBuffer(inputBuffer, {
-                json_parse_logs: true,
-                pii_scrub_logs: true,
+                jsonParse: true,
+                piiScrub: true,
             })
             expect(pii.piiReplacements).toBe(2)
             const [_, __, decoded] = await decodeLogRecords(outputBuffer!)
@@ -697,8 +703,8 @@ describe('log-record-avro', () => {
 
             const inputBuffer = await encodeLogRecords(LOG_RECORD_SCHEMA, 'zstandard', records)
             await processLogMessageBuffer(inputBuffer, {
-                json_parse_logs: false,
-                pii_scrub_logs: true,
+                jsonParse: false,
+                piiScrub: true,
             })
 
             expect(spy).not.toHaveBeenCalled()
@@ -746,8 +752,8 @@ describe('log-record-avro', () => {
 
             const inputBuffer = await encodeLogRecords(LOG_RECORD_SCHEMA, 'zstandard', records)
             await processLogMessageBuffer(inputBuffer, {
-                json_parse_logs: true,
-                pii_scrub_logs: true,
+                jsonParse: true,
+                piiScrub: true,
             })
 
             expect(spy).toHaveBeenCalledTimes(2)
@@ -777,8 +783,8 @@ describe('log-record-avro', () => {
 
             const inputBuffer = await encodeLogRecords(LOG_RECORD_SCHEMA, 'zstandard', records)
             const { value: outputBuffer, pii } = await processLogMessageBuffer(inputBuffer, {
-                json_parse_logs: true,
-                pii_scrub_logs: true,
+                jsonParse: true,
+                piiScrub: true,
             })
             expect(pii).toEqual({ piiReplacements: 0 })
             const [_, __, decoded] = await decodeLogRecords(outputBuffer!)
@@ -795,10 +801,8 @@ describe('log-record-avro', () => {
         it('rejects promise for invalid AVRO data', async () => {
             const invalidBuffer = Buffer.from('not avro data')
 
-            await expect(processLogMessageBuffer(invalidBuffer, { json_parse_logs: true })).rejects.toThrow()
-            await expect(
-                processLogMessageBuffer(invalidBuffer, { json_parse_logs: false, pii_scrub_logs: true })
-            ).rejects.toThrow()
+            await expect(processLogMessageBuffer(invalidBuffer, { jsonParse: true, piiScrub: false })).rejects.toThrow()
+            await expect(processLogMessageBuffer(invalidBuffer, { jsonParse: false, piiScrub: true })).rejects.toThrow()
         })
 
         it('limits attributes to 50 when parsing JSON body', async () => {
@@ -828,7 +832,10 @@ describe('log-record-avro', () => {
             ]
 
             const inputBuffer = await encodeLogRecords(LOG_RECORD_SCHEMA, 'zstandard', records)
-            const { value: outputBuffer, pii } = await processLogMessageBuffer(inputBuffer, { json_parse_logs: true })
+            const { value: outputBuffer, pii } = await processLogMessageBuffer(inputBuffer, {
+                jsonParse: true,
+                piiScrub: false,
+            })
             expect(pii).toEqual({ piiReplacements: 0 })
             const [_, __, decoded] = await decodeLogRecords(outputBuffer!)
 

--- a/nodejs/src/logs/log-record-avro.ts
+++ b/nodejs/src/logs/log-record-avro.ts
@@ -4,7 +4,6 @@ import { Histogram } from 'prom-client'
 import { Readable } from 'stream'
 
 import { instrumented } from '~/common/tracing/tracing-utils'
-import type { LogsSettings } from '~/types'
 
 import { recordLogProcessingDuration } from './ingestion-otel-metrics'
 import { type LogBodyParseResult, parseLogBodyForIngestion } from './log-body-parse'
@@ -281,16 +280,25 @@ const scrubBatch = instrumented({
 })
 
 /**
+ * Which body transforms run on decoded records. The consumer derives this from the team's settings
+ * and from what it knows about its own records, so a decision such as "these records carry no body"
+ * is expressed here and never by rewriting the team's settings.
+ */
+export type BodyTransforms = {
+    jsonParse: boolean
+    piiScrub: boolean
+}
+
+/**
  * Applies PII scrub and optional JSON parse + attribute enrichment to decoded records in place.
  * Used by the main buffer processor and by the sampling path (which must decode even when
  * json_parse / pii_scrub are off, then optionally runs this when either flag is on).
  */
 export async function transformDecodedLogRecordsInPlace(
     records: LogRecord[],
-    settings: LogsSettings
+    transforms: BodyTransforms
 ): Promise<PiiScrubStats> {
-    const jsonParse = settings.json_parse_logs ?? false
-    const piiScrub = settings.pii_scrub_logs ?? false
+    const { jsonParse, piiScrub } = transforms
     let pii: PiiScrubStats = EMPTY_PII
     if (jsonParse && piiScrub) {
         pii = await scrubBatch(records)
@@ -335,11 +343,11 @@ export type BufferProcessingMode = 'passthrough' | 'decode_only' | 'decode_and_r
  * `passthrough` adds a decode and an encode.
  */
 export function bufferProcessingMode(
-    settings: LogsSettings,
+    transforms: BodyTransforms,
     stageCount: number,
     hasVisitor: boolean
 ): BufferProcessingMode {
-    const normalizeActive = (settings.json_parse_logs ?? false) || (settings.pii_scrub_logs ?? false)
+    const normalizeActive = transforms.jsonParse || transforms.piiScrub
     if (normalizeActive || stageCount > 0) {
         return 'decode_and_reencode'
     }
@@ -364,11 +372,11 @@ export const processLogMessageBuffer = instrumented({
     ...logRecordProcessInstrumentOpts,
 })(async function processLogMessageBufferImpl(
     buffer: Buffer,
-    settings: LogsSettings,
+    transforms: BodyTransforms,
     options: ProcessLogMessageBufferOptions = {}
 ): Promise<ProcessLogMessageBufferResult> {
     const { onRecordsDecoded, stages = [] } = options
-    const processingMode = bufferProcessingMode(settings, stages.length, Boolean(onRecordsDecoded))
+    const processingMode = bufferProcessingMode(transforms, stages.length, Boolean(onRecordsDecoded))
 
     if (processingMode === 'passthrough') {
         // Passthrough: nothing mutates or drops and no visitor needs the records — forward untouched.
@@ -376,8 +384,7 @@ export const processLogMessageBuffer = instrumented({
     }
 
     // Read only by the duration labels in the `finally`, which the passthrough return never reaches.
-    const jsonParse = settings.json_parse_logs ?? false
-    const piiScrub = settings.pii_scrub_logs ?? false
+    const { jsonParse, piiScrub } = transforms
     const startTime = Date.now()
     let codec = 'unknown'
 
@@ -389,7 +396,7 @@ export const processLogMessageBuffer = instrumented({
             throw new Error('avro schema metadata not found')
         }
 
-        const pii = await transformDecodedLogRecordsInPlace(records, settings)
+        const pii = await transformDecodedLogRecordsInPlace(records, transforms)
         onRecordsDecoded?.(records)
 
         const { kept, stats } = await runPipelineStages(records, stages)
@@ -422,6 +429,6 @@ export const processLogMessageBuffer = instrumented({
     }
 }) as (
     buffer: Buffer,
-    settings: LogsSettings,
+    transforms: BodyTransforms,
     options?: ProcessLogMessageBufferOptions
 ) => Promise<ProcessLogMessageBufferResult>

--- a/nodejs/src/logs/log-record-avro.ts
+++ b/nodejs/src/logs/log-record-avro.ts
@@ -279,11 +279,6 @@ const scrubBatch = instrumented({
     return Promise.resolve({ piiReplacements })
 })
 
-/**
- * Which body transforms run on decoded records. The consumer derives this from the team's settings
- * and from what it knows about its own records, so a decision such as "these records carry no body"
- * is expressed here and never by rewriting the team's settings.
- */
 export type BodyTransforms = {
     jsonParse: boolean
     piiScrub: boolean

--- a/nodejs/src/logs/logs-ingestion-consumer.test.ts
+++ b/nodejs/src/logs/logs-ingestion-consumer.test.ts
@@ -2205,6 +2205,30 @@ describe('LogsIngestionConsumer', () => {
             expect(tracesConsumer['isPatternMaskingEnabledForTeam'](team.id)).toEqual(false)
         })
 
+        it('skips the JSON stage even when json_parse_logs is on, because a trace record has no body', async () => {
+            await hub.postgres.query(
+                PostgresUse.COMMON_WRITE,
+                `UPDATE posthog_team SET logs_settings = $1 WHERE id = $2`,
+                [JSON.stringify({ json_parse_logs: true }), team.id],
+                'updateTeamLogsSettings'
+            )
+            hub.teamManager['lazyLoader'].markForRefresh(String(team.id))
+            const tracesConsumer = createTracesIngestionConsumer()
+            await tracesConsumer.start()
+            try {
+                const messages = await createKafkaMessages([createLogMessage()], { token: team.api_token })
+                await waitForBackgroundTasks(tracesConsumer.processKafkaBatch(messages))
+
+                const produced = getProducedKafkaMessages().filter((m) => m.topic === KAFKA_LOGS_CLICKHOUSE)
+                expect(produced).toHaveLength(1)
+                // Byte-identical: the buffer was forwarded without a decode and re-encode.
+                expect(produced[0].value).toEqual(messages[0].value)
+                expect(produced[0].headers['json-parse']).toEqual('false')
+            } finally {
+                await tracesConsumer.stop()
+            }
+        })
+
         it('meters usage as traces, not logs', async () => {
             const tracesConsumer = createTracesIngestionConsumer()
             tracesConsumer['queueUsageMetric'](team.id, 'bytes_ingested', 500)

--- a/nodejs/src/logs/logs-ingestion-consumer.test.ts
+++ b/nodejs/src/logs/logs-ingestion-consumer.test.ts
@@ -2222,8 +2222,8 @@ describe('LogsIngestionConsumer', () => {
                 const produced = getProducedKafkaMessages().filter((m) => m.topic === KAFKA_LOGS_CLICKHOUSE)
                 expect(produced).toHaveLength(1)
                 // Byte-identical: the buffer was forwarded without a decode and re-encode.
-                expect(produced[0].value).toEqual(messages[0].value)
-                expect(produced[0].headers['json-parse']).toEqual('false')
+                expect(produced[0]?.value).toEqual(messages[0].value)
+                expect(produced[0]?.headers?.['json-parse']).toEqual('false')
             } finally {
                 await tracesConsumer.stop()
             }

--- a/nodejs/src/logs/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs/logs-ingestion-consumer.ts
@@ -348,8 +348,6 @@ export class LogsIngestionConsumer {
     // Billing identity for quota enforcement and usage metering; overridden by subclasses (e.g. traces).
     protected quotaResource: QuotaResource = 'logs_mb_ingested'
     protected appSource = 'logs'
-    /** Whether records carry a `body`. The body stages (JSON parse, pattern masking) are skipped when
-     * they do not; a subclass whose records have no body overrides this to false. */
     protected recordsHaveBody = true
     protected kafkaConsumer: KafkaConsumerInterface
     private appMetricsAggregator: AppMetricsAggregator
@@ -456,10 +454,7 @@ export class LogsIngestionConsumer {
         return this.recordsHaveBody && teamIdMatchesCsv(this.patternMaskingEnabledTeamsRaw, teamId)
     }
 
-    /**
-     * A record with no body has no JSON to parse, whatever the team's setting says. PII scrub is not
-     * gated the same way because it also scrubs attribute values.
-     */
+    // PII scrub is not gated on `recordsHaveBody` because it also scrubs attribute values.
     private bodyTransformsFor(logsSettings: LogsSettings): BodyTransforms {
         return {
             jsonParse: this.recordsHaveBody && (logsSettings.json_parse_logs ?? false),

--- a/nodejs/src/logs/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs/logs-ingestion-consumer.ts
@@ -454,6 +454,18 @@ export class LogsIngestionConsumer {
     }
 
     /**
+     * Logs only. `TracesIngestionConsumer` reads the same team settings, but a trace record has no
+     * `body`, so `json_parse_logs` would decode and re-encode every span batch to parse nothing.
+     * Returns a derived object; the team cache entry is left untouched.
+     */
+    private logsSettingsForSource(logsSettings: LogsSettings): LogsSettings {
+        if (this.appSource === 'logs') {
+            return logsSettings
+        }
+        return { ...logsSettings, json_parse_logs: false }
+    }
+
+    /**
      * Builds the hog log transformation hook for a message, or undefined when the team
      * is not gated in or has no enabled transformation_log functions (the existence
      * check is an in-process cache hit, preserving the no-decode passthrough).
@@ -894,7 +906,7 @@ export class LogsIngestionConsumer {
                         const team = await this.retryOnDependencyUnavailable(() =>
                             this.deps.teamManager.getTeam(message.teamId)
                         )
-                        const logsSettings = team?.logs_settings || {}
+                        const logsSettings = this.logsSettingsForSource(team?.logs_settings || {})
 
                         // Extract settings with defaults
                         const jsonParse = logsSettings.json_parse_logs ?? false

--- a/nodejs/src/logs/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs/logs-ingestion-consumer.ts
@@ -32,6 +32,7 @@ import {
 import { logsPatternForcedDecodeCounter, makePatternMaskingStage } from './log-pattern-stage'
 import { type PiiScrubStats } from './log-pii-scrub'
 import {
+    type BodyTransforms,
     type LogRecord,
     type LogRecordsTransform,
     bufferProcessingMode,
@@ -456,6 +457,17 @@ export class LogsIngestionConsumer {
     }
 
     /**
+     * A record with no body has no JSON to parse, whatever the team's setting says. PII scrub is not
+     * gated the same way because it also scrubs attribute values.
+     */
+    private bodyTransformsFor(logsSettings: LogsSettings): BodyTransforms {
+        return {
+            jsonParse: this.recordsHaveBody && (logsSettings.json_parse_logs ?? false),
+            piiScrub: logsSettings.pii_scrub_logs ?? false,
+        }
+    }
+
+    /**
      * Builds the hog log transformation hook for a message, or undefined when the team
      * is not gated in or has no enabled transformation_log functions (the existence
      * check is an in-process cache hit, preserving the no-decode passthrough).
@@ -506,6 +518,7 @@ export class LogsIngestionConsumer {
               contentBytesTotal: number
           }
     > {
+        const transforms = this.bodyTransformsFor(logsSettings)
         const samplingCache = this.deps.samplingRulesCache
         const samplingEvalEnabled = this.isSamplingEvalEnabledForTeam(message.teamId)
         let ruleSet: CompiledRuleSet | null = null
@@ -547,7 +560,7 @@ export class LogsIngestionConsumer {
         // so a batch that would have passed through pays both, and one already decoded for a visitor
         // pays the encode. The counter prices each.
         if (this.isPatternMaskingEnabledForTeam(message.teamId)) {
-            const modeWithoutMasking = bufferProcessingMode(logsSettings, stages.length, Boolean(onRecordsDecoded))
+            const modeWithoutMasking = bufferProcessingMode(transforms, stages.length, Boolean(onRecordsDecoded))
             if (modeWithoutMasking !== 'decode_and_reencode') {
                 logsPatternForcedDecodeCounter.inc({ from: modeWithoutMasking })
             }
@@ -573,7 +586,7 @@ export class LogsIngestionConsumer {
                   : 'passthrough',
         })
 
-        const { value, pii, drops } = await processLogMessageBuffer(message.message.value!, logsSettings, {
+        const { value, pii, drops } = await processLogMessageBuffer(message.message.value!, transforms, {
             onRecordsDecoded,
             stages,
         })
@@ -896,15 +909,10 @@ export class LogsIngestionConsumer {
                         const team = await this.retryOnDependencyUnavailable(() =>
                             this.deps.teamManager.getTeam(message.teamId)
                         )
-                        const teamLogsSettings = team?.logs_settings || {}
-                        // With no body, `json_parse_logs` would decode and re-encode every batch to parse
-                        // nothing. The copy leaves the team cache entry untouched.
-                        const logsSettings = this.recordsHaveBody
-                            ? teamLogsSettings
-                            : { ...teamLogsSettings, json_parse_logs: false }
+                        const logsSettings = team?.logs_settings || {}
 
                         // Extract settings with defaults
-                        const jsonParse = logsSettings.json_parse_logs ?? false
+                        const { jsonParse } = this.bodyTransformsFor(logsSettings)
                         const retentionDays = logsSettings.retention_days ?? DEFAULT_LOGS_RETENTION_DAYS
 
                         // Retention is uniform per team; stash it for the retention usage metrics.

--- a/nodejs/src/logs/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs/logs-ingestion-consumer.ts
@@ -347,6 +347,9 @@ export class LogsIngestionConsumer {
     // Billing identity for quota enforcement and usage metering; overridden by subclasses (e.g. traces).
     protected quotaResource: QuotaResource = 'logs_mb_ingested'
     protected appSource = 'logs'
+    /** Whether records carry a `body`. The body stages (JSON parse, pattern masking) are skipped when
+     * they do not; a subclass whose records have no body overrides this to false. */
+    protected recordsHaveBody = true
     protected kafkaConsumer: KafkaConsumerInterface
     private appMetricsAggregator: AppMetricsAggregator
     private redis: RedisV2
@@ -445,24 +448,11 @@ export class LogsIngestionConsumer {
     }
 
     /**
-     * Logs only. `TracesIngestionConsumer` subclasses this one and reads the same config key, but a
-     * trace record has no `body` field, so masking one measures nothing and would mix trace shapes
-     * into the log-body split these metrics exist to produce.
+     * A body-less record masks to nothing and would mix its shapes into the log-body split these
+     * metrics exist to produce, so the gate is off for a subclass whose records carry no body.
      */
     private isPatternMaskingEnabledForTeam(teamId: number): boolean {
-        return this.appSource === 'logs' && teamIdMatchesCsv(this.patternMaskingEnabledTeamsRaw, teamId)
-    }
-
-    /**
-     * Logs only. `TracesIngestionConsumer` reads the same team settings, but a trace record has no
-     * `body`, so `json_parse_logs` would decode and re-encode every span batch to parse nothing.
-     * Returns a derived object; the team cache entry is left untouched.
-     */
-    private logsSettingsForSource(logsSettings: LogsSettings): LogsSettings {
-        if (this.appSource === 'logs') {
-            return logsSettings
-        }
-        return { ...logsSettings, json_parse_logs: false }
+        return this.recordsHaveBody && teamIdMatchesCsv(this.patternMaskingEnabledTeamsRaw, teamId)
     }
 
     /**
@@ -906,7 +896,12 @@ export class LogsIngestionConsumer {
                         const team = await this.retryOnDependencyUnavailable(() =>
                             this.deps.teamManager.getTeam(message.teamId)
                         )
-                        const logsSettings = this.logsSettingsForSource(team?.logs_settings || {})
+                        const teamLogsSettings = team?.logs_settings || {}
+                        // With no body, `json_parse_logs` would decode and re-encode every batch to parse
+                        // nothing. The copy leaves the team cache entry untouched.
+                        const logsSettings = this.recordsHaveBody
+                            ? teamLogsSettings
+                            : { ...teamLogsSettings, json_parse_logs: false }
 
                         // Extract settings with defaults
                         const jsonParse = logsSettings.json_parse_logs ?? false

--- a/nodejs/src/logs/traces-ingestion-consumer.ts
+++ b/nodejs/src/logs/traces-ingestion-consumer.ts
@@ -6,6 +6,8 @@ export class TracesIngestionConsumer extends LogsIngestionConsumer {
     // Meter and quota-limit traces against their own billing identity, not logs'.
     protected override quotaResource = 'traces_mb_ingested' as const
     protected override appSource = 'traces'
+    // A span has no `body`, so the JSON parse and pattern masking stages have nothing to read.
+    protected override recordsHaveBody = false
 
     constructor(config: LogsIngestionConsumerConfig & TracesIngestionConsumerConfig, deps: LogsIngestionConsumerDeps) {
         // Topics are wired into `deps.outputs` by the server, so the only consumer-level


### PR DESCRIPTION
## Problem

- Trace spans for a team with `json_parse_logs` on run the JSON parse stage, and it has nothing to parse. A trace record has no `body` field.
- The stage forces a decode and re-encode of every span batch for that team, so the consumer pays the full Avro round trip for no output.
- Any throw in that stage quarantines the span batch to the dead-letter topic. That is the path #92714 hit and #93996 reverted.
- The traces consumer is a subclass of the logs consumer and reads the same team settings. Pattern masking already skips traces for the same reason. JSON parse did not.

## Changes

- Nobody sees a difference. Spans for a team with `json_parse_logs` on now pass the consumer untouched, and their Kafka `json-parse` header reads `false`.
- The logs consumer gains one attribute, `recordsHaveBody`, next to `quotaResource` and `appSource`. The traces subclass overrides it to `false`.
- The buffer processor no longer reads the team's `LogsSettings`. It takes a `BodyTransforms` decision, two booleans for JSON parse and PII scrub.
- The consumer derives that decision in one place from the team settings and `recordsHaveBody`. The team settings object is never copied or rewritten.
- The pattern masking gate used to compare `appSource` to the string `'logs'`; it now reads the attribute too. Mechanical.
- `log-record-avro.test.ts` call sites move from the settings shape to the decision shape. Mechanical.
- PII scrub is not gated. It scrubs attribute values as well as `body`, and spans carry attributes.

## How did you test this code?

- `logs-ingestion-consumer.test.ts` gains a `TracesIngestionConsumer` case with `json_parse_logs` on. It asserts the produced buffer is byte-identical to the input and the `json-parse` header is `false`. Without the guard the batch is decoded and re-encoded, so the buffer differs and the case fails. No existing test ran a traces consumer with JSON parsing on.
- Ran that describe block locally against the dev Postgres and Redis. Not run: the rest of the nodejs suite. Nothing ran against live traffic.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

- Open PR search: #96491 reapplies the JSON start scan with a guard for an `undefined` body. This PR is independent of it and removes the stage for spans regardless.
- Three drafts preceded this shape. The first flipped the flag on the team settings object in place. The second gated on `appSource === 'logs'` in a method. The third passed a copy of the settings with the flag off. Each expressed a consumer decision by rewriting team configuration, so the module contract changed to take the decision instead.
- Nothing in this PR carries material from the session that is not already public.
