### PR TITLE
fix: treat driver connect failures as transient

### DIFF
--- a/ee/clickhouse/test/test_error.py
+++ b/ee/clickhouse/test/test_error.py
@@ -1,6 +1,6 @@
 import pytest
 
-from clickhouse_driver.errors import ServerException
+from clickhouse_driver.errors import NetworkError, ServerException, SocketTimeoutError
 
 from posthog.clickhouse.client import sync_execute
 from posthog.errors import (
@@ -261,3 +261,14 @@ def test_memory_limit_wraps_by_which_ceiling_was_hit(message, expected_per_query
     if is_cluster:
         assert isinstance(wrapped, CH_TRANSIENT_ERRORS)
         assert classify_query_error(wrapped) == QueryErrorCategory.RATE_LIMITED
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        SocketTimeoutError("(clickhouse.example.com:9440)"),
+        NetworkError("Connection refused (clickhouse.example.com:9440)"),
+    ],
+)
+def test_failing_to_open_a_clickhouse_connection_is_transient(error):
+    assert isinstance(wrap_clickhouse_query_error(error), CH_TRANSIENT_ERRORS)

--- a/posthog/errors.py
+++ b/posthog/errors.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Optional
 
-from clickhouse_driver.errors import ServerException
+from clickhouse_driver.errors import NetworkError, ServerException, SocketTimeoutError
 
 from posthog.hogql.errors import ExposedHogQLError
 
@@ -1047,10 +1047,17 @@ CLICKHOUSE_ERROR_CODE_LOOKUP: dict[int, ErrorCodeMeta] = {
 # CHQueryErrorQueryWasCancelled (394) is deliberately absent: a deploy cancelling in-flight queries
 # and an operator or user deliberately killing one are indistinguishable at this layer, so callers
 # that want the deploy case retried opt in themselves (see COHORT_RECALCULATION_TRANSIENT_ERRORS).
+# The two clickhouse_driver classes are raised only while a connection is being opened (connect, or
+# the ping-then-reconnect on a stale pooled socket), before any query is sent, so nothing has run and
+# a retry is safe. They are not ServerExceptions, so wrap_clickhouse_query_error passes them through
+# untouched: a bare "Code: 209. (host:9440)" is the driver's 10s connect_timeout firing, typically
+# because a node dropped out of the cluster's load balancer for a few seconds.
 CH_TRANSIENT_ERRORS = (
     CHQueryErrorS3Error,
     CHQueryErrorS3FileChangedDuringRead,
     CHQueryErrorTableIsReadOnly,
     ClickHouseAtCapacity,
     ClickHouseClusterMemoryLimitExceeded,
+    NetworkError,
+    SocketTimeoutError,
 )

--- a/posthog/temporal/tests/test_alerts_activities.py
+++ b/posthog/temporal/tests/test_alerts_activities.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest_asyncio
 from asgiref.sync import sync_to_async
+from clickhouse_driver.errors import NetworkError, SocketTimeoutError
 from temporalio.exceptions import ApplicationError
 from temporalio.testing import ActivityEnvironment
 
@@ -491,7 +492,7 @@ class TestEvaluateAlert:
     # an error instead sends the alert silent until its next cadence slot, an hour for hourly ones.
     @pytest.mark.parametrize(
         "error_class",
-        [ClickHouseAtCapacity, ClickHouseClusterMemoryLimitExceeded],
+        [ClickHouseAtCapacity, ClickHouseClusterMemoryLimitExceeded, SocketTimeoutError, NetworkError],
     )
     async def test_evaluate_reraises_ch_transient_error(self, alert, error_class) -> None:
         with patch(


### PR DESCRIPTION
## Problem

An hourly alert whose ClickHouse connection times out is recorded as failed and emails its owner, even though the query never ran. The driver raises `SocketTimeoutError` (code 209) or `NetworkError` (code 210) from `connect()` when a node drops out of the cluster's load balancer for a few seconds. Neither is a `ServerException`, so `wrap_clickhouse_query_error` passes them through, and they were never in `CH_TRANSIENT_ERRORS`, so `evaluate_alert` records an error instead of re-raising for its retry policy.

## Changes

- Add the driver's `SocketTimeoutError` and `NetworkError` to `CH_TRANSIENT_ERRORS`. Alerts now retry a failed connect through `ALERT_EVALUATE_RETRY_POLICY` instead of failing the check.
- Everything else keyed off that tuple picks it up too: cohort recalculation, cache warming, exports, signals, and the Celery tasks that use it as `autoretry_for`.
- Both errors are raised only while a connection is being opened, before any query is sent, so a retry can't run anything twice.

## How did you test this code?

`pytest ee/clickhouse/test/test_error.py posthog/temporal/tests/test_alerts_activities.py`, plus the cohorts, exports, feature flag sync, cache warming, experiments and data catalog tests that import `CH_TRANSIENT_ERRORS`.

`test_failing_to_open_a_clickhouse_connection_is_transient` fails if either driver error drops out of the tuple or gets wrapped into a non-transient class. The two new `test_evaluate_reraises_ch_transient_error` cases fail if `evaluate_alert` goes back to recording a connect failure as an errored check.

Not run: repo-wide mypy.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No doc mentions `CH_TRANSIENT_ERRORS`.

## 🤖 Agent context

Claude Code wrote the change and tests after tracing a support ticket where a customer's hourly `$exception` alerts failed with `Code: 209.` during a short connectivity blip on the offline cluster. Skills used: writing-tests, writing-code-comments, writing-pr-descriptions. The fix was requested after the investigation; the diff and tests are agent-written.
