### PR TITLE
feat(flags): keep a feature flag to one product

### DIFF
--- a/products/early_access_features/backend/api.py
+++ b/products/early_access_features/backend/api.py
@@ -38,6 +38,7 @@ from products.feature_flags.backend.encrypted_flag_payloads import REDACTED_PAYL
 from products.feature_flags.backend.facade.api import create_flag, update_flag
 from products.feature_flags.backend.facade.filters import set_feature_enrollment
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
+from products.feature_flags.backend.ownership import FLAG_OWNER_EARLY_ACCESS, assert_flag_available_for, flag_owner_kind
 
 from .models import EarlyAccessFeature
 
@@ -434,6 +435,10 @@ class EarlyAccessFeatureSerializerCreateOnly(EarlyAccessFeatureSerializer):
                     f"Linked feature flag {feature_flag.key} already has a feature attached to it."
                 )
 
+            # The check above keeps one feature per flag; this one keeps the flag out of a
+            # second product.
+            assert_flag_available_for(feature_flag, product=FLAG_OWNER_EARLY_ACCESS)
+
             if feature_flag.aggregation_group_type_index is not None:
                 raise serializers.ValidationError(
                     "Group-based feature flags are not supported for Early Access Features."
@@ -461,10 +466,10 @@ class EarlyAccessFeatureSerializerCreateOnly(EarlyAccessFeatureSerializer):
             ).first()
             if existing_flag is not None:
                 # Linking is only advice worth giving when the flag is actually linkable; the check
-                # above rejects a flag that already has a feature attached.
+                # above rejects a flag another product already owns.
                 remedy = (
                     "Rename this feature."
-                    if existing_flag.features.exists()
+                    if flag_owner_kind(existing_flag) is not None
                     else "Rename this feature, or link the existing flag instead."
                 )
                 raise serializers.ValidationError(

--- a/products/early_access_features/backend/api.py
+++ b/products/early_access_features/backend/api.py
@@ -435,8 +435,7 @@ class EarlyAccessFeatureSerializerCreateOnly(EarlyAccessFeatureSerializer):
                     f"Linked feature flag {feature_flag.key} already has a feature attached to it."
                 )
 
-            # The check above keeps one feature per flag; this one keeps the flag out of a
-            # second product.
+            # The check above keeps one feature per flag; this one keeps out other products.
             assert_flag_available_for(feature_flag, product=FLAG_OWNER_EARLY_ACCESS)
 
             if feature_flag.aggregation_group_type_index is not None:

--- a/products/early_access_features/backend/api.py
+++ b/products/early_access_features/backend/api.py
@@ -382,7 +382,7 @@ class EarlyAccessFeatureSerializerCreateOnly(EarlyAccessFeatureSerializer):
     feature_flag_id = serializers.IntegerField(
         required=False,
         write_only=True,
-        help_text="Optional ID of an existing feature flag to link. If omitted, a new flag is auto-created from the feature name. The flag must not already be linked to another feature, must not be group-based, and must not be multivariate.",
+        help_text="Optional ID of an existing feature flag to link. If omitted, a new flag is auto-created from the feature name. The flag must not already be linked to another feature, must not belong to another product such as a survey or experiment, must not be group-based, and must not be multivariate.",
     )
     _create_in_folder = serializers.CharField(required=False, allow_blank=True, write_only=True)
 
@@ -465,7 +465,8 @@ class EarlyAccessFeatureSerializerCreateOnly(EarlyAccessFeatureSerializer):
             ).first()
             if existing_flag is not None:
                 # Linking is only advice worth giving when the flag is actually linkable; the check
-                # above rejects a flag another product already owns.
+                # above rejects a flag that already has a feature attached, or that another
+                # product owns.
                 remedy = (
                     "Rename this feature."
                     if flag_owner_kind(existing_flag) is not None
@@ -497,8 +498,10 @@ class EarlyAccessFeatureSerializerCreateOnly(EarlyAccessFeatureSerializer):
         if feature_flag_id:
             feature_flag = FeatureFlag.objects.get(pk=feature_flag_id, team_id=self.context["team_id"])
 
-            # Only require feature_flag:write when we actually mutate the linked flag (active
-            # stage). Linking an existing flag without changing it is not a flag write.
+            # Linking claims the flag, which stops other products adopting it, so editor access
+            # is required whatever the stage. Only the active stage writes the flag row.
+            assert_feature_flag_rbac_access(self.user_access_control, feature_flag=feature_flag)
+
             if validated_data.get("stage") in EarlyAccessFeature.ActiveStage:
                 assert_feature_flag_write_scope(
                     self.context["request"],
@@ -507,7 +510,6 @@ class EarlyAccessFeatureSerializerCreateOnly(EarlyAccessFeatureSerializer):
                     team_id=self.context["team_id"],
                     feature_flag_id=feature_flag.id,
                 )
-                assert_feature_flag_rbac_access(self.user_access_control, feature_flag=feature_flag)
                 update_flag(
                     feature_flag,
                     {"filters": set_feature_enrollment(feature_flag.get_filters(), True)},

--- a/products/early_access_features/backend/test/test_early_access_feature.py
+++ b/products/early_access_features/backend/test/test_early_access_feature.py
@@ -420,20 +420,39 @@ class TestEarlyAccessFeature(APIBaseTest):
             },
         )
 
