### PR TITLE
feat(insights): add metric charts to SQL insights

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -3132,6 +3132,10 @@ snapshots:
         hash: v1.k794b7964.8f97758bb77e6ce5bf8743f49fc35ea00acd2e7e5da7b5428ec27c8f132479a9.uEmiN3xmnUkboRF7LBi99Ns_vWu1jTNSZd2bMuINdEU
     insights-sqlbargraph--stacked-bar-with-negative-values--light:
         hash: v1.k794b7964.e9f32e35e60194c76df1aad0e7963ca99bc76d2b6099437c5e679c4959feb976.3DeROLuvQPwEHmWPIxoY7SxfXAcAgX6gufInnDLnBh0
+    insights-sqlmetriccard--default--dark:
+        hash: v1.k794b7964.76f4e3c4cd2804af666f0468d31072602124556d82aa223b6660cd97271f4caa.928VYvoGe3aVu00xSR4wclIUv-vp_qsvqn8BKWUsDBQ
+    insights-sqlmetriccard--default--light:
+        hash: v1.k794b7964.1ad68ec9b7d4211384f53994f7abdc82065e2c801e22332589f4a60f1590b761.GR_EaYQlS2zbCj74wsiYr8BbKZmtoI016arf1ZcA28c
     insights-sqlpiegraph--breakdown-colors--dark:
         hash: v1.k794b7964.01928cb0ffb1554a01ffae8f214773557e22647fea676e40007a7803cec0af32.fk7qZ2CtcV_Ouq_6xOxJ7wqRdxmck-P18wvqRq1jLsc
     insights-sqlpiegraph--breakdown-colors--light:
@@ -3577,9 +3581,9 @@ snapshots:
     lemon-ui-icons3--shelf-s--light:
         hash: v1.k794b7964.1d5bcc73ae4ac5d20365176bf2c688249e26ca5be7e0cb663213aa1d968f9684.DeYOLC7IgPaFuulmbprhU64CPMsp9qn0e7MOo7AjB-E
     lemon-ui-icons3--shelf-t--dark:
-        hash: v1.k794b7964.266ace0cc426daa451e5e9ebc6bd9207b8312006c3204bbe626c4bba9a8d34f5.cydV_QOHzmYQCStDda2BAMb10GXwAHypEikMw3TAqL4
+        hash: v1.k794b7964.5ff1657fdbe447ae9bdfcdd40492d1a9d888cd8100cdd235d06b427f0fdaf089.ti_aYMtJzaNpjmr0bYAdFT7_TQI7f-SnTh31trhz0pQ
     lemon-ui-icons3--shelf-t--light:
-        hash: v1.k794b7964.2ccf046a32aae0bcf1c03ee1f99c2b8ef2d50cbf2c6d2e93686fc505fe710a41.jvCW2LZ8gg_Qn3HW8nz22FkHMBPm8f7wkVjt-lyZhOw
+        hash: v1.k794b7964.32b7f9b829c3082b5b3e3dc517b62f234b76f4c3290210f7a524bd9f98a82ab8.UinV4Lq9mrCVtde2PapxbYiSjLZDHeDpzArmyB3GJPI
     lemon-ui-icons3--shelf-u--dark:
         hash: v1.k794b7964.8c34f50c0e4bf5874ee0b544bc35ddb64d76f3dddf15b6d03e00c172dbaabba1.2cX2NWgpIQ23P7HbmyTSaIaUA88m5xVoUjT5djupG-g
     lemon-ui-icons3--shelf-u--light:

--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
@@ -20,7 +20,7 @@ import { InsightsTable } from 'scenes/insights/views/InsightsTable/InsightsTable
 import { getQueryBasedInsightModel } from '~/queries/nodes/InsightViz/utils'
 import { Query } from '~/queries/Query/Query'
 import { SharingConfigurationSettings } from '~/queries/schema/schema-general'
