### PR TITLE
chore(migrations): correct the two-phase column drop guidance

### DIFF
--- a/.agents/skills/django-migrations/SKILL.md
+++ b/.agents/skills/django-migrations/SKILL.md
@@ -30,6 +30,21 @@ To retire a model/table:
 
 Full guide: `safe-django-migrations.md` (`## Dropping Tables`, `### Removing a whole product or app`). Deleting a migration your branch added but never merged to master is allowed (regenerating).
 
+## Retire a column in two phases
+
+Deleting the field and running `makemigrations` is not the first phase.
+Django generates a plain `RemoveField`, which drops the column in the same deploy that removes the code.
+Old pods still write to that column, and a rollback finds it gone.
+
+1. Remove all usage and the field from the model. `makemigrations`, then wrap the generated `RemoveField` in `migrations.SeparateDatabaseAndState(state_operations=[...], database_operations=[])`. The column stays in Postgres. Example: `posthog/migrations/1328_remove_userproductlist_reason_state.py`.
+2. Deploy, wait at least one full deploy cycle, and confirm no deployed code reads the column.
+3. Drop the column in a NEW `RunSQL` migration with `ALTER TABLE ... DROP COLUMN IF EXISTS`. Example: `posthog/migrations/1340_drop_userproductlist_reason_columns.py`.
+
+`RemoveFieldAnalyzer` scores a bare `RemoveField` at 5, the highest risk the "Migration Risk Analysis" CI job reports.
+The phase 2 drop scores low only when `check_drop_properly_staged` finds the phase 1 state removal in an ancestor migration, so the two phases must land in that order and never in one migration.
+
+Full guide: `safe-django-migrations.md` (`## Dropping Columns`).
+
 ## Retire dedicated migration tests
 
 A data migration test protects the rollout, not the permanent behavior of the product. Remove the dedicated test after all supported environments have applied the migration, the rollback window has closed, and no supported upgrade still relies on the old data state.

--- a/docs/published/handbook/engineering/safe-django-migrations.md
+++ b/docs/published/handbook/engineering/safe-django-migrations.md
@@ -233,17 +233,44 @@ Leaving the table in place — code gone, table dropped in a follow-up — is a 
 
 ### Safe Approach
 