+    def test_cant_link_a_flag_another_product_owns(self):
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            filters={"groups": [{"properties": [], "rollout_percentage": None}]},
+            key="owned-by-survey",
+            created_by=self.user,
+        )
+        Survey.objects.create(team=self.team, name="s", type="popover", targeting_flag=flag)
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/early_access_feature/",
+            data={"name": "Poacher", "description": "d", "stage": "beta", "feature_flag_id": flag.id},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert "already belongs to a survey" in str(response.json())
+
     @parameterized.expand(
         [
-            ("linkable_flag", False, "Rename this feature, or link the existing flag instead."),
-            ("flag_already_attached", True, "Rename this feature."),
+            ("linkable_flag", None, "Rename this feature, or link the existing flag instead."),
+            ("flag_already_attached", "feature", "Rename this feature."),
+            ("flag_owned_by_survey", "survey", "Rename this feature."),
         ]
     )
-    def test_cant_create_early_access_feature_with_duplicate_key(self, _name, attach_existing_feature, remedy):
+    def test_cant_create_early_access_feature_with_duplicate_key(self, _name, existing_owner, remedy):
         flag = FeatureFlag.objects.create(
             team=self.team,
             filters={"groups": [{"properties": [], "rollout_percentage": None}]},
             key="hick-bondoogling",
             created_by=self.user,
         )
-        if attach_existing_feature:
+        if existing_owner == "feature":
             EarlyAccessFeature.objects.create(
                 team=self.team,
                 name="Hick bondoogling (original)",
@@ -441,6 +460,8 @@ class TestEarlyAccessFeature(APIBaseTest):
                 stage="beta",
                 feature_flag=flag,
             )
+        elif existing_owner == "survey":
+            Survey.objects.create(team=self.team, name="s", type="popover", targeting_flag=flag)
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/early_access_feature/",

--- a/products/early_access_features/frontend/generated/api.schemas.ts
+++ b/products/early_access_features/frontend/generated/api.schemas.ts
@@ -247,7 +247,7 @@ export interface EarlyAccessFeatureSerializerCreateOnlyApi {
      * @nullable
      */
     readonly assignee: EarlyAccessFeatureSerializerCreateOnlyApiAssignee
-    /** Optional ID of an existing feature flag to link. If omitted, a new flag is auto-created from the feature name. The flag must not already be linked to another feature, must not be group-based, and must not be multivariate. */
+    /** Optional ID of an existing feature flag to link. If omitted, a new flag is auto-created from the feature name. The flag must not already be linked to another feature, must not belong to another product such as a survey or experiment, must not be group-based, and must not be multivariate. */
     feature_flag_id?: number
     readonly feature_flag: MinimalFeatureFlagApi
     _create_in_folder?: string

--- a/products/early_access_features/frontend/generated/api.zod.ts
+++ b/products/early_access_features/frontend/generated/api.zod.ts
@@ -42,7 +42,7 @@ export const EarlyAccessFeatureCreateBody = /* @__PURE__ */ zod
             .number()
             .optional()
             .describe(
-                'Optional ID of an existing feature flag to link. If omitted, a new flag is auto-created from the feature name. The flag must not already be linked to another feature, must not be group-based, and must not be multivariate.'
+                'Optional ID of an existing feature flag to link. If omitted, a new flag is auto-created from the feature name. The flag must not already be linked to another feature, must not belong to another product such as a survey or experiment, must not be group-based, and must not be multivariate.'
             ),
         _create_in_folder: zod.string().optional(),
     })

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -104,6 +104,7 @@ from products.feature_flags.backend.facade.filters import (
     strip_group_cohort_restriction,
 )
 from products.feature_flags.backend.models.feature_flag import FeatureFlag, experiment_eligibility_error
