### PR TITLE
fix(desktop): skip the macOS integration test on merge queue batches

### DIFF
--- a/.github/workflows/desktop-test.yml
+++ b/.github/workflows/desktop-test.yml
@@ -130,7 +130,20 @@ jobs:
     integration-test:
         needs: changes
         # Fail closed: if change detection itself failed, run instead of skipping.
-        if: ${{ !cancelled() && github.event_name != 'merge_group' && (needs.changes.result != 'success' || needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true') }}
+        #
+        # Also skipped on trunk-merge/** heads. Trunk's queue opens a real PR, so
+        # the merge_group arm never matches and this ran on every batch. Every
+        # batched PR already ran it in full, and depot-macos-26 is the suite's only
+        # macOS runner, where an hour-long wait at peak holds the queue instead of
+        # one author's PR. Scoped to same-repo heads so a fork cannot opt out by
+        # naming its branch trunk-merge/**. While the live-model `e2e` job still
+        # needs this one, it skips there too, the cascade merge_group relies on.
+        if: >-
+            !cancelled() &&
+            github.event_name != 'merge_group' &&
+            !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.head_ref, 'trunk-merge/')) &&
+            (needs.changes.result != 'success' || needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true')
         runs-on: depot-macos-26
         timeout-minutes: 45
         permissions:


### PR DESCRIPTION
## Problem

- Desktop engineers watch the merge queue stall on a job that tests nothing new. The `integration-test` job runs for about 5 minutes but waits for a `depot-macos-26` slot, and recent master runs waited 0, 0, 2, 3, 5, 5, 12, 57, and 76 minutes for one.
- That wait now happens inside the merge path. `desktop-test.yml` tries to skip the job on the merge queue with `github.event_name != 'merge_group'`, but master lands through Trunk, which opens a real pull request from a `trunk-merge/**` branch. The event is `pull_request`, so the guard never matches and the job runs on every batch.
- The batch run adds no coverage. Desktop PRs run this suite in full with no draft narrowing, so every batched PR already passed it.
- On a batch the wait blocks the whole queue rather than one author's pull request.

## Changes

- Merge queue batches no longer request a macOS runner, so a batch reaches master without sitting behind the macOS pool.
- The `e2e` job currently needs `integration-test`, so it skips on those heads too. That is the same cascade the `merge_group` arm already relies on, and `Desktop Tests Pass` counts a skipped dependency as a pass.
- Everything else is unchanged. `unit-test`, typecheck, quality, and build still run on batches, where they are cheap and can catch a conflict the batch introduces.
- The new condition is scoped to same-repo heads, so a fork cannot opt out of the job by naming its branch `trunk-merge/**`. This matches `desktop-agent-release-verify.yml`, `desktop-react-doctor.yml`, and the `backend-coupling` job in `desktop-ci.yml`.

This narrows demand on the macOS pool rather than fixing allocation, so it stacks with the other work in flight rather than replacing it.

```mermaid
flowchart LR
    A["trunk-merge/** batch"] --> B["changes"]
    B --> C["unit-test<br/>(linux, ~1m)"]
    B --> D["integration-test<br/>(depot-macos-26, ~5m run,<br/>up to ~76m queued)"]
    C --> E["e2e (linux)"]
    D --> E
    E --> F["Desktop Tests Pass"]
    style D fill:#F54E00,stroke:#1D4AFF,color:#fff
```

```mermaid
flowchart LR
    A["trunk-merge/** batch"] --> B["changes"]
    B --> C["unit-test<br/>(linux, ~1m)"]
    B --> D["integration-test<br/>skipped"]
    C --> E["e2e<br/>skipped (needs integration-test)"]
    D --> E
    E --> F["Desktop Tests Pass"]
    style D fill:#30ABC6,stroke:#1D4AFF,color:#fff
    style E fill:#30ABC6,stroke:#1D4AFF,color:#fff
```

## How did you test this code?

- No tests were added. The change is a workflow condition, and this repo has no harness that evaluates a GitHub Actions `if:` expression.
- `bin/hogli lint:workflows` passes (9 checks, 134 workflows), and `actionlint .github/workflows/desktop-test.yml` is clean. `bin/hogli ci:preflight --fix` reports 0 failures.
- The condition was confirmed against a live job rather than reasoned about. The job log for [job 102040205744](https://github.com/PostHog/posthog/actions/runs/34219859678/job/102040205744) on a `trunk-merge/pr-96071/...` head prints `Expanded: (!false && ('pull_request' != 'merge_group') && ...)`, then `Result: true`, then `Requested labels: depot-macos-26`.
- Queue and run times come from the jobs API over recent `desktop-test.yml` runs on master.
- Not verified: that a real batch now skips the job. That needs a merge queue run on this condition, which only exists once this lands.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update is needed. The change affects CI scheduling only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from a [Slack thread](https://posthog.slack.com/archives/C09ADEV3AJD/p1788868957508959) that started as a question about failing and slow desktop tests. Those turned out to be two unrelated things: the four failing assertions are already fixed by [#96427](https://github.com/PostHog/posthog/pull/96427), and the wall clock is this macOS queue. This PR addresses only the second.

Invoked `/authoring-ci-workflows` and `/writing-pr-descriptions`. Used read, bash, and edit; no subagents.

Two open drafts already target the macOS pool, and neither covers this. [#95852](https://github.com/PostHog/posthog/pull/95852) moves the web E2E suite to its own Linux job and drops `integration-test` from `e2e`'s `needs`; [#94509](https://github.com/PostHog/posthog/pull/94509) caps the smoke step and evicts cache-warming runs in the release workflows. Both reduce time spent on a macOS runner; neither stops the batch from asking for one. If #95852 lands, `e2e` no longer cascades and would run on batches again — the comment in the diff is worded for that, and guarding `e2e` separately would be a follow-up decision, not part of this fix. #95852 also edits `desktop-test.yml`, but in the job's steps rather than its condition.

The diff contains no customer data or other non-public material.
