### PR TITLE
chore(ci): adopt shared uv setup action

### DIFF
--- a/.depot/workflows/ci-backend-update-test-timing.yml
+++ b/.depot/workflows/ci-backend-update-test-timing.yml
@@ -26,9 +26,7 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+              uses: ./.github/actions/setup-uv
 
             - name: Find newest Backend CI run with timing artifacts
               id: find-backend-run

--- a/.depot/workflows/ci-backend-update-test-timing.yml
+++ b/.depot/workflows/ci-backend-update-test-timing.yml
@@ -27,6 +27,8 @@ jobs:
 
             - name: Install uv
               uses: ./.depot/actions/setup-uv
+              with:
+                  enable-cache: false
 
             - name: Find newest Backend CI run with timing artifacts
               id: find-backend-run

--- a/.depot/workflows/ci-backend-update-test-timing.yml
+++ b/.depot/workflows/ci-backend-update-test-timing.yml
@@ -26,7 +26,7 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Install uv
-              uses: ./.github/actions/setup-uv
+              uses: ./.depot/actions/setup-uv
 
             - name: Find newest Backend CI run with timing artifacts
               id: find-backend-run

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -726,10 +726,8 @@ jobs:
             # --no-project` for the dependent cascade; the script pins tach, so no
             # Python project sync is needed. A missing uv widens the cascade to
             # every product rather than failing the job.
-            - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+            - uses: ./.github/actions/setup-uv
               continue-on-error: true
-              with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
             - name: Restore test durations from cache
               # Restore fresh timings so shard counts match GitHub Actions; miss falls back to committed.
               uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -781,9 +779,7 @@ jobs:
               # selector failure does, not fail the job that gates every test job.
               continue-on-error: true
               if: env.SELECTION_APPLIES == 'true' && needs.changes.outputs.legacy == 'true' && vars.DISABLE_BACKEND_TEST_SELECTION != 'true'
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.28'
+              uses: ./.github/actions/setup-uv
 
             - name: Run the backend test selector
               id: select
@@ -941,9 +937,8 @@ jobs:
 
             - name: Install uv
               id: setup-uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              uses: ./.github/actions/setup-uv
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
@@ -1169,9 +1164,7 @@ jobs:
                   python-version: 3.13.13
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+              uses: ./.github/actions/setup-uv
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
             - name: Bootstrap scaffold product
@@ -1253,9 +1246,7 @@ jobs:
                   python-version: 3.13.13
                   token: ${{ steps.app-token.outputs.token || github.token }}
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.28'
+              uses: ./.github/actions/setup-uv
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
             - name: Validate changed product.yaml owners
@@ -1336,9 +1327,8 @@ jobs:
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
             - name: Install uv
               id: setup-uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              uses: ./.github/actions/setup-uv
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -10,9 +10,12 @@
 # Intentional deltas vs canonical (everything else is kept apples-to-apples):
 # - runs-on: depot-* labels instead of ubuntu-latest
 # - action paths: ./.depot/actions/... instead of ./.github/actions/... (pnpm-install,
-#   setup-sqlx-cli, setup-python-cached, and paths-filter mirror the canonical
-#   composites; any deltas are documented in each mirror's header). setup-turbo has no
-#   mirror because there is nothing Depot needs to strip from it.
+#   setup-sqlx-cli, setup-python-cached, setup-uv, and paths-filter mirror the canonical
+#   composites; any deltas are documented in each mirror's header). Every local action a
+#   depot workflow uses needs a mirror even when byte-identical: Depot resolves
+#   ./.github/actions/<x> from .depot/actions/<x>, so a missing mirror fails the step at
+#   setup with "action manifest not found". setup-turbo is referenced below with no
+#   mirror and is red for exactly that reason; it needs one.
 # - permissions: pull-requests:read (no comment/auto-commit side effects)
 # - Stripped side effects: artifact uploads, CI report section posters (canonical
 #   additionally skips these on trunk-merge/** branches to save GITHUB_TOKEN budget;
@@ -408,6 +411,7 @@ jobs:
                         - 'products/*/turbo.json'
                         # Make sure we run if someone is explicitly changing the workflow
                         - .depot/workflows/ci-backend.yml
+                        - .depot/actions/setup-uv/**
                         - .github/clickhouse-versions.json
                         # We use docker compose for tests, make sure we rerun on
                         # changes to docker-compose.dev.yml e.g. dependency
@@ -458,6 +462,7 @@ jobs:
                         - 'products/*/manifest.tsx'
                         - rust/feature-flags/src/properties/property_models.rs
                         - .depot/workflows/ci-backend.yml