+from products.feature_flags.backend.ownership import FLAG_OWNER_EXPERIMENT, assert_flag_available_for
 from products.notifications.backend.facade.api import (
     NotificationData,
     NotificationType,
@@ -1545,6 +1546,9 @@ class ExperimentService:
         existing_flag = FeatureFlag.objects.filter(key=feature_flag_key, team_id=self.team.id).first()
 
         if existing_flag:
+            # Not in _validate_existing_flag: launch calls that too, on a flag this experiment
+            # already owns.
+            assert_flag_available_for(existing_flag, product=FLAG_OWNER_EXPERIMENT)
             self._validate_existing_flag(existing_flag)
             variants = existing_flag.variants or list(DEFAULT_VARIANTS)
             return existing_flag, variants

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -61,6 +61,7 @@ from products.experiments.backend.models.experiment import (
 from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
 from products.feature_flags.backend.facade.api import set_flag_active, update_flag
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
+from products.surveys.backend.models import Survey
 from products.warehouse_sources.backend.facade.models import DataWarehouseCredential, DataWarehouseTable
 
 
@@ -5876,6 +5877,15 @@ class TestExperimentService(APIBaseTest):
 
         updated = service.update_experiment(experiment, {"deleted": True}, allow_unknown_events=True)
         assert updated.deleted is True
+
+    def test_cannot_adopt_a_flag_another_product_owns(self):
+        flag = self._create_flag(key="owned-by-survey")
+        Survey.objects.create(team=self.team, name="s", type="popover", targeting_flag=flag)
+
+        with self.assertRaises(ValidationError) as cm:
+            self._service().create_experiment(name="Poacher", feature_flag_key="owned-by-survey")
+
+        assert "already belongs to a survey" in str(cm.exception)
 
     def test_clone_regenerates_metric_uuids(self):
         """Cloning an experiment must produce metrics with fresh uuids — never shared with the source."""

--- a/products/feature_flags/backend/ownership.py
+++ b/products/feature_flags/backend/ownership.py
@@ -39,8 +39,7 @@ def flag_owner_kind(flag: "FeatureFlag") -> str | None:
     """Return the product that owns this flag, or None when nothing owns it.
 
     Ownership decides which approval policy family governs a write, so a flag must have at most one
-    owner. Production already satisfies that: of the owned flags in US, all but three have exactly
-    one owner. `assert_flag_available_for` keeps it that way.
+    owner. `assert_flag_available_for` keeps it that way.
     """
     for accessor, kind, manager in _OWNING_ACCESSORS:
         related = getattr(flag, accessor)

--- a/products/feature_flags/backend/ownership.py
+++ b/products/feature_flags/backend/ownership.py
@@ -1,0 +1,65 @@
+from typing import TYPE_CHECKING
+
+from rest_framework import serializers
+
+if TYPE_CHECKING:
+    from products.feature_flags.backend.models.feature_flag import FeatureFlag
+
+FLAG_OWNER_EXPERIMENT = "experiment"
+FLAG_OWNER_SURVEY = "survey"
+FLAG_OWNER_PRODUCT_TOUR = "product_tour"
+FLAG_OWNER_EARLY_ACCESS = "early_access_feature"
+
+_OWNER_LABELS = {
+    FLAG_OWNER_EXPERIMENT: "an experiment",
+    FLAG_OWNER_SURVEY: "a survey",
+    FLAG_OWNER_PRODUCT_TOUR: "a product tour",
+    FLAG_OWNER_EARLY_ACCESS: "an early access feature",
+}
+
+# Reverse accessors keep this free of cross-product imports.
+#
+# `linked_flag` is absent on purpose: a survey or product tour may point at another product's flag
+# to target its audience, which references the flag without owning it.
+_OWNING_ACCESSORS: tuple[tuple[str, str], ...] = (
+    ("experiment_set", FLAG_OWNER_EXPERIMENT),
+    ("surveys_targeting_flag", FLAG_OWNER_SURVEY),
+    ("surveys_internal_targeting_flag", FLAG_OWNER_SURVEY),
+    ("surveys_internal_response_sampling_flag", FLAG_OWNER_SURVEY),
+    ("product_tours_internal_targeting_flag", FLAG_OWNER_PRODUCT_TOUR),
+    ("features", FLAG_OWNER_EARLY_ACCESS),
+)
+
+
+def flag_owner_kind(flag: "FeatureFlag") -> str | None:
+    """Return the product that owns this flag, or None when nothing owns it.
+
+    Ownership decides which approval policy family governs a write, so a flag must have at most one
+    owner. Production already satisfies that: of the owned flags in US, all but three have exactly
+    one owner. `assert_flag_unowned` keeps it that way.
+    """
+    for accessor, kind in _OWNING_ACCESSORS:
+        if getattr(flag, accessor).exists():
+            return kind
+    return None
+
+
+def assert_flag_available_for(flag: "FeatureFlag", *, product: str) -> None:
+    """Reject adopting a flag that a different product already owns.
+
+    Ownership decides which approval policy family governs a write, so what must stay unambiguous
+    is the owning *product*, not the owning object. Two experiments sharing one flag still resolve
+    to one family, so this permits it; a product that wants one object per flag enforces that
+    itself, as early access features do.
+
+    Call this only when a write points a product at a flag it did not point at before. Re-saving a
+    parent that already owns the flag must not raise, so the caller compares the incoming id
+    against the stored one first.
+    """
+    owner = flag_owner_kind(flag)
+    if owner is not None and owner != product:
+        raise serializers.ValidationError(
+            f"The feature flag {flag.key} already belongs to {_OWNER_LABELS[owner]}. "
+            f"A flag can belong to one thing at a time. Pick a different flag, "
+            f"or edit this one where it is already used."
+        )

--- a/products/feature_flags/backend/ownership.py
+++ b/products/feature_flags/backend/ownership.py
@@ -38,8 +38,7 @@ _OWNING_ACCESSORS: tuple[tuple[str, str, str | None], ...] = (
 def flag_owner_kind(flag: "FeatureFlag") -> str | None:
     """Return the product that owns this flag, or None when nothing owns it.
 
-    Ownership decides which approval policy family governs a write, so a flag must have at most one
-    owner. `assert_flag_available_for` keeps it that way.
+    A flag may be owned by at most one product. `assert_flag_available_for` keeps it that way.
     """
     for accessor, kind, manager in _OWNING_ACCESSORS:
         related = getattr(flag, accessor)
@@ -53,10 +52,9 @@ def flag_owner_kind(flag: "FeatureFlag") -> str | None:
 def assert_flag_available_for(flag: "FeatureFlag", *, product: str) -> None:
     """Reject adopting a flag that a different product already owns.
 
-    Ownership decides which approval policy family governs a write, so what must stay unambiguous
-    is the owning *product*, not the owning object. Two experiments sharing one flag still resolve
-    to one family, so this permits it; a product that wants one object per flag enforces that
-    itself, as early access features do.
+    What must stay unambiguous is the owning *product*, not the owning object. Two experiments
+    sharing one flag leave one owner, so this permits it; a product that wants one object per flag
+    enforces that itself, as early access features do.
 
     Call this only when a write points a product at a flag it did not point at before. Re-saving a
     parent that already owns the flag must not raise, so the caller compares the incoming id
@@ -70,6 +68,5 @@ def assert_flag_available_for(flag: "FeatureFlag", *, product: str) -> None:
     if owner is not None and owner != product:
         raise serializers.ValidationError(
             f"The feature flag {flag.key} already belongs to {_OWNER_LABELS[owner]}. "
-            f"A flag can belong to one thing at a time. Pick a different flag, "
-            f"or edit this one where it is already used."
+            f"Pick a different flag, or edit this one where it is already used."
         )

--- a/products/feature_flags/backend/ownership.py
+++ b/products/feature_flags/backend/ownership.py
@@ -17,8 +17,6 @@ _OWNER_LABELS = {
     FLAG_OWNER_EARLY_ACCESS: "an early access feature",
 }
 
-# Reverse accessors keep this free of cross-product imports.
-#
 # `linked_flag` is absent on purpose: a survey or product tour may point at another product's flag
 # to target its audience, which references the flag without owning it.
 _OWNING_ACCESSORS: tuple[tuple[str, str], ...] = (
@@ -36,7 +34,7 @@ def flag_owner_kind(flag: "FeatureFlag") -> str | None:
 
     Ownership decides which approval policy family governs a write, so a flag must have at most one
     owner. Production already satisfies that: of the owned flags in US, all but three have exactly
-    one owner. `assert_flag_unowned` keeps it that way.
+    one owner. `assert_flag_available_for` keeps it that way.
     """
     for accessor, kind in _OWNING_ACCESSORS:
         if getattr(flag, accessor).exists():
@@ -55,6 +53,10 @@ def assert_flag_available_for(flag: "FeatureFlag", *, product: str) -> None:
     Call this only when a write points a product at a flag it did not point at before. Re-saving a
     parent that already owns the flag must not raise, so the caller compares the incoming id
     against the stored one first.
+
+    This reads before the caller writes, so two products adopting the same free flag at the same
+    moment can both pass. No database constraint can span the four owning tables, so the remaining
+    window is accepted rather than locked.
     """
     owner = flag_owner_kind(flag)
     if owner is not None and owner != product:

--- a/products/feature_flags/backend/ownership.py
+++ b/products/feature_flags/backend/ownership.py
@@ -19,13 +19,19 @@ _OWNER_LABELS = {
 
 # `linked_flag` is absent on purpose: a survey or product tour may point at another product's flag
 # to target its audience, which references the flag without owning it.
-_OWNING_ACCESSORS: tuple[tuple[str, str], ...] = (
-    ("experiment_set", FLAG_OWNER_EXPERIMENT),
-    ("surveys_targeting_flag", FLAG_OWNER_SURVEY),
-    ("surveys_internal_targeting_flag", FLAG_OWNER_SURVEY),
-    ("surveys_internal_response_sampling_flag", FLAG_OWNER_SURVEY),
-    ("product_tours_internal_targeting_flag", FLAG_OWNER_PRODUCT_TOUR),
-    ("features", FLAG_OWNER_EARLY_ACCESS),
+#
+# The third element names the manager to read the relation through, or None for the default one.
+# Django builds a reverse accessor from the related model's default manager, and
+# `ProductTour.objects` hides archived tours. An archived tour keeps its `internal_targeting_flag`,
+# so the default manager would report that flag as free while a tour still holds it, and
+# unarchiving the tour would then produce the second owner this module exists to prevent.
+_OWNING_ACCESSORS: tuple[tuple[str, str, str | None], ...] = (
+    ("experiment_set", FLAG_OWNER_EXPERIMENT, None),
+    ("surveys_targeting_flag", FLAG_OWNER_SURVEY, None),
+    ("surveys_internal_targeting_flag", FLAG_OWNER_SURVEY, None),
+    ("surveys_internal_response_sampling_flag", FLAG_OWNER_SURVEY, None),
+    ("product_tours_internal_targeting_flag", FLAG_OWNER_PRODUCT_TOUR, "all_objects"),
+    ("features", FLAG_OWNER_EARLY_ACCESS, None),
 )
 
 
@@ -36,8 +42,11 @@ def flag_owner_kind(flag: "FeatureFlag") -> str | None:
     owner. Production already satisfies that: of the owned flags in US, all but three have exactly
     one owner. `assert_flag_available_for` keeps it that way.
     """
-    for accessor, kind in _OWNING_ACCESSORS:
-        if getattr(flag, accessor).exists():
+    for accessor, kind, manager in _OWNING_ACCESSORS:
+        related = getattr(flag, accessor)
+        if manager is not None:
+            related = related(manager=manager)
+        if related.exists():
             return kind
     return None
 

--- a/products/feature_flags/backend/test/test_ownership.py
+++ b/products/feature_flags/backend/test/test_ownership.py
@@ -30,6 +30,9 @@ class TestFlagOwnership(APIBaseTest):
     def _own_by_product_tour(self, flag: FeatureFlag) -> None:
         ProductTour.objects.create(team=self.team, name="t", internal_targeting_flag=flag)
 
+    def _own_by_archived_product_tour(self, flag: FeatureFlag) -> None:
+        ProductTour.objects.create(team=self.team, name="t", internal_targeting_flag=flag, archived=True)
+
     def _own_by_early_access(self, flag: FeatureFlag) -> None:
         EarlyAccessFeature.objects.create(team=self.team, name="f", stage="beta", feature_flag=flag)
 
@@ -43,6 +46,7 @@ class TestFlagOwnership(APIBaseTest):
             ("survey internal flag", "_own_by_survey_internal", "survey"),
             ("survey sampling flag", "_own_by_survey_sampling", "survey"),
             ("product tour", "_own_by_product_tour", "product_tour"),
+            ("archived product tour", "_own_by_archived_product_tour", "product_tour"),
             ("early access feature", "_own_by_early_access", "early_access_feature"),
             ("survey linked flag", "_reference_by_survey_linked_flag", None),
             ("nothing", None, None),

--- a/products/feature_flags/backend/test/test_ownership.py
+++ b/products/feature_flags/backend/test/test_ownership.py
@@ -33,6 +33,9 @@ class TestFlagOwnership(APIBaseTest):
     def _own_by_archived_product_tour(self, flag: FeatureFlag) -> None:
         ProductTour.objects.create(team=self.team, name="t", internal_targeting_flag=flag, archived=True)
 
+    def _own_by_deleted_experiment(self, flag: FeatureFlag) -> None:
+        Experiment.objects.create(team=self.team, name="exp", feature_flag=flag, deleted=True)
+
     def _own_by_early_access(self, flag: FeatureFlag) -> None:
         EarlyAccessFeature.objects.create(team=self.team, name="f", stage="beta", feature_flag=flag)
 
@@ -48,6 +51,7 @@ class TestFlagOwnership(APIBaseTest):
             ("product tour", "_own_by_product_tour", "product_tour"),
             ("archived product tour", "_own_by_archived_product_tour", "product_tour"),
             ("early access feature", "_own_by_early_access", "early_access_feature"),
+            ("deleted experiment", "_own_by_deleted_experiment", "experiment"),
             ("survey linked flag", "_reference_by_survey_linked_flag", None),
             ("nothing", None, None),
         ]
@@ -86,6 +90,26 @@ class TestSurveyFlagAdoptionGuard(APIBaseTest):
         response = self.client.post(
             f"/api/projects/{self.team.id}/surveys/",
             data={"name": "poacher", "type": "popover", "targeting_flag_id": flag.id},
+            format="json",
+        )
+
+        assert response.status_code == 400, response.json()
+        assert "already belongs to an experiment" in str(response.json())
+
+    def test_survey_cannot_be_repointed_at_a_flag_another_product_owns(self) -> None:
+        created = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={"name": "plain", "type": "popover"},
+            format="json",
+        )
+        assert created.status_code == 201, created.json()
+
+        flag = FeatureFlag.objects.create(team=self.team, key="taken-by-experiment", created_by=self.user)
+        Experiment.objects.create(team=self.team, name="exp", feature_flag=flag)
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{created.json()['id']}/",
+            data={"targeting_flag_id": flag.id},
             format="json",
         )
 

