### PR TITLE
fix(replay-vision): report the calling surface as creation_method outside the app

### DIFF
--- a/products/replay_vision/backend/api/scanners.py
+++ b/products/replay_vision/backend/api/scanners.py
@@ -152,7 +152,7 @@ class ScannerCreationMethod(models.TextChoices):
     SCRATCH = "scratch", "From scratch"
 
 
-def _reported_creation_method(request: Request | None, claimed: str | None) -> str | None:
+def _reported_creation_method(context: dict[str, Any], claimed: str | None) -> str | None:
     """What `creation_method` says on the created event.
 
     The field answers how a person filled the creation form, so only a request from the app can
@@ -163,10 +163,15 @@ def _reported_creation_method(request: Request | None, claimed: str | None) -> s
 
     Worth the override rather than only filling in a missing value: the wizard creates several times
     more scanners than the app does, and it already sends a method on some of its calls.
+
+    Max reaches the serializer directly with no HTTP request, so it declares its surface in the
+    context the same way it passes `user`. Without that it would fall through as unattributed, which
+    is the one gap a request-derived source cannot close.
     """
-    if request is None:
+    request = context.get("request")
+    source = get_event_source(request) if request is not None else context.get("event_source")
+    if source is None:
         return claimed
-    source = get_event_source(request)
     return claimed if source == EventSource.WEB else source.value
 
 
