### PR TITLE
fix(hogbox-preview): enable the checkout's feature flags

### DIFF
--- a/tools/hogbox-preview/hogbox_preview/stack.py
+++ b/tools/hogbox-preview/hogbox_preview/stack.py
@@ -33,6 +33,7 @@ Recipe (mount-over-image — the default, ~minutes per PR):
 
 from __future__ import annotations
 
+import re
 import sys
 import secrets
 
@@ -60,6 +61,22 @@ _CSRF_TRUSTED_ORIGINS = ",".join(f"https://*.boxes.hogland.{env}.posthog.dev" fo
 # the seed defaults ever change, change these too.
 _DEMO_EMAIL = "test@posthog.com"
 _DEMO_PASSWORD = "12345678"
+
+# A preview is a self-hosted, non-debug instance, and there the SPA discards every
+# posthog-js flag value and honors only the keys the server sends in
+# PERSISTED_FEATURE_FLAGS (areClientFeatureFlagsHonored in
+# frontend/src/lib/logic/featureFlagLogic.ts). Unset, that hides every flag-gated
+# product from the sidebar and renders every flagged surface in its pre-flag state,
+# so a preview cannot show flagged work at all. Enabling the checkout's own flag
+# list matches what `manage.py sync_feature_flags` gives a local dev instance,
+# minus the flags that command holds back.
+_FEATURE_FLAGS_TSX = "frontend/src/lib/constants.tsx"
+_SYNC_FEATURE_FLAGS_PY = "posthog/management/commands/sync_feature_flags.py"
+# Both blocks list one name per line as the first quoted token, so the same awk
+# reads them; only the quote character differs between the .tsx and the .py.
+_SINGLE_QUOTE = "\\047"
+_DOUBLE_QUOTE = "\\042"
+_FLAG_KEY = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 # PostHog's prod settings refuse to boot on the default SECRET_KEY, so the
 # override must supply one (the migrate `run --rm web` one-off needs it too).
@@ -262,6 +279,40 @@ class PostHogPreviewStack:
             timeout=600,
         )
 
+    def _quoted_names_in_block(self, path: str, start: str, end: str, quote: str) -> list[str]:
+        """First quoted token of every line between two markers of a file in the box."""
+        program = (
+            f"awk '/{start}/{{f=1;next}} f&&/{end}/{{exit}} f{{n=split($0,a,\"{quote}\"); if (n>1) print a[2]}}' {path}"
+        )
+        result = self.backend.exec(program, timeout=30)
+        if not result.ok:
+            return []
+        return [name for name in (line.strip() for line in result.stdout.splitlines()) if _FLAG_KEY.match(name)]
+
+    def persisted_feature_flags(self) -> str:
+        """The PR checkout's feature flag keys, comma-joined for PERSISTED_FEATURE_FLAGS.
+
+        Empty when the flag list can't be read: a preview that opens with its
+        flags off is better than one that fails to come up.
+        """
+        try:
+            keys = self._quoted_names_in_block(
+                f"{self.repo_dir}/{_FEATURE_FLAGS_TSX}",
+                "export const FEATURE_FLAGS",
+                "^}",
+                _SINGLE_QUOTE,
+            )
+            held_back = self._quoted_names_in_block(
+                f"{self.repo_dir}/{_SYNC_FEATURE_FLAGS_PY}",
+                "^INACTIVE_FLAGS = ",
+                "^\\]",
+                _DOUBLE_QUOTE,
+            )
+        except Exception as e:  # noqa: BLE001
+            sys.stderr.write(f"[hogbox-preview] feature flags left off (could not read the flag list): {e}\n")
+            return ""
+        return ",".join(sorted(set(keys) - set(held_back)))
+
     def write_override(self) -> None:
         # This override MUST stay in sync with hogland's
         # scripts/posthog-preview-setup.sh (the golden bake script). Both write
@@ -343,6 +394,9 @@ class PostHogPreviewStack:
             # inert no-op on an image that predates it.
             "      - USE_LOCAL_SETUP=1",
         ]