--- a/products/feature_flags/backend/test/test_ownership.py
+++ b/products/feature_flags/backend/test/test_ownership.py
@@ -7,6 +7,7 @@ from products.early_access_features.backend.models import EarlyAccessFeature
 from products.experiments.backend.models.experiment import Experiment
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 from products.feature_flags.backend.ownership import FLAG_OWNER_SURVEY, assert_flag_available_for, flag_owner_kind
+from products.product_tours.backend.models import ProductTour
 from products.surveys.backend.models import Survey
 
 
@@ -23,6 +24,12 @@ class TestFlagOwnership(APIBaseTest):
     def _own_by_survey_internal(self, flag: FeatureFlag) -> None:
         Survey.objects.create(team=self.team, name="s", type="popover", internal_targeting_flag=flag)
 
+    def _own_by_survey_sampling(self, flag: FeatureFlag) -> None:
+        Survey.objects.create(team=self.team, name="s", type="popover", internal_response_sampling_flag=flag)
+
+    def _own_by_product_tour(self, flag: FeatureFlag) -> None:
+        ProductTour.objects.create(team=self.team, name="t", internal_targeting_flag=flag)
+
     def _own_by_early_access(self, flag: FeatureFlag) -> None:
         EarlyAccessFeature.objects.create(team=self.team, name="f", stage="beta", feature_flag=flag)
 
