### PR TITLE
chore(clickhouse): bump hclexp to the v1.0.2 SQL parser

### DIFF
--- a/posthog/clickhouse/hcl/bin/image.txt
+++ b/posthog/clickhouse/hcl/bin/image.txt
@@ -1,1 +1,1 @@
-ghcr.io/posthog/chschema:sha-171d6fe
+ghcr.io/posthog/chschema:sha-9d9192f


### PR DESCRIPTION
## Problem

The pinned hclexp build decides how every golden in this directory is canonicalized, so a change to its SQL parser can rewrite them without anyone changing a layer.

- `bin/image.txt` pins the build that `check.sh` runs in CI and that `gen-golden.sh` writes goldens with.
- chschema PostHog/chschema#249 moves `clickhouse-sql-parser` from v1.0.1 to v1.0.2. It is a dependency bump with no intended behavior change.
- A parser that formats one expression differently would move the goldens, and the gate would fail on every unrelated PR until someone regenerated them.

## Changes

- The pin moves to `sha-9d9192f`. Nothing else changes: no layer, golden, or sql file moves.
- The parser rewrites nothing. Regenerating every golden and sql file under the new pin leaves all 70 byte-identical to the committed ones.

## How did you test this code?

- `check.sh` passes under the new pin: five envs validate, 34 compositions match their committed goldens, duplicates match the baseline of 2, sql is fresh.
- `gen-golden.sh` and `gen-sql.sh` were rerun under the new pin and produced no diff at all, which is the check that would catch a canonicalization change.
- Reconcile against the node dumps in PostHog/clickhouse-schema is unchanged at 32 / 29 / 12 operations for dev / prod-us / prod-eu, with 16 unsafe rows.
- `hogli ci:preflight --strict` reports 0 failures.
- Not run: `check-live.sh`, which needs a live ClickHouse.
- No new tests. The change is a one-line pin, gated by `check.sh` in CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The bump changes no documented behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code.

Stacked on #96339, which carries the schema work. This layer is only the pin, so it can land or be reverted on its own.

**Public artifact:** the diff is a single image tag. No hostnames, credentials, or customer identifiers.
