### PR TITLE
fix(aio): state the JSON contract in the LLM tagger prompt

### DIFF
--- a/posthog/temporal/ai_observability/run_tagger.py
+++ b/posthog/temporal/ai_observability/run_tagger.py
@@ -111,7 +111,12 @@ def build_tagger_system_prompt(prompt: str, tags: list[dict[str, str]], min_tags
 Available tags:
 {tag_list}
 
-{constraint} Only use tags from the list above. If no tags apply, return an empty list."""
+{constraint} Only use tags from the list above. If no tags apply, return an empty list.
+
+Respond with one JSON object and nothing else, in this exact shape:
+{{"tags": ["<tag name>", ...], "reasoning": "<brief explanation>"}}
+
+Always include both keys. Set "tags" to an array of tag name strings from the list above, and use an empty array when no tags apply. Do not send the tags as an object of names to true or false, and do not send a number or a bare string. Set "reasoning" to one or two sentences on why you selected those tags. Do not wrap the JSON in markdown fences, and do not add other keys."""
 
 
 @dataclass

--- a/posthog/temporal/ai_observability/test_run_tagger.py
+++ b/posthog/temporal/ai_observability/test_run_tagger.py
@@ -103,6 +103,15 @@ class TestBuildTaggerSystemPrompt:
             ("Test", [{"name": "a"}], 0, None, ["Select as many tags as apply"], []),
             # User prompt passthrough
             ("Which features are used?", [{"name": "a"}], 0, None, ["Which features are used?"], []),
+            # JSON contract for providers that do not enforce the response schema
+            (
+                "Test",
+                [{"name": "a"}],
+                0,
+                None,
+                ['"tags"', '"reasoning"', "Always include both keys"],
+                [],
+            ),
         ],
     )
     def test_build_tagger_system_prompt(


### PR DESCRIPTION
## Problem

- An LLM tagger running on a model that does not enforce a response schema produces no tags at all, and the run still reports success.
- The tagger prompt describes the task in prose but never describes the JSON. It names no keys, and it never mentions `reasoning`, which exists only as a field description in the dynamic schema.
- A model that ignores the requested schema answers in its own shape. Observed replies include a map of tag names to booleans, an object with `tags` and no `reasoning`, and a bare number.
- Pydantic rejects each reply. `execute_tagger_activity` marks the parse error non-retryable, so the workflow skips the event and emits no `$ai_tag` event.
- Evidence: [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a07021-30f1-78f1-8790-289e06b02004).

## Changes

- A tagger on a permissive model now produces tags instead of nothing, because the prompt states the response contract that the schema alone did not guarantee.
- The prompt requires one JSON object with both `tags` and `reasoning`, tag names as an array of strings, no markdown fences, and no extra keys. It rules out the three shapes above by name.
- The change is one prompt string and one test case. No UI changes, and no change to the tagger schema or the workflow.

> [!NOTE]
> This narrows the failure rather than removing it. A model can still ignore the prompt. Coercing loose shapes before validation, making `reasoning` optional, and retrying once with a repair prompt are separate changes.

## How did you test this code?

- Added one case to `TestBuildTaggerSystemPrompt`. It catches removal of the JSON contract from the prompt, which is the regression that let the bad shapes through. No existing case asserted the response format.
- Ran `posthog/temporal/ai_observability/test_run_tagger.py` against Postgres and ClickHouse from `docker-compose.dev.yml`.
- `hogli ci:preflight --fix` reports no failures. The complexity warning on `execute_tagger_activity` predates this change.
- Not checked: behavior against a live provider that ignores the schema. That needs a key for such a route. mypy did not run, because the diff is one string literal and one test tuple.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow or setting changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app, from a thread that started on an error tracking alert for this issue. Skills invoked: `/writing-tests` and `/writing-pr-descriptions`.

The session traced the failure to the OpenRouter route, where `beta.chat.completions.parse` asks for a strict `json_schema` that the gateway forwards on a best effort basis. Five responses were identified: schema coercion, an optional `reasoning` field, this prompt contract, a repair retry, and validating the model choice when a tagger is saved. Scope was narrowed to the prompt on request.

No duplicate: `gh pr list --state open` searches for "tagger structured output" and `build_tagger_system_prompt` returned nothing.

Public artifact: the prompt text is written fresh. The bad reply shapes are described in general terms, with no customer identifiers and no volume figures.
