### PR TITLE
fix(desktop): gate the release tag on master Desktop Tests

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -240,15 +240,18 @@ jobs:
                     echo "OK: codex-acp/$f"
                   done
 
-            - name: Install Rosetta for the x64 smoke test
+            - name: Install Rosetta for the x64 e2e run
               if: matrix.arch == 'x64'
               run: pgrep -xq oahd || sudo softwareupdate --install-rosetta --agree-to-license
 
-            - name: Smoke test packaged app
+            # The PR gate runs the Electron suite on Linux, so this is the only macOS
+            # run left in the pipeline. It carries the boot and IPC coverage for the
+            # signed build, so it runs the whole suite instead of the smoke spec.
+            - name: Run the Electron e2e suite against the packaged app
               env:
                   CI: true
                   E2E_APP_ARCH: ${{ matrix.arch }}
-              run: pnpm --filter code exec playwright test --config=tests/e2e/playwright.config.ts tests/e2e/tests/smoke.spec.ts
+              run: pnpm --filter code exec playwright test --config=tests/e2e/playwright.config.ts
 
             - name: Upload Playwright report
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/desktop-tag.yml
+++ b/.github/workflows/desktop-tag.yml
@@ -34,6 +34,7 @@ jobs:
         permissions:
             contents: write
             actions: write
+            checks: read
             pull-requests: write
             issues: write
         runs-on: depot-ubuntu-24.04
@@ -125,9 +126,9 @@ jobs:
                   gh workflow run desktop-tag.yml -f quiet_retries="$NEXT"
                   echo "proceed=false" >> "$GITHUB_OUTPUT"
 
-            # A release is cut from master, and the merge queue does not run the desktop
-            # suites on its batches, so the master push run is the only signal that the
-            # tree being tagged still boots.
+            # A release is cut from master. The merge queue tests a batch branch, not the
+            # master commit, so the master push run is the only per-commit signal that
+            # the tree being tagged still boots.
             - name: Find the last desktop commit
               id: desktop-head
               if: steps.quiet.outputs.proceed != 'false' && steps.labeler.outputs.authorized != 'false' && github.event.inputs.ignore_master_ci != 'true'

--- a/.github/workflows/desktop-tag.yml
+++ b/.github/workflows/desktop-tag.yml
@@ -38,7 +38,7 @@ jobs:
             pull-requests: write
             issues: write
         runs-on: depot-ubuntu-24.04
-        timeout-minutes: 45
+        timeout-minutes: 60
         steps:
             - name: Get app token
               id: app-token
@@ -126,65 +126,83 @@ jobs:
                   gh workflow run desktop-tag.yml -f quiet_retries="$NEXT"
                   echo "proceed=false" >> "$GITHUB_OUTPUT"
 
-            # A release is cut from master. The merge queue tests a batch branch, not the
-            # master commit, so the master push run is the only per-commit signal that
-            # the tree being tagged still boots.
-            - name: Find the last desktop commit
-              id: desktop-head
+            # A release is cut from master, and nothing tests a master commit on push, so
+            # the tag job runs Desktop Tests on the tree it is about to tag and waits.
+            - name: Run Desktop Tests on master
+              id: master-ci-run
               if: steps.quiet.outputs.proceed != 'false' && steps.labeler.outputs.authorized != 'false' && github.event.inputs.ignore_master_ci != 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
               run: |
