### PR TITLE
feat(notebooks): add cell and block keyboard shortcuts

### DIFF
--- a/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.test.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.test.ts
@@ -477,6 +477,34 @@ function createTouchList(touches: Touch[]): TouchList {
 }
 
 describe('MarkdownNotebook', () => {
+    it('moves a component block whose own control holds focus', () => {
+        // A cell's Run button takes focus on click, so the block element itself is not the active
+        // element. Resolving only exact matches moved whatever block still held the caret.
+        const onChange = jest.fn()
+        const registry = createMarkdownNotebookRegistry([
+            {
+                tagName: 'Embed',
+                label: 'Embed',
+                category: 'Media',
+                ViewComponent: () => createElement('button', { type: 'button', 'data-attr': 'embed-run' }, 'Run'),
+            },
+        ])
+        const { container } = render(
+            createElement(MarkdownNotebook, {
+                value: withNotebookTitle('First\n\n<Embed url="https://posthog.com" />'),
+                onChange,
+                registry,
+            })
+        )
+
+        const embedControl = container.querySelector('[data-attr="embed-run"]') as HTMLButtonElement
+        embedControl.focus()
+
+        fireEvent.keyDown(embedControl, { key: 'ArrowUp', altKey: true })
+
+        expect(onChange).toHaveBeenLastCalledWith(withNotebookTitle('<Embed url="https://posthog.com" />\n\nFirst'))
+    })
+
     it('moves the focused block past its neighbour with Alt+Up and Alt+Down', () => {
         const onChange = jest.fn()
         const { container } = render(

--- a/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.test.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.test.ts
@@ -477,6 +477,41 @@ function createTouchList(touches: Touch[]): TouchList {
 }
 
 describe('MarkdownNotebook', () => {
+    it('moves the focused block past its neighbour with Alt+Up and Alt+Down', () => {
+        const onChange = jest.fn()
+        const { container } = render(
+            createElement(MarkdownNotebook, { value: withNotebookTitle('First\n\nSecond\n\nThird'), onChange })
+        )
+
+        const secondBlock = getBodyTextBlock(container, 1)
+        secondBlock.focus()
+
+        fireEvent.keyDown(secondBlock, { key: 'ArrowDown', altKey: true })
+        expect(onChange).toHaveBeenLastCalledWith(withNotebookTitle('First\n\nThird\n\nSecond'))
+
+        fireEvent.keyDown(secondBlock, { key: 'ArrowUp', altKey: true })
+        expect(onChange).toHaveBeenLastCalledWith(withNotebookTitle('First\n\nSecond\n\nThird'))
+    })
+
+    it('claims Cmd+S inside a code editor, where the browser would offer to save the page', () => {
+        const onSaveRequested = jest.fn()
+        const { container } = render(
+            createElement(MarkdownNotebook, { value: withNotebookTitle('Body'), onSaveRequested })
+        )
+
+        // Monaco renders a textarea inside `.monaco-editor`, which every other notebook shortcut
+        // steps around so the editor keeps its own keys. Saving is the exception.
+        const editor = document.createElement('div')
+        editor.className = 'monaco-editor'
+        const editorInput = document.createElement('textarea')
+        editor.appendChild(editorInput)
+        getBodyTextBlock(container, 0).appendChild(editor)
+
+        fireEvent.keyDown(editorInput, { key: 's', metaKey: true })
+
+        expect(onSaveRequested).toHaveBeenCalledTimes(1)
+    })
+
     it('round-trips supported markdown blocks and inline formatting', () => {
         const markdown = `# Heading
 

--- a/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.tsx
@@ -5053,9 +5053,21 @@ function MarkdownNotebookEditor({
         const nodes = documentRef.current.nodes
         const activeElement = window.document.activeElement
         if (activeElement instanceof HTMLElement) {
-            const focusedNode = nodes.find((node) => blockRefs.current[node.id] === activeElement)
-            if (focusedNode) {
-                return focusedNode.id
+            const nodeIdsByElement = new Map<HTMLElement, string>()
+            for (const node of nodes) {
+                const blockElement = blockRefs.current[node.id]
+                if (blockElement) {
+                    nodeIdsByElement.set(blockElement, node.id)
+                }
+            }
+
+            // Focus often sits on a control inside the block rather than on the block itself, such as
+            // a cell's Run button, so the owning block is the nearest one above the focused element.
+            for (let element: HTMLElement | null = activeElement; element; element = element.parentElement) {
+                const focusedNodeId = nodeIdsByElement.get(element)
+                if (focusedNodeId) {
+                    return focusedNodeId
+                }
             }
         }
 

--- a/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.tsx
@@ -286,6 +286,8 @@ export type MarkdownNotebookProps = {
     canvasHeader?: ReactNode
     className?: string
     autoFocus?: boolean
+    /** Called on Cmd/Ctrl+S. Without it the key stays with the browser. */
+    onSaveRequested?: () => void
     showDebug?: boolean
     debugOpen?: boolean
     onDebugOpenChange?: (isOpen: boolean) => void
@@ -609,6 +611,7 @@ function MarkdownNotebookEditor({
     canvasHeader,
     className,
     autoFocus = false,
+    onSaveRequested,
     showDebug = false,
     debugOpen,
     onDebugOpenChange,
@@ -4794,7 +4797,22 @@ function MarkdownNotebookEditor({
     }
 
     const handleNotebookKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
-        if (mode !== 'edit' || event.altKey || !(event.metaKey || event.ctrlKey)) {
+        if (mode !== 'edit') {
+            return
+        }
+
+        // Claimed before the native-editable guard below, so Cmd+S inside a code editor does not
+        // fall through to the browser's "save page" dialog.
+        if (
+            onSaveRequested &&
+            (event.metaKey || event.ctrlKey) &&
+            !event.altKey &&
+            !event.shiftKey &&
+            event.key.toLowerCase() === 's'
+        ) {
+            event.preventDefault()
+            event.stopPropagation()
+            onSaveRequested()
             return
         }
 
@@ -4802,6 +4820,25 @@ function MarkdownNotebookEditor({
             event.target instanceof HTMLElement &&
             (event.target.closest('.MarkdownNotebook__debug-drawer') || isNativeEditableElement(event.target))
         ) {
+            return
+        }
+
+        // Placed after the native-editable guard, so Monaco keeps Alt+Up/Down for moving a line.
+        if (
+            event.altKey &&
+            !event.metaKey &&
+            !event.ctrlKey &&
+            !event.shiftKey &&
+            (event.key === 'ArrowUp' || event.key === 'ArrowDown')
+        ) {
+            if (moveActiveBlock(event.key === 'ArrowUp' ? 'previous' : 'next')) {
+                event.preventDefault()
+                event.stopPropagation()
+            }
+            return
+        }
+
+        if (event.altKey || !(event.metaKey || event.ctrlKey)) {
             return
         }
 
@@ -4986,17 +5023,17 @@ function MarkdownNotebookEditor({
         return Math.max(1, Math.min(boundaryIndex, renderedNodes.length))
     }
 
-    const moveBlockToBoundary = (nodeId: string, boundaryIndex: number): void => {
+    const moveBlockToBoundary = (nodeId: string, boundaryIndex: number): boolean => {
         const currentDocument = documentRef.current
         const nodes = currentDocument.nodes.length ? currentDocument.nodes : [emptyNodeRef.current]
         const fromIndex = nodes.findIndex((node) => node.id === nodeId)
         if (fromIndex <= 0) {
-            return
+            return false
         }
 
         const clampedBoundaryIndex = Math.max(1, Math.min(boundaryIndex, nodes.length))
         if (clampedBoundaryIndex === fromIndex || clampedBoundaryIndex === fromIndex + 1) {
-            return
+            return false
         }
 
         const nextNodes = [...nodes]
@@ -5007,6 +5044,45 @@ function MarkdownNotebookEditor({
             movedNode
         )
         commitDocument({ ...currentDocument, nodes: nextNodes })
+        return true
+    }
+
+    // A text block never holds focus, because the canvas is the single editing host, so it has to
+    // be resolved from the caret instead.
+    const getKeyboardActiveNodeId = (): string | null => {
+        const nodes = documentRef.current.nodes
+        const activeElement = window.document.activeElement
+        if (activeElement instanceof HTMLElement) {
+            const focusedNode = nodes.find((node) => blockRefs.current[node.id] === activeElement)
+            if (focusedNode) {
+                return focusedNode.id
+            }
+        }
+
+        const anchorNode = window.getSelection()?.anchorNode ?? null
+        const anchorElement = anchorNode instanceof HTMLElement ? anchorNode : (anchorNode?.parentElement ?? null)
+        const blockElement = anchorElement?.closest('[data-markdown-notebook-node-id]')
+        if (!(blockElement instanceof HTMLElement) || !canvasRef.current?.contains(blockElement)) {
+            return null
+        }
+
+        return blockElement.dataset.markdownNotebookNodeId ?? null
+    }
+
+    // `moveBlockToBoundary` takes an insert boundary rather than an index, which is why moving down
+    // is `+ 2` and not `+ 1`.
+    const moveActiveBlock = (direction: 'previous' | 'next'): boolean => {
+        const nodeId = getKeyboardActiveNodeId()
+        if (!nodeId) {
+            return false
+        }
+
+        const fromIndex = documentRef.current.nodes.findIndex((node) => node.id === nodeId)
+        if (fromIndex < 0) {
+            return false
+        }
+
+        return moveBlockToBoundary(nodeId, direction === 'previous' ? fromIndex - 1 : fromIndex + 2)
     }
 
     const handleBlockDragStart = (event: ReactDragEvent<HTMLDivElement>, nodeId: string): void => {

--- a/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.test.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { useContext, useEffect, useMemo } from 'react'
 
 import { useComponentPanelState } from './componentPanelContext'
+import { usePublishNotebookComponentRunHandler } from './componentRunHandlers'
 import { NotebookComponentRunStatusContext } from './componentRunStatus'
 import { NotebookComponentToolbarExtrasContext } from './componentToolbarExtras'
 import { NotebookComponentShell } from './NotebookComponentShell'
@@ -19,6 +20,81 @@ function PanelStateProbe(): JSX.Element {
         </div>
     )
 }
+
+type RunnableCellOptions = {
+    run?: jest.Mock
+    disabledReason?: string | null
+    moveFocusToAdjacentNode?: jest.Mock
+    insertParagraphAfterNode?: jest.Mock
+    /** 'native' mirrors an EditContext Monaco, which also renders an IME textarea the caret must
+     * not land in. 'textarea' mirrors an older build, where the textarea is the real input. */
+    withEditor?: false | 'native' | 'textarea'
+    runnable?: boolean
+}
+
+function renderCell({
+    run = jest.fn(),
+    disabledReason = null,
+    moveFocusToAdjacentNode = jest.fn(() => false),
+    insertParagraphAfterNode = jest.fn(),
+    withEditor = false,
+    runnable = true,
+}: RunnableCellOptions = {}): HTMLElement {
+    const registry = createMarkdownNotebookRegistry([
+        {
+            tagName: 'Cell',
+            label: 'Cell',
+            category: 'Test',
+            ViewComponent: () =>
+                withEditor === 'native' ? (
+                    <div className="monaco-editor">
+                        <div className="native-edit-context" tabIndex={0} data-attr="cell-editor" />
+                        <textarea className="ime-text-area" data-attr="cell-ime" />
+                    </div>
+                ) : withEditor === 'textarea' ? (
+                    <div className="monaco-editor">
+                        <textarea className="inputarea" data-attr="cell-editor" />
+                    </div>
+                ) : (
+                    <div data-attr="cell-results">Results</div>
+                ),
+            ToolbarComponent: runnable
+                ? function CellToolbar(): JSX.Element {
+                      usePublishNotebookComponentRunHandler({ run, disabledReason })
+                      return <button type="button">Run</button>
+                  }
+                : undefined,
+        },
+    ])
+
+    const { container } = render(
+        <NotebookComponentShell
+            node={{ id: 'cell-node', type: 'component', tagName: 'Cell', props: {} }}
+            mode="edit"
+            componentPanels={{ filters: false, results: true }}
+            persistComponentPanelVisibility={false}
+            isSelected={false}
+            registry={registry}
+            toggleComponentPanel={jest.fn()}
+            setLocalComponentPanels={jest.fn()}
+            rememberComponentPanels={jest.fn()}
+            setBlockRef={jest.fn()}
+            updateNode={jest.fn()}
+            deleteNode={jest.fn()}
+            deleteSelectedNotebookBlocks={jest.fn(() => false)}
+            insertParagraphAfterNode={insertParagraphAfterNode}
+            moveFocusToAdjacentNode={moveFocusToAdjacentNode}
+        />
+    )
+
+    return container.querySelector('.MarkdownNotebook__component-shell') as HTMLElement
+}
+
+const RUN_SHORTCUTS: [string, { metaKey?: boolean; ctrlKey?: boolean; shiftKey?: boolean }, boolean][] = [
+    ['Cmd+Enter', { metaKey: true }, false],
+    ['Ctrl+Enter', { ctrlKey: true }, false],
+    ['Shift+Enter', { shiftKey: true }, true],
+]
 
 describe('NotebookComponentShell', () => {
     it('provides markdown component panel state to rendered components', () => {
@@ -666,5 +742,52 @@ describe('NotebookComponentShell', () => {
         rerender(buildShell({ filters: false, results: false }))
         expect(within(container).queryByText('Results')).toBeNull()
         expect(within(container).getByLabelText('More actions')).toBeTruthy()
+    })
+
+    test.each(RUN_SHORTCUTS)('%s runs the cell from anywhere inside it', (_name, modifiers, movesOn) => {
+        const run = jest.fn()
+        const moveFocusToAdjacentNode = jest.fn(() => false)
+        const shell = renderCell({ run, moveFocusToAdjacentNode })
+
+        // Fired on the results, not the shell: a run has to start with focus anywhere in the cell.
+        fireEvent.keyDown(within(shell).getByTestId('cell-results'), { key: 'Enter', ...modifiers })
+
+        expect(run).toHaveBeenCalledTimes(1)
+        expect(moveFocusToAdjacentNode.mock.calls).toEqual(movesOn ? [['cell-node', 'next', 0]] : [])
+    })
+
+    test.each(RUN_SHORTCUTS)('%s does not run a cell that published a disabled reason', (_name, modifiers) => {
+        // A run already in flight disables the button; a second one races the poller and strands
+        // the spinner, so the shortcut has to refuse it too.
+        const run = jest.fn()
+        const shell = renderCell({ run, disabledReason: 'This cell is already running' })
+
+        fireEvent.keyDown(within(shell).getByTestId('cell-results'), { key: 'Enter', ...modifiers })
+
+        expect(run).not.toHaveBeenCalled()
+    })
+
+    test.each([
+        ['EditContext Monaco', 'native'],
+        ['textarea Monaco', 'textarea'],
+    ] as const)('moves focus out of a %s cell on Escape and back in on Enter', (_name, withEditor) => {
+        const shell = renderCell({ withEditor })
+        const editor = within(shell).getByTestId('cell-editor')
+        editor.focus()
+
+        fireEvent.keyDown(editor, { key: 'Escape' })
+        expect(document.activeElement).toBe(shell)
+
+        fireEvent.keyDown(shell, { key: 'Enter' })
+        expect(document.activeElement).toBe(editor)
+    })
+
+    it('keeps Enter adding a paragraph below a block that cannot run', () => {
+        const insertParagraphAfterNode = jest.fn()
+        const shell = renderCell({ runnable: false, insertParagraphAfterNode })
+
+        fireEvent.keyDown(shell, { key: 'Enter' })
+
+        expect(insertParagraphAfterNode).toHaveBeenCalledTimes(1)
     })
 })

--- a/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.test.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useContext, useEffect, useMemo } from 'react'
+import { createPortal } from 'react-dom'
 
 import { useComponentPanelState } from './componentPanelContext'
 import { usePublishNotebookComponentRunHandler } from './componentRunHandlers'
@@ -30,6 +31,8 @@ type RunnableCellOptions = {
      * not land in. 'textarea' mirrors an older build, where the textarea is the real input. */
     withEditor?: false | 'native' | 'textarea'
     runnable?: boolean
+    /** Renders the block's content through a portal, the way a modal or menu does. */
+    portalContent?: boolean
 }
 
 function renderCell({
@@ -39,6 +42,7 @@ function renderCell({
     insertParagraphAfterNode = jest.fn(),
     withEditor = false,
     runnable = true,
+    portalContent = false,
 }: RunnableCellOptions = {}): HTMLElement {
     const registry = createMarkdownNotebookRegistry([
         {
@@ -46,7 +50,9 @@ function renderCell({
             label: 'Cell',
             category: 'Test',
             ViewComponent: () =>
-                withEditor === 'native' ? (
+                portalContent ? (
+                    createPortal(<div data-attr="cell-portal">Portaled</div>, document.body)
+                ) : withEditor === 'native' ? (
                     <div className="monaco-editor">
                         <div className="native-edit-context" tabIndex={0} data-attr="cell-editor" />
                         <textarea className="ime-text-area" data-attr="cell-ime" />
@@ -780,6 +786,18 @@ describe('NotebookComponentShell', () => {
 
         fireEvent.keyDown(shell, { key: 'Enter' })
         expect(document.activeElement).toBe(editor)
+    })
+
+    it("ignores run shortcuts from a block's portaled modal or menu", () => {
+        // React bubbles a portal's events through the component tree, so they reach this shell even
+        // though the portal's DOM sits outside it. A source editor in a modal must keep its own keys.
+        const run = jest.fn()
+        renderCell({ run, portalContent: true })
+
+        fireEvent.keyDown(screen.getByTestId('cell-portal'), { key: 'Enter', shiftKey: true })
+        fireEvent.keyDown(screen.getByTestId('cell-portal'), { key: 'Enter', metaKey: true })
+
+        expect(run).not.toHaveBeenCalled()
     })
 
     it('keeps Enter adding a paragraph below a block that cannot run', () => {

--- a/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.tsx
@@ -38,6 +38,7 @@ import {
     DEFAULT_COMPONENT_PANEL_VISIBILITY,
     withPersistedComponentPanelProps,
 } from './componentPanels'
+import { NotebookComponentRunHandler, NotebookComponentRunHandlerContext } from './componentRunHandlers'
 import { useNotebookComponentRunStatus } from './componentRunStatus'
 import {
     NotebookComponentToolbarExtras,
@@ -132,6 +133,7 @@ export function NotebookComponentShell({
     const canToggleComponentPanels = mode === 'edit'
     const hasOpenComponentPanel = componentPanels.filters || componentPanels.results
     const [toolbarExtras, setToolbarExtras] = useState<NotebookComponentToolbarExtras | null>(null)
+    const [runHandler, setRunHandler] = useState<NotebookComponentRunHandler | null>(null)
     const titleDisplay = getComponentTitleDisplay(node, definition)
     const toolbarTitle = getComponentToolbarTitle(node, definition, titleDisplay.label)
     const isTitleEditable = definition?.editableTitle !== false
@@ -329,8 +331,70 @@ export function NotebookComponentShell({
             event.currentTarget.blur()
         }
     }
+    const isRunnableCell = !!runHandler
+
+    const runFromKeyboard = (): boolean => {
+        if (!runHandler || runHandler.disabledReason) {
+            return false
+        }
+
+        runHandler.run()
+        return true
+    }
+
+    const focusCellEditor = (shell: HTMLElement): boolean => {
+        // Focusing the editor wrapper does nothing, because Monaco reads keystrokes from a hidden
+        // input of its own. Keep the bare `textarea` last: an EditContext Monaco also renders one
+        // for IME, and focusing that one leaves the caret outside the editor.
+        const editorInput = shell.querySelector<HTMLElement>(
+            '.monaco-editor .native-edit-context, .monaco-editor textarea.inputarea, .monaco-editor textarea'
+        )
+        if (!editorInput) {
+            return false
+        }
+
+        editorInput.focus()
+        return true
+    }
+
     const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
-        if (mode !== 'edit' || event.target !== event.currentTarget) {
+        // A handler closer to the key already claimed it, such as Monaco's own Cmd+Enter.
+        if (mode !== 'edit' || event.defaultPrevented) {
+            return
+        }
+
+        // Deliberately overrides Monaco's Shift+Enter, which inserts a plain newline that Enter
+        // already gives you.
+        if (event.key === 'Enter' && !event.altKey && (event.metaKey || event.ctrlKey || event.shiftKey)) {
+            const movesOn = event.shiftKey && !event.metaKey && !event.ctrlKey
+            if (runFromKeyboard()) {
+                event.preventDefault()
+                event.stopPropagation()
+                if (movesOn) {
+                    moveFocusToAdjacentNode(node.id, 'next', 0)
+                }
+            }
+            return
+        }
+
+        // Monaco keeps Escape while it has something to dismiss (the suggestion list, the find
+        // box) and releases it once it has not, so this only fires when the editor is done with it.
+        if (
+            isRunnableCell &&
+            event.key === 'Escape' &&
+            event.target !== event.currentTarget &&
+            !event.metaKey &&
+            !event.ctrlKey &&
+            !event.altKey &&
+            !event.shiftKey
+        ) {
+            event.preventDefault()
+            event.stopPropagation()
+            event.currentTarget.focus()
+            return
+        }
+
+        if (event.target !== event.currentTarget) {
             return
         }
 
@@ -355,6 +419,9 @@ export function NotebookComponentShell({
 
         if (event.key === 'Enter' && !event.shiftKey) {
             event.preventDefault()
+            if (isRunnableCell && focusCellEditor(event.currentTarget)) {
+                return
+            }
             insertParagraphAfterNode()
         }
     }
@@ -443,7 +510,12 @@ export function NotebookComponentShell({
                     {ToolbarComponent ? (
                         <div className="MarkdownNotebook__component-toolbar-controls">
                             <NotebookComponentToolbarErrorBoundary node={node}>
-                                <ToolbarComponent node={node} notebookMode={mode} updateProps={updateProps} />
+                                {/* The run control publishes the cell's run action from here: the
+                                    toolbar is the one part of a cell that stays mounted while the
+                                    cell is collapsed, so the run shortcuts keep working when it is. */}
+                                <NotebookComponentRunHandlerContext.Provider value={setRunHandler}>
+                                    <ToolbarComponent node={node} notebookMode={mode} updateProps={updateProps} />
+                                </NotebookComponentRunHandlerContext.Provider>
                             </NotebookComponentToolbarErrorBoundary>
                         </div>
                     ) : null}

--- a/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.tsx
@@ -363,6 +363,13 @@ export function NotebookComponentShell({
             return
         }
 
+        // A modal or menu a block renders portals its DOM out of the shell, yet React still bubbles
+        // its events here through the component tree. Without this the source editor inside a
+        // widget's modal would run the cell on Shift+Enter instead of taking the newline.
+        if (event.target instanceof Node && !event.currentTarget.contains(event.target)) {
+            return
+        }
+
         // Deliberately overrides Monaco's Shift+Enter, which inserts a plain newline that Enter
         // already gives you.
         if (event.key === 'Enter' && !event.altKey && (event.metaKey || event.ctrlKey || event.shiftKey)) {

--- a/frontend/src/lib/components/MarkdownNotebook/README.md
+++ b/frontend/src/lib/components/MarkdownNotebook/README.md
@@ -52,9 +52,30 @@ Because of this, all editing behavior must be dispatched from root-level handler
 - `handleRootEditableKeyDown` (canvas `onKeyDown`) — Tab indentation, Enter splits, Backspace/Delete semantics, ArrowDown below a trailing code block
 - the native `beforeinput` capture listener — `insertParagraph`/`insertLineBreak` (inside code blocks these insert a literal `\n` through the model, since the browser default inserts `<br>` elements that are invisible to `textContent`), `deleteContent*`, `historyUndo/Redo`, and a last-resort guard that cancels any unclaimed native range edit crossing inline-editable boundaries — the browser would otherwise restructure React-managed elements in place (e.g. merge two `<li>`s) and the next React commit would crash with `removeChild` DOM exceptions
 - `handleRootEditableInput` (canvas `onInput`) — syncing typed text back into the document model
-- `handleNotebookKeyDown` (notebook root `onKeyDownCapture`) — Cmd/Ctrl shortcuts: bold/italic/underline (`B`/`I`/`U`), strikethrough (`Shift+X`), scoped select-all (`A`), copy of a focused component (`C`)
+- `handleNotebookKeyDown` (notebook root `onKeyDownCapture`) — Cmd/Ctrl shortcuts: bold/italic/underline (`B`/`I`/`U`), strikethrough (`Shift+X`), scoped select-all (`A`), copy of a focused component (`C`), save (`S`), and `Alt+Up`/`Alt+Down` to move the active block past its neighbour
 
 These resolve the affected block with `getInlineEditableElementForSelection` and the `data-markdown-notebook-*` attributes. Do **not** add keyboard handlers to inner block components: they only fire in JSDOM tests (where events are dispatched directly on inner elements), so they create behavior that passes tests but never runs in the app.
+
+Two of the root shortcuts sit either side of the guard that skips native editable elements (`input`, `textarea`, `select`, `.monaco-editor`), and the order is the behavior. `Cmd/Ctrl+S` is claimed **before** it, so saving works inside a code editor too — left to the browser there, it opens the "save page" dialog over the notebook. `Alt+Up`/`Alt+Down` sits **after** it, so a code editor keeps the same keys for moving a line.
+
+`Cmd/Ctrl+S` calls the host's `onSaveRequested`; without that prop the key stays with the browser. The notebooks scene points it at `notebookLogic`'s `saveNotebookNow`, which skips the autosave debounce and applies the gates the autosave path already applies.
+
+## Cell keys
+
+A component block that publishes a run handler (`usePublishNotebookComponentRunHandler`, from `componentRunHandlers.ts`) is a **cell**, and `NotebookComponentShell` gives it notebook keys on top of the document keys every block has. The generic editor never learns what SQL or Python is: the block's toolbar control publishes `run()` and the `disabledReason` guarding it, so a shortcut can never start a run the Run button would refuse — an in-flight run included, since a second one races the poller and strands the spinner.
+
+| Key              | Where it works       | What it does                                    |
+| ---------------- | -------------------- | ----------------------------------------------- |
+| `Cmd/Ctrl+Enter` | anywhere in the cell | Runs the cell                                   |
+| `Shift+Enter`    | anywhere in the cell | Runs the cell and moves focus to the next block |
+| `Escape`         | inside the editor    | Moves focus out to the cell                     |
+| `Enter`          | on the cell          | Moves focus back into the editor                |
+
+The run keys reach the whole cell so a run still starts with focus on the results or on a collapsed cell, where there is no editor on screen. Monaco binds its own `Cmd+Enter` and stops the event there, so a run from inside the editor never reaches the shell twice; `Shift+Enter` it treats as a plain newline, which `Enter` already gives you. `Escape` arrives only once Monaco has nothing left to dismiss (its suggestion list, its find box), which is what makes it safe to take.
+
+`Escape`/`Enter` apply to cells alone. On every other block `Enter` keeps adding a paragraph below it, which is the document behavior. A cell therefore gives that up: add a block after one from the insert boundary instead.
+
+`Enter` focuses the element Monaco actually reads keystrokes from, and which one that is depends on the build. An EditContext-based Monaco uses `.native-edit-context` and renders a second textarea only for IME, so focusing that textarea puts the caret nowhere. The selector tries the EditContext element first and keeps the bare `textarea` last for older builds. `NotebookComponentShell.test.tsx` covers both shapes, because JSDOM alone cannot tell them apart.
 
 ## Sync model
 

--- a/frontend/src/lib/components/MarkdownNotebook/README.md
+++ b/frontend/src/lib/components/MarkdownNotebook/README.md
@@ -62,7 +62,7 @@ Two of the root shortcuts sit either side of the guard that skips native editabl
 
 ## Cell keys
 
-A component block that publishes a run handler (`usePublishNotebookComponentRunHandler`, from `componentRunHandlers.ts`) is a **cell**, and `NotebookComponentShell` gives it notebook keys on top of the document keys every block has. The generic editor never learns what SQL or Python is: the block's toolbar control publishes `run()` and the `disabledReason` guarding it, so a shortcut can never start a run the Run button would refuse — an in-flight run included, since a second one races the poller and strands the spinner.
+A component block that publishes a run handler (`usePublishNotebookComponentRunHandler`, from `componentRunHandlers.ts`) is a **cell**, and `NotebookComponentShell` gives it notebook keys on top of the document keys every block has. The SQL, Python, and generated-widget blocks publish one; the legacy code blocks do not, so they keep the document keys alone. The generic editor never learns what SQL or Python is: the block's toolbar control publishes `run()` and the `disabledReason` guarding it, so a shortcut can never start a run the Run button would refuse — an in-flight run included, since a second one races the poller and strands the spinner.
 
 | Key              | Where it works       | What it does                                    |
 | ---------------- | -------------------- | ----------------------------------------------- |
@@ -72,6 +72,8 @@ A component block that publishes a run handler (`usePublishNotebookComponentRunH
 | `Enter`          | on the cell          | Moves focus back into the editor                |
 
 The run keys reach the whole cell so a run still starts with focus on the results or on a collapsed cell, where there is no editor on screen. Monaco binds its own `Cmd+Enter` and stops the event there, so a run from inside the editor never reaches the shell twice; `Shift+Enter` it treats as a plain newline, which `Enter` already gives you. `Escape` arrives only once Monaco has nothing left to dismiss (its suggestion list, its find box), which is what makes it safe to take.
+
+The shell only handles keys that happened inside its own DOM. A block that renders a modal or a menu portals that DOM out of the shell, and React still bubbles its events here through the component tree, so without the check a source editor in a modal would run the cell on `Shift+Enter` instead of taking the newline.
 
 `Escape`/`Enter` apply to cells alone. On every other block `Enter` keeps adding a paragraph below it, which is the document behavior. A cell therefore gives that up: add a block after one from the insert boundary instead.
 

--- a/frontend/src/lib/components/MarkdownNotebook/componentRunHandlers.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/componentRunHandlers.ts
@@ -1,0 +1,29 @@
+import { createContext, useContext, useEffect } from 'react'
+
+/** `disabledReason` mirrors the run button's own gate, so a shortcut can never start a run the
+ * button would refuse. */
+export type NotebookComponentRunHandler = {
+    run: () => void
+    disabledReason?: string | null
+}
+
+// Lets the shell own the cell's key handling while knowing nothing about SQL or Python.
+export const NotebookComponentRunHandlerContext = createContext<
+    ((handler: NotebookComponentRunHandler | null) => void) | null
+>(null)
+
+export function usePublishNotebookComponentRunHandler(handler: NotebookComponentRunHandler | null): void {
+    const publishRunHandler = useContext(NotebookComponentRunHandlerContext)
+    const run = handler?.run
+    const disabledReason = handler?.disabledReason ?? null
+
+    useEffect(() => {
+        if (!publishRunHandler) {
+            return
+        }
+
+        publishRunHandler(run ? { run, disabledReason } : null)
+
+        return () => publishRunHandler(null)
+    }, [publishRunHandler, run, disabledReason])
+}

--- a/frontend/src/lib/components/MarkdownNotebook/index.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/index.ts
@@ -15,6 +15,8 @@ export {
     getMarkdownNotebookComponentDefaultProps,
     mergeMarkdownNotebookRegistries,
 } from './registry'
+export { NotebookComponentRunHandlerContext, usePublishNotebookComponentRunHandler } from './componentRunHandlers'
+export type { NotebookComponentRunHandler } from './componentRunHandlers'
 export { NotebookComponentRunStatusContext } from './componentRunStatus'
 export type { NotebookComponentRunStatus, NotebookComponentRunStatusResolver } from './componentRunStatus'
 export { parseMarkdownNotebook, serializeMarkdownNotebook, htmlElementToInlineNodes } from './markdown'

--- a/frontend/src/scenes/notebooks/Nodes/components/NotebookCodeCellRunButton.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/components/NotebookCodeCellRunButton.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react'
 
 import { IconPlayFilled } from '@posthog/icons'
 
+import { usePublishNotebookComponentRunHandler } from 'lib/components/MarkdownNotebook/componentRunHandlers'
 import type { NotebookComponentToolbarProps } from 'lib/components/MarkdownNotebook/types'
 import { getSerializableProps } from 'lib/components/MarkdownNotebook/utils'
 import { IconCancel } from 'lib/lemon-ui/icons'
@@ -51,11 +52,9 @@ export function NotebookCodeCellRunButton({ node, updateProps }: NotebookCompone
     // will answer for. That excludes a public share, a viewer-level reader, and a history preview,
     // all of which render this toolbar in view mode. Without the gate they get a control that
     // returns 403, and a preview would run a version of the code the reader is not editing.
-    if (isShared || !canEditNotebook) {
-        return null
-    }
+    const canRun = !isShared && canEditNotebook
 
-    const run = (): void => {
+    const run = useCallback((): void => {
         // A SQL cell's editor holds the code and the connection a keystroke or a just-picked
         // connection before the document does, so prefer it while it is open. A Python cell has no
         // such logic mounted and runs from the document.
@@ -73,6 +72,18 @@ export function NotebookCodeCellRunButton({ node, updateProps }: NotebookCompone
               }
             : {}
         runNode(overrides)
+    }, [nodeId, runNode])
+
+    // A run in flight blocks the shortcuts, because the button turns into Cancel there and a run
+    // shortcut must never become a stop.
+    usePublishNotebookComponentRunHandler(
+        canRun
+            ? { run, disabledReason: isRunning ? 'This cell is already running' : (operationBlockReason ?? null) }
+            : null
+    )
+
+    if (!canRun) {
+        return null
     }
 
     return (

--- a/frontend/src/scenes/notebooks/Notebook/MarkdownNotebookV2Renderer.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/MarkdownNotebookV2Renderer.tsx
@@ -106,6 +106,7 @@ export function MarkdownNotebookV2({ debugOpen, onDebugOpenChange }: MarkdownNot
         reportMarkdownMergeConflicts,
         publishMarkdownCaret,
         setMarkdownAIPresenceActive,
+        saveNotebookNow,
     } = useActions(notebookLogic)
     const { setShowKernelInfo } = useActions(notebookSettingsLogic)
     const remoteMarkdown = useMemo(() => getMarkdownNotebookMarkdown(notebook?.content), [notebook?.content])
@@ -701,6 +702,7 @@ export function MarkdownNotebookV2({ debugOpen, onDebugOpenChange }: MarkdownNot
                     extraInsertCommands={isEditable ? buildExtraInsertCommands : undefined}
                     hiddenInsertCommandKeys={hiddenInsertCommandKeys}
                     onChange={isEditable ? handleMarkdownNotebookChange : undefined}
+                    onSaveRequested={isEditable ? saveNotebookNow : undefined}
                     onConflict={reportMarkdownMergeConflicts}
                     remoteCarets={remoteCarets}
                     onCaretChange={isEditable ? publishMarkdownCaret : undefined}

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -551,6 +551,9 @@ export interface notebookLogicActions {
         error: string
         errorObject?: any
     }
+    saveNotebookNow: () => {
+        value: true
+    }
     saveNotebookSuccess: (
         notebook: NotebookType | null,
         payload?: {
@@ -810,6 +813,7 @@ export const notebookLogic = kea<notebookLogicType>([
         showMarkdownMergeConflictDetails: (conflicts: NotebookCollaborationConflict[]) => ({ conflicts }),
         dismissMarkdownMergeConflictDetails: true,
         saveNotebook: (notebook: Pick<NotebookType, 'content' | 'title'>) => ({ notebook }),
+        saveNotebookNow: true,
         renameNotebook: (title: string) => ({ title }),
         setEditingNodeEditing: (nodeId: string, editing: boolean) => ({ nodeId, editing }),
         exportJSON: true,
@@ -1972,6 +1976,20 @@ export const notebookLogic = kea<notebookLogicType>([
             actions.setMarkdownEditorDraft(null)
             actions.setAutosavePaused(false)
             actions.setLocalContent(buildMarkdownNotebookContent(nextMarkdown, values.markdownEditorNodeId))
+        },
+
+        saveNotebookNow: () => {
+            // Autosave already saves every edit, so this only skips its debounce and repeats the
+            // gates that path applies. No local content means the notebook is already saved.
+            if (values.previewContent || values.autosavePaused || values.isLocalOnly) {
+                return
+            }
+
+            if (!values.localContent || !values.content || values.notebookLoading) {
+                return
+            }
+
+            actions.saveNotebook({ content: values.content, title: values.title })
         },
 
         setLocalContent: async ({ jsonContent, skipCapture }, breakpoint) => {

--- a/products/notebooks/frontend/NotebookNodeGeneratedWidget/NotebookGeneratedWidgetRunButton.tsx
+++ b/products/notebooks/frontend/NotebookNodeGeneratedWidget/NotebookGeneratedWidgetRunButton.tsx
@@ -2,6 +2,7 @@ import { useActions, useMountedLogic, useValues } from 'kea'
 
 import { IconPlayFilled } from '@posthog/icons'
 
+import { usePublishNotebookComponentRunHandler } from 'lib/components/MarkdownNotebook/componentRunHandlers'
 import type { NotebookComponentToolbarProps } from 'lib/components/MarkdownNotebook/types'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { notebookLogic } from 'scenes/notebooks/Notebook/notebookLogic'
@@ -51,6 +52,14 @@ function EditableNotebookGeneratedWidgetRunButton({
     })
     const { dataRefreshInFlight, runDataDependenciesDisabledReason } = useValues(logic)
     const { runDataDependencies } = useActions(logic)
+
+    // A refresh in flight blocks the shortcuts, matching the button, which is disabled while it loads.
+    usePublishNotebookComponentRunHandler({
+        run: runDataDependencies,
+        disabledReason: dataRefreshInFlight
+            ? 'This widget is already running'
+            : (runDataDependenciesDisabledReason ?? null),
+    })
 
     return (
         <LemonButton


### PR DESCRIPTION
## Problem

Running a markdown notebook cell needs the mouse unless the caret already sits in the code editor.

- `Cmd+Enter` is bound inside Monaco only, so it does nothing when the editor is collapsed, when the notebook is in view mode, or when focus sits on the results.
- Once focus is in a code editor, no key gets it back out to the notebook.
- Reordering a block needs a drag. There is no keyboard route.
- Saving needs waiting out the autosave debounce, and `Cmd+S` opens the browser's "save page" dialog over the notebook.

## Changes

| Key | Where it works | Effect |
| --- | --- | --- |
| `Cmd/Ctrl+Enter` | anywhere in the cell | Runs the cell |
| `Shift+Enter` | anywhere in the cell | Runs the cell, moves focus to the next block |
| `Escape` | inside the code editor | Moves focus out to the cell |
| `Enter` | on the cell | Moves focus back into the editor |
| `Alt+Up` / `Alt+Down` | any block | Moves the block past its neighbour |
| `Cmd/Ctrl+S` | anywhere in the notebook | Saves now, skipping the autosave debounce |

- A cell publishes its run action through a new context bridge, `componentRunHandlers.ts`, so the generic editor keeps no SQL or Python knowledge.
- The SQL, Python, and generated-widget blocks publish a run action, so all three take the run shortcuts.
- The shell ignores keys from a block's portaled modal or menu. React bubbles those through the component tree even though their DOM sits outside the shell, so the source editor in a widget's modal keeps its newline on `Shift+Enter`.
- The shortcut reuses the Run button's own `disabledReason` rather than calling the run action directly. It therefore cannot start a run the button refuses, including one already in flight, which would race the poller and strand the spinner.
- Publishing a run handler is what marks a block as a cell. `Escape` and `Enter` apply to those alone.
- Legacy code cells (`Query`, `Python`, `DuckSQL`, `HogQLSQL`) publish no run action, so they get no run shortcuts and keep `Enter` adding a paragraph below.
- `Cmd+S` is claimed before the guard that skips native editable elements, so it works inside a code editor too. `Alt+Up`/`Alt+Down` sits after that guard, so Monaco keeps those keys for moving a line.
- Nothing looks different. The change is keyboard-only, so there is no screenshot.

> [!NOTE]
> A cell gives up `Enter` as the way to add a paragraph below it. The insert boundary "+" still does that.

## How did you test this code?

Automated, in `NotebookComponentShell.test.tsx` and `MarkdownNotebook.test.ts`:

- The run shortcuts fire from a child of the cell, not just the shell, so a collapsed cell keeps working.
- A published `disabledReason` blocks every run shortcut, guarding the double-run case.
- `Escape` and `Enter` move focus for both Monaco DOM shapes. Reverting the selector fails the EditContext case and passes the textarea case, so the case has teeth.
- `Enter` still adds a paragraph below a block that cannot run.
- `Alt+Up`/`Alt+Down` reorder a block, covering the boundary arithmetic that the drag tests do not reach.
- `Cmd+S` fires from inside a native editable element, guarding the handler ordering.
- A portaled child cannot trigger a run. Removing the guard fails this case, so it has teeth.

Manual, against a local dev stack on this branch, with a SQL cell that returned a real result:

- `Cmd+Enter` inside Monaco issued exactly one `POST /sql_v2/run/`, which confirms Monaco stops the event before the shell sees it.
- `Cmd+Enter` from the cell shell and `Shift+Enter` from both the shell and the editor each issued one run.
- With `Cmd+S`, the save request left at 49 ms after an edit. Autosave alone left at 716 ms.

Not checked: Playwright, any browser other than Chrome, and the widget shortcuts in a browser. The widget path is covered by the automated cases above and shares the bridge the SQL cell was verified on.

<details>
<summary>A defect the browser caught that JSDOM could not</summary>

`Enter` first failed to return focus to the editor. The selector was `.monaco-editor textarea`, but this app runs an EditContext build of Monaco, which reads keystrokes from `.native-edit-context` and renders a textarea only for IME. Focusing that textarea leaves the caret nowhere. The JSDOM test passed because its stand-in editor was a plain textarea. The selector now tries the EditContext element first, and the test covers both shapes.

</details>

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`frontend/src/lib/components/MarkdownNotebook/README.md` gains a "Cell keys" section and records why the two notebook-root shortcuts sit on opposite sides of the native-editable guard.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The scope was picked from four candidate groups; a shortcut help sheet was offered and dropped. `Shift+Enter` deliberately overrides Monaco's newline, because `Enter` already inserts one and every notebook product binds `Shift+Enter` to run. An earlier draft wrapped the whole component shell in the run-handler provider, which reindented the render and turned an 80-line diff into 419; scoping the provider to the toolbar keeps the reach and drops the churn.

No duplicate: `gh pr list --state open --search "notebook keyboard shortcuts"` found only an unrelated SQL editing performance PR.

Public artifact: the diff, the tests, and this description come from the repository alone. No customer or session material is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBo3B94rS45PgjqtT28KTm