+                        - .depot/actions/setup-uv/**
                         - .github/clickhouse-versions.json
                         - docker-compose.dev.yml
                         - docker-compose.profiles.yml
@@ -726,7 +731,7 @@ jobs:
             # --no-project` for the dependent cascade; the script pins tach, so no
             # Python project sync is needed. A missing uv widens the cascade to
             # every product rather than failing the job.
-            - uses: ./.github/actions/setup-uv
+            - uses: ./.depot/actions/setup-uv
               continue-on-error: true
             - name: Restore test durations from cache
               # Restore fresh timings so shard counts match GitHub Actions; miss falls back to committed.
@@ -779,7 +784,7 @@ jobs:
               # selector failure does, not fail the job that gates every test job.
               continue-on-error: true
               if: env.SELECTION_APPLIES == 'true' && needs.changes.outputs.legacy == 'true' && vars.DISABLE_BACKEND_TEST_SELECTION != 'true'
-              uses: ./.github/actions/setup-uv
+              uses: ./.depot/actions/setup-uv
 
             - name: Run the backend test selector
               id: select
@@ -937,7 +942,7 @@ jobs:
 
             - name: Install uv
               id: setup-uv
-              uses: ./.github/actions/setup-uv
+              uses: ./.depot/actions/setup-uv
               with:
                   enable-cache: true
                   cache-dependency-glob: uv.lock
@@ -1164,7 +1169,7 @@ jobs:
                   python-version: 3.13.13
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
             - name: Install uv
-              uses: ./.github/actions/setup-uv
+              uses: ./.depot/actions/setup-uv
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
             - name: Bootstrap scaffold product
@@ -1246,7 +1251,7 @@ jobs:
                   python-version: 3.13.13
                   token: ${{ steps.app-token.outputs.token || github.token }}
             - name: Install uv
-              uses: ./.github/actions/setup-uv
+              uses: ./.depot/actions/setup-uv
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
             - name: Validate changed product.yaml owners
@@ -1327,7 +1332,7 @@ jobs:
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
             - name: Install uv
               id: setup-uv
-              uses: ./.github/actions/setup-uv
+              uses: ./.depot/actions/setup-uv
               with:
                   enable-cache: true
                   cache-dependency-glob: uv.lock

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -11,11 +11,8 @@
 # - runs-on: depot-* labels instead of ubuntu-latest
 # - action paths: ./.depot/actions/... instead of ./.github/actions/... (pnpm-install,
 #   setup-sqlx-cli, setup-python-cached, setup-uv, and paths-filter mirror the canonical
-#   composites; any deltas are documented in each mirror's header). Every local action a
-#   depot workflow uses needs a mirror even when byte-identical: Depot resolves
-#   ./.github/actions/<x> from .depot/actions/<x>, so a missing mirror fails the step at
-#   setup with "action manifest not found". setup-turbo is referenced below with no
-#   mirror and is red for exactly that reason; it needs one.
+#   composites; any deltas are documented in each mirror's header). Keep the local
+#   action mirrors available in .depot/actions so Depot can resolve their manifests.
 # - permissions: pull-requests:read (no comment/auto-commit side effects)
 # - Stripped side effects: artifact uploads, CI report section posters (canonical
 #   additionally skips these on trunk-merge/** branches to save GITHUB_TOKEN budget;
@@ -732,6 +729,8 @@ jobs:
             # Python project sync is needed. A missing uv widens the cascade to
             # every product rather than failing the job.
             - uses: ./.depot/actions/setup-uv
+              with:
+                  enable-cache: false
               continue-on-error: true
             - name: Restore test durations from cache
               # Restore fresh timings so shard counts match GitHub Actions; miss falls back to committed.
@@ -785,6 +784,8 @@ jobs:
               continue-on-error: true
               if: env.SELECTION_APPLIES == 'true' && needs.changes.outputs.legacy == 'true' && vars.DISABLE_BACKEND_TEST_SELECTION != 'true'
               uses: ./.depot/actions/setup-uv
+              with:
+                  enable-cache: false
 
             - name: Run the backend test selector
               id: select
@@ -943,10 +944,6 @@ jobs:
             - name: Install uv
               id: setup-uv
               uses: ./.depot/actions/setup-uv
-              with:
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
-                  save-cache: ${{ github.ref == 'refs/heads/master' }}
             - name: Install SAML dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'
               run: sudo rm -f /etc/apt/sources.list.d/*twingate* && sudo apt-get update && sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
@@ -1170,6 +1167,8 @@ jobs:
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
             - name: Install uv
               uses: ./.depot/actions/setup-uv
+              with:
+                  enable-cache: false
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
             - name: Bootstrap scaffold product
@@ -1252,6 +1251,8 @@ jobs:
                   token: ${{ steps.app-token.outputs.token || github.token }}
             - name: Install uv
               uses: ./.depot/actions/setup-uv
+              with:
+                  enable-cache: false
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
             - name: Validate changed product.yaml owners
@@ -1333,10 +1334,6 @@ jobs:
             - name: Install uv
               id: setup-uv
               uses: ./.depot/actions/setup-uv
-              with:
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
-                  save-cache: ${{ github.ref == 'refs/heads/master' }}
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'
               run: |
@@ -1592,6 +1589,7 @@ jobs:
               with:
                   python-version: 3.13.13
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
+            # Direct install: Generated changes target the PR head, which may predate the local action.
             - name: Install uv
               id: setup-uv
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
@@ -2068,11 +2066,12 @@ jobs:
               with:
                   path: ${{ runner.tool_cache }}/Python/${{ matrix.python-version }}
                   key: python-toolcache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}
+            # Direct install: Tests run the explicit PR head, which may predate the local action.
             - name: Install uv
               id: setup-uv-tests
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+                  version: '0.11.28'
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/build-deltalite.yml
+++ b/.github/workflows/build-deltalite.yml
@@ -222,9 +222,10 @@ jobs:
               with:
                   python-version: 3.13.13
 
+            # Direct install: Publishing commits to the PR head, which may predate the local action.
             - name: Install uv
               id: setup-uv
-              uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
               with:
                   version: '0.11.28'
                   enable-cache: true

--- a/.github/workflows/build-hogql-parser-npm.yml
+++ b/.github/workflows/build-hogql-parser-npm.yml
@@ -157,11 +157,12 @@ jobs:
               with:
                   node-version-file: .nvmrc
 
+            # Direct install: Publishing commits to the PR head, which may predate the local action.
             - name: Install uv
               id: setup-uv
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+                  version: '0.11.28'
 
             - name: Update @posthog/hogql-parser in frontend
               shell: bash

--- a/.github/workflows/build-hogql-parser-rs.yml
+++ b/.github/workflows/build-hogql-parser-rs.yml
@@ -208,9 +208,10 @@ jobs:
               with:
                   python-version: 3.13.13
 
+            # Direct install: Publishing commits to the PR head, which may predate the local action.
             - name: Install uv
               id: setup-uv
-              uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
               with:
                   version: '0.11.28'
                   enable-cache: true

--- a/.github/workflows/build-hogql-parser.yml
+++ b/.github/workflows/build-hogql-parser.yml
@@ -198,11 +198,12 @@ jobs:
               with:
                   python-version: 3.13.13
 
+            # Direct install: Publishing commits to the PR head, which may predate the local action.
             - name: Install uv
               id: setup-uv
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+                  version: '0.11.28'
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -13,6 +13,7 @@ on:
     pull_request:
         paths:
             - '.github/workflows/cd-sandbox-base-image.yml'
+            - '.github/actions/setup-uv/**'
             - 'products/tasks/backend/sandbox/images/**'
             - 'products/desktop/packages/agent-shadow/**'
             - 'products/posthog_ai/scripts/**'
@@ -63,6 +64,7 @@ jobs:
                   filters: |
                       sandbox_image:
                         - '.github/workflows/cd-sandbox-base-image.yml'
+                        - '.github/actions/setup-uv/**'
                         - 'products/tasks/backend/sandbox/images/**'
                         - 'products/desktop/packages/agent-shadow/**'
                         - 'products/*/skills/**'

--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -181,9 +181,8 @@ jobs:
                   token: ${{ github.token }}
 
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              uses: ./.github/actions/setup-uv
               with:
-                  version: '0.11.28'
                   enable-cache: true
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
 

--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -184,9 +184,6 @@ jobs:
 
             - name: Install uv
               uses: ./.github/actions/setup-uv
-              with:
-                  enable-cache: true
-                  save-cache: ${{ github.ref == 'refs/heads/master' }}
 
             - name: Install python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev

--- a/.github/workflows/cd-tasks-golden-snapshot.yml
+++ b/.github/workflows/cd-tasks-golden-snapshot.yml
@@ -234,6 +234,7 @@ jobs:
                   python-version-file: 'pyproject.toml'
                   token: ${{ github.token }}
 
+            # Direct install: The requested historical source revision may not contain the local action.
             - name: Install uv
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
               with:

--- a/.github/workflows/ci-agent-skills.yml
+++ b/.github/workflows/ci-agent-skills.yml
@@ -47,6 +47,7 @@ jobs:
                         - 'products/*/backend/max_tools.py'
                         - 'products/posthog_ai/**'
                         - '.github/workflows/ci-agent-skills.yml'
