### PR TITLE
fix(conversations): bridge zendesk ticket allocation locks

### DIFF
--- a/products/conversations/backend/models/ticket.py
+++ b/products/conversations/backend/models/ticket.py
@@ -1,13 +1,13 @@
 from typing import TYPE_CHECKING
 
-from django.db import connection, models, transaction
+from django.db import models, transaction
 
 from posthog.models.utils import UUIDTModel
 
 from .constants import Channel, ChannelDetail, Priority, Status
 
 # Two-arg lock namespace for ticket_number allocation. Keep this value stable:
-# mixed-version allocators only serialize if they use the same pair.
+# every allocator (create_with_number and bulk import) must use the same pair.
 _TICKET_NUMBER_LOCK_NAMESPACE = 0x0C0F_5E71
 
 if TYPE_CHECKING:
@@ -15,6 +15,22 @@ if TYPE_CHECKING:
 
 
 class TicketManager(models.Manager):
+    def lock_ticket_number_allocation(self, team_id: int) -> None:
+        """Serialize next ticket_number assignment until the current transaction commits.
+
+        Callers must be inside ``transaction.atomic()``. This is an advisory lock
+        keyed by team, not a ``SELECT FOR UPDATE`` on ``Team``, so unrelated writers
+        of team-child rows do not wait.
+        """
+        db_connection = transaction.get_connection(self.db)
+        if not db_connection.in_atomic_block:
+            raise RuntimeError("lock_ticket_number_allocation requires an open transaction")
+        with db_connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT pg_advisory_xact_lock(%s, %s)",
+                [_TICKET_NUMBER_LOCK_NAMESPACE, team_id],
+            )
+
     def create_with_number(self, **kwargs):
         """Create a ticket with the next ticket_number for its team."""
         from posthog.models import Team
@@ -23,17 +39,10 @@ class TicketManager(models.Manager):
         if not team:
             raise ValueError("team is required")
 
-        with transaction.atomic():
-            # Advisory lock first so every allocator shares one mutex. The Team
-            # row lock stays so processes that only lock Team still serialize.
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    "SELECT pg_advisory_xact_lock(%s, %s)",
-                    [_TICKET_NUMBER_LOCK_NAMESPACE, team.id],
-                )
-            # nosemgrep: hot-parent-row-select-for-update -- keep Team lock until every allocator takes the advisory lock first
-            Team.objects.select_for_update().get(id=team.id)
-
+        with transaction.atomic(using=self.db):
+            self.lock_ticket_number_allocation(team.id)
+            # nosemgrep: hot-parent-row-select-for-update -- mixed-version allocators still share only the Team lock
+            Team.objects.using(self.db).select_for_update().get(id=team.id)
             max_num = self.filter(team=team).aggregate(models.Max("ticket_number"))["ticket_number__max"] or 0
             kwargs["ticket_number"] = max_num + 1
             return self.create(**kwargs)

--- a/products/conversations/backend/models/ticket.py
+++ b/products/conversations/backend/models/ticket.py
@@ -16,11 +16,10 @@ if TYPE_CHECKING:
 
 class TicketManager(models.Manager):
     def lock_ticket_number_allocation(self, team_id: int) -> None:
-        """Serialize next ticket_number assignment until the current transaction commits.
+        """Acquire the team-scoped transaction lock for ticket number assignment.
 
