### PR TITLE
chore(ai): cover cancellation and history regression flows

### DIFF
--- a/docs/internal/posthog-ai-e2e.md
+++ b/docs/internal/posthog-ai-e2e.md
@@ -23,7 +23,7 @@ Cancellation or replacement of the owning run or approval stops retries.
 Transport errors, unrelated 503 responses, and JSON-RPC errors inside HTTP 200 do not qualify for automatic readiness retries.
 An ambiguous transport failure could follow successful execution; replaying it could execute a tool twice.
 
-## Coverage and remaining flows
+## Regression coverage
 
 The startup and approvals layer adds these five regression flows:
 
@@ -57,7 +57,19 @@ It reproduces queued text remaining in the composer after submission; this test 
 The other queue cases advance that debounce with the browser clock so they independently exercise their delivery transitions.
 These are browser interaction checks with held task commands, not real agent-delivery checks.
 
-The browser suite runs three cases for each of Claude and Codex:
+The cancellation and history layer adds the last five flows in `flows-cancellation-history.spec.ts`:
+
+11. Startup Stop waits for the current agent and prompt. Navigating away clears the pending cancellation intent.
+12. Pending cancellation blocks duplicate Escape, steering, and approvals; a failed cancellation allows an explicit retry.
+13. Context pickers and queue editors retain Escape. Main chat handles Escape while reading; the sidebar requires composer focus.
+14. Sidebar attachment preserves the startup draft and focus at normal and narrow viewport widths.
+15. Reload, stream reconnect, and resolution from another client leave only the current run's unresolved approval actionable.
+
+These cases use controlled task commands and stream events. They currently reproduce two additional regressions:
+late task creation redirects back after navigation, and clicking the main transcript leaves focus outside its Escape boundary.
+Both assertions remain enabled.
+
+The original recovery browser suite runs three cases for each of Claude and Codex:
 
 - Submit from the new-chat composer while a seeded warm workflow waits for registration, recover on the original run, send a follow-up, and reload without duplicate messages.
 - Submit while the worker is held, then release it and verify one persisted message and response on the original run.
@@ -82,5 +94,5 @@ Existing Kea, component, and backend tests cover many individual transitions; th
 | History and reconnects     | Reload a pending approval, reconnect, or resolve it from another client. Only the owning run's unresolved approval remains actionable.                            |
 
 Keep deadline, token-validation, error-classification, duplicate-click, and stale-completion matrices in the existing backend and Kea tests with controlled clocks.
-The browser cases should prove delivery, visible recovery, and persisted effects across service boundaries.
+Use the real-service browser cases to prove delivery, visible recovery, and persisted effects across service boundaries.
 Run runtime-sensitive journeys with both Claude and Codex; test focus and layout variations with the cheaper component or browser surface harness.