+                        - '.github/actions/setup-uv/**'
                         - 'services/mcp/schema/**'
                         # check-skills zips products/*/skills/* via `hogli build:skills`
                         # (see build.py's affected-path map), so posthog_ai's frontend

--- a/.github/workflows/ci-agent-skills.yml
+++ b/.github/workflows/ci-agent-skills.yml
@@ -180,9 +180,8 @@ jobs:
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              uses: ./.github/actions/setup-uv
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/ci-agent-skills.yml
+++ b/.github/workflows/ci-agent-skills.yml
@@ -182,10 +182,6 @@ jobs:
 
             - name: Install uv
               uses: ./.github/actions/setup-uv
-              with:
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
-                  save-cache: ${{ github.ref == 'refs/heads/master' }}
 
             - name: Install python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev

--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -97,10 +97,11 @@ jobs:
               with:
                   python-version-file: 'pyproject.toml'
 
+            # Direct install: Evaluations run the explicit PR head, which may predate the local action.
             - name: Install uv
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+                  version: '0.11.28'
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -46,9 +46,9 @@ jobs:
                   token: ${{ steps.app-token.outputs.token }}
 
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              uses: ./.github/actions/setup-uv
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+                  enable-cache: false
 
             - name: Find Backend CI run to use
               id: find-backend-run

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -582,10 +582,8 @@ jobs:
             # --no-project` for the dependent cascade; the script pins tach, so no
             # Python project sync is needed. A missing uv widens the cascade to
             # every product rather than failing the job.
-            - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+            - uses: ./.github/actions/setup-uv
               continue-on-error: true
-              with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
 
             - name: Restore test durations from cache
               # Shard counts are derived from .test_durations (Amdahl). Restore the newest
@@ -667,9 +665,7 @@ jobs:
               # selector failure does, not fail the job that gates every test job.
               continue-on-error: true
               if: env.SELECTION_APPLIES == 'true' && needs.changes.outputs.legacy == 'true' && vars.DISABLE_BACKEND_TEST_SELECTION != 'true'
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.28'
+              uses: ./.github/actions/setup-uv
 
             - name: Run the backend test selector
               id: select
@@ -861,9 +857,8 @@ jobs:
 
             - name: Install uv
               id: setup-uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              uses: ./.github/actions/setup-uv
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
@@ -1287,9 +1282,7 @@ jobs:
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+              uses: ./.github/actions/setup-uv
 
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
@@ -1446,9 +1439,7 @@ jobs:
                   token: ${{ steps.app-token.outputs.token || github.token }}
 
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.28'
+              uses: ./.github/actions/setup-uv
 
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
@@ -1559,9 +1550,8 @@ jobs:
 
             - name: Install uv
               id: setup-uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              uses: ./.github/actions/setup-uv
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
@@ -4063,9 +4053,7 @@ jobs:
                   filter: blob:none
 
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.28'
+              uses: ./.github/actions/setup-uv
 
             - name: Download JUnit artifacts
               uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -4343,10 +4331,8 @@ jobs:
               with:
                   path: ./core-artifacts
                   pattern: coverage-core-*
-            - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+            - uses: ./.github/actions/setup-uv
               if: steps.reporter.outputs.available == 'true'
-              with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
             - name: Build coverage report
               # diff-cover is declared inline (PEP 723) in coverage_report.py; uv provisions it.
               if: steps.reporter.outputs.available == 'true'

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -245,6 +245,7 @@ jobs:
                         - 'products/*/turbo.json'
                         # Make sure we run if someone is explicitly changing the workflow
                         - .github/workflows/ci-backend.yml
+                        - .github/actions/setup-uv/**
                         - .github/clickhouse-versions.json
                         # We use docker compose for tests, make sure we rerun on
                         # changes to docker-compose.dev.yml e.g. dependency
@@ -295,6 +296,7 @@ jobs:
                         - 'products/*/manifest.tsx'
                         - rust/feature-flags/src/properties/property_models.rs
                         - .github/workflows/ci-backend.yml
