### PR TITLE
fix(aio): cap llm tagger output and skip truncated responses

### DIFF
--- a/posthog/temporal/ai_observability/evaluation_llm_judge.py
+++ b/posthog/temporal/ai_observability/evaluation_llm_judge.py
@@ -35,6 +35,7 @@ from products.ai_observability.backend.llm.errors import (
     ContextWindowExceededError,
     ModelNotFoundError,
     ModelPermissionError,
+    OutputLengthExceededError,
     ProviderConnectionError,
     QuotaExceededError,
     RateLimitError,
@@ -177,14 +178,14 @@ def _build_errored_trace_result(allows_na: bool) -> EvaluationActivityResult:
     return result
 
 
-def _build_context_window_skip_result(
-    allows_na: bool, *, is_byok: bool, key_id: str | None
+def _build_skip_result(
+    allows_na: bool, *, is_byok: bool, key_id: str | None, skip_reason: str, reasoning: str
 ) -> EvaluationActivityResult:
     """Per-item skip, not a terminal user error that disables the eval."""
     result: EvaluationActivityResult = {
         "result_type": "boolean",
         "verdict": None if allows_na else False,
-        "reasoning": "Evaluation input exceeded the model's context window; evaluation skipped.",
+        "reasoning": reasoning,
         "input_tokens": 0,
         "output_tokens": 0,
         "total_tokens": 0,
@@ -192,7 +193,7 @@ def _build_context_window_skip_result(
         "key_id": key_id,
         "allows_na": allows_na,
         "skipped": True,
-        "skip_reason": "context_window_exceeded",
+        "skip_reason": skip_reason,
     }
     if allows_na:
         result["applicable"] = False
@@ -301,6 +302,13 @@ def call_llm_judge(
     is_byok = resolved.is_byok
     key_id = str(provider_key.id) if provider_key else None
 
+    # Tags ride along on anything error tracking captures in this activity's context, so a failure
+    # says which team and evaluation hit it rather than only which provider module raised.
+    posthoganalytics.tag("team_id", team_id)
+    posthoganalytics.tag("evaluation_id", evaluation["id"])
+    posthoganalytics.tag("provider", provider)
+    posthoganalytics.tag("model", model)
+
     type_config = get_output_type_config(allows_na)
     response_format = type_config.response_format
 
@@ -407,7 +415,25 @@ def call_llm_judge(
     except ContextWindowExceededError:
         # Skip rather than raise: retrying can't fix an over-window prompt and just spams error tracking.
         increment_errors("context_window_exceeded", provider=provider)
-        return _build_context_window_skip_result(allows_na, is_byok=is_byok, key_id=key_id)
+        return _build_skip_result(
+            allows_na,
+            is_byok=is_byok,
+            key_id=key_id,
+            skip_reason="context_window_exceeded",
+            reasoning="Evaluation input exceeded the model's context window; evaluation skipped.",
+        )
+
+    except OutputLengthExceededError:
+        # Truncation repeats on the same prompt, so skip the item rather than retrying it or
+        # raising into error tracking. The counter is what a rambling model shows up in.
+        increment_errors("output_length_exceeded", provider=provider)
+        return _build_skip_result(
+            allows_na,
+            is_byok=is_byok,
+            key_id=key_id,
+            skip_reason="output_length_exceeded",
+            reasoning="Judge response hit the model's output token limit; evaluation skipped.",
+        )
 
     except ProviderConnectionError:
         # Transient transport failure (connection reset, read timeout). Retrying usually succeeds,

--- a/posthog/temporal/ai_observability/metrics.py
+++ b/posthog/temporal/ai_observability/metrics.py
@@ -92,6 +92,23 @@ def increment_errors(error_type: str, *, provider: str | None = None) -> None:
     counter.add(1)
 
 
+def increment_tagger_errors(error_type: str, *, provider: str | None = None) -> None:
+    """Track tagger error categorization, kept out of `llma_eval_errors` so eval dashboards and
+    alerts stay about evals.
+
+    This is where a skipped tagger run shows up: a skip returns a result rather than raising, so
+    nothing else records it.
+    """
+    if not activity.in_activity() and not workflow.in_workflow():
+        return
+    attrs: dict[str, str | int | float | bool] = {"error_type": error_type}
+    if provider is not None:
+        attrs["provider"] = provider
+    meter = get_metric_meter(attrs)
+    counter = meter.create_counter("llma_tagger_errors", "Tagger error counts by type")
+    counter.add(1)
+
+
 def increment_user_errors(error_type: str, *, provider: str | None = None) -> None:
     """Track user-actionable eval errors separately from system failures.
 

--- a/posthog/temporal/ai_observability/run_tagger.py
+++ b/posthog/temporal/ai_observability/run_tagger.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import structlog
 import temporalio
+import posthoganalytics
 from pydantic import BaseModel, Field
 from structlog.contextvars import bind_contextvars
 from temporalio.common import RetryPolicy
@@ -15,6 +16,7 @@ from posthog.sync import database_sync_to_async
 from posthog.temporal.ai_observability.evaluation_event_io import extract_event_io
 from posthog.temporal.ai_observability.evaluation_workflow_activities import update_key_state_activity
 from posthog.temporal.ai_observability.message_utils import extract_text_from_messages
+from posthog.temporal.ai_observability.metrics import increment_tagger_errors
 from posthog.temporal.ai_observability.model_resolution import model_spec
 from posthog.temporal.ai_observability.team_capture import capture_internal_for_team
 from posthog.temporal.common.base import PostHogWorkflow
@@ -25,6 +27,7 @@ from products.ai_observability.backend.llm.errors import (
     AuthenticationError,
     ModelNotFoundError,
     ModelPermissionError,
+    OutputLengthExceededError,
     QuotaExceededError,
     RateLimitError,
     StructuredOutputParseError,
@@ -37,6 +40,11 @@ logger = structlog.get_logger(__name__)
 # Attribution fallback for $ai_tag events if a result omits its model. The model actually
 # used is resolved per-run by model_spec() (see posthog.temporal.ai_observability.model_resolution).
 DEFAULT_TAGGER_MODEL = DEFAULT_MODEL_BY_PROVIDER["openai"]
+
+# A tagger answers with a short tag list and one reasoning string, so a healthy run needs a small
+# fraction of this. The cap keeps that room and stops a model that starts rambling in about a
+# second, instead of letting it spend the model's whole output window on a truncated response.
+TAGGER_MAX_OUTPUT_TOKENS = 2048
 
 LLM_TAGGER_RETRY_POLICY = RetryPolicy(
     maximum_attempts=3,
@@ -227,6 +235,14 @@ async def execute_tagger_activity(inputs: ExecuteTaggerInputs) -> dict[str, Any]
     input_data = extract_text_from_messages(io.input_raw)
     output_data = extract_text_from_messages(io.output_raw)
 
+    bind_contextvars(team_id=team_id, tagger_id=tagger["id"], provider=provider, model=model)
+    # Tags ride along on anything error tracking captures in this activity's context, so a failure
+    # says which team and tagger hit it rather than only which provider module raised.
+    posthoganalytics.tag("team_id", team_id)
+    posthoganalytics.tag("tagger_id", tagger["id"])
+    posthoganalytics.tag("provider", provider)
+    posthoganalytics.tag("model", model)
+
     system_prompt = build_tagger_system_prompt(prompt, tags, min_tags, max_tags)
     tag_names = [tag["name"] for tag in tags]
     response_format = build_tag_result_schema(tag_names, min_tags, max_tags)
@@ -251,6 +267,7 @@ Output: {output_data}"""
                 messages=[{"role": "user", "content": user_prompt}],
                 provider=provider,
                 response_format=response_format,
+                max_tokens=TAGGER_MAX_OUTPUT_TOKENS,
             )
         )
     except AuthenticationError:
@@ -290,7 +307,29 @@ Output: {output_data}"""
             f"Model '{model}' not found.",
             non_retryable=True,
         )
+    except OutputLengthExceededError as e:
+        # Truncation repeats on the same prompt, so retrying only spends tokens, and raising would
+        # mint an error tracking issue for a run nobody can act on. Skip the run and let the
+        # counter carry the signal.
+        increment_tagger_errors("output_length_exceeded", provider=provider)
+        logger.warning(
+            "Tagger response hit the output token limit; skipping run",
+            tagger_id=tagger["id"],
+            provider=provider,
+            model=model,
+            max_output_tokens=TAGGER_MAX_OUTPUT_TOKENS,
+            error=str(e),
+        )
+        return {
+            "tags": [],
+            "reasoning": "",
+            "skipped": True,
+            "skip_reason": "output_length_exceeded",
+            "message": str(e),
+            "tagger_id": tagger["id"],
+        }
     except StructuredOutputParseError as e:
+        increment_tagger_errors("parse_error", provider=provider)
         raise ApplicationError(
             str(e),
             {"error_type": "parse_error"},
@@ -323,8 +362,6 @@ Output: {output_data}"""
         )
 
     usage = response.usage
-
-    bind_contextvars(provider=provider, model=model)
 
     return {
         "tags": validated_tags,
@@ -647,6 +684,11 @@ class RunTaggerWorkflow(PostHogWorkflow):
                             retry_policy=RetryPolicy(maximum_attempts=2),
                         )
                 raise
+
+            if result.get("skipped"):
+                # A skipped run has no tags to report, so it emits no $ai_tag event, the same as
+                # the skips the handler above returns.
+                return result
 
         # Activity 3: Emit tagger event
         await temporalio.workflow.execute_activity(

--- a/posthog/temporal/ai_observability/test_run_evaluation.py
+++ b/posthog/temporal/ai_observability/test_run_evaluation.py
@@ -24,6 +24,7 @@ from products.ai_observability.backend.llm.errors import (
     ContextWindowExceededError,
     ModelNotFoundError,
     ModelPermissionError,
+    OutputLengthExceededError,
     QuotaExceededError,
     RateLimitError,
     StructuredOutputParseError,
@@ -390,6 +391,21 @@ class TestRunEvaluationWorkflow:
             assert len(sent_prompt) < raw_size
 
     @pytest.mark.parametrize(
+        "error,expected_skip_reason",
+        [
+            pytest.param(
+                ContextWindowExceededError("prompt is too long: 300000 tokens > 272000 maximum"),
+                "context_window_exceeded",
+                id="input_over_context_window",
+            ),
+            pytest.param(
+                OutputLengthExceededError("Model output hit the token limit"),
+                "output_length_exceeded",
+                id="output_truncated",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
         "output_config,expected_verdict,expected_applicable",
         [
             pytest.param({}, False, None, id="without_na"),
@@ -397,8 +413,15 @@ class TestRunEvaluationWorkflow:
         ],
     )
     @pytest.mark.django_db(transaction=True)
-    def test_execute_llm_judge_activity_skips_on_context_window_exceeded(
-        self, output_config, expected_verdict, expected_applicable, setup_data, active_key_config
+    def test_execute_llm_judge_activity_skips_without_a_usable_response(
+        self,
+        output_config,
+        expected_verdict,
+        expected_applicable,
+        error,
+        expected_skip_reason,
+        setup_data,
+        active_key_config,
     ):
         team = setup_data["team"]
         evaluation_obj = setup_data["evaluation"]
@@ -423,14 +446,12 @@ class TestRunEvaluationWorkflow:
         with patch("posthog.temporal.ai_observability.evaluation_llm_judge.Client") as mock_client_class:
             mock_client = MagicMock()
             mock_client_class.return_value = mock_client
-            mock_client.complete.side_effect = ContextWindowExceededError(
-                "prompt is too long: 300000 tokens > 272000 maximum"
-            )
+            mock_client.complete.side_effect = error
 
             result = execute_llm_judge_activity(ExecuteLLMJudgeInputs(evaluation=evaluation, event_data=event_data))
 
         assert result["skipped"] is True
-        assert result["skip_reason"] == "context_window_exceeded"
+        assert result["skip_reason"] == expected_skip_reason
         assert result["verdict"] is expected_verdict
         assert result.get("applicable") is expected_applicable
         assert result.get("terminal_user_error") is not True

--- a/posthog/temporal/ai_observability/test_run_tagger.py
+++ b/posthog/temporal/ai_observability/test_run_tagger.py
@@ -11,10 +11,12 @@ from temporalio.exceptions import ApplicationError
 from posthog.api.capture import CaptureInternalError
 from posthog.models import Organization, Team
 
+from products.ai_observability.backend.llm.errors import OutputLengthExceededError
 from products.ai_observability.backend.models.provider_keys import LLMProviderKey
 from products.ai_observability.backend.models.taggers import Tagger
 
 from .run_tagger import (
+    TAGGER_MAX_OUTPUT_TOKENS,
     EmitTaggerEventInputs,
     ExecuteTaggerInputs,
     RunTaggerInputs,
@@ -197,6 +199,39 @@ class TestRunTaggerWorkflow:
                 assert result["input_tokens"] == 100
                 assert result["output_tokens"] == 20
                 mock_client.complete.assert_called_once()
+                assert mock_client.complete.call_args.args[0].max_tokens == TAGGER_MAX_OUTPUT_TOKENS
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db(transaction=True)
+    async def test_execute_tagger_skips_when_the_response_is_truncated(self, setup_data):
+        # A truncated response repeats on the same prompt, so the activity returns a skip instead
+        # of raising, which would retry the run and fail the workflow.
+        tagger_obj = setup_data["tagger"]
+        team = setup_data["team"]
+
+        tagger = {
+            "id": str(tagger_obj.id),
+            "name": "Feature Tagger",
+            "tagger_config": make_tagger_config(),
+            "team_id": team.id,
+        }
+
+        with patch("posthog.temporal.ai_observability.run_tagger.Client") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+            mock_client.complete.side_effect = OutputLengthExceededError("Model output hit the token limit")
+
+            with patch("posthog.temporal.ai_observability.model_resolution.EvaluationConfig") as mock_eval_config:
+                mock_config = _mock_config_with_active_key()
+                mock_eval_config.objects.get_or_create.return_value = (mock_config, False)
+
+                result = await execute_tagger_activity(
+                    ExecuteTaggerInputs(tagger=tagger, event_data=create_mock_event_data(team.id))
+                )
+
+        assert result["skipped"] is True
+        assert result["skip_reason"] == "output_length_exceeded"
+        assert result["tags"] == []
 
     @pytest.mark.asyncio
     @pytest.mark.django_db(transaction=True)

--- a/products/ai_observability/backend/llm/errors.py
+++ b/products/ai_observability/backend/llm/errors.py
@@ -66,6 +66,13 @@ class ContextWindowExceededError(LLMError):
     """Raised when the prompt exceeds the model's context window."""
 
 
+class OutputLengthExceededError(LLMError):
+    """Raised when the model stopped at its output token limit, so the response is truncated.
+
+    Not retryable: the same prompt truncates the same way. Callers skip the run instead.
+    """
+
+
 _CONTEXT_WINDOW_ERROR_MARKERS = (
     "context_length_exceeded",
     "maximum context length",
@@ -141,6 +148,8 @@ def user_facing_error_message(error: Exception | None) -> str:
         return "The provider is rate limiting this key. Wait a moment, then try again."
     if isinstance(error, ContextWindowExceededError):
         return "This conversation is too long for the model's context window. Shorten it, then try again."
+    if isinstance(error, OutputLengthExceededError):
+        return "The model's response was cut off. Try again."
     if isinstance(error, ProviderConnectionError):
         return "Could not reach the model provider. Try again."
     if isinstance(error, StructuredOutputParseError):

--- a/products/ai_observability/backend/llm/providers/anthropic.py
+++ b/products/ai_observability/backend/llm/providers/anthropic.py
@@ -20,6 +20,7 @@ from products.ai_observability.backend.llm.errors import (
     LLMError,
     ModelNotFoundError,
     ModelPermissionError,
+    OutputLengthExceededError,
     ProviderConnectionError,
     QuotaExceededError,
     RateLimitError,
@@ -181,6 +182,8 @@ class AnthropicAdapter:
                 try:
                     parsed = request.response_format.model_validate_json(content)
                 except Exception as e:
+                    if response.stop_reason == "max_tokens":
+                        raise OutputLengthExceededError(f"Model output hit the token limit: {e}") from e
                     raise StructuredOutputParseError(f"Failed to parse structured output: {e}") from e
 
             return CompletionResponse(

--- a/products/ai_observability/backend/llm/providers/gemini.py
+++ b/products/ai_observability/backend/llm/providers/gemini.py
@@ -21,6 +21,7 @@ from products.ai_observability.backend.llm.errors import (
     LLMError,
     ModelNotFoundError,
     ModelPermissionError,
+    OutputLengthExceededError,
     ProviderConnectionError,
     QuotaExceededError,
     RateLimitError,
@@ -37,6 +38,18 @@ from products.ai_observability.backend.llm.types import (
 from products.ai_observability.backend.providers.formatters.gemini_formatter import convert_anthropic_messages_to_gemini
 
 logger = logging.getLogger(__name__)
+
+
+def _hit_output_token_limit(response: Any) -> bool:
+    """Whether Gemini stopped the response at the output token limit, which truncates the JSON.
+
+    Read defensively: the field is an enum in some SDK versions and a plain string in others.
+    """
+    for candidate in getattr(response, "candidates", None) or []:
+        reason = getattr(candidate, "finish_reason", None)
+        if getattr(reason, "name", None) == "MAX_TOKENS" or reason == "MAX_TOKENS":
+            return True
+    return False
 
 
 class GeminiConfig:
@@ -130,6 +143,8 @@ class GeminiAdapter:
                 try:
                     parsed = request.response_format.model_validate_json(content)
                 except Exception as e:
+                    if _hit_output_token_limit(response):
+                        raise OutputLengthExceededError(f"Model output hit the token limit: {e}") from e
                     logger.warning(f"Failed to parse structured output from Gemini: {e}")
                     raise StructuredOutputParseError(f"Failed to parse structured output: {e}") from e
 

--- a/products/ai_observability/backend/llm/providers/openai.py
+++ b/products/ai_observability/backend/llm/providers/openai.py
@@ -24,6 +24,7 @@ from products.ai_observability.backend.llm.errors import (
     LLMError,
     ModelNotFoundError,
     ModelPermissionError,
+    OutputLengthExceededError,
     ProviderConnectionError,
     QuotaExceededError,
     RateLimitError,
@@ -159,6 +160,7 @@ class OpenAIAdapter:
                         model=request.model,
                         messages=messages,
                         response_format=request.response_format,
+                        max_completion_tokens=request.max_tokens,
                         **(self._build_analytics_kwargs(analytics, client)),
                     )
                     parsed = response.choices[0].message.parsed
@@ -177,9 +179,13 @@ class OpenAIAdapter:
                     if "response_format" in str(e).lower() or "json_schema" in str(e).lower():
                         return self._complete_with_json_fallback(client, request, messages, analytics)
                     raise
-                except (ValidationError, openai.LengthFinishReasonError) as e:
-                    # json_schema does not enforce cross-field validators, while the SDK raises a separate
-                    # exception for length-limited output. Normalize both so callers skip invalid output.
+                except openai.LengthFinishReasonError as e:
+                    # The SDK raises this when the model stopped at the output limit, which leaves the
+                    # JSON truncated. Kept apart from a parse error so callers can skip it quietly.
+                    raise OutputLengthExceededError(f"Model output hit the token limit: {e}") from e
+                except ValidationError as e:
+                    # json_schema does not enforce cross-field validators. Normalize the violation so
+                    # callers skip invalid output.
                     raise StructuredOutputParseError(f"Failed to parse structured output: {e}") from e
             else:
                 create_response = client.chat.completions.create(

--- a/products/ai_observability/backend/llm/providers/test/test_openai_adapter.py
+++ b/products/ai_observability/backend/llm/providers/test/test_openai_adapter.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, ValidationError, model_validator
 
 from products.ai_observability.backend.llm.errors import (
     ContextWindowExceededError,
+    OutputLengthExceededError,
     QuotaExceededError,
     StructuredOutputParseError,
 )
@@ -205,13 +206,15 @@ class TestOpenAIAdapterErrorMapping:
 
     @parameterized.expand(
         [
-            ("length_finish_reason", _length_finish_reason_error),
-            ("cross_field_validator", _cross_field_error),
+            ("length_finish_reason", _length_finish_reason_error, OutputLengthExceededError),
+            ("cross_field_validator", _cross_field_error, StructuredOutputParseError),
         ]
     )
-    def test_structured_output_parse_errors_map_to_parse_error(
-        self, _name: str, make_error: Callable[[], Exception]
+    def test_structured_output_failures_map_to_their_own_error(
+        self, _name: str, make_error: Callable[[], Exception], expected: type[Exception]
     ) -> None:
+        # A truncated response and unreadable output are handled differently by callers: one is a
+        # quiet skip, the other a parse failure. They cannot share an error class.
         adapter = OpenAIAdapter()
         mock_client = MagicMock()
         mock_client.beta.chat.completions.parse.side_effect = make_error()
@@ -224,8 +227,30 @@ class TestOpenAIAdapterErrorMapping:
         )
 
         with patch("products.ai_observability.backend.llm.providers.openai.openai.OpenAI", return_value=mock_client):
-            with pytest.raises(StructuredOutputParseError):
+            with pytest.raises(expected):
                 adapter.complete(request, api_key="sk-test", analytics=AnalyticsContext(capture=False))
+
+    def test_structured_output_request_forwards_the_output_token_cap(self) -> None:
+        # Without this the structured-output path ignores max_tokens and a runaway response bills
+        # the model's whole output window before it fails.
+        adapter = OpenAIAdapter()
+        mock_client = MagicMock()
+        mock_client.beta.chat.completions.parse.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(parsed=_Verdict(verdict=True)))], usage=None
+        )
+        request = CompletionRequest(
+            model="gpt-5-mini",
+            system="s",
+            messages=[{"role": "user", "content": "x"}],
+            provider="openai",
+            response_format=_Verdict,
+            max_tokens=2048,
+        )
+
+        with patch("products.ai_observability.backend.llm.providers.openai.openai.OpenAI", return_value=mock_client):
+            adapter.complete(request, api_key="sk-test", analytics=AnalyticsContext(capture=False))
+
+        assert mock_client.beta.chat.completions.parse.call_args.kwargs["max_completion_tokens"] == 2048
 
 
 class TestOpenAIStreamErrorSurfacing:

--- a/products/ai_observability/backend/llm/test/test_errors.py
+++ b/products/ai_observability/backend/llm/test/test_errors.py
@@ -10,6 +10,7 @@ from products.ai_observability.backend.llm.errors import (
     LLMError,
     ModelNotFoundError,
     ModelPermissionError,
+    OutputLengthExceededError,
     ProviderConnectionError,
     ProviderMismatchError,
     QuotaExceededError,
@@ -134,6 +135,7 @@ class TestUserFacingErrorMessage(SimpleTestCase):
             (QuotaExceededError("insufficient_quota"),),
             (RateLimitError("429"),),
             (ContextWindowExceededError("too long"),),
+            (OutputLengthExceededError("cut off"),),
             (ProviderConnectionError("reset by peer"),),
             (StructuredOutputParseError("bad json"),),
         ]


### PR DESCRIPTION
## Problem

- An LLM tagger stops adding tags to traces, and nothing in the product says why.
- The tagger asks for structured output with no output token cap, so a model that keeps writing runs to its own output window and returns truncated JSON.
- The OpenAI SDK reports that as a length finish reason. `complete` folded it into `StructuredOutputParseError`, `execute_tagger_activity` re-raised it as a non-retryable `ApplicationError`, and the workflow skipped the event without emitting an `$ai_tag` event.
- The structured-output path never forwarded `max_tokens`, so no caller could cap output there. Every failed run paid for the model's whole output window first.
- The raise also captured one exception per run, so a single tagger config filled error tracking with an issue nobody can act on run by run. Evidence: [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a07022-60f6-7381-9a8b-e4983a74f860), a continuous burst that lasted about a day.
- The exception carried no team or tagger identity, so error tracking could not say whose tagger hit it.

## Changes

- A tagger that hits this now keeps working: the truncated run ends on its own, and later events still get tags.
- Tagger requests carry a 2048 output token cap. A tagger answers with a short tag list and one reasoning string, so the cap leaves a healthy run untouched and stops a rambling one in about a second.
- The OpenAI structured-output path forwards `max_tokens` as `max_completion_tokens`. That one kwarg is what stops the token burn, so it is the line to check first.
- Truncation gets its own error class, `OutputLengthExceededError`, instead of sharing `StructuredOutputParseError`. The tagger returns a skip and counts it in `llma_tagger_errors`. The judge returns its existing per-item skip.
- Anthropic and Gemini raise the new error when the provider reports that it stopped at the output limit.
- Exceptions from the tagger and judge activities carry `team_id`, `tagger_id` or `evaluation_id`, `provider`, and `model`.
- One string a person reads changes: the playground message for a cut-off response. No UI changes.
- Mechanical: the judge's skip builder takes the skip reason and reasoning as arguments, with both call sites updated.

> [!NOTE]
> The judge keeps no output cap. A rambling judge run now skips quietly instead of raising, so the counter is the only place it shows. Capping the judge needs its own output distribution, which this PR does not measure.

Refs #96844, which fixes a different tagger failure in the same file by stating the JSON contract in the prompt.

## How did you test this code?

- `posthog/temporal/ai_observability/test_run_tagger.py`, against Postgres and ClickHouse from `docker-compose.dev.yml`. The new case catches the activity raising on a truncated response instead of returning a skip, which is the behavior behind the linked issue. The happy-path case now asserts the request carries the cap, which nothing asserted before.
- `products/ai_observability/backend/llm/providers/test/test_openai_adapter.py`. The parameterized parse-error case splits by expected class, so folding truncation back into the parse error fails. A new case asserts the parse call forwards `max_completion_tokens`, because a revert of that kwarg is otherwise invisible.
- `posthog/temporal/ai_observability/test_run_evaluation.py`. The existing context-window skip test is parameterized over the new error, so both per-item judge skips are covered.
- `uv run mypy --cache-fine-grained .` and `hogli ci:preflight --fix` report no failures. Preflight advises merging master in for workflow staleness.
- Not checked: any live provider call, and the Anthropic and Gemini truncation branches, which need a real provider response carrying that stop reason.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow, API, or setting changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by the PostHog Slack app (Claude Code) from a Slack thread that started with the error tracking alert linked above. Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`.
- No duplicate: `gh pr list --state open --search` surfaced [#96844](https://github.com/PostHog/posthog/pull/96844), which changes the tagger prompt so permissive models answer in the right shape. It sets no cap and does not classify truncation, so this PR is still needed. Nothing open covers the output limit.
- The 2048 value comes from the observed output size of successful `$ai_tag` events in PostHog's own project, which sit far below it. The alternative was shipping the telemetry first and setting the cap from a cross-team distribution. A generous cap plus the new counter gets the burn under control now and still exposes the distribution.
- Patch coverage: the tagger and OpenAI paths are covered by the tests above. The Anthropic and Gemini truncation branches are not.
- Public artifact: the work started from an error tracking issue in PostHog's own project. Nothing here carries customer data, run counts, cost figures, or Slack content, and no fixture derives from that material.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A006STKHR/p1788587703565519?thread_ts=1788587703.565519&cid=C0A006STKHR)*
