### PR TITLE
feat(marketing-analytics): filter traffic no integration reports cost for

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -30814,6 +30814,10 @@
         "IntegrationFilter": {
             "additionalProperties": false,
             "properties": {
+                "includeNonIntegrated": {
+                    "description": "Keep rows that no integration reports cost for, such as organic, email or an unmapped source. Defaults to true.",
+                    "type": "boolean"
+                },
                 "integrationSourceIds": {
                     "description": "Selected integration source IDs to filter by (e.g., table IDs or source map IDs)",
                     "items": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1919,6 +1919,8 @@ export interface CompareFilter {
 export interface IntegrationFilter {
     /** Selected integration source IDs to filter by (e.g., table IDs or source map IDs) */
     integrationSourceIds?: string[]
+    /** Keep rows that no integration reports cost for, such as organic, email or an unmapped source. Defaults to true. */
+    includeNonIntegrated?: boolean
 }
 
 /** `FunnelsFilterType` minus everything inherited from `FilterType` and persons modal related params */

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsFilters/IntegrationFilter.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsFilters/IntegrationFilter.tsx
@@ -20,12 +20,14 @@ export function IntegrationFilter(): JSX.Element {
     const allSourceIds = allAvailableSourcesWithStatus.map((s) => s.id)
     const isAllSelected = selectedIds.length === allSourceIds.length && allSourceIds.length > 0
     const isSomeSelected = selectedIds.length > 0 && selectedIds.length < allSourceIds.length
+    // Absent means included, so only an explicit false hides these rows.
+    const includeNonIntegrated = integrationFilter.includeNonIntegrated !== false
 
     const handleToggleAll = (): void => {
         if (isAllSelected || isSomeSelected) {
-            setIntegrationFilter({ integrationSourceIds: [] })
+            setIntegrationFilter({ integrationSourceIds: [], includeNonIntegrated })
         } else {
-            setIntegrationFilter({ integrationSourceIds: allSourceIds })
+            setIntegrationFilter({ integrationSourceIds: allSourceIds, includeNonIntegrated })
         }
     }
 
@@ -34,7 +36,11 @@ export function IntegrationFilter(): JSX.Element {
             ? selectedIds.filter((id) => id !== sourceId)
             : [...selectedIds, sourceId]
 
-        setIntegrationFilter({ integrationSourceIds: newIds })
+        setIntegrationFilter({ integrationSourceIds: newIds, includeNonIntegrated })
+    }
+
+    const handleToggleNonIntegrated = (): void => {
+        setIntegrationFilter({ integrationSourceIds: selectedIds, includeNonIntegrated: !includeNonIntegrated })
     }
 
     const formatSourceLabel = (source: { name: string; type: string; prefix?: string }): string => {
@@ -44,7 +50,7 @@ export function IntegrationFilter(): JSX.Element {
 
     const displayValue = (): string => {
         if (selectedIds.length === 0 || isAllSelected) {
-            return 'All integrations'
+            return includeNonIntegrated ? 'All integrations' : 'Integrated only'
         }
         if (selectedIds.length === 1) {
             const source = allAvailableSourcesWithStatus.find((s) => s.id === selectedIds[0])
@@ -101,6 +107,19 @@ export function IntegrationFilter(): JSX.Element {
                             </span>
                         </LemonButton>
                     ))}
+                    <div className="border-t border-border my-1" />
+                    <LemonButton
+                        fullWidth
+                        size="small"
+                        onClick={handleToggleNonIntegrated}
+                        className="justify-start"
+                        tooltip="Traffic no integration reports cost for, like organic, email, or a source you haven't mapped yet."
+                    >
+                        <span className="flex items-center gap-2">
+                            <LemonCheckbox checked={includeNonIntegrated} className="pointer-events-none" />
+                            <span className="flex-1">No integration</span>
+                        </span>
+                    </LemonButton>
                 </div>
             }
         >

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1721,6 +1721,13 @@ class IntegrationFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    includeNonIntegrated: bool | None = Field(
+        default=None,
+        description=(
+            "Keep rows that no integration reports cost for, such as organic, email or"
+            " an unmapped source. Defaults to true."
+        ),
+    )
     integrationSourceIds: list[str] | None = Field(
         default=None,
         description=("Selected integration source IDs to filter by (e.g., table IDs or source map IDs)"),

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -7659,6 +7659,8 @@ export const MarketingAnalyticsDrillDownLevelApi = {
 } as const
 
 export interface IntegrationFilterApi {
+    /** Keep rows that no integration reports cost for, such as organic, email or an unmapped source. Defaults to true. */
+    includeNonIntegrated?: boolean | null
     /** Selected integration source IDs to filter by (e.g., table IDs or source map IDs) */
     integrationSourceIds?: string[] | null
 }

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_table_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_table_query_runner.py
@@ -167,7 +167,11 @@ class MarketingAnalyticsTableQueryRunner(MarketingAnalyticsBaseQueryRunner[Marke
             return [campaign_alias, MarketingAnalyticsBaseColumns.SOURCE.value]
 
     def _build_paginated_query(
-        self, select_columns: list[ast.Expr], select_from: ast.JoinExpr | None, ctes=None
+        self,
+        select_columns: list[ast.Expr],
+        select_from: ast.JoinExpr | None,
+        ctes=None,
+        where: ast.Expr | None = None,
     ) -> ast.SelectQuery:
         """Build a paginated SelectQuery with common logic"""
         # Extract column names for order by
@@ -183,6 +187,7 @@ class MarketingAnalyticsTableQueryRunner(MarketingAnalyticsBaseQueryRunner[Marke
             select=select_columns,
             select_from=select_from,
             ctes=ctes,
+            where=where,
             order_by=order_by_exprs,
             limit=ast.Constant(value=actual_limit),
             offset=ast.Constant(value=offset),
@@ -192,7 +197,7 @@ class MarketingAnalyticsTableQueryRunner(MarketingAnalyticsBaseQueryRunner[Marke
         """Execute the query and return results with pagination support"""
         query = self.to_query()
         filtered_select = self._get_filtered_select_columns(query)
-        return self._build_paginated_query(filtered_select, query.select_from, query.ctes)
+        return self._build_paginated_query(filtered_select, query.select_from, query.ctes, query.where)
 
     def calculate_with_compare(self) -> ast.SelectQuery:
         """Execute the query and return results with pagination support"""
@@ -376,9 +381,16 @@ class MarketingAnalyticsTableQueryRunner(MarketingAnalyticsBaseQueryRunner[Marke
         if level == MarketingAnalyticsDrillDownLevel.CHANNEL_SOURCE:
             self._append_sessions_join(from_clause, joined_ctes, conversion_columns_mapping)
 
+        where = (
+            ast.Call(name="notEmpty", args=[self._cost_side_grouping_value()])
+            if self._non_integrated_rows_excluded()
+            else None
+        )
+
         return ast.SelectQuery(
             select=list(conversion_columns_mapping.values()),
             select_from=from_clause,
+            where=where,
         )
 
     def _append_sessions_join(
@@ -442,6 +454,22 @@ class MarketingAnalyticsTableQueryRunner(MarketingAnalyticsBaseQueryRunner[Marke
             base_join.next_join = current_join
         return initial_join
 
+    def _cost_side_grouping_value(self) -> ast.Expr:
+        """The cost side's grouping value, which is empty exactly when no cost row matched.
+
+        Every level puts its grouping value in this column — the campaign name at campaign level,
+        the channel or source at the others. Under `join_use_nulls = 0` an unmatched side returns
+        the type default, so an empty string here means the row came from the conversion side only.
+        """
+        return ast.Call(
+            name="toString",
+            args=[
+                ast.Field(
+                    chain=self.config.get_campaign_cost_field_chain(MarketingAnalyticsColumnsSchemaNames.CAMPAIGN)
+                )
+            ],
+        )
+
     def _null_without_cost_row(self, column: ast.Expr) -> ast.Expr:
         """Wrap a cost-side metric so it reads as absent, not as zero, when no cost row matched.
 
@@ -454,26 +482,17 @@ class MarketingAnalyticsTableQueryRunner(MarketingAnalyticsBaseQueryRunner[Marke
         guarded = ast.Call(
             name="if",
             args=[
-                ast.Call(
-                    name="empty",
-                    args=[
-                        ast.Call(
-                            name="toString",
-                            args=[
-                                ast.Field(
-                                    chain=self.config.get_campaign_cost_field_chain(
-                                        MarketingAnalyticsColumnsSchemaNames.CAMPAIGN
-                                    )
-                                )
-                            ],
-                        )
-                    ],
-                ),
+                ast.Call(name="empty", args=[self._cost_side_grouping_value()]),
                 ast.Constant(value=None),
                 expr,
             ],
         )
         return ast.Alias(alias=alias, expr=guarded) if alias else guarded
+
+    def _non_integrated_rows_excluded(self) -> bool:
+        """True when the user cleared the filter's non-integrated option."""
+        integration_filter = getattr(self.query, "integrationFilter", None)
+        return bool(integration_filter) and integration_filter.includeNonIntegrated is False
 
     def _build_order_by_exprs(self, select_columns: list[str]) -> list[ast.OrderExpr]:
         """Build ORDER BY expressions from query orderBy with proper null handling"""

--- a/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_table_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_table_query_runner.py
@@ -10,6 +10,7 @@ from posthog.schema import (
     ConversionGoalFilter1,
     ConversionGoalFilter3,
     DateRange,
+    IntegrationFilter,
     MarketingAnalyticsBaseColumns,
     MarketingAnalyticsDrillDownLevel,
     MarketingAnalyticsTableQuery,
@@ -756,6 +757,41 @@ class TestMarketingAnalyticsTableQueryRunner(ClickhouseTestMixin, BaseTest):
         no_spend_row = next(row for row in result.results if row[campaign_idx].value == "fall_sale_newsletter")
         assert no_spend_row[cost_idx].value is None
         assert no_spend_row[clicks_idx].value is None
+
+    def test_integration_filter_can_exclude_campaigns_with_no_ad_spend(self):
+        session_id = str(uuid7("2023-01-15"))
+        for event in ("$pageview", "purchase"):
+            _create_event(
+                team=self.team,
+                event=event,
+                distinct_id=session_id,
+                timestamp="2023-01-15",
+                properties={
+                    "$session_id": session_id,
+                    "utm_source": "newsletter",
+                    "utm_campaign": "fall_sale_newsletter",
+                },
+            )
+        flush_persons_and_events()
+
+        def campaigns_for(integration_filter: IntegrationFilter | None) -> set:
+            query = MarketingAnalyticsTableQuery(
+                dateRange=self.default_date_range,
+                limit=DEFAULT_LIMIT,
+                offset=0,
+                properties=[],
+                drillDownLevel=MarketingAnalyticsDrillDownLevel.CAMPAIGN,
+                draftConversionGoal=self._create_test_conversion_goal(goal_id="filter_goal"),
+                integrationFilter=integration_filter,
+            )
+            result = self._create_query_runner(query).calculate()
+            assert result.columns is not None
+            campaign_idx = result.columns.index(MarketingAnalyticsBaseColumns.CAMPAIGN)
+            return {row[campaign_idx].value for row in result.results}
+
+        assert "fall_sale_newsletter" in campaigns_for(None)
+        assert "fall_sale_newsletter" in campaigns_for(IntegrationFilter(includeNonIntegrated=True))
+        assert "fall_sale_newsletter" not in campaigns_for(IntegrationFilter(includeNonIntegrated=False))
 
     def test_channel_source_drill_down_emits_both_channel_and_source_columns(self):
         """The whole point of the composite level: Source survives as a column (it's excluded at

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -6697,6 +6697,8 @@ export const MarketingAnalyticsDrillDownLevelApi = {
 } as const
 
 export interface IntegrationFilterApi {
+    /** Keep rows that no integration reports cost for, such as organic, email or an unmapped source. Defaults to true. */
+    includeNonIntegrated?: boolean | null
     /** Selected integration source IDs to filter by (e.g., table IDs or source map IDs) */
     integrationSourceIds?: string[] | null
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -7906,6 +7906,8 @@ export namespace Schemas {
     } as const;
 
     export interface IntegrationFilter {
+      /** Keep rows that no integration reports cost for, such as organic, email or an unmapped source. Defaults to true. */
+      includeNonIntegrated?: boolean | null;
       /** Selected integration source IDs to filter by (e.g., table IDs or source map IDs) */
       integrationSourceIds?: string[] | null;
     }


### PR DESCRIPTION
## Problem

Picking one ad platform in the integrations filter still shows newsletter, push and organic rows. Someone who selects "Google Ads" to see what Google cost them gets rows Google never charged for.

The filter only ever narrowed the list of cost adapters. Nothing filtered the conversion side, and the final query carried no WHERE clause. Campaign level used to hide this by accident: under its LEFT JOIN every row had to come from the filtered cost side. #96746's parent removed that restriction, and channel, source and channel+source never had it.

## Changes

- The integrations filter gains a **No integration** option, checked by default. Nobody loses rows without asking for it.
- Clearing it drops every row the cost side never matched, at all four levels. On a project with 86 campaigns the table goes to 52.
- The filter button reads "Integrated only" when the option is off, so the state is visible without opening the dropdown.
- Turning it off at channel level also hides Organic Search, Direct and Email. That follows from what the option means, and is the most visible consequence to weigh.
- Mechanical: the WHERE now survives into the paginated query, which previously rebuilt the SelectQuery and dropped it.

The option keys off the cost side's grouping value, not off a UTM source mapped back to an integration id. That mapping cannot be done faithfully: the filter works in integration ids, one per connected account, while the conversion side only has a normalized source string. Two Google Ads accounts share the same source name, so a source-based filter cannot tell them apart and would quietly do nothing. Self-managed sources are worse, since their source name is user-configured. Asking "did this row come from the cost side at all" needs none of that, and the predicate already exists for the null-metric guard.

## How did you test this code?

New test: `test_integration_filter_can_exclude_campaigns_with_no_ad_spend`, covering the default, an explicit true, and an explicit false. It catches a runner that ignores the flag. It found a real bug while being written — the WHERE was built but the pagination wrapper discarded it, so the filter did nothing.

The compare path builds its own query, so the generated AST was inspected on both paths: the predicate appears once on the plain path and twice on compare, one per period.

The scene was loaded locally: the option renders last in the dropdown, checked; clearing it takes the campaign table from 86 rows to 52, and every remaining row has real spend.

Not verified: no Jest test covers this component. The filter had no backend test either before this PR.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`, `/writing-tests`, `/writing-ui-components`, `/writing-user-facing-copy`.

An automated review on the parent PR raised this gap and escalated it rather than guessing at the semantics, arguing that the only faithful fix needed a source-to-integration mapping that does not exist. This design sidesteps that: it asks a question about the row's origin instead of about its source name, which the existing predicate already answers.

The default is checked rather than always-on. An option that cannot be cleared would describe the gap without closing it.

Public artifact: nothing here comes from outside this repository.
