### PR TITLE
fix(web): restore optional memory diagnostics

### DIFF
--- a/docs/internal/django-startup-time.md
+++ b/docs/internal/django-startup-time.md
@@ -25,7 +25,31 @@ This is the laziness Django already intends: the URLconf is the entry point, and
 
 Web is the exception and resolves it eagerly: `wsgi.py`/`asgi.py` build the URLconf at import, pre-fork, inside the GC window — because the k8s probes (`/_livez`, `/_readyz`) are served by short-circuiting middleware and never resolve URLs, each worker would otherwise build the router on its **first live request** (measured at multiple seconds per worker, after every deploy).
 Pre-building lands the router in the frozen heap at worker boot — exactly the pre-lazy-router behavior for web, while every other process keeps the win.
-`test_web_entrypoint_prebuilds_the_router` pins this; a prefork smoke (gunicorn `--preload`, 4 workers) verified workers inherit the built router and serve cold requests without it.
+`test_web_entrypoint_initializes_router_and_memory_probe` pins this; a prefork smoke (gunicorn `--preload`, 4 workers) verified workers inherit the built router and serve cold requests without it.
+
+When `WEB_MEMORY_PROBE_ENABLED=true`, WSGI also installs the SIGUSR2 memory probe during worker import, on the main thread.
+Do not defer signal registration to the first WSGI request: Granian serves it on a blocking thread, where Python rejects `signal.signal()`.
+ASGI installs the probe on the first request because its event loop runs on the worker's main thread.
+Granian 2.8.2 loads the application inside `WorkerProcess.wrap_target`, before setting worker shutdown handlers
+(`SIGINT`/`SIGTERM`, leaving `SIGUSR2` intact). Failed-worker and RSS-driven replacements use the same loader,
+so each replacement installs its own handler. ASGI lifespan startup alone does not arm the probe.
+The probe creates loggers only after Django configures logging; its `disable_existing_loggers` setting
+would otherwise silence a logger created during the initial WSGI imports.
+
+The probe is disabled by default and does no collection or trimming until signalled. Target a worker PID,
+not the Granian supervisor, and wait for handler installation (for ASGI, after a first request).
+Without an installed handler, SIGUSR2 can terminate the process.
+Signals arriving during a probe are dropped; later signals run another probe. Diagnostic exceptions are
+contained, including failures while logging the error.
+
+GC and `malloc_trim(0)` run synchronously and can pause requests; this is an occasional diagnostic, not a
+scheduled cleanup. Collection leaves the frozen startup heap frozen. On CPython 3.13, collection already in
+progress causes a nested `gc.collect()` to return zero, so that sample is inconclusive. Small GC/trim deltas
+do not prove all memory is live: frozen objects, concurrent allocations, and non-glibc allocators limit the
+measurement. Missing `/proc`, `mallinfo2`, or `malloc_trim` produces null fields where unavailable.
+
+This flag is independent of `WEB_MEMORY_SAMPLE_INTERVAL_SECONDS` (the periodic RSS gauge/log, default 30 seconds)
+and `GRANIAN_WORKERS_MAX_RSS` (Granian's automatic worker recycling). Neither invokes this diagnostic.
 
 ### 2. Model registration
 

--- a/posthog/test/repo_invariants/test_startup_import_budget.py
+++ b/posthog/test/repo_invariants/test_startup_import_budget.py
@@ -438,15 +438,20 @@ def test_no_new_heavy_imports_at_setup() -> None:
 # pre-fork, so workers share it copy-on-write. Without this, each worker builds the router
 # on its first live request (k8s probes short-circuit in middleware and never warm it),
 # which measured at multiple seconds per worker after every deploy.
-def test_web_entrypoint_prebuilds_the_router() -> None:
+def test_web_entrypoint_initializes_router_and_memory_probe() -> None:
     probe = """
 import os
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
+os.environ["WEB_MEMORY_PROBE_ENABLED"] = "true"
 import posthog.wsgi  # noqa: F401 — the real web entry; builds the app and resolves the URLconf
 import sys
 assert "posthog.api.rest_router" in sys.modules, "wsgi import did not build the API router"
 from django.urls import get_resolver
 assert get_resolver()._populated or get_resolver().url_patterns, "URLconf not resolved"
+import signal
+from posthog.web_memory_probe import _handle_probe
+assert signal.getsignal(signal.SIGUSR2) is _handle_probe, "WSGI boot did not install the memory probe"
+signal.raise_signal(signal.SIGUSR2)
 print("WSGI_PREBUILD_OK")
 """
     result = subprocess.run(
@@ -457,3 +462,5 @@ print("WSGI_PREBUILD_OK")
     )
     assert result.returncode == 0, f"posthog.wsgi import failed:\n{result.stderr[-2000:]}"
     assert "WSGI_PREBUILD_OK" in result.stdout, result.stdout[-500:]
+    output = result.stdout + result.stderr
+    assert "web_memory_probe" in output and "gc_collected" in output, "SIGUSR2 did not log memory diagnostics"

--- a/posthog/test/test_web_memory_probe.py
+++ b/posthog/test/test_web_memory_probe.py
@@ -1,0 +1,63 @@
+import gc
+import signal
+import logging
+from collections.abc import Iterator
+from contextlib import ExitStack
+
+import pytest
+from unittest.mock import patch
+
+from structlog.testing import LogCapture, capture_logs
+
+from posthog.web_memory_probe import install_memory_probe_handler
+
+
+@pytest.fixture
+def installed_probe(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    previous = signal.getsignal(signal.SIGUSR2)
+    monkeypatch.setenv("WEB_MEMORY_PROBE_ENABLED", "true")
+    try:
+        install_memory_probe_handler()
+        yield
+    finally:
+        signal.signal(signal.SIGUSR2, previous)
+
+
+def test_disabled_probe_preserves_signal_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("WEB_MEMORY_PROBE_ENABLED", raising=False)
+    previous = signal.getsignal(signal.SIGUSR2)
+    install_memory_probe_handler()
+    assert signal.getsignal(signal.SIGUSR2) == previous
+
+
+def test_overlapping_signals_are_dropped_and_later_probes_work(installed_probe: None) -> None:
+    def signal_during_collection(phase: str, info: dict[str, int]) -> None:
+        signal.raise_signal(signal.SIGUSR2)
+
+    gc.callbacks.append(signal_during_collection)
+    try:
+        with capture_logs() as events:
+            signal.raise_signal(signal.SIGUSR2)
+    finally:
+        gc.callbacks.remove(signal_during_collection)
+
+    assert [event["event"] for event in events] == ["web_memory_probe"]
+    with capture_logs() as events:
+        signal.raise_signal(signal.SIGUSR2)
+    assert [event["event"] for event in events] == ["web_memory_probe"]
+
+
+@pytest.mark.parametrize("failure", ["collection", "diagnostic_logging", "error_logging"])
+def test_probe_failure_does_not_escape_and_later_probes_work(installed_probe: None, failure: str) -> None:
+    with capture_logs(), ExitStack() as patches:
+        if failure == "diagnostic_logging":
+            patches.enter_context(patch.object(LogCapture, "__call__", side_effect=RuntimeError("logging failed")))
+        else:
+            patches.enter_context(patch.object(gc, "collect", side_effect=RuntimeError("collection failed")))
+            if failure == "error_logging":
+                patches.enter_context(patch.object(logging.Logger, "exception", side_effect=RuntimeError("log failed")))
+        signal.raise_signal(signal.SIGUSR2)
+
+    with capture_logs() as events:
+        signal.raise_signal(signal.SIGUSR2)
+    assert [event["event"] for event in events] == ["web_memory_probe"]

--- a/posthog/web_memory_probe.py
+++ b/posthog/web_memory_probe.py
@@ -3,13 +3,13 @@ import os
 import ctypes
 import signal
 import logging
+import threading
 from types import FrameType
 
 import structlog
 
-logger = logging.getLogger(__name__)
-
 PROBE_ENABLED_ENV = "WEB_MEMORY_PROBE_ENABLED"
+_probe_lock = threading.Lock()
 
 # glibc mallinfo2() layout — all size_t (see `man mallinfo2`). mallinfo2 (glibc >= 2.33)
 # supersedes mallinfo(), whose int fields overflow on the multi-GB heaps we care about.
@@ -74,7 +74,7 @@ def _read_vmrss_kb() -> int | None:
 def _mallinfo2() -> dict[str, int] | None:
     """glibc allocator stats: how much the process has taken from the OS and how much is
     parked on free lists (fordblks) rather than returned. Quantifies reclaimable
-    fragmentation directly, in O(1), without a heap walk. None where libc/mallinfo2 is
+    fragmentation without walking the Python heap. None where libc/mallinfo2 is
     unavailable (non-glibc, e.g. dev macOS)."""
     if _LIBC is None:
         return None
@@ -86,25 +86,32 @@ def _mallinfo2() -> dict[str, int] | None:
 
 
 def _handle_probe(signum: int, frame: FrameType | None) -> None:
-    """SIGUSR2 handler — a one-shot memory diagnostic for a single worker. Python delivers
-    signals on the main thread between bytecodes, so ordinary work (logging, ctypes calls)
-    is safe here; logging's RLock is reentrant for the same thread, so interrupting a log
-    call can't self-deadlock.
+    # A signal can interrupt an earlier probe, including its GC callbacks or logging.
+    # Never wait here: the interrupted probe cannot release the lock until we return.
+    if not _probe_lock.acquire(blocking=False):
+        return
+    try:
+        _run_probe()
+    except Exception:
+        try:
+            logging.getLogger(__name__).exception("web memory probe failed")
+        except Exception:
+            # Logging may itself be the failed diagnostic; don't unwind server code.
+            pass
+    finally:
+        _probe_lock.release()
 
-    Captures mallinfo2 *before* gc/trim disturb it (malloc_trim hands back exactly the
-    reclaimable free-list pages, so a post-trim fordblks reads what's left, not what was
-    hoarded), then RSS at three points plus malloc_trim's own return value. Read the verdict
-    as — note gc.collect() frees cycles into glibc's free list, NOT back to the OS, so RSS
-    may not move even when collection happened; key the cycle call off the count, not RSS:
-      gc_collected large                 -> reference cycles are a factor (Python-level / gc tuning),
-                                            independent of whether RSS moved
-      (rss_before - rss_after_trim) large -> glibc was holding reclaimable pages (malloc_released == 1);
-        or malloc_released == 1             jemalloc decay or a periodic trim would recover it -> the jemalloc gate
-      both small                         -> memory is genuinely live (only fetching/retaining less helps)
 
-    mallinfo2_before.fordblks vs uordblks is the free-list-vs-live split before trim runs.
-    The gc.collect() costs a single pause on the one worker that's signalled, which is why
-    this is fired by hand on a chosen pod, never on a schedule."""
+def _run_probe() -> None:
+    """Run a synchronous diagnostic on the signalled worker's main thread.
+
+    Capture mallinfo2 before GC and trim change the allocator's free lists. gc_collected
+    counts unreachable objects, not bytes; collecting cycles need not reduce RSS.
+    malloc_released reports whether glibc returned any pages, not how many.
+    Collection skips the frozen startup heap. Concurrent request allocations can obscure
+    RSS deltas, and glibc statistics do not describe a replacement allocator's heap.
+    Small collection counts and RSS deltas therefore do not prove that all memory is live.
+    GC and trim can pause requests, so fire this manually, never on a schedule."""
     log = structlog.get_logger("posthog.web_memory_probe")
     mallinfo_before = _mallinfo2()
     rss_before = _read_vmrss_kb()
@@ -140,10 +147,9 @@ def _handle_probe(signum: int, frame: FrameType | None) -> None:
 def install_memory_probe_handler() -> None:
     """Register the SIGUSR2 memory-probe handler, gated by WEB_MEMORY_PROBE_ENABLED.
 
-    MUST be called from inside each worker (see posthog/asgi.py and posthog/wsgi.py): signal
-    handlers can only be registered from the main thread, and the handler has to live in the
-    process that serves requests. Registering it there also keeps it clear of any signal reset
-    the server does during worker init.
+    MUST be called on each worker's main thread: WSGI installs during module import,
+    before requests enter Granian's blocking thread pool; ASGI installs on the first request
+    in the event loop. Granian's shutdown handlers leave SIGUSR2 untouched.
 
     Inert until armed: with the flag unset (default) nothing is registered at all, and even
     when armed the handler does nothing until a SIGUSR2 actually arrives. So the safe way to
@@ -153,7 +159,7 @@ def install_memory_probe_handler() -> None:
         return
     try:
         signal.signal(signal.SIGUSR2, _handle_probe)
-        logger.info("web memory probe handler installed on SIGUSR2")
+        logging.getLogger(__name__).info("web memory probe handler installed on SIGUSR2")
     except (ValueError, OSError):
         # signal.signal raises ValueError off the main thread; stay best-effort.
-        logger.exception("failed to install web memory probe handler")
+        logging.getLogger(__name__).exception("failed to install web memory probe handler")

--- a/posthog/wsgi.py
+++ b/posthog/wsgi.py
@@ -84,6 +84,10 @@ def _log_web_worker_started() -> None:
 
 _log_web_worker_started()
 
+# Granian imports this module on each worker's main thread, before WSGI requests
+# run in its blocking thread pool where Python forbids signal registration.
+install_memory_probe_handler()
+
 # The query_cache RedisCluster must be discovered by the process that uses it: a client
 # built at import time is inherited, sockets and all, by anything forked afterwards.
 # Defer the prewarm to the first request; the factory also pid-guards the cache as a
@@ -105,8 +109,5 @@ def application(environ, start_response):
         # Threads do not survive a fork, so start the sampler from the process that
         # actually serves requests.
         start_web_memory_sampler()
-        # Signal handlers install only from the main thread, so this logs a handled failure
-        # when the server calls the app off it. Inert unless the env flag is set.
-        install_memory_probe_handler()
         _prewarmed = True
     return _django_application(environ, start_response)


### PR DESCRIPTION
## Problem

- Operators cannot obtain optional WSGI memory diagnostics: registration runs off the main thread, and Django disables the logger.
- This predates [chore: remove nginx unit](https://github.com/PostHog/posthog/pull/94467).

## Changes

- Diagnostics register at worker import and retain working logging.
- Overlapping signals are dropped; diagnostic exceptions stay contained.
- Sampling and recycling remain independent.

## How did you test this code?

- Regression tests cover registration, emitted logs, overlapping signals, and failure recovery.
- Granian 2.8.2 smoke exercised WSGI/ASGI signals and respawn on macOS.
- Unchecked locally: Linux trimming and RSS-triggered recycling.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- Documents lifecycle and diagnostic limitations.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex; Git, gh, Flox, pytest, Ruff.
- Skills: code-review, maintaining-python-tests, django-startup-time, writing-tests, writing-code-comments, source-command-conventions, simplify, running-ci-preflight, writing-pr-descriptions.
- Duplicate search found none; no private source material.
