### PR TITLE
perf(desktop): drop task descriptions from full-list fetches

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.test.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.test.ts
@@ -479,6 +479,12 @@ describe("PostHogAPIClient", () => {
     ["pinned", { pinned: true }, "pinned", "true"],
     ["commented-by", { commentedBy: 17 }, "commented_by", "17"],
     ["mentions", { mentions: 19 }, "mentions", "19"],
+    [
+      "include-description opt-out",
+      { includeDescription: false },
+      "include_description",
+      "false",
+    ],
   ])("sends the %s task-list filter", async (_name, options, param, value) => {
     const fetch = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ results: [], count: 0 }), {
@@ -499,6 +505,29 @@ describe("PostHogAPIClient", () => {
     expect(url.pathname).toBe("/api/projects/42/tasks/");
     expect(url.searchParams.get(param)).toBe(value);
   });
+
+  it.each([undefined, { includeDescription: true }])(
+    "omits include_description unless the caller opts out (%o)",
+    async (options) => {
+      const fetch = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ results: [], count: 0 }), {
+          status: 200,
+        }),
+      );
+      const client = new PostHogAPIClient(
+        "https://app.posthog.test",
+        async () => "token",
+        async () => "token",
+        42,
+        { fetch },
+      );
+
+      await client.getTasksPage(options);
+
+      const url = fetch.mock.calls[0][0] as URL;
+      expect(url.searchParams.has("include_description")).toBe(false);
+    },
+  );
 
   it.each([
     "user_message",

--- a/products/desktop/packages/api-client/src/posthog-client.test.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.test.ts
@@ -479,12 +479,7 @@ describe("PostHogAPIClient", () => {
     ["pinned", { pinned: true }, "pinned", "true"],
     ["commented-by", { commentedBy: 17 }, "commented_by", "17"],
     ["mentions", { mentions: 19 }, "mentions", "19"],
-    [
-      "include-description opt-out",
-      { includeDescription: false },
-      "include_description",
-      "false",
-    ],
+    ["basic summary", { basic: true }, "basic", "true"],
   ])("sends the %s task-list filter", async (_name, options, param, value) => {
     const fetch = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ results: [], count: 0 }), {
@@ -506,8 +501,8 @@ describe("PostHogAPIClient", () => {
     expect(url.searchParams.get(param)).toBe(value);
   });
 
-  it.each([undefined, { includeDescription: true }])(
-    "omits include_description unless the caller opts out (%o)",
+  it.each([undefined, { basic: false }])(
+    "omits basic unless the caller asks for the summary payload (%o)",
     async (options) => {
       const fetch = vi.fn().mockResolvedValue(
         new Response(JSON.stringify({ results: [], count: 0 }), {
@@ -525,7 +520,7 @@ describe("PostHogAPIClient", () => {
       await client.getTasksPage(options);
 
       const url = fetch.mock.calls[0][0] as URL;
-      expect(url.searchParams.has("include_description")).toBe(false);
+      expect(url.searchParams.has("basic")).toBe(false);
     },
   );
 

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -239,11 +239,11 @@ export interface TaskListOptions {
   /** Case-insensitive substring match over task title, description, and number. */
   search?: string;
   /**
-   * Whether list rows carry the task description body. Defaults to true on the server. Pass
-   * false from a surface that does not render the description, to drop the field that
+   * Ask for the basic list payload: a summary shape with heavy fields dropped. Defaults to
+   * false. A surface that does not render the description sets this to skip the field that
    * dominates the list payload.
    */
-  includeDescription?: boolean;
+  basic?: boolean;
   /** Filter by the status of the task's most recent run. */
   status?: string;
   /** Filter by the state of the latest run's pull request (open/draft/merged/closed). */
@@ -2852,8 +2852,8 @@ export class PostHogAPIClient {
       params.ordering = options.ordering;
     }
 
-    if (options?.includeDescription === false) {
-      params.include_description = false;
+    if (options?.basic) {
+      params.basic = true;
     }
 
     const data = await this.api.get(`/api/projects/{project_id}/tasks/`, {

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -238,6 +238,12 @@ export interface TaskListOptions {
   channel?: string;
   /** Case-insensitive substring match over task title, description, and number. */
   search?: string;
+  /**
+   * Whether list rows carry the task description body. Defaults to true on the server. Pass
+   * false from a surface that does not render the description, to drop the field that
+   * dominates the list payload.
+   */
+  includeDescription?: boolean;
   /** Filter by the status of the task's most recent run. */
   status?: string;
   /** Filter by the state of the latest run's pull request (open/draft/merged/closed). */
@@ -2844,6 +2850,10 @@ export class PostHogAPIClient {
 
     if (options?.ordering) {
       params.ordering = options.ordering;
+    }
+
+    if (options?.includeDescription === false) {
+      params.include_description = false;
     }
 
     const data = await this.api.get(`/api/projects/{project_id}/tasks/`, {

--- a/products/desktop/packages/ui/src/features/tasks/useTasks.ts
+++ b/products/desktop/packages/ui/src/features/tasks/useTasks.ts
@@ -38,6 +38,9 @@ export function useTasks(
         repository: filters?.repository,
         createdBy,
         internal,
+        // The sidebar and every other full-list consumer narrow the task before use
+        // and never read its description, so drop that body from the list payload.
+        includeDescription: false,
       }) as unknown as Promise<Task[]>,
     {
       enabled: (options?.enabled ?? true) && !!currentUser?.id,
@@ -77,6 +80,8 @@ export function useSlackTasks(options?: {
       client.getTasks({
         originProduct: "slack",
         internal,
+        // Only slack origin/thread fields are read off these rows; drop the description body.
+        includeDescription: false,
       }) as unknown as Promise<Task[]>,
     {
       enabled: options?.enabled ?? true,

--- a/products/desktop/packages/ui/src/features/tasks/useTasks.ts
+++ b/products/desktop/packages/ui/src/features/tasks/useTasks.ts
@@ -39,8 +39,8 @@ export function useTasks(
         createdBy,
         internal,
         // The sidebar and every other full-list consumer narrow the task before use
-        // and never read its description, so drop that body from the list payload.
-        includeDescription: false,
+        // and never read its description, so ask for the basic payload without it.
+        basic: true,
       }) as unknown as Promise<Task[]>,
     {
       enabled: (options?.enabled ?? true) && !!currentUser?.id,
@@ -80,8 +80,8 @@ export function useSlackTasks(options?: {
       client.getTasks({
         originProduct: "slack",
         internal,
-        // Only slack origin/thread fields are read off these rows; drop the description body.
-        includeDescription: false,
+        // Only slack origin/thread fields are read off these rows; ask for the basic payload.
+        basic: true,
       }) as unknown as Promise<Task[]>,
     {
       enabled: options?.enabled ?? true,


### PR DESCRIPTION
## Problem

A person opening the inbox on a task-heavy project waits while the task list transfers every task's full description body. The sidebar, command center, and the other full-list consumers narrow each task before use and never read its description, so that text is downloaded and thrown away on the first load.

## Changes

- The full-list task hook and the slack-list hook now request `basic=true`, so the server returns a summary payload without the description body.
- Detail views are unaffected: a single task still carries its description through the single-task endpoint.
- Mechanical: a new `basic` option on the API client maps to the `basic` query param.

Nothing looks different; the sidebar already narrowed the description away before rendering.

## How did you test this code?

- Extended the api-client task-list filter test: `basic: true` sends `basic=true`, and the param is absent by default or when false. This guards the opt-out silently reverting to full payloads.
- `vitest` (6 cases), `tsc --noEmit` on `@posthog/api-client` and `@posthog/ui`, and Biome all pass.
- Safe against an older backend: `basic` is an unknown query key there, which the endpoint ignores, so the response is unchanged until the backend ships the param.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Desktop). Invoked the `/writing-tests` skill. Confirmed no full-list consumer reads `task.description` (the sidebar narrows it away in `narrowFullTask`), so asking every full-list fetch for the basic payload is safe. Pairs with the backend param [#96642](https://github.com/PostHog/posthog/pull/96642); this can ship in any order since an older backend ignores the unknown param.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