@@ -793,7 +798,7 @@ class ReplayScannerSerializer(TaggedItemSerializerMixin, UserAccessControlSerial
             {
                 **_scanner_lifecycle_properties(scanner),
                 "creation_flow_variant": _goal_flow_variant(user, team),
-                "creation_method": _reported_creation_method(self.context.get("request"), creation_method),
+                "creation_method": _reported_creation_method(self.context, creation_method),
             },
             team=team,
             request=self.context.get("request"),

--- a/products/replay_vision/backend/api/scanners.py
+++ b/products/replay_vision/backend/api/scanners.py
@@ -29,7 +29,7 @@ from posthog.schema import RecordingsQuery
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin, set_tags_on_object
-from posthog.event_usage import report_user_action
+from posthog.event_usage import EventSource, get_event_source, report_user_action
 from posthog.exceptions import QuotaLimitExceeded
 from posthog.models.tag import tagify
 from posthog.models.tagged_item import TaggedItem
@@ -142,11 +142,32 @@ class ScannerCreationMethod(models.TextChoices):
 
     Separate from the creation-flow experiment arm, which says only which flow a person was offered.
     Someone offered the AI flow can still fill the form by hand, so this is what says what they did.
+
+    These are the values a caller may send. The property reported on the event can also hold an
+    `EventSource` — see `_reported_creation_method`.
     """
 
     AI = "ai", "AI draft"
     TEMPLATE = "template", "Template"
     SCRATCH = "scratch", "From scratch"
+
+
+def _reported_creation_method(request: Request | None, claimed: str | None) -> str | None:
+    """What `creation_method` says on the created event.
+
+    The field answers how a person filled the creation form, so only a request from the app can
+    answer it at all. Every other surface reports its own source instead, which keeps the values
+    mutually exclusive: `ai`/`template`/`scratch` mean a person in the editor, anything else names
+    the caller. An agent creating a scanner over MCP is not someone building one by hand, and
+    letting it report `scratch` inflates the hand-built side of the creation-flow comparison.
+
+    Worth the override rather than only filling in a missing value: the wizard creates several times
+    more scanners than the app does, and it already sends a method on some of its calls.
+    """
+    if request is None:
+        return claimed
+    source = get_event_source(request)
+    return claimed if source == EventSource.WEB else source.value
 
 
 def _goal_flow_variant(user: User, team: Team) -> str | None:
@@ -365,7 +386,8 @@ class ReplayScannerSerializer(TaggedItemSerializerMixin, UserAccessControlSerial
             "How the creator built this scanner: from an AI draft, from a template, or from scratch. "
             "Reported to product analytics at creation and not stored on the scanner. Independent of "
             "any experiment the creator is in, since a person offered the AI flow can still fill the "
-            "form by hand. Ignored on update."
+            "form by hand. Only the app can answer this, so a request from anywhere else reports the "
+            "calling surface instead of whatever it sends here. Ignored on update."
         ),
     )
     scanner_config = serializers.JSONField(
@@ -766,11 +788,12 @@ class ReplayScannerSerializer(TaggedItemSerializerMixin, UserAccessControlSerial
             # read from the flag, so it carries intent to treat and keeps the arms comparable: someone
             # offered the AI flow counts as treated even when they ignore it. `creation_method` is what
             # the person actually did, which is what says whether AI-built scanners turn out better.
-            # None when the caller is not the app, since only the UI knows how the form was filled.
+            # It names the calling surface when the caller is not the app, since only the UI knows
+            # how the form was filled.
             {
                 **_scanner_lifecycle_properties(scanner),
                 "creation_flow_variant": _goal_flow_variant(user, team),
-                "creation_method": creation_method,
+                "creation_method": _reported_creation_method(self.context.get("request"), creation_method),
             },
             team=team,
             request=self.context.get("request"),

--- a/products/replay_vision/backend/max_tools.py
+++ b/products/replay_vision/backend/max_tools.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field
 from rest_framework.exceptions import Throttled
 
 from posthog.clickhouse.client.connection import ClickHouseUser
+from posthog.event_usage import EventSource
 from posthog.exceptions import QuotaLimitExceeded
 from posthog.models.team import Team
 from posthog.models.user import User
@@ -1080,7 +1081,13 @@ class CreateReplayVisionScannerTool(ReplayVisionGatesMixin, MaxTool):
                 "sampling_rate": sampling_rate,
                 "enabled": enabled,
             },
-            context={"get_team": lambda: self._team, "user": self._user},
+            # No HTTP request here, so the surface can't be derived from one. Declared instead, or
+            # the creation-flow comparison counts a scanner Max made as one nobody can account for.
+            context={
+                "get_team": lambda: self._team,
+                "user": self._user,
+                "event_source": EventSource.POSTHOG_AI,
+            },
         )
         if not serializer.is_valid():
             return _first_error(serializer.errors), {"error": "invalid_config"}

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -1050,58 +1050,34 @@ class TestScannerLifecycleTelemetry(_VisionAPITestCase):
         expected = flag_value if isinstance(flag_value, str) else None
         self.assertEqual(created[0].kwargs["properties"]["creation_flow_variant"], expected)
 
-    def test_create_reports_how_the_scanner_was_built(self):
+    @parameterized.expand(
+        [
+            ("app", {}, "ai", "ai"),
+            ("wizard", {"HTTP_USER_AGENT": "posthog/wizard 1.2.3"}, "scratch", "wizard"),
+        ]
+    )
+    def test_create_reports_how_the_scanner_was_built(
+        self, _name: str, headers: dict[str, str], claimed: str, expected: str
+    ) -> None:
         # The arm says which flow the person was offered; this says what they did with it. Someone
         # offered the AI flow can still fill the form by hand, so a metric comparing AI-built against
         # hand-built scanners needs this and cannot read it off the arm.
+        #
+        # Only the app has a form, so a caller that has none reports its surface instead of what it
+        # claims. Resolved from a real user agent, since the question is whether a caller's surface
+        # reaches the serializer at all — a patched source asserts only that the branch exists.
         with patch("posthoganalytics.capture") as capture:
             resp = self.client.post(
                 self.scanners_url,
                 data={
-                    "name": "telemetry-method",
+                    "name": f"telemetry-method-{_name}",
                     "scanner_type": ScannerType.MONITOR,
                     "scanner_config": {"prompt": "did checkout complete?"},
                     "model": ScannerModel.GEMINI_3_8_FLASH,
-                    "creation_method": "ai",
+                    "creation_method": claimed,
                 },
                 format="json",
-            )
-
-        self.assertEqual(resp.status_code, 201, resp.json())
-        created = [
-            call for call in capture.call_args_list if call.kwargs.get("event") == "replay_vision_scanner_created"
-        ]
-        self.assertEqual(created[0].kwargs["properties"]["creation_method"], "ai")
-        # Telemetry only: it must not reach the model, whose constructor would reject it.
-        self.assertFalse(hasattr(ReplayScanner.objects.get(id=resp.json()["id"]), "creation_method"))
-
-    @parameterized.expand(
-        [
-            ("wizard", EventSource.WIZARD, "wizard"),
-            ("mcp", EventSource.MCP, "mcp"),
-        ]
-    )
-    def test_create_outside_the_app_reports_the_surface_not_what_it_claims(
-        self, _name: str, source: EventSource, expected: str
-    ) -> None:
-        # Only the app has a form, so only the app can say how one was filled. The wizard creates
-        # several times more scanners than the app does and sends a method on some of those calls,
-        # so honouring the claim would report hundreds of agent-built scanners as hand-built and
-        # inflate the manual side of the creation-flow comparison.
-        with (
-            patch("products.replay_vision.backend.api.scanners.get_event_source", return_value=source),
-            patch("posthoganalytics.capture") as capture,
-        ):
-            resp = self.client.post(
-                self.scanners_url,
-                data={
-                    "name": f"telemetry-surface-{_name}",
-                    "scanner_type": ScannerType.MONITOR,
-                    "scanner_config": {"prompt": "did checkout complete?"},
-                    "model": ScannerModel.GEMINI_3_8_FLASH,
-                    "creation_method": "scratch",
-                },
-                format="json",
+                **headers,
             )
 
         self.assertEqual(resp.status_code, 201, resp.json())
@@ -1109,6 +1085,36 @@ class TestScannerLifecycleTelemetry(_VisionAPITestCase):
             call for call in capture.call_args_list if call.kwargs.get("event") == "replay_vision_scanner_created"
         ]
         self.assertEqual(created[0].kwargs["properties"]["creation_method"], expected)
+        # Telemetry only: it must not reach the model, whose constructor would reject it.
+        self.assertFalse(hasattr(ReplayScanner.objects.get(id=resp.json()["id"]), "creation_method"))
+
+    def test_create_without_a_request_reports_the_declared_surface(self) -> None:
+        # Max reaches the serializer directly, so there is no request to derive a surface from and
+        # nothing would be reported at all. It declares one in the context instead, the same way it
+        # passes `user`. Left unattributed, its scanners land in the same bucket as the app's.
+        self.organization.is_ai_data_processing_approved = True
+        self.organization.save()
+        serializer = ReplayScannerSerializer(
+            data={
+                "name": "telemetry-surface-max",
+                "scanner_type": ScannerType.MONITOR,
+                "scanner_config": {"prompt": "did checkout complete?"},
+                "model": ScannerModel.GEMINI_3_8_FLASH,
+            },
+            context={
+                "get_team": lambda: self.team,
+                "user": self.user,
+                "event_source": EventSource.POSTHOG_AI,
+            },
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        with patch("posthoganalytics.capture") as capture:
+            serializer.save()
+
+        created = [
+            call for call in capture.call_args_list if call.kwargs.get("event") == "replay_vision_scanner_created"
+        ]
+        self.assertEqual(created[0].kwargs["properties"]["creation_method"], "posthog_ai")
 
     def test_update_ignores_how_the_scanner_was_built(self):
         # The UI PATCHes the whole form back, so an edit resends this. A scanner is built once, and

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -15,6 +15,7 @@ from parameterized import parameterized
 from temporalio.exceptions import WorkflowAlreadyStartedError
 
 from posthog.api.tagged_item import set_tags_on_object
+from posthog.event_usage import EventSource
 from posthog.models import Organization, PersonalAPIKey, Team, User
 from posthog.models.tagged_item import TaggedItem
 from posthog.models.utils import generate_random_token_personal, hash_key_value, uuid7
@@ -1073,6 +1074,41 @@ class TestScannerLifecycleTelemetry(_VisionAPITestCase):
         self.assertEqual(created[0].kwargs["properties"]["creation_method"], "ai")
         # Telemetry only: it must not reach the model, whose constructor would reject it.
         self.assertFalse(hasattr(ReplayScanner.objects.get(id=resp.json()["id"]), "creation_method"))
+
+    @parameterized.expand(
+        [
+            ("wizard", EventSource.WIZARD, "wizard"),
+            ("mcp", EventSource.MCP, "mcp"),
+        ]
+    )
+    def test_create_outside_the_app_reports_the_surface_not_what_it_claims(
+        self, _name: str, source: EventSource, expected: str
+    ) -> None:
+        # Only the app has a form, so only the app can say how one was filled. The wizard creates
+        # several times more scanners than the app does and sends a method on some of those calls,
+        # so honouring the claim would report hundreds of agent-built scanners as hand-built and
+        # inflate the manual side of the creation-flow comparison.
+        with (
+            patch("products.replay_vision.backend.api.scanners.get_event_source", return_value=source),
+            patch("posthoganalytics.capture") as capture,
+        ):
+            resp = self.client.post(
+                self.scanners_url,
+                data={
+                    "name": f"telemetry-surface-{_name}",
+                    "scanner_type": ScannerType.MONITOR,
+                    "scanner_config": {"prompt": "did checkout complete?"},
+                    "model": ScannerModel.GEMINI_3_8_FLASH,
+                    "creation_method": "scratch",
+                },
+                format="json",
+            )
+
+        self.assertEqual(resp.status_code, 201, resp.json())
+        created = [
+            call for call in capture.call_args_list if call.kwargs.get("event") == "replay_vision_scanner_created"
+        ]
+        self.assertEqual(created[0].kwargs["properties"]["creation_method"], expected)
 
     def test_update_ignores_how_the_scanner_was_built(self):
         # The UI PATCHes the whole form back, so an edit resends this. A scanner is built once, and

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -1057,7 +1057,7 @@ class TestScannerLifecycleTelemetry(_VisionAPITestCase):
         ]
     )
     def test_create_reports_how_the_scanner_was_built(
-        self, _name: str, headers: dict[str, str], claimed: str, expected: str
+        self, _name: str, headers: dict[str, Any], claimed: str, expected: str
     ) -> None:
         # The arm says which flow the person was offered; this says what they did with it. Someone
         # offered the AI flow can still fill the form by hand, so a metric comparing AI-built against

--- a/products/replay_vision/frontend/generated/api.schemas.ts
+++ b/products/replay_vision/frontend/generated/api.schemas.ts
@@ -864,7 +864,7 @@ export interface ReplayScannerApi {
      * * `scorer` - Scorer
      * * `summarizer` - Summarizer */
     scanner_type: ScannerTypeEnumApi
-    /** How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Ignored on update.
+    /** How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Only the app can answer this, so a request from anywhere else reports the calling surface instead of whatever it sends here. Ignored on update.
      *
      * * `ai` - AI draft
      * * `template` - Template
@@ -988,7 +988,7 @@ export interface PatchedReplayScannerApi {
      * * `scorer` - Scorer
      * * `summarizer` - Summarizer */
     scanner_type?: ScannerTypeEnumApi
-    /** How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Ignored on update.
+    /** How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Only the app can answer this, so a request from anywhere else reports the calling surface instead of whatever it sends here. Ignored on update.
      *
      * * `ai` - AI draft
      * * `template` - Template

--- a/products/replay_vision/frontend/generated/api.zod.ts
+++ b/products/replay_vision/frontend/generated/api.zod.ts
@@ -549,7 +549,7 @@ export const VisionScannersCreateBody = /* @__PURE__ */ zod
             ])
             .optional()
             .describe(
-                'How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Ignored on update.\n\n\* `ai` - AI draft\n\* `template` - Template\n\* `scratch` - From scratch'
+                'How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Only the app can answer this, so a request from anywhere else reports the calling surface instead of whatever it sends here. Ignored on update.\n\n\* `ai` - AI draft\n\* `template` - Template\n\* `scratch` - From scratch'
             ),
         scanner_config: zod
             .unknown()
@@ -691,7 +691,7 @@ export const VisionScannersPartialUpdateBody = /* @__PURE__ */ zod
             ])
             .optional()
             .describe(
-                'How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Ignored on update.\n\n\* `ai` - AI draft\n\* `template` - Template\n\* `scratch` - From scratch'
+                'How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Only the app can answer this, so a request from anywhere else reports the calling surface instead of whatever it sends here. Ignored on update.\n\n\* `ai` - AI draft\n\* `template` - Template\n\* `scratch` - From scratch'
             ),
         scanner_config: zod
             .unknown()

--- a/products/replay_vision/frontend/replay_scanners/ScannerEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ScannerEditorScene.tsx
@@ -221,7 +221,9 @@ export function ScannerEditorSceneComponent(): JSX.Element {
                                     </p>
                                 </div>
                                 <ScannerTemplatePicker />
-                                <ScannerGoalDraft />
+                                {/* The goal flow supersedes this box, so someone who has already
+                                    turned it down to build by hand should not be offered it again. */}
+                                {!goalFlow && <ScannerGoalDraft />}
                             </>
                         )
                     ) : step === 'overview' ? (

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerTypeConfigEditor.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerTypeConfigEditor.tsx
@@ -13,8 +13,10 @@ import {
     LemonTextArea,
 } from '@posthog/lemon-ui'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { useMaxTool } from 'scenes/max/useMaxTool'
 
 import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
@@ -23,6 +25,19 @@ import { useAttachedContext } from 'products/posthog_ai/frontend/api/logics'
 
 import { replayScannerLogic } from '../replayScannerLogic'
 import { ClassifierScannerConfig, SummarizerScannerConfig, scannerTypeLabel } from '../types'
+
+/** Whether this form should offer no AI help at all.
+ *
+ * In the goal-based flow the AI path is the flow itself, so someone who turned it down to build by
+ * hand gets one path or the other rather than a half-AI middle. Only while creating: editing a
+ * saved scanner is not that choice, and someone who did use the flow keeps the entry points so they
+ * can rework what it drafted. Multivariate flag, so a truthy check would strip the control arm too
+ * and change what the experiment compares. */
+function useManualWithoutAi(scannerId: string): boolean {
+    const { isNew, goalDraft } = useValues(replayScannerLogic({ id: scannerId }))
+    const { featureFlags } = useValues(featureFlagLogic)
+    return isNew && !goalDraft && featureFlags[FEATURE_FLAGS.VISION_GOAL_BASED_CREATION_FLOW] === 'test'
+}
 
 export const SUMMARIZER_LENGTH_OPTIONS: { value: SummarizerScannerConfig['length']; label: string }[] = [
     { value: 'short', label: 'Short (1-2 sentences)' },
@@ -47,6 +62,7 @@ function ScannerPromptField({
     const { setScannerValue } = useActions(logic)
     // The AI already wrote this prompt one step ago, so offering to write it reads as a no-op.
     const promptWasDrafted = isNew && !!goalDraft
+    const manualWithoutAi = useManualWithoutAi(scannerId)
 
     const onDraftedPrompt = useCallback(
         (toolOutput: { prompt?: string; error?: string }) => {
@@ -91,7 +107,7 @@ function ScannerPromptField({
         <div className="space-y-2">
             <div className="flex flex-wrap items-center justify-between gap-2">
                 <label className="text-sm font-medium">{label}</label>
-                {openMax && (
+                {openMax && !manualWithoutAi && (
                     <LemonButton
                         size="xsmall"
                         type="secondary"
@@ -183,6 +199,7 @@ function ClassifierTagsField({ scannerId }: { scannerId: string }): JSX.Element 
     const hasTags = (config?.tags ?? []).length > 0
     // The draft already filled these in, so the offer is more of them, not a first set.
     const categoriesWereDrafted = isNew && !!goalDraft && !!config?.tags?.length
+    const manualWithoutAi = useManualWithoutAi(scannerId)
     // The param only survives on a new scanner whose config a valid template prefilled: the picker
     // drops it when the blank card is chosen, and loadScanner strips it on load when a goal draft
     // outranks the template or the key is unknown.
@@ -205,21 +222,23 @@ function ClassifierTagsField({ scannerId }: { scannerId: string }): JSX.Element 
                             >
                                 Clear all
                             </LemonButton>
-                            <LemonButton
-                                size="xsmall"
-                                type="secondary"
-                                icon={<IconAI />}
-                                loading={tagSuggestionsLoading}
-                                disabledReason={
-                                    hasPrompt ? undefined : 'Add a prompt first so suggestions match your goal'
-                                }
-                                onClick={() => loadTagSuggestions()}
-                                data-attr="replay-vision-suggest-tags-with-ai"
-                            >
-                                {categoriesWereDrafted
-                                    ? 'Suggest more categories'
-                                    : 'Suggest categories with PostHog AI'}
-                            </LemonButton>
+                            {!manualWithoutAi && (
+                                <LemonButton
+                                    size="xsmall"
+                                    type="secondary"
+                                    icon={<IconAI />}
+                                    loading={tagSuggestionsLoading}
+                                    disabledReason={
+                                        hasPrompt ? undefined : 'Add a prompt first so suggestions match your goal'
+                                    }
+                                    onClick={() => loadTagSuggestions()}
+                                    data-attr="replay-vision-suggest-tags-with-ai"
+                                >
+                                    {categoriesWereDrafted
+                                        ? 'Suggest more categories'
+                                        : 'Suggest categories with PostHog AI'}
+                                </LemonButton>
+                            )}
                         </span>
                     </span>
                 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -56927,7 +56927,7 @@ export namespace Schemas {
        * * `scorer` - Scorer
        * * `summarizer` - Summarizer */
       scanner_type: ScannerTypeEnum;
-      /** How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Ignored on update.
+      /** How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Only the app can answer this, so a request from anywhere else reports the calling surface instead of whatever it sends here. Ignored on update.
        *
        * * `ai` - AI draft
        * * `template` - Template
@@ -67033,7 +67033,7 @@ export namespace Schemas {
        * * `scorer` - Scorer
        * * `summarizer` - Summarizer */
       scanner_type?: ScannerTypeEnum;
-      /** How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Ignored on update.
+      /** How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Only the app can answer this, so a request from anywhere else reports the calling surface instead of whatever it sends here. Ignored on update.
        *
        * * `ai` - AI draft
        * * `template` - Template

--- a/services/mcp/src/generated/replay_vision/api.ts
+++ b/services/mcp/src/generated/replay_vision/api.ts
@@ -324,7 +324,7 @@ export const VisionScannersCreateBody = () => zod
             ])
             .optional()
             .describe(
-                'How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Ignored on update.\n\n\* `ai` - AI draft\n\* `template` - Template\n\* `scratch` - From scratch'
+                'How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Only the app can answer this, so a request from anywhere else reports the calling surface instead of whatever it sends here. Ignored on update.\n\n\* `ai` - AI draft\n\* `template` - Template\n\* `scratch` - From scratch'
             ),
         scanner_config: zod
             .unknown()
@@ -487,7 +487,7 @@ export const VisionScannersPartialUpdateBody = () => zod
             ])
             .optional()
             .describe(
-                'How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Ignored on update.\n\n\* `ai` - AI draft\n\* `template` - Template\n\* `scratch` - From scratch'
+                'How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Only the app can answer this, so a request from anywhere else reports the calling surface instead of whatever it sends here. Ignored on update.\n\n\* `ai` - AI draft\n\* `template` - Template\n\* `scratch` - From scratch'
             ),
         scanner_config: zod
             .unknown()

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/vision-scanners-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/vision-scanners-create.json
@@ -13,7 +13,7 @@
                     "type": "null"
                 }
             ],
-            "description": "How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Ignored on update.\n\n* `ai` - AI draft\n* `template` - Template\n* `scratch` - From scratch"
+            "description": "How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Only the app can answer this, so a request from anywhere else reports the calling surface instead of whatever it sends here. Ignored on update.\n\n* `ai` - AI draft\n* `template` - Template\n* `scratch` - From scratch"
         },
         "credit_limit": {
             "anyOf": [

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/vision-scanners-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/vision-scanners-update.json
@@ -12,7 +12,7 @@
                     "type": "null"
                 }
             ],
-            "description": "How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Ignored on update.\n\n* `ai` - AI draft\n* `template` - Template\n* `scratch` - From scratch"
+            "description": "How the creator built this scanner: from an AI draft, from a template, or from scratch. Reported to product analytics at creation and not stored on the scanner. Independent of any experiment the creator is in, since a person offered the AI flow can still fill the form by hand. Only the app can answer this, so a request from anywhere else reports the calling surface instead of whatever it sends here. Ignored on update.\n\n* `ai` - AI draft\n* `template` - Template\n* `scratch` - From scratch"
         },
         "credit_limit": {
             "anyOf": [


### PR DESCRIPTION
## Problem

`creation_method` on `replay_vision_scanner_created` is meant to say how a person built a scanner — from an AI draft, a template, or by hand — so the goal-based creation-flow experiment can compare AI-built scanners against hand-built ones. Only the app can answer it, because only the app has a form.

Every other surface either says nothing or says something misleading. Over the last two weeks the wizard created several times more scanners than the app did and left the field empty on most of them, while sending `template` or `scratch` on the rest. MCP reports `scratch`, which reads as a person filling the form by hand. Max reaches the serializer directly with no HTTP request, so its creations — a few hundred across many teams — carry nothing at all. The result is that the AI-vs-manual comparison counts agent-built scanners on its manual side, and the majority of rows fall into an `unknown` bucket that hides the split entirely.

## Changes

- Any request that isn't from the app now reports its own `EventSource` as `creation_method` — `wizard`, `mcp`, `api`, and so on — instead of an empty value or whatever it claimed. The values stay mutually exclusive: `ai`/`template`/`scratch` mean a person in the editor, anything else names the caller.
- Max declares its surface in the serializer context, the same way it already passes `user`. A request-derived source cannot reach it, so without this its scanners stay unattributed and sit in the same bucket as the app's.
- This overrides a claimed value rather than only filling in a missing one, because the surfaces that get it wrong are the ones that do send something. Fill-when-absent would leave MCP's `scratch` in place, which is the specific case that corrupts the comparison.
- `ScannerCreationMethod` is unchanged, so the accepted request values are the same three. Only the reported property widens.
- Mechanical: the serializer `help_text` gains a sentence saying the app is the only surface that can answer this, which flows into the OpenAPI spec and the generated frontend and MCP types.

The companion dashboard tiles were separately scoped to `source = 'web'`, which is what makes today's numbers readable; this change is what makes the programmatic creations legible rather than merely excluded.

## How did you test this code?

Automated only — this environment has no Django/ClickHouse test runner, so nothing was executed locally and no manual check was done. Relying on CI.

`test_create_reports_how_the_scanner_was_built` gains a wizard case, which guards the regression nothing else caught: a non-app caller sending `creation_method: "scratch"` previously had that value reported verbatim, and no test asserted anything about non-app callers at all. It extends that test rather than standing alone because it is the same behavior with a different caller. It sends a real `posthog/wizard` user agent rather than patching `get_event_source`, since the question is whether a caller's surface reaches the serializer at all — a patch would assert only that the branch exists.

`test_create_without_a_request_reports_the_declared_surface` is standalone because its setup genuinely differs: it constructs the serializer directly with Max's request-less context, which no HTTP test can express. It guards the case where someone drops `event_source` from the Max tool's context and its scanners silently go unattributed again.

One caveat worth a reviewer's eye: `products/replay_vision/frontend/generated/api.schemas.ts` is generated, and codegen could not be run here (no Django in this environment). Its two `help_text` occurrences were updated by hand. The CI bot has since regenerated the sibling artifacts (`api.zod.ts` and the MCP types) and left that file untouched, which confirms the hand-edit matched the generator.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Started from a dashboard whose arm/method split was collapsing into `unknown`. The first hypothesis, raised in discussion, was that MCP was the culprit and should be labelled as such. Querying `replay_vision_scanner_created` grouped by `source`, `access_method`, and `creation_method` showed otherwise: the wizard accounted for the large majority of unlabelled creations, MCP for a small fraction, and coverage on `web` was already around 88%. That reframed the fix from "label MCP" to "derive from the calling surface for everything that isn't the app", and separately showed the dashboard needed a `source = 'web'` filter rather than a code change to be readable today.

The Max gap surfaced from a reviewer question about whether the change would actually propagate from the wizard and MCP code paths. It does for those — the same `get_event_source(request)` already resolves `source` correctly on this very event, which is the evidence that the value reaches the serializer. Checking that also turned up the request-less path, which no request-derived source can reach, and which accounts for the events carrying no `source` at all. Those events still carry no `source` property; that is a pre-existing gap in the shared event shape and deliberately out of scope here.

Overriding a claimed value versus only filling a missing one was the main design decision; the data showing MCP actively reporting `scratch` is what settled it. Skills invoked: `/writing-tests`, which is what turned the duplicated wizard test into a case on the existing one. No customer data, session material, or operational figures appear in this diff or description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