@@ -34,19 +41,21 @@ class TestFlagOwnership(APIBaseTest):
             ("experiment", "_own_by_experiment", "experiment"),
             ("survey targeting flag", "_own_by_survey_targeting", "survey"),
             ("survey internal flag", "_own_by_survey_internal", "survey"),
+            ("survey sampling flag", "_own_by_survey_sampling", "survey"),
+            ("product tour", "_own_by_product_tour", "product_tour"),
             ("early access feature", "_own_by_early_access", "early_access_feature"),
             ("survey linked flag", "_reference_by_survey_linked_flag", None),
             ("nothing", None, None),
         ]
     )
-    def test_flag_owner_kind(self, name, setup, expected):
+    def test_flag_owner_kind(self, name: str, setup: str | None, expected: str | None) -> None:
         flag = self._flag(f"owned-by-{name.replace(' ', '-')}")
         if setup:
             getattr(self, setup)(flag)
 
         assert flag_owner_kind(flag) == expected
 
-    def test_guard_rejects_a_flag_a_different_product_owns(self):
+    def test_guard_rejects_a_flag_a_different_product_owns(self) -> None:
         flag = self._flag("taken")
         self._own_by_experiment(flag)
 
@@ -55,11 +64,10 @@ class TestFlagOwnership(APIBaseTest):
 
         assert "already belongs to an experiment" in str(cm.exception)
 
