### PR TITLE
fix(surveys): notify for a completed response from every SDK

### DIFF
--- a/frontend/src/scenes/surveys/surveyNotificationModalLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationModalLogic.test.ts
@@ -250,15 +250,11 @@ describe('surveyNotificationModalLogic', () => {
             value: 'Chrome',
             operator: PropertyOperator.Exact,
         }
-        const saved = getSurveyNotificationFilters('survey-abc', false)
+        const saved = getSurveyNotificationFilters('survey-abc')
         const branch = saved.events![branchIndex]
         branch.properties = [...(branch.properties ?? []), customRestriction]
 
-        const merged = mergeResponseFiltersIntoExistingFilters(
-            saved,
-            getSurveyNotificationFilters('survey-abc', false),
-            []
-        )
+        const merged = mergeResponseFiltersIntoExistingFilters(saved, getSurveyNotificationFilters('survey-abc'), [])
 
         const sentBranches = merged?.events?.filter((event) => event.id === SurveyEventName.SENT)
         expect(sentBranches).toHaveLength(2)
@@ -274,7 +270,7 @@ describe('surveyNotificationModalLogic', () => {
             value: 'Chrome',
             operator: PropertyOperator.Exact,
         }
-        const saved = getSurveyNotificationFilters('survey-abc', false)
+        const saved = getSurveyNotificationFilters('survey-abc')
         saved.events![0].properties = [...(saved.events![0].properties ?? []), customRestriction]
 
         // Reloading between saves is what makes this bite: the restriction lands on both branches,
@@ -282,16 +278,8 @@ describe('surveyNotificationModalLogic', () => {
         // deduplicated by object identity would keep both copies and double them on every save.
         const reload = (filters: HogFunctionType['filters']): HogFunctionType['filters'] =>
             JSON.parse(JSON.stringify(filters))
-        let merged = mergeResponseFiltersIntoExistingFilters(
-            saved,
-            getSurveyNotificationFilters('survey-abc', false),
-            []
-        )
-        merged = mergeResponseFiltersIntoExistingFilters(
-            reload(merged),
-            getSurveyNotificationFilters('survey-abc', false),
-            []
-        )
+        let merged = mergeResponseFiltersIntoExistingFilters(saved, getSurveyNotificationFilters('survey-abc'), [])
+        merged = mergeResponseFiltersIntoExistingFilters(reload(merged), getSurveyNotificationFilters('survey-abc'), [])
 
         const sentBranches = merged?.events?.filter((event) => event.id === SurveyEventName.SENT)
         for (const sentBranch of sentBranches ?? []) {
@@ -306,14 +294,10 @@ describe('surveyNotificationModalLogic', () => {
     // dismissal-only. Rebuilding them unconditionally would hand it back the completed-response
     // branches on the next unrelated save, sending exactly what the user opted out of.
     it('leaves a dismissal-only notification without sent branches', () => {
-        const saved = getSurveyNotificationFilters('survey-abc', false)
+        const saved = getSurveyNotificationFilters('survey-abc')
         saved.events = saved.events?.filter((event) => event.id === SurveyEventName.DISMISSED)
 
-        const merged = mergeResponseFiltersIntoExistingFilters(
-            saved,
-            getSurveyNotificationFilters('survey-abc', false),
-            []
-        )
+        const merged = mergeResponseFiltersIntoExistingFilters(saved, getSurveyNotificationFilters('survey-abc'), [])
 
         expect(merged?.events?.filter((event) => event.id === SurveyEventName.SENT)).toHaveLength(0)
         expect(merged?.events?.filter((event) => event.id === SurveyEventName.DISMISSED)).toHaveLength(1)

--- a/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
@@ -26,7 +26,6 @@ import {
     buildSurveyExampleInvocationGlobals,
     getSurveyNotificationFilters,
     getSurveyIdBasedResponseKey,
-    surveyEmitsPartialSentEvents,
 } from 'scenes/surveys/utils'
 import { urls } from 'scenes/urls'
 
@@ -451,7 +450,6 @@ async function buildSurveyNotificationPayload({
             template,
             destination: form.destination,
             surveyId: survey.id,
-            emitsPartialSentEvents: surveyEmitsPartialSentEvents(survey),
             form,
         })
     }
@@ -471,7 +469,6 @@ async function buildSurveyNotificationPayload({
         destination: form.destination,
         surveyName: survey.name,
         surveyId: survey.id,
-        emitsPartialSentEvents: surveyEmitsPartialSentEvents(survey),
         form,
     })
 }
@@ -705,14 +702,12 @@ function createSurveyNotificationPayload({
     destination,
     surveyName,
     surveyId,
-    emitsPartialSentEvents,
     form,
 }: {
     template: HogFunctionTemplateType
     destination: DestinationKey
     surveyName?: string | null
     surveyId: string
-    emitsPartialSentEvents: boolean
     form: SurveyNotificationForm
 }): Partial<HogFunctionType> {
     const destinationOption = DESTINATION_OPTIONS.find((option) => option.value === destination)
@@ -770,11 +765,7 @@ function createSurveyNotificationPayload({
         description: subTemplate?.description ?? `Survey notification for ${destinationOption.label}`,
         inputs,
         inputs_schema: template.inputs_schema,
-        filters: getSurveyNotificationFilters(
-            surveyId,
-            emitsPartialSentEvents,
-            buildResponseFilterProperties(form.responseFilters)
-        ),
+        filters: getSurveyNotificationFilters(surveyId, buildResponseFilterProperties(form.responseFilters)),
         hog: template.code,
         icon_url: template.icon_url,
         enabled: true,
@@ -848,14 +839,12 @@ function updateSurveyNotificationPayload({
     template,
     destination,
     surveyId,
-    emitsPartialSentEvents,
     form,
 }: {
     notification: HogFunctionType
     template: HogFunctionTemplateType
     destination: DestinationKey
     surveyId: string
-    emitsPartialSentEvents: boolean
     form: SurveyNotificationForm
 }): Partial<HogFunctionType> {
     const payload = createSurveyNotificationPayload({
@@ -863,7 +852,6 @@ function updateSurveyNotificationPayload({
         destination,
         surveyName: null,
         surveyId,
-        emitsPartialSentEvents,
         form,
     })
 
@@ -909,7 +897,6 @@ function createCopiedSurveyNotificationPayload({
         destination,
         surveyName: survey.name,
         surveyId: survey.id,
-        emitsPartialSentEvents: surveyEmitsPartialSentEvents(survey),
         form,
     })
 
@@ -930,11 +917,7 @@ function createCopiedSurveyNotificationPayload({
         },
         mappings: remapSurveyResponseProperties(notification.mappings, survey),
         masking: notification.masking,
-        filters: getSurveyNotificationFilters(
-            survey.id,
-            surveyEmitsPartialSentEvents(survey),
-            buildResponseFilterProperties(form.responseFilters)
-        ),
+        filters: getSurveyNotificationFilters(survey.id, buildResponseFilterProperties(form.responseFilters)),
         hog: remapSurveyResponseProperties(notification.hog, survey) ?? template.code,
         icon_url: notification.icon_url ?? template.icon_url,
         enabled: true,

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -43,7 +43,6 @@ import {
     sanitizeSurveyAppearance,
     sanitizeSurveyDisplayConditions,
     splitChoicesOnPaste,
-    surveyEmitsPartialSentEvents,
     validateCSSProperty,
     validateSurveyAppearance,
 } from './utils'
@@ -190,9 +189,12 @@ describe('survey utils', () => {
         })
     })
 
+    // Only posthog-js sets `$survey_completed` on a `survey sent` event. The mobile SDKs and an API
+    // survey's own code leave it off, so the completed-unset branch is what carries their completed
+    // submissions to a destination. Both sent branches stay unconditional for that reason.
     describe('getSurveyNotificationFilters', () => {
         it('builds survey-specific notification filters', () => {
-            expect(getSurveyNotificationFilters('survey-123', true)).toEqual({
+            expect(getSurveyNotificationFilters('survey-123')).toEqual({
                 events: [
                     {
                         id: SurveyEventName.SENT,
@@ -209,6 +211,24 @@ describe('survey utils', () => {
                                 type: PropertyFilterType.Event,
                                 value: true,
                                 operator: PropertyOperator.Exact,
+                            },
+                        ],
+                    },
+                    {
+                        id: SurveyEventName.SENT,
+                        type: 'events',
+                        properties: [
+                            {
+                                key: SurveyEventProperties.SURVEY_ID,
+                                type: PropertyFilterType.Event,
+                                value: 'survey-123',
+                                operator: PropertyOperator.Exact,
+                            },
+                            {
+                                key: SurveyEventProperties.SURVEY_COMPLETED,
+                                type: PropertyFilterType.Event,
+                                value: PropertyOperator.IsNotSet,
+                                operator: PropertyOperator.IsNotSet,
                             },
                         ],
                     },
@@ -232,36 +252,6 @@ describe('survey utils', () => {
                     },
                 ],
             })
-        })
-
-        it('also matches a sent event with no completion flag when partial responses are off', () => {
-            const sentBranches = getSurveyNotificationFilters('survey-123', false).events?.filter(
-                (event) => event.id === SurveyEventName.SENT
-            )
-
-            expect(sentBranches).toHaveLength(2)
-            expect(sentBranches?.[1].properties).toContainEqual({
-                key: SurveyEventProperties.SURVEY_COMPLETED,
-                type: PropertyFilterType.Event,
-                value: PropertyOperator.IsNotSet,
-                operator: PropertyOperator.IsNotSet,
-            })
-        })
-    })
-
-    // An API survey's `survey sent` events come from the integrator's own code, which has no reason
-    // to set `$survey_completed` — so requiring it left the notification silently matching nothing.
-    describe('surveyEmitsPartialSentEvents', () => {
-        it.each([
-            [SurveyType.Popover, true, true],
-            [SurveyType.Popover, false, false],
-            [SurveyType.Widget, true, true],
-            [SurveyType.API, true, false],
-            [SurveyType.API, false, false],
-        ])('%s with partial responses %s', (type, enablePartialResponses, expected) => {
-            expect(surveyEmitsPartialSentEvents({ type, enable_partial_responses: enablePartialResponses })).toBe(
-                expected
-            )
         })
     })
 

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -1378,29 +1378,19 @@ export function getSurveyDisplayConditionsSummary(survey: Survey | NewSurvey): S
 }
 
 /**
- * True when posthog-js emits an intermediate `survey sent` event per answered question, sharing one
- * `$survey_submission_id`, with only the last carrying `$survey_completed: true`. Requiring the
- * property to be `true` is what keeps a notification from firing once per question, so it is only
- * worth requiring here.
+ * posthog-js sets `$survey_completed` on every `survey sent` event, so an intermediate partial event
+ * carries an explicit `false` and only the final one carries `true`. Matching `= true` is what keeps
+ * a notification from firing once per answered question.
  *
- * An API survey has no posthog-js rendering it. The integrator sends one event per submission from
- * their own code and marks a partial one with an explicit `$survey_completed: false`, the way
- * posthog-js does, so absent means completed there whatever `enable_partial_responses` says.
- */
-export function surveyEmitsPartialSentEvents(survey: Pick<Survey, 'type' | 'enable_partial_responses'>): boolean {
-    return (survey.enable_partial_responses ?? false) && survey.type !== SurveyType.API
-}
-
-/**
- * Without intermediate partial events, posthog-js has no partial submission to distinguish a
- * complete one from, so it never sets `$survey_completed` and requiring `= true` matches nothing.
- * Accept the property being absent as completed too, the same way the response summary counts them
- * (`enable_partial_responses` branch in `ee/surveys/summaries/headline_summary.py`). An explicit
- * `false` stays excluded: a survey switched from partial to non-partial keeps its old partials.
+ * Every other producer leaves the property off the event entirely: the mobile SDKs do not implement
+ * partial responses, and an API survey's events come from the integrator's own code. Matching
+ * `= true` alone would notify no one for a completed submission there, so treat the property being
+ * absent as completed too, the same way the response summary counts them (`enable_partial_responses`
+ * branch in `ee/surveys/summaries/headline_summary.py`). An explicit `false` stays excluded, so a
+ * posthog-js partial event still does not notify.
  */
 export function getSurveyNotificationFilters(
     surveyId: string,
-    emitsPartialSentEvents: boolean,
     extraSentEventProperties: EventPropertyFilter[] = []
 ): CyclotronJobFiltersType {
     const surveyIdProperty: EventPropertyFilter = {
@@ -1439,15 +1429,11 @@ export function getSurveyNotificationFilters(
                 type: 'events',
                 properties: sentEventProperties,
             },
-            ...(emitsPartialSentEvents
-                ? []
-                : [
-                      {
-                          id: SurveyEventName.SENT,
-                          type: 'events' as const,
-                          properties: completedUnsetEventProperties,
-                      },
-                  ]),
+            {
+                id: SurveyEventName.SENT,
+                type: 'events',
+                properties: completedUnsetEventProperties,
+            },
             {
                 id: SurveyEventName.DISMISSED,
                 type: 'events',


### PR DESCRIPTION
## Problem

A survey notification never fires for a completed response when the survey uses an SDK other than posthog-js and has partial response collection turned on. The person gets alerted about dismissals and hears nothing about the responses they care about.

- Only posthog-js sets `$survey_completed` on a `survey sent` event. The mobile SDKs do not implement partial response collection, and an API survey's events come from the integrator's own code, so both leave the property off.
- The notification matched a completed response through `$survey_completed = true`. It matched a second branch for the property being absent only when the survey had partial response collection off.
- A survey with the setting on therefore matched no completed submission from those producers. The dismissal branch still fired, so a partial answer set reached the destination while the completed one did not.

## Changes

- A completed response from any SDK now reaches the notification destination. The branch that matches an event with no `$survey_completed` property is unconditional.
- Re-saving an affected notification repairs it. Sent branches were already rebuilt from freshly built filters on save.
- Mechanical: this removes `surveyEmitsPartialSentEvents` and the parameter that carried its result through four call sites. No caller needs the distinction now.
- Nothing looks different. The change only affects which events a notification matches.

The once-per-question guard still holds. posthog-js sets `$survey_completed` on every `survey sent` event, explicitly `false` on an intermediate partial one, so the absent-property branch cannot match a posthog-js partial event.

## How did you test this code?

- `frontend/src/scenes/surveys/utils.test.ts` and `frontend/src/scenes/surveys/surveyNotificationModalLogic.test.ts` pass.
- The filter-shape test now asserts all three branches, so dropping either sent branch fails it. This replaces a test that asserted the same branch only for the partial-off case, which is the case that was never broken.
- Read `sendSurveySentEvent` in posthog-ios and `sendSurveyEvent` in posthog-js to confirm which one sets the property.
- Checked the frontend lint and format.
- The full TypeScript check did not finish. The compiler exited with code 137 in this sandbox. The last complete run reported no errors in the changed files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No document under `docs/` covers survey notification triggers.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- The session started from a support question about a partial survey response missing from the results tab, and found this defect while confirming which SDK rendered the survey.
- The session invoked `/debugging-surveys`, `/writing-user-facing-copy`, `/writing-simplified-technical-english`, `/writing-tests`, and `/writing-pr-descriptions`.
- A search found no matching open issue and no matching open pull request. The public change contains no task-provided content.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