-Use the same multi-phase pattern as [Dropping Tables](#dropping-tables):
+Use the same multi-phase pattern as [Dropping Tables](#dropping-tables).
+Deleting the field and running `makemigrations` is **not** phase 1 on its own: Django generates a plain `RemoveField`, which drops the column in the same deploy that removes the code.
 
-1. Remove the field from your Django model (keeps column in database)
-2. Deploy and verify no code references it (application servers, workers, background jobs)
-3. Wait at least one full deployment cycle
-4. Optionally drop the column with `RemoveField` in a later migration
+**Phase 1: remove the field from Django state only.**
+Delete every reference to the field and the field itself from the model, run `makemigrations`, then wrap the generated `RemoveField` in `SeparateDatabaseAndState`:
+
+```python
+# 1328_remove_userproductlist_reason_state.py
+operations = [
+    migrations.SeparateDatabaseAndState(
+        state_operations=[
+            migrations.RemoveField(model_name="userproductlist", name="reason"),
+        ],
+        database_operations=[],
+    ),
+]
+```
+
+The column stays in Postgres, so in-flight requests on the old release keep working and a rollback still finds it.
+Deploy this, and verify no code references the field (application servers, workers, background jobs).
+
+**Phase 2: drop the column, at least one full deployment cycle later.**
+
+```python
+# 1340_drop_userproductlist_reason_columns.py
+operations = [
+    migrations.RunSQL(
+        sql='ALTER TABLE "posthog_userproductlist" DROP COLUMN IF EXISTS "reason";',
+        reverse_sql='ALTER TABLE "posthog_userproductlist" ADD COLUMN IF NOT EXISTS "reason" varchar(32) NULL;',
+    ),
+]
+```
 
 **Important notes:**
 
-- `RemoveField` operations are irreversible - column data is permanently deleted
-- `DROP COLUMN` takes an `ACCESS EXCLUSIVE` lock (briefly) - schedule during low-traffic windows
+- Dropping a column is irreversible - the data is permanently deleted. `reverse_sql` can re-add an empty column so the migration unapplies, but it cannot restore the values
+- `DROP COLUMN` takes an `ACCESS EXCLUSIVE` lock (briefly) - on a [hot table](#altering-hot-tables) schedule it for a low-traffic window
+- The "Migration Risk Analysis" CI job scores a bare `RemoveField` at 5, its highest risk. Phase 2 scores low only when the analyzer finds the phase 1 state removal in an ancestor migration, so the two phases must land in that order
 - Consider leaving unused columns indefinitely to avoid data loss risks
 
 ## Renaming Tables

--- a/posthog/management/migration_analysis/operations.py
+++ b/posthog/management/migration_analysis/operations.py
@@ -170,10 +170,10 @@ class RemoveFieldAnalyzer(OperationAnalyzer):
             score=5,
             reason="Dropping column breaks backwards compatibility and can't rollback",
             details={"model": op.model_name, "field": op.name},
-            guidance=f"""Multi-phase column drop:
-1. Remove field from Django model (keeps column in DB)
+            guidance=f"""Use SeparateDatabaseAndState for multi-phase column drops:
+1. Remove field from Django state (state_operations only, column stays in DB)
 2. Wait at least one full deployment cycle
-3. Optionally drop column with RemoveField
+3. Drop the column with RunSQL: ALTER TABLE ... DROP COLUMN IF EXISTS
 
 [See the migration safety guide]({SAFE_MIGRATIONS_DOCS_URL}#dropping-columns)""",
         )


### PR DESCRIPTION
## Problem

An engineer who retires a Postgres column and follows our own guidance drops it in a single deploy, which breaks in-flight requests on the old release and makes a rollback fail.

Three places describe phase 1 of a column drop as "remove the field from the Django model (keeps column in DB)". That is not what happens. `makemigrations` turns a removed field into a bare `RemoveField`, which drops the column immediately. The correct phase 1 wraps that `RemoveField` in `SeparateDatabaseAndState`, which is what the repo's own migrations do.

The guidance also contradicted the linter that reads it. `check_drop_properly_staged` downgrades the risk of a phase 2 `DROP COLUMN IF EXISTS` only when it finds a prior state-only removal in an ancestor migration. Nobody following the old steps produced that artifact.

## Changes

- The "Migration Risk Analysis" CI job now tells the author to remove the field from Django state only, and to drop the column later with `RunSQL`. It previously told them to remove it from the model and then drop it with a second `RemoveField`.
- The handbook's "Dropping columns" section now shows both phases as code, and cites the two migrations in this repo that already follow the pattern.
- The `django-migrations` skill gains a column procedure, next to the model and table procedure it already carried. Its description always claimed column coverage, but the body only covered tables.

All three changes are text. No analyzer scoring, no migration behavior, and nothing a product user sees changes.

## How did you test this code?

- `uv run pytest posthog/management/migration_analysis/test/test_risk_analyzer.py` passes. No test asserts on the guidance strings, so none needed updating.
- `hogli lint:skills` passes. The 5 advisory warnings it prints are pre-existing and sit in unrelated skills.
- `ruff check` and `ruff format --check` pass on the changed Python file.

No new tests. The change is guidance text, and there is no regression a test would catch that the existing staged-drop tests do not already cover.

Not checked: nothing was run against a database, and no migration was generated or applied.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`docs/published/handbook/engineering/safe-django-migrations.md` is updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in PostHog Desktop. Skills invoked: `/django-migrations`, `/writing-skills`, `/writing-pr-descriptions`.

The session started as an audit of whether `is_hipaa` is still used, and whether a skill covers safe column removal. Both turned out to already be true, so neither piece of the original request produced code. The contradiction between the guidance text and `check_drop_properly_staged` surfaced while verifying the linter, and is the only defect found.

No duplicate: `gh pr list --state open --search "column drop guidance"` found nothing covering this.

Public artifact: every example in the diff comes from migrations already committed to this repo.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