-    def test_guard_allows_a_free_flag(self):
+    def test_guard_allows_a_free_flag(self) -> None:
         assert_flag_available_for(self._flag("free"), product=FLAG_OWNER_SURVEY)
 
-    def test_guard_allows_the_same_product_to_share_a_flag(self):
-        # Experiment cloning relies on this.
+    def test_guard_allows_the_same_product_to_share_a_flag(self) -> None:
         flag = self._flag("shared")
         self._own_by_experiment(flag)
 
@@ -67,7 +75,7 @@ class TestFlagOwnership(APIBaseTest):
 
 
 class TestSurveyFlagAdoptionGuard(APIBaseTest):
-    def test_survey_cannot_adopt_a_flag_another_product_owns(self):
+    def test_survey_cannot_adopt_a_flag_another_product_owns(self) -> None:
         flag = FeatureFlag.objects.create(team=self.team, key="experiment-flag", created_by=self.user)
         Experiment.objects.create(team=self.team, name="exp", feature_flag=flag)
 
@@ -80,7 +88,7 @@ class TestSurveyFlagAdoptionGuard(APIBaseTest):
         assert response.status_code == 400, response.json()
         assert "already belongs to an experiment" in str(response.json())
 
-    def test_survey_can_be_saved_again_with_the_flag_it_already_owns(self):
+    def test_survey_can_be_saved_again_with_the_flag_it_already_owns(self) -> None:
         created = self.client.post(
             f"/api/projects/{self.team.id}/surveys/",
             data={

--- a/products/feature_flags/backend/test/test_ownership.py
+++ b/products/feature_flags/backend/test/test_ownership.py
@@ -1,0 +1,103 @@
+from posthog.test.base import APIBaseTest
+
+from parameterized import parameterized
+from rest_framework import serializers
+
+from products.early_access_features.backend.models import EarlyAccessFeature
+from products.experiments.backend.models.experiment import Experiment
+from products.feature_flags.backend.models.feature_flag import FeatureFlag
+from products.feature_flags.backend.ownership import FLAG_OWNER_SURVEY, assert_flag_available_for, flag_owner_kind
+from products.surveys.backend.models import Survey
+
+
+class TestFlagOwnership(APIBaseTest):
+    def _flag(self, key: str) -> FeatureFlag:
+        return FeatureFlag.objects.create(team=self.team, key=key, name=key, created_by=self.user)
+
+    def _own_by_experiment(self, flag: FeatureFlag) -> None:
+        Experiment.objects.create(team=self.team, name="exp", feature_flag=flag)
+
+    def _own_by_survey_targeting(self, flag: FeatureFlag) -> None:
+        Survey.objects.create(team=self.team, name="s", type="popover", targeting_flag=flag)
+
+    def _own_by_survey_internal(self, flag: FeatureFlag) -> None:
+        Survey.objects.create(team=self.team, name="s", type="popover", internal_targeting_flag=flag)
+
+    def _own_by_early_access(self, flag: FeatureFlag) -> None:
+        EarlyAccessFeature.objects.create(team=self.team, name="f", stage="beta", feature_flag=flag)
+
+    def _reference_by_survey_linked_flag(self, flag: FeatureFlag) -> None:
+        Survey.objects.create(team=self.team, name="s", type="popover", linked_flag=flag)
+
+    @parameterized.expand(
+        [
+            ("experiment", "_own_by_experiment", "experiment"),
+            ("survey targeting flag", "_own_by_survey_targeting", "survey"),
+            ("survey internal flag", "_own_by_survey_internal", "survey"),
+            ("early access feature", "_own_by_early_access", "early_access_feature"),
+            ("survey linked flag", "_reference_by_survey_linked_flag", None),
+            ("nothing", None, None),
+        ]
+    )
+    def test_flag_owner_kind(self, name, setup, expected):
+        flag = self._flag(f"owned-by-{name.replace(' ', '-')}")
+        if setup:
+            getattr(self, setup)(flag)
+
+        assert flag_owner_kind(flag) == expected
+
+    def test_guard_rejects_a_flag_a_different_product_owns(self):
+        flag = self._flag("taken")
+        self._own_by_experiment(flag)
+
+        with self.assertRaises(serializers.ValidationError) as cm:
+            assert_flag_available_for(flag, product=FLAG_OWNER_SURVEY)
+
+        assert "already belongs to an experiment" in str(cm.exception)
+
+    def test_guard_allows_a_free_flag(self):
+        assert_flag_available_for(self._flag("free"), product=FLAG_OWNER_SURVEY)
+
+    def test_guard_allows_the_same_product_to_share_a_flag(self):
+        # Experiment cloning relies on this.
+        flag = self._flag("shared")
+        self._own_by_experiment(flag)
+
+        assert_flag_available_for(flag, product="experiment")
+
+
+class TestSurveyFlagAdoptionGuard(APIBaseTest):
+    def test_survey_cannot_adopt_a_flag_another_product_owns(self):
+        flag = FeatureFlag.objects.create(team=self.team, key="experiment-flag", created_by=self.user)
+        Experiment.objects.create(team=self.team, name="exp", feature_flag=flag)
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={"name": "poacher", "type": "popover", "targeting_flag_id": flag.id},
+            format="json",
+        )
+
+        assert response.status_code == 400, response.json()
+        assert "already belongs to an experiment" in str(response.json())
+
+    def test_survey_can_be_saved_again_with_the_flag_it_already_owns(self):
+        created = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={
+                "name": "targeted",
+                "type": "popover",
+                "targeting_flag_filters": {"groups": [{"variant": None, "rollout_percentage": 50, "properties": []}]},
+            },
+            format="json",
+        )
+        assert created.status_code == 201, created.json()
+        survey = Survey.objects.get(id=created.json()["id"])
+        assert survey.targeting_flag_id is not None
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={"targeting_flag_id": survey.targeting_flag_id, "name": "renamed"},
+            format="json",
+        )
+
+        assert response.status_code == 200, response.json()

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -1526,9 +1526,12 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
         targeting_flag_id = data.get("targeting_flag_id")
         if targeting_flag_id:
             try:
