### PR TITLE
feat(flags): push coverage stats for the flag definitions cache

### DIFF
--- a/products/feature_flags/backend/tasks.py
+++ b/products/feature_flags/backend/tasks.py
@@ -16,7 +16,10 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.api.capture import capture_batch_internal
 from posthog.models.team import Team
 from posthog.scoping_audit import skip_team_scope_audit
-from posthog.storage.hypercache_manager import HYPERCACHE_SIGNAL_UPDATE_COUNTER
+from posthog.storage.hypercache_manager import (
+    HYPERCACHE_SIGNAL_UPDATE_COUNTER,
+    get_cache_stats as get_cache_stats_generic,
+)
 from posthog.tasks.utils import CeleryQueue, PushGatewayTask
 
 from products.feature_flags.backend.canary import run_local_eval_canary
@@ -489,11 +492,18 @@ def refresh_expiring_flag_definitions_cache_entries(self: PushGatewayTask) -> No
     successful_gauge.set(counts.successful)
     failed_gauge.set(counts.failed)
 
+    # Scan after refresh for metrics (pushes to Pushgateway via get_cache_stats)
+    stats_after = get_cache_stats_generic(FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG)
+
     duration = time.time() - start_time
     logger.info(
         "Completed flag definitions cache refresh",
         successful_refreshes=counts.successful,
         failed_refreshes=counts.failed,
+        total_cached=stats_after.get("total_cached", 0),
+        total_teams=stats_after.get("total_teams", 0),
+        cache_coverage=stats_after.get("cache_coverage", "unknown"),
+        ttl_distribution=stats_after.get("ttl_distribution", {}),
         duration_seconds=duration,
     )
 

--- a/products/feature_flags/backend/test/test_flag_definitions_cache_tasks.py
+++ b/products/feature_flags/backend/test/test_flag_definitions_cache_tasks.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from posthog.storage.cache_expiry_manager import CacheRefreshCounts
 from posthog.tasks.test.utils import PushGatewayTaskTestMixin
 
+from products.feature_flags.backend.local_evaluation import FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG
 from products.feature_flags.backend.tasks import (
     cleanup_stale_flag_definitions_expiry_tracking_task,
     refresh_expiring_flag_definitions_cache_entries,
@@ -12,8 +13,9 @@ from products.feature_flags.backend.tasks import (
 
 
 class TestRefreshExpiringFlagDefinitionsCacheEntries(PushGatewayTaskTestMixin, TestCase):
+    @patch("products.feature_flags.backend.tasks.get_cache_stats_generic", return_value={})
     @patch("posthog.storage.cache_expiry_manager.refresh_expiring_caches")
-    def test_refreshes_cache(self, mock_refresh: MagicMock) -> None:
+    def test_refreshes_cache(self, mock_refresh: MagicMock, mock_stats: MagicMock) -> None:
         mock_refresh.return_value = CacheRefreshCounts(successful=5, failed=0)
 
         refresh_expiring_flag_definitions_cache_entries()
@@ -21,6 +23,7 @@ class TestRefreshExpiringFlagDefinitionsCacheEntries(PushGatewayTaskTestMixin, T
         mock_refresh.assert_called_once()
         assert self.registry.get_sample_value("posthog_flag_definitions_cache_refresh_successful_count") == 5
         assert self.registry.get_sample_value("posthog_flag_definitions_cache_refresh_failed_count") == 0
+        mock_stats.assert_called_once_with(FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG)
 
     @patch("posthog.storage.cache_expiry_manager.refresh_expiring_caches")
     def test_propagates_error(self, mock_refresh: MagicMock) -> None:


### PR DESCRIPTION
## Problem

Nobody can see how much of the flag definitions cache is populated without running a management command and reading its stdout.

- The coverage series does not exist. `posthog_hypercache_coverage_percent{cache_name="flag_definitions"}` returns nothing, while `cache_name="flags"` returns a series.
- The hourly definitions refresh task never calls `get_cache_stats`. The sibling flags task does.
- The flag definitions cache cutover needs this number to check that a backfill reached every team.

## Changes

- Grafana can now chart coverage, entry count, and expiry-tracked count for the flag definitions cache, refreshed hourly.
- The task calls the generic `get_cache_stats` with `FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG`, which already carries `cache_name="flag_definitions"`.
- The scan follows the cache's configured Redis, so it measures the dedicated cluster where that alias is set.
- The completion log gains the four fields the flags task already logs. That part is mechanical.
- Cost: one hourly `SCAN` plus a sampled `MEMORY USAGE` pass. The flags cache runs the identical pass on the same cluster 20 minutes earlier, at :15 against this task's :35.

> [!NOTE]
> The coverage percent divides cached entries by every team, and only teams that have had a flag are cached. The number therefore reads low. The arithmetic is right and the panel is easy to misread. Presentation is a separate change.

## How did you test this code?

- Extended `test_refreshes_cache` in `products/feature_flags/backend/test/test_flag_definitions_cache_tasks.py` to assert the task calls `get_cache_stats` with the definitions config.
- The regression it catches: passing the flags config instead. That labels the series `flags` and double-counts the flags cache under a name that looks right.
- No existing test covered the flags task's equivalent push, so there was no closer test to extend.
- Not checked: the series itself. Confirm after deploy by querying `posthog_hypercache_coverage_percent{cache_name="flag_definitions"}`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior, API, or config changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5) wrote the change from a written brief and a subplan.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `review-code --fix`, `simplify`.
- `review-code --fix` and `simplify` ran nine agents and applied no fixes. Two suggestions were declined: a zero-arg `get_cache_stats()` wrapper in `local_evaluation.py`, which the spec ruled out, and an import alias rename, where the current spelling matches three other cache modules.
- Follow-up, not introduced here: `get_cache_stats` swallows exceptions and returns an error dict, so all five callers log "Completed" on a failed scan and drop the error string.
- No duplicate: `gh pr list --state open --search "flag definitions cache stats coverage"` found nothing covering this.
- Patch coverage: the extended test covers both changed production lines.
- Public artifact: the work drew on an internal plan. Nothing from it reached the diff or this description.
