### PR TITLE
fix(data-warehouse): open a view in the SQL editor faster

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5697,8 +5697,15 @@ const api = {
         async list(): Promise<PaginatedResponse<DataWarehouseSavedQuery>> {
             return await new ApiRequest().dataWarehouseSavedQueries().get()
         },
-        async get(viewId: DataWarehouseSavedQuery['id']): Promise<DataWarehouseSavedQuery> {
-            return await new ApiRequest().dataWarehouseSavedQuery(viewId).get()
+        async get(
+            viewId: DataWarehouseSavedQuery['id'],
+            options?: { includeMaterialization?: boolean }
+        ): Promise<DataWarehouseSavedQuery> {
+            const request = new ApiRequest().dataWarehouseSavedQuery(viewId)
+            if (options?.includeMaterialization === false) {
+                return await request.withQueryString({ include_materialization: 'false' }).get()
+            }
+            return await request.get()
         },
         async create(data: Partial<DataWarehouseSavedQuery> & { types: string[][] }): Promise<DataWarehouseSavedQuery> {
             return await new ApiRequest().dataWarehouseSavedQueries().create({ data })

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -3528,6 +3528,13 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     actions.setViewLoading(true)
                     actions.setViewQueryLoading(true)
 
+                    const viewDetail = api.dataWarehouseSavedQueries
+                        .get(viewId, { includeMaterialization: false })
+                        .then(
+                            (loaded) => ({ view: loaded, failed: false }),
+                            () => ({ view: null, failed: true })
+                        )
+
                     if (values.dataWarehouseSavedQueries.length === 0) {
                         await dataWarehouseViewsLogic.asyncActions.loadDataWarehouseSavedQueries()
                     }
@@ -3542,14 +3549,14 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
 
                     // Fetch the full view with query if not already loaded
                     if (!view.query) {
-                        try {
-                            view = await api.dataWarehouseSavedQueries.get(viewId)
-                        } catch {
+                        const detail = await viewDetail
+                        if (detail.failed || !detail.view) {
                             lemonToast.error('Failed to load view details')
                             actions.setViewLoading(false)
                             actions.setViewQueryLoading(false)
                             return
                         }
+                        view = detail.view
                     }
 
                     const queryToOpen = searchParams.open_query ? searchParams.open_query : (view.query?.query ?? '')

--- a/products/data_warehouse/backend/presentation/views/saved_query.py
+++ b/products/data_warehouse/backend/presentation/views/saved_query.py
@@ -11,7 +11,7 @@ from django.db.models.functions import Cast
 import structlog
 import posthoganalytics
 from asgiref.sync import async_to_sync
-from drf_spectacular.utils import extend_schema, extend_schema_field
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_field
 from rest_framework import exceptions, filters, request, response, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.pagination import PageNumberPagination
@@ -514,15 +514,7 @@ class DataWarehouseSavedQuerySerializerMixin:
         if not isinstance(query, dict) or "query" not in query:
             return []
 
-        team_id = self.context["team_id"]  # type: ignore[attr-defined]
-        database = self.context.get("database", None)  # type: ignore[attr-defined]
-        if not database:
-            database = Database.create_for(
-                team_id=team_id,
-                user=cast(User, self.context["request"].user),  # type: ignore[attr-defined]
-            )
-
-        context = HogQLContext(team_id=team_id, database=database)
+        context = HogQLContext(team_id=self.context["team_id"])  # type: ignore[attr-defined]
 
         descriptions = view_annotation_map(view)
         fields = serialize_fields(view.hogql_definition().fields, context, view.name_chain, table_type="external")
@@ -742,6 +734,14 @@ class DataWarehouseSavedQuerySerializer(
         help_text="How far incremental materialization has progressed. Null until the first run "
         "records any. Written by the materialization run, not by this API.",
     )
+
+    MATERIALIZATION_FIELDS = ("sync_frequency_bounds", "suspended")
+
+    def to_representation(self, instance: DataWarehouseSavedQuery) -> dict[str, Any]:
+        if not self.context.get("include_materialization", True):
+            for name in self.MATERIALIZATION_FIELDS:
+                self.fields.pop(name, None)
+        return super().to_representation(instance)
 
     class Meta:
         model = DataWarehouseSavedQuery
@@ -1506,18 +1506,38 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, AccessControlViewSe
     def get_serializer_context(self) -> dict[str, Any]:
         context = super().get_serializer_context()
         request_data = getattr(self.request, "data", {})
-        should_include_database = self.action in {"create", "list", "retrieve"} or (
+        should_include_database = self.action == "create" or (
             self.action in {"update", "partial_update"} and ("name" in request_data or "query" in request_data)
         )
 
         if should_include_database:
             context["database"] = Database.create_for(team_id=self.team_id, user=cast(User, self.request.user))
+        context["include_materialization"] = not (
+            self.action == "retrieve" and self.request.query_params.get("include_materialization") == "false"
+        )
         return context
 
     def get_serializer_class(self):
         if self.action == "list":
             return DataWarehouseSavedQueryMinimalSerializer
         return DataWarehouseSavedQuerySerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="include_materialization",
+                type=bool,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description=(
+                    "Pass `false` to leave out `sync_frequency_bounds` and `suspended`. Each costs a DAG "
+                    "walk, which a caller that only needs the query body can skip."
+                ),
+            )
+        ]
+    )
+    def retrieve(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
+        return super().retrieve(request, *args, **kwargs)
 
     def safely_get_queryset(self, queryset):
         base_queryset = (

--- a/products/data_warehouse/backend/tests/api/test_saved_query.py
+++ b/products/data_warehouse/backend/tests/api/test_saved_query.py
@@ -15,6 +15,8 @@ from django.utils import timezone
 
 from parameterized import parameterized
 
+from posthog.hogql.database.database import Database
+
 from posthog.models import ActivityLog
 from posthog.models.activity_logging.activity_log import Detail
 
@@ -992,6 +994,31 @@ class TestSavedQuery(APIBaseTest):
         )
 
         self.assertNotIn("sync_frequency_bounds", DataWarehouseSavedQueryMinimalSerializer().fields)
+
+    def test_retrieve_can_leave_out_the_materialization_fields(self):
+        saved_query = self._create_saved_query_for_frequency_tests()
+        url = f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query['id']}/"
+
+        plain = self.client.get(url).json()
+        self.assertIn("sync_frequency_bounds", plain)
+        self.assertIn("suspended", plain)
+
+        without = self.client.get(f"{url}?include_materialization=false").json()
+        self.assertNotIn("sync_frequency_bounds", without)
+        self.assertNotIn("suspended", without)
+
+    def test_reads_do_not_build_the_hogql_database(self):
+        saved_query = self._create_saved_query_for_frequency_tests()
+        views_module = "products.data_warehouse.backend.presentation.views.saved_query"
+
+        with patch(f"{views_module}.Database.create_for", wraps=Database.create_for) as create_for:
+            detail = self.client.get(f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query['id']}/")
+            listing = self.client.get(f"/api/environments/{self.team.id}/warehouse_saved_queries/")
+
+        self.assertEqual(detail.status_code, 200)
+        self.assertEqual(listing.status_code, 200)
+        self.assertEqual([c["name"] for c in detail.json()["columns"]], ["event"])
+        create_for.assert_not_called()
 
     def _create_saved_query(self) -> dict:
         response = self.client.post(

--- a/products/data_warehouse/frontend/generated/api.schemas.ts
+++ b/products/data_warehouse/frontend/generated/api.schemas.ts
@@ -5116,6 +5116,13 @@ export type WarehouseSavedQueriesListParams = {
     search?: string
 }
 
+export type WarehouseSavedQueriesRetrieveParams = {
+    /**
+     * Pass `false` to leave out `sync_frequency_bounds` and `suspended`. Each costs a DAG walk, which a caller that only needs the query body can skip.
+     */
+    include_materialization?: boolean
+}
+
 export type WarehouseSavedQueryDraftsListParams = {
     /**
      * Number of results to return per page.

--- a/products/data_warehouse/frontend/generated/api.ts
+++ b/products/data_warehouse/frontend/generated/api.ts
@@ -81,6 +81,7 @@ import type {
     WarehouseColumnAnnotationsListParams,
     WarehouseExpressionsListParams,
     WarehouseSavedQueriesListParams,
+    WarehouseSavedQueriesRetrieveParams,
     WarehouseSavedQueryDraftsListParams,
     WarehouseStatusResponseApi,
     WarehouseTablesListParams,
@@ -1509,8 +1510,24 @@ export const warehouseSavedQueriesCreate = async (
     })
 }
 
-export const getWarehouseSavedQueriesRetrieveUrl = (projectId: string, id: string) => {
-    return `/api/projects/${projectId}/warehouse_saved_queries/${id}/`
+export const getWarehouseSavedQueriesRetrieveUrl = (
+    projectId: string,
+    id: string,
+    params?: WarehouseSavedQueriesRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/warehouse_saved_queries/${id}/?${stringifiedParams}`
+        : `/api/projects/${projectId}/warehouse_saved_queries/${id}/`
 }
 
 /**
@@ -1519,9 +1536,10 @@ export const getWarehouseSavedQueriesRetrieveUrl = (projectId: string, id: strin
 export const warehouseSavedQueriesRetrieve = async (
     projectId: string,
     id: string,
+    params?: WarehouseSavedQueriesRetrieveParams,
     options?: RequestInit
 ): Promise<DataWarehouseSavedQueryApi> => {
-    return apiMutator<DataWarehouseSavedQueryApi>(getWarehouseSavedQueriesRetrieveUrl(projectId, id), {
+    return apiMutator<DataWarehouseSavedQueryApi>(getWarehouseSavedQueriesRetrieveUrl(projectId, id, params), {
         ...options,
         method: 'GET',
     })

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -102792,6 +102792,13 @@ export namespace Schemas {
     search?: string;
     };
 
+    export type WarehouseSavedQueriesRetrieveParams = {
+    /**
+     * Pass `false` to leave out `sync_frequency_bounds` and `suspended`. Each costs a DAG walk, which a caller that only needs the query body can skip.
+     */
+    include_materialization?: boolean;
+    };
+
     export type WarehouseSavedQueriesCheckSuiteRunsListParams = {
     /**
      * Number of results to return per page.

--- a/services/mcp/src/generated/data_warehouse/api.ts
+++ b/services/mcp/src/generated/data_warehouse/api.ts
@@ -413,6 +413,15 @@ export const WarehouseSavedQueriesRetrieveParams = () => zod.object({
         ),
 })
 
+export const WarehouseSavedQueriesRetrieveQueryParams = () => zod.object({
+    include_materialization: zod
+        .boolean()
+        .optional()
+        .describe(
+            'Pass `false` to leave out `sync_frequency_bounds` and `suspended`. Each costs a DAG walk, which a caller that only needs the query body can skip.'
+        ),
+})
+
 /**
  * Create, Read, Update and Delete Warehouse Tables.
  */

--- a/services/mcp/src/tools/generated/data_warehouse.ts
+++ b/services/mcp/src/tools/generated/data_warehouse.ts
@@ -293,7 +293,10 @@ const viewDelete = (): ToolBase<ReturnType<typeof ViewDeleteSchema>, Schemas.Dat
 
 const ViewGetSchema = () => {
     const WarehouseSavedQueriesRetrieveParams = orvalSchemas.WarehouseSavedQueriesRetrieveParams()
-    return WarehouseSavedQueriesRetrieveParams.omit({ project_id: true })
+    const WarehouseSavedQueriesRetrieveQueryParams = orvalSchemas.WarehouseSavedQueriesRetrieveQueryParams()
+    return WarehouseSavedQueriesRetrieveParams.omit({ project_id: true }).extend(
+        WarehouseSavedQueriesRetrieveQueryParams.shape
+    )
 }
 
 const viewGet = (): ToolBase<ReturnType<typeof ViewGetSchema>, WithPostHogUrl<Schemas.DataWarehouseSavedQuery>> => ({
@@ -304,6 +307,9 @@ const viewGet = (): ToolBase<ReturnType<typeof ViewGetSchema>, WithPostHogUrl<Sc
         const result = await context.api.request<Schemas.DataWarehouseSavedQuery>({
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/warehouse_saved_queries/${encodeURIComponent(String(params.id))}/`,
+            query: {
+                include_materialization: params.include_materialization,
+            },
         })
         return await withPostHogUrl(context, result, `/sql?open_view=${result.id}`)
     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/view-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/view-get.json
@@ -4,6 +4,10 @@
         "id": {
             "description": "A UUID string identifying this data warehouse saved query.",
             "type": "string"
+        },
+        "include_materialization": {
+            "description": "Also return `sync_frequency_bounds` and `suspended`. These cost a DAG walk per view, so they are omitted unless the caller renders the materialization panel.",
+            "type": "boolean"
         }
     },
     "required": ["id"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/view-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/view-get.json
@@ -6,7 +6,7 @@
             "type": "string"
         },
         "include_materialization": {
-            "description": "Also return `sync_frequency_bounds` and `suspended`. These cost a DAG walk per view, so they are omitted unless the caller renders the materialization panel.",
+            "description": "Pass `false` to leave out `sync_frequency_bounds` and `suspended`. Each costs a DAG walk, which a caller that only needs the query body can skip.",
             "type": "boolean"
         }
     },


### PR DESCRIPTION
## Problem

Opening a saved view in the SQL editor shows a spinner for a second or more before the query appears, on every open.

Three costs add up on that path:

- The editor waits for the full view list before it starts fetching the view body, and the list never carries the body.
- Every list and retrieve of a saved query builds a HogQL database for the team, even though the columns it serializes come from the row.
- Every retrieve walks the DAG twice, for `sync_frequency_bounds` and `suspended`, which only the materialization panel reads.

In production the detail endpoint sits at p50 385 ms and p95 2.5 s, and the list endpoint at p50 85 ms and p95 333 ms (US, 6 h window on 2026-09-08).

## Changes

- The SQL editor starts the view detail fetch immediately and overlaps it with the list load. The view opens as soon as both return.
- Reading a saved query no longer builds the HogQL database. Only create and query edits still build one, for validation.
- Retrieve accepts `?include_materialization=false`, which leaves out `sync_frequency_bounds` and `suspended`. The SQL editor's open path passes it. Every other caller gets the same response as before.

Mechanical: the regenerated OpenAPI types and MCP client for the new query parameter.

## How did you test this code?

- `test_reads_do_not_build_the_hogql_database` fails on master: list and retrieve called `Database.create_for`.
- `test_retrieve_can_leave_out_the_materialization_fields` fails on master: the parameter was ignored.
- Existing `open_view` Jest tests cover the reordered fetch.
- Not run: the full frontend typecheck is red on this workspace for unrelated products, so CI carries it.
- Not measured: the production latency after the change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The first cut made the two fields opt-in, which changed the retrieve contract for every caller while the generated types still marked the fields required. Review caught it, so the default is now unchanged and the SQL editor opts out. The fields drop out in `to_representation` rather than `get_fields`, because `get_fields` also removes them from the OpenAPI schema.

No open PR covers this. The committed code and tests carry nothing from the session beyond the repository.