-                FeatureFlag.objects.get(pk=targeting_flag_id, team_id=self.context["team_id"])
+                targeting_flag = FeatureFlag.objects.get(pk=targeting_flag_id, team_id=self.context["team_id"])
             except FeatureFlag.DoesNotExist:
                 raise serializers.ValidationError("Targeting Feature Flag with this ID does not exist")
+            # Re-saving a survey with the flag it already owns is not an adoption.
+            if self.instance is None or self.instance.targeting_flag_id != targeting_flag_id:
+                assert_flag_available_for(targeting_flag, product=FLAG_OWNER_SURVEY)
 
         linked_insight_id = data.get("linked_insight_id")
         if linked_insight_id:
@@ -1716,12 +1719,6 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
                 team_id=self.context["team_id"],
                 feature_flag_id=validated_data["targeting_flag_id"],
             )
-            assert_flag_available_for(
-                FeatureFlag.objects.get(
-                    pk=validated_data["targeting_flag_id"], team__project_id=self.context["project_id"]
-                ),
-                product=FLAG_OWNER_SURVEY,
-            )
         if validated_data.get("targeting_flag_filters"):
             assert_feature_flag_write_scope(
                 self.context["request"],
@@ -1773,13 +1770,6 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
                 team_id=self.context["team_id"],
                 feature_flag_id=validated_data["targeting_flag_id"],
             )
-            if validated_data["targeting_flag_id"] != instance.targeting_flag_id:
-                assert_flag_available_for(
-                    FeatureFlag.objects.get(
-                        pk=validated_data["targeting_flag_id"], team__project_id=self.context["project_id"]
-                    ),
-                    product=FLAG_OWNER_SURVEY,
-                )
 
         if validated_data.get("remove_targeting_flag"):
             if instance.targeting_flag:

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -75,6 +75,7 @@ from products.feature_flags.backend.api.feature_flag import (
     assert_feature_flag_write_scope,
 )
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
+from products.feature_flags.backend.ownership import FLAG_OWNER_SURVEY, assert_flag_available_for
 from products.product_analytics.backend.facade.models import Insight
 from products.surveys.backend.models import MAX_ITERATION_COUNT, Survey, SurveyResponseArchive, ensure_question_ids
 from products.surveys.backend.responses import (
@@ -1715,6 +1716,12 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
                 team_id=self.context["team_id"],
                 feature_flag_id=validated_data["targeting_flag_id"],
             )
+            assert_flag_available_for(
+                FeatureFlag.objects.get(
+                    pk=validated_data["targeting_flag_id"], team__project_id=self.context["project_id"]
+                ),
+                product=FLAG_OWNER_SURVEY,
+            )
         if validated_data.get("targeting_flag_filters"):
             assert_feature_flag_write_scope(
                 self.context["request"],
@@ -1766,6 +1773,13 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
                 team_id=self.context["team_id"],
                 feature_flag_id=validated_data["targeting_flag_id"],
             )