+                        - .github/actions/setup-uv/**
                         - .github/clickhouse-versions.json
                         - docker-compose.dev.yml
                         - docker-compose.profiles.yml

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -585,6 +585,8 @@ jobs:
             # Python project sync is needed. A missing uv widens the cascade to
             # every product rather than failing the job.
             - uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
               continue-on-error: true
 
             - name: Restore test durations from cache
@@ -668,6 +670,8 @@ jobs:
               continue-on-error: true
               if: env.SELECTION_APPLIES == 'true' && needs.changes.outputs.legacy == 'true' && vars.DISABLE_BACKEND_TEST_SELECTION != 'true'
               uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
 
             - name: Run the backend test selector
               id: select
@@ -860,10 +864,6 @@ jobs:
             - name: Install uv
               id: setup-uv
               uses: ./.github/actions/setup-uv
-              with:
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
-                  save-cache: ${{ github.ref == 'refs/heads/master' }}
 
             - name: Install SAML dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'
@@ -1285,6 +1285,8 @@ jobs:
 
             - name: Install uv
               uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
 
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
@@ -1442,6 +1444,8 @@ jobs:
 
             - name: Install uv
               uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
 
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
@@ -1553,10 +1557,6 @@ jobs:
             - name: Install uv
               id: setup-uv
               uses: ./.github/actions/setup-uv
-              with:
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
-                  save-cache: ${{ github.ref == 'refs/heads/master' }}
 
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'
@@ -2302,11 +2302,12 @@ jobs:
                   path: ${{ runner.tool_cache }}/Python/3.13.13
                   key: python-toolcache-${{ runner.os }}-${{ runner.arch }}-3.13.13
 
+            # Direct install: Generated changes target the PR head, which may predate the local action.
             - name: Install uv
               id: setup-uv
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+                  version: '0.11.28'
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
@@ -2942,11 +2943,12 @@ jobs:
                   path: ${{ runner.tool_cache }}/Python/${{ matrix.python-version }}
                   key: python-toolcache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}
 
+            # Direct install: Tests run the explicit PR head, which may predate the local action.
             - name: Install uv
               id: setup-uv-tests
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+                  version: '0.11.28'
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
@@ -4056,6 +4058,8 @@ jobs:
 
             - name: Install uv
               uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
 
             - name: Download JUnit artifacts
               uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -4252,10 +4256,11 @@ jobs:
                     echo "Trusted timing reporter is not available on the checked-out ref for attempt $GITHUB_RUN_ATTEMPT; skipping emit."
                   fi
                   echo "available=$available" >> "$GITHUB_OUTPUT"
+            # Direct install: The trusted PR base used for reporting may predate the local action.
             - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
               if: steps.timing-reporter.outputs.available == 'true'
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+                  version: '0.11.28'
             - name: Download junit artifacts
               if: steps.timing-reporter.outputs.available == 'true'
               uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v6.0.0
@@ -4334,6 +4339,8 @@ jobs:
                   path: ./core-artifacts
                   pattern: coverage-core-*
             - uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
               if: steps.reporter.outputs.available == 'true'
             - name: Build coverage report
               # diff-cover is declared inline (PEP 723) in coverage_report.py; uv provisions it.

--- a/.github/workflows/ci-clickhouse-multinode-migrations.yml
+++ b/.github/workflows/ci-clickhouse-multinode-migrations.yml
@@ -78,9 +78,6 @@ jobs:
 
             - name: Install uv
               uses: ./.github/actions/setup-uv
-              with:
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
 
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev

--- a/.github/workflows/ci-clickhouse-multinode-migrations.yml
+++ b/.github/workflows/ci-clickhouse-multinode-migrations.yml
@@ -76,9 +76,8 @@ jobs:
                   python-version: 3.13.13
 
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              uses: ./.github/actions/setup-uv
               with:
-                  version: '0.11.28'
                   enable-cache: true
                   cache-dependency-glob: uv.lock
 

--- a/.github/workflows/ci-clickhouse-multinode-migrations.yml
+++ b/.github/workflows/ci-clickhouse-multinode-migrations.yml
@@ -15,6 +15,7 @@ on:
             - 'tools/infra-scripts/clickhouse-multinode/**'
             - 'posthog/clickhouse/hcl/**'
             - '.github/workflows/ci-clickhouse-multinode-migrations.yml'
+            - '.github/actions/setup-uv/**'
     workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -61,6 +61,8 @@ jobs:
               with:
                   clean: false
             - uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
             - run: uv run .github/scripts/check-dagster-paths.py
 
     # Job to decide if we should run dagster ci
@@ -372,6 +374,8 @@ jobs:
 
             - name: Install uv
               uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
 
             - name: Download the last published durations
               # The selector's full-run cutoff and shard sizing read .test_durations,
@@ -527,10 +531,6 @@ jobs:
             - name: Install uv
               id: setup-uv
               uses: ./.github/actions/setup-uv
-              with:
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
-                  save-cache: ${{ github.ref == 'refs/heads/master' }}
 
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -60,9 +60,7 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   clean: false
-            - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.28'
+            - uses: ./.github/actions/setup-uv
             - run: uv run .github/scripts/check-dagster-paths.py
 
     # Job to decide if we should run dagster ci
@@ -371,9 +369,7 @@ jobs:
                   filter: blob:none
 
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.28'
+              uses: ./.github/actions/setup-uv
 
             - name: Download the last published durations
               # The selector's full-run cutoff and shard sizing read .test_durations,
@@ -528,9 +524,8 @@ jobs:
 
             - name: Install uv
               id: setup-uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              uses: ./.github/actions/setup-uv
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -201,6 +201,7 @@ jobs:
                         - 'products/web_analytics/backend/**/*.py'
                         # Make sure we run if someone is explicitly change the workflow
                         - .github/workflows/ci-dagster.yml
