### PR TITLE
fix(desktop): stop the CI paths filter skipping runtime markdown

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -52,10 +52,14 @@ jobs:
                   predicate-quantifier: every
                   filters: |
                       # Wider excludes than desktop-quality.yml, which keeps .vscode and
-                      # .claude in scope because Biome lints them.
+                      # .claude in scope because Biome lints them. Only documentation
+                      # markdown is excluded: the app loads markdown under src/ at runtime.
                       code:
                         - "products/desktop/**"
-                        - "!products/desktop/**/*.md"
+                        - "!products/desktop/*.md"
+                        - "!products/desktop/**/README.md"
+                        - "!products/desktop/**/AGENTS.md"
+                        - "!products/desktop/**/CLAUDE.md"
                         - "!products/desktop/docs/**"
                         - "!products/desktop/.vscode/**"
                         - "!products/desktop/.claude/**"

--- a/.github/workflows/desktop-quality.yml
+++ b/.github/workflows/desktop-quality.yml
@@ -46,11 +46,14 @@ jobs:
                   token: ${{ steps.app-token.outputs.token || github.token }}
                   predicate-quantifier: every
                   filters: |
-                      # Biome lints tracked JSON in .vscode/.claude, so only workflow
-                      # YAML and prose are ignored.
+                      # Biome lints tracked JSON in .vscode/.claude, so only workflow YAML and
+                      # documentation markdown are ignored: the app loads markdown under src/ at runtime.
                       code:
                         - "products/desktop/**"
-                        - "!products/desktop/**/*.md"
+                        - "!products/desktop/*.md"
+                        - "!products/desktop/**/README.md"
+                        - "!products/desktop/**/AGENTS.md"
+                        - "!products/desktop/**/CLAUDE.md"
                         - "!products/desktop/docs/**"
                         - "!products/desktop/.husky/**"
                         - "!products/desktop/LICENSE"

--- a/.github/workflows/desktop-test.yml
+++ b/.github/workflows/desktop-test.yml
@@ -60,10 +60,14 @@ jobs:
                   predicate-quantifier: every
                   filters: |
                       # Wider excludes than desktop-quality.yml, which keeps .vscode and
-                      # .claude in scope because Biome lints them.
+                      # .claude in scope because Biome lints them. Only documentation
+                      # markdown is excluded: the app loads markdown under src/ at runtime.
                       code:
                         - "products/desktop/**"
-                        - "!products/desktop/**/*.md"
+                        - "!products/desktop/*.md"
+                        - "!products/desktop/**/README.md"
+                        - "!products/desktop/**/AGENTS.md"
+                        - "!products/desktop/**/CLAUDE.md"
                         - "!products/desktop/docs/**"
                         - "!products/desktop/.vscode/**"
                         - "!products/desktop/.claude/**"

--- a/.github/workflows/desktop-typecheck.yml
+++ b/.github/workflows/desktop-typecheck.yml
@@ -52,10 +52,14 @@ jobs:
                   predicate-quantifier: every
                   filters: |
                       # Wider excludes than desktop-quality.yml, which keeps .vscode and
-                      # .claude in scope because Biome lints them.
+                      # .claude in scope because Biome lints them. Only documentation
+                      # markdown is excluded: the app loads markdown under src/ at runtime.
                       code:
                         - "products/desktop/**"
-                        - "!products/desktop/**/*.md"
+                        - "!products/desktop/*.md"
+                        - "!products/desktop/**/README.md"
+                        - "!products/desktop/**/AGENTS.md"
+                        - "!products/desktop/**/CLAUDE.md"
                         - "!products/desktop/docs/**"
                         - "!products/desktop/.vscode/**"
                         - "!products/desktop/.claude/**"


### PR DESCRIPTION
## Problem

- A desktop PR that only edits markdown the app loads at runtime merges with every desktop suite skipped.
- The four desktop suites share a paths filter that excludes every `.md` under `products/desktop/`.
- The harness reads `bundled-agents/*.md`, several `SKILL.md` files and the canvas templates from `src/` at runtime.
- #96406 changed only the three bundled agent files, reported green with zero jobs run, and broke master.

## Changes

- A PR that edits markdown under `src/` now runs build, quality, typecheck and test.
- The filter excludes only documentation: top-level markdown, `README.md`, `AGENTS.md`, `CLAUDE.md` and `docs/`.
- The same four lines replace the one exclusion in all four workflows. Mechanical.

Bottom layer of a stack. #96677 gates the release tag on master CI and #96679 moves the Electron e2e suite to Linux.

Follow-up, out of scope here: the four workflows carry the same `changes` job and filter list. A shared composite action would leave one copy to edit.

## How did you test this code?

- `hogli lint:workflows` and `actionlint` pass locally.
- Not run: the workflows themselves. This PR's own run only proves the filter still parses. The regression it prevents is a markdown-only PR skipping the suites, which CI on this PR cannot show.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1 orchestrating, Opus subagent implementing). Skills invoked: /stacking-prs, /authoring-ci-workflows, /writing-code-comments, /writing-pr-descriptions, /simplify. Found while tracing why #96406 merged red. No open PR fixes the filter; #96427 fixed the tests it broke. Nothing in this PR comes from outside the repository and the public GitHub history.

https://claude.ai/code/session_01AAfrGhk4pdw6Y4X5pEnb9f
