### PR TITLE
chore(tests): drop the browser column test_modifier_passthrough materializes

### DIFF
--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -6,7 +6,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 from freezegun import freeze_time
-from posthog.test.base import APIBaseTest, BaseTest, ClickhouseTestMixin
+from posthog.test.base import APIBaseTest, BaseTest, ClickhouseTestMixin, cleanup_materialized_columns
 from unittest import mock
 
 from django.conf import settings
@@ -691,6 +691,9 @@ class TestQueryRunner(BaseTest):
 
             from ee.clickhouse.materialized_columns.analyze import materialize
 
+            # The column outlives this test otherwise, and every later test on the shard that
+            # filters on $browser then snapshots the materialized form
+            self.addCleanup(cleanup_materialized_columns)
             materialize("events", "$browser")
         except ModuleNotFoundError:
             # EE not available? Assume we're good


### PR DESCRIPTION
## Problem

Any backend test that filters on `$browser` and snapshots its query can fail with `Query does not match snapshot`, depending only on which tests share its shard. The snapshot shows `mat_$browser` where master has `JSONExtractRaw(events.properties, '$browser')`.

`TestQueryRunner.test_modifier_passthrough` in `posthog/hogql_queries/test/test_query_runner.py` calls `materialize("events", "$browser")` and never drops the column. Its class is a plain `BaseTest` whose `tearDown` only clears the Django cache, so the column stays on the ClickHouse events table for the rest of the process. On #95171 it landed on the same shard as the session recording listing tests three runs in a row, and the snapshot bot rewrote the snapshot each time.

## Changes

- The test registers `cleanup_materialized_columns` with `addCleanup` before materializing, the same cleanup the `also_test_with_materialized_columns` decorator runs.

## How did you test this code?

Not run locally: the change is a cleanup registration. On #95171, Core shard 3 in check mode shows the leak with this test at `posthog/hogql_queries/test/test_query_runner.py::TestQueryRunner::test_modifier_passthrough` passing earlier on the shard and six session recording tests failing after it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No

## 🤖 Agent context

Found while landing #95171, where the snapshot bot kept rewriting a snapshot in a file that PR does not touch. Traced by listing the tests that ran on the failing shard before the first failure and grepping them for `materialize`.