### PR TITLE
feat(replay-vision): attribute scan spend to the scanner's creator

### DIFF
--- a/products/replay_vision/backend/temporal/activities/observation_state.py
+++ b/products/replay_vision/backend/temporal/activities/observation_state.py
@@ -1,5 +1,6 @@
-from collections.abc import Callable, Container
-from uuid import UUID
+from collections.abc import Callable, Container, Mapping
+from typing import Any
+from uuid import UUID, uuid5
 
 from django.db import transaction
 from django.utils import timezone
@@ -91,6 +92,57 @@ def _capture_terminal_scan(*, observation_id: UUID, status: ObservationStatus, s
             "kind": kind,
             # The version that produced this scan, from the snapshot rather than the live scanner, so a
             # later edit cannot retro-attribute a failure to the config that replaced it.
+            "scanner_version": obs["scanner_snapshot__scanner_version"],
+            "team_id": obs["team_id"],
+            "organization_id": str(obs["team__organization_id"]),
+        },
+        # Mirrors posthog.event_usage.groups() without fetching the Team row.
+        groups={
+            "instance": SITE_URL,
+            "organization": str(obs["team__organization_id"]),
+            "project": str(obs["team__uuid"]),
+        },
+    )
+
+
+def _capture_credits_spent(
+    *,
+    observation_id: UUID,
+    scanner_type: str,
+    model: str,
+    credits: int,
+    obs: Mapping[str, Any],
+) -> None:
+    """Spend telemetry attributed to the person who created the scanner.
+
+    `replay_vision_scan_completed` is keyed to a synthetic per-team distinct id, so it shares no
+    person with `replay_vision_scanner_created` and an experiment cannot join the two. That leaves
+    every Replay Vision experiment able to guardrail only on the spend forecast shown at
+    configuration time, never on the spend that actually happened. This event carries the same
+    figures under the creator's distinct id, which is the join key an experiment metric needs.
+
+    Attribution is to the scanner's creator, not to whoever triggered the scan, because a scheduled
+    sweep has no user behind it and the creation is the decision that causes the recurring spend.
+    """
+    distinct_id = obs["scanner__created_by__distinct_id"]
+    if not distinct_id:
+        # No creator (an inline or API-minted scanner, or a deleted user) leaves nobody to attribute
+        # to. Summing this event therefore undercounts total spend; `replay_vision_scan_completed`
+        # stays the complete record.
+        return
+    posthoganalytics.capture(
+        distinct_id=distinct_id,
+        event="replay_vision_credits_spent",
+        # Derived from the observation id so a retry cannot duplicate the row, and distinct from the
+        # id `replay_vision_scan_completed` already uses, so neither event dedups the other away.
+        uuid=str(uuid5(observation_id, "replay_vision_credits_spent")),
+        properties={
+            "observation_id": str(observation_id),
+            "scanner_id": str(obs["scanner_id"]),
+            "scanner_type": scanner_type,
+            "model": model,
+            "credits": credits,
+            "triggered_by": obs["triggered_by"],
             "scanner_version": obs["scanner_snapshot__scanner_version"],
             "team_id": obs["team_id"],
             "organization_id": str(obs["team__organization_id"]),
@@ -209,6 +261,7 @@ def mark_observation_succeeded_activity(inputs: MarkObservationSucceededInputs) 
             "created_at",
             "scanner_snapshot__model",
             "scanner_snapshot__scanner_version",
+            "scanner__created_by__distinct_id",
         ).get(pk=inputs.observation_id)
         model = obs["scanner_snapshot__model"] or ""
         credits = observation_credits_for_model(model)
@@ -266,3 +319,19 @@ def mark_observation_succeeded_activity(inputs: MarkObservationSucceededInputs) 
             "project": str(obs["team__uuid"]),
         },
     )
+    if receipt_created:
+        try:
+            _capture_credits_spent(
+                observation_id=inputs.observation_id,
+                scanner_type=inputs.scanner_type.value,
+                model=model,
+                credits=credits,
+                obs=obs,
+            )
+        except Exception:
+            # Fail-soft: the scan is billed and the receipt is written, so raising here would fail an
+            # activity whose work is done, purely over telemetry.
+            logger.exception(
+                "replay_vision.observation.credits_spent_capture_failed",
+                observation_id=str(inputs.observation_id),
+            )

