### PR TITLE
chore(ai): cover queue and steering regression flows

### DIFF
--- a/docs/internal/posthog-ai-e2e.md
+++ b/docs/internal/posthog-ai-e2e.md
@@ -44,6 +44,19 @@ The successor asks the model to continue the old conversation before processing 
 Replay rejects that undeclared turn even when the eventual follow-up and history assertions pass.
 The test remains enabled so this regression blocks the AI check until corrected.
 
+The queue and steering layer adds the next five flows in `flows-queue-steering.spec.ts`:
+
+6. A queued follow-up waits for both approval confirmation and turn completion, in either order.
+7. Steer and Escape deliver the saved queue once while preserving a separate unsent draft.
+8. Steering requested during approval delivery waits for confirmation and clears its deferred action after failure.
+9. Failed queue delivery preserves message order and supports explicit retry, editing, removal, and fresh delivery.
+10. Escape with an empty saved queue cancels the active turn and preserves an unsent draft.
+
+An additional case within queue submission freezes the draft debounce and submits immediately.
+It reproduces queued text remaining in the composer after submission; this test also remains enabled.
+The other queue cases advance that debounce with the browser clock so they independently exercise their delivery transitions.
+These are browser interaction checks with held task commands, not real agent-delivery checks.
+
 The browser suite runs three cases for each of Claude and Codex:
 
 - Submit from the new-chat composer while a seeded warm workflow waits for registration, recover on the original run, send a follow-up, and reload without duplicate messages.