-        Callers must be inside ``transaction.atomic()``. This is an advisory lock
-        keyed by team, not a ``SELECT FOR UPDATE`` on ``Team``, so unrelated writers
-        of team-child rows do not wait.
+        Callers must be inside ``transaction.atomic()`` and acquire this before
+        any other allocation lock.
         """
         db_connection = transaction.get_connection(self.db)
         if not db_connection.in_atomic_block:
@@ -41,7 +40,7 @@ class TicketManager(models.Manager):
 
         with transaction.atomic(using=self.db):
             self.lock_ticket_number_allocation(team.id)
-            # nosemgrep: hot-parent-row-select-for-update -- mixed-version allocators still share only the Team lock
+            # nosemgrep: hot-parent-row-select-for-update -- preserves compatibility with Team-lock-only allocators
             Team.objects.using(self.db).select_for_update().get(id=team.id)
             max_num = self.filter(team=team).aggregate(models.Max("ticket_number"))["ticket_number__max"] or 0
             kwargs["ticket_number"] = max_num + 1

--- a/products/conversations/backend/temporal/zendesk_import/activities.py
+++ b/products/conversations/backend/temporal/zendesk_import/activities.py
@@ -621,8 +621,8 @@ def _apply_denormalized_counters(team: Team, built: list[_BuiltTicket]) -> None:
 
 def _persist_ticket_batch(team: Team, built: list[_BuiltTicket], tags_by_name: dict[str, Tag]) -> int:
     # Phase 3: Persist tickets + comments in a single transaction (no network I/O). Ticket numbers
-    # are assigned under the same lock that guards bulk_create, so concurrent batch activities can't
-    # collide on unique_ticket_number_per_team.
+    # are assigned under the same advisory lock as create_with_number, so live creates and
+    # concurrent batch activities can't collide on unique_ticket_number_per_team.
     #
     # IMPORTANT: persist historical rows with bulk_create/bulk_update ONLY. These bypass the
     # post_save/pre_save receivers in products/conversations/backend/signals.py, which is what
@@ -632,6 +632,8 @@ def _persist_ticket_batch(team: Team, built: list[_BuiltTicket], tags_by_name: d
     # Comment.objects.create(), or .save() would fire those signals for every imported row —
     # triggering workflows and re-sending replies to real customers for years-old tickets. Don't.
     with transaction.atomic():
+        Ticket.objects.lock_ticket_number_allocation(team.id)
+        # nosemgrep: hot-parent-row-select-for-update -- mixed-version import allocators still share only the Team lock
         Team.objects.select_for_update().get(id=team.id)
         max_num = Ticket.objects.filter(team_id=team.id).aggregate(Max("ticket_number"))["ticket_number__max"] or 0
         tickets_to_create = [b.ticket for b in built]

--- a/products/conversations/backend/temporal/zendesk_import/activities.py
+++ b/products/conversations/backend/temporal/zendesk_import/activities.py
@@ -633,7 +633,7 @@ def _persist_ticket_batch(team: Team, built: list[_BuiltTicket], tags_by_name: d
     # triggering workflows and re-sending replies to real customers for years-old tickets. Don't.
     with transaction.atomic():
         Ticket.objects.lock_ticket_number_allocation(team.id)
-        # nosemgrep: hot-parent-row-select-for-update -- mixed-version import allocators still share only the Team lock
+        # nosemgrep: hot-parent-row-select-for-update -- preserves compatibility with Team-lock-only import allocators
         Team.objects.select_for_update().get(id=team.id)
         max_num = Ticket.objects.filter(team_id=team.id).aggregate(Max("ticket_number"))["ticket_number__max"] or 0
         tickets_to_create = [b.ticket for b in built]

--- a/products/conversations/backend/temporal/zendesk_import/tests/test_activities.py
+++ b/products/conversations/backend/temporal/zendesk_import/tests/test_activities.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
 from typing import Any
 
-from posthog.test.base import BaseTest
+from posthog.test.base import BaseTest, NonAtomicBaseTest
 from unittest.mock import MagicMock, patch
+
+from django.db import close_old_connections, connection, transaction
+from django.db.utils import OperationalError
 
 from parameterized import parameterized
 
@@ -16,8 +21,10 @@ from products.conversations.backend.temporal.zendesk_import.activities import (
     ImportBatchInput,
     UpdateJobProgressInput,
     UpdateJobStatusInput,
+    _BuiltTicket,
     _import_ticket_batch_sync,
     _parse_zendesk_datetime,
+    _persist_ticket_batch,
     _update_job_progress_sync,
     _update_job_status_sync,
 )
@@ -614,6 +621,57 @@ class TestZendeskImportBatchActivity(BaseTest):
 
         self.assertEqual((result.imported, result.skipped, result.failed), (0, 0, 1))
         self.assertFalse(Ticket.objects.filter(team=self.team, zendesk_ticket_id=404).exists())
+
+
+class TestZendeskTicketNumberAllocationConcurrency(NonAtomicBaseTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def test_import_uses_the_live_allocator_advisory_lock(self) -> None:
+        lock_acquired = Event()
+        release_lock = Event()
+
+        def hold_live_allocator_lock() -> None:
+            close_old_connections()
+            try:
+                with transaction.atomic():
+                    Ticket.objects.lock_ticket_number_allocation(self.team.id)
+                    lock_acquired.set()
+                    if not release_lock.wait(timeout=5):
+                        raise TimeoutError("test did not release the advisory lock")
+            finally:
+                close_old_connections()
+
+        built = _BuiltTicket(
+            ticket=Ticket(
+                team=self.team,
+                widget_session_id="zendesk-lock-bridge",
+                distinct_id="requester@example.com",
+                channel_source=Channel.EMAIL,
+            ),
+            comments=[],
+            tag_names=[],
+            customer_message_count=0,
+            agent_reply_count=0,
+            created_at=None,
+            updated_at=None,
+        )
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            lock_future = executor.submit(hold_live_allocator_lock)
+            if not lock_acquired.wait(timeout=5):
+                release_lock.set()
+                lock_future.result(timeout=1)
+                self.fail("live allocator did not acquire the advisory lock")
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute("SET lock_timeout = '250ms'")
+                with self.assertRaises(OperationalError):
+                    _persist_ticket_batch(self.team, [built], {})
+            finally:
+                with connection.cursor() as cursor:
+                    cursor.execute("SET lock_timeout = 0")
+                release_lock.set()
+            lock_future.result(timeout=5)
 
 
 class TestZendeskImportJobUpdates(BaseTest):

--- a/products/conversations/backend/temporal/zendesk_import/tests/test_activities.py
+++ b/products/conversations/backend/temporal/zendesk_import/tests/test_activities.py
@@ -12,7 +12,7 @@ from django.db.utils import OperationalError
 
 from parameterized import parameterized
 
-from posthog.models import Tag
+from posthog.models import Tag, Team
 from posthog.models.comment import Comment
 
 from products.conversations.backend.models import EmailChannel, EmailChannelKind, Ticket, ZendeskImportJob
@@ -626,18 +626,22 @@ class TestZendeskImportBatchActivity(BaseTest):
 class TestZendeskTicketNumberAllocationConcurrency(NonAtomicBaseTest):
     CLASS_DATA_LEVEL_SETUP = False
 
-    def test_import_uses_the_live_allocator_advisory_lock(self) -> None:
+    @parameterized.expand([("advisory",), ("team_row",)])
+    def test_import_waits_for_each_bridge_lock(self, held_lock: str) -> None:
         lock_acquired = Event()
         release_lock = Event()
 
-        def hold_live_allocator_lock() -> None:
+        def hold_allocation_lock() -> None:
             close_old_connections()
             try:
                 with transaction.atomic():
-                    Ticket.objects.lock_ticket_number_allocation(self.team.id)
+                    if held_lock == "advisory":
+                        Ticket.objects.lock_ticket_number_allocation(self.team.id)
+                    else:
+                        Team.objects.select_for_update().get(id=self.team.id)
                     lock_acquired.set()
                     if not release_lock.wait(timeout=5):
-                        raise TimeoutError("test did not release the advisory lock")
+                        raise TimeoutError("test did not release the allocation lock")
             finally:
                 close_old_connections()
 
@@ -657,15 +661,15 @@ class TestZendeskTicketNumberAllocationConcurrency(NonAtomicBaseTest):
         )
 
         with ThreadPoolExecutor(max_workers=1) as executor:
-            lock_future = executor.submit(hold_live_allocator_lock)
+            lock_future = executor.submit(hold_allocation_lock)
             if not lock_acquired.wait(timeout=5):
                 release_lock.set()
                 lock_future.result(timeout=1)
-                self.fail("live allocator did not acquire the advisory lock")
+                self.fail(f"allocator did not acquire the {held_lock} lock")
             try:
                 with connection.cursor() as cursor:
                     cursor.execute("SET lock_timeout = '250ms'")
-                with self.assertRaises(OperationalError):
+                with self.assertRaisesRegex(OperationalError, "canceling statement due to lock timeout"):
                     _persist_ticket_batch(self.team, [built], {})
             finally:
                 with connection.cursor() as cursor:


### PR DESCRIPTION
## Problem

A Zendesk import can collide with a live ticket create on `unique_ticket_number_per_team`.
[#96340](https://github.com/PostHog/posthog/pull/96340) put live allocation on an advisory lock, then a Team row lock.
Import still used only the Team row lock, so the two paths do not share one mutex after that deploy.

## Changes

- Zendesk import takes the same advisory lock as live allocation, then keeps the Team row lock.
- Live allocation still takes both locks. Ticket numbers stay unique during a mixed deploy.
- Nothing in the product UI looks different.

> [!NOTE]
> Do not drop the Team row lock in this PR. That is the next deploy, after this bridge is everywhere.

## How did you test this code?

- Concurrent live creates still get unique sequential numbers.
- Zendesk batch still assigns gap-free numbers after a pre-existing max.
- New lock-timeout test: import waits when another session holds the advisory lock or the Team row lock.