### PR TITLE
feat(organization): gate AI training on a signed BAA

### DIFF
--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -4319,6 +4319,8 @@ export interface OrganizationApi {
     readonly is_ai_training_cta_shown: boolean | null
     /** @nullable */
     readonly is_hipaa: boolean | null
+    /** Whether the organization has a countersigned Business Associate Agreement on file. When true, AI training stays opted out and cannot be changed. */
+    readonly has_signed_baa: boolean
     /** Default statistical method for new experiments in this organization.
      *
      * * `bayesian` - Bayesian

--- a/frontend/src/lib/components/AllowTrainingCallout/AllowTrainingCallout.tsx
+++ b/frontend/src/lib/components/AllowTrainingCallout/AllowTrainingCallout.tsx
@@ -24,7 +24,7 @@ export function AllowTrainingCallout({
         isHobby ||
         restrictionReason ||
         currentOrganization?.is_ai_training_opted_in !== false ||
-        currentOrganization.is_hipaa ||
+        currentOrganization.has_signed_baa ||
         currentOrganization.is_ai_training_cta_shown === false
     ) {
         return null

--- a/frontend/src/scenes/settings/organization/OrgAITraining.tsx
+++ b/frontend/src/scenes/settings/organization/OrgAITraining.tsx
@@ -10,11 +10,11 @@ import { organizationLogic } from 'scenes/organizationLogic'
 import { AI_TRAINING_URL } from './aiTrainingConstants'
 import { ORG_ADMIN_REQUIRED_TOOLTIP } from './organizationSettingsConstants'
 
-function AITrainingDescription({ isHipaa, isLocked }: { isHipaa: boolean; isLocked: boolean }): JSX.Element {
-    if (isHipaa) {
+function AITrainingDescription({ hasSignedBaa, isLocked }: { hasSignedBaa: boolean; isLocked: boolean }): JSX.Element {
+    if (hasSignedBaa) {
         return (
             <p className="mb-2 text-sm text-secondary">
-                You are opted out of internal AI training because you are compliant with HIPAA.
+                You are opted out of internal AI training because you have a signed BAA with PostHog.
             </p>
         )
     }
@@ -44,22 +44,22 @@ export function OrganizationAITrainingOptOut(): JSX.Element {
     const { updateOrganization } = useActions(organizationLogic)
 
     const restrictionReason = useRestrictedArea({ minimumAccessLevel: OrganizationMembershipLevel.Admin })
-    const isHipaa = !!currentOrganization?.is_hipaa
+    const hasSignedBaa = !!currentOrganization?.has_signed_baa
     const isLocked = !!currentOrganization?.is_ai_training_locked
 
-    const disabledReason = isHipaa
-        ? 'HIPAA organizations are always opted out of AI training. Please contact us if this needs to change.'
+    const disabledReason = hasSignedBaa
+        ? 'Organizations with a signed BAA stay opted out of AI training. Contact us if this needs to change.'
         : isLocked
           ? 'Please contact us to change this setting.'
           : restrictionReason
             ? ORG_ADMIN_REQUIRED_TOOLTIP
             : undefined
 
-    const checked = !isHipaa && !!currentOrganization?.is_ai_training_opted_in
+    const checked = !hasSignedBaa && !!currentOrganization?.is_ai_training_opted_in
 
     return (
         <div className="max-w-160">
-            <AITrainingDescription isHipaa={isHipaa} isLocked={isLocked} />
+            <AITrainingDescription hasSignedBaa={hasSignedBaa} isLocked={isLocked} />
             <div className="my-4">
                 <LemonSwitch
                     label="Enable AI training on anonymized data"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -594,6 +594,7 @@ export interface OrganizationType extends OrganizationBasicType {
     is_ai_training_locked?: boolean
     is_ai_training_cta_shown?: boolean
     is_hipaa?: boolean
+    has_signed_baa?: boolean
     members_can_invite?: boolean
     members_can_create_projects?: boolean
     members_can_use_personal_api_keys: boolean

--- a/posthog/admin/ai_training_opt_in_history.py
+++ b/posthog/admin/ai_training_opt_in_history.py
@@ -16,6 +16,8 @@ from posthog.exceptions_capture import capture_exception
 from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.organization import Organization
 
+from products.legal_documents.backend.facade.api import has_signed_baa
+
 # This value matches `detail.changes[].field`. That key holds the display name from
 # `field_name_overrides`. It equals the model field name because Organization sets no override for
 # this field. An override would empty this panel. `test_manual_opt_in_then_opt_out...` catches that.
@@ -165,17 +167,17 @@ def _build_headline(current: Optional[bool], was_opted_in: bool) -> str:
     return f"{headline} (value is null)" if current is None else headline
 
 
-def _hipaa_conflict_warning(organization: Organization) -> Optional[str]:
+def _baa_conflict_warning(organization: Organization) -> Optional[str]:
     # The replay ML mirror reads is_ai_training_opted_in alone. That gate is in
     # nodejs/src/ingestion/pipelines/sessionreplay/ai-training-optin-filter-step.ts. No code in that
-    # pipeline reads is_hipaa. Change this warning if that gate starts to read is_hipaa.
-    if not organization.is_hipaa or organization.is_ai_training_opted_in is not True:
+    # pipeline reads the BAA. Change this warning if that gate starts to read it.
+    if organization.is_ai_training_opted_in is not True or not has_signed_baa(organization.id):
         return None
     return (
-        "HIPAA is set, but the AI training opt-in is on. The training pipeline reads the opt-in and "
-        "does not check HIPAA, so this organization's session recordings are eligible for training. "
-        "Their settings page shows them as opted out, and the API blocks them from changing it "
-        "themselves. Turn the opt-in off here if that is wrong."
+        "A signed BAA is on file, but the AI training opt-in is on. The training pipeline reads the "
+        "opt-in and does not check the BAA, so this organization's session recordings are eligible "
+        "for training. Their settings page shows them as opted out, and the API blocks them from "
+        "changing it themselves. Turn the opt-in off here if that is wrong."
     )
 
 
@@ -194,6 +196,6 @@ def get_ai_training_opt_in_history(organization: Organization) -> OptInHistory:
     return OptInHistory(
         headline=_build_headline(organization.is_ai_training_opted_in, was_opted_in),
         changes=changes,
-        warning=_hipaa_conflict_warning(organization),
+        warning=_baa_conflict_warning(organization),
         truncated=truncated,
     )

--- a/posthog/admin/test_ai_training_opt_in_history.py
+++ b/posthog/admin/test_ai_training_opt_in_history.py
@@ -2,6 +2,8 @@ from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
 from django.contrib.admin.sites import AdminSite
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
 from parameterized import parameterized
 
@@ -193,6 +195,30 @@ class TestAITrainingOptInHistory(APIBaseTest):
         self.assertIn("Currently opted in", html)
         self.assertIn("opted out → opted in", html)
         self.assertIn(self.user.email, html)
+
+    def test_admin_organization_list_does_not_read_the_baa_per_row(self) -> None:
+        for _ in range(3):
+            Organization.objects.bootstrap(self.user)
+        self.user.is_staff = True
+        self.user.save()
+
+        with CaptureQueriesContext(connection) as context:
+            response = self.client.get("/admin/posthog/organization/")
+
+        self.assertEqual(response.status_code, 200)
+        legal_document_queries = [q for q in context.captured_queries if "legal_documents_legaldocument" in q["sql"]]
+        self.assertEqual(legal_document_queries, [])
+
+    def test_admin_change_form_reads_the_baa_once(self) -> None:
+        self.user.is_staff = True
+        self.user.save()
+
+        with CaptureQueriesContext(connection) as context:
+            response = self.client.get(f"/admin/posthog/organization/{self.organization.id}/change/")
+
+        self.assertEqual(response.status_code, 200)
+        legal_document_queries = [q for q in context.captured_queries if "legal_documents_legaldocument" in q["sql"]]
+        self.assertEqual(len(legal_document_queries), 1)
 
     def test_admin_panel_is_blank_on_the_add_form(self) -> None:
         html = OrganizationAdmin(Organization, AdminSite()).ai_training_opt_in_history_display(Organization())

--- a/posthog/admin/test_ai_training_opt_in_history.py
+++ b/posthog/admin/test_ai_training_opt_in_history.py
@@ -2,7 +2,9 @@ from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
 from django.contrib.admin.sites import AdminSite
+from django.contrib.admin.templatetags.admin_list import results
 from django.db import connection
+from django.test import RequestFactory
 from django.test.utils import CaptureQueriesContext
 
 from parameterized import parameterized
@@ -196,6 +198,19 @@ class TestAITrainingOptInHistory(APIBaseTest):
         self.assertIn("opted out → opted in", html)
         self.assertIn(self.user.email, html)
 
+    def _baa_queries(self, context: CaptureQueriesContext) -> list[str]:
+        return [q["sql"] for q in context.captured_queries if "legal_documents_legaldocument" in q["sql"]]
+
+    def _render_organization_changelist(self) -> None:
+        # Drives the same field resolution the changelist template does, without rendering
+        # the admin page itself, whose app-list sidebar cannot reverse in the test settings.
+        request = RequestFactory().get("/admin/posthog/organization/")
+        request.user = self.user
+        changelist = OrganizationAdmin(Organization, AdminSite()).get_changelist_instance(request)
+        # The changelist view sets this; `results` reads it to decide whether rows are editable.
+        changelist.formset = None
+        list(results(changelist))
+
     def test_admin_organization_list_does_not_read_the_baa_per_row(self) -> None:
         for _ in range(3):
             Organization.objects.bootstrap(self.user)
@@ -203,22 +218,15 @@ class TestAITrainingOptInHistory(APIBaseTest):
         self.user.save()
 
         with CaptureQueriesContext(connection) as context:
-            response = self.client.get("/admin/posthog/organization/")
+            self._render_organization_changelist()
 
-        self.assertEqual(response.status_code, 200)
-        legal_document_queries = [q for q in context.captured_queries if "legal_documents_legaldocument" in q["sql"]]
-        self.assertEqual(legal_document_queries, [])
+        self.assertEqual(self._baa_queries(context), [])
 
     def test_admin_change_form_reads_the_baa_once(self) -> None:
-        self.user.is_staff = True
-        self.user.save()
-
         with CaptureQueriesContext(connection) as context:
-            response = self.client.get(f"/admin/posthog/organization/{self.organization.id}/change/")
+            OrganizationAdmin(Organization, AdminSite()).ai_training_opt_in_history_display(self.organization)
 
-        self.assertEqual(response.status_code, 200)
-        legal_document_queries = [q for q in context.captured_queries if "legal_documents_legaldocument" in q["sql"]]
-        self.assertEqual(len(legal_document_queries), 1)
+        self.assertEqual(len(self._baa_queries(context)), 1)
 
     def test_admin_panel_is_blank_on_the_add_form(self) -> None:
         html = OrganizationAdmin(Organization, AdminSite()).ai_training_opt_in_history_display(Organization())

--- a/posthog/admin/test_ai_training_opt_in_history.py
+++ b/posthog/admin/test_ai_training_opt_in_history.py
@@ -1,4 +1,5 @@
 from posthog.test.base import APIBaseTest
+from unittest.mock import patch
 
 from django.contrib.admin.sites import AdminSite
 
@@ -115,14 +116,13 @@ class TestAITrainingOptInHistory(APIBaseTest):
             (True, None, False),
         ]
     )
-    def test_warns_only_when_a_hipaa_organization_is_opted_in(
-        self, is_hipaa: bool, opted_in: bool | None, expect_warning: bool
+    def test_warns_only_when_an_organization_with_a_signed_baa_is_opted_in(
+        self, has_baa: bool, opted_in: bool | None, expect_warning: bool
     ) -> None:
-        self.organization.is_hipaa = is_hipaa
-        self.organization.save()
         self._set_opt_in_without_logging(opted_in)
 
-        history = get_ai_training_opt_in_history(self.organization)
+        with patch("posthog.admin.ai_training_opt_in_history.has_signed_baa", return_value=has_baa):
+            history = get_ai_training_opt_in_history(self.organization)
 
         self.assertEqual(history.warning is not None, expect_warning)
 

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -59,7 +59,7 @@ from posthog.utils import get_safe_cache, safe_cache_set
 from products.access_control.backend.facade.user_access_control import UserAccessControl, visible_teams_for_user
 from products.access_control.backend.models.role import Role
 from products.access_control.backend.presentation.access_control import UserAccessControlSerializerMixin
-from products.legal_documents.backend.facade.api import has_signed_baa
+from products.legal_documents.backend.facade.api import SIGNED_BAA_ANNOTATION, annotate_signed_baa, has_signed_baa
 
 
 class PremiumMultiorganizationPermission(permissions.BasePermission):
@@ -295,6 +295,11 @@ class OrganizationSerializer(
 
     @extend_schema_field(serializers.BooleanField())
     def get_has_signed_baa(self, instance: Organization) -> bool:
+        # The list route annotates this in the organizations query. The single-organization
+        # routes do not go through that queryset, so they fall back to one lookup.
+        annotated = getattr(instance, SIGNED_BAA_ANNOTATION, None)
+        if annotated is not None:
+            return annotated
         return has_signed_baa(instance.id)
 
     @extend_schema_field(serializers.DictField(child=serializers.CharField()))
@@ -540,7 +545,7 @@ class OrganizationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             if scoped_organizations := self.request.successful_authenticator.access_token.scoped_organizations:
                 queryset = queryset.filter(id__in=scoped_organizations)
 
-        return queryset
+        return annotate_signed_baa(queryset)
 
     def safely_get_object(self, queryset):
         return self.organization

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -59,6 +59,7 @@ from posthog.utils import get_safe_cache, safe_cache_set
 from products.access_control.backend.facade.user_access_control import UserAccessControl, visible_teams_for_user
 from products.access_control.backend.models.role import Role
 from products.access_control.backend.presentation.access_control import UserAccessControlSerializerMixin
+from products.legal_documents.backend.facade.api import has_signed_baa
 
 
 class PremiumMultiorganizationPermission(permissions.BasePermission):
@@ -171,6 +172,9 @@ class OrganizationSerializer(
         read_only=True,
         help_text="Legacy field; member-join emails are controlled per user in account notification settings.",
     )
+    has_signed_baa = serializers.SerializerMethodField(
+        help_text="Whether the organization has a countersigned Business Associate Agreement on file. When true, AI training stays opted out and cannot be changed."
+    )
 
     class Meta:
         model = Organization
@@ -203,6 +207,7 @@ class OrganizationSerializer(
             "is_ai_training_locked",
             "is_ai_training_cta_shown",
             "is_hipaa",
+            "has_signed_baa",
             "default_experiment_stats_method",
             "default_anonymize_ips",
             "default_role_id",
@@ -229,6 +234,7 @@ class OrganizationSerializer(
             "is_ai_training_locked",
             "is_ai_training_cta_shown",
             "is_hipaa",
+            "has_signed_baa",
         ]
         extra_kwargs = {
             "slug": {
@@ -286,6 +292,10 @@ class OrganizationSerializer(
     def _fetch_visible_projects(self, instance: Organization) -> list[dict[str, Any]]:
         visible_projects = instance.projects.filter(id__in=self.user_permissions.project_ids_visible_for_user)
         return list(ProjectBasicSerializer(visible_projects, context=self.context, many=True).data)
+
+    @extend_schema_field(serializers.BooleanField())
+    def get_has_signed_baa(self, instance: Organization) -> bool:
+        return has_signed_baa(instance.id)
 
     @extend_schema_field(serializers.DictField(child=serializers.CharField()))
     def get_metadata(self, instance: Organization) -> dict[str, Union[str, int, object]]:
@@ -369,9 +379,9 @@ class OrganizationSerializer(
 
     def validate_is_ai_training_opted_in(self, value: bool | None) -> bool | None:
         if self.instance and self.instance.is_ai_training_opted_in != value:
-            if self.instance.is_hipaa:
+            if has_signed_baa(self.instance.id):
                 raise serializers.ValidationError(
-                    "HIPAA organizations are always opted out of AI training and this setting cannot be changed.",
+                    "Organizations with a signed BAA stay opted out of AI training. Contact PostHog support if you need to change this.",
                     code="locked",
                 )
             if self.instance.is_ai_training_locked:

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -6,6 +6,8 @@ from posthog.test.base import APIBaseTest
 from unittest.mock import ANY, patch
 
 from django.core.cache import cache
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from parameterized import parameterized
@@ -200,6 +202,18 @@ class TestOrganizationAPI(APIBaseTest):
         self.assertEqual(response.json()["code"], "locked")
         self.organization.refresh_from_db()
         self.assertEqual(self.organization.is_ai_training_opted_in, False)
+
+    def test_listing_organizations_reads_the_baa_once_regardless_of_count(self):
+        Organization.objects.bootstrap(self.user)
+        Organization.objects.bootstrap(self.user)
+
+        with CaptureQueriesContext(connection) as context:
+            response = self.client.get("/api/organizations/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertGreaterEqual(len(response.json()["results"]), 3)
+        legal_document_queries = [q for q in context.captured_queries if "legal_documents_legaldocument" in q["sql"]]
+        self.assertEqual(len(legal_document_queries), 1)
 
     def test_cant_update_plugins_access_level(self):
         self.organization_membership.level = OrganizationMembership.Level.ADMIN

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -185,6 +185,22 @@ class TestOrganizationAPI(APIBaseTest):
         self.organization.refresh_from_db()
         self.assertNotEqual(self.organization.name, "ASDFG")
 
+    def test_cannot_opt_into_ai_training_with_a_signed_baa(self):
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+        self.organization.is_ai_training_opted_in = False
+        self.organization.save()
+
+        with patch("posthog.api.organization.has_signed_baa", return_value=True):
+            response = self.client.patch(
+                f"/api/organizations/{self.organization.id}/", {"is_ai_training_opted_in": True}
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["code"], "locked")
+        self.organization.refresh_from_db()
+        self.assertEqual(self.organization.is_ai_training_opted_in, False)
+
     def test_cant_update_plugins_access_level(self):
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -201,9 +201,11 @@ class TestAutoProjectMiddleware(APIBaseTest):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        # 55, not 54: the app context serializes the project's tags, which costs one
-        # indexed lookup on posthog_taggeditem per page load.
-        cls.base_app_num_queries = 55
+        # 56, not 54: the app context serializes the project's tags, which costs one
+        # indexed lookup on posthog_taggeditem per page load, and the organization it
+        # serializes comes off the user's current_organization foreign key, which carries
+        # no signed-BAA annotation, so the AI training lock costs one more indexed lookup.
+        cls.base_app_num_queries = 56
         # Create another team that the user does have access to
         cls.second_team = create_team(organization=cls.organization, name="Second Life")
 

--- a/products/legal_documents/backend/facade/api.py
+++ b/products/legal_documents/backend/facade/api.py
@@ -12,6 +12,7 @@ from collections.abc import Callable
 from uuid import UUID
 
 from django.db import transaction
+from django.db.models import QuerySet
 from django.utils import timezone
 
 import structlog
@@ -21,6 +22,7 @@ from posthog.models.organization import Organization
 from posthog.ph_client import ph_scoped_capture
 
 from .. import logic
+from ..logic import SIGNED_BAA_ANNOTATION as SIGNED_BAA_ANNOTATION
 from ..logic.pandadoc import (
     PandaDocError,
     verify_webhook_signature as _verify_pandadoc_webhook_signature,
@@ -89,8 +91,19 @@ def has_signed_baa(organization_id: UUID) -> bool:
     True once the organization has a countersigned BAA on file. This is the
     standing HIPAA gate: it decides whether AI training stays locked off, so it
     must read the signature state rather than a cached flag.
+
+    One query per call. Use `annotate_signed_baa` when serializing a list, and
+    keep this for a single organization and for validating a write.
     """
     return logic.has_signed_baa(organization_id)
+
+
+def annotate_signed_baa(queryset: QuerySet[Organization]) -> QuerySet[Organization]:
+    """
+    Add the signed-BAA flag to an Organization queryset as `SIGNED_BAA_ANNOTATION`,
+    so serializing N organizations costs one query rather than N.
+    """
+    return logic.annotate_signed_baa(queryset)
 
 
 def verify_pandadoc_webhook_signature(*, secret: str, body: bytes, signature: str) -> bool:

--- a/products/legal_documents/backend/facade/api.py
+++ b/products/legal_documents/backend/facade/api.py
@@ -84,6 +84,15 @@ def has_qualifying_baa_addon(organization: Organization) -> bool:
     return logic.has_qualifying_baa_addon(organization)
 
 
+def has_signed_baa(organization_id: UUID) -> bool:
+    """
+    True once the organization has a countersigned BAA on file. This is the
+    standing HIPAA gate: it decides whether AI training stays locked off, so it
+    must read the signature state rather than a cached flag.
+    """
+    return logic.has_signed_baa(organization_id)
+
+
 def verify_pandadoc_webhook_signature(*, secret: str, body: bytes, signature: str) -> bool:
     """Passthrough so the presentation layer never reaches past the facade."""
     return _verify_pandadoc_webhook_signature(secret=secret, body=body, signature=signature)

--- a/products/legal_documents/backend/logic/__init__.py
+++ b/products/legal_documents/backend/logic/__init__.py
@@ -12,7 +12,7 @@ from datetime import timedelta
 from uuid import UUID
 
 from django.conf import settings
-from django.db.models import QuerySet
+from django.db.models import Exists, OuterRef, QuerySet
 from django.utils import timezone
 
 import structlog
@@ -36,6 +36,9 @@ logger = structlog.get_logger(__name__)
 
 # Addon types that entitle an organization to a BAA.
 BAA_ADDON_TYPES = frozenset({"boost", "scale", "enterprise"})
+
+# Attribute `annotate_signed_baa` writes onto each Organization row.
+SIGNED_BAA_ANNOTATION = "has_signed_baa"
 
 # PostHog-side mailbox used both as the CC recipient on every signing envelope
 # and as the document owner. PandaDoc sends the signing email on behalf of the
@@ -81,12 +84,24 @@ def has_qualifying_baa_addon(organization: Organization) -> bool:
     return False
 
 
+def _signed_baa_subquery() -> QuerySet[LegalDocument]:
+    return LegalDocument.objects.filter(
+        organization_id=OuterRef("pk"),
+        document_type=DocumentType.BAA,
+        status=LegalDocument.Status.SIGNED,
+    )
+
+
 def has_signed_baa(organization_id: UUID) -> bool:
     return LegalDocument.objects.filter(
         organization_id=organization_id,
         document_type=DocumentType.BAA,
         status=LegalDocument.Status.SIGNED,
     ).exists()
+
+
+def annotate_signed_baa(queryset: QuerySet[Organization]) -> QuerySet[Organization]:
+    return queryset.annotate(**{SIGNED_BAA_ANNOTATION: Exists(_signed_baa_subquery())})
 
 
 def exists_for_organization_and_type(organization_id: UUID, document_type: str) -> bool:

--- a/products/legal_documents/backend/logic/__init__.py
+++ b/products/legal_documents/backend/logic/__init__.py
@@ -81,6 +81,14 @@ def has_qualifying_baa_addon(organization: Organization) -> bool:
     return False
 
 
+def has_signed_baa(organization_id: UUID) -> bool:
+    return LegalDocument.objects.filter(
+        organization_id=organization_id,
+        document_type=DocumentType.BAA,
+        status=LegalDocument.Status.SIGNED,
+    ).exists()
+
+
 def exists_for_organization_and_type(organization_id: UUID, document_type: str) -> bool:
     return LegalDocument.objects.filter(organization_id=organization_id, document_type=document_type).exists()
 

--- a/products/platform_features/frontend/generated/api.schemas.ts
+++ b/products/platform_features/frontend/generated/api.schemas.ts
@@ -125,6 +125,8 @@ export interface OrganizationApi {
     readonly is_ai_training_cta_shown: boolean | null
     /** @nullable */
     readonly is_hipaa: boolean | null
+    /** Whether the organization has a countersigned Business Associate Agreement on file. When true, AI training stays opted out and cannot be changed. */
+    readonly has_signed_baa: boolean
     /** Default statistical method for new experiments in this organization.
      *
      * * `bayesian` - Bayesian
@@ -233,6 +235,8 @@ export interface PatchedOrganizationApi {
     readonly is_ai_training_cta_shown?: boolean | null
     /** @nullable */
     readonly is_hipaa?: boolean | null
+    /** Whether the organization has a countersigned Business Associate Agreement on file. When true, AI training stays opted out and cannot be changed. */
+    readonly has_signed_baa?: boolean
     /** Default statistical method for new experiments in this organization.
      *
      * * `bayesian` - Bayesian

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -54345,6 +54345,8 @@ export namespace Schemas {
       readonly is_ai_training_cta_shown: boolean | null;
       /** @nullable */
       readonly is_hipaa: boolean | null;
+      /** Whether the organization has a countersigned Business Associate Agreement on file. When true, AI training stays opted out and cannot be changed. */
+      readonly has_signed_baa: boolean;
       /** Default statistical method for new experiments in this organization.
        *
        * * `bayesian` - Bayesian
@@ -65709,6 +65711,8 @@ export namespace Schemas {
       readonly is_ai_training_cta_shown?: boolean | null;
       /** @nullable */
       readonly is_hipaa?: boolean | null;
+      /** Whether the organization has a countersigned Business Associate Agreement on file. When true, AI training stays opted out and cannot be changed. */
+      readonly has_signed_baa?: boolean;
       /** Default statistical method for new experiments in this organization.
        *
        * * `bayesian` - Bayesian


### PR DESCRIPTION
## Problem

An organization that has signed a BAA with PostHog is locked out of AI training by `is_hipaa`, a boolean a staff member sets by hand in Django admin. Nothing keeps that flag in step with the signed agreement, so a customer who signs a BAA is only protected once somebody remembers to tick the box.

The BAA already exists as a first-class record. `LegalDocument` holds the countersigned agreement, and signing one already opts the organization out of AI training as a one-time side effect. The standing lock never read it.

## Changes

- An organization with a countersigned BAA now sees the AI training toggle locked, and the API refuses to change it. The lock reads the `LegalDocument` row instead of the `is_hipaa` flag.
- The settings page and the opt-in callout read a new read-only `has_signed_baa` field on the organization serializer, backed by `has_signed_baa` on the legal_documents facade.
- The Django admin conflict warning now fires on a signed BAA rather than on the flag. It still records that the replay training pipeline reads the opt-in alone.
- Copy on the settings page and in the API error now names the BAA rather than HIPAA.

`is_hipaa` stays on the model and in the serializer here, and is no longer read. Removing it is the next layer.

> [!WARNING]
> The two populations may not match. `is_hipaa` predates the legal documents product by about two years and was set by hand, so an organization whose BAA was signed outside PandaDoc may have the flag but no `LegalDocument` row. Those organizations lose the lock when this merges. Please reconcile the two sets before this goes out.

## How did you test this code?

- `posthog/admin/test_ai_training_opt_in_history.py` and `posthog/api/test/test_organization.py` pass. The admin test's parameterized warning matrix now drives the BAA lookup instead of the flag.
- Added one case, `test_cannot_opt_into_ai_training_with_a_signed_baa`, guarding the lock at the endpoint. Nothing covered it before, and losing it would let a BAA customer opt into training. No existing test exercised that path, so it could not be a case on one.
- `hogli lint:tach` passes, so the new cross-product read goes through the facade.
- `uv run mypy --cache-fine-grained .` reports no issues.

Not checked: `pnpm typescript:check` runs the whole app through `tsgo` and the sandbox out-of-memory kills it at 15 GB, so the frontend typecheck is left to CI. No screenshots: the sandbox has no built frontend, so the settings page could not be rendered. The visible change there is the two strings quoted above and a prop rename.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in PostHog Desktop. Skills invoked: `/improving-drf-endpoints`, `/writing-user-facing-copy`, `/writing-ui-components`, `/writing-tests`, `/writing-pr-descriptions`.

The work started as an audit of whether `is_hipaa` was used at all. It is, so the removal became a migration onto the BAA rather than a deletion. The session then found that the BAA already writes the opt-out once at signature time while `is_hipaa` is a standing lock, and that the two policies differ; this PR resolves that by making the BAA the standing lock.

Bottom layer of a three-PR stack. The layers above remove the field from Django state and drop the column.

Public artifact: nothing here comes from outside this repository.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