--- a/products/posthog_ai/frontend/e2e/flows-queue-steering.spec.ts
+++ b/products/posthog_ai/frontend/e2e/flows-queue-steering.spec.ts
@@ -1,0 +1,166 @@
+import { approval, expect, message, notification, test } from './runSurfaceTest'
+
+test.describe('Queues and steering', () => {
+    test('queue submission before the draft debounce clears the composer', async ({ page, surface }) => {
+        await surface.open()
+        await page.clock.pauseAt(new Date(Date.now() + 1_000))
+        await page.getByTestId('sandbox-composer-input').fill('Save this pasted direction once.')
+        await page.getByTestId('sandbox-composer-send').click()
+        await expect(page.getByText('Up next', { exact: true })).toBeVisible()
+        await expect(page.getByTestId('sandbox-composer-input')).toHaveValue('')
+        await expect(page.getByText('Save this pasted direction once.', { exact: true })).toHaveCount(1)
+        expect(surface.commands).toHaveLength(0)
+    })
+
+    for (const firstGate of ['approval', 'turn'] as const) {
+        test(`queued follow-up waits for both gates when ${firstGate} finishes first`, async ({ page, surface }) => {
+            await surface.open()
+            await surface.emit(approval())
+            await page.getByTestId('run-approval').getByText('Allow', { exact: true }).click()
+            const permission = await surface.command(0)
+            await surface.queue('Send this after the approved turn.')
+            await expect(page.getByRole('button', { name: 'Stop', exact: true })).toBeVisible()
+            await expect(page.getByTestId('run-approval')).toHaveCount(1)
+            const gates = {
+                approval: async () => {
+                    await permission.respond()
+                    await expect(page.getByTestId('run-approval')).toHaveCount(0)
+                },
+                turn: async () => {
+                    await surface.emit(notification('_posthog/turn_complete'))
+                    await expect(page.getByRole('button', { name: 'Stop', exact: true })).toBeHidden()
+                },
+            }
+            await gates[firstGate]()
+            await expect(page.getByText('Up next', { exact: true })).toBeVisible()
+            expect(surface.commands).toHaveLength(1)
+            await gates[firstGate === 'approval' ? 'turn' : 'approval']()
+            const followup = await surface.command(1)
+            expect(followup.body).toMatchObject({
+                method: 'user_message',
+                params: { content: 'Send this after the approved turn.' },
+            })
+            await followup.respond()
+            await surface.emit(message('The queued follow-up completed.'), notification('_posthog/turn_complete'))
+            await expect(page.getByText('The queued follow-up completed.', { exact: true })).toBeVisible()
+            await expect(page.getByText('Up next', { exact: true })).toBeHidden()
+            expect(surface.commands).toHaveLength(2)
+        })
+    }
+
+    for (const trigger of ['button', 'Escape'] as const) {
+        test(`${trigger} steers saved messages without sending the separate draft`, async ({ page, surface }) => {
+            await surface.open()
+            await surface.queue('First saved direction.')
+            await surface.queue('Second saved direction.')
+            await page.getByTestId('sandbox-composer-input').fill('This draft is not ready.')
+            const steer = {
+                button: () => page.getByTestId('run-queue-steer').click(),
+                Escape: () => page.getByTestId('sandbox-composer-input').press('Escape'),
+            }
+            await steer[trigger]()
+            const command = await surface.command(0)
+            expect(command.body).toMatchObject({
+                method: 'user_message',
+                params: { content: 'First saved direction.\n\nSecond saved direction.', steer: true },
+            })
+            await command.respond()
+            await surface.emit(message('The saved directions were received.'))
+            await expect(page.getByText('The saved directions were received.', { exact: true })).toBeVisible()
+            await expect(page.getByTestId('sandbox-composer-input')).toHaveValue('This draft is not ready.')
+            await expect(page.getByText('Up next', { exact: true })).toBeHidden()
+            expect(surface.commands).toHaveLength(1)
+        })
+    }
+
+    for (const outcome of ['confirmed', 'failed'] as const) {
+        test(`deferred steering handles ${outcome} approval delivery`, async ({ page, surface }) => {
+            await surface.open()
+            await surface.emit(approval())
+            await page.getByTestId('run-approval').getByText('Allow', { exact: true }).click()
+            const permission = await surface.command(0)
+            await surface.queue('Steer after approval confirmation.')
+            await page.getByTestId('run-queue-steer').click()
+            await expect(page.getByTestId('run-queue-steer')).toBeDisabled()
+            expect(surface.commands).toHaveLength(1)
+            const resolve = {
+                confirmed: async () => {
+                    await permission.respond()
+                    const steering = await surface.command(1)
+                    expect(steering.body).toMatchObject({
+                        method: 'user_message',
+                        params: { content: 'Steer after approval confirmation.', steer: true },
+                    })
+                    await steering.respond()
+                    await surface.emit(message('Deferred steering completed.'))
+                    await expect(page.getByText('Deferred steering completed.', { exact: true })).toBeVisible()
+                    await expect(page.getByText('Up next', { exact: true })).toBeHidden()
+                    expect(surface.commands).toHaveLength(2)
+                },
+                failed: async () => {
+                    await permission.respond({
+                        jsonrpc: '2.0',
+                        error: { code: -32000, message: 'Synthetic approval failure' },
+                    })
+                    await expect(page.getByTestId('run-approval')).toBeVisible()
+                    await page.getByTestId('run-approval').getByText('Allow', { exact: true }).click()
+                    await (await surface.command(1)).respond()
+                    await expect(page.getByTestId('run-approval')).toHaveCount(0)
+                    await expect(page.getByTestId('run-queue-steer')).toBeEnabled()
+                    await expect(page.getByText('Up next', { exact: true })).toBeVisible()
+                    expect(surface.commands).toHaveLength(2)
+                },
+            }
+            await resolve[outcome]()
+        })
+    }
+
+    test('failed queue delivery preserves order and supports explicit retry and editing', async ({ page, surface }) => {
+        await surface.open()
+        await surface.queue('Older saved direction.')
+        await page.getByTestId('run-queue-steer').click()
+        const failed = await surface.command(0)
+        await failed.respond({ jsonrpc: '2.0', error: { code: -32000, message: 'Synthetic send failure' } })
+        await expect(page.getByText('Up next', { exact: true })).toBeVisible()
+        await surface.queue('Newer saved direction.')
+        await page.getByTestId('run-queue-steer').click()
+        const retry = await surface.command(1)
+        expect(retry.body).toMatchObject({
+            params: { content: 'Older saved direction.\n\nNewer saved direction.', steer: true },
+        })
+        await retry.respond({ jsonrpc: '2.0', error: { code: -32000, message: 'Synthetic send failure' } })
+        await expect(page.getByText('Up next', { exact: true })).toBeVisible()
+        await page.getByText('Older saved direction.\n\nNewer saved direction.', { exact: true }).hover()
+        await page.getByRole('button', { name: 'Edit message', exact: true }).click()
+        const editor = page.getByTestId('run-queue-editor')
+        await editor.getByRole('textbox').fill('Edited saved direction.')
+        await editor.getByRole('button', { name: 'Save', exact: true }).click()
+        await expect(editor).toBeHidden()
+        await expect(page.getByText('Edited saved direction.', { exact: true })).toBeVisible()
+        await page.getByText('Edited saved direction.', { exact: true }).hover()
+        await page.getByRole('button', { name: 'Remove from queue', exact: true }).click()
+        await expect(page.getByText('Up next', { exact: true })).toBeHidden()
+        expect(surface.commands).toHaveLength(2)
+        await surface.queue('A fresh direction.')
+        await surface.emit(notification('_posthog/turn_complete'))
+        const fresh = await surface.command(2)
+        expect(fresh.body).toMatchObject({ params: { content: 'A fresh direction.' } })
+        await fresh.respond()
+        await surface.emit(message('The fresh direction completed.'), notification('_posthog/turn_complete'))
+        await expect(page.getByText('The fresh direction completed.', { exact: true })).toBeVisible()
+    })
+
+    test('Escape cancels an active turn when the saved queue is empty', async ({ page, surface }) => {
+        await surface.open()
+        await page.getByTestId('sandbox-composer-input').fill('Keep this unsent draft.')
+        await page.getByTestId('sandbox-composer-input').press('Escape')
+        const cancel = await surface.command(0)
+        expect(cancel.body).toMatchObject({ method: 'cancel' })
+        await expect(page.getByTestId('sandbox-composer-send')).toBeDisabled()
+        await cancel.respond()
+        await surface.emit(notification('_posthog/turn_complete'))
+        await expect(page.getByTestId('sandbox-composer-send')).toBeEnabled()
+        await expect(page.getByTestId('sandbox-composer-input')).toHaveValue('Keep this unsent draft.')
+        expect(surface.commands).toHaveLength(1)
+    })
+})