--- a/products/replay_vision/backend/tests/test_temporal.py
+++ b/products/replay_vision/backend/tests/test_temporal.py
@@ -1192,6 +1192,91 @@ class TestObservationStateActivities:
         assert properties["organization_id"] == str(observation.team.organization_id)
         assert kwargs["groups"]["organization"] == str(observation.team.organization_id)
 
+    def test_spend_is_attributed_to_the_scanner_creator_once_per_billed_scan(self) -> None:
+        # `replay_vision_scan_completed` is keyed to a synthetic per-team id, so it cannot be joined
+        # to the creator. Without this event no experiment can guardrail on realized spend.
+        scanner = _make_scanner()
+        creator = User.objects.create_and_join(
+            organization=scanner.team.organization, email="creator@example.com", password=None
+        )
+        scanner.created_by = creator
+        scanner.save()
+        observation = _make_observation(scanner, status=ObservationStatus.RUNNING, started_at=timezone.now())
+        result = ScannerResult(model_output=MonitorOutput(verdict="yes", reasoning="ok", confidence=0.9))
+        inputs = MarkObservationSucceededInputs(
+            observation_id=observation.id, scanner_result=result, scanner_type=ScannerType.MONITOR
+        )
+
+        with patch(
+            "products.replay_vision.backend.temporal.activities.observation_state.posthoganalytics.capture"
+        ) as capture:
+            mark_observation_succeeded_activity(inputs)
+
+        spend = [c for c in capture.call_args_list if c.kwargs["event"] == "replay_vision_credits_spent"]
+        assert len(spend) == 1
+        kwargs = spend[0].kwargs
+        assert kwargs["distinct_id"] == creator.distinct_id
+        properties = kwargs["properties"]
+        assert properties["credits"] == observation_credits_for_model(observation.scanner_snapshot["model"])
+        assert properties["scanner_id"] == str(scanner.id)
+        assert properties["scanner_version"] == observation.scanner_snapshot["scanner_version"]
+        assert properties["organization_id"] == str(observation.team.organization_id)
+        # A shared dedup key would let ingestion drop one of the two events for the same scan.
+        completed = [c for c in capture.call_args_list if c.kwargs["event"] == "replay_vision_scan_completed"]
+        assert kwargs["uuid"] != completed[0].kwargs["uuid"]
+
+    def test_no_spend_event_when_the_scan_was_already_billed(self) -> None:
+        # A transition that finds the receipt already written is a re-settle, not a fresh charge.
+        # The sticky status guard returns before this point, so the receipt is the only thing
+        # standing between a re-settle and a second spend event for one billed scan.
+        scanner = _make_scanner()
+        creator = User.objects.create_and_join(
+            organization=scanner.team.organization, email="billed@example.com", password=None
+        )
+        scanner.created_by = creator
+        scanner.save()
+        observation = _make_observation(scanner, status=ObservationStatus.RUNNING, started_at=timezone.now())
+        ReplayObservationUsage.objects.create(
+            observation_id=observation.id,
+            organization_id=scanner.team.organization_id,
+            team_id=scanner.team_id,
+            scanner_id=scanner.id,
+            observation_created_at=observation.created_at,
+            model=observation.scanner_snapshot["model"],
+            credits=observation_credits_for_model(observation.scanner_snapshot["model"]),
+        )
+        result = ScannerResult(model_output=MonitorOutput(verdict="yes", reasoning="ok", confidence=0.9))
+
+        with patch(
+            "products.replay_vision.backend.temporal.activities.observation_state.posthoganalytics.capture"
+        ) as capture:
+            mark_observation_succeeded_activity(
+                MarkObservationSucceededInputs(
+                    observation_id=observation.id, scanner_result=result, scanner_type=ScannerType.MONITOR
+                )
+            )
+
+        assert [c.kwargs["event"] for c in capture.call_args_list] == ["replay_vision_scan_completed"]
+
+    def test_no_spend_event_when_the_scanner_has_no_creator(self) -> None:
+        # An inline or API-minted scanner has nobody to attribute to; emitting anyway would either
+        # crash on a null distinct id or invent a person.
+        scanner = _make_scanner()
+        assert scanner.created_by is None
+        observation = _make_observation(scanner, status=ObservationStatus.RUNNING, started_at=timezone.now())
+        result = ScannerResult(model_output=MonitorOutput(verdict="yes", reasoning="ok", confidence=0.9))
+
+        with patch(
+            "products.replay_vision.backend.temporal.activities.observation_state.posthoganalytics.capture"
+        ) as capture:
+            mark_observation_succeeded_activity(
+                MarkObservationSucceededInputs(
+                    observation_id=observation.id, scanner_result=result, scanner_type=ScannerType.MONITOR
+                )
+            )
+
+        assert [c.kwargs["event"] for c in capture.call_args_list] == ["replay_vision_scan_completed"]
+
     def test_mark_failed_writes_no_usage_receipt(self) -> None:
         scanner = _make_scanner()
         observation = _make_observation(scanner, status=ObservationStatus.RUNNING, started_at=timezone.now())


