### PR TITLE
feat(wizard): refuse mints with a 403 and a reason instead of a 404

### DIFF
--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -590,7 +590,7 @@ class SetupWizardViewSet(viewsets.ViewSet):
         except Exception as e:
             logger.warning("wizard_gateway_token: rollout flag unavailable, minting", error=str(e))
             rolled_out = None
-        if rolled_out is False:
+        if rolled_out is not True:
             refuse_absent_gateway(
                 "not_rolled_out", "Wizard gateway tokens are switched off for this organization.", user=user
             )

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -498,7 +498,8 @@ class SetupWizardViewSet(viewsets.ViewSet):
         body = request.data if isinstance(request.data, dict) else {}
         program = body.get("program")
         product = wizard_product_node(program)
-        reads_reason = bool(body.get("reads_refusal_reason"))
+        # Only a literal true: any other truthy shape keeps the 404 a fallback needs.
+        reads_reason = body.get("reads_refusal_reason") is True
 
         def refuse(outcome: str, exc: exceptions.APIException, *, user: User | None = None) -> NoReturn:
             _refuse_mint(outcome, exc, program=program, product_node=product, user=user, team=team)
@@ -576,8 +577,9 @@ class SetupWizardViewSet(viewsets.ViewSet):
             # Ahead of the rollout gate, so a ban reads as a ban whatever the flag says.
             refuse("blocked", exceptions.PermissionDenied(WIZARD_BLOCKED_DETAIL), user=user)
 
-        # A kill switch, not a rollout: only a literal False refuses. An outage
-        # (None or a raise) mints, since refusing would end every wizard run.
+        # A kill switch, not a rollout gate: only a literal False refuses. With the
+        # legacy product off there is no second path, so reading an outage as "not
+        # rolled out" turns a flag-service blip into a global wizard outage.
         try:
             rolled_out = posthoganalytics.feature_enabled(
                 "wizard-gateway-v2",
@@ -590,13 +592,15 @@ class SetupWizardViewSet(viewsets.ViewSet):
         except Exception as e:
             logger.warning("wizard_gateway_token: rollout flag unavailable, minting", error=str(e))
             rolled_out = None
+        else:
+            if rolled_out is None:
+                logger.warning("wizard_gateway_token: rollout flag returned no verdict, minting")
         if rolled_out is False:
             refuse_absent_gateway(
                 "not_rolled_out", "Wizard gateway tokens are switched off for this organization.", user=user
             )
 
         # A closed set: refusing keeps every pinned node one that carries a budget.
-        # A program this deploy does not list is a stale or unregistered build.
         if product is None:
             refuse_absent_gateway(
                 "program_unknown", "Unrecognized wizard program. Upgrade with: npx @posthog/wizard@latest", user=user

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -229,9 +229,7 @@ class SetupWizardViewSet(viewsets.ViewSet):
 
         return []
 
-    # NoReturn matches DRF, whose own throttled() is typed Never; ty cannot see
-    # that super() always raises, so its narrower read is suppressed here.
-    def throttled(self, request: Request, wait: float) -> NoReturn:  # ty: ignore[invalid-return-type]
+    def throttled(self, request: Request, wait: float) -> NoReturn:
         # A rejection from DRF's own throttle check returns before the action body, so
         # it counts here. A reservation that raises inside a body counts there instead.
         if self.action == "cloud_run":

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -229,7 +229,9 @@ class SetupWizardViewSet(viewsets.ViewSet):
 
         return []
 
-    def throttled(self, request: Request, wait: float) -> None:
+    # NoReturn matches DRF, whose own throttled() is typed Never; ty cannot see
+    # that super() always raises, so its narrower read is suppressed here.
+    def throttled(self, request: Request, wait: float) -> NoReturn:  # ty: ignore[invalid-return-type]
         # A rejection from DRF's own throttle check returns before the action body, so
         # it counts here. A reservation that raises inside a body counts there instead.
         if self.action == "cloud_run":

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -117,6 +117,20 @@ def _organization_ids_for_query(team_ids: list[int]) -> list[str]:
     ]
 
 
+def _refuse_mint(
+    outcome: str,
+    exc: exceptions.APIException,
+    *,
+    program: object,
+    product_node: str | None,
+    user: User | None = None,
+    team: Team | None = None,
+) -> NoReturn:
+    """Count and raise one mint refusal, so no exit can skip the counter."""
+    WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome=outcome).inc()
+    raise exc
+
+
 class SetupWizardSerializer(serializers.Serializer):
     hash = serializers.CharField()
 
@@ -462,9 +476,16 @@ class SetupWizardViewSet(viewsets.ViewSet):
         a 404 as "stay on the legacy gateway", so rollout is controlled here rather
         than by a CLI release. Every other failure fails the run.
         """
+        # Resolved above the first gate so every refusal names the program.
+        program = request.data.get("program") if isinstance(request.data, dict) else None
+        product = wizard_product_node(program)
+
+        def refuse(outcome: str, exc: exceptions.APIException, *, user: User | None = None) -> NoReturn:
+            _refuse_mint(outcome, exc, program=program, product_node=product, user=user, team=team)
+
+        team: Team | None = None
         if not wizard_gateway_configured():
-            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="unconfigured").inc()
-            raise exceptions.NotFound("Wizard gateway tokens are not available.")
+            refuse("unconfigured", exceptions.NotFound("Wizard gateway tokens are not available."))
 
         authenticator = OAuthAccessTokenAuthentication()
         # authenticate() raises its own AuthenticationFailed, so the count wraps the
@@ -476,9 +497,8 @@ class SetupWizardViewSet(viewsets.ViewSet):
             user, _ = result
             if not user:
                 raise AuthenticationFailed("Invalid access token.")
-        except AuthenticationFailed:
-            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="invalid_token").inc()
-            raise
+        except AuthenticationFailed as e:
+            refuse("invalid_token", e)
 
         access_token = authenticator.access_token
         # llm_gateway:read is on every sandbox and agent token, so the scope alone
@@ -486,30 +506,33 @@ class SetupWizardViewSet(viewsets.ViewSet):
         application = getattr(access_token, "application", None)
         client_id = getattr(application, "client_id", None)
         if not client_id or client_id not in settings.WIZARD_GATEWAY_CLIENT_IDS:
-            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="not_wizard_app").inc()
-            raise AuthenticationFailed("Access token was not issued to the wizard.")
+            refuse("not_wizard_app", AuthenticationFailed("Access token was not issued to the wizard."), user=user)
 
         # The token's own scope text: the `scopes` property filters through
         # OAUTH2_PROVIDER["SCOPES"], where a narrowing would silently drop the scope.
         if RequiredGatewayScope not in (access_token.scope or "").split():
-            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="scope_missing").inc()
-            raise AuthenticationFailed("Access token lacks the gateway scope.")
+            refuse("scope_missing", AuthenticationFailed("Access token lacks the gateway scope."), user=user)
 
         scoped_team_ids = access_token.scoped_teams or []
         if len(scoped_team_ids) != 1:
-            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="team_ambiguous").inc()
-            raise exceptions.ValidationError("Access token must be scoped to exactly one team.")
+            refuse(
+                "team_ambiguous",
+                exceptions.ValidationError("Access token must be scoped to exactly one team."),
+                user=user,
+            )
         team = Team.objects.select_related("organization").filter(id=scoped_team_ids[0]).first()
         if team is None:
             # Deliberately 403: a 404 would read as "not rolled out" and downgrade
             # the run to legacy, but a vanished team is an authorization failure.
-            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="team_missing").inc()
-            raise exceptions.PermissionDenied(ERROR_PROJECT_NOT_FOUND)
+            refuse("team_missing", exceptions.PermissionDenied(ERROR_PROJECT_NOT_FOUND), user=user)
 
         # scoped_teams is frozen at consent, so re-check what it cannot see.
         if not oauth_credential_authorized(access_token, team):
-            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="unauthorized").inc()
-            raise exceptions.PermissionDenied("Access token is no longer authorized for this project.")
+            refuse(
+                "unauthorized",
+                exceptions.PermissionDenied("Access token is no longer authorized for this project."),
+                user=user,
+            )
 
         distinct_id = str(user.distinct_id)
         if wizard_identity_blocked(
@@ -522,8 +545,7 @@ class SetupWizardViewSet(viewsets.ViewSet):
         ):
             # 403 and not 404, ahead of the rollout gate: the CLI reads 404 as "stay
             # on legacy", moving a banned run onto the looser surface.
-            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="blocked").inc()
-            raise exceptions.PermissionDenied(WIZARD_BLOCKED_DETAIL)
+            refuse("blocked", exceptions.PermissionDenied(WIZARD_BLOCKED_DETAIL), user=user)
 
         if not posthoganalytics.feature_enabled(
             "wizard-gateway-v2",
@@ -533,16 +555,17 @@ class SetupWizardViewSet(viewsets.ViewSet):
             only_evaluate_locally=False,
             send_feature_flag_events=False,
         ):
-            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="not_rolled_out").inc()
-            raise exceptions.NotFound("Wizard gateway tokens are not rolled out for this organization.")
+            refuse(
+                "not_rolled_out",
+                exceptions.NotFound("Wizard gateway tokens are not rolled out for this organization."),
+                user=user,
+            )
 
         # Refusing keeps every pinned node one that carries a budget.
-        product = wizard_product_node(request.data.get("program") if isinstance(request.data, dict) else None)
         if product is None:
             # 404 and not 400: the CLI falls back only on 404, so an unlisted
             # program keeps running on legacy instead of dying. It still cannot mint.
-            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="program_unknown").inc()
-            raise exceptions.NotFound("Unrecognized wizard program.")
+            refuse("program_unknown", exceptions.NotFound("Unrecognized wizard program."), user=user)
         override = wizard_limit_override(
             distinct_id=distinct_id,
             email=user.email,
@@ -551,11 +574,10 @@ class SetupWizardViewSet(viewsets.ViewSet):
         )
         try:
             reserved = reserve_wizard_mint(request, self, limit=override.mints_per_day)
-        except exceptions.Throttled:
+        except exceptions.Throttled as e:
             # The reservation raises after check_throttles ran, so the throttled()
             # hook never sees it.
-            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="throttled").inc()
-            raise
+            refuse("throttled", e, user=user)
         try:
             minted = mint_wizard_gateway_token(
                 obo=str(team.organization_id), user=distinct_id, product=product, cap_usd=override.cap_usd

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -229,7 +229,7 @@ class SetupWizardViewSet(viewsets.ViewSet):
 
         return []
 
-    def throttled(self, request: Request, wait: float) -> NoReturn:
+    def throttled(self, request: Request, wait: float) -> None:
         # A rejection from DRF's own throttle check returns before the action body, so
         # it counts here. A reservation that raises inside a body counts there instead.
         if self.action == "cloud_run":
@@ -495,18 +495,28 @@ class SetupWizardViewSet(viewsets.ViewSet):
         shown to the user and its `code` naming the outcome.
         """
         # Resolved above the first gate so every refusal names the program.
-        program = request.data.get("program") if isinstance(request.data, dict) else None
+        body = request.data if isinstance(request.data, dict) else {}
+        program = body.get("program")
         product = wizard_product_node(program)
+        reads_reason = bool(body.get("reads_refusal_reason"))
 
         def refuse(outcome: str, exc: exceptions.APIException, *, user: User | None = None) -> NoReturn:
             _refuse_mint(outcome, exc, program=program, product_node=product, user=user, team=team)
 
+        def refuse_absent_gateway(outcome: str, message: str, *, user: User | None = None) -> NoReturn:
+            """Refuse one of the three outcomes the CLI's legacy fallback absorbed.
+
+            A build that still falls back needs the 404 to reach the legacy
+            gateway, which carries its own retirement message; it renders a 403
+            as revoked project access instead. Only a client that says it reads
+            the reason gets one. Drop this once those builds are gone.
+            """
+            exc = exceptions.PermissionDenied(message) if reads_reason else exceptions.NotFound(message)
+            refuse(outcome, exc, user=user)
+
         team: Team | None = None
         if not wizard_gateway_configured():
-            refuse(
-                "unconfigured",
-                exceptions.PermissionDenied("The PostHog AI gateway is not configured on this instance."),
-            )
+            refuse_absent_gateway("unconfigured", "The PostHog AI gateway is not configured on this instance.")
 
         authenticator = OAuthAccessTokenAuthentication()
         # authenticate() raises its own AuthenticationFailed, so the count wraps the
@@ -581,19 +591,15 @@ class SetupWizardViewSet(viewsets.ViewSet):
             logger.warning("wizard_gateway_token: rollout flag unavailable, minting", error=str(e))
             rolled_out = None
         if rolled_out is False:
-            refuse(
-                "not_rolled_out",
-                exceptions.PermissionDenied("Wizard gateway tokens are switched off for this organization."),
-                user=user,
+            refuse_absent_gateway(
+                "not_rolled_out", "Wizard gateway tokens are switched off for this organization.", user=user
             )
 
         # A closed set: refusing keeps every pinned node one that carries a budget.
         # A program this deploy does not list is a stale or unregistered build.
         if product is None:
-            refuse(
-                "program_unknown",
-                exceptions.PermissionDenied("Unrecognized wizard program. Upgrade with: npx @posthog/wizard@latest"),
-                user=user,
+            refuse_absent_gateway(
+                "program_unknown", "Unrecognized wizard program. Upgrade with: npx @posthog/wizard@latest", user=user
             )
         override = wizard_limit_override(
             distinct_id=distinct_id,

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -590,7 +590,7 @@ class SetupWizardViewSet(viewsets.ViewSet):
         except Exception as e:
             logger.warning("wizard_gateway_token: rollout flag unavailable, minting", error=str(e))
             rolled_out = None
-        if rolled_out is not True:
+        if rolled_out is False:
             refuse_absent_gateway(
                 "not_rolled_out", "Wizard gateway tokens are switched off for this organization.", user=user
             )

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.utils.crypto import get_random_string
 
+import structlog
 import posthoganalytics
 from drf_spectacular.utils import extend_schema
 from google.genai.types import GenerateContentConfig, Schema
@@ -22,7 +23,7 @@ from posthoganalytics.ai.openai import OpenAI
 from prometheus_client import Counter
 from rest_framework import exceptions, response, serializers, status, viewsets
 from rest_framework.decorators import action
-from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.exceptions import AuthenticationFailed, ErrorDetail
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -59,6 +60,8 @@ from posthog.storage.gateway_credential_cache import (
 from posthog.user_permissions import UserPermissions
 
 from products.tasks.backend.facade import api as tasks_facade
+
+logger = structlog.get_logger(__name__)
 
 SETUP_WIZARD_CACHE_PREFIX = "setup-wizard:v1:"
 SETUP_WIZARD_CACHE_TIMEOUT = 600
@@ -126,9 +129,24 @@ def _refuse_mint(
     user: User | None = None,
     team: Team | None = None,
 ) -> NoReturn:
-    """Count and raise one mint refusal, so no exit can skip the counter."""
+    """Count and raise one mint refusal, so no exit can skip the counter.
+
+    The outcome rides as the body's `code`: the exception handler renders every
+    APIException as {type, code, detail, attr}, so a dict detail would be
+    flattened and a separate key dropped. The CLI shows `detail` and reports `code`.
+    """
     WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome=outcome).inc()
+    detail = ErrorDetail(_detail_text(exc), code=outcome)
+    # The handler reads a ValidationError's codes as a list, every other class's as a string.
+    exc.detail = [detail] if isinstance(exc, exceptions.ValidationError) else detail
     raise exc
+
+
+def _detail_text(exc: exceptions.APIException) -> str:
+    detail = exc.detail
+    if isinstance(detail, list):
+        return str(detail[0]) if detail else str(exc.default_detail)
+    return str(detail)
 
 
 class SetupWizardSerializer(serializers.Serializer):
@@ -472,9 +490,9 @@ class SetupWizardViewSet(viewsets.ViewSet):
         """Mint a scoped gateway token for a wizard run.
 
         The CLI uses the returned phe_ (pinned product=wizard / obo=<customer org>,
-        capped, expiring) as its gateway bearer and re-calls near expiry. It treats
-        a 404 as "stay on the legacy gateway", so rollout is controlled here rather
-        than by a CLI release. Every other failure fails the run.
+        capped, expiring) as its gateway bearer and re-calls near expiry. There is
+        no other gateway: every refusal ends the run, with the body's `detail`
+        shown to the user and its `code` naming the outcome.
         """
         # Resolved above the first gate so every refusal names the program.
         program = request.data.get("program") if isinstance(request.data, dict) else None
@@ -485,7 +503,10 @@ class SetupWizardViewSet(viewsets.ViewSet):
 
         team: Team | None = None
         if not wizard_gateway_configured():
-            refuse("unconfigured", exceptions.NotFound("Wizard gateway tokens are not available."))
+            refuse(
+                "unconfigured",
+                exceptions.PermissionDenied("The PostHog AI gateway is not configured on this instance."),
+            )
 
         authenticator = OAuthAccessTokenAuthentication()
         # authenticate() raises its own AuthenticationFailed, so the count wraps the
@@ -522,8 +543,7 @@ class SetupWizardViewSet(viewsets.ViewSet):
             )
         team = Team.objects.select_related("organization").filter(id=scoped_team_ids[0]).first()
         if team is None:
-            # Deliberately 403: a 404 would read as "not rolled out" and downgrade
-            # the run to legacy, but a vanished team is an authorization failure.
+            # 403: a vanished team is an authorization failure, not a missing route.
             refuse("team_missing", exceptions.PermissionDenied(ERROR_PROJECT_NOT_FOUND), user=user)
 
         # scoped_teams is frozen at consent, so re-check what it cannot see.
@@ -543,29 +563,38 @@ class SetupWizardViewSet(viewsets.ViewSet):
             team_ids=[team.id],
             surface="gateway_token",
         ):
-            # 403 and not 404, ahead of the rollout gate: the CLI reads 404 as "stay
-            # on legacy", moving a banned run onto the looser surface.
+            # Ahead of the rollout gate, so a ban reads as a ban whatever the flag says.
             refuse("blocked", exceptions.PermissionDenied(WIZARD_BLOCKED_DETAIL), user=user)
 
-        if not posthoganalytics.feature_enabled(
-            "wizard-gateway-v2",
-            distinct_id,
-            groups={"organization": str(team.organization_id), "project": str(team.id)},
-            group_properties={"organization": {"id": str(team.organization_id)}},
-            only_evaluate_locally=False,
-            send_feature_flag_events=False,
-        ):
+        # A kill switch, not a rollout: only a literal False refuses. An outage
+        # (None or a raise) mints, since refusing would end every wizard run.
+        try:
+            rolled_out = posthoganalytics.feature_enabled(
+                "wizard-gateway-v2",
+                distinct_id,
+                groups={"organization": str(team.organization_id), "project": str(team.id)},
+                group_properties={"organization": {"id": str(team.organization_id)}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        except Exception as e:
+            logger.warning("wizard_gateway_token: rollout flag unavailable, minting", error=str(e))
+            rolled_out = None
+        if rolled_out is False:
             refuse(
                 "not_rolled_out",
-                exceptions.NotFound("Wizard gateway tokens are not rolled out for this organization."),
+                exceptions.PermissionDenied("Wizard gateway tokens are switched off for this organization."),
                 user=user,
             )
 
-        # Refusing keeps every pinned node one that carries a budget.
+        # A closed set: refusing keeps every pinned node one that carries a budget.
+        # A program this deploy does not list is a stale or unregistered build.
         if product is None:
-            # 404 and not 400: the CLI falls back only on 404, so an unlisted
-            # program keeps running on legacy instead of dying. It still cannot mint.
-            refuse("program_unknown", exceptions.NotFound("Unrecognized wizard program."), user=user)
+            refuse(
+                "program_unknown",
+                exceptions.PermissionDenied("Unrecognized wizard program. Upgrade with: npx @posthog/wizard@latest"),
+                user=user,
+            )
         override = wizard_limit_override(
             distinct_id=distinct_id,
             email=user.email,

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -773,11 +773,22 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
 
     @override_settings(WIZARD_GATEWAY_MINT_KEY="")
     def test_unconfigured_is_403_with_a_reason(self):
-        response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
+        response = self.client.post(
+            self.GATEWAY_TOKEN_URL, {"reads_refusal_reason": True}, headers={"authorization": "Bearer pha_test"}
+        )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
         assert response.json()["code"] == "unconfigured"
         assert response.json()["detail"] == "The PostHog AI gateway is not configured on this instance."
+
+    @override_settings(WIZARD_GATEWAY_MINT_KEY="")
+    def test_a_client_that_still_falls_back_keeps_its_404(self):
+        # A build without the reason reader renders a 403 as revoked project
+        # access; the 404 is what sends it to the legacy gateway's own message.
+        response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, response.content
+        assert response.json()["code"] == "unconfigured"
 
     @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
     @patch("posthog.api.wizard.http.mint_wizard_gateway_token", return_value=MINTED)
@@ -809,11 +820,18 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     def test_flag_off_is_403_with_a_reason(self, mock_authentication, mock_flag, mock_authorized):
         self._mock_oauth(mock_authentication)
         response = self.client.post(
-            self.GATEWAY_TOKEN_URL, {"program": "integration"}, headers={"authorization": "Bearer pha_test"}
+            self.GATEWAY_TOKEN_URL,
+            {"program": "integration", "reads_refusal_reason": True},
+            headers={"authorization": "Bearer pha_test"},
         )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
         assert response.json()["code"] == "not_rolled_out"
+
+        legacy = self.client.post(
+            self.GATEWAY_TOKEN_URL, {"program": "integration"}, headers={"authorization": "Bearer pha_test"}
+        )
+        assert legacy.status_code == status.HTTP_404_NOT_FOUND, legacy.content
 
     @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
     @patch("posthog.api.wizard.http.mint_wizard_gateway_token", return_value=MINTED)
@@ -1154,7 +1172,9 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     def test_unlisted_program_is_refused(self, mock_authentication, mock_flag, mock_authorized, mock_mint):
         self._mock_oauth(mock_authentication)
         response = self.client.post(
-            self.GATEWAY_TOKEN_URL, {"program": "invented"}, headers={"authorization": "Bearer pha_test"}
+            self.GATEWAY_TOKEN_URL,
+            {"program": "invented", "reads_refusal_reason": True},
+            headers={"authorization": "Bearer pha_test"},
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
         assert response.json()["code"] == "program_unknown"
@@ -1167,7 +1187,9 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
     def test_missing_program_is_refused(self, mock_authentication, mock_flag, mock_authorized, mock_mint):
         self._mock_oauth(mock_authentication)
-        response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
+        response = self.client.post(
+            self.GATEWAY_TOKEN_URL, {"reads_refusal_reason": True}, headers={"authorization": "Bearer pha_test"}
+        )
         assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
         assert response.json()["code"] == "program_unknown"
         mock_mint.assert_not_called()
@@ -1184,7 +1206,7 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
         self._mock_oauth(mock_authentication)
         response = self.client.post(
             self.GATEWAY_TOKEN_URL,
-            data=json.dumps({"program": ["integration"]}),
+            data=json.dumps({"program": ["integration"], "reads_refusal_reason": True}),
             content_type="application/json",
             headers={"authorization": "Bearer pha_test"},
         )

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -13,7 +13,7 @@ from django.utils import timezone
 
 from prometheus_client import REGISTRY
 from rest_framework import status
-from rest_framework.exceptions import Throttled
+from rest_framework.exceptions import AuthenticationFailed, Throttled
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
@@ -772,9 +772,12 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
         return mock_authenticator
 
     @override_settings(WIZARD_GATEWAY_MINT_KEY="")
-    def test_unconfigured_is_404(self):
+    def test_unconfigured_is_403_with_a_reason(self):
         response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
+        assert response.json()["code"] == "unconfigured"
+        assert response.json()["detail"] == "The PostHog AI gateway is not configured on this instance."
 
     @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
     @patch("posthog.api.wizard.http.mint_wizard_gateway_token", return_value=MINTED)
@@ -803,17 +806,71 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
     @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=False)
     @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
-    def test_flag_off_is_404(self, mock_authentication, mock_flag, mock_authorized):
+    def test_flag_off_is_403_with_a_reason(self, mock_authentication, mock_flag, mock_authorized):
         self._mock_oauth(mock_authentication)
-        response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        response = self.client.post(
+            self.GATEWAY_TOKEN_URL, {"program": "integration"}, headers={"authorization": "Bearer pha_test"}
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
+        assert response.json()["code"] == "not_rolled_out"
+
+    @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
+    @patch("posthog.api.wizard.http.mint_wizard_gateway_token", return_value=MINTED)
+    @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled")
+    @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
+    def test_a_rollout_flag_outage_mints(self, mock_authentication, mock_flag, mock_mint, mock_authorized):
+        # The flag is a kill switch: only a literal False refuses. An outage must
+        # not end every wizard run.
+        self._mock_oauth(mock_authentication)
+
+        for outage in ({"return_value": None}, {"side_effect": RuntimeError("flags down")}):
+            mock_flag.reset_mock(return_value=True, side_effect=True)
+            mock_flag.configure_mock(**outage)
+            response = self.client.post(
+                self.GATEWAY_TOKEN_URL, {"program": "integration"}, headers={"authorization": "Bearer pha_test"}
+            )
+            assert response.status_code == status.HTTP_201_CREATED, (outage, response.content)
+
+        assert mock_mint.call_count == 2
+
+    @override_settings(DEBUG=False)
+    @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
+    @patch("posthog.api.wizard.http.mint_wizard_gateway_token", return_value=MINTED)
+    @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
+    @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
+    def test_every_refusal_names_its_outcome_as_the_code(
+        self, mock_authentication, mock_flag, mock_mint, mock_authorized
+    ):
+        # The outcome the counter labels is what the CLI reports, whichever
+        # exception class the gate raised, including the re-raised ones.
+        self._mock_oauth(mock_authentication, scoped_teams=[self.team.id, self.team.id + 1])
+        ambiguous = self.client.post(
+            self.GATEWAY_TOKEN_URL, {"program": "integration"}, headers={"authorization": "Bearer pha_test"}
+        )
+        assert (ambiguous.status_code, ambiguous.json()["code"]) == (status.HTTP_400_BAD_REQUEST, "team_ambiguous")
+
+        self._mock_oauth(mock_authentication)
+        for _ in range(5):
+            self.client.post(
+                self.GATEWAY_TOKEN_URL, {"program": "integration"}, headers={"authorization": "Bearer pha_test"}
+            )
+        throttled = self.client.post(
+            self.GATEWAY_TOKEN_URL, {"program": "integration"}, headers={"authorization": "Bearer pha_test"}
+        )
+        assert (throttled.status_code, throttled.json()["code"]) == (status.HTTP_429_TOO_MANY_REQUESTS, "throttled")
+
+        mock_authentication.return_value.authenticate.side_effect = AuthenticationFailed("Invalid access token.")
+        invalid = self.client.post(
+            self.GATEWAY_TOKEN_URL, {"program": "integration"}, headers={"authorization": "Bearer pha_test"}
+        )
+        assert (invalid.status_code, invalid.json()["code"]) == (status.HTTP_401_UNAUTHORIZED, "invalid_token")
 
     @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
     @patch("posthog.api.wizard.http.mint_wizard_gateway_token", return_value=MINTED)
     @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
     @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
     def test_blocked_identity_is_403_and_never_mints(self, mock_authentication, mock_flag, mock_mint, mock_authorized):
-        # 403 rather than 404, which the CLI reads as "stay on legacy".
         self._mock_oauth(mock_authentication)
         self.mock_blocklist.return_value = True
 
@@ -830,8 +887,7 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=False)
     @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
     def test_a_ban_outranks_the_rollout_gate(self, mock_authentication, mock_flag, mock_mint, mock_authorized):
-        # Not-rolled-out answers 404 and downgrades to legacy, so the ban has to
-        # land first whatever the rollout says.
+        # A banned account reads "blocked", not "switched off", whatever the flag says.
         self._mock_oauth(mock_authentication)
         self.mock_blocklist.return_value = True
 
@@ -1100,7 +1156,9 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
         response = self.client.post(
             self.GATEWAY_TOKEN_URL, {"program": "invented"}, headers={"authorization": "Bearer pha_test"}
         )
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
+        assert response.json()["code"] == "program_unknown"
+        assert "npx @posthog/wizard@latest" in response.json()["detail"]
         mock_mint.assert_not_called()
 
     @patch("posthog.api.wizard.http.mint_wizard_gateway_token")
@@ -1110,7 +1168,8 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     def test_missing_program_is_refused(self, mock_authentication, mock_flag, mock_authorized, mock_mint):
         self._mock_oauth(mock_authentication)
         response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
+        assert response.json()["code"] == "program_unknown"
         mock_mint.assert_not_called()
 
     @patch("posthog.api.wizard.http.mint_wizard_gateway_token")
@@ -1129,7 +1188,7 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
             content_type="application/json",
             headers={"authorization": "Bearer pha_test"},
         )
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
         mock_mint.assert_not_called()
 
     @override_settings(DEBUG=False)

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -783,8 +783,7 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
 
     @override_settings(WIZARD_GATEWAY_MINT_KEY="")
     def test_a_client_that_still_falls_back_keeps_its_404(self):
-        # A build without the reason reader renders a 403 as revoked project
-        # access; the 404 is what sends it to the legacy gateway's own message.
+        # The 404 is what sends a still-falling-back build to the legacy message.
         response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
 
         assert response.status_code == status.HTTP_404_NOT_FOUND, response.content
@@ -838,8 +837,7 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled")
     @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
     def test_a_rollout_flag_outage_mints(self, mock_authentication, mock_flag, mock_mint, mock_authorized):
-        # The flag is a kill switch: only a literal False refuses. An outage must
-        # not end every wizard run.
+        # An outage is not a False, and must not end every wizard run.
         self._mock_oauth(mock_authentication)
 
         for outage in ({"return_value": None}, {"side_effect": RuntimeError("flags down")}):
@@ -860,8 +858,6 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     def test_every_refusal_names_its_outcome_as_the_code(
         self, mock_authentication, mock_flag, mock_mint, mock_authorized
     ):
-        # The outcome the counter labels is what the CLI reports, whichever
-        # exception class the gate raised, including the re-raised ones.
         self._mock_oauth(mock_authentication, scoped_teams=[self.team.id, self.team.id + 1])
         ambiguous = self.client.post(
             self.GATEWAY_TOKEN_URL, {"program": "integration"}, headers={"authorization": "Bearer pha_test"}
@@ -1179,6 +1175,25 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
         assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
         assert response.json()["code"] == "program_unknown"
         assert "npx @posthog/wizard@latest" in response.json()["detail"]
+        mock_mint.assert_not_called()
+
+    @patch("posthog.api.wizard.http.mint_wizard_gateway_token")
+    @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
+    @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
+    @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
+    def test_a_non_boolean_capability_keeps_the_compatible_status(
+        self, mock_authentication, mock_flag, mock_authorized, mock_mint
+    ):
+        self._mock_oauth(mock_authentication)
+        for claimed in ("false", "true", 1, [], {"a": 1}):
+            with self.subTest(claimed=claimed):
+                response = self.client.post(
+                    self.GATEWAY_TOKEN_URL,
+                    data=json.dumps({"reads_refusal_reason": claimed}),
+                    content_type="application/json",
+                    headers={"authorization": "Bearer pha_test"},
+                )
+                assert response.status_code == status.HTTP_404_NOT_FOUND, response.content
         mock_mint.assert_not_called()
 
     @patch("posthog.api.wizard.http.mint_wizard_gateway_token")

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -1185,6 +1185,7 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
         self, mock_authentication, mock_flag, mock_authorized, mock_mint
     ):
         self._mock_oauth(mock_authentication)
+        claimed: object
         for claimed in ("false", "true", 1, [], {"a": 1}):
             with self.subTest(claimed=claimed):
                 response = self.client.post(

--- a/posthog/llm/wizard_gateway_token.py
+++ b/posthog/llm/wizard_gateway_token.py
@@ -130,10 +130,9 @@ def wizard_product_node(program: str | None) -> str | None:
     folded into a generic node. Gateway budgets match a node value exactly, so
     folding would report a new program's spend as plain wizard spend and leave the
     program itself with no budget of its own, and the drift would be silent.
-    A refusal is visible in the mint outcome counter, and the endpoint answers it
-    with a 404, the one status the CLI falls back on: a program this deploy has
-    not been told about keeps running on the legacy gateway rather than having
-    its run killed, while still being unable to mint.
+    A refusal ends the run with an upgrade message and shows in the mint outcome
+    counter as `program_unknown`; a new program is registered in the CLI, this
+    setting, and a budget row.
     """
     # isinstance first: the value is caller JSON, and an unhashable one (a list
     # or object) raises on the set membership below, inside a throttle that runs
@@ -164,7 +163,8 @@ class WizardGatewayMintError(Exception):
 
 
 def wizard_gateway_configured() -> bool:
-    """Every one of the four is required; any missing piece answers 404.
+    """Every one of the four is required; any missing piece refuses every mint
+    as `unconfigured`.
 
     The program list is a hard requirement, not a refinement: an empty one
     refuses every program, so without it the deploy would report itself

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1208,8 +1208,7 @@ except ValueError:
     AI_GATEWAY_TEAM_TIER_OVERRIDES = {}
 
 # Wizard gateway-token mint. Any of the four unset refuses every mint as
-# `unconfigured`, which ends the wizard run: there is no other gateway. The
-# status is 403 for a client that says it reads the reason and 404 otherwise.
+# `unconfigured`, which ends the wizard run: there is no other gateway.
 WIZARD_GATEWAY_URL = get_from_env("WIZARD_GATEWAY_URL", "")
 WIZARD_GATEWAY_MINT_KEY = get_from_env("WIZARD_GATEWAY_MINT_KEY", "")
 # OAuth application client ids allowed to mint: llm_gateway:read is an internal

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1207,8 +1207,9 @@ try:
 except ValueError:
     AI_GATEWAY_TEAM_TIER_OVERRIDES = {}
 
-# Wizard gateway-token mint. Any of the four unset refuses every mint with a 403
-# (`unconfigured`), which ends the wizard run: there is no other gateway.
+# Wizard gateway-token mint. Any of the four unset refuses every mint as
+# `unconfigured`, which ends the wizard run: there is no other gateway. The
+# status is 403 for a client that says it reads the reason and 404 otherwise.
 WIZARD_GATEWAY_URL = get_from_env("WIZARD_GATEWAY_URL", "")
 WIZARD_GATEWAY_MINT_KEY = get_from_env("WIZARD_GATEWAY_MINT_KEY", "")
 # OAuth application client ids allowed to mint: llm_gateway:read is an internal

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1207,8 +1207,8 @@ try:
 except ValueError:
     AI_GATEWAY_TEAM_TIER_OVERRIDES = {}
 
-# Wizard gateway-token mint. WIZARD_GATEWAY_MINT_KEY unset disables the endpoint
-# (404), which the CLI treats as "stay on the legacy gateway".
+# Wizard gateway-token mint. Any of the four unset refuses every mint with a 403
+# (`unconfigured`), which ends the wizard run: there is no other gateway.
 WIZARD_GATEWAY_URL = get_from_env("WIZARD_GATEWAY_URL", "")
 WIZARD_GATEWAY_MINT_KEY = get_from_env("WIZARD_GATEWAY_MINT_KEY", "")
 # OAuth application client ids allowed to mint: llm_gateway:read is an internal


### PR DESCRIPTION
## Problem

Three wizard mint refusals answered 404, which the CLI reads as "this instance has no gateway" and handles by silently falling back to the legacy one. So an organization with the rollout off, or a stale build naming an unregistered program, kept spending on the path this work exists to close, and the user was never told why.

## Changes

The three refusals carry a reason, and the status follows what the client can do with it.

- The eleven counter-then-raise pairs in the mint handler collapse into one `_refuse_mint`, so no exit can refuse without counting it and naming its outcome.
- `unconfigured`, `not_rolled_out` and `program_unknown` answer **403 with a machine-readable outcome**, but only for a client that sends `reads_refusal_reason`. A build that still falls back gets the 404 it needs to reach the legacy gateway's own retirement message, and that branch goes when those builds do.
- The outcome rides in the response body's `code`: the exception handler flattens a dict detail, so a separate key would be dropped.
- The rollout flag becomes a **kill switch rather than a gate**: only a literal `False` refuses, so a flag-service outage mints instead of taking the wizard down. Once the legacy product is off there is no second path, so reading an outage as "not rolled out" turns a blip into a global wizard outage. Containment that must survive a blip fails closed elsewhere: the blocklist runs above this, and the limit-override flag falls back to the defaults, so no outage here widens a limit. A mint with no verdict is logged so the window stays visible.
- `reads_refusal_reason` is read strictly: only a literal `true` opts in, so a build sending `"false"` or any other truthy shape keeps the 404 its fallback needs rather than a 403 it renders as revoked project access.

## How did you test this code?

Automated only. `pytest posthog/api/wizard` asserts the rendered body through the real exception handler rather than an assumed shape, covers both the capable and the falling-back client on each of the three outcomes, and pins that a flag outage still mints.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

