### PR TITLE
fix(ci): make non-verdict storybook artifact uploads non-blocking

### DIFF
--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -302,7 +302,11 @@ jobs:
             # shard.
             # module-graph.json only exists once the Vite build completes, so no
             # `if: always()`: on a failed/cancelled build it would just warn.
+            # select-stories falls back to the full matrix when the graph is
+            # missing, so a failed upload costs one narrowing opportunity rather
+            # than the build and the whole visual-regression matrix behind it.
             - name: Upload module-graph artifact
+              continue-on-error: true
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               with:
                   name: storybook-module-graph
@@ -689,8 +693,12 @@ jobs:
                       vr-cli/products/visual_review/cli/node_modules
                   key: ${{ steps.restore-vr-cli.outputs.cache-primary-key }}
 
+            # The "Fail on test-runner failure" step below is the verdict, so a
+            # failed upload must not red a passing shard. ci-storybook-update-test-timing
+            # requires a complete set of shards, so it skips a run that loses one.
             - name: Upload test results
               if: always()
+              continue-on-error: true
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               with:
                   name: junit-results-storybook-${{ matrix.browser }}-${{ matrix.shard }}


### PR DESCRIPTION
## Problem

Storybook CI reds on a PR that has nothing wrong with it, because GitHub's artifact service intermittently returns 403.

- The error is `Failed to FinalizeArtifact: ... (403) Forbidden: Error from intermediary`. [Example run](https://github.com/PostHog/posthog/actions/runs/34249835953/job/102141197175).
- Two Storybook upload steps block on that call, so a 403 fails the step and the job.
- `Upload module-graph artifact` runs in `build-storybook`, so its failure takes down the whole visual-regression matrix behind it.
- Neither upload produces the job's verdict. Both carry reporting or optimization data.
- The failure rate on completed Storybook runs climbed from 3% to 19.6% over five hours on 2026-09-08, while Frontend CI stayed at roughly 1 in 27.

The 403 hits GitHub-hosted `ubuntu-latest` shards and Depot shards alike, so this is not a runner problem and nothing in the repo can prevent it. GitHub reported no incident.

## Changes

- A Storybook run now survives a 403 from the artifact service instead of reporting a red check.
- Both upload steps get step-level `continue-on-error: true`.
- `Upload module-graph artifact` becomes non-blocking. `select-stories` already routes a missing graph to `fall_back_to_full selector_error`, so the run pays a full matrix instead of a narrowed one.
- `Upload test results` becomes non-blocking. The `Fail on test-runner failure` step below it is the verdict, which is the same reason the adjacent Trunk upload is already non-blocking.
- `ci-storybook-update-test-timing` requires 16 chromium and 4 webkit shards before it uses these files, so it skips a run that loses one rather than writing skewed timings.

The change is 8 added lines in one file: two `continue-on-error` keys and the comments that explain why each is safe.

> [!NOTE]
> This trades a false red for a slower run. When the module-graph upload fails, that PR runs the full 16-shard matrix rather than a narrowed one. Story selection telemetry records it as `skip_reason=selector_error`, so the rate stays visible in the DevEx project.

Step-level `continue-on-error` is deliberate. A job-level one posts a `failure` check run even when the run goes green.

### What this does not fix

`Download Storybook build artifact` also fails with the same 403, and that one has to stay blocking, because a shard cannot run tests without the build. Making downloads resilient needs a retry wrapper, which is a larger change and not in this PR.

## How did you test this code?

No new tests. The change adds no logic, and no test can exercise a third-party 403.

- `bin/hogli lint:workflows` passes, 9 checks across 134 workflows.
- `actionlint` reports the same 10 pre-existing shellcheck findings before and after, all on untouched lines.
- `bin/hogli ci:preflight --strict` passes.
- Not checked: the fallback path itself. Confirming it needs a real artifact-service failure, which cannot be produced on demand. The path is read from the workflow, at [`ci-storybook.yml#L1180-L1184`](https://github.com/PostHog/posthog/blob/bba0e9b2396e6155131ff4a3b188ed37886639fe/.github/workflows/ci-storybook.yml#L1180-L1184).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This changes CI wiring only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in Claude Code. The work started as a diagnosis of a red Storybook check, not as a request for this change. Reading the logs showed the failing steps were all artifact operations, and comparing hourly failure rates across workflows showed the damage concentrated on Storybook because it uploads a 62 MB artifact and fans it out to 20 shards.

Skills invoked: `/authoring-ci-workflows`, `/writing-code-comments`, `/writing-pr-descriptions`.

One decision worth flagging for review. Making an upload non-blocking is only safe if the consumer degrades rather than passing green on missing data. That was checked before the edit: `select-stories` falls back to the full matrix, and the timing job requires a complete shard set. Had either silently reported success, the right fix would have been a retry, not `continue-on-error`.

Scope grew by one step during the session. The `Upload test results` step was not in the original proposal, and it was added after the logs showed it failing the same way with the verdict already living in a separate step.

No duplicate: `gh pr list --state open --search "storybook artifact upload"` and a search for `FinalizeArtifact` returned nothing related.

Public artifact: every fact here comes from public GitHub Actions runs on this repo. No customer or internal material is involved.