### PR DESCRIPTION
## Problem

No Replay Vision experiment can tell whether a change made customers spend more. It can only measure the estimate shown while configuring a scanner, never the credits actually burned.

- `replay_vision_scan_completed` is captured against `replay_vision_distinct_id(team_id)`, a synthetic per-team id.
- `replay_vision_scanner_created` is captured against the real person who created the scanner.
- The two therefore share no person, so an experiment metric cannot join them and realized spend is unreachable per arm.

That leaves a metered product whose experiments can push people toward pricier scanners with nothing measuring the bill that follows.

## Changes

- Replay Vision emits `replay_vision_credits_spent` for each billed scan, attributed to the person who created the scanner. Realized spend becomes usable as an experiment metric and a guardrail for the first time.
- The event carries the same figures as the success event (`credits`, `model`, `scanner_type`, `scanner_version`, `triggered_by`), so an analysis can split spend by config without a second source.
- `replay_vision_scan_completed` is untouched. No existing event, property, dashboard, or query changes.
- Attribution is to the scanner's creator, not to whoever triggered the scan. A scheduled sweep has no user behind it, and the creation is the decision that causes the recurring spend.
- The emit is gated on the usage receipt, which is the billing record. A re-settled observation cannot charge a person twice.
- A scanner with no creator emits nothing, because there is nobody to attribute to.

The event's own dedup key is derived from the observation id rather than reusing it. `replay_vision_scan_completed` already uses the raw observation id, and a shared key would let ingestion drop one of the two events for the same scan.

> [!NOTE]
> Summing this event undercounts total spend, by design. Inline and API-minted scanners have no creator, so their scans are absent. `replay_vision_scan_completed` remains the complete record; this event is the person-attributed view of it.

One event per billed scan is a real addition to a high-throughput stream. The alternative, re-keying the existing event to the creator, was rejected: it would silently move every existing consumer of `replay_vision_scan_completed` onto a different person and break anything grouping on the per-team id.

## How did you test this code?

Three new cases in the existing `TestObservationStateActivities` block:

- Spend is attributed to the creator's distinct id, carries the right credits and version, and its dedup key differs from the success event's. Nothing asserted the join key before, and a shared key is invisible until ingestion drops an event.
- A scan whose receipt already exists emits no spend event. This is the re-settle path, and without it a person could be charged twice for one scan.
- A scanner with no creator emits only the success event. Without this, the null case would either attribute spend to nobody or crash on a null distinct id.

Mutation-checked. Four mutations, each killing only its own test: reusing the observation id as the dedup key, dropping the receipt gate, dropping the no-creator guard, and swapping the creator for the synthetic team id.

Worth flagging for the reviewer: the receipt gate initially looked covered and was not. The first version of the attribution test called the activity twice to prove a retry could not double-charge, and it passed with the gate removed. The sticky status transition returns before the gate is ever reached, so the retry proved nothing. The third test above replaces that assertion by constructing the state that actually reaches the gate, a live transition against a pre-existing receipt, and it does kill the mutation.

Not run: the Temporal workflow integration suites, because this environment has no Temporal worker. The change touches one activity's post-commit telemetry, which the unit tests exercise directly.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code, in a session auditing Replay Vision's instrumentation. This gap surfaced while concluding an experiment that wanted a spend guardrail and could not have one.

Skills invoked: `/writing-tests`, `/writing-code-comments`, and `/writing-pr-descriptions`.

The companion-event shape was chosen over re-keying the existing event specifically for backwards compatibility, at the cost of extra volume. The receipt gate was chosen over a time or status gate because the receipt already carries exactly-once billing semantics, so the spend event inherits them rather than inventing a second rule.

No duplicate: `gh pr list --state open --search` over the spend, credits, and attribution keywords found nothing covering this.

No customer data, session content, or non-public material is in this diff. The tests use the existing in-repo factories and a reserved example domain.