-                  # Scoped to products/desktop/: master carries commits from every product,
-                  # and only a desktop commit dispatches the desktop push run.
-                  echo "sha=$(git log -1 --format=%H HEAD -- products/desktop/)" >> "$GITHUB_OUTPUT"
+                  DISPATCHED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+                  gh workflow run desktop-test.yml --ref master
+                  # The run appears a few seconds after the dispatch call returns.
+                  RUN=""
+                  for _ in $(seq 1 12); do
+                    sleep 5
+                    RUN=$(gh run list --workflow desktop-test.yml --event workflow_dispatch --branch master --limit 5 \
+                      --json databaseId,headSha,createdAt \
+                      --jq "[.[] | select(.createdAt >= \"$DISPATCHED_AT\")] | first | select(. != null) | \"\(.databaseId) \(.headSha)\"")
+                    [ -n "$RUN" ] && break
+                  done
+                  if [ -z "$RUN" ]; then
+                    echo "::warning::Desktop Tests did not start on master, so the release tag is held."
+                    echo "proceed=false" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+                  echo "run_id=${RUN%% *}" >> "$GITHUB_OUTPUT"
+                  echo "sha=${RUN##* }" >> "$GITHUB_OUTPUT"
+                  echo "proceed=true" >> "$GITHUB_OUTPUT"
 
-            - name: Wait for Desktop Tests on the last desktop commit
+            - name: Wait for Desktop Tests
               id: master-ci
-              if: steps.desktop-head.outputs.sha != ''
+              if: steps.master-ci-run.outputs.sha != ''
               uses: ./.github/actions/wait-for-check
               with:
                   token: ${{ github.token }}
                   checkName: Desktop Tests Pass
-                  ref: ${{ steps.desktop-head.outputs.sha }}
-                  # The push run takes about ten minutes when runners are free. The wait
-                  # plus the quiet period stays inside the job timeout.
-                  timeoutSeconds: '1200'
+                  ref: ${{ steps.master-ci-run.outputs.sha }}
+                  # The Linux suite finishes in about fifteen minutes. The wait plus the
+                  # quiet period stays inside the job timeout.
+                  timeoutSeconds: '1500'
                   intervalSeconds: '30'
 
             - name: Hold the tag unless Desktop Tests passed
               id: master-ci-verdict
-              if: steps.desktop-head.outputs.sha != ''
+              if: steps.master-ci-run.outputs.sha != ''
               env:
                   CONCLUSION: ${{ steps.master-ci.outputs.conclusion }}
-                  SHA: ${{ steps.desktop-head.outputs.sha }}
+                  SHA: ${{ steps.master-ci-run.outputs.sha }}
+                  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.master-ci-run.outputs.run_id }}
                   EVENT_NAME: ${{ github.event_name }}
                   COMMENT_TOKEN: ${{ github.token }}
                   REPOSITORY: ${{ github.repository }}
                   PR_NUMBER: ${{ github.event.pull_request.number }}
               run: |
                   if [ "$CONCLUSION" = "success" ]; then
-                    echo "Desktop Tests passed on ${SHA}."
+                    echo "Desktop Tests passed on ${SHA}: ${RUN_URL}"
                     echo "proceed=true" >> "$GITHUB_OUTPUT"
                     exit 0
                   fi
 
                   echo "proceed=false" >> "$GITHUB_OUTPUT"
                   if [ "$CONCLUSION" = "timed_out" ]; then
-                    echo "Desktop Tests has not completed on ${SHA}. The next scheduled run picks it up."
+                    echo "Desktop Tests has not completed on ${SHA}. The next scheduled run picks it up. ${RUN_URL}"
                     exit 0
                   fi
 
-                  CHECKS_URL="${GITHUB_SERVER_URL}/${REPOSITORY}/commit/${SHA}/checks"
-                  echo "::warning::Desktop Tests concluded '${CONCLUSION}' on ${SHA}, so the release tag is held. ${CHECKS_URL}"
+                  echo "::warning::Desktop Tests concluded '${CONCLUSION}' on ${SHA}, so the release tag is held. ${RUN_URL}"
                   if [ "$EVENT_NAME" = "pull_request" ]; then
                     GH_TOKEN="$COMMENT_TOKEN" gh pr comment "$PR_NUMBER" --repo "$REPOSITORY" \
