### PR TITLE
fix(mcp): attribute tracked events to the session client

### DIFF
--- a/services/mcp/src/hono/request-context.ts
+++ b/services/mcp/src/hono/request-context.ts
@@ -20,6 +20,7 @@ import {
     buildMCPRequestContext,
     buildMCPSessionAnalyticsProperties,
     getEffectiveMCPClientContext,
+    getEffectiveMCPClientIdentity,
     type MCPRequestContext,
     type MCPSessionContext,
 } from './mcp-context'
@@ -221,23 +222,27 @@ export class RequestContext {
         requestContext: MCPRequestContext = this.requestContext,
         sessionContext: MCPSessionContext | null = this.sessionContext
     ): Record<string, unknown> {
+        // `clientInfo` arrives on `initialize` only, so a mid-session call carries none of
+        // it. Resolve live-first with the session-pinned value per field, the way
+        // `buildBaseProperties` does for tool calls, or these events record no client.
+        const clientIdentity = getEffectiveMCPClientIdentity(requestContext, sessionContext)
         return {
             $ai_product: 'mcp',
             $mcp_source: MCP_ANALYTICS_SOURCE,
             $mcp_server_name: MCP_SERVER_NAME,
             $mcp_server_version: MCP_SERVER_VERSION,
-            $mcp_client_name: requestContext.mcpClientName,
-            $mcp_client_version: requestContext.mcpClientVersion,
+            $mcp_client_name: clientIdentity.mcpClientName,
+            $mcp_client_version: clientIdentity.mcpClientVersion,
             $mcp_client_user_agent: requestContext.clientUserAgent,
-            $mcp_protocol_version: requestContext.mcpProtocolVersion,
+            $mcp_protocol_version: clientIdentity.mcpProtocolVersion,
             $mcp_transport: requestContext.transport,
             $mcp_session_id: requestContext.mcpSessionId,
             $mcp_conversation_id: requestContext.mcpConversationId,
-            $mcp_consumer: requestContext.mcpConsumer,
+            $mcp_consumer: clientIdentity.mcpConsumer,
             $mcp_mode: requestContext.mode,
             $mcp_region: requestContext.region,
             mcp_runtime: 'hono',
-            $mcp_vendor_client: requestContext.mcpVendorClient,
+            $mcp_vendor_client: clientIdentity.mcpVendorClient,
             ...buildMCPSessionAnalyticsProperties(sessionContext),
         }
     }

--- a/services/mcp/tests/hono/request-context.test.ts
+++ b/services/mcp/tests/hono/request-context.test.ts
@@ -172,6 +172,43 @@ describe('RequestContext', () => {
         })
     })
 
+    // `agent-feedback` and the context-switch events capture through `trackEvent`, which
+    // reads these properties. `clientInfo` arrives on `initialize` only, so reading the
+    // request alone records no client for every call after the first.
+    describe('buildClientProperties', () => {
+        it('falls back to the session client identity mid-session', () => {
+            const ctx = new RequestContext(fakeRedis(), env, makeProps({ mcpClientName: undefined }))
+            ctx.setMcpContexts(
+                { authMethod: 'personal_api_key', mcpClientName: undefined },
+                {
+                    mcpClientName: 'claude-code',
+                    mcpClientVersion: '1.0',
+                    mcpProtocolVersion: '2025-03-26',
+                    mcpConsumer: 'plugin',
+                    mcpVendorClient: 'ClaudeCode',
+                }
+            )
+
+            expect(ctx.buildClientProperties()).toMatchObject({
+                $mcp_client_name: 'claude-code',
+                $mcp_client_version: '1.0',
+                $mcp_protocol_version: '2025-03-26',
+                $mcp_consumer: 'plugin',
+                $mcp_vendor_client: 'ClaudeCode',
+            })
+        })
+
+        it('keeps the live request identity when the call carries one', () => {
+            const ctx = new RequestContext(fakeRedis(), env, makeProps({ mcpClientName: 'cursor' }))
+            ctx.setMcpContexts(
+                { authMethod: 'personal_api_key', mcpClientName: 'cursor' },
+                { mcpClientName: 'claude-code' }
+            )
+
+            expect(ctx.buildClientProperties()).toMatchObject({ $mcp_client_name: 'cursor' })
+        })
+    })
+
     describe('getDistinctId', () => {
         it('deduplicates concurrent calls into a single API request', async () => {
             mockMe.mockResolvedValue({ success: true, data: { distinct_id: 'user-123' } })


### PR DESCRIPTION
## Problem

Three events record no client, so nothing on them can be attributed to Claude Code, Cursor, or anything else. Measured across the last 90 days in PostHog's own project, nearly every one is affected.

| Event | Emitted by |
| --- | --- |
| `mcp feedback submitted` | the `agent-feedback` tool |
| `mcp project switched` | `switch-project` |
| `mcp organization switched` | `switch-organization` |

Each of them loses the same five properties:

- `$mcp_client_name`
- `$mcp_client_version`
- `$mcp_protocol_version`
- `$mcp_consumer`
- `$mcp_vendor_client`

`RequestContext.buildClientProperties` reads all five straight off the request. `clientInfo` arrives on `initialize` only, so a mid-session call carries none of them, and every call after the first in a session records blanks. The small remainder that do carry a client are the ones that landed on the handshake itself.

The tool-call path does not have this problem. `buildBaseProperties` in `hono/analytics.ts` already resolves the same five fields live-first with the session-pinned value per field, through `getEffectiveMCPClientIdentity`. So `$mcp_tool_call` attributes correctly while these three do not, on the same server. The `trackEvent` path was never given the same treatment.

## Changes

- `agent-feedback` reports and context switches now carry the client that made them, so a breakdown by `$mcp_client_name` stops collapsing into one empty bucket.
- `buildClientProperties` resolves those five fields through `getEffectiveMCPClientIdentity`, so the two capture paths agree.
- `$mcp_client_user_agent`, `$mcp_transport`, `$mcp_session_id`, `$mcp_conversation_id`, `$mcp_mode` and `$mcp_region` still come off the request. They are per-request facts, not handshake identity.

No behavior change beyond attribution, and no backfill: events already captured stay blank.

## How did you test this code?

Two cases in `tests/hono/request-context.test.ts`, one for each direction of the fallback: a mid-session call with no request identity resolves the session's, and a call that carries its own keeps it. The second is what stops a naive fix from pinning stale identity onto a request that supplied a live one.

Verified the pair actually catches the bug: with the fix reverted and the tests kept, the first case fails.

Ran locally: `vitest run tests/unit`, `pnpm test:hono`, `pnpm fix`, `tsc --noEmit`, `hogli ci:preflight`. Not run: the Python suites, which this diff does not reach.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in Claude Code, directed by the assignee. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

- Found while comparing #95837 against #96072 and #96424. #95837 fixes this as a side effect of a different approach to the missing-capability channel, and that PR is being closed, so the fix would otherwise be lost. Lifted here on its own because it is unrelated to the channel work and stands by itself.
- Independent of both of those PRs: branched off `master`, touches neither of their files.
- Public artifact: the diff carries no material from the agent session. Every string in it is written for this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

