### PR TITLE
feat(experiments): add ttl verdict banner to staff cache health tab

### DIFF
--- a/frontend/src/scenes/experiments/staff/CacheHealth.tsx
+++ b/frontend/src/scenes/experiments/staff/CacheHealth.tsx
@@ -45,27 +45,38 @@ function ttlStatus(partition: string): { label: string; type: LemonTagType } {
 // dated before today means that stopped, so it gets a headline verdict instead of a table row
 // the reader has to scan for.
 function TtlVerdictBanner({ tables }: { tables: CacheTableStats[] }): JSX.Element | null {
-    const readable = tables.filter((table) => !table.unavailable)
-    if (readable.length === 0) {
+    if (tables.length === 0) {
         return null
     }
+    const readable = tables.filter((table) => !table.unavailable)
+    const unavailable = tables.filter((table) => table.unavailable)
     const today = dayjs().format('YYYYMMDD')
     const expired = readable.flatMap((table) => table.partitions.filter((partition) => partition.partition < today))
-    if (expired.length === 0) {
+    if (expired.length > 0) {
+        const days = new Set(expired.map((partition) => partition.partition))
+        const bytes = expired.reduce((sum, partition) => sum + partition.bytes_on_disk, 0)
+        const oldest = [...days].sort()[0]
         return (
-            <LemonBanner type="success" className="mb-4">
-                TTL cleanup is keeping up. No expired data is waiting to be dropped.
+            <LemonBanner type="error" className="mb-4">
+                Expired data from {days.size} {days.size === 1 ? 'day' : 'days'} ({humanizeBytes(bytes)}) is still on
+                disk, oldest from {formatPartitionDay(oldest)}. ClickHouse is not dropping expired partitions. Check TTL
+                merges on the cluster.
             </LemonBanner>
         )
     }
-    const days = new Set(expired.map((partition) => partition.partition))
-    const bytes = expired.reduce((sum, partition) => sum + partition.bytes_on_disk, 0)
-    const oldest = [...days].sort()[0]
+    // A green verdict from partial data would hide the exact failure it exists to surface,
+    // so an unreadable table degrades the verdict to unknown.
+    if (unavailable.length > 0) {
+        return (
+            <LemonBanner type="warning" className="mb-4">
+                TTL status is unknown for {unavailable.map((table) => tableLabel(table.table)).join(' and ')}:
+                system.parts could not be read. No expired data in the tables that were checked.
+            </LemonBanner>
+        )
+    }
     return (
-        <LemonBanner type="error" className="mb-4">
-            Expired data from {days.size} {days.size === 1 ? 'day' : 'days'} ({humanizeBytes(bytes)}) is still on disk,
-            oldest from {formatPartitionDay(oldest)}. ClickHouse is not dropping expired partitions. Check TTL merges on
-            the cluster.
+        <LemonBanner type="success" className="mb-4">
+            TTL cleanup is keeping up. No expired data is waiting to be dropped.
         </LemonBanner>
     )
 }

--- a/frontend/src/scenes/experiments/staff/CacheHealth.tsx
+++ b/frontend/src/scenes/experiments/staff/CacheHealth.tsx
@@ -5,6 +5,7 @@ import { TimeSeriesBarChart } from '@posthog/quill-charts'
 
 import { useChartTheme } from 'lib/charts/hooks'
 import { dayjs } from 'lib/dayjs'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonCard } from 'lib/lemon-ui/LemonCard'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
@@ -38,6 +39,35 @@ function ttlStatus(partition: string): { label: string; type: LemonTagType } {
     }
     const days = dayjs(partitionToISO(partition)).diff(dayjs().startOf('day'), 'day')
     return { label: `Drops in ${days}d`, type: 'muted' }
+}
+
+// The tables self-clean only while TTL merges keep dropping expired partitions. Any partition
+// dated before today means that stopped, so it gets a headline verdict instead of a table row
+// the reader has to scan for.
+function TtlVerdictBanner({ tables }: { tables: CacheTableStats[] }): JSX.Element | null {
+    const readable = tables.filter((table) => !table.unavailable)
+    if (readable.length === 0) {
+        return null
+    }
+    const today = dayjs().format('YYYYMMDD')
+    const expired = readable.flatMap((table) => table.partitions.filter((partition) => partition.partition < today))
+    if (expired.length === 0) {
+        return (
+            <LemonBanner type="success" className="mb-4">
+                TTL cleanup is keeping up. No expired data is waiting to be dropped.
+            </LemonBanner>
+        )
+    }
+    const days = new Set(expired.map((partition) => partition.partition))
+    const bytes = expired.reduce((sum, partition) => sum + partition.bytes_on_disk, 0)
+    const oldest = [...days].sort()[0]
+    return (
+        <LemonBanner type="error" className="mb-4">
+            Expired data from {days.size} {days.size === 1 ? 'day' : 'days'} ({humanizeBytes(bytes)}) is still on disk,
+            oldest from {formatPartitionDay(oldest)}. ClickHouse is not dropping expired partitions. Check TTL merges on
+            the cluster.
+        </LemonBanner>
+    )
 }
 
 // "experiment_exposures_preaggregated" -> "exposures" — the key the backend uses for growth series
@@ -212,6 +242,7 @@ export function CacheHealth(): JSX.Element {
                     </LemonButton>
                 </div>
             </div>
+            {cacheHealth ? <TtlVerdictBanner tables={tables} /> : null}
             <div className="flex flex-wrap gap-4 mb-4">
                 {!cacheHealth && cacheHealthLoading
                     ? [0, 1].map((i) => (


### PR DESCRIPTION
## Problem

When ClickHouse stops dropping expired partitions from the experiment preaggregation tables, the only signal on `/experiments/staff` is a red tag buried in the partition breakdown table. Staff have to scroll and scan for it, and this is the one condition that makes the cache tables grow without bound.

## Changes

- The Cache health tab now opens with a verdict banner. Green when all data on disk is within its expiry window. Red when expired partitions linger, with the day count, size on disk, oldest date, and the next step.
- Frontend only. The banner is computed from the `cache_health` response the tab already loads, using the same date comparison as the per-row TTL tags.

No screenshot: the tab needs production data, and the light worktree cannot run the app.

## How did you test this code?

- No new test. The banner reuses the date comparison the existing per-row TTL tags already use, and there is no jest coverage for this scene to extend.
- Not run: frontend typecheck (light worktree without `node_modules`); CI covers it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None (internal staff tooling).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: /wt, /writing-ui-components, /writing-user-facing-copy, /writing-code-comments, /writing-pr-descriptions. Follow-up to #96150; second of the staff-tooling insights discussed there (TTL health headline).
