### PR TITLE
fix(alerts): explain pending destinations

### DIFF
--- a/products/alerts/frontend/components/AlertNotificationDestinationEditor.test.tsx
+++ b/products/alerts/frontend/components/AlertNotificationDestinationEditor.test.tsx
@@ -25,6 +25,9 @@ jest.mock('@posthog/lemon-ui', () => ({
     LemonSelect: () => <select />,
     LemonSkeleton: () => <div>Loading integrations</div>,
     LemonTag: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+    Tooltip: ({ children, title }: { children: ReactNode; title: string }) => (
+        <span data-tooltip={title}>{children}</span>
+    ),
 }))
 
 jest.mock('lib/integrations/SlackIntegrationHelpers', () => ({
@@ -122,5 +125,38 @@ describe('AlertNotificationDestinationEditor', () => {
 
         expect(onAdd).toHaveBeenCalledTimes(1)
         expect(onWizardKeyDown).not.toHaveBeenCalled()
+    })
+
+    it('explains how to save a pending destination', () => {
+        render(
+            <AlertNotificationDestinationEditor
+                destinations={{
+                    showExisting: false,
+                    existingLoading: false,
+                    existing: [],
+                    pending: [{ key: 'webhook-0', title: 'Webhook', onRemove: jest.fn() }],
+                }}
+                notificationType={{ options: [], value: 'webhook', onChange: jest.fn() }}
+                slack={{
+                    notificationType: 'slack',
+                    integrationsLoading: false,
+                    integrationsFailed: false,
+                    onRetryIntegrations: jest.fn(),
+                    integrations: [],
+                    channelValue: null,
+                    onChannelValueChange: jest.fn(),
+                }}
+                url={{
+                    input: { placeholder: 'https://example.com/webhook' },
+                    value: '',
+                    onChange: jest.fn(),
+                }}
+                add={{ onClick: jest.fn() }}
+            />
+        )
+
+        expect(screen.getByText('Pending').closest('[data-tooltip]')?.getAttribute('data-tooltip')).toBe(
+            'Save this alert to add this destination.'
+        )
     })
 })

--- a/products/alerts/frontend/components/AlertNotificationDestinationEditor.tsx
+++ b/products/alerts/frontend/components/AlertNotificationDestinationEditor.tsx
@@ -10,6 +10,7 @@ import {
     LemonSkeleton,
     LemonTag,
     LemonTagType,
+    Tooltip,
 } from '@posthog/lemon-ui'
 
 import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
@@ -197,9 +198,11 @@ function PendingDestinations({
                     <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2 flex-wrap">
                             <span className="text-sm font-medium truncate">{destination.title}</span>
-                            <LemonTag type="warning" size="small">
-                                Pending
-                            </LemonTag>
+                            <Tooltip title="Save this alert to add this destination.">
+                                <LemonTag type="warning" size="small">
+                                    Pending
+                                </LemonTag>
+                            </Tooltip>
                         </div>
                         {destination.detail ? (
                             <span className="text-xs text-muted-alt truncate block">{destination.detail}</span>


### PR DESCRIPTION
## Problem

People who add an alert destination cannot see why its Pending tag appears.

**Why:** The alert save adds the destination, so the tag needs to explain that required action.

## Changes

- The Pending tag now shows a tooltip that explains how to add the destination.

![Pending destination tooltip](https://raw.githubusercontent.com/PostHog/pr-assets/7b7ad78e003ef6574484452c26608a833c0547ac/2026/09/38234055-5232-486d-a437-d8bc8c89e5ef.png)

## How did you test this code?

- Added a component test that keeps the Pending tooltip text.
- Ran the focused Jest test and frontend format, lint, and CI preflight checks.
- Not run: the repository-wide TypeScript check. The runner stopped it for memory use.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools: PostHog Slack app, Storybook, and Jest.
- Skills: writing-ui-components, writing-user-facing-copy, writing-tests, and writing-pr-descriptions.
- The open-PR search found no duplicate. The screenshot uses only Storybook fixture data.

---

*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09BDQLM8KA/p1788883157090779?thread_ts=1788883157.090779&cid=C09BDQLM8KA)*