### PR TITLE
feat(approvals): copy feature flag policies to experiment policies

### DIFF
--- a/products/approvals/backend/migrations/0003_copy_feature_flag_policies_to_experiments.py
+++ b/products/approvals/backend/migrations/0003_copy_feature_flag_policies_to_experiments.py
@@ -1,0 +1,58 @@
+from django.db import migrations
+
+# Each feature flag action and the experiment action that will replace it once experiment-owned
+# flags leave `feature_flag.*` scope. Copying now, ahead of that change, keeps the 22 organizations
+# with policies at the coverage they have today.
+ACTION_MAP = {
+    "feature_flag.enable": "experiment.launch",
+    "feature_flag.disable": "experiment.pause",
+    "feature_flag.update": "experiment.update",
+}
+
+COPIED_FIELDS = (
+    "organization_id",
+    "team_id",
+    "conditions",
+    "approver_config",
+    "allow_self_approve",
+    "bypass_org_membership_levels",
+    "expires_after",
+    "enabled",
+    "created_by_id",
+)
+
+
+def copy_policies(apps, schema_editor):
+    ApprovalPolicy = apps.get_model("approvals", "ApprovalPolicy")
+
+    for source_action, target_action in ACTION_MAP.items():
+        for policy in ApprovalPolicy.objects.filter(action_key=source_action):
+            # A policy is scoped to a team, so copy per row rather than per organization.
+            if ApprovalPolicy.objects.filter(
+                action_key=target_action,
+                organization_id=policy.organization_id,
+                team_id=policy.team_id,
+            ).exists():
+                continue
+
+            copy = ApprovalPolicy.objects.create(
+                action_key=target_action,
+                **{field: getattr(policy, field) for field in COPIED_FIELDS},
+            )
+            # Dropping these would narrow who can bypass the copy relative to the source.
+            copy.bypass_roles.set(policy.bypass_roles.all())
+
+
+def remove_copied_policies(apps, schema_editor):
+    ApprovalPolicy = apps.get_model("approvals", "ApprovalPolicy")
+    ApprovalPolicy.objects.filter(action_key__in=ACTION_MAP.values()).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("approvals", "0002_alter_changerequest_validation_status"),
+    ]
+
+    operations = [
+        migrations.RunPython(copy_policies, remove_copied_policies),
+    ]

--- a/products/approvals/backend/migrations/0003_copy_feature_flag_policies_to_experiments.py
+++ b/products/approvals/backend/migrations/0003_copy_feature_flag_policies_to_experiments.py
@@ -1,8 +1,8 @@
 from django.db import migrations
 
 # Each feature flag action and the experiment action that will replace it once experiment-owned
-# flags leave `feature_flag.*` scope. Copying now, ahead of that change, keeps the 22 organizations
-# with policies at the coverage they have today.
+# flags leave `feature_flag.*` scope. Copying now, ahead of that change, keeps organizations with
+# existing policies at the coverage they have today.
 ACTION_MAP = {
     "feature_flag.enable": "experiment.launch",
     "feature_flag.disable": "experiment.pause",

--- a/products/approvals/backend/migrations/0003_copy_feature_flag_policies_to_experiments.py
+++ b/products/approvals/backend/migrations/0003_copy_feature_flag_policies_to_experiments.py
@@ -43,16 +43,15 @@ def copy_policies(apps, schema_editor):
             copy.bypass_roles.set(policy.bypass_roles.all())
 
 
-def remove_copied_policies(apps, schema_editor):
-    ApprovalPolicy = apps.get_model("approvals", "ApprovalPolicy")
-    ApprovalPolicy.objects.filter(action_key__in=ACTION_MAP.values()).delete()
-
-
 class Migration(migrations.Migration):
     dependencies = [
         ("approvals", "0002_alter_changerequest_validation_status"),
     ]
 
     operations = [
-        migrations.RunPython(copy_policies, remove_copied_policies),
+        # The reverse keeps the copies rather than deleting by target key. `action_key` is
+        # writable through the policy API, so such a delete would also remove a policy that
+        # already held the target key and was skipped, and any policy a person writes later.
+        # The copies are inert while the experiment actions are unregistered.
+        migrations.RunPython(copy_policies, migrations.RunPython.noop),
     ]

--- a/products/approvals/backend/migrations/max_migration.txt
+++ b/products/approvals/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0002_alter_changerequest_validation_status
+0003_copy_feature_flag_policies_to_experiments

--- a/products/approvals/backend/tests/test_copy_policies_migration.py
+++ b/products/approvals/backend/tests/test_copy_policies_migration.py
@@ -1,0 +1,93 @@
+import importlib
+from datetime import timedelta
+
+from posthog.test.base import APIBaseTest
+
+from parameterized import parameterized
+
+from posthog.models import Team
+
+from products.approvals.backend.models import ApprovalPolicy
+
+# Delete this once the migration has run everywhere and the rollback window has closed.
+MIGRATION = importlib.import_module(
+    "products.approvals.backend.migrations.0003_copy_feature_flag_policies_to_experiments"
+)
+
+
+class FakeApps:
+    def get_model(self, app_label: str, model_name: str) -> type[ApprovalPolicy]:
+        return ApprovalPolicy
+
+
+def run_migration() -> None:
+    MIGRATION.copy_policies(FakeApps(), None)
+
+
+class TestCopyFeatureFlagPoliciesToExperiments(APIBaseTest):
+    def _policy(self, action_key: str, *, team: Team | None = None, **overrides) -> ApprovalPolicy:
+        return ApprovalPolicy.objects.create(
+            organization=self.organization,
+            team=team if team is not None else self.team,
+            action_key=action_key,
+            conditions=overrides.pop("conditions", {}),
+            approver_config=overrides.pop("approver_config", {"quorum": 1, "users": [self.user.id]}),
+            created_by=self.user,
+            **overrides,
+        )
+
+    @parameterized.expand(
+        [
+            ("feature_flag.enable", "experiment.launch"),
+            ("feature_flag.disable", "experiment.pause"),
+            ("feature_flag.update", "experiment.update"),
+        ]
+    )
+    def test_each_flag_action_gets_its_experiment_action(self, source: str, target: str) -> None:
+        self._policy(source)
+
+        run_migration()
+
+        assert ApprovalPolicy.objects.filter(action_key=target, team=self.team).count() == 1
+
+    def test_copies_per_team_not_per_organization(self) -> None:
+        other_team = Team.objects.create(organization=self.organization, name="other")
+        self._policy("feature_flag.enable")
+        self._policy("feature_flag.enable", team=other_team)
+
+        run_migration()
+
+        copied_teams = set(
+            ApprovalPolicy.objects.filter(action_key="experiment.launch").values_list("team_id", flat=True)
+        )
+        assert copied_teams == {self.team.id, other_team.id}
+
+    def test_carries_the_whole_policy_across(self) -> None:
+        source = self._policy(
+            "feature_flag.update",
+            conditions={"type": "before_after", "field": "rollout_percentage", "operator": ">", "value": 0},
+            approver_config={"quorum": 2, "users": [self.user.id]},
+            allow_self_approve=True,
+            bypass_org_membership_levels=[15],
+            expires_after=timedelta(days=3),
+            enabled=False,
+        )
+
+        run_migration()
+
+        copy = ApprovalPolicy.objects.get(action_key="experiment.update", team=self.team)
+        for field in MIGRATION.COPIED_FIELDS:
+            assert getattr(copy, field) == getattr(source, field), field
+
+    def test_running_twice_creates_nothing_new(self) -> None:
+        self._policy("feature_flag.enable")
+
+        run_migration()
+        run_migration()
+
+        assert ApprovalPolicy.objects.filter(action_key="experiment.launch").count() == 1
+
+    def test_leaves_an_organization_without_policies_alone(self) -> None:
+        run_migration()
+
+        assert not ApprovalPolicy.objects.filter(action_key__startswith="experiment.").exists()

--- a/products/approvals/backend/tests/test_copy_policies_migration.py
+++ b/products/approvals/backend/tests/test_copy_policies_migration.py
@@ -7,6 +7,7 @@ from parameterized import parameterized
 
 from posthog.models import Team
 
+from products.access_control.backend.models.role import Role
 from products.approvals.backend.models import ApprovalPolicy
 
 # Delete this once the migration has run everywhere and the rollback window has closed.
@@ -63,6 +64,7 @@ class TestCopyFeatureFlagPoliciesToExperiments(APIBaseTest):
         assert copied_teams == {self.team.id, other_team.id}
 
     def test_carries_the_whole_policy_across(self) -> None:
+        role = Role.objects.create(organization=self.organization, name="Approvers")
         source = self._policy(
             "feature_flag.update",
             conditions={"type": "before_after", "field": "rollout_percentage", "operator": ">", "value": 0},
@@ -72,12 +74,15 @@ class TestCopyFeatureFlagPoliciesToExperiments(APIBaseTest):
             expires_after=timedelta(days=3),
             enabled=False,
         )
+        source.bypass_roles.set([role])
 
         run_migration()
 
         copy = ApprovalPolicy.objects.get(action_key="experiment.update", team=self.team)
         for field in MIGRATION.COPIED_FIELDS:
             assert getattr(copy, field) == getattr(source, field), field
+        # bypass_roles is a many-to-many, so the migration copies it outside COPIED_FIELDS.
+        assert list(copy.bypass_roles.all()) == [role]
 
     def test_running_twice_creates_nothing_new(self) -> None:
         self._policy("feature_flag.enable")


### PR DESCRIPTION
## Problem

Experiment-owned flags are about to leave `feature_flag.*` scope, so that a policy meant for feature rollouts stops gating experiment launches. Nothing else covers them yet, so on the day that lands the 22 organizations with approval policies lose coverage on roughly 60% of their flags with no notice.

This PR closes that gap ahead of time. It changes nothing a person can observe today.

## Changes

- Every existing approval policy gains its experiment equivalent, so coverage survives the later scope change.
- Nothing is gated differently yet. The new rows are inert until the actions are registered, which happens in a later PR.
- Mechanical: one reversible data migration and its tests. No schema change.

The mapping mirrors the three flag actions one for one:

| Flag action | Experiment action | What it covers |
| --- | --- | --- |
| `feature_flag.enable` | `experiment.launch` | launch, resume, and the PATCH path that launches by setting `start_date` |
| `feature_flag.disable` | `experiment.pause` | pause |
| `feature_flag.update` | `experiment.update` | a change to the variant split, and shipping a winning variant |

One action per flag action is what preserves current behavior. All 22 organizations gate `enable` but only 8 gate `update`, so collapsing to a single `experiment.*` action would hand the other 14 rollout gating they never asked for.

`end`, `archive`, `unarchive`, `reset` and `freeze_exposure` never touch `active` or `rollout_percentage`, so they stay ungated exactly as today. `set_flag_active` has four call sites, and they are launch, pause, resume, and the PATCH launch path.

**Why the rows are safe to land before enforcement.** `get_action` returns `Optional` and yields `None` for an unregistered key. `ApprovalPolicySerializer` exposes `action_key` as a plain field and never resolves the action class. `_resolve_actions` raises only for keys passed to `@approval_gate`.

> [!NOTE]
> Two details that decide correctness rather than style.
> Policies are scoped to a team, and 22 organizations hold 32 teams, so the copy runs per row. Copying per organization would drop the second team of any organization that has one.
> `bypass_roles` is a many-to-many, so copying only scalar fields would narrow who can bypass the copy relative to its source. Production has no rows in that table today, so this is defensive.

## How did you test this code?

7 tests in `test_copy_policies_migration.py`. Each names a way the migration could quietly give an organization the wrong coverage:

- one case per action, so a transposed mapping cannot pass
- two teams in one organization, which fails if the copy is written per organization
- whole-row fidelity across every copied field, so dropping one is caught
- running twice, which must add nothing
- an organization with no policies, which must stay untouched

They import the migration's function and run it against the real model. The repository has no migration-executor test pattern and this did not seem the place to invent one. Delete them once the migration has run in every environment and the rollback window has closed, per `/django-migrations`.

Ran locally: the full `products/approvals/backend/tests/` suite (276 tests), repo-wide `mypy`, and `hogli ci:preflight --strict` including the migration-conflict check. All clean.

Not run: anything outside `products/approvals`. No frontend files changed.

Production shape confirmed read-only before writing the migration: 26 policies in US, none organization-wide, no bypass-role rows.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5), directed throughout.

Second step of a larger design that scopes approval policies by the product owning a flag. The design doc lives outside this repository. The first step is #96578, which this does not depend on. Both branch from master and touch different files.

The action taxonomy was derived rather than chosen: the experiment UI verbs and the MCP tool names were compared, then narrowed to the ones that actually move the two fields policies gate. `experiment.update` covering both a split change and shipping a winner was a deliberate call, taken over splitting `ship_variant` into its own action, because it keeps the migration one to one.

Production Postgres was read through Metabase to size the affected population and confirm the policy shape. Only aggregate counts informed the work, and none appear in this diff.

Skills invoked: `/django-migrations`, `/writing-tests`, `/writing-pr-descriptions`.

https://claude.ai/code/session_01EvsnTBQkfd1NMU5uYx8XSQ