### PR DESCRIPTION
## Problem

Queued PostHog AI follow-ups can be lost, duplicated, or sent before an approval finishes unless the combined browser interactions stay covered.

## Changes

- Cover both approval/turn completion orders before queued delivery.
- Cover Steer and Escape preserving the separate composer draft.
- Cover deferred steering after successful and failed approval delivery.
- Cover failed queue ordering, explicit retry, editing, removal, and fresh delivery.
- Cover Escape cancellation when the saved queue is empty.

The tests use controlled task commands and stream events. Production behavior is unchanged.
Ordering cases observe the first gate's rendered result before releasing the second; approval retries wait for confirmed resolution.

## How did you test this code?

[Current browser CI](https://github.com/PostHog/posthog/actions/runs/34249565506/job/102141067011) passes every new controlled browser case with the frontend fixes from #96773.
The [current real-agent CI run](https://github.com/PostHog/posthog/actions/runs/34249565506/job/102140646936) fails only the warm-resume case in each provider.
Both retries reproduce the extra continuation turn; #96752 contains the separate fix.

The previous [CI browser run](https://github.com/PostHog/posthog/actions/runs/34244870158/job/102125355638) reproduces the fast-submit draft regression; every other selected case passes.
The previous [real-agent run](https://github.com/PostHog/posthog/actions/runs/34244870158/job/102124923067) reproduces the inherited warm-resume failure in both providers; all other cases pass.

The browser cases were run locally with zero retries, alongside lint and preflight.
They cover the rendered queue, draft, and approval controls together; the existing logic tests exercise their individual transitions.

A focused fast-submit case exposes queued text remaining in the composer when submission precedes the draft debounce.
The branch now inherits #96773, and the fast-submit case passes locally. The warm-resume fix remains separate in #96752; ten-repeat CI stability validation remains outstanding.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Added flows 6–10 and the fast-submit reproduction to the AI recovery guide.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used Git, GitHub CLI, Flox, and Playwright. Skills: stacking-prs, writing-tests, playwright-test, writing-code-comments, running-ci-preflight, writing-pr-descriptions.
This is the second of three test layers. Fixtures are synthetic; no existing stack branch was updated.