--- a/products/posthog_ai/frontend/e2e/flows-cancellation-history.spec.ts
+++ b/products/posthog_ai/frontend/e2e/flows-cancellation-history.spec.ts
@@ -1,0 +1,185 @@
+import { RUN_ID, approval, expect, message, notification, ready, test } from './runSurfaceTest'
+
+test.describe('Cancellation, focus and history', () => {
+    for (const navigate of [false, true]) {
+        test(`startup Stop waits for the current prompt and clears on navigation=${navigate}`, async ({
+            page,
+            surface,
+        }) => {
+            surface.history = []
+            const creation = await surface.holdCreation()
+            await page.goto(`/project/${surface.teamId}/tasks/new`)
+            await page.getByTestId('task-composer-input').fill('Start the synthetic task.')
+            await page.getByTestId('task-composer-send').click()
+            const request = await creation.request
+            await expect(page.getByTestId('run-startup-stop')).toBeVisible()
+            await page.getByTestId('run-startup-stop').click()
+            await expect(page.getByTestId('run-startup-stop')).toBeDisabled()
+            expect(surface.commands).toHaveLength(0)
+            const finish = {
+                stay: async () => {
+                    await request.respond(surface.task())
+                    await surface.connected()
+                    await surface.emit(ready('previous-run'))
+                    await expect(page.getByTestId('sandbox-composer-send')).toBeDisabled()
+                    expect(surface.commands).toHaveLength(0)
+                    await surface.emit(message('Start the synthetic task.', 'user'))
+                    await expect(page.getByTestId('sandbox-composer-send')).toBeDisabled()
+                    expect(surface.commands).toHaveLength(0)
+                    await surface.emit(ready())
+                    const cancel = await surface.command(0)
+                    expect(cancel.runId).toBe(RUN_ID)
+                    expect(cancel.body).toMatchObject({ method: 'cancel' })
+                    await cancel.respond()
+                    await surface.emit(notification('_posthog/turn_complete'))
+                    await expect(page.getByTestId('sandbox-composer-input')).toBeEditable()
+                    await page.getByTestId('sandbox-composer-input').fill('A follow-up after stopping.')
+                    await expect(page.getByTestId('sandbox-composer-send')).toBeEnabled()
+                    expect(surface.commands).toHaveLength(1)
+                },
+                leave: async () => {
+                    await page.getByRole('link', { name: 'Activity', exact: true }).click()
+                    await expect(page).toHaveURL(/\/activity\/explore/)
+                    await request.respond(surface.task())
+                    await expect(page).toHaveURL(/\/activity\/explore/)
+                    await expect(page.getByTestId('run-startup-stop')).toBeHidden()
+                    surface.history = [
+                        ready(),
+                        message('Start the synthetic task.', 'user'),
+                        message('Working on the synthetic task.'),
+                    ]
+                    await surface.open()
+                    await expect(page.getByTestId('sandbox-composer-input')).toBeEditable()
+                    expect(surface.commands).toHaveLength(0)
+                },
+            }
+            await finish[navigate ? 'leave' : 'stay']()
+        })
+    }
+
+    test('Stop blocks conflicting actions and recovers from a failed cancellation', async ({ page, surface }) => {
+        await surface.open()
+        await surface.queue('Keep the saved direction.')
+        await page.getByTestId('sandbox-composer-send').click()
+        const first = await surface.command(0)
+        expect(first.body).toMatchObject({ method: 'cancel' })
+        await expect(page.getByTestId('sandbox-composer-send')).toBeDisabled()
+        await expect(page.getByTestId('run-queue-steer')).toBeDisabled()
+        await page.getByTestId('sandbox-composer-input').press('Escape')
+        await surface.emit(approval())
+        await expect(page.getByTestId('run-approval')).toBeHidden()
+        expect(surface.commands).toHaveLength(1)
+        await first.respond({ jsonrpc: '2.0', error: { code: -32000, message: 'Synthetic cancellation failure' } })
+        await expect(page.getByTestId('run-approval')).toBeVisible()
+        await page.getByTestId('run-approval').getByText('Allow', { exact: true }).click()
+        await (await surface.command(1)).respond()
+        await expect(page.getByTestId('sandbox-composer-send')).toBeEnabled()
+        await page.getByTestId('sandbox-composer-send').click()
+        const retry = await surface.command(2)
+        expect(retry.body).toMatchObject({ method: 'cancel' })
+        await retry.respond()
+        await surface.emit(notification('_posthog/turn_complete'))
+        await expect(page.getByTestId('sandbox-composer-input')).toBeEditable()
+        await expect(page.getByText('Keep the saved direction.', { exact: true })).toBeVisible()
+    })
+
+    test('Escape respects a real context picker and queue editor before returning to the main chat', async ({
+        page,
+        surface,
+    }) => {
+        await surface.open()
+        await surface.queue('Edit this saved direction.')
+        await page.getByTestId('posthog-ai-context-picker').click()
+        await expect(page.getByTestId('taxonomic-filter-searchfield')).toBeVisible()
+        await page.keyboard.press('Escape')
+        await expect(page.getByTestId('taxonomic-filter-searchfield')).toBeHidden()
+        expect(surface.commands).toHaveLength(0)
+        await page.getByText('Edit this saved direction.', { exact: true }).hover()
+        await page.getByRole('button', { name: 'Edit message', exact: true }).click()
+        const editor = page.getByTestId('run-queue-editor')
+        await editor.getByRole('textbox').fill('An unfinished edit.')
+        await editor.getByRole('textbox').press('Escape')
+        await expect(editor).toBeVisible()
+        expect(surface.commands).toHaveLength(0)
+        await editor.getByRole('button', { name: 'Cancel', exact: true }).click()
+        await expect(editor).toBeHidden()
+        await page.getByText('Working on the synthetic task.', { exact: true }).click()
+        await page.keyboard.press('Escape')
+        await expect(page.getByText('Up next', { exact: true })).toBeHidden()
+        const steer = await surface.command(0)
+        expect(steer.body).toMatchObject({
+            method: 'user_message',
+            params: { content: 'Edit this saved direction.', steer: true },
+        })
+        await steer.respond()
+        await expect(page.getByText('Up next', { exact: true })).toBeHidden()
+    })
+
+    for (const width of [1440, 780]) {
+        test(`sidebar keeps startup draft and focus at viewport width ${width}`, async ({ page, surface }) => {
+            await page.setViewportSize({ width, height: 1000 })
+            const creation = await surface.holdCreation()
+            await surface.openSidebar()
+            await page.getByTestId('task-composer-input').fill('Start in the sidebar.')
+            await page.getByTestId('task-composer-send').click()
+            const request = await creation.request
+            const startup = page.getByTestId('sandbox-composer-input')
+            await expect(startup).toBeEditable()
+            await startup.fill('Preserve this startup draft.')
+            await expect(startup).toBeFocused()
+            await request.respond(surface.task())
+            await surface.connected()
+            await surface.emit(
+                ready(),
+                message('Start in the sidebar.', 'user'),
+                message('Working on the synthetic task.')
+            )
+            await expect(page.getByText('Working on the synthetic task.', { exact: true })).toBeVisible()
+            await expect(page.getByTestId('sandbox-composer-input')).toHaveValue('Preserve this startup draft.')
+            await expect(page.getByTestId('sandbox-composer-input')).toBeFocused()
+            await page.getByText('Working on the synthetic task.', { exact: true }).click()
+            await page.keyboard.press('Escape')
+            await expect(page.getByTestId('sandbox-composer-input')).toHaveValue('Preserve this startup draft.')
+            expect(surface.commands).toHaveLength(0)
+            await page.getByTestId('sandbox-composer-input').press('Escape')
+            const cancel = await surface.command(0)
+            expect(cancel.body).toMatchObject({ method: 'cancel' })
+            await cancel.respond()
+            await surface.emit(notification('_posthog/turn_complete'))
+            await expect(page.getByTestId('sandbox-composer-send')).toBeEnabled()
+        })
+    }
+
+    test('reload and reconnect keep only the owning unresolved approval actionable', async ({ page, surface }) => {
+        surface.history.push(
+            notification('_posthog/run_started', { runId: 'previous-run' }, 'previous-run'),
+            approval('permission', 'old-approval', 'previous-run'),
+            notification('_posthog/run_started', { runId: RUN_ID }),
+            approval('permission', 'current-approval')
+        )
+        await surface.open()
+        const card = page.getByTestId('run-approval')
+        await expect(card).toBeVisible()
+        await page.reload()
+        await surface.connected()
+        await expect(card).toBeVisible()
+        expect(surface.commands).toHaveLength(0)
+        await surface.reconnect()
+        await expect(card).toBeVisible()
+        expect(surface.commands).toHaveLength(0)
+        await surface.emit(notification('_posthog/permission_resolved', { requestId: 'current-approval' }))
+        await expect(card).toBeHidden()
+        await page.reload()
+        await surface.connected()
+        await expect(page.getByTestId('sandbox-composer-input')).toBeEditable()
+        await expect(card).toBeHidden()
+        expect(surface.commands).toHaveLength(0)
+        await surface.emit(approval('permission', 'fresh-approval'))
+        await card.getByText('Allow', { exact: true }).click()
+        const command = await surface.command(0)
+        expect(command.runId).toBe(RUN_ID)
+        expect(command.body).toMatchObject({ params: { requestId: 'fresh-approval' } })
+        await command.respond()
+        await expect(card).toBeHidden()
+    })
+})