+            if validated_data["targeting_flag_id"] != instance.targeting_flag_id:
+                assert_flag_available_for(
+                    FeatureFlag.objects.get(
+                        pk=validated_data["targeting_flag_id"], team__project_id=self.context["project_id"]
+                    ),
+                    product=FLAG_OWNER_SURVEY,
+                )
 
         if validated_data.get("remove_targeting_flag"):
             if instance.targeting_flag:

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -30208,7 +30208,7 @@ export namespace Schemas {
          * @nullable
          */
       readonly assignee: EarlyAccessFeatureSerializerCreateOnlyAssignee;
-      /** Optional ID of an existing feature flag to link. If omitted, a new flag is auto-created from the feature name. The flag must not already be linked to another feature, must not be group-based, and must not be multivariate. */
+      /** Optional ID of an existing feature flag to link. If omitted, a new flag is auto-created from the feature name. The flag must not already be linked to another feature, must not belong to another product such as a survey or experiment, must not be group-based, and must not be multivariate. */
       feature_flag_id?: number;
       readonly feature_flag: MinimalFeatureFlag;
       _create_in_folder?: string;

--- a/services/mcp/src/generated/early_access_features/api.ts
+++ b/services/mcp/src/generated/early_access_features/api.ts
@@ -62,7 +62,7 @@ export const EarlyAccessFeatureCreateBody = () => zod
             .number()
             .optional()
             .describe(
-                'Optional ID of an existing feature flag to link. If omitted, a new flag is auto-created from the feature name. The flag must not already be linked to another feature, must not be group-based, and must not be multivariate.'
+                'Optional ID of an existing feature flag to link. If omitted, a new flag is auto-created from the feature name. The flag must not already be linked to another feature, must not belong to another product such as a survey or experiment, must not be group-based, and must not be multivariate.'
             ),
         _create_in_folder: zod.string().optional(),
     })

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/early-access-feature-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/early-access-feature-create.json
@@ -20,7 +20,7 @@
             "description": "URL to external documentation for this feature. Shown to users in the opt-in UI."
         },
         "feature_flag_id": {
-            "description": "Optional ID of an existing feature flag to link. If omitted, a new flag is auto-created from the feature name. The flag must not already be linked to another feature, must not be group-based, and must not be multivariate.",
+            "description": "Optional ID of an existing feature flag to link. If omitted, a new flag is auto-created from the feature name. The flag must not already be linked to another feature, must not belong to another product such as a survey or experiment, must not be group-based, and must not be multivariate.",
             "type": "number"
         },
         "name": {


### PR DESCRIPTION
## Problem

Nothing stops one feature flag belonging to an experiment, a survey, and an early access feature at the same time. Early access checked only for another early access feature; no other product checked at all.

- A survey can be pointed at any existing flag, on create and on update. `update()` documents re-pointing as intended behavior.
- An experiment adopts an existing flag by key, and the code notes it "may already serve traffic".
- Early access adopts a flag by id.

This matters because ownership is what will decide which approval policy family governs a flag. With two owners the question has no single answer, and adopting a flag into a second product silently moves it out of the policy that covered it.

Production says the invariant already holds in practice, so this codifies reality rather than imposing a new constraint: of the owned flags in US, **284,690 have exactly one owner and 3 have two**.

## Changes

- A person adopting a flag another product owns now gets a 400 explaining where the flag is already used, instead of silently creating a second owner.
- Sharing a flag **within** one product still works. Two experiments resolve to one owner, and experiment cloning depends on it.
- Linking is untouched. `linked_flag` references a flag without owning it, so a survey may still target another product's flag.
- Early access keeps its existing one-feature-per-flag error unchanged, and gains the cross-product guard alongside it.
- `ownership.py` derives the owner through reverse accessors, so it needs no cross-product imports and no new `tach` entries.

No model change, no migration, no backfill. Ownership stays derived from the relations that already exist.

The alternative was storing provenance on the flag as an immutable column. Rejected: it adds a second source of truth that can disagree with the relations, and its only advantage was closing paths that can be closed directly. This closes them directly.

> [!NOTE]
> The guard rejects only a *different* product. An earlier revision rejected any owned flag and broke experiment cloning, which shares a flag key with its source by default. That footgun is left alone. It is a correctness wart the clone docstring already warns about, not a governance problem, because both owners are experiments.

## How did you test this code?

New `test_ownership.py`, 11 cases. The parameterized owner cases catch a new owning relation being added without registering it, which would make the flag silently unowned and governable by the wrong family. The `linked_flag` case pins the reference-versus-ownership distinction, which is the easiest part to get backwards.

Two API cases cover wiring the helper cannot: that the survey endpoint actually reaches the guard, and that re-saving a survey with the flag it already owns does not trip it. The second is the false-positive that would otherwise break every survey save.

Ran locally: `products/feature_flags/backend/test/test_ownership.py`, plus the full suites for the four products this touches (experiments, surveys, early access, product tours) — 1,905 existing tests, all passing. Repo-wide `mypy` clean, `hogli lint:tach` clean, `hogli ci:preflight --strict` 0 failures, `hogli build:openapi` produced no drift.

Not run: anything outside those four products.

No frontend files changed, so nothing looks different beyond the new validation error.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5), directed throughout.

This is the first step of a larger design: scoping approval policies by the product that owns a flag, so a policy meant for feature rollouts stops gating survey targeting. The design doc lives outside this repo.

The step changed shape twice under review. It began as a stored `creation_context` column with a backfill; that was rejected in favor of deriving ownership and guarding the writes, on the argument that a second source of truth buys nothing once the mutation paths are closed. The guard itself then narrowed from "any owner" to "a different product" when the experiment suite caught cloning.

Production Postgres was queried read-only through Metabase to size the affected population. Only aggregate counts informed the work, and none of it appears in this diff.

Skills invoked: `/django-migrations` (during the abandoned column approach), `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

https://claude.ai/code/session_01EvsnTBQkfd1NMU5uYx8XSQ