-                      --body "Auto-release is on hold: Desktop Tests concluded \`${CONCLUSION}\` on master (${CHECKS_URL}). It ships with the next scheduled release once master is green." || true
+                      --body "Auto-release is on hold: Desktop Tests concluded \`${CONCLUSION}\` on master (${RUN_URL}). It ships with the next scheduled release once master is green." || true
                   fi
 
             - name: Compute version and create tag
-              if: steps.quiet.outputs.proceed != 'false' && steps.labeler.outputs.authorized != 'false' && steps.master-ci-verdict.outputs.proceed != 'false'
+              if: steps.quiet.outputs.proceed != 'false' && steps.labeler.outputs.authorized != 'false' && steps.master-ci-run.outputs.proceed != 'false' && steps.master-ci-verdict.outputs.proceed != 'false'
               env:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
                   REPOSITORY: ${{ github.repository }}
+                  TESTED_SHA: ${{ steps.master-ci-run.outputs.sha }}
               run: |
                   LATEST_TAG=$(git tag --list 'desktop-v[0-9]*.[0-9]*' --sort=-v:refname | grep -E '^desktop-v[0-9]+\.[0-9]+(\.0)?$' | head -1 || true)
 
@@ -193,13 +211,20 @@ jobs:
                     exit 1
                   fi
 