+        persisted_flags = self.persisted_feature_flags()
+        if persisted_flags:
+            lines.append(f"      - PERSISTED_FEATURE_FLAGS={persisted_flags}")
         lines += [
             "  plugins:",
             f"    image: {self.CDP_IMAGE}",

--- a/tools/hogbox-preview/tests/test_persisted_feature_flags.py
+++ b/tools/hogbox-preview/tests/test_persisted_feature_flags.py
@@ -1,0 +1,101 @@
+"""Unit tests for the preview's PERSISTED_FEATURE_FLAGS env.
+
+Self-contained: no network, no live box. A fake backend answers the two awk
+reads with file contents, so the test covers the parse and the compose line.
+
+    cd tools/hogbox-preview && python -m unittest discover tests
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    from hogbox_preview.backend import ExecResult
+    from hogbox_preview.stack import PostHogPreviewStack
+
+    HAVE_SDK = True
+except ImportError:
+    HAVE_SDK = False
+
+_CONSTANTS_TSX = """
+export const FEATURE_FLAGS = {
+    // Eternal feature flags, shouldn't be removed
+    ENGINEERING_ANALYTICS: 'engineering-analytics', // owner: #team-devex
+    CONTROL_SUPPORT_LOGIN: 'control_support_login', // owner: #team-support
+    MULTIVARIATE: 'some-multivariate', // owner: #team-x, multivariate=control,test
+} satisfies Record<string, string>
+
+export const ENTITY_MATCH_TYPE = 'entities'
+"""
+
+_SYNC_FEATURE_FLAGS_PY = """
+INACTIVE_FLAGS = [
+    "control_support_login",
+    "halloween-override",
+]
+
+
+class Command(BaseCommand):
+    help = "Add and enable all feature flags"
+"""
+
+
+class _FileServingBackend:
+    """Duck-typed PreviewBackend: answers the awk reads and records the override."""
+
+    def __init__(self, files: dict[str, str]):
+        self.files: dict[str, str] = {}
+        self._sources = files
+
+    def exec(self, command: str, *, timeout: int = 120) -> ExecResult:
+        for name, body in self._sources.items():
+            if name in command:
+                program = command.split("'")[1]
+                return ExecResult(0, _run_awk(program, body), "")
+        return ExecResult(1, "", "no such file")
+
+    def write_file(self, remote_path, content) -> None:
+        self.files[remote_path] = content if isinstance(content, str) else content.decode()
+
+
+def _run_awk(program: str, body: str) -> str:
+    import shutil
+    import subprocess
+
+    awk = shutil.which("awk")
+    if awk is None:
+        raise unittest.SkipTest("awk not available")
+    return subprocess.run([awk, program], input=body, capture_output=True, text=True, check=True).stdout
+
+
+def _override_lines(stack, backend: _FileServingBackend) -> list[str]:
+    stack.write_override()
+    return backend.files[f"{stack.repo_dir}/{stack.OVERRIDE}"].splitlines()
+
+
+@unittest.skipUnless(HAVE_SDK, "posthog-hogland SDK not installed")
+class PersistedFeatureFlagsTest(unittest.TestCase):
+    def _flag_env(self, backend: _FileServingBackend) -> str | None:
+        stack = PostHogPreviewStack(backend)
+        for line in _override_lines(stack, backend):
+            stripped = line.strip().lstrip("- ")
+            if stripped.startswith("PERSISTED_FEATURE_FLAGS="):
+                return stripped.split("=", 1)[1]
+        return None
+
+    def test_override_carries_the_checkout_flags_without_the_held_back_ones(self):
+        backend = _FileServingBackend(
+            {"constants.tsx": _CONSTANTS_TSX, "sync_feature_flags.py": _SYNC_FEATURE_FLAGS_PY}
+        )
+
+        self.assertEqual(self._flag_env(backend), "engineering-analytics,some-multivariate")
+
+    def test_unreadable_flag_list_leaves_the_env_out(self):
+        backend = _FileServingBackend({})
+
+        self.assertIsNone(self._flag_env(backend))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

- A hogbox preview hides every flag-gated product, so a reviewer opening one cannot see engineering analytics, visual review, tasks, links, or any other flagged surface.
- The SPA on a preview reports `cloud: false` and `is_debug: false`, and [`areClientFeatureFlagsHonored`](https://github.com/PostHog/posthog/blob/master/frontend/src/lib/logic/featureFlagLogic.ts#L20) then discards every posthog-js flag value.
- What is left is `PERSISTED_FEATURE_FLAGS`, which the preview never sets, so the app runs with an empty flag set.
- Checked on the preview for [hide the retired project environments route](https://github.com/PostHog/posthog/pull/95171): `posthog.isFeatureEnabled('engineering-analytics')` returns `true`, the product row is in `custom_products`, and the sidebar still omits it along with every other flagged product.

## Changes

- A preview now opens with the flags on, so flagged work is reviewable in the sidebar and in the scenes behind it.
- The compose override sets `PERSISTED_FEATURE_FLAGS` from the box's own PR checkout, which matches what `manage.py sync_feature_flags` gives a local dev instance.
- Two `awk` reads collect the keys: `FEATURE_FLAGS` in `frontend/src/lib/constants.tsx`, minus `INACTIVE_FLAGS` in `sync_feature_flags.py`, so the held-back flags stay off and the list never drifts from that command.
- Keys that do not match `^[a-zA-Z0-9_-]+$` are dropped, so nothing from a PR checkout can inject compose YAML.
- A failed read leaves the variable out and the preview comes up as it does today.
- Reading from the box, not the runner, is what covers a PR that adds a new flag: the credentialed `deploy` job checks out master, and the box holds the PR.
- Nothing renders differently outside a preview.

> [!NOTE]
> The hogland bake script writes the same compose file, and this tool clobbers it per PR, so previews get the variable without a hogland change. Mirroring it there keeps the two in sync.

## How did you test this code?

- `python -m unittest discover tests` in `tools/hogbox-preview`: 49 pass, including two new cases.
- The new cases catch the compose line going missing and an `INACTIVE_FLAGS` entry leaking in. No existing test reads the flag list.
- Ran `persisted_feature_flags()` against this checkout through a local shell backend: 384 keys, 9795 bytes, `engineering-analytics` and `visual-review` present, no held-back key.
- Not run: a real preview. Bringing one up needs the credentialed CI job.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5), starting from the question of why engineering analytics was missing from a preview sidebar. Diagnosis used chrome-devtools MCP against two live previews to read the app context, the flag values, and the rendered nav.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- The first two candidate causes, a missing `UserProductList` row and a false flag, were both refuted in the browser before landing on the self-hosted flag gate.
- Setting the variable from the checkout beats hand-listing flags per PR, which would need an author action for every flagged review.
- Public artifact: no session material reaches this diff. The test fixtures are invented.

https://claude.ai/code/session_01MHR6LScXv1pMiiCSqekX8n
