### PR TITLE
fix(desktop): take desktop tests off the master push lane

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -69,7 +69,21 @@ jobs:
     build:
         needs: changes
         # Fail closed: if change detection itself failed, run instead of skipping.
-        if: ${{ !cancelled() && github.event_name != 'merge_group' && (needs.changes.result != 'success' || needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true') }}
+        #
+        # A draft pull request skips this job, so a draft pays for the quality, typecheck
+        # and unit test jobs only. This job is what proves the bundler still works, which
+        # a typecheck cannot tell you, so the signal comes back on ready_for_review, which
+        # desktop-ci.yml dispatches on for this reason.
+        #
+        # trunk-merge/** heads are exempt because Trunk opens its batch pull requests as
+        # drafts. Without that clause, the draft check would skip the one run that gates
+        # master.
+        if: >-
+            !cancelled() &&
+            github.event_name != 'merge_group' &&
+            (github.event.pull_request.draft != true ||
+            startsWith(github.head_ref, 'trunk-merge/')) &&
+            (needs.changes.result != 'success' || needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true')
         runs-on: depot-ubuntu-24.04-4
         timeout-minutes: 30
         permissions:

--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -11,7 +11,11 @@ name: Desktop CI
 # any PR that requires them stuck waiting for status.
 
 on:
+    # ready_for_review is included because the children skip their expensive jobs on a
+    # draft. Without it, marking a desktop pull request ready would dispatch nothing and
+    # the author would wait for an unrelated push to get that coverage back.
     pull_request:
+        types: [opened, synchronize, reopened, ready_for_review]
     # Required so the `Desktop * Pass` checks report on merge queue entries —
     # without it the queue would wait for them until timeout. The children skip
     # all real jobs on merge_group (the suite already ran in full on the PR) and

--- a/.github/workflows/desktop-test.yml
+++ b/.github/workflows/desktop-test.yml
@@ -11,12 +11,12 @@ on:
                 required: false
             POSTHOG_CODE_E2E_GATEWAY_URL:
                 required: false
-    # Master coverage comes from this cron, not from the push. Pull requests and merge
-    # queue batches already run the suite per change, and its macOS job asks a fixed,
-    # shared pool that cannot autoscale for a runner. The gap a cron has to cover is
-    # drift from outside the repo: an Electron, Playwright or runner-image change. Daily
-    # matches desktop-update-e2e.yml, the other macOS desktop job. 05:00 UTC is the
-    # emptiest hour measured on the pool, and clear of that job at 07:00.
+    # A cron carries master coverage for this suite. Pull requests and merge queue
+    # batches run it per change, so the only gap left on master is drift from outside
+    # the repo: a new Electron, Playwright or runner-image version. Daily is enough for
+    # that, and it keeps demand on depot-macos-26 low, which is a fixed pool shared
+    # across Depot customers that cannot autoscale for a runner. 05:03 UTC holds this
+    # run clear of desktop-update-e2e.yml, the other daily job on that pool, at 07:00.
     schedule:
         - cron: '3 5 * * *'
 

--- a/.github/workflows/desktop-test.yml
+++ b/.github/workflows/desktop-test.yml
@@ -133,7 +133,23 @@ jobs:
     integration-test:
         needs: changes
         # Fail closed: if change detection itself failed, run instead of skipping.
-        if: ${{ !cancelled() && github.event_name != 'merge_group' && (needs.changes.result != 'success' || needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true') }}
+        #
+        # A draft pull request skips this job. depot-macos-26 is a fixed pool that Depot
+        # shares between customers, and Apple's 24-hour minimum lease stops it from
+        # autoscaling, so a runner requested per draft push can wait many times longer
+        # than the job runs. The author gets the signal back on ready_for_review, which
+        # desktop-ci.yml dispatches on for this reason, the same way desktop-build.yml
+        # does.
+        #
+        # trunk-merge/** heads are exempt because Trunk opens its batch pull requests as
+        # drafts. Without that clause, the draft check would skip the one run that gates
+        # master.
+        if: >-
+            !cancelled() &&
+            github.event_name != 'merge_group' &&
+            (github.event.pull_request.draft != true ||
+            startsWith(github.head_ref, 'trunk-merge/')) &&
+            (needs.changes.result != 'success' || needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true')
         runs-on: depot-macos-26
         timeout-minutes: 45
         permissions:

--- a/.github/workflows/desktop-test.yml
+++ b/.github/workflows/desktop-test.yml
@@ -130,20 +130,7 @@ jobs:
     integration-test:
         needs: changes
         # Fail closed: if change detection itself failed, run instead of skipping.
-        #
-        # Also skipped on trunk-merge/** heads. Trunk's queue opens a real PR, so
-        # the merge_group arm never matches and this ran on every batch. Every
-        # batched PR already ran it in full, and depot-macos-26 is the suite's only
-        # macOS runner, where an hour-long wait at peak holds the queue instead of
-        # one author's PR. Scoped to same-repo heads so a fork cannot opt out by
-        # naming its branch trunk-merge/**. While the live-model `e2e` job still
-        # needs this one, it skips there too, the cascade merge_group relies on.
-        if: >-
-            !cancelled() &&
-            github.event_name != 'merge_group' &&
-            !(github.event.pull_request.head.repo.full_name == github.repository &&
-            startsWith(github.head_ref, 'trunk-merge/')) &&
-            (needs.changes.result != 'success' || needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true')
+        if: ${{ !cancelled() && github.event_name != 'merge_group' && (needs.changes.result != 'success' || needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true') }}
         runs-on: depot-macos-26
         timeout-minutes: 45
         permissions:

--- a/.github/workflows/desktop-test.yml
+++ b/.github/workflows/desktop-test.yml
@@ -11,11 +11,14 @@ on:
                 required: false
             POSTHOG_CODE_E2E_GATEWAY_URL:
                 required: false
-    push:
-        branches: [master]
-        paths:
-            - 'products/desktop/**'
-            - '.github/workflows/desktop-test.yml'
+    # Master coverage comes from this cron, not from the push. Pull requests and merge
+    # queue batches already run the suite per change, and its macOS job asks a fixed,
+    # shared pool that cannot autoscale for a runner. The gap a cron has to cover is
+    # drift from outside the repo: an Electron, Playwright or runner-image change. Daily
+    # matches desktop-update-e2e.yml, the other macOS desktop job. 05:00 UTC is the
+    # emptiest hour measured on the pool, and clear of that job at 07:00.
+    schedule:
+        - cron: '3 5 * * *'
 
 concurrency:
     group: desktop-test-${{ github.head_ref || github.ref }}

--- a/.github/workflows/desktop-warm-caches.yml
+++ b/.github/workflows/desktop-warm-caches.yml
@@ -12,10 +12,10 @@ name: Desktop Warm Caches
 on:
     push:
         branches: [master]
-        # Every cache key here hashes pnpm-lock.yaml alone, and the install steps already
-        # no-op when all three caches hit. Firing on any products/desktop/** push therefore
-        # took a macOS runner from a fixed, shared pool just to learn it had nothing to do.
-        # workflow_dispatch reseeds by hand if a cache is ever evicted.
+        # Every cache key in this workflow hashes pnpm-lock.yaml alone, so no other file
+        # can invalidate one. A wider filter would spend a macOS runner from a fixed,
+        # shared pool on install steps that no-op when all three caches hit. Use
+        # workflow_dispatch to reseed by hand if a cache is evicted.
         paths:
             - 'products/desktop/pnpm-lock.yaml'
             - '.github/workflows/desktop-warm-caches.yml'

--- a/.github/workflows/desktop-warm-caches.yml
+++ b/.github/workflows/desktop-warm-caches.yml
@@ -12,8 +12,12 @@ name: Desktop Warm Caches
 on:
     push:
         branches: [master]
+        # Every cache key here hashes pnpm-lock.yaml alone, and the install steps already
+        # no-op when all three caches hit. Firing on any products/desktop/** push therefore
+        # took a macOS runner from a fixed, shared pool just to learn it had nothing to do.
+        # workflow_dispatch reseeds by hand if a cache is ever evicted.
         paths:
-            - 'products/desktop/**'
+            - 'products/desktop/pnpm-lock.yaml'
             - '.github/workflows/desktop-warm-caches.yml'
     workflow_dispatch:
 


### PR DESCRIPTION
## Problem

- A desktop pull request or merge queue batch waits up to 76 minutes for a macOS test that runs in 6 minutes. [Run 34207978083](https://github.com/PostHog/posthog/actions/runs/34207978083) queued 76 minutes, ran 5.9, and passed.
- `depot-macos-26` is a fixed pool shared across Depot customers, with no autoscaling, because Apple requires a 24-hour minimum lease. We can change how often we join that queue, not our position in it.
- The waits are not self-inflicted. For 71 of those 76 minutes, no PostHog macOS job was running at all. The most PostHog macOS jobs seen running at once, over three weeks, is two.
- Master pushes make most of the requests. Every `products/desktop/**` push asks for two macOS runners: the integration test and the macOS cache warmer.

Jobs on `depot-macos-26` over 24 hours, from the GitHub jobs API:

| Lane | Jobs | Run minutes | Queued minutes |
| --- | --- | --- | --- |
| master push, `desktop-test` integration test | 24 | 135 | 337 |
| master push, `desktop-warm-caches` | 23 | 87 | 287 |
| pull request | 8 | 63 | 0 |
| release tag | 4 | 45 | 0 |
| merge queue batch | 3 | 20 | 1 |
| master push, `desktop-update-e2e` | 1 | 9 | 0 |

- #96546 cut the merge queue batch lane, which is 3 of those 63 jobs. It also removed the one run that tests the tree that lands.

## Changes

- `desktop-test.yml` stops running on master pushes. A daily 05:03 UTC cron carries master coverage instead. Nothing dispatches on a desktop push, so the Linux jobs stop repeating the batch as well.
- The merge queue batch tests macOS again. This reverts #96546, so the batch keeps covering the merged tree.
- `desktop-warm-caches` now fires only when `products/desktop/pnpm-lock.yaml` changes. Every cache key in that workflow hashes that one file, and its install steps already no-op when all three caches hit, so the other runs took a macOS runner to learn they had nothing to do.

Across the last 7 days the master lane drops from 100 macOS jobs, from 50 pushes, to 23: 7 scheduled plus 16 lockfile changes.

The diff removes more lines than it adds. Skipping the workflow beats guarding the macOS job by event, which would leave the run dispatching and the Linux jobs repeating work the batch already did.

> [!NOTE]
> The `e2e` job needs `integration-test`, so the live-model gateway suite follows this schedule on master. It still runs on every pull request and every batch. Its `pnpm` cache save keys off `github.ref`, which a cron run still satisfies.

Before:

```mermaid
flowchart LR
    A["desktop PR"] --> M1["macOS integration test"]
    B["merge queue batch"] --> S1["skipped by #96546"]
    C["master push"] --> M2["macOS integration test"]
    C --> M3["macOS cache warmer"]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class M1 phBlue;
    class M2,M3 phRed;
    class S1 phGray;
```

After:

```mermaid
flowchart LR
    A["desktop PR"] --> M1["macOS integration test"]
    B["merge queue batch"] --> M2["macOS integration test"]
    C["master push"] --> S1["no run"]
    D["daily 05:03 UTC"] --> M3["macOS integration test"]
    E["pnpm-lock.yaml push"] --> M4["macOS cache warmer"]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class M1,M2 phBlue;
    class M3,M4 phYellow;
    class S1 phGray;
```

## How did you test this code?

- No tests were added. The change is a trigger and a job condition, and this repo has no harness that evaluates a GitHub Actions `if:` expression.
- `actionlint`, `bin/hogli lint:workflows` and `bin/hogli ci:preflight` all pass on this branch.
- The queue and run times come from the jobs API over recent runs of `desktop-test.yml`, `desktop-ci.yml`, `desktop-warm-caches.yml`, `desktop-update-e2e.yml` and `desktop-release.yml`. Push frequency comes from `git log` over `origin/master`.
- The workflow was read for anything else the push lane carried. Only the `e2e` job's `pnpm` cache save is ref-scoped, and a cron run keeps `github.ref` at `refs/heads/master`.
- Not verified: that the cron fires, and that a desktop master push now dispatches nothing. Both need a run on this trigger, which exists only once this lands.
- No manual testing. A workflow trigger cannot be exercised locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The change affects CI scheduling only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from a [Slack thread](https://posthog.slack.com/archives/C09ADEV3AJD/p1788868957508959) about slow desktop tests. The thread's working diagnosis was contention on the macOS pool, so the first fix cut merge queue demand (#96546). The job timings then showed the long waits happen while PostHog's own macOS jobs sit idle, which moved the target from the batch lane to the master-push lane, and made reverting #96546 part of the fix rather than a reversal of it.

Skills invoked: `/authoring-ci-workflows` and `/writing-pr-descriptions`.

Two rounds of review from the driver shaped the result. The first draft guarded the macOS job with `github.event_name != 'push'` and kept the trigger, which still dispatched a run per desktop push; skipping the workflow replaced it. The cron started at six-hourly, until measured push frequency made that a 44% cut.

On cadence: the hourly master lane in `/authoring-ci-workflows` is the documented pattern for this substitution, and hourly cannot work here, because 24 runs a day is what this PR removes. Daily master crons are already common in this repo, including for suites: `ci-hobby.yml` at 06:00, `ci-e2e-playwright-audit.yml` at 07:00, `ci-storybook-update-test-timing.yml` at 04:00, and `desktop-update-e2e.yml`, which runs a `depot-macos-26` job daily at 07:00. `ci-geoip-canary.yml` runs six-hourly. So the cadence is in-house, but this is the first daily lane that replaces a suite's master-push coverage.

`desktop-test.yml` is in neither `GATING_WORKFLOWS` nor `SCHEDULED_GATING_WORKFLOWS` in `ci-alerts-devex.yml`, so no desktop lane pages today. Registering the new cron there is a follow-up: the alerter's scheduled thresholds assume an hourly cadence, and a daily lane needs its own arms.

No duplicate: #95852 and #94509 are open drafts on the same pool. Both cut the time a job spends on a macOS runner; neither cuts how many runners the repo asks for.

The diff carries no customer data or other non-public material.