+                  # The tag points at the commit the suite ran on, which can be newer than
+                  # this checkout, so fetch master before the commit is used.
+                  if [ -n "$TESTED_SHA" ]; then
+                    git fetch --no-tags origin master
+                  fi
+                  TARGET="${TESTED_SHA:-HEAD}"
+
                   VERSION_PART=${LATEST_TAG#desktop-v}
                   MAJOR=$(echo "$VERSION_PART" | cut -d. -f1)
                   MINOR=$(echo "$VERSION_PART" | cut -d. -f2)
 
                   # Scoped to products/desktop/: an unscoped count would include every PostHog
                   # commit and inflate patch numbers meaninglessly.
-                  PATCH=$(git rev-list "$LATEST_TAG"..HEAD --count -- products/desktop/)
+                  PATCH=$(git rev-list "$LATEST_TAG".."$TARGET" --count -- products/desktop/)
 
                   if [ "$PATCH" -eq 0 ]; then
                     echo "No desktop commits since $LATEST_TAG. Nothing to release."
@@ -217,5 +242,5 @@ jobs:
 
                   git config user.email "github-actions[bot]@users.noreply.github.com"
                   git config user.name "github-actions[bot]"
-                  git tag -a "$TAG" -m "Release $TAG"
+                  git tag -a "$TAG" -m "Release $TAG" "$TARGET"
                   git push "https://x-access-token:${GH_TOKEN}@github.com/$REPOSITORY" "$TAG"

--- a/.github/workflows/desktop-tag.yml
+++ b/.github/workflows/desktop-tag.yml
@@ -8,6 +8,10 @@ on:
             quiet_retries:
                 type: number
                 default: 0
+            ignore_master_ci:
+                description: Skip the master Desktop Tests check, for a break-glass release.
+                type: boolean
+                default: false
     pull_request:
         types: [closed]
         branches:
@@ -33,7 +37,7 @@ jobs:
             pull-requests: write
             issues: write
         runs-on: depot-ubuntu-24.04
-        timeout-minutes: 30
+        timeout-minutes: 45
         steps:
             - name: Get app token
               id: app-token
@@ -121,8 +125,62 @@ jobs:
                   gh workflow run desktop-tag.yml -f quiet_retries="$NEXT"
                   echo "proceed=false" >> "$GITHUB_OUTPUT"
 
+            # A release is cut from master, and the merge queue does not run the desktop
+            # suites on its batches, so the master push run is the only signal that the
+            # tree being tagged still boots.
+            - name: Find the last desktop commit
+              id: desktop-head
+              if: steps.quiet.outputs.proceed != 'false' && steps.labeler.outputs.authorized != 'false' && github.event.inputs.ignore_master_ci != 'true'
+              run: |
+                  # Scoped to products/desktop/: master carries commits from every product,
+                  # and only a desktop commit dispatches the desktop push run.
+                  echo "sha=$(git log -1 --format=%H HEAD -- products/desktop/)" >> "$GITHUB_OUTPUT"
+
+            - name: Wait for Desktop Tests on the last desktop commit
+              id: master-ci
+              if: steps.desktop-head.outputs.sha != ''
+              uses: ./.github/actions/wait-for-check
+              with:
+                  token: ${{ github.token }}
+                  checkName: Desktop Tests Pass
+                  ref: ${{ steps.desktop-head.outputs.sha }}
+                  # The push run takes about ten minutes when runners are free. The wait
+                  # plus the quiet period stays inside the job timeout.
+                  timeoutSeconds: '1200'
+                  intervalSeconds: '30'
+
+            - name: Hold the tag unless Desktop Tests passed
+              id: master-ci-verdict
+              if: steps.desktop-head.outputs.sha != ''
+              env:
+                  CONCLUSION: ${{ steps.master-ci.outputs.conclusion }}
+                  SHA: ${{ steps.desktop-head.outputs.sha }}
+                  EVENT_NAME: ${{ github.event_name }}
+                  COMMENT_TOKEN: ${{ github.token }}
+                  REPOSITORY: ${{ github.repository }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+              run: |
+                  if [ "$CONCLUSION" = "success" ]; then
+                    echo "Desktop Tests passed on ${SHA}."
+                    echo "proceed=true" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+
+                  echo "proceed=false" >> "$GITHUB_OUTPUT"
+                  if [ "$CONCLUSION" = "timed_out" ]; then
+                    echo "Desktop Tests has not completed on ${SHA}. The next scheduled run picks it up."
+                    exit 0
+                  fi
+
+                  CHECKS_URL="${GITHUB_SERVER_URL}/${REPOSITORY}/commit/${SHA}/checks"
+                  echo "::warning::Desktop Tests concluded '${CONCLUSION}' on ${SHA}, so the release tag is held. ${CHECKS_URL}"
+                  if [ "$EVENT_NAME" = "pull_request" ]; then
+                    GH_TOKEN="$COMMENT_TOKEN" gh pr comment "$PR_NUMBER" --repo "$REPOSITORY" \
+                      --body "Auto-release is on hold: Desktop Tests concluded \`${CONCLUSION}\` on master (${CHECKS_URL}). It ships with the next scheduled release once master is green." || true
+                  fi
+
             - name: Compute version and create tag
-              if: steps.quiet.outputs.proceed != 'false' && steps.labeler.outputs.authorized != 'false'
+              if: steps.quiet.outputs.proceed != 'false' && steps.labeler.outputs.authorized != 'false' && steps.master-ci-verdict.outputs.proceed != 'false'
               env:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
                   REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/desktop-test.yml
+++ b/.github/workflows/desktop-test.yml
@@ -19,6 +19,8 @@ on:
     # run clear of desktop-update-e2e.yml, the other daily job on that pool, at 07:00.
     schedule:
         - cron: '3 5 * * *'
+    # desktop-tag.yml dispatches this workflow on the tree it is about to tag.
+    workflow_dispatch:
 
 concurrency:
     group: desktop-test-${{ github.head_ref || github.ref }}

--- a/products/desktop/docs/UPDATES.md
+++ b/products/desktop/docs/UPDATES.md
@@ -31,7 +31,7 @@ Remote announcements can drive this flow: a `required-update` announcement block
 
 1. A base tag like `desktop-v0.15` marks the start of a minor version.
 2. `.github/workflows/desktop-tag.yml` (monorepo root) runs on a twice-daily schedule. It computes `desktop-vX.Y.PATCH`, where PATCH is the number of commits since the base tag that touched `products/desktop/`, waits for a quiet period, then pushes the tag.
-3. It also refuses to tag while the `Desktop Tests Pass` check on master is missing, still running, or failed for the last commit that touched `products/desktop/`. While that check is still running it waits up to twenty minutes and then leaves the release to the next scheduled run. A manual dispatch with `ignore_master_ci` skips the check, for a break-glass release.
+3. Before it tags, it runs `Desktop Tests` on master and tags the commit that run tested. It refuses to tag if that run fails. If the run has not finished within twenty-five minutes, it leaves the release to the next scheduled run. A manual dispatch with `ignore_master_ci` skips the check, for a break-glass release.
 4. The tag push triggers `desktop-release.yml`, which builds and publishes the release.
 5. No manual `package.json` updates are needed.
 

--- a/products/desktop/docs/UPDATES.md
+++ b/products/desktop/docs/UPDATES.md
@@ -31,8 +31,9 @@ Remote announcements can drive this flow: a `required-update` announcement block
 
 1. A base tag like `desktop-v0.15` marks the start of a minor version.
 2. `.github/workflows/desktop-tag.yml` (monorepo root) runs on a twice-daily schedule. It computes `desktop-vX.Y.PATCH`, where PATCH is the number of commits since the base tag that touched `products/desktop/`, waits for a quiet period, then pushes the tag.
-3. The tag push triggers `desktop-release.yml`, which builds and publishes the release.
-4. No manual `package.json` updates are needed.
+3. It also refuses to tag while the `Desktop Tests Pass` check on master is missing, still running, or failed for the last commit that touched `products/desktop/`. While that check is still running it waits up to twenty minutes and then leaves the release to the next scheduled run. A manual dispatch with `ignore_master_ci` skips the check, for a break-glass release.
+4. The tag push triggers `desktop-release.yml`, which builds and publishes the release.
+5. No manual `package.json` updates are needed.
 
 ## Releasing a patch
 


### PR DESCRIPTION
## Problem

- Desktop users can receive a release cut from a master commit whose Desktop Tests failed.
- `desktop-tag.yml` tags master twice a day after a quiet period and never reads a CI result.
- On 2026-09-08 master went red at 10:06 and the 17:00 tag would have shipped it if #96427 had not landed first.
- The release job verifies the signed macOS build with the four-assertion smoke spec only.

## Changes

- The tag job now runs Desktop Tests on master, waits for that run through the shared `wait-for-check` action, and tags the commit it tested.
- A failed run holds the release. A run that has not finished within twenty-five minutes leaves the release to the next schedule.
- Master no longer runs Desktop Tests on push since #96633, so an on-demand run is the only per-release signal. It is Linux only after #96679 and adds about fifteen minutes to a release.
- A held label-triggered release comments on the merged PR with the failed run.
- A manual dispatch with `ignore_master_ci` skips the check, for a break-glass release.
- The release job runs the whole Electron e2e suite against the signed build instead of the smoke spec.
- The suite adds about a minute on a runner the job already holds, so it costs no extra macOS allocation.
- The docs list the new hold and the break-glass input.

> [!NOTE]
> Trunk lanes merge in parallel, so the master tree can differ from any batch the queue tested. This run is the only test of the exact tree that ships.

## How did you test this code?

- `hogli lint:workflows`, `actionlint` and `shellcheck` on the new step pass locally.
- The check-run lookup is the shared `wait-for-check` action, already used by `ci-hobby.yml`.
- Not run: the tag workflow itself. It only fires on schedule, on a labeled merge, or on manual dispatch against master.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/desktop/docs/UPDATES.md` describes the hold and the break-glass input.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1 orchestrating, Opus subagent implementing). Skills invoked: /stacking-prs, /authoring-ci-workflows, /writing-code-comments, /writing-pr-descriptions, /simplify. Middle layer of a stack on the paths filter fix. First design waited for the master push run of Desktop Tests. #96633 removed that push run while this PR was in review, so the job now dispatches the workflow itself. A hand-rolled poll was replaced by the existing `wait-for-check` action in the simplify pass.

https://claude.ai/code/session_01AAfrGhk4pdw6Y4X5pEnb9f