-import { getDisplay, isDataTableNode, isInsightVizNode, isTrendsQuery } from '~/queries/utils'
+import { getDisplay, isDataTableNode, isInsightVizNode, isMetricInsightQuery, isTrendsQuery } from '~/queries/utils'
 import { ChartDisplayType, DataColorThemeModel, InsightLogicProps, InsightModel } from '~/types'
 
 export function ExportedInsight({
@@ -59,7 +59,7 @@ export function ExportedInsight({
     // legend layout here as the chart they get normalized to.
     const trendsDisplay = isInsightVizNode(query) && isTrendsQuery(query.source) ? getDisplay(query.source) : undefined
     const isBoxPlot = trendsDisplay === ChartDisplayType.BoxPlot
-    const isMetric = trendsDisplay === ChartDisplayType.Metric
+    const isMetric = isMetricInsightQuery(query)
     const showLegend =
         legend &&
         isInsightVizNode(query) &&

--- a/frontend/src/exporter/Exporter.tsx
+++ b/frontend/src/exporter/Exporter.tsx
@@ -18,8 +18,7 @@ import { teamLogic } from 'scenes/teamLogic'
 
 import { ExporterLogin } from '~/exporter/ExporterLogin'
 import { ExportType, ExportedData } from '~/exporter/types'
-import { isInsightVizNode, isTrendsQuery } from '~/queries/utils'
-import { ChartDisplayType } from '~/types'
+import { isMetricInsightQuery } from '~/queries/utils'
 
 import { exporterViewLogic } from './exporterViewLogic'
 
@@ -98,13 +97,7 @@ export function Exporter(props: ExportedData): JSX.Element {
     // Applies to both saved insights and ad-hoc query exports — the image exporter narrows
     // the screenshot viewport for both.
     const metricQuery = insight?.query ?? query
-    const metric =
-        metricQuery &&
-        isInsightVizNode(metricQuery) &&
-        isTrendsQuery(metricQuery.source) &&
-        metricQuery.source.trendsFilter?.display === ChartDisplayType.Metric
-            ? metricQuery
-            : undefined
+    const metric = isMetricInsightQuery(metricQuery)
 
     const { currentTeam } = useValues(teamLogic)
     const { ref: elementRef, height, width } = useResizeObserver()

--- a/frontend/src/exporter/scenes/ExporterQueryScene.tsx
+++ b/frontend/src/exporter/scenes/ExporterQueryScene.tsx
@@ -12,7 +12,7 @@ import { DISPLAYS_WITH_IN_CHART_LEGEND } from 'scenes/insights/insightVizDataLog
 
 import { Query } from '~/queries/Query/Query'
 import { SharingConfigurationSettings } from '~/queries/schema/schema-general'
-import { getDisplay, isInsightVizNode, isTrendsQuery } from '~/queries/utils'
+import { getDisplay, isInsightVizNode, isMetricInsightQuery, isTrendsQuery } from '~/queries/utils'
 import { ChartDisplayType, InsightLogicProps } from '~/types'
 
 import { ExportedData } from '../types'
@@ -78,12 +78,7 @@ export default function ExporterQueryScene({
 
     return (
         <BindLogic logic={insightLogic} props={insightLogicProps}>
-            <div
-                className={clsx(
-                    'ExportedInsight',
-                    trendsDisplay === ChartDisplayType.Metric && 'ExportedInsight--metric'
-                )}
-            >
+            <div className={clsx('ExportedInsight', isMetricInsightQuery(query) && 'ExportedInsight--metric')}>
                 {title && (
                     <div className="ExportedInsight__header">
                         <div className="ExportedInsight__header__title">{title}</div>

--- a/frontend/src/lib/components/Cards/InsightCard/sqlVisualizationSupport.test.ts
+++ b/frontend/src/lib/components/Cards/InsightCard/sqlVisualizationSupport.test.ts
@@ -65,19 +65,14 @@ describe('dashboard SQL visualization support', () => {
             const autoVisualizationType = getAutoVisualizationType(columns, response.result.length)
             const numericalColumns = columns.filter((column) => column.type.isNumerical)
 
-            const options = getTableDisplayOptions(
-                columns,
-                numericalColumns,
-                autoVisualizationType,
-                (displayType) =>
-                    sqlVisualizationDisabledReason(
-                        displayType,
-                        baseQuery,
-                        columns,
-                        response.result.length,
-                        autoVisualizationType
-                    ),
-                true
+            const options = getTableDisplayOptions(columns, numericalColumns, autoVisualizationType, (displayType) =>
+                sqlVisualizationDisabledReason(
+                    displayType,
+                    baseQuery,
+                    columns,
+                    response.result.length,
+                    autoVisualizationType
+                )
             )
 
             const enabled = options
@@ -87,24 +82,39 @@ describe('dashboard SQL visualization support', () => {
 
             expect(enabled.length).toBeGreaterThan(0)
 
-            for (const displayType of enabled) {
-                const saved = applyVisualizationType(baseQuery, displayType, columns, response.result.length)
+            const chartTypes = enabled.filter((displayType) => {
                 const resolved =
                     displayType === ChartDisplayType.Auto ? autoVisualizationType : (displayType as ChartDisplayType)
+                return ![ChartDisplayType.ActionsTable, ChartDisplayType.BoldNumber].includes(resolved)
+            })
 
-                const needsYAxis = ![ChartDisplayType.ActionsTable, ChartDisplayType.BoldNumber].includes(resolved)
-                if (!needsYAxis) {
-                    continue
-                }
+            for (const displayType of chartTypes) {
+                const saved = applyVisualizationType(baseQuery, displayType, columns, response.result.length)
 
-                if (resolved !== ChartDisplayType.Metric) {
-                    expect(saved.chartSettings?.xAxis?.column).toEqual(expect.any(String))
-                }
+                expect(saved.chartSettings?.xAxis?.column).toEqual(expect.any(String))
                 expect(saved.chartSettings?.yAxis?.length ?? 0).toBeGreaterThan(0)
-                if (resolved === ChartDisplayType.Metric) {
-                    expect(saved.chartSettings?.yAxis).toHaveLength(1)
-                }
             }
+        }
+    )
+
+    it.each([responses['date and numeric'], responses['a single numeric column']])(
+        'sets up a dashboard Metric from numeric results',
+        (response) => {
+            const columns = columnsFromResponse(response)
+            const autoVisualizationType = getAutoVisualizationType(columns, response.result.length)
+
+            expect(
+                sqlVisualizationDisabledReason(
+                    ChartDisplayType.Metric,
+                    baseQuery,
+                    columns,
+                    response.result.length,
+                    autoVisualizationType
+                )
+            ).toBeUndefined()
+
+            const saved = applyVisualizationType(baseQuery, ChartDisplayType.Metric, columns, response.result.length)
+            expect(saved.chartSettings?.yAxis).toHaveLength(1)
         }
     )
 

--- a/frontend/src/lib/components/Cards/InsightCard/sqlVisualizationSupport.test.ts
+++ b/frontend/src/lib/components/Cards/InsightCard/sqlVisualizationSupport.test.ts
@@ -65,14 +65,19 @@ describe('dashboard SQL visualization support', () => {
             const autoVisualizationType = getAutoVisualizationType(columns, response.result.length)
             const numericalColumns = columns.filter((column) => column.type.isNumerical)
 
-            const options = getTableDisplayOptions(columns, numericalColumns, autoVisualizationType, (displayType) =>
-                sqlVisualizationDisabledReason(
-                    displayType,
-                    baseQuery,
-                    columns,
-                    response.result.length,
-                    autoVisualizationType
-                )
+            const options = getTableDisplayOptions(
+                columns,
+                numericalColumns,
+                autoVisualizationType,
+                (displayType) =>
+                    sqlVisualizationDisabledReason(
+                        displayType,
+                        baseQuery,
+                        columns,
+                        response.result.length,
+                        autoVisualizationType
+                    ),
+                true
             )
 
             const enabled = options
@@ -87,13 +92,18 @@ describe('dashboard SQL visualization support', () => {
                 const resolved =
                     displayType === ChartDisplayType.Auto ? autoVisualizationType : (displayType as ChartDisplayType)
 
-                const needsAxes = ![ChartDisplayType.ActionsTable, ChartDisplayType.BoldNumber].includes(resolved)
-                if (!needsAxes) {
+                const needsYAxis = ![ChartDisplayType.ActionsTable, ChartDisplayType.BoldNumber].includes(resolved)
+                if (!needsYAxis) {
                     continue
                 }
 
-                expect(saved.chartSettings?.xAxis?.column).toEqual(expect.any(String))
+                if (resolved !== ChartDisplayType.Metric) {
+                    expect(saved.chartSettings?.xAxis?.column).toEqual(expect.any(String))
+                }
                 expect(saved.chartSettings?.yAxis?.length ?? 0).toBeGreaterThan(0)
+                if (resolved === ChartDisplayType.Metric) {
+                    expect(saved.chartSettings?.yAxis).toHaveLength(1)
+                }
             }
         }
     )

--- a/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
+++ b/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
@@ -4,7 +4,14 @@ import { IconGlobe, IconGraph, IconPieChart, IconRetentionHeatmap, IconTrends } 
 import { LemonSelect, LemonSelectOptions } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
-import { Icon123, IconAreaChart, IconCumulativeChart, IconDonutChart, IconTableChart } from 'lib/lemon-ui/icons'
+import {
+    Icon123,
+    IconAreaChart,
+    IconCumulativeChart,
+    IconDonutChart,
+    IconTableChart,
+    IconTrendingUp,
+} from 'lib/lemon-ui/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
@@ -140,7 +147,7 @@ export function ChartFilter(): JSX.Element {
                     ? [
                           {
                               value: ChartDisplayType.Metric,
-                              icon: <IconTrends />,
+                              icon: <IconTrendingUp />,
                               label: 'Metric',
                               labelInMenu: (
                                   <ChartFilterOptionLabel

--- a/frontend/src/lib/components/Metric/MetricDirectionColorPickers.tsx
+++ b/frontend/src/lib/components/Metric/MetricDirectionColorPickers.tsx
@@ -1,0 +1,49 @@
+import clsx from 'clsx'
+
+import { getSeriesColorPalette } from 'lib/colors'
+import { LemonColorPicker } from 'lib/lemon-ui/LemonColor'
+
+const PRESET_COLORS = getSeriesColorPalette()
+
+export interface MetricDirectionColorPickersProps {
+    increaseColor: string
+    decreaseColor: string
+    onIncrease: (color: string) => void
+    onDecrease: (color: string) => void
+    className?: string
+    rowClassName?: string
+}
+
+export function MetricDirectionColorPickers({
+    increaseColor,
+    decreaseColor,
+    onIncrease,
+    onDecrease,
+    className,
+    rowClassName,
+}: MetricDirectionColorPickersProps): JSX.Element {
+    return (
+        <div className={clsx('flex flex-col', className)}>
+            <div className={clsx('flex items-center justify-between gap-2', rowClassName)}>
+                <span className="font-normal">Increase</span>
+                <LemonColorPicker
+                    colors={PRESET_COLORS}
+                    selectedColor={increaseColor}
+                    onSelectColor={onIncrease}
+                    showCustomColor
+                    preventPopoverClose
+                />
+            </div>
+            <div className={clsx('flex items-center justify-between gap-2', rowClassName)}>
+                <span className="font-normal">Decrease</span>
+                <LemonColorPicker
+                    colors={PRESET_COLORS}
+                    selectedColor={decreaseColor}
+                    onSelectColor={onDecrease}
+                    showCustomColor
+                    preventPopoverClose
+                />
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/lib/components/Metric/metricSummary.ts
+++ b/frontend/src/lib/components/Metric/metricSummary.ts
@@ -58,6 +58,28 @@ export function computeMetricSummary(summary: MetricSummary, total: number, data
     return summary === 'latest' ? finite[finite.length - 1] : mean(finite)
 }
 
+export interface MetricLineColorOptions {
+    colorByDirection: boolean
+    change: MetricChange | null | undefined
+    increaseColor: string
+    decreaseColor: string
+    /** Color used when the line is not colored by direction. */
+    fallback?: string
+}
+
+export function resolveMetricLineColor({
+    colorByDirection,
+    change,
+    increaseColor,
+    decreaseColor,
+    fallback,
+}: MetricLineColorOptions): string | undefined {
+    if (!colorByDirection || change == null) {
+        return fallback
+    }
+    return change.value >= 0 ? increaseColor : decreaseColor
+}
+
 export interface MetricSeriesSummary {
     total: number
     data: number[] | undefined

--- a/frontend/src/lib/lemon-ui/icons/icons.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.tsx
@@ -780,6 +780,14 @@ export function IconTrendingFlatDown(props: LemonIconProps): JSX.Element {
 }
 
 /** Material Design Trending Down icon. */
+export function IconTrendingUp(props: LemonIconProps): JSX.Element {
+    return (
+        <LemonIconBase {...props}>
+            <path d="m16 6 2.29 2.29-4.88 4.88-4-4L2 16.59 3.41 18l6-6 4 4 6.3-6.29L22 12V6z" fill="currentColor" />
+        </LemonIconBase>
+    )
+}
+
 export function IconTrendingDown(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlMetricCard.stories.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlMetricCard.stories.tsx
@@ -1,0 +1,37 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { AxisSeries } from '../../dataVisualizationLogic'
+import { SqlMetricCard } from './SqlMetricCard'
+
+const meta: Meta<typeof SqlMetricCard> = {
+    title: 'Insights/SqlMetricCard',
+    component: SqlMetricCard,
+    parameters: {
+        layout: 'fullscreen',
+        testOptions: { snapshotBrowsers: ['chromium'] },
+    },
+}
+export default meta
+
+type Story = StoryObj<typeof SqlMetricCard>
+
+const xData: AxisSeries<string> = {
+    column: { name: 'month', type: { name: 'STRING', isNumerical: false }, label: 'month', dataIndex: 0 },
+    data: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+}
+
+const yData: AxisSeries<number | null>[] = [
+    {
+        column: { name: 'revenue', type: { name: 'FLOAT', isNumerical: true }, label: 'revenue', dataIndex: 1 },
+        data: [4200, 5100, 4700, 5400, 6000, 6400],
+        settings: { formatting: { prefix: '$', style: 'short' } },
+    },
+]
+
+export const Default: Story = {
+    render: () => (
+        <div className="h-screen w-full flex flex-col">
+            <SqlMetricCard xData={xData} yData={yData} />
+        </div>
+    ),
+}

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlMetricCard.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlMetricCard.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom'
 
 import { cleanup, screen, waitFor } from '@testing-library/react'
 
-import { setupJsdom, setupSyncRaf } from '@posthog/quill-charts/testing'
+import { getHogChart, hoverAtIndex, setupJsdom, setupSyncRaf } from '@posthog/quill-charts/testing'
 
 import { buildDataVisualizationQuery, renderDataVisualization } from '~/test/insight-testing'
 import { ChartDisplayType } from '~/types'
@@ -43,6 +43,7 @@ describe('SqlMetricCard', () => {
                     ['revenue', 'Float64'],
                 ],
                 results: [
+                    ['2026-01-04', null],
                     ['2026-01-03', 1500],
                     ['2026-01-02', null],
                     ['2026-01-01', 1000],
@@ -53,5 +54,8 @@ describe('SqlMetricCard', () => {
         await waitFor(() => expect(screen.getByText('$1,500')).toBeInTheDocument())
         expect(screen.getByText('2026-01-03')).toBeInTheDocument()
         expect(container.querySelector('[data-attr="metric-card-sparkline"]')).toBeInTheDocument()
+
+        hoverAtIndex(getHogChart(container).element, 1, 3)
+        await waitFor(() => expect(screen.getByText('2026-01-02')).toBeInTheDocument())
     })
 })

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlMetricCard.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlMetricCard.test.tsx
@@ -1,0 +1,57 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, screen, waitFor } from '@testing-library/react'
+
+import { setupJsdom, setupSyncRaf } from '@posthog/quill-charts/testing'
+
+import { buildDataVisualizationQuery, renderDataVisualization } from '~/test/insight-testing'
+import { ChartDisplayType } from '~/types'
+
+let cleanupJsdom: () => void
+let cleanupRaf: () => void
+
+beforeEach(() => {
+    cleanupJsdom = setupJsdom()
+    cleanupRaf = setupSyncRaf()
+})
+
+afterEach(() => {
+    cleanupRaf()
+    cleanupJsdom()
+    cleanup()
+})
+
+describe('SqlMetricCard', () => {
+    it('renders the latest numeric value and sparkline with SQL formatting', async () => {
+        const { container } = renderDataVisualization({
+            query: buildDataVisualizationQuery({
+                display: ChartDisplayType.Metric,
+                chartSettings: {
+                    xAxis: { column: 'day' },
+                    yAxis: [
+                        {
+                            column: 'revenue',
+                            settings: { formatting: { style: 'number', prefix: '$', decimalPlaces: 0 } },
+                        },
+                    ],
+                },
+            }),
+            response: {
+                columns: ['day', 'revenue'],
+                types: [
+                    ['day', 'Date'],
+                    ['revenue', 'Float64'],
+                ],
+                results: [
+                    ['2026-01-03', 1500],
+                    ['2026-01-02', null],
+                    ['2026-01-01', 1000],
+                ],
+            },
+        })
+
+        await waitFor(() => expect(screen.getByText('$1,500')).toBeInTheDocument())
+        expect(screen.getByText('2026-01-03')).toBeInTheDocument()
+        expect(container.querySelector('[data-attr="metric-card-sparkline"]')).toBeInTheDocument()
+    })
+})

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlMetricCard.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlMetricCard.test.tsx
@@ -52,10 +52,38 @@ describe('SqlMetricCard', () => {
         })
 
         await waitFor(() => expect(screen.getByText('$1,500')).toBeInTheDocument())
-        expect(screen.getByText('2026-01-03')).toBeInTheDocument()
+        expect(screen.getByText('Jan 3, 2026')).toBeInTheDocument()
         expect(container.querySelector('[data-attr="metric-card-sparkline"]')).toBeInTheDocument()
 
         hoverAtIndex(getHogChart(container).element, 1, 3)
-        await waitFor(() => expect(screen.getByText('2026-01-02')).toBeInTheDocument())
+        await waitFor(() => expect(screen.getByText('Jan 2, 2026')).toBeInTheDocument())
+    })
+
+    it('applies the metric settings for the headline and change pill', async () => {
+        renderDataVisualization({
+            query: buildDataVisualizationQuery({
+                display: ChartDisplayType.Metric,
+                chartSettings: {
+                    xAxis: { column: 'day' },
+                    yAxis: [{ column: 'revenue' }],
+                    metric: { summary: 'total', showChange: false },
+                },
+            }),
+            response: {
+                columns: ['day', 'revenue'],
+                types: [
+                    ['day', 'Date'],
+                    ['revenue', 'Float64'],
+                ],
+                results: [
+                    ['2026-01-01', 1000],
+                    ['2026-01-02', 1500],
+                ],
+            },
+        })
+
+        await waitFor(() => expect(screen.getByText('2500')).toBeInTheDocument())
+        expect(screen.getByText('Total')).toBeInTheDocument()
+        expect(screen.queryByText('+50%')).not.toBeInTheDocument()
     })
 })

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlMetricCard.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlMetricCard.tsx
@@ -23,14 +23,22 @@ export interface SqlMetricCardProps {
 export const SqlMetricCard = ({ xData, yData, presetChartHeight, className }: SqlMetricCardProps): JSX.Element => {
     const theme = useChartTheme()
     const series = yData[0]
-    const points = useMemo(() => {
-        const data =
-            series?.data.flatMap((value, index) =>
-                value != null && Number.isFinite(value) ? [{ value, label: xData?.data[index] ?? '' }] : []
-            ) ?? []
+    const { data, labels, latestValue } = useMemo(() => {
+        const points =
+            series?.data.map((value, index) => ({
+                value: value != null && Number.isFinite(value) ? value : NaN,
+                label: xData?.data[index] ?? '',
+            })) ?? []
         const isDateAxis = xData?.column.type.name === 'DATE' || xData?.column.type.name === 'DATETIME'
+        const sortedPoints = isDateAxis ? points.sort((a, b) => Date.parse(a.label) - Date.parse(b.label)) : points
+        const lastFiniteIndex = sortedPoints.findLastIndex((point) => Number.isFinite(point.value))
+        const visiblePoints = sortedPoints.slice(0, lastFiniteIndex + 1)
 
-        return isDateAxis ? data.sort((a, b) => Date.parse(a.label) - Date.parse(b.label)) : data
+        return {
+            data: visiblePoints.map((point) => point.value),
+            labels: xData && xData.column.dataIndex !== -1 ? visiblePoints.map((point) => point.label) : undefined,
+            latestValue: lastFiniteIndex === -1 ? undefined : sortedPoints[lastFiniteIndex].value,
+        }
     }, [series, xData])
 
     return (
@@ -40,11 +48,12 @@ export const SqlMetricCard = ({ xData, yData, presetChartHeight, className }: Sq
                 'h-full': !presetChartHeight,
             })}
         >
-            {series && points.length > 0 ? (
+            {series && latestValue !== undefined ? (
                 <MetricCard
                     title={null}
-                    data={points.map(({ value }) => value)}
-                    labels={points.map(({ label }) => label)}
+                    value={latestValue}
+                    data={data}
+                    labels={labels}
                     theme={theme}
                     color={series.settings?.display?.color}
                     changeInline

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlMetricCard.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlMetricCard.tsx
@@ -1,0 +1,63 @@
+import clsx from 'clsx'
+import { useMemo } from 'react'
+
+import { MetricCard } from '@posthog/quill-charts'
+
+import { useChartTheme } from 'lib/charts/hooks'
+import { InsightEmptyState } from 'scenes/insights/EmptyStates'
+
+import { makeChartErrorHandler } from 'products/product_analytics/frontend/insights/trends/shared/chartErrorHandler'
+
+import { AxisSeries } from '../../dataVisualizationLogic'
+import { formatSqlSeriesValue } from './sqlLineGraphAdapter'
+
+const handleChartError = makeChartErrorHandler('sql-metric-chart')
+
+export interface SqlMetricCardProps {
+    xData: AxisSeries<string> | null
+    yData: AxisSeries<number | null>[]
+    presetChartHeight?: boolean
+    className?: string
+}
+
+export const SqlMetricCard = ({ xData, yData, presetChartHeight, className }: SqlMetricCardProps): JSX.Element => {
+    const theme = useChartTheme()
+    const series = yData[0]
+    const points = useMemo(() => {
+        const data =
+            series?.data.flatMap((value, index) =>
+                value != null && Number.isFinite(value) ? [{ value, label: xData?.data[index] ?? '' }] : []
+            ) ?? []
+        const isDateAxis = xData?.column.type.name === 'DATE' || xData?.column.type.name === 'DATETIME'
+
+        return isDateAxis ? data.sort((a, b) => Date.parse(a.label) - Date.parse(b.label)) : data
+    }, [series, xData])
+
+    return (
+        <div
+            className={clsx(className, 'Metric ph-no-capture rounded bg-surface-primary flex flex-1 min-h-0 p-3', {
+                'h-[60vh]': presetChartHeight,
+                'h-full': !presetChartHeight,
+            })}
+        >
+            {series && points.length > 0 ? (
+                <MetricCard
+                    title={null}
+                    data={points.map(({ value }) => value)}
+                    labels={points.map(({ label }) => label)}
+                    theme={theme}
+                    color={series.settings?.display?.color}
+                    changeInline
+                    hoverChangeFromPreviousPoint
+                    sparklineFill
+                    sparklineClassName="mt-4 -mx-3 -mb-3"
+                    formatValue={(value) => formatSqlSeriesValue(value, series.settings)}
+                    dataAttr="metric-value"
+                    onError={handleChartError}
+                />
+            ) : (
+                <InsightEmptyState sampleDataVariant="number" />
+            )}
+        </div>
+    )
+}

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlMetricCard.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlMetricCard.tsx
@@ -1,34 +1,26 @@
 import clsx from 'clsx'
-import { useValues } from 'kea'
-import { useMemo } from 'react'
 
 import { MetricCard } from '@posthog/quill-charts'
 
 import { useChartTheme } from 'lib/charts/hooks'
 import {
-    METRIC_COLOR_BY_DIRECTION_DEFAULT,
     METRIC_DEFAULT_DECREASE_COLOR,
     METRIC_DEFAULT_INCREASE_COLOR,
     METRIC_SHOW_CHANGE_DEFAULT,
     METRIC_SUMMARY_LABELS,
-    type MetricSummary,
-    computeMetricChange,
-    computeMetricSummary,
 } from 'lib/components/Metric/metricSummary'
 import { hexToRGBA } from 'lib/utils/colors'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
-import { teamLogic } from 'scenes/teamLogic'
 
 import { MetricChartSettings } from '~/queries/schema/schema-general'
 
 import { makeChartErrorHandler } from 'products/product_analytics/frontend/insights/trends/shared/chartErrorHandler'
 
 import { AxisSeries } from '../../dataVisualizationLogic'
-import { buildSqlDateLabelFormatter, formatSqlSeriesValue } from './sqlLineGraphAdapter'
+import { formatSqlSeriesValue } from './sqlLineGraphAdapter'
+import { useSqlMetricModel } from './useSqlMetricModel'
 
 const handleChartError = makeChartErrorHandler('sql-metric-chart')
-
-export const SQL_METRIC_SUMMARY_DEFAULT: MetricSummary = 'latest'
 
 const makeChangeColor = (hex: string): { background: string; foreground: string } => ({
     background: hexToRGBA(hex, 0.1),
@@ -51,43 +43,7 @@ export const SqlMetricCard = ({
     className,
 }: SqlMetricCardProps): JSX.Element => {
     const theme = useChartTheme()
-    const { timezone } = useValues(teamLogic)
-    const series = yData[0]
-    const { data, labels, latestValue } = useMemo(() => {
-        const points =
-            series?.data.map((value, index) => ({
-                value: value != null && Number.isFinite(value) ? value : NaN,
-                label: xData?.data[index] ?? '',
-            })) ?? []
-        const isDateAxis = xData?.column.type.name === 'DATE' || xData?.column.type.name === 'DATETIME'
-        const sortedPoints = isDateAxis ? points.sort((a, b) => Date.parse(a.label) - Date.parse(b.label)) : points
-        const lastFiniteIndex = sortedPoints.findLastIndex((point) => Number.isFinite(point.value))
-        const visiblePoints = sortedPoints.slice(0, lastFiniteIndex + 1)
-        const formatLabel = xData ? buildSqlDateLabelFormatter(xData, timezone) : undefined
-
-        return {
-            data: visiblePoints.map((point) => point.value),
-            labels:
-                xData && xData.column.dataIndex !== -1
-                    ? visiblePoints.map((point) => (formatLabel ? formatLabel(point.label) : point.label))
-                    : undefined,
-            latestValue: lastFiniteIndex === -1 ? undefined : sortedPoints[lastFiniteIndex].value,
-        }
-    }, [series, xData, timezone])
-
-    const summary = metricSettings?.summary ?? SQL_METRIC_SUMMARY_DEFAULT
-    const total = data.filter((value) => Number.isFinite(value)).reduce((sum, value) => sum + value, 0)
-    const headlineValue = computeMetricSummary(summary, total, data)
-    const change = computeMetricChange(data)
-    const colorByDirection = metricSettings?.colorByDirection ?? METRIC_COLOR_BY_DIRECTION_DEFAULT
-    const increaseLineColor = metricSettings?.lineIncreaseColor ?? METRIC_DEFAULT_INCREASE_COLOR
-    const decreaseLineColor = metricSettings?.lineDecreaseColor ?? METRIC_DEFAULT_DECREASE_COLOR
-    const lineColor =
-        colorByDirection && change != null
-            ? change.value >= 0
-                ? increaseLineColor
-                : decreaseLineColor
-            : series?.settings?.display?.color
+    const model = useSqlMetricModel({ xData, yData, metricSettings })
 
     return (
         <div
@@ -96,15 +52,15 @@ export const SqlMetricCard = ({
                 'h-full': !presetChartHeight,
             })}
         >
-            {series && latestValue !== undefined ? (
+            {model ? (
                 <MetricCard
                     title={null}
-                    value={headlineValue}
-                    data={data}
-                    labels={labels}
+                    value={model.headlineValue}
+                    data={model.data}
+                    labels={model.labels}
                     theme={theme}
-                    color={lineColor}
-                    change={change}
+                    color={model.lineColor}
+                    change={model.change}
                     changeTooltip="Comparing the first point to the latest point."
                     showChange={metricSettings?.showChange ?? METRIC_SHOW_CHANGE_DEFAULT}
                     positiveColor={makeChangeColor(
@@ -113,12 +69,12 @@ export const SqlMetricCard = ({
                     negativeColor={makeChangeColor(
                         metricSettings?.changeDecreaseColor ?? METRIC_DEFAULT_DECREASE_COLOR
                     )}
-                    restingSubtitle={summary === 'latest' ? undefined : METRIC_SUMMARY_LABELS[summary]}
+                    restingSubtitle={model.summary === 'latest' ? undefined : METRIC_SUMMARY_LABELS[model.summary]}
                     changeInline
                     hoverChangeFromPreviousPoint
                     sparklineFill
                     sparklineClassName="mt-4 -mx-3 -mb-3"
-                    formatValue={(value) => formatSqlSeriesValue(value, series.settings)}
+                    formatValue={(value) => formatSqlSeriesValue(value, model.series.settings)}
                     dataAttr="metric-value"
                     onError={handleChartError}
                 />

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlMetricCard.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlMetricCard.tsx
@@ -1,27 +1,57 @@
 import clsx from 'clsx'
+import { useValues } from 'kea'
 import { useMemo } from 'react'
 
 import { MetricCard } from '@posthog/quill-charts'
 
 import { useChartTheme } from 'lib/charts/hooks'
+import {
+    METRIC_COLOR_BY_DIRECTION_DEFAULT,
+    METRIC_DEFAULT_DECREASE_COLOR,
+    METRIC_DEFAULT_INCREASE_COLOR,
+    METRIC_SHOW_CHANGE_DEFAULT,
+    METRIC_SUMMARY_LABELS,
+    type MetricSummary,
+    computeMetricChange,
+    computeMetricSummary,
+} from 'lib/components/Metric/metricSummary'
+import { hexToRGBA } from 'lib/utils/colors'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { MetricChartSettings } from '~/queries/schema/schema-general'
 
 import { makeChartErrorHandler } from 'products/product_analytics/frontend/insights/trends/shared/chartErrorHandler'
 
 import { AxisSeries } from '../../dataVisualizationLogic'
-import { formatSqlSeriesValue } from './sqlLineGraphAdapter'
+import { buildSqlDateLabelFormatter, formatSqlSeriesValue } from './sqlLineGraphAdapter'
 
 const handleChartError = makeChartErrorHandler('sql-metric-chart')
+
+export const SQL_METRIC_SUMMARY_DEFAULT: MetricSummary = 'latest'
+
+const makeChangeColor = (hex: string): { background: string; foreground: string } => ({
+    background: hexToRGBA(hex, 0.1),
+    foreground: hex,
+})
 
 export interface SqlMetricCardProps {
     xData: AxisSeries<string> | null
     yData: AxisSeries<number | null>[]
+    metricSettings?: MetricChartSettings
     presetChartHeight?: boolean
     className?: string
 }
 
-export const SqlMetricCard = ({ xData, yData, presetChartHeight, className }: SqlMetricCardProps): JSX.Element => {
+export const SqlMetricCard = ({
+    xData,
+    yData,
+    metricSettings,
+    presetChartHeight,
+    className,
+}: SqlMetricCardProps): JSX.Element => {
     const theme = useChartTheme()
+    const { timezone } = useValues(teamLogic)
     const series = yData[0]
     const { data, labels, latestValue } = useMemo(() => {
         const points =
@@ -33,13 +63,31 @@ export const SqlMetricCard = ({ xData, yData, presetChartHeight, className }: Sq
         const sortedPoints = isDateAxis ? points.sort((a, b) => Date.parse(a.label) - Date.parse(b.label)) : points
         const lastFiniteIndex = sortedPoints.findLastIndex((point) => Number.isFinite(point.value))
         const visiblePoints = sortedPoints.slice(0, lastFiniteIndex + 1)
+        const formatLabel = xData ? buildSqlDateLabelFormatter(xData, timezone) : undefined
 
         return {
             data: visiblePoints.map((point) => point.value),
-            labels: xData && xData.column.dataIndex !== -1 ? visiblePoints.map((point) => point.label) : undefined,
+            labels:
+                xData && xData.column.dataIndex !== -1
+                    ? visiblePoints.map((point) => (formatLabel ? formatLabel(point.label) : point.label))
+                    : undefined,
             latestValue: lastFiniteIndex === -1 ? undefined : sortedPoints[lastFiniteIndex].value,
         }
-    }, [series, xData])
+    }, [series, xData, timezone])
+
+    const summary = metricSettings?.summary ?? SQL_METRIC_SUMMARY_DEFAULT
+    const total = data.filter((value) => Number.isFinite(value)).reduce((sum, value) => sum + value, 0)
+    const headlineValue = computeMetricSummary(summary, total, data)
+    const change = computeMetricChange(data)
+    const colorByDirection = metricSettings?.colorByDirection ?? METRIC_COLOR_BY_DIRECTION_DEFAULT
+    const increaseLineColor = metricSettings?.lineIncreaseColor ?? METRIC_DEFAULT_INCREASE_COLOR
+    const decreaseLineColor = metricSettings?.lineDecreaseColor ?? METRIC_DEFAULT_DECREASE_COLOR
+    const lineColor =
+        colorByDirection && change != null
+            ? change.value >= 0
+                ? increaseLineColor
+                : decreaseLineColor
+            : series?.settings?.display?.color
 
     return (
         <div
@@ -51,11 +99,21 @@ export const SqlMetricCard = ({ xData, yData, presetChartHeight, className }: Sq
             {series && latestValue !== undefined ? (
                 <MetricCard
                     title={null}
-                    value={latestValue}
+                    value={headlineValue}
                     data={data}
                     labels={labels}
                     theme={theme}
-                    color={series.settings?.display?.color}
+                    color={lineColor}
+                    change={change}
+                    changeTooltip="Comparing the first point to the latest point."
+                    showChange={metricSettings?.showChange ?? METRIC_SHOW_CHANGE_DEFAULT}
+                    positiveColor={makeChangeColor(
+                        metricSettings?.changeIncreaseColor ?? METRIC_DEFAULT_INCREASE_COLOR
+                    )}
+                    negativeColor={makeChangeColor(
+                        metricSettings?.changeDecreaseColor ?? METRIC_DEFAULT_DECREASE_COLOR
+                    )}
+                    restingSubtitle={summary === 'latest' ? undefined : METRIC_SUMMARY_LABELS[summary]}
                     changeInline
                     hoverChangeFromPreviousPoint
                     sparklineFill

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
@@ -292,7 +292,7 @@ export function buildSqlTooltipConfig(
 }
 
 /** Returns a tooltip label formatter for date/datetime x-axes, or undefined for non-date axes. */
-function buildSqlDateLabelFormatter(
+export function buildSqlDateLabelFormatter(
     xData: AxisSeries<string>,
     timezone: string
 ): ((label: string) => string) | undefined {

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/useSqlMetricModel.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/useSqlMetricModel.ts
@@ -1,0 +1,103 @@
+import { useValues } from 'kea'
+import { useMemo } from 'react'
+
+import { type MetricChange } from '@posthog/quill-charts'
+
+import {
+    METRIC_COLOR_BY_DIRECTION_DEFAULT,
+    METRIC_DEFAULT_DECREASE_COLOR,
+    METRIC_DEFAULT_INCREASE_COLOR,
+    type MetricSummary,
+    computeMetricChange,
+    computeMetricSummary,
+    resolveMetricLineColor,
+} from 'lib/components/Metric/metricSummary'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { MetricChartSettings } from '~/queries/schema/schema-general'
+
+import { AxisSeries } from '../../dataVisualizationLogic'
+import { buildSqlDateLabelFormatter } from './sqlLineGraphAdapter'
+
+export const SQL_METRIC_SUMMARY_DEFAULT: MetricSummary = 'latest'
+
+export interface SqlMetricModelArgs {
+    xData: AxisSeries<string> | null
+    yData: AxisSeries<number | null>[]
+    metricSettings?: MetricChartSettings
+}
+
+export interface SqlMetricModel {
+    series: AxisSeries<number | null>
+    summary: MetricSummary
+    data: number[]
+    labels: string[] | undefined
+    headlineValue: number
+    change: MetricChange | null | undefined
+    lineColor: string | undefined
+}
+
+interface SqlMetricPoints {
+    data: number[]
+    labels: string[] | undefined
+    latestValue: number | undefined
+}
+
+function buildSqlMetricPoints(
+    series: AxisSeries<number | null> | undefined,
+    xData: AxisSeries<string> | null,
+    timezone: string
+): SqlMetricPoints {
+    const points =
+        series?.data.map((value, index) => ({
+            value: value != null && Number.isFinite(value) ? value : NaN,
+            label: xData?.data[index] ?? '',
+        })) ?? []
+    const isDateAxis = xData?.column.type.name === 'DATE' || xData?.column.type.name === 'DATETIME'
+    const sortedPoints = isDateAxis ? points.sort((a, b) => Date.parse(a.label) - Date.parse(b.label)) : points
+    const lastFiniteIndex = sortedPoints.findLastIndex((point) => Number.isFinite(point.value))
+    const visiblePoints = sortedPoints.slice(0, lastFiniteIndex + 1)
+    const formatLabel = xData ? buildSqlDateLabelFormatter(xData, timezone) : undefined
+
+    return {
+        data: visiblePoints.map((point) => point.value),
+        labels:
+            xData && xData.column.dataIndex !== -1
+                ? visiblePoints.map((point) => (formatLabel ? formatLabel(point.label) : point.label))
+                : undefined,
+        latestValue: lastFiniteIndex === -1 ? undefined : sortedPoints[lastFiniteIndex].value,
+    }
+}
+
+/** Returns null when there is no series or no finite value to show. */
+export function useSqlMetricModel({ xData, yData, metricSettings }: SqlMetricModelArgs): SqlMetricModel | null {
+    const { timezone } = useValues(teamLogic)
+    const series = yData[0]
+    const points = useMemo(() => buildSqlMetricPoints(series, xData, timezone), [series, xData, timezone])
+
+    return useMemo(() => {
+        if (!series || points.latestValue === undefined) {
+            return null
+        }
+        const { data, labels } = points
+        const summary = metricSettings?.summary ?? SQL_METRIC_SUMMARY_DEFAULT
+        const total = data.filter((value) => Number.isFinite(value)).reduce((sum, value) => sum + value, 0)
+        const change = computeMetricChange(data)
+
+        return {
+            series,
+            summary,
+            data,
+            labels,
+            headlineValue: computeMetricSummary(summary, total, data),
+            change,
+            lineColor: resolveMetricLineColor({
+                colorByDirection: metricSettings?.colorByDirection ?? METRIC_COLOR_BY_DIRECTION_DEFAULT,
+                change,
+                increaseColor: metricSettings?.lineIncreaseColor ?? METRIC_DEFAULT_INCREASE_COLOR,
+                decreaseColor: metricSettings?.lineDecreaseColor ?? METRIC_DEFAULT_DECREASE_COLOR,
+                fallback: series.settings?.display?.color,
+            }),
+        }
+    }, [series, points, metricSettings])
+}

--- a/frontend/src/queries/nodes/DataVisualization/Components/DisplayTab.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/DisplayTab.test.tsx
@@ -236,6 +236,52 @@ describe('DisplayTab', () => {
         await waitFor(() => expect(query.chartSettings?.boxPlot?.excludeOutliers).toBe(false))
     })
 
+    it('offers only the metric settings for a metric and persists them', async () => {
+        initKeaTests()
+
+        const key = 'display-tab-metric-test'
+        let query: DataVisualizationNode = {
+            kind: NodeKind.DataVisualizationNode,
+            source: {
+                kind: NodeKind.HogQLQuery,
+                query: 'select day, revenue from summaries',
+            },
+            display: ChartDisplayType.Metric,
+            chartSettings: { metric: { summary: 'average' } },
+        }
+
+        const props: DataVisualizationLogicProps = {
+            key,
+            query,
+            dataNodeCollectionId: key,
+            setQuery: (setter) => {
+                query = setter(query)
+            },
+        }
+
+        dataVisualizationLogic(props).mount()
+        displayLogic({ key }).mount()
+
+        render(
+            <BindLogic logic={dataVisualizationLogic} props={props}>
+                <BindLogic logic={displayLogic} props={{ key }}>
+                    <DisplayTab />
+                </BindLogic>
+            </BindLogic>
+        )
+
+        const user = userEvent.setup()
+
+        expect(await screen.findByText('Headline value')).toBeInTheDocument()
+        expect(screen.queryByText('Show legend')).not.toBeInTheDocument()
+        expect(screen.queryByText('Left Y-axis')).not.toBeInTheDocument()
+        expect(screen.queryByText('Goals')).not.toBeInTheDocument()
+
+        await user.click(screen.getByText('Show change'))
+
+        await waitFor(() => expect(query.chartSettings?.metric).toEqual({ summary: 'average', showChange: false }))
+    })
+
     it('offers scatter axis settings and drops the panels a scatter has no support for', async () => {
         initKeaTests()
 

--- a/frontend/src/queries/nodes/DataVisualization/Components/DisplayTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/DisplayTab.tsx
@@ -13,11 +13,20 @@ import {
 } from '@posthog/lemon-ui'
 
 import { GoalLinesList } from 'lib/components/GoalLinesList'
+import { MetricDirectionColorPickers } from 'lib/components/Metric/MetricDirectionColorPickers'
+import {
+    METRIC_COLOR_BY_DIRECTION_DEFAULT,
+    METRIC_DEFAULT_DECREASE_COLOR,
+    METRIC_DEFAULT_INCREASE_COLOR,
+    METRIC_SHOW_CHANGE_DEFAULT,
+    type MetricSummary,
+} from 'lib/components/Metric/metricSummary'
 
 import { ChartDisplayType } from '~/types'
 
 import { dataVisualizationLogic } from '../dataVisualizationLogic'
 import { displayLogic } from '../displayLogic'
+import { SQL_METRIC_SUMMARY_DEFAULT } from './Charts/SqlMetricCard'
 
 const PIE_SLICE_CONTENT_OPTIONS: { value: 'labels' | 'values' | 'none'; label: string }[] = [
     { value: 'labels', label: 'Labels' },
@@ -37,6 +46,12 @@ const LEGEND_POSITION_OPTIONS: { value: 'top' | 'bottom' | 'left' | 'right'; lab
     { value: 'right', label: 'Right' },
 ]
 
+const METRIC_SUMMARY_OPTIONS: { value: MetricSummary; label: string }[] = [
+    { value: 'latest', label: 'Latest' },
+    { value: 'total', label: 'Total' },
+    { value: 'average', label: 'Average' },
+]
+
 const LINE_STYLE_OPTIONS: { value: 'smooth' | 'linear'; label: string }[] = [
     { value: 'smooth', label: 'Smooth' },
     { value: 'linear', label: 'Straight' },
@@ -51,6 +66,7 @@ export const DisplayTab = (): JSX.Element => {
     const isPieChart = effectiveVisualizationType === ChartDisplayType.ActionsPie
     const isScatterPlot = effectiveVisualizationType === ChartDisplayType.ScatterPlot
     const isBoxPlot = effectiveVisualizationType === ChartDisplayType.BoxPlot
+    const isMetric = effectiveVisualizationType === ChartDisplayType.Metric
     // Scatter and box plots have a single Y axis, so there is no separate right axis to configure.
     const isSingleAxisChart = isScatterPlot || isBoxPlot
     const isLineChart =
@@ -125,6 +141,84 @@ export const DisplayTab = (): JSX.Element => {
                     }}
                 />
             </>
+        )
+    }
+
+    if (isMetric) {
+        const metric = chartSettings.metric ?? {}
+        const showChange = metric.showChange ?? METRIC_SHOW_CHANGE_DEFAULT
+        const colorByDirection = metric.colorByDirection ?? METRIC_COLOR_BY_DIRECTION_DEFAULT
+
+        return (
+            <div className="flex flex-col w-full">
+                <LemonCollapse
+                    embedded
+                    defaultActiveKeys={['metric']}
+                    multiple
+                    panels={[
+                        {
+                            key: 'metric',
+                            header: 'Metric',
+                            className: 'p-2 flex flex-col gap-2',
+                            content: (
+                                <>
+                                    <div className="flex flex-col gap-1">
+                                        <LemonLabel>Headline value</LemonLabel>
+                                        <LemonSelect
+                                            className="w-full"
+                                            data-attr="data-visualization-metric-summary"
+                                            value={metric.summary ?? SQL_METRIC_SUMMARY_DEFAULT}
+                                            options={METRIC_SUMMARY_OPTIONS}
+                                            onChange={(value) => updateChartSettings({ metric: { summary: value } })}
+                                            fullWidth
+                                        />
+                                    </div>
+                                    <LemonSwitch
+                                        className="flex-1 w-full"
+                                        label="Show change"
+                                        checked={showChange}
+                                        onChange={(value) => updateChartSettings({ metric: { showChange: value } })}
+                                    />
+                                    {showChange && (
+                                        <MetricDirectionColorPickers
+                                            className="gap-2"
+                                            increaseColor={metric.changeIncreaseColor ?? METRIC_DEFAULT_INCREASE_COLOR}
+                                            decreaseColor={metric.changeDecreaseColor ?? METRIC_DEFAULT_DECREASE_COLOR}
+                                            onIncrease={(color) =>
+                                                updateChartSettings({ metric: { changeIncreaseColor: color } })
+                                            }
+                                            onDecrease={(color) =>
+                                                updateChartSettings({ metric: { changeDecreaseColor: color } })
+                                            }
+                                        />
+                                    )}
+                                    <LemonSwitch
+                                        className="flex-1 w-full"
+                                        label="Color by trend"
+                                        checked={colorByDirection}
+                                        onChange={(value) =>
+                                            updateChartSettings({ metric: { colorByDirection: value } })
+                                        }
+                                    />
+                                    {colorByDirection && (
+                                        <MetricDirectionColorPickers
+                                            className="gap-2"
+                                            increaseColor={metric.lineIncreaseColor ?? METRIC_DEFAULT_INCREASE_COLOR}
+                                            decreaseColor={metric.lineDecreaseColor ?? METRIC_DEFAULT_DECREASE_COLOR}
+                                            onIncrease={(color) =>
+                                                updateChartSettings({ metric: { lineIncreaseColor: color } })
+                                            }
+                                            onDecrease={(color) =>
+                                                updateChartSettings({ metric: { lineDecreaseColor: color } })
+                                            }
+                                        />
+                                    )}
+                                </>
+                            ),
+                        },
+                    ]}
+                />
+            </div>
         )
     }
 

--- a/frontend/src/queries/nodes/DataVisualization/Components/DisplayTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/DisplayTab.tsx
@@ -26,7 +26,7 @@ import { ChartDisplayType } from '~/types'
 
 import { dataVisualizationLogic } from '../dataVisualizationLogic'
 import { displayLogic } from '../displayLogic'
-import { SQL_METRIC_SUMMARY_DEFAULT } from './Charts/SqlMetricCard'
+import { SQL_METRIC_SUMMARY_DEFAULT } from './Charts/useSqlMetricModel'
 
 const PIE_SLICE_CONTENT_OPTIONS: { value: 'labels' | 'values' | 'none'; label: string }[] = [
     { value: 'labels', label: 'Labels' },

--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -55,14 +55,19 @@ export const SeriesTab = (): JSX.Element => {
     const { addSeriesBreakdown } = useActions(breakdownLogic)
 
     const isScatterPlot = effectiveVisualizationType === ChartDisplayType.ScatterPlot
+    const isMetric = effectiveVisualizationType === ChartDisplayType.Metric
     const availableBreakdownColumns = getAvailableSeriesBreakdownColumns(columns, selectedXAxis, selectedYAxis)
-    const hideAddYSeries = yData.length >= numericalColumns.length
-    // A breakdown buckets rows by x value, which a point cloud can't survive — a scatter reads the x
-    // column's own values instead, so the option does nothing there.
+    const hideAddYSeries = isMetric ? yData.length >= 1 : yData.length >= numericalColumns.length
+    // Metric and scatter charts accept one series, so a breakdown does not apply.
     const hideAddSeriesBreakdown =
-        isScatterPlot || showSeriesBreakdown || selectedXAxis === null || availableBreakdownColumns.length === 0
+        isScatterPlot ||
+        isMetric ||
+        showSeriesBreakdown ||
+        selectedXAxis === null ||
+        availableBreakdownColumns.length === 0
     const showSeriesBreakdownSelector =
         !isScatterPlot &&
+        !isMetric &&
         selectedXAxis !== null &&
         showSeriesBreakdown &&
         (selectedSeriesBreakdownColumn !== null || availableBreakdownColumns.length > 0)
@@ -499,8 +504,11 @@ export const YSeriesDisplayTab = ({ ySeriesLogicProps }: { ySeriesLogicProps: YS
     const { updateSeriesIndex } = useActions(dataVisualizationLogic)
 
     const isPieChart = effectiveVisualizationType === ChartDisplayType.ActionsPie
-    // Neither a pie nor a scatter has a second gutter, a trend line, or a bar/line/area choice.
-    const hideChartSpecificOptions = isPieChart || effectiveVisualizationType === ChartDisplayType.ScatterPlot
+    // Pie, metric, and scatter charts do not use these series controls.
+    const hideChartSpecificOptions =
+        isPieChart ||
+        effectiveVisualizationType === ChartDisplayType.Metric ||
+        effectiveVisualizationType === ChartDisplayType.ScatterPlot
     const showColorPicker = !showTableSettings && !selectedSeriesBreakdownColumn
     const showLabelInput = showTableSettings || !selectedSeriesBreakdownColumn
 

--- a/frontend/src/queries/nodes/DataVisualization/Components/SideBar.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SideBar.test.tsx
@@ -1,0 +1,67 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { BindLogic } from 'kea'
+
+import { DataVisualizationNode, HogQLQueryResponse, NodeKind } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import { ChartDisplayType } from '~/types'
+
+import { dataNodeLogic } from '../../DataNode/dataNodeLogic'
+import { DataVisualizationLogicProps, SideBarTab, dataVisualizationLogic } from '../dataVisualizationLogic'
+import { SideBar } from './SideBar'
+
+const query: DataVisualizationNode = {
+    kind: NodeKind.DataVisualizationNode,
+    source: { kind: NodeKind.HogQLQuery, query: 'SELECT day, revenue FROM events' },
+    display: ChartDisplayType.Metric,
+}
+
+const response: HogQLQueryResponse = {
+    columns: ['day', 'revenue'],
+    types: [
+        ['day', 'Date'],
+        ['revenue', 'Float64'],
+    ],
+    results: [['2026-01-01', 100]],
+    hogql: '',
+    hasMore: false,
+}
+
+describe('SideBar', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('shows the series tab when the selected tab is not supported by a metric', async () => {
+        initKeaTests()
+        const props: DataVisualizationLogicProps = {
+            key: 'metric-sidebar',
+            query,
+            cachedResults: response,
+            dataNodeCollectionId: 'metric-sidebar',
+        }
+        const dataNode = dataNodeLogic({
+            key: props.key,
+            query: query.source,
+            cachedResults: response,
+            dataNodeCollectionId: props.dataNodeCollectionId,
+        })
+        const logic = dataVisualizationLogic(props)
+        dataNode.mount()
+        logic.mount()
+        logic.actions.setSideBarTab(SideBarTab.Display)
+
+        render(
+            <BindLogic logic={dataVisualizationLogic} props={props}>
+                <SideBar />
+            </BindLogic>
+        )
+
+        expect(await screen.findByText('X-axis')).toBeInTheDocument()
+        expect(screen.queryByText('Show legend')).not.toBeInTheDocument()
+
+        logic.unmount()
+        dataNode.unmount()
+    })
+})

--- a/frontend/src/queries/nodes/DataVisualization/Components/SideBar.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SideBar.test.tsx
@@ -50,7 +50,7 @@ describe('SideBar', () => {
         const logic = dataVisualizationLogic(props)
         dataNode.mount()
         logic.mount()
-        logic.actions.setSideBarTab(SideBarTab.Display)
+        logic.actions.setSideBarTab(SideBarTab.ConditionalFormatting)
 
         render(
             <BindLogic logic={dataVisualizationLogic} props={props}>
@@ -59,7 +59,7 @@ describe('SideBar', () => {
         )
 
         expect(await screen.findByText('X-axis')).toBeInTheDocument()
-        expect(screen.queryByText('Show legend')).not.toBeInTheDocument()
+        expect(screen.queryByText('Conditional formatting')).not.toBeInTheDocument()
 
         logic.unmount()
         dataNode.unmount()

--- a/frontend/src/queries/nodes/DataVisualization/Components/SideBar.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SideBar.tsx
@@ -55,17 +55,19 @@ export const SideBar = (): JSX.Element => {
         [effectiveVisualizationType]
     )
 
+    const activeTab = tabs.some((tab) => tab.key === activeSideBarTab) ? activeSideBarTab : SideBarTab.Series
+
     return (
         <div className="bg-surface-primary w-[18rem] flex flex-col">
             <LemonTabs
                 size="small"
-                activeKey={activeSideBarTab}
+                activeKey={activeTab}
                 onChange={(tab) => setSideBarTab(tab as SideBarTab)}
                 tabs={tabs}
                 className="pt-1"
                 barClassName="px-3"
             />
-            <div className="flex-1 overflow-y-auto">{TABS_TO_CONTENT[activeSideBarTab].content}</div>
+            <div className="flex-1 overflow-y-auto">{TABS_TO_CONTENT[activeTab].content}</div>
         </div>
     )
 }

--- a/frontend/src/queries/nodes/DataVisualization/Components/SideBar.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SideBar.tsx
@@ -19,7 +19,6 @@ type TabContent = {
 export const isDisplayTabSupported = (displayType: ChartDisplayType): boolean =>
     displayType !== ChartDisplayType.ActionsTable &&
     displayType !== ChartDisplayType.BoldNumber &&
-    displayType !== ChartDisplayType.Metric &&
     displayType !== ChartDisplayType.TwoDimensionalHeatmap
 
 const TABS_TO_CONTENT: Record<SideBarTab, TabContent> = {

--- a/frontend/src/queries/nodes/DataVisualization/Components/SideBar.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SideBar.tsx
@@ -19,6 +19,7 @@ type TabContent = {
 export const isDisplayTabSupported = (displayType: ChartDisplayType): boolean =>
     displayType !== ChartDisplayType.ActionsTable &&
     displayType !== ChartDisplayType.BoldNumber &&
+    displayType !== ChartDisplayType.Metric &&
     displayType !== ChartDisplayType.TwoDimensionalHeatmap
 
 const TABS_TO_CONTENT: Record<SideBarTab, TabContent> = {

--- a/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.test.tsx
@@ -4,6 +4,9 @@ import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BindLogic } from 'kea'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
 import { DataVisualizationNode, HogQLQueryResponse, NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import { ChartDisplayType } from '~/types'
@@ -31,19 +34,29 @@ describe('TableDisplay', () => {
         cleanup()
     })
 
-    it('offers box plots and saves the selected display', async () => {
+    it.each([
+        ['Box plot', ChartDisplayType.BoxPlot, false],
+        ['Metric', ChartDisplayType.Metric, true],
+    ])('offers %s and saves the selected display', async (label, display, metricInsightEnabled) => {
         initKeaTests()
+
+        if (metricInsightEnabled) {
+            const flags = featureFlagLogic()
+            flags.mount()
+            flags.actions.setFeatureFlags([FEATURE_FLAGS.METRIC_INSIGHT], { [FEATURE_FLAGS.METRIC_INSIGHT]: true })
+        }
 
         let query: DataVisualizationNode = {
             kind: NodeKind.DataVisualizationNode,
             source: { kind: NodeKind.HogQLQuery, query: 'select * from summaries' },
             display: ChartDisplayType.ActionsTable,
         }
+        const key = `table-display-${display}`
         const props: DataVisualizationLogicProps = {
-            key: 'table-display-box-plot',
+            key,
             query,
             cachedResults,
-            dataNodeCollectionId: 'table-display-box-plot',
+            dataNodeCollectionId: key,
             setQuery: (setter) => {
                 query = setter(query)
             },
@@ -65,8 +78,11 @@ describe('TableDisplay', () => {
 
         const user = userEvent.setup()
         await user.click(screen.getByTestId('chart-filter'))
-        await user.click(await screen.findByText('Box plot'))
+        await user.click(await screen.findByText(label))
 
-        await waitFor(() => expect(query.display).toBe(ChartDisplayType.BoxPlot))
+        await waitFor(() => expect(query.display).toBe(display))
+        if (display === ChartDisplayType.Metric) {
+            expect(query.chartSettings?.yAxis).toHaveLength(1)
+        }
     })
 })

--- a/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.test.tsx
@@ -29,60 +29,73 @@ const cachedResults: HogQLQueryResponse = {
     ],
 }
 
+function renderTableDisplay(
+    key: string,
+    featureFlags: Record<string, string | boolean> = {}
+): () => DataVisualizationNode {
+    initKeaTests()
+
+    const flags = featureFlagLogic()
+    flags.mount()
+    flags.actions.setFeatureFlags(Object.keys(featureFlags), featureFlags)
+
+    let query: DataVisualizationNode = {
+        kind: NodeKind.DataVisualizationNode,
+        source: { kind: NodeKind.HogQLQuery, query: 'select * from summaries' },
+        display: ChartDisplayType.ActionsTable,
+    }
+    const props: DataVisualizationLogicProps = {
+        key,
+        query,
+        cachedResults,
+        dataNodeCollectionId: key,
+        setQuery: (setter) => {
+            query = setter(query)
+        },
+    }
+
+    dataNodeLogic({
+        key: props.key,
+        query: query.source,
+        cachedResults,
+        dataNodeCollectionId: props.dataNodeCollectionId,
+    }).mount()
+    dataVisualizationLogic(props).mount()
+
+    render(
+        <BindLogic logic={dataVisualizationLogic} props={props}>
+            <TableDisplay />
+        </BindLogic>
+    )
+
+    return () => query
+}
+
+async function selectDisplay(label: string): Promise<void> {
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId('chart-filter'))
+    await user.click(await screen.findByText(label))
+}
+
 describe('TableDisplay', () => {
     afterEach(() => {
         cleanup()
     })
 
-    it.each([
-        ['Box plot', ChartDisplayType.BoxPlot, false],
-        ['Metric', ChartDisplayType.Metric, true],
-    ])('offers %s and saves the selected display', async (label, display, metricInsightEnabled) => {
-        initKeaTests()
+    it('offers box plots and saves the selected display', async () => {
+        const query = renderTableDisplay('table-display-box-plot')
 
-        if (metricInsightEnabled) {
-            const flags = featureFlagLogic()
-            flags.mount()
-            flags.actions.setFeatureFlags([FEATURE_FLAGS.METRIC_INSIGHT], { [FEATURE_FLAGS.METRIC_INSIGHT]: true })
-        }
+        await selectDisplay('Box plot')
 
-        let query: DataVisualizationNode = {
-            kind: NodeKind.DataVisualizationNode,
-            source: { kind: NodeKind.HogQLQuery, query: 'select * from summaries' },
-            display: ChartDisplayType.ActionsTable,
-        }
-        const key = `table-display-${display}`
-        const props: DataVisualizationLogicProps = {
-            key,
-            query,
-            cachedResults,
-            dataNodeCollectionId: key,
-            setQuery: (setter) => {
-                query = setter(query)
-            },
-        }
+        await waitFor(() => expect(query().display).toBe(ChartDisplayType.BoxPlot))
+    })
 
-        dataNodeLogic({
-            key: props.key,
-            query: query.source,
-            cachedResults,
-            dataNodeCollectionId: props.dataNodeCollectionId,
-        }).mount()
-        dataVisualizationLogic(props).mount()
+    it('offers metrics behind the feature flag and saves one Y-series', async () => {
+        const query = renderTableDisplay('table-display-metric', { [FEATURE_FLAGS.METRIC_INSIGHT]: true })
 
-        render(
-            <BindLogic logic={dataVisualizationLogic} props={props}>
-                <TableDisplay />
-            </BindLogic>
-        )
+        await selectDisplay('Metric')
 
-        const user = userEvent.setup()
-        await user.click(screen.getByTestId('chart-filter'))
-        await user.click(await screen.findByText(label))
-
-        await waitFor(() => expect(query.display).toBe(display))
-        if (display === ChartDisplayType.Metric) {
-            expect(query.chartSettings?.yAxis).toHaveLength(1)
-        }
+        await waitFor(() => expect(query().display).toBe(ChartDisplayType.Metric))
+        expect(query().chartSettings?.yAxis).toHaveLength(1)
     })
 })

--- a/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
@@ -4,7 +4,7 @@ import { IconGraph, IconLifecycle, IconPieChart, IconScatter, IconTrends } from 
 import { LemonSelect, LemonSelectOptions, LemonSelectProps } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
-import { Icon123, IconAreaChart, IconHeatmap, IconTableChart } from 'lib/lemon-ui/icons'
+import { Icon123, IconAreaChart, IconHeatmap, IconTableChart, IconTrendingUp } from 'lib/lemon-ui/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { ChartDisplayType } from '~/types'
@@ -78,17 +78,6 @@ export function getTableDisplayOptions(
                     icon: <Icon123 />,
                     label: 'Big number',
                 },
-                ...(metricInsightEnabled
-                    ? [
-                          {
-                              value: ChartDisplayType.Metric,
-                              icon: <IconTrends />,
-                              label: 'Metric',
-                              disabledReason:
-                                  numericalColumns.length === 0 ? 'Requires at least one numeric column' : undefined,
-                          },
-                      ]
-                    : []),
             ],
         },
         {
@@ -102,6 +91,17 @@ export function getTableDisplayOptions(
                         ? 'Requires at least two columns, including one numeric column'
                         : undefined,
                 },
+                ...(metricInsightEnabled
+                    ? [
+                          {
+                              value: ChartDisplayType.Metric,
+                              icon: <IconTrendingUp />,
+                              label: 'Metric',
+                              disabledReason:
+                                  numericalColumns.length === 0 ? 'Requires at least one numeric column' : undefined,
+                          },
+                      ]
+                    : []),
                 {
                     value: ChartDisplayType.ActionsBar,
                     icon: <IconGraph />,

--- a/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
@@ -3,7 +3,9 @@ import { useActions, useValues } from 'kea'
 import { IconGraph, IconLifecycle, IconPieChart, IconScatter, IconTrends } from '@posthog/icons'
 import { LemonSelect, LemonSelectOptions, LemonSelectProps } from '@posthog/lemon-ui'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { Icon123, IconAreaChart, IconHeatmap, IconTableChart } from 'lib/lemon-ui/icons'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { ChartDisplayType } from '~/types'
 
@@ -46,7 +48,8 @@ export function getTableDisplayOptions(
     columns: Column[],
     numericalColumns: Column[],
     autoVisualizationType: ChartDisplayType,
-    disabledReasonFor?: (displayType: ChartDisplayType) => string | undefined
+    disabledReasonFor?: (displayType: ChartDisplayType) => string | undefined,
+    metricInsightEnabled = false
 ): LemonSelectOptions<ChartDisplayType> {
     const canDisplayContinuousChart = columns.length > 1 && numericalColumns.length > 0
     const canDisplayScatterPlot = numericalColumns.length > 1
@@ -75,6 +78,17 @@ export function getTableDisplayOptions(
                     icon: <Icon123 />,
                     label: 'Big number',
                 },
+                ...(metricInsightEnabled
+                    ? [
+                          {
+                              value: ChartDisplayType.Metric,
+                              icon: <IconTrends />,
+                              label: 'Metric',
+                              disabledReason:
+                                  numericalColumns.length === 0 ? 'Requires at least one numeric column' : undefined,
+                          },
+                      ]
+                    : []),
             ],
         },
         {
@@ -165,6 +179,7 @@ export const TableDisplay = ({
 }: TableDisplayProps): JSX.Element => {
     const { setVisualizationType } = useActions(dataVisualizationLogic)
     const { autoVisualizationType, columns, numericalColumns, visualizationType } = useValues(dataVisualizationLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     return (
         <LemonSelect
@@ -175,7 +190,13 @@ export const TableDisplay = ({
             loading={loading}
             onChange={setVisualizationType}
             optionTooltipPlacement="left"
-            options={getTableDisplayOptions(columns, numericalColumns, autoVisualizationType, disabledReasonFor)}
+            options={getTableDisplayOptions(
+                columns,
+                numericalColumns,
+                autoVisualizationType,
+                disabledReasonFor,
+                !!featureFlags[FEATURE_FLAGS.METRIC_INSIGHT]
+            )}
             renderButtonContent={() => renderDisplayTypeLabel(visualizationType, autoVisualizationType)}
             size="small"
             value={visualizationType}

--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -327,7 +327,14 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
     } else if (effectiveVisualizationType === ChartDisplayType.BoldNumber) {
         component = <HogQLBoldNumber />
     } else if (effectiveVisualizationType === ChartDisplayType.Metric) {
-        component = <SqlMetricCard xData={xData} yData={yData} presetChartHeight={presetChartHeight} />
+        component = (
+            <SqlMetricCard
+                xData={xData}
+                yData={yData}
+                metricSettings={chartSettings.metric}
+                presetChartHeight={presetChartHeight}
+            />
+        )
     }
 
     if (props.embedded) {

--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -37,6 +37,7 @@ import { QueryFeature } from '../DataTable/queryFeatures'
 import { PieChart } from './Components/Charts/PieChart'
 import { SqlBoxPlot } from './Components/Charts/SqlBoxPlot'
 import { SqlChart } from './Components/Charts/SqlChart'
+import { SqlMetricCard } from './Components/Charts/SqlMetricCard'
 import { SqlScatterGraph } from './Components/Charts/SqlScatterGraph'
 import { TwoDimensionalHeatmap } from './Components/Heatmap/TwoDimensionalHeatmap'
 import { seriesBreakdownLogic } from './Components/seriesBreakdownLogic'
@@ -325,10 +326,21 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
         component = <TwoDimensionalHeatmap allowSorting={!(props.embedded && readOnly)} />
     } else if (effectiveVisualizationType === ChartDisplayType.BoldNumber) {
         component = <HogQLBoldNumber />
+    } else if (effectiveVisualizationType === ChartDisplayType.Metric) {
+        component = <SqlMetricCard xData={xData} yData={yData} presetChartHeight={presetChartHeight} />
     }
 
     if (props.embedded) {
-        return <div className="DataVisualization InsightCard__viz">{component}</div>
+        return (
+            <div
+                className={clsx(
+                    'DataVisualization InsightCard__viz',
+                    effectiveVisualizationType === ChartDisplayType.Metric && 'InsightCard__viz--Metric'
+                )}
+            >
+                {component}
+            </div>
+        )
     }
 
     return (

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -535,6 +535,10 @@ export function applyVisualizationType(
         chartSettings.pie = { ...chartSettings.pie, sliceContent: 'labels' }
     }
 
+    if (visualizationType === ChartDisplayType.Metric) {
+        yAxis = yAxis.slice(0, 1)
+    }
+
     if (
         [ChartDisplayType.ActionsLineGraph, ChartDisplayType.ActionsAreaGraph].includes(visualizationType) &&
         shouldUseFirstNumericColumnAsContinuousChartXAxis(columns, numericalColumns, selectedXAxis, selectedYAxis)
@@ -847,7 +851,8 @@ export interface dataVisualizationLogicMeta {
                 | TraceSpansQueryResponse
                 | null,
             columns: Column[],
-            chartSettings: ChartSettings
+            chartSettings: ChartSettings,
+            effectiveVisualizationType: ChartDisplayType
         ) => AxisSeries<number | null>[]
         xData: (
             selectedXAxis: string | null,
@@ -1450,7 +1455,7 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             (query: DataVisualizationNode): boolean => query.tableSettings?.transpose ?? false,
         ],
         yData: [
-            (s) => [s.selectedYAxis, s.response, s.columns, s.chartSettings],
+            (s) => [s.selectedYAxis, s.response, s.columns, s.chartSettings, s.effectiveVisualizationType],
             (
                 ySeries: (SelectedYAxis | null)[] | null,
                 response:
@@ -1469,7 +1474,8 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                     | import('~/queries/schema/schema-general').TraceSpansAttributeBreakdownQueryResponse
                     | import('~/queries/schema/schema-general').TraceSpansQueryResponse,
                 columns: Column[],
-                chartSettings: ChartSettings
+                chartSettings: ChartSettings,
+                visualizationType: ChartDisplayType
             ): AxisSeries<number | null>[] => {
                 if (!response || ySeries === null || ySeries.length === 0) {
                     return [EmptyYAxisSeries]
@@ -1483,7 +1489,7 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                           ? response.result
                           : []
 
-                return ySeries
+                const seriesData = ySeries
                     .map((series): AxisSeries<number | null> | null => {
                         if (!series) {
                             return EmptyYAxisSeries
@@ -1528,6 +1534,8 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                         }
                     })
                     .filter((series): series is AxisSeries<number | null> => Boolean(series))
+
+                return visualizationType === ChartDisplayType.Metric ? seriesData.slice(0, 1) : seriesData
             },
         ],
         xData: [

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -429,6 +429,13 @@ const mergeChartSettings = (state: ChartSettings, settings: ChartSettings): Char
                       ...settings.boxPlot,
                   }
                 : undefined,
+        metric:
+            state.metric || settings.metric
+                ? {
+                      ...state.metric,
+                      ...settings.metric,
+                  }
+                : undefined,
         leftYAxisSettings:
             state.leftYAxisSettings || settings.leftYAxisSettings
                 ? {

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -1489,7 +1489,8 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                           ? response.result
                           : []
 
-                const seriesData = ySeries
+                const mappedSeries = visualizationType === ChartDisplayType.Metric ? ySeries.slice(0, 1) : ySeries
+                const seriesData = mappedSeries
                     .map((series): AxisSeries<number | null> | null => {
                         if (!series) {
                             return EmptyYAxisSeries
@@ -1535,7 +1536,7 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                     })
                     .filter((series): series is AxisSeries<number | null> => Boolean(series))
 
-                return visualizationType === ChartDisplayType.Metric ? seriesData.slice(0, 1) : seriesData
+                return seriesData
             },
         ],
         xData: [

--- a/frontend/src/queries/nodes/DataVisualization/sqlVisualizationSupport.ts
+++ b/frontend/src/queries/nodes/DataVisualization/sqlVisualizationSupport.ts
@@ -19,7 +19,7 @@ const VISUALIZATION_SUPPORT: Record<ChartDisplayType, VisualizationSupport> = {
     [ChartDisplayType.ScatterPlot]: 'manual',
     [ChartDisplayType.TwoDimensionalHeatmap]: 'manual',
     [ChartDisplayType.ActionsBarValue]: 'manual',
-    [ChartDisplayType.Metric]: 'manual',
+    [ChartDisplayType.Metric]: 'axes',
     [ChartDisplayType.WorldMap]: 'manual',
     [ChartDisplayType.CalendarHeatmap]: 'manual',
     [ChartDisplayType.BoxPlot]: 'manual',
@@ -48,11 +48,12 @@ export function sqlVisualizationDisabledReason(
     }
 
     const nextQuery = applyVisualizationType(query, displayType, columns, rowCount)
-    if (nextQuery.chartSettings?.xAxis && nextQuery.chartSettings.yAxis?.length) {
+    const hasYAxis = !!nextQuery.chartSettings?.yAxis?.length
+    if (hasYAxis && (drawnAs === ChartDisplayType.Metric || nextQuery.chartSettings?.xAxis)) {
         return undefined
     }
 
-    return nextQuery.chartSettings?.yAxis?.length
+    return hasYAxis
         ? 'This insight has no column left to label the X-axis'
         : 'This insight has no numeric column to plot'
 }

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -16485,6 +16485,9 @@
                     "enum": ["top", "bottom", "left", "right"],
                     "type": "string"
                 },
+                "metric": {
+                    "$ref": "#/definitions/MetricChartSettings"
+                },
                 "pie": {
                     "$ref": "#/definitions/PieChartSettings"
                 },
@@ -37809,6 +37812,44 @@
                 "threads"
             ],
             "type": "string"
+        },
+        "MetricChartSettings": {
+            "additionalProperties": false,
+            "properties": {
+                "changeDecreaseColor": {
+                    "description": "Change pill color when the series went down. Defaults to red.",
+                    "type": "string"
+                },
+                "changeIncreaseColor": {
+                    "description": "Change pill color when the series went up. Defaults to green.",
+                    "type": "string"
+                },
+                "colorByDirection": {
+                    "default": false,
+                    "description": "Color the sparkline by whether the series went up or down.",
+                    "type": "boolean"
+                },
+                "lineDecreaseColor": {
+                    "description": "Sparkline color when the series went down. Defaults to red.",
+                    "type": "string"
+                },
+                "lineIncreaseColor": {
+                    "description": "Sparkline color when the series went up. Defaults to green.",
+                    "type": "string"
+                },
+                "showChange": {
+                    "default": true,
+                    "description": "Show the change pill comparing the first point to the latest point.",
+                    "type": "boolean"
+                },
+                "summary": {
+                    "default": "latest",
+                    "description": "Which value the resting headline shows: the latest point, the total, or the average of the returned points.",
+                    "enum": ["total", "average", "latest"],
+                    "type": "string"
+                }
+            },
+            "type": "object"
         },
         "MetricPropertyFilter": {
             "additionalProperties": false,

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1371,6 +1371,26 @@ export interface ScatterChartSettings {
     showBestFit?: boolean
 }
 
+export interface MetricChartSettings {
+    /** Which value the resting headline shows: the latest point, the total, or the average of the returned points.
+     * @default latest */
+    summary?: 'total' | 'average' | 'latest'
+    /** Show the change pill comparing the first point to the latest point.
+     * @default true */
+    showChange?: boolean
+    /** Change pill color when the series went up. Defaults to green. */
+    changeIncreaseColor?: string
+    /** Change pill color when the series went down. Defaults to red. */
+    changeDecreaseColor?: string
+    /** Color the sparkline by whether the series went up or down.
+     * @default false */
+    colorByDirection?: boolean
+    /** Sparkline color when the series went up. Defaults to green. */
+    lineIncreaseColor?: string
+    /** Sparkline color when the series went down. Defaults to red. */
+    lineDecreaseColor?: string
+}
+
 export interface BoxPlotSettings {
     xAxisColumn?: string | null
     seriesColumn?: string | null
@@ -1421,6 +1441,7 @@ export interface ChartSettings {
     pie?: PieChartSettings
     scatter?: ScatterChartSettings
     boxPlot?: BoxPlotSettings
+    metric?: MetricChartSettings
     /** Per-breakdown-value color customizations. Keyed by the raw breakdown column value. */
     resultCustomizations?: Record<string, ResultCustomizationByValue>
     /** Chart rendering style overrides (line shape). Only applies to line and area charts. */

--- a/frontend/src/queries/utils.test.ts
+++ b/frontend/src/queries/utils.test.ts
@@ -5,7 +5,7 @@ import { dayjs } from 'lib/dayjs'
 import { getAppContext } from 'lib/utils/getAppContext'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { DataTableNode, DataVisualizationNode, NodeKind } from '~/queries/schema/schema-general'
+import { DataTableNode, DataVisualizationNode, Node, NodeKind } from '~/queries/schema/schema-general'
 import type { InsightQueryNode } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import { AppContext, ChartDisplayType, FunnelVizType, TeamType } from '~/types'
@@ -18,6 +18,7 @@ import {
     escapePropertyAsHogQLIdentifier,
     getDisplay,
     hogql,
+    isMetricInsightQuery,
     queryUsesDataWarehouse,
     queryVizDefinitelyRendersToCanvas,
     queryVizRendersToCanvas,
@@ -478,5 +479,42 @@ describe('getDisplay', () => {
         ],
     ])('normalizes the deprecated ActionsStackedBar alias to ActionsBar for %s', (_, query) => {
         expect(getDisplay(query as InsightQueryNode)).toEqual(ChartDisplayType.ActionsBar)
+    })
+})
+
+describe('isMetricInsightQuery', () => {
+    it.each([
+        [
+            'SQL metric',
+            {
+                kind: NodeKind.DataVisualizationNode,
+                source: { kind: NodeKind.HogQLQuery, query: 'select 1' },
+                display: ChartDisplayType.Metric,
+            },
+            true,
+        ],
+        [
+            'trends metric',
+            {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    series: [],
+                    trendsFilter: { display: ChartDisplayType.Metric },
+                },
+            },
+            true,
+        ],
+        [
+            'SQL line chart',
+            {
+                kind: NodeKind.DataVisualizationNode,
+                source: { kind: NodeKind.HogQLQuery, query: 'select 1' },
+                display: ChartDisplayType.ActionsLineGraph,
+            },
+            false,
+        ],
+    ])('identifies a %s', (_label, query, expected) => {
+        expect(isMetricInsightQuery(query as Node)).toBe(expected)
     })
 })

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -492,6 +492,10 @@ export const getDisplay = (query: InsightQueryNode): ChartDisplayType | undefine
     return undefined
 }
 
+export const isMetricInsightQuery = (query?: Record<string, any> | null): boolean =>
+    (isDataVisualizationNode(query) && query.display === ChartDisplayType.Metric) ||
+    (isInsightVizNode(query) && isTrendsQuery(query.source) && getDisplay(query.source) === ChartDisplayType.Metric)
+
 // Display types whose viz paints to a <canvas> (Chart.js / quill-charts), which repaints on every resize
 // frame. Everything else renders as DOM/SVG and is cheap to keep mounted while a tile is resized.
 const CANVAS_CHART_DISPLAY_TYPES = new Set<ChartDisplayType>([

--- a/frontend/src/scenes/dashboard/tileLayouts.test.ts
+++ b/frontend/src/scenes/dashboard/tileLayouts.test.ts
@@ -2,7 +2,8 @@ import { Layout, LayoutItem } from 'react-grid-layout'
 
 import { calculateDuplicateLayout, calculateInsertionLayout, calculateLayouts } from 'scenes/dashboard/tileLayouts'
 
-import { DashboardLayoutSize, DashboardTile, QueryBasedInsightModel, TileLayout } from '~/types'
+import { NodeKind } from '~/queries/schema/schema-general'
+import { ChartDisplayType, DashboardLayoutSize, DashboardTile, QueryBasedInsightModel, TileLayout } from '~/types'
 
 function textTileWithLayout(
     layouts: Record<DashboardLayoutSize, TileLayout>,
@@ -62,6 +63,24 @@ describe('calculating tile layouts', () => {
         ]
 
         expect(calculateLayouts(tiles).sm?.[0]).toMatchObject({ w: 2, h: 1 })
+    })
+
+    it('defaults SQL metric tiles without a stored layout to 3 by 3', () => {
+        const tiles: DashboardTile<QueryBasedInsightModel>[] = [
+            {
+                id: 1,
+                insight: {
+                    query: {
+                        kind: NodeKind.DataVisualizationNode,
+                        source: { kind: NodeKind.HogQLQuery, query: 'SELECT count() FROM events' },
+                        display: ChartDisplayType.Metric,
+                    },
+                },
+                layouts: {},
+            } as unknown as DashboardTile<QueryBasedInsightModel>,
+        ]
+
+        expect(calculateLayouts(tiles).sm?.[0]).toMatchObject({ w: 3, h: 3 })
     })
 
     it('when the tiles have only 2-col layouts, 1 col layout is calculated', () => {

--- a/frontend/src/scenes/dashboard/tileLayouts.ts
+++ b/frontend/src/scenes/dashboard/tileLayouts.ts
@@ -10,7 +10,7 @@ import { textCardConverter } from 'lib/components/Cards/TextCard/textCardMarkdow
 import { BREAKPOINT_COLUMN_COUNTS } from 'scenes/dashboard/dashboardUtils'
 
 import { getQueryBasedInsightModel } from '~/queries/nodes/InsightViz/utils'
-import { isFunnelsQuery, isPathsQuery, isRetentionQuery, isTrendsQuery } from '~/queries/utils'
+import { isFunnelsQuery, isMetricInsightQuery, isPathsQuery, isRetentionQuery, isTrendsQuery } from '~/queries/utils'
 import { ChartDisplayType, DashboardLayoutSize, DashboardTile, QueryBasedInsightModel } from '~/types'
 
 import { getImageOnlyTextCardImage } from 'products/dashboards/frontend/components/ImageTile/imageTileUtils'
@@ -268,7 +268,7 @@ export const calculateLayouts = (
             } else if (isTrendsQuery(query) && query.trendsFilter?.display === ChartDisplayType.BoldNumber) {
                 defaultW = 2
                 defaultH = 2
-            } else if (isTrendsQuery(query) && query.trendsFilter?.display === ChartDisplayType.Metric) {
+            } else if (isMetricInsightQuery(query)) {
                 defaultW = 3
                 defaultH = 3
             }

--- a/frontend/src/scenes/dashboard/tileLayouts.ts
+++ b/frontend/src/scenes/dashboard/tileLayouts.ts
@@ -268,7 +268,7 @@ export const calculateLayouts = (
             } else if (isTrendsQuery(query) && query.trendsFilter?.display === ChartDisplayType.BoldNumber) {
                 defaultW = 2
                 defaultH = 2
-            } else if (isMetricInsightQuery(query)) {
+            } else if (isMetricInsightQuery(query?.query)) {
                 defaultW = 3
                 defaultH = 3
             }

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -49,6 +49,7 @@ import { DataTableRow } from '~/queries/nodes/DataTable/dataTableLogic'
 import { PieChart } from '~/queries/nodes/DataVisualization/Components/Charts/PieChart'
 import { SqlBoxPlot } from '~/queries/nodes/DataVisualization/Components/Charts/SqlBoxPlot'
 import { SqlChart } from '~/queries/nodes/DataVisualization/Components/Charts/SqlChart'
+import { SqlMetricCard } from '~/queries/nodes/DataVisualization/Components/Charts/SqlMetricCard'
 import { SqlScatterGraph } from '~/queries/nodes/DataVisualization/Components/Charts/SqlScatterGraph'
 import { TwoDimensionalHeatmap } from '~/queries/nodes/DataVisualization/Components/Heatmap/TwoDimensionalHeatmap'
 import { seriesBreakdownLogic } from '~/queries/nodes/DataVisualization/Components/seriesBreakdownLogic'
@@ -1044,10 +1045,21 @@ function InternalDataTableVisualization(
         component = <TwoDimensionalHeatmap />
     } else if (effectiveVisualizationType === ChartDisplayType.BoldNumber) {
         component = <HogQLBoldNumber />
+    } else if (effectiveVisualizationType === ChartDisplayType.Metric) {
+        component = <SqlMetricCard xData={xData} yData={yData} presetChartHeight={presetChartHeight} />
     }
 
     if (props.embedded && !props.showSettingsPanel) {
-        return <div className="DataVisualization InsightCard__viz">{component}</div>
+        return (
+            <div
+                className={clsx(
+                    'DataVisualization InsightCard__viz',
+                    effectiveVisualizationType === ChartDisplayType.Metric && 'InsightCard__viz--Metric'
+                )}
+            >
+                {component}
+            </div>
+        )
     }
 
     return (

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -1046,7 +1046,14 @@ function InternalDataTableVisualization(
     } else if (effectiveVisualizationType === ChartDisplayType.BoldNumber) {
         component = <HogQLBoldNumber />
     } else if (effectiveVisualizationType === ChartDisplayType.Metric) {
-        component = <SqlMetricCard xData={xData} yData={yData} presetChartHeight={presetChartHeight} />
+        component = (
+            <SqlMetricCard
+                xData={xData}
+                yData={yData}
+                metricSettings={chartSettings.metric}
+                presetChartHeight={presetChartHeight}
+            />
+        )
     }
 
     if (props.embedded && !props.showSettingsPanel) {

--- a/frontend/src/scenes/data-warehouse/editor/bi/BIEditor.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/bi/BIEditor.tsx
@@ -18,9 +18,11 @@ import { LemonButton, LemonCard, LemonInput, LemonLabel, LemonSearchableSelect, 
 
 import { HogQLDropdown } from 'lib/components/HogQLDropdown/HogQLDropdown'
 import { Resizer } from 'lib/components/Resizer/Resizer'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { Icon123, IconAreaChart, IconHeatmap, IconTableChart } from 'lib/lemon-ui/icons'
 import { LemonCalendarSelectInput } from 'lib/lemon-ui/LemonCalendar/LemonCalendarSelect'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { cn } from 'lib/utils/css-classes'
 
 import { ChartDisplayType } from '~/types'
@@ -54,6 +56,7 @@ const CHART_TYPE_OPTIONS: { value: ChartDisplayType; label: string; icon: JSX.El
     { value: ChartDisplayType.ActionsPie, label: 'Pie chart', icon: <IconPieChart /> },
     { value: ChartDisplayType.TwoDimensionalHeatmap, label: 'Pivot table', icon: <IconHeatmap /> },
     { value: ChartDisplayType.BoldNumber, label: 'Big number', icon: <Icon123 /> },
+    { value: ChartDisplayType.Metric, label: 'Metric', icon: <IconTrends /> },
 ]
 
 const AGGREGATION_OPTIONS: { value: BIAggregation; label: string }[] = [
@@ -104,6 +107,7 @@ export function BIEditor({ tabId }: { tabId: string }): JSX.Element {
     const { activeDropShelf, activeExpressionEditorId, availableDataSources, config, databaseLoading, sortOptions } =
         useValues(logic)
     const { biEditorHeight, biEditorResizerProps } = useValues(editorSizingLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
     const { setDatabaseTreeCollapsed } = useActions(editorSizingLogic)
     const { locateTable } = useActions(queryDatabaseLogic)
     const {
@@ -247,7 +251,10 @@ export function BIEditor({ tabId }: { tabId: string }): JSX.Element {
                 <div className="flex flex-col gap-1">
                     <LemonLabel>Chart type</LemonLabel>
                     <div className="flex flex-wrap gap-1" role="group" aria-label="Chart type">
-                        {CHART_TYPE_OPTIONS.map((option) => (
+                        {CHART_TYPE_OPTIONS.filter(
+                            (option) =>
+                                option.value !== ChartDisplayType.Metric || !!featureFlags[FEATURE_FLAGS.METRIC_INSIGHT]
+                        ).map((option) => (
                             <LemonButton
                                 key={option.value}
                                 type={config.chartType === option.value ? 'primary' : 'secondary'}

--- a/frontend/src/scenes/insights/EditorFilters/MetricFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/MetricFilters.tsx
@@ -2,9 +2,8 @@ import { useActions, useValues } from 'kea'
 
 import { LemonSelect } from '@posthog/lemon-ui'
 
-import { getSeriesColorPalette } from 'lib/colors'
+import { MetricDirectionColorPickers } from 'lib/components/Metric/MetricDirectionColorPickers'
 import { LemonCheckbox } from 'lib/lemon-ui/LemonCheckbox'
-import { LemonColorPicker } from 'lib/lemon-ui/LemonColor'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import {
     METRIC_COLOR_BY_DIRECTION_DEFAULT,
@@ -16,45 +15,6 @@ import {
 } from 'scenes/insights/views/Metric/Metric.utils'
 
 import { insightLogic } from '../insightLogic'
-
-const PRESET_COLORS = getSeriesColorPalette()
-
-function DirectionColorPickers({
-    increaseColor,
-    decreaseColor,
-    onIncrease,
-    onDecrease,
-}: {
-    increaseColor: string
-    decreaseColor: string
-    onIncrease: (color: string) => void
-    onDecrease: (color: string) => void
-}): JSX.Element {
-    return (
-        <div className="flex flex-col gap-1 pl-5">
-            <div className="flex items-center justify-between gap-2 p-1 px-2">
-                <span className="font-normal">Increase</span>
-                <LemonColorPicker
-                    colors={PRESET_COLORS}
-                    selectedColor={increaseColor}
-                    onSelectColor={onIncrease}
-                    showCustomColor
-                    preventPopoverClose
-                />
-            </div>
-            <div className="flex items-center justify-between gap-2 p-1 px-2">
-                <span className="font-normal">Decrease</span>
-                <LemonColorPicker
-                    colors={PRESET_COLORS}
-                    selectedColor={decreaseColor}
-                    onSelectColor={onDecrease}
-                    showCustomColor
-                    preventPopoverClose
-                />
-            </div>
-        </div>
-    )
-}
 
 export function MetricSummaryFilter(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
@@ -97,7 +57,9 @@ export function MetricShowChangeFilter(): JSX.Element {
                 size="small"
             />
             {showChange && (
-                <DirectionColorPickers
+                <MetricDirectionColorPickers
+                    className="gap-1 pl-5"
+                    rowClassName="p-1 px-2"
                     increaseColor={trendsFilter?.metricChangeIncreaseColor ?? METRIC_DEFAULT_INCREASE_COLOR}
                     decreaseColor={trendsFilter?.metricChangeDecreaseColor ?? METRIC_DEFAULT_DECREASE_COLOR}
                     onIncrease={(color) => updateInsightFilter({ metricChangeIncreaseColor: color })}
@@ -125,7 +87,9 @@ export function MetricColorFilter(): JSX.Element {
                 size="small"
             />
             {colorByDirection && (
-                <DirectionColorPickers
+                <MetricDirectionColorPickers
+                    className="gap-1 pl-5"
+                    rowClassName="p-1 px-2"
                     increaseColor={trendsFilter?.metricLineIncreaseColor ?? METRIC_DEFAULT_INCREASE_COLOR}
                     decreaseColor={trendsFilter?.metricLineDecreaseColor ?? METRIC_DEFAULT_DECREASE_COLOR}
                     onIncrease={(color) => updateInsightFilter({ metricLineIncreaseColor: color })}

--- a/frontend/src/scenes/insights/views/Metric/Metric.tsx
+++ b/frontend/src/scenes/insights/views/Metric/Metric.tsx
@@ -36,6 +36,7 @@ import {
     METRIC_SHOW_CHANGE_DEFAULT,
     METRIC_SUMMARY_DEFAULT,
     METRIC_SUMMARY_LABELS,
+    resolveMetricLineColor,
     selectCurrentSeries,
     selectPreviousSeriesSummary,
 } from './Metric.utils'
@@ -72,17 +73,16 @@ export function MetricCard({ inCardView }: ChartParams): JSX.Element {
     )
     const changeTooltip = getMetricChangeTooltip(summary, previousSeries != null, interval)
 
-    const isIncrease = (change?.value ?? 0) >= 0
     const pillColors = {
         positiveColor: makeChangeColor(trendsFilter?.metricChangeIncreaseColor ?? METRIC_DEFAULT_INCREASE_COLOR),
         negativeColor: makeChangeColor(trendsFilter?.metricChangeDecreaseColor ?? METRIC_DEFAULT_DECREASE_COLOR),
     }
-    const lineIncreaseColor = trendsFilter?.metricLineIncreaseColor ?? METRIC_DEFAULT_INCREASE_COLOR
-    const lineDecreaseColor = trendsFilter?.metricLineDecreaseColor ?? METRIC_DEFAULT_DECREASE_COLOR
-    let lineColor: string | undefined
-    if ((trendsFilter?.metricColorByDirection ?? METRIC_COLOR_BY_DIRECTION_DEFAULT) && change != null) {
-        lineColor = isIncrease ? lineIncreaseColor : lineDecreaseColor
-    }
+    const lineColor = resolveMetricLineColor({
+        colorByDirection: trendsFilter?.metricColorByDirection ?? METRIC_COLOR_BY_DIRECTION_DEFAULT,
+        change,
+        increaseColor: trendsFilter?.metricLineIncreaseColor ?? METRIC_DEFAULT_INCREASE_COLOR,
+        decreaseColor: trendsFilter?.metricLineDecreaseColor ?? METRIC_DEFAULT_DECREASE_COLOR,
+    })
 
     // Format the backend day labels the app's way, without the year ("June 16" rather than "16-Jun-2026").
     const labels =

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -267,6 +267,7 @@ from posthog.schema_enums import (
     StickinessOperator as StickinessOperator,
     Style as Style,
     SubscriptionDropoffMode as SubscriptionDropoffMode,
+    Summary as Summary,
     SurveyMatchType as SurveyMatchType,
     SurveyPosition as SurveyPosition,
     SurveyQuestionBranchingType as SurveyQuestionBranchingType,
@@ -2268,6 +2269,43 @@ class MaxProductInfo(BaseModel):
     projected_amount_usd_with_limit: str | None = None
     type: str
     usage_limit: float | None = None
+
+
+class MetricChartSettings(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    changeDecreaseColor: str | None = Field(
+        default=None,
+        description="Change pill color when the series went down. Defaults to red.",
+    )
+    changeIncreaseColor: str | None = Field(
+        default=None,
+        description="Change pill color when the series went up. Defaults to green.",
+    )
+    colorByDirection: bool | None = Field(
+        default=False,
+        description="Color the sparkline by whether the series went up or down.",
+    )
+    lineDecreaseColor: str | None = Field(
+        default=None,
+        description="Sparkline color when the series went down. Defaults to red.",
+    )
+    lineIncreaseColor: str | None = Field(
+        default=None,
+        description="Sparkline color when the series went up. Defaults to green.",
+    )
+    showChange: bool | None = Field(
+        default=True,
+        description=("Show the change pill comparing the first point to the latest point."),
+    )
+    summary: Summary | None = Field(
+        default=Summary.LATEST,
+        description=(
+            "Which value the resting headline shows: the latest point, the total, or"
+            " the average of the returned points."
+        ),
+    )
 
 
 class MetricsAlertConfig(BaseModel):
@@ -15604,6 +15642,7 @@ class ChartSettings(BaseModel):
             " type: right for pie, top for the rest."
         ),
     )
+    metric: MetricChartSettings | None = None
     pie: PieChartSettings | None = None
     resultCustomizations: dict[str, ResultCustomizationByValue] | None = Field(
         default=None,

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -3304,6 +3304,12 @@ class MetaAdsDefaultSources(StrEnum):
     THREADS = "threads"
 
 
+class Summary(StrEnum):
+    TOTAL = "total"
+    AVERAGE = "average"
+    LATEST = "latest"
+
+
 class MetricsAggregation(StrEnum):
     SUM = "sum"
     AVG = "avg"

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -8937,6 +8937,31 @@ export interface YAxisSettingsApi {
     startAtZero?: boolean | null
 }
 
+export type SummaryApi = (typeof SummaryApi)[keyof typeof SummaryApi]
+
+export const SummaryApi = {
+    Total: 'total',
+    Average: 'average',
+    Latest: 'latest',
+} as const
+
+export interface MetricChartSettingsApi {
+    /** Change pill color when the series went down. Defaults to red. */
+    changeDecreaseColor?: string | null
+    /** Change pill color when the series went up. Defaults to green. */
+    changeIncreaseColor?: string | null
+    /** Color the sparkline by whether the series went up or down. */
+    colorByDirection?: boolean | null
+    /** Sparkline color when the series went down. Defaults to red. */
+    lineDecreaseColor?: string | null
+    /** Sparkline color when the series went up. Defaults to green. */
+    lineIncreaseColor?: string | null
+    /** Show the change pill comparing the first point to the latest point. */
+    showChange?: boolean | null
+    /** Which value the resting headline shows: the latest point, the total, or the average of the returned points. */
+    summary?: SummaryApi | null
+}
+
 export type SliceContentApi = (typeof SliceContentApi)[keyof typeof SliceContentApi]
 
 export const SliceContentApi = {
@@ -9041,6 +9066,7 @@ export interface ChartSettingsApi {
     leftYAxisSettings?: YAxisSettingsApi | null
     /** Where the legend sits relative to the chart. Unset falls back per chart type: right for pie, top for the rest. */
     legendPosition?: LegendPositionApi | null
+    metric?: MetricChartSettingsApi | null
     pie?: PieChartSettingsApi | null
     /** Per-breakdown-value color customizations. Keyed by the raw breakdown column value. */
     resultCustomizations?: ChartSettingsApiResultCustomizations

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -7975,6 +7975,31 @@ export interface YAxisSettingsApi {
     startAtZero?: boolean | null
 }
 
+export type SummaryApi = (typeof SummaryApi)[keyof typeof SummaryApi]
+
+export const SummaryApi = {
+    Total: 'total',
+    Average: 'average',
+    Latest: 'latest',
+} as const
+
+export interface MetricChartSettingsApi {
+    /** Change pill color when the series went down. Defaults to red. */
+    changeDecreaseColor?: string | null
+    /** Change pill color when the series went up. Defaults to green. */
+    changeIncreaseColor?: string | null
+    /** Color the sparkline by whether the series went up or down. */
+    colorByDirection?: boolean | null
+    /** Sparkline color when the series went down. Defaults to red. */
+    lineDecreaseColor?: string | null
+    /** Sparkline color when the series went up. Defaults to green. */
+    lineIncreaseColor?: string | null
+    /** Show the change pill comparing the first point to the latest point. */
+    showChange?: boolean | null
+    /** Which value the resting headline shows: the latest point, the total, or the average of the returned points. */
+    summary?: SummaryApi | null
+}
+
 export type SliceContentApi = (typeof SliceContentApi)[keyof typeof SliceContentApi]
 
 export const SliceContentApi = {
@@ -8079,6 +8104,7 @@ export interface ChartSettingsApi {
     leftYAxisSettings?: YAxisSettingsApi | null
     /** Where the legend sits relative to the chart. Unset falls back per chart type: right for pie, top for the rest. */
     legendPosition?: LegendPositionApi | null
+    metric?: MetricChartSettingsApi | null
     pie?: PieChartSettingsApi | null
     /** Per-breakdown-value color customizations. Keyed by the raw breakdown column value. */
     resultCustomizations?: ChartSettingsApiResultCustomizations

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -8720,6 +8720,32 @@ export namespace Schemas {
       startAtZero?: boolean | null;
     }
 
+    export type Summary = typeof Summary[keyof typeof Summary];
+
+
+    export const Summary = {
+      Total: 'total',
+      Average: 'average',
+      Latest: 'latest',
+    } as const;
+
+    export interface MetricChartSettings {
+      /** Change pill color when the series went down. Defaults to red. */
+      changeDecreaseColor?: string | null;
+      /** Change pill color when the series went up. Defaults to green. */
+      changeIncreaseColor?: string | null;
+      /** Color the sparkline by whether the series went up or down. */
+      colorByDirection?: boolean | null;
+      /** Sparkline color when the series went down. Defaults to red. */
+      lineDecreaseColor?: string | null;
+      /** Sparkline color when the series went up. Defaults to green. */
+      lineIncreaseColor?: string | null;
+      /** Show the change pill comparing the first point to the latest point. */
+      showChange?: boolean | null;
+      /** Which value the resting headline shows: the latest point, the total, or the average of the returned points. */
+      summary?: Summary | null;
+    }
+
     export type SliceContent = typeof SliceContent[keyof typeof SliceContent];
 
 
@@ -8830,6 +8856,7 @@ export namespace Schemas {
       leftYAxisSettings?: YAxisSettings | null;
       /** Where the legend sits relative to the chart. Unset falls back per chart type: right for pie, top for the rest. */
       legendPosition?: LegendPosition | null;
+      metric?: MetricChartSettings | null;
       pie?: PieChartSettings | null;
       /** Per-breakdown-value color customizations. Keyed by the raw breakdown column value. */
       resultCustomizations?: ChartSettingsResultCustomizations;


### PR DESCRIPTION
## Problem

People can show a SQL query as a big number, but cannot pair its latest value with a trend.

## Changes

- SQL insights can show one numeric series as a Metric chart.
- The chart shows the latest dated value, a sparkline, and change across returned points.
- The date under the number reads like the line chart tooltip, for example "Sep 9, 2026" in the team timezone.
- A Display tab offers the same settings as the trends Metric: headline value (latest, total, or average), a change pill with its colors, and color by trend with its colors.
- The settings live under `chartSettings.metric` and pass through the SQL editor, dashboard cards, and exports alike.
- The picker lists Metric under Charts, next to Line chart, with a heavier trending icon than before. The trends chart picker uses the same icon.
- Mechanical: the increase and decrease color pickers moved out of the trends filter file into a shared component, and the generated Python schema was regenerated.
- The existing `metric-insight` flag controls the picker. Saved Metric queries continue to render when the flag is off.
- Dashboard cards, exports, and the BI editor use the same Metric renderer and compact layout.
- The renderer orders date rows chronologically and omits null values from the sparkline.

Before this change, SQL chart pickers did not offer Metric and saved Metric queries rendered no chart.

![SQL Metric chart](https://raw.githubusercontent.com/PostHog/pr-assets/1847e0a670ad2255995aaebbe263698a879cb387/2026/09/abf3a37c-2749-4ba4-8802-e79004ea9104.png)

The Display tab for a Metric:

![pr96725-sidebar-full](https://raw.githubusercontent.com/PostHog/pr-assets/58bc4a1b82a046c99aa6b8a052a58b87ee5a3440/2026/09/b686d7c7-5639-4589-b99d-70a3c0bf9f05.png)

## How did you test this code?

- Targeted Jest tests cover picker gating, single-series setup, SQL formatting, dated row order, dashboard support, and Metric query detection.
- Two more Jest cases: the card applies the total headline and hidden change pill from its settings, and the Display tab shows only the Metric panel and persists a toggle.
- Storybook rendered the Metric chart at 800 px and 520 px widths in Chromium.
- Checked by hand in a local dev stack: the insight page, the SQL editor with each Display setting, and the picker grouping.
- Not checked by hand: dashboard cards and exports with the new settings, and dark mode.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. The chart uses the existing Metric name and SQL visualization controls.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Desktop used Explore subagents, PostHog MCP, Storybook, and Playwright.
- Skills invoked: `/writing-ui-components`, `/working-with-charts`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-kea-logics`, `/writing-code-comments`, `/running-ci-preflight`, and `/writing-pr-descriptions`.
- The implementation reuses the existing Metric component and feature flag instead of adding another card or rollout control.
- The duplicate search found no open pull request that adds Metric charts to SQL insights.
- The diff uses repository context and invented fixture values only.
- A later Claude Code session added the date formatting, the picker grouping and icon, and the Display settings, and verified them with Playwright against a local stack.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*