+                        - .github/actions/setup-uv/**
                         # The test selector guards itself: selector changes run the
                         # suite (full mode), which executes its unit tests first
                         - tools/dagster_test_selection.py
@@ -241,6 +242,7 @@ jobs:
                         - 'posthog/dags/**'
                         - 'products/*/dags/**'
                         - .github/workflows/ci-dagster.yml
+                        - .github/actions/setup-uv/**
                         - tools/dagster_test_selection.py
                         - tools/test_dagster_test_selection.py
 

--- a/.github/workflows/ci-deltalite-python.yml
+++ b/.github/workflows/ci-deltalite-python.yml
@@ -45,6 +45,7 @@ jobs:
               with:
                   sparse-checkout: |
                       rust/
+                      .github/actions/setup-uv
                       pyproject.toml
                   sparse-checkout-cone-mode: false
                   clean: false
@@ -69,9 +70,7 @@ jobs:
                   save-if: ${{ github.ref == 'refs/heads/master' }}
 
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+              uses: ./.github/actions/setup-uv
 
             - name: Create venv with test dependencies
               # Versions are read straight from the repo's pyproject.toml so parity is

--- a/.github/workflows/ci-deltalite-python.yml
+++ b/.github/workflows/ci-deltalite-python.yml
@@ -73,6 +73,8 @@ jobs:
 
             - name: Install uv
               uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
 
             - name: Create venv with test dependencies
               # Versions are read straight from the repo's pyproject.toml so parity is

--- a/.github/workflows/ci-deltalite-python.yml
+++ b/.github/workflows/ci-deltalite-python.yml
@@ -15,6 +15,7 @@ on:
         paths:
             - rust/deltalite/**
             - .github/workflows/ci-deltalite-python.yml
+            - .github/actions/setup-uv/**
             # The parity suite runs against the repo's pinned deltalake/pyarrow/duckdb, so
             # re-run it whenever those pins move.
             - pyproject.toml
@@ -25,6 +26,7 @@ on:
         paths:
             - rust/deltalite/**
             - .github/workflows/ci-deltalite-python.yml
+            - .github/actions/setup-uv/**
             - pyproject.toml
             - uv.lock
 

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -590,11 +590,12 @@ jobs:
                   python-version: 3.13.13
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
+            # Direct install: Tests run the explicit PR head, which may predate the local action.
             - name: Install uv
               id: setup-uv
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+                  version: '0.11.28'
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -1070,6 +1070,7 @@ jobs:
                     echo "Trusted Jest reporter is not available on the checked-out ref for attempt $GITHUB_RUN_ATTEMPT; skipping emit."
                   fi
                   echo "available=$available" >> "$GITHUB_OUTPUT"
+            # Direct install: The trusted PR base used for reporting may predate the local action.
             - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
               if: steps.test-reporter.outputs.available == 'true'
               with:

--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -253,6 +253,8 @@ jobs:
               continue-on-error: true
             - name: Install uv
               uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
             - name: Set environment variables from previous job
               run: |
                   echo "PREVIEW_MODE=${{ github.event_name == 'pull_request' && needs.wait-for-docker-image.outputs.preview-mode || 'false' }}" >> $GITHUB_ENV

--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -251,9 +251,7 @@ jobs:
                   [ -d "data" ] && docker run --rm -v "$(pwd)/data:/data" alpine sh -c "rm -rf /data/seaweedfs /data/minio" || true
               continue-on-error: true
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
-              with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+              uses: ./.github/actions/setup-uv
             - name: Set environment variables from previous job
               run: |
                   echo "PREVIEW_MODE=${{ github.event_name == 'pull_request' && needs.wait-for-docker-image.outputs.preview-mode || 'false' }}" >> $GITHUB_ENV

--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -83,6 +83,7 @@ jobs:
                         - 'docker/**'
                         - uv.lock
                         - .github/workflows/ci-hobby.yml
+                        - .github/actions/setup-uv/**
                       installer:
                         - 'bin/hobby-installer/**'
 

--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -99,9 +99,8 @@ jobs:
 
             - name: Install uv
               id: setup-uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              uses: ./.github/actions/setup-uv
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
@@ -211,9 +210,8 @@ jobs:
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
             - name: Install uv
               id: setup-uv-hogql-python
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              uses: ./.github/actions/setup-uv
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -64,6 +64,7 @@ jobs:
                         - requirements.txt
                         - requirements-dev.txt
                         - .github/workflows/ci-hog.yml
+                        - .github/actions/setup-uv/**
 
     hog-tests:
         needs: changes

--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -101,10 +101,6 @@ jobs:
             - name: Install uv
               id: setup-uv
               uses: ./.github/actions/setup-uv
-              with:
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
-                  save-cache: ${{ github.ref == 'refs/heads/master' }}
 
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'
@@ -212,10 +208,6 @@ jobs:
             - name: Install uv
               id: setup-uv-hogql-python
               uses: ./.github/actions/setup-uv
-              with:
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
-                  save-cache: ${{ github.ref == 'refs/heads/master' }}
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv-hogql-python.outputs.cache-hit != 'true'
               run: |

--- a/.github/workflows/ci-lint-workflows.yml
+++ b/.github/workflows/ci-lint-workflows.yml
@@ -29,9 +29,8 @@ jobs:
                   python-version-file: 'pyproject.toml'
 
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              uses: ./.github/actions/setup-uv
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/ci-lint-workflows.yml
+++ b/.github/workflows/ci-lint-workflows.yml
@@ -30,10 +30,6 @@ jobs:
 
             - name: Install uv
               uses: ./.github/actions/setup-uv
-              with:
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
-                  save-cache: ${{ github.ref == 'refs/heads/master' }}
 
             - name: Install python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev

--- a/.github/workflows/ci-llm-gateway.yml
+++ b/.github/workflows/ci-llm-gateway.yml
@@ -50,6 +50,7 @@ jobs:
                       llm_gateway:
                         - 'services/llm-gateway/**'
                         - '.github/workflows/ci-llm-gateway.yml'
+                        - '.github/actions/setup-uv/**'
 
     llm-gateway:
         name: LLM Gateway Tests

--- a/.github/workflows/ci-llm-gateway.yml
+++ b/.github/workflows/ci-llm-gateway.yml
@@ -71,9 +71,7 @@ jobs:
                   token: ${{ github.token }}
 
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+              uses: ./.github/actions/setup-uv
 
             - name: Install dependencies
               run: uv sync --frozen --dev

--- a/.github/workflows/ci-llm-gateway.yml
+++ b/.github/workflows/ci-llm-gateway.yml
@@ -73,6 +73,8 @@ jobs:
 
             - name: Install uv
               uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
 
             - name: Install dependencies
               run: uv sync --frozen --dev

--- a/.github/workflows/ci-master-run-traces.yml
+++ b/.github/workflows/ci-master-run-traces.yml
@@ -57,6 +57,7 @@ jobs:
               with:
                   sparse-checkout: |
                       .github/scripts/report_workflow_run_traces.py
+                      .github/actions/setup-uv
                   sparse-checkout-cone-mode: false
 
             # Reads job durations from the Actions API — the same purpose as
@@ -72,9 +73,7 @@ jobs:
                   private-key: ${{ secrets.GH_APP_TELEMETRY_PRIVATE_KEY }}
                   skip-token-revoke: true
 
-            - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+            - uses: ./.github/actions/setup-uv
 
             # Deliberately not continue-on-error: a red tick is what holds the watermark
             # at the last clean one, so the next tick re-covers the window. This workflow

--- a/.github/workflows/ci-master-run-traces.yml
+++ b/.github/workflows/ci-master-run-traces.yml
@@ -74,6 +74,8 @@ jobs:
                   skip-token-revoke: true
 
             - uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
 
             # Deliberately not continue-on-error: a red tick is what holds the watermark
             # at the last clean one, so the next tick re-covers the window. This workflow

--- a/.github/workflows/ci-mcp-ui-apps.yml
+++ b/.github/workflows/ci-mcp-ui-apps.yml
@@ -70,10 +70,6 @@ jobs:
 
             - name: Install uv # Needed for formatting generated code and running scripts
               uses: ./.github/actions/setup-uv
-              with:
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
-                  save-cache: ${{ github.ref == 'refs/heads/master' }}
 
             - name: Mint setup-action GitHub token
               id: setup-gh-token

--- a/.github/workflows/ci-mcp-ui-apps.yml
+++ b/.github/workflows/ci-mcp-ui-apps.yml
@@ -68,9 +68,8 @@ jobs:
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Install uv # Needed for formatting generated code and running scripts
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              uses: ./.github/actions/setup-uv
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/ci-mcp-ui-apps.yml
+++ b/.github/workflows/ci-mcp-ui-apps.yml
@@ -56,6 +56,7 @@ jobs:
                         - 'products/product_analytics/frontend/insights/**'
                         - 'products/*/frontend/generated/**'
                         - '.github/workflows/ci-mcp-ui-apps.yml'
+                        - '.github/actions/setup-uv/**'
 
     build-and-report:
         name: Build and validate UI Apps

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -134,6 +134,7 @@ jobs:
                         - 'tools/hogli-commands/hogli_commands/hints.py'
                         # CI config
                         - '.github/workflows/ci-mcp.yml'
+                        - '.github/actions/setup-uv/**'
                         - '.github/workflows/mcp-publish.yml'
                         # The integration tests drive a running Django server over HTTP and
                         # never import pytest modules, so exclude them. Narrow on purpose:

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -206,10 +206,6 @@ jobs:
 
             - name: Install uv
               uses: ./.github/actions/setup-uv
-              with:
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
-                  save-cache: ${{ github.ref == 'refs/heads/master' }}
 
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
@@ -427,10 +423,6 @@ jobs:
 
             - name: Install uv
               uses: ./.github/actions/setup-uv
-              with:
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
-                  save-cache: ${{ github.ref == 'refs/heads/master' }}
 
             - name: Install SAML (python3-saml) dependencies
               shell: bash

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -204,9 +204,8 @@ jobs:
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              uses: ./.github/actions/setup-uv
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
@@ -426,9 +425,8 @@ jobs:
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              uses: ./.github/actions/setup-uv
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -463,9 +463,8 @@ jobs:
 
             - name: Install uv
               id: setup-uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              uses: ./.github/actions/setup-uv
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
@@ -786,9 +785,8 @@ jobs:
 
             - name: Install uv
               id: setup-uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              uses: ./.github/actions/setup-uv
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -466,10 +466,6 @@ jobs:
             - name: Install uv
               id: setup-uv
               uses: ./.github/actions/setup-uv
-              with:
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
-                  save-cache: ${{ github.ref == 'refs/heads/master' }}
 
             - name: Install rust
               uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -788,10 +784,6 @@ jobs:
             - name: Install uv
               id: setup-uv
               uses: ./.github/actions/setup-uv
-              with:
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
-                  save-cache: ${{ github.ref == 'refs/heads/master' }}
 
             - name: Install rust
               uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -971,6 +963,7 @@ jobs:
                     echo "Trusted timings reporter is not available on the checked-out ref; skipping speed report."
                   fi
                   echo "available=$available" >> "$GITHUB_OUTPUT"
+            # Direct install: Timing updates target the PR head, which may predate the local action.
             - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
               if: steps.test-reporter.outputs.available == 'true'
               with:

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -80,6 +80,7 @@ jobs:
                   filters: |
                       nodejs:
                         - .github/workflows/ci-nodejs.yml
+                        - .github/actions/setup-uv/**
                         # The report job executes these after Jest uploads its JUnit artifacts.
                         - '.github/actions/report-jest-timings/**'
                         - '.github/scripts/report_test_timings.py'
@@ -133,6 +134,7 @@ jobs:
                         - 'rust/**'
                         - 'proto/**'
                         - '.github/workflows/ci-nodejs.yml'
+                        - '.github/actions/setup-uv/**'
 
             - name: Install rust for affected-crate detection
               # Not needed on schedule either: the decision step below already returns

--- a/.github/workflows/ci-owners-live-lint.yml
+++ b/.github/workflows/ci-owners-live-lint.yml
@@ -56,9 +56,7 @@ jobs:
                   token: ${{ steps.app-token.outputs.token || github.token }}
 
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.28'
+              uses: ./.github/actions/setup-uv
 
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev

--- a/.github/workflows/ci-owners-live-lint.yml
+++ b/.github/workflows/ci-owners-live-lint.yml
@@ -57,6 +57,8 @@ jobs:
 
             - name: Install uv
               uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
 
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev

--- a/.github/workflows/ci-replay-vision-evals.yml
+++ b/.github/workflows/ci-replay-vision-evals.yml
@@ -95,8 +95,6 @@ jobs:
               if: steps.gate.outputs.enabled == 'true'
               uses: ./.github/actions/setup-uv
               with:
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
                   save-cache: false
 
             - name: Install python dependencies

--- a/.github/workflows/ci-replay-vision-evals.yml
+++ b/.github/workflows/ci-replay-vision-evals.yml
@@ -93,9 +93,8 @@ jobs:
 
             - name: Install uv
               if: steps.gate.outputs.enabled == 'true'
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              uses: ./.github/actions/setup-uv
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: false

--- a/.github/workflows/ci-rust-flags-integration.yml
+++ b/.github/workflows/ci-rust-flags-integration.yml
@@ -93,9 +93,8 @@ jobs:
                   python-version: '3.13.13'
 
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              uses: ./.github/actions/setup-uv
               with:
-                  version: '0.11.28'
                   enable-cache: true
 
             - name: Install system dependencies

--- a/.github/workflows/ci-rust-flags-integration.yml
+++ b/.github/workflows/ci-rust-flags-integration.yml
@@ -14,6 +14,7 @@ on:
             - 'posthog/models/cohort/**'
             - 'posthog/models/group_type_mapping.py'
             - '.github/workflows/ci-rust-flags-integration.yml'
+            - '.github/actions/setup-uv/**'
     push:
         branches:
             - master
@@ -28,6 +29,7 @@ on:
             - 'posthog/models/cohort/**'
             - 'posthog/models/group_type_mapping.py'
             - '.github/workflows/ci-rust-flags-integration.yml'
+            - '.github/actions/setup-uv/**'
 
 permissions:
     contents: read

--- a/.github/workflows/ci-rust-flags-integration.yml
+++ b/.github/workflows/ci-rust-flags-integration.yml
@@ -96,8 +96,6 @@ jobs:
 
             - name: Install uv
               uses: ./.github/actions/setup-uv
-              with:
-                  enable-cache: true
 
             - name: Install system dependencies
               # protobuf-compiler (protoc) is needed to build personhog-router: its

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -408,9 +408,8 @@ jobs:
 
             - name: Install uv
               id: setup-uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              uses: ./.github/actions/setup-uv
               with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -53,6 +53,7 @@ jobs:
                         - 'rust/**'
                         - 'proto/**'
                         - '.github/workflows/ci-rust.yml'
+                        - '.github/actions/setup-uv/**'
                         - '.github/workflows/rust.yml'
                         - '.github/workflows/rust-docker-build.yml'
                         - '.github/actions/setup-protoc/**'

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -410,10 +410,6 @@ jobs:
             - name: Install uv
               id: setup-uv
               uses: ./.github/actions/setup-uv
-              with:
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
-                  save-cache: ${{ github.ref == 'refs/heads/master' }}
 
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -9,6 +9,7 @@ on:
             - .github/scripts/**
             - .github/auto-assign-labels.json
             - .github/workflows/ci-scripts.yml
+            - .github/actions/setup-uv/**
             # trunk-impacted-targets.test.js reads proto/ and fails on a tree the
             # table does not declare, so adding one has to run these tests.
             - proto/**

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -77,9 +77,7 @@ jobs:
                   node-version-file: .nvmrc
 
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.28'
+              uses: ./.github/actions/setup-uv
 
             # The preinstalled python3 runs these standalone tests, so no
             # setup-python step. defusedxml + opentelemetry + tools/owners are

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -79,6 +79,8 @@ jobs:
 
             - name: Install uv
               uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
 
             # The preinstalled python3 runs these standalone tests, so no
             # setup-python step. defusedxml + opentelemetry + tools/owners are

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -589,9 +589,7 @@ jobs:
                   fi
 
             - name: Install uv for dependency analysis
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+              uses: ./.github/actions/setup-uv
 
             - name: Check for Python dependency changes that affect analytics platform temporal worker
               id: check_python_changes_analytics_platform_temporal_worker

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -590,6 +590,8 @@ jobs:
 
             - name: Install uv for dependency analysis
               uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
 
             - name: Check for Python dependency changes that affect analytics platform temporal worker
               id: check_python_changes_analytics_platform_temporal_worker

--- a/.github/workflows/hogbox-preview-cleanup.yml
+++ b/.github/workflows/hogbox-preview-cleanup.yml
@@ -69,6 +69,8 @@ jobs:
             # uv (repo convention): --no-project skips the monorepo sync, --with
             # pins the first-party SDK (exempted from the 7-day soak in [tool.uv]).
             - uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
             - name: Reap previews for closed PRs
               working-directory: tools/hogbox-preview
               env:

--- a/.github/workflows/hogbox-preview-cleanup.yml
+++ b/.github/workflows/hogbox-preview-cleanup.yml
@@ -68,9 +68,7 @@ jobs:
                   echo "HOG_TOKEN=$token" >> "$GITHUB_ENV"
             # uv (repo convention): --no-project skips the monorepo sync, --with
             # pins the first-party SDK (exempted from the 7-day soak in [tool.uv]).
-            - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+            - uses: ./.github/actions/setup-uv
             - name: Reap previews for closed PRs
               working-directory: tools/hogbox-preview
               env:

--- a/.github/workflows/hogbox-preview-env.yml
+++ b/.github/workflows/hogbox-preview-env.yml
@@ -523,12 +523,10 @@ jobs:
             # --no-project skips the posthog monorepo (don't sync it); --with pins
             # the SDK into an ephemeral env. posthog-hogland is first-party and
             # exempted from the 7-day soak in [tool.uv].
-            - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+            - uses: ./.github/actions/setup-uv
               id: uv
               if: steps.token.outcome == 'success'
               continue-on-error: true
-              with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
 
             - name: Bring up preview
               id: build
@@ -803,10 +801,8 @@ jobs:
                   [ -n "$token" ] && [ "$token" != "null" ] || { echo "::error::OIDC mint failed after 3 attempts"; exit 1; }
                   echo "::add-mask::$token"
                   echo "HOG_TOKEN=$token" >> "$GITHUB_ENV"
-            - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+            - uses: ./.github/actions/setup-uv
               continue-on-error: true
-              with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
             - name: Destroy preview box + pen
               continue-on-error: true
               working-directory: tools/hogbox-preview

--- a/.github/workflows/hogbox-preview-env.yml
+++ b/.github/workflows/hogbox-preview-env.yml
@@ -524,6 +524,8 @@ jobs:
             # the SDK into an ephemeral env. posthog-hogland is first-party and
             # exempted from the 7-day soak in [tool.uv].
             - uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
               id: uv
               if: steps.token.outcome == 'success'
               continue-on-error: true
@@ -802,6 +804,8 @@ jobs:
                   echo "::add-mask::$token"
                   echo "HOG_TOKEN=$token" >> "$GITHUB_ENV"
             - uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
               continue-on-error: true
             - name: Destroy preview box + pen
               continue-on-error: true

--- a/.github/workflows/pr-autoresolve-conflicts.yml
+++ b/.github/workflows/pr-autoresolve-conflicts.yml
@@ -265,6 +265,7 @@ jobs:
                   bin/ci-wait-for-docker launch --background --down db clickhouse
 
             # --- Environment: uv + pnpm for classic resolution; python only for the heavy path ---
+            # Direct install: Conflicting branches cannot incorporate master to obtain the local action.
             - name: Set up uv
               if: steps.merge.outputs.skip != 'true' && steps.merge.outputs.graphite != 'true'
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -44,9 +44,7 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
-              with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+              uses: ./.github/actions/setup-uv
 
             - name: Cleanup specific PR droplet
               if: inputs.pr_number != ''

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -45,6 +45,8 @@ jobs:
 
             - name: Install uv
               uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
 
             - name: Cleanup specific PR droplet
               if: inputs.pr_number != ''

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -109,10 +109,8 @@ jobs:
                   echo "HOG_TOKEN=$token" >> "$GITHUB_ENV"
             # uv (repo convention): --no-project skips the monorepo sync, --with
             # pins the first-party SDK (exempted from the 7-day soak in [tool.uv]).
-            - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+            - uses: ./.github/actions/setup-uv
               if: steps.gate.outputs.had_preview == 'true'
-              with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
             - name: Destroy preview box + pen
               if: steps.gate.outputs.had_preview == 'true'
               working-directory: tools/hogbox-preview

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -70,14 +70,17 @@ jobs:
             # so master's copy is correct and removes that exec vector.
             #
             # The teardown imports only tools/hogbox-preview and the external
-            # posthog-hogland SDK, so a sparse blobless checkout of that one
-            # directory replaces a full clone of the monorepo.
+            # posthog-hogland SDK, so a sparse blobless checkout of that
+            # directory replaces a full clone of the monorepo. The checkout
+            # also includes .github/actions/setup-uv because a step can only
+            # use a local action that exists in the workspace.
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               if: steps.gate.outputs.had_preview == 'true'
               with:
                   ref: ${{ github.event.repository.default_branch }}
                   sparse-checkout: |
                       tools/hogbox-preview/
+                      .github/actions/setup-uv/
                   sparse-checkout-cone-mode: false
                   filter: blob:none
             - name: Connect to Tailscale (tag:hogland-ci)

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -110,6 +110,8 @@ jobs:
             # uv (repo convention): --no-project skips the monorepo sync, --with
             # pins the first-party SDK (exempted from the 7-day soak in [tool.uv]).
             - uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
               if: steps.gate.outputs.had_preview == 'true'
             - name: Destroy preview box + pen
               if: steps.gate.outputs.had_preview == 'true'

--- a/.github/workflows/publish-hogli.yml
+++ b/.github/workflows/publish-hogli.yml
@@ -36,6 +36,8 @@ jobs:
                   python-version: '3.13.13'
 
             - uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
 
             - name: Verify tag matches package version
               shell: bash

--- a/.github/workflows/publish-hogli.yml
+++ b/.github/workflows/publish-hogli.yml
@@ -35,9 +35,7 @@ jobs:
               with:
                   python-version: '3.13.13'
 
-            - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.28'
+            - uses: ./.github/actions/setup-uv
 
             - name: Verify tag matches package version
               shell: bash

--- a/.github/workflows/test-quarantine.yml
+++ b/.github/workflows/test-quarantine.yml
@@ -29,6 +29,8 @@ jobs:
 
             - name: Install uv
               uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
 
             - name: Check quarantine file
               # Same as `hogli test:quarantine check`, without installing the dev

--- a/.github/workflows/test-quarantine.yml
+++ b/.github/workflows/test-quarantine.yml
@@ -27,9 +27,7 @@ jobs:
                   python-version-file: 'pyproject.toml'
 
             - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+              uses: ./.github/actions/setup-uv
 
             - name: Check quarantine file
               # Same as `hogli test:quarantine check`, without installing the dev

--- a/.github/workflows/test-quarantine.yml
+++ b/.github/workflows/test-quarantine.yml
@@ -6,6 +6,7 @@ on:
             - .test_quarantine.json
             - tools/hogli-commands/hogli_commands/quarantine/**
             - .github/workflows/test-quarantine.yml
+            - .github/actions/setup-uv/**
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/trunk-impacted-targets.yml
+++ b/.github/workflows/trunk-impacted-targets.yml
@@ -85,6 +85,8 @@ jobs:
             # tach, so no Python project sync is needed. A missing uv widens those
             # products to every backend lane rather than failing the job.
             - uses: ./.github/actions/setup-uv
+              with:
+                  enable-cache: false
               continue-on-error: true
 
             # Split from the computation below so the cargo steps can be skipped

--- a/.github/workflows/trunk-impacted-targets.yml
+++ b/.github/workflows/trunk-impacted-targets.yml
@@ -84,10 +84,8 @@ jobs:
             # --no-project` to find a changed product's importers; the script pins
             # tach, so no Python project sync is needed. A missing uv widens those
             # products to every backend lane rather than failing the job.
-            - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+            - uses: ./.github/actions/setup-uv
               continue-on-error: true
-              with:
-                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
 
             # Split from the computation below so the cargo steps can be skipped
             # on the PRs that do not need them, which is nearly all of them.


### PR DESCRIPTION
## Problem

Most workflows still repeat exact uv pins after the [shared action](https://github.com/PostHog/posthog/pull/96867) provides a common setup entry point.

Each uv upgrade still requires a large mechanical workflow diff after the base layer lands.

## Changes

- Forty-nine of 64 GitHub and Depot setup steps now use the composite, including the base layer's Python quality job.
- Fifteen steps retain direct pins because their checkout can select a revision without the new action.
- Each exception names its checkout contract; existing pnpm composites do not guarantee that the new uv action exists in older trees.
- Tool-only jobs disable dependency caching; project jobs keep explicit overrides where their lockfile or cache policy differs.
- Conditions, environments, outputs, identifiers, and non-cache inputs remain unchanged.
- The mechanical migration includes sparse-checkout paths and upgrades the last two v7.3.0 callers to v7.6.0. No product behavior changes.

**Before**

```mermaid
flowchart LR
    GitHub{{GitHub job}} --> GitHubSetup[setup-uv]
    Depot{{Depot job}} --> DepotSetup[setup-uv]
    GitHubSetup --> GitHubPin[(Inline exact pin)]
    DepotSetup --> DepotPin[(Inline exact pin)]

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class GitHub,Depot phYellow;
    class GitHubSetup,DepotSetup phBlue;
    class GitHubPin,DepotPin phGray;
```

**After**

```mermaid
flowchart LR
    GitHub{{GitHub job}} --> Shared[Shared setup action]
    Depot{{Depot job}} --> Shared
    Shared --> Pin[(Exact CI pin)]
    Revision{{Revision-checkout job}} --> Direct[Direct setup-uv]
    Direct --> Exception[(Matching exact pin)]

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class GitHub,Depot,Revision phYellow;
    class Shared,Direct phBlue;
    class Pin,Exception phGray;
```

## How did you test this code?

- Local checks: focused unittest suite, compatibility validator, workflow lint, CI-equivalent actionlint, and strict preflight.
- A structural comparison checks controls and non-cache inputs across all 64 setup steps.
- A checkout audit checks the sparse paths and every direct-install exception.
- The [Depot smoke run](https://depot.dev/orgs/ntsdt08fpt/workflows/hwl37p2jql?job=rrqmn7wg52&attempt=p127b6668r) verifies the mirrored composite at the upgrade layer's uv 0.12.5 pin, with GitHub REST blocked.
- Full application suites were not rerun locally. Fresh PR checks are pending.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The parent PR adds `docs/internal/uv-in-ci.md`; inline exception comments identify each checkout contract.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

pi used repository tools, GitHub CLI, Depot CLI, and public Astral source. No customer material informed the changes.

Skills: `/authoring-ci-workflows`, `/writing-code-comments`, `/writing-user-facing-copy`, `/depot-ci`, `/running-ci-preflight`, `/simplify`, `/code-review`, `/qa-team`, `/writing-pr-descriptions`, and `/stacking-prs`.

The checkout audit removed an unnecessary exception from the scheduled timing updater. The stack keeps the primitive separate from caller adoption.