### PR DESCRIPTION
## Problem

PostHog AI reviewers need browser coverage for stopping during startup, preserving sidebar drafts, and restoring approvals after reconnects.

## Changes

- Cover startup Stop waiting for the current prompt and clearing its pending intent after navigation.
- Cover cancellation blocking conflicting actions and allowing retry after failure.
- Cover Escape ownership in the main chat, sidebar, context picker, and queue editor.
- Cover sidebar draft and focus preservation across attachment at normal and narrow widths.
- Cover reload, reconnect, and another client's approval resolution retaining only the owning approval.

The tests use controlled task commands and stream events. Production behavior is unchanged.

## How did you test this code?

[Current browser CI](https://github.com/PostHog/posthog/actions/runs/34249594919/job/102141196306) passes every new controlled browser case with the frontend fixes from #96773.
The [current real-agent CI run](https://github.com/PostHog/posthog/actions/runs/34249594919/job/102140761074) fails only the warm-resume case in each provider.
Both retries reproduce the extra continuation turn; #96752 contains the separate fix.

Local browser runs use zero retries. These cases exercise focus, navigation, and rendered controls across component boundaries.

The previous [CI browser run](https://github.com/PostHog/posthog/actions/runs/34244878870/job/102125446811) confirms Escape fails after clicking the main transcript.
It also reproduces the inherited fast-submit queue failure. The startup-navigation case passed CI after failing in an earlier local run.
The previous [real-agent run](https://github.com/PostHog/posthog/actions/runs/34244878870/job/102124821893) reproduces the inherited warm-resume failure in both providers; all other cases pass.
The branch now inherits #96773. Local browser verification passes the draft, Escape, and navigation regressions after those fixes.
The warm-resume fix remains separate in #96752; ten-repeat CI stability validation remains outstanding.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Added flows 11–15 and the reproduced navigation and Escape regressions to the AI recovery guide.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used Git, GitHub CLI, Flox, and Playwright. Skills: stacking-prs, writing-tests, playwright-test, writing-code-comments, running-ci-preflight, writing-pr-descriptions.
This is the third test layer above #96178. Fixtures are synthetic; existing stack branches remain untouched.



