### PR TITLE
fix(aio): stop worker drains from filing llm judge error issues

### DIFF
--- a/posthog/temporal/ai_observability/evaluation_llm_judge.py
+++ b/posthog/temporal/ai_observability/evaluation_llm_judge.py
@@ -416,6 +416,13 @@ def call_llm_judge(
         increment_errors("connection_error", provider=provider)
         raise
 
+    except temporalio.exceptions.CancelledError:
+        # A worker drain or a workflow cancel interrupts the judge at whatever line it reached, so
+        # the fingerprint differs per cancellation. Logging it would file a new error tracking issue
+        # every time, so track it as a metric and re-raise for the retry policy instead.
+        increment_errors("cancelled", provider=provider)
+        raise
+
     except Exception as e:
         logger.exception(
             "Unhandled error from LLM client",

--- a/posthog/temporal/ai_observability/test_run_evaluation.py
+++ b/posthog/temporal/ai_observability/test_run_evaluation.py
@@ -10,7 +10,7 @@ from asgiref.sync import sync_to_async
 from parameterized import parameterized
 from temporalio import activity
 from temporalio.api.enums.v1 import EventType
-from temporalio.exceptions import ApplicationError
+from temporalio.exceptions import ApplicationError, CancelledError
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Replayer, UnsandboxedWorkflowRunner, Worker
 
@@ -1527,6 +1527,37 @@ class TestRunEvaluationWorkflow:
                 execute_llm_judge_activity(ExecuteLLMJudgeInputs(evaluation=evaluation, event_data=event_data))
 
             mock_increment_errors.assert_called_once_with(expected_label, provider="openai")
+
+    @pytest.mark.django_db(transaction=True)
+    def test_execute_llm_judge_activity_cancellation_is_counted_but_not_logged(self, setup_data, active_key_config):
+        evaluation_obj = setup_data["evaluation"]
+        team = setup_data["team"]
+
+        evaluation = {
+            "id": str(evaluation_obj.id),
+            "name": "Test Evaluation",
+            "evaluation_type": "llm_judge",
+            "evaluation_config": {"prompt": "Is this accurate?"},
+            "output_type": "boolean",
+            "output_config": {},
+            "team_id": team.id,
+        }
+        event_data = create_mock_event_data(team.id)
+
+        with (
+            patch("posthog.temporal.ai_observability.evaluation_llm_judge.Client") as mock_client_class,
+            patch("posthog.temporal.ai_observability.evaluation_llm_judge.increment_errors") as mock_increment_errors,
+            patch("posthog.temporal.ai_observability.evaluation_llm_judge.logger") as mock_logger,
+        ):
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+            mock_client.complete.side_effect = CancelledError("Cancelled")
+
+            with pytest.raises(CancelledError):
+                execute_llm_judge_activity(ExecuteLLMJudgeInputs(evaluation=evaluation, event_data=event_data))
+
+            mock_increment_errors.assert_called_once_with("cancelled", provider="openai")
+            mock_logger.exception.assert_not_called()
 
     @pytest.mark.django_db(transaction=True)
     def test_execute_llm_judge_activity_terminal_team_requires_provider_key(self, setup_data):


### PR DESCRIPTION
## Problem

- A Temporal worker drain during an AI observability evaluation files a brand new error tracking issue, so the owning team gets an alert with nothing to act on.
- `temporalio.exceptions.CancelledError` interrupts the judge at whatever line it reached, so the fingerprint differs on every cancellation and no issue ever repeats.
- `call_llm_judge` catches the cancellation in its generic handler, which calls `logger.exception` and creates that issue.

## Changes

- Cancellations stop reaching error tracking, so the alert channel only sees judge failures a person can act on.
- The judge counts a cancellation under the `cancelled` error metric and re-raises it for the retry policy.
- The new branch sits next to the `ProviderConnectionError` branch, which already handles a transient failure this way.
- Evaluation behavior stays the same. Temporal still retries the activity under `LLM_JUDGE_RETRY_POLICY`.
- The branch lives in the shared `call_llm_judge`, so it covers the single-event and the trace-level judge workflows.

## How did you test this code?

- Added `test_execute_llm_judge_activity_cancellation_is_counted_but_not_logged`. It catches the regression where someone drops the branch or moves it below the generic handler, which returns to one issue per cancellation.
- Ran the `TestRunEvaluationWorkflow` class in the sandbox against Postgres and ClickHouse.
- Not run: the rest of the backend suite, and repo-wide mypy.
- No manual testing. The sandbox runs no Temporal worker that executes judge activities.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The work started from an error tracking alert raised in Slack, linked in the footer below. Investigation showed a single cancellation that landed inside the Gemini client constructor, before any request went to the provider, with no repeat and no cluster of cancellations around it. That ruled out a provider fault and pointed at cancellation noise rather than a broken evaluation.

The branch tracks a metric and re-raises rather than returning a skip result, because a cancelled attempt must stay retryable. Other cancellation sources elsewhere in the repo were left alone.

Skills invoked: `/investigating-error-issue`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

No duplicate: `gh pr list --state open --search` for open PRs on this path and this exception found nothing.

Public artifact: no session material reached the diff. The test evaluation and event data come from existing fixtures in the test file.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A006STKHR/p1788662833393489?thread_ts=1788662833.393489&cid=C0A006STKHR)*
