### PR TITLE
fix(tasks): require message-driven resume in sandbox snapshots

### DIFF
--- a/docs/published/handbook/engineering/ai/sandboxed-agents.md
+++ b/docs/published/handbook/engineering/ai/sandboxed-agents.md
@@ -492,6 +492,9 @@ user message echoes. Existing unmarked transcript entries are unchanged.
 Full filesystem snapshots contain an agent binary. Prewarmed resumes require its
 `prewarmedResumeMessageDriven` capability; the older `prewarmedResumeIdle` capability
 alone is insufficient. An incompatible snapshot uses the existing fresh-agent fallback.
+The check applies to ACP runs, because the capability belongs to the ACP agent server.
+Pi runs keep their snapshot, because the Pi server starts no turn of its own and loads
+its session history from the API.
 Publish the updated agent and rebuild sandbox images before deploying the stricter
 backend capability gate, so the fallback supplies a compatible agent.
 

--- a/docs/published/handbook/engineering/ai/sandboxed-agents.md
+++ b/docs/published/handbook/engineering/ai/sandboxed-agents.md
@@ -489,9 +489,11 @@ same-run restores stay idle until a message arrives. Internal recovery instructi
 use hidden content blocks; adapters and transcript rendering omit those blocks from
 user message echoes. Existing unmarked transcript entries are unchanged.
 
-The agent advertises `prewarmedResumeMessageDriven` alongside `prewarmedResumeIdle`.
-Publish the updated agent and rebuild sandbox images before changing backend snapshot
-compatibility checks to require the new capability.
+Full filesystem snapshots contain an agent binary. Prewarmed resumes require its
+`prewarmedResumeMessageDriven` capability; the older `prewarmedResumeIdle` capability
+alone is insufficient. An incompatible snapshot uses the existing fresh-agent fallback.
+Publish the updated agent and rebuild sandbox images before deploying the stricter
+backend capability gate, so the fallback supplies a compatible agent.
 
 ## Local development
 

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -498,7 +498,7 @@ class SandboxBase(ABC):
         )
         return result.exit_code == 0
 
-    def agent_server_supports_prewarmed_resume_idle(self) -> bool:
+    def agent_server_supports_prewarmed_resume_message_driven(self) -> bool:
         result = self.execute(
             "grep -q prewarmedResumeMessageDriven /scripts/node_modules/.bin/agent-server",
             timeout_seconds=10,

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -500,7 +500,7 @@ class SandboxBase(ABC):
 
     def agent_server_supports_prewarmed_resume_idle(self) -> bool:
         result = self.execute(
-            "grep -q prewarmedResumeIdle /scripts/node_modules/.bin/agent-server",
+            "grep -q prewarmedResumeMessageDriven /scripts/node_modules/.bin/agent-server",
             timeout_seconds=10,
         )
         return result.exit_code == 0

--- a/products/tasks/backend/logic/services/tests/test_docker_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_docker_sandbox.py
@@ -46,7 +46,7 @@ def test_prewarmed_resume_requires_message_driven_agent(
         return ExecutionResult(stdout=result.stdout, stderr=result.stderr, exit_code=result.returncode)
 
     with patch.object(sandbox, "execute", side_effect=execute_probe):
-        assert sandbox.agent_server_supports_prewarmed_resume_idle() is expected
+        assert sandbox.agent_server_supports_prewarmed_resume_message_driven() is expected
 
 
 def test_wait_for_agent_server_ready_timeout_is_retryable_and_not_captured(sandbox: DockerSandbox):

--- a/products/tasks/backend/logic/services/tests/test_docker_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_docker_sandbox.py
@@ -1,4 +1,6 @@
 import shlex
+import subprocess
+from pathlib import Path
 
 import pytest
 from unittest.mock import patch
@@ -20,6 +22,31 @@ def sandbox() -> DockerSandbox:
 
 def _log_result() -> ExecutionResult:
     return ExecutionResult(stdout="agent-server log", stderr="", exit_code=0)
+
+
+@pytest.mark.parametrize(
+    ("capabilities", "expected"),
+    [
+        ("", False),
+        ("prewarmedResumeIdle", False),
+        ("prewarmedResumeIdle prewarmedResumeMessageDriven", True),
+    ],
+)
+def test_prewarmed_resume_requires_message_driven_agent(
+    sandbox: DockerSandbox, tmp_path: Path, capabilities: str, expected: bool
+) -> None:
+    binary = tmp_path / "agent-server"
+    binary.write_text(capabilities)
+
+    def execute_probe(command: str, *, timeout_seconds: int) -> ExecutionResult:
+        args = shlex.split(command)
+        assert args[-1] == "/scripts/node_modules/.bin/agent-server"
+        args[-1] = str(binary)
+        result = subprocess.run(args, capture_output=True, text=True, timeout=timeout_seconds)
+        return ExecutionResult(stdout=result.stdout, stderr=result.stderr, exit_code=result.returncode)
+
+    with patch.object(sandbox, "execute", side_effect=execute_probe):
+        assert sandbox.agent_server_supports_prewarmed_resume_idle() is expected
 
 
 def test_wait_for_agent_server_ready_timeout_is_retryable_and_not_captured(sandbox: DockerSandbox):

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -319,7 +319,7 @@ def _prewarmed_resume_needs_fresh_agent(
     ):
         return False
     try:
-        return not sandbox.agent_server_supports_prewarmed_resume_idle()
+        return not sandbox.agent_server_supports_prewarmed_resume_message_driven()
     except Exception:
         logger.warning("prewarmed_resume_agent_capability_probe_failed", extra={"run_id": ctx.run_id})
         return True

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -298,10 +298,15 @@ def _prewarmed_resume_needs_fresh_agent(
     *,
     used_snapshot: bool,
 ) -> bool:
-    """Whether a full resume snapshot bundled an agent that cannot idle before the resumed prompt."""
+    """Whether a restored full snapshot bundled an agent that cannot idle before the resumed prompt.
+
+    A repository snapshot (``snapshot_id``) restores the same filesystem as a resume snapshot
+    (``snapshot_external_id``), so it supplies the snapshot's own agent binary too and needs the
+    same probe. Only a directory restore keeps the vetted image's agent.
+    """
     if (
         not used_snapshot
-        or prepared.snapshot_external_id is None
+        or (prepared.snapshot_external_id is None and prepared.snapshot_id is None)
         or prepared.snapshot_kind == SNAPSHOT_KIND_DIRECTORY
         or not (ctx.state or {}).get("prewarmed")
         or not (ctx.state or {}).get("resume_from_run_id")

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -304,6 +304,12 @@ def _prewarmed_resume_needs_fresh_agent(
     (``snapshot_external_id``), so it supplies the snapshot's own agent binary too and needs the
     same probe. Only a directory restore keeps the vetted image's agent.
     """
+    # `prewarmedResumeMessageDriven` is an ACP capability, advertised and consumed only by the
+    # ACP agent server. The Pi server dispatches no startup turn and downloads its session
+    # history from the API instead of the snapshot, so probing a Pi bundle for the string
+    # rejects a healthy snapshot and re-clones the repository for no behavior change.
+    if ctx.task_runtime == Task.Runtime.PI:
+        return False
     if (
         not used_snapshot
         or (prepared.snapshot_external_id is None and prepared.snapshot_id is None)

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox.py
@@ -246,7 +246,7 @@ def test_old_full_snapshot_agent_is_rejected_only_for_prewarmed_resume(
         snapshot_kind=snapshot_kind,
     )
     sandbox = mocker.Mock()
-    sandbox.agent_server_supports_prewarmed_resume_idle.return_value = capability
+    sandbox.agent_server_supports_prewarmed_resume_message_driven.return_value = capability
 
     assert _prewarmed_resume_needs_fresh_agent(context, prepared, sandbox, used_snapshot=True) is expected
 

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox.py
@@ -157,31 +157,53 @@ def test_sandbox_image_kind(image_source: str, custom_image_name: str | None, ex
 
 
 @pytest.mark.parametrize(
-    "snapshot_kind, state, capability, expected",
+    "snapshot_id, snapshot_external_id, snapshot_kind, state, capability, expected",
     [
         (
+            None,
+            "snapshot-1",
             SNAPSHOT_KIND_FILESYSTEM,
             {"prewarmed": True, "resume_from_run_id": "previous-run"},
             False,
             True,
         ),
         (
+            None,
+            "snapshot-1",
             SNAPSHOT_KIND_FILESYSTEM,
             {"prewarmed": True, "resume_from_run_id": "previous-run"},
             True,
             False,
         ),
         (
+            None,
+            "snapshot-1",
             SNAPSHOT_KIND_DIRECTORY,
             {"prewarmed": True, "resume_from_run_id": "previous-run"},
             False,
             False,
         ),
-        (SNAPSHOT_KIND_FILESYSTEM, {"resume_from_run_id": "previous-run"}, False, False),
+        (None, "snapshot-1", SNAPSHOT_KIND_FILESYSTEM, {"resume_from_run_id": "previous-run"}, False, False),
+        (
+            "snapshot-row-1",
+            None,
+            SNAPSHOT_KIND_FILESYSTEM,
+            {"prewarmed": True, "resume_from_run_id": "previous-run"},
+            False,
+            True,
+        ),
+        (
+            "snapshot-row-1",
+            None,
+            SNAPSHOT_KIND_DIRECTORY,
+            {"prewarmed": True, "resume_from_run_id": "previous-run"},
+            False,
+            False,
+        ),
     ],
 )
 def test_old_full_snapshot_agent_is_rejected_only_for_prewarmed_resume(
-    mocker, snapshot_kind, state, capability, expected
+    mocker, snapshot_id, snapshot_external_id, snapshot_kind, state, capability, expected
 ):
     context = _context_for_desktop_bootstrap()
     context.state = state
@@ -191,8 +213,8 @@ def test_old_full_snapshot_agent_is_rejected_only_for_prewarmed_resume(
         github_token="",
         branch=None,
         environment_variables={},
-        snapshot_id=None,
-        snapshot_external_id="snapshot-1",
+        snapshot_id=snapshot_id,
+        snapshot_external_id=snapshot_external_id,
         used_snapshot=True,
         should_create_snapshot=False,
         shallow_clone=True,

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox.py
@@ -157,9 +157,10 @@ def test_sandbox_image_kind(image_source: str, custom_image_name: str | None, ex
 
 
 @pytest.mark.parametrize(
-    "snapshot_id, snapshot_external_id, snapshot_kind, state, capability, expected",
+    "task_runtime, snapshot_id, snapshot_external_id, snapshot_kind, state, capability, expected",
     [
         (
+            Task.Runtime.ACP,
             None,
             "snapshot-1",
             SNAPSHOT_KIND_FILESYSTEM,
@@ -168,6 +169,7 @@ def test_sandbox_image_kind(image_source: str, custom_image_name: str | None, ex
             True,
         ),
         (
+            Task.Runtime.ACP,
             None,
             "snapshot-1",
             SNAPSHOT_KIND_FILESYSTEM,
@@ -176,6 +178,7 @@ def test_sandbox_image_kind(image_source: str, custom_image_name: str | None, ex
             False,
         ),
         (
+            Task.Runtime.ACP,
             None,
             "snapshot-1",
             SNAPSHOT_KIND_DIRECTORY,
@@ -183,8 +186,17 @@ def test_sandbox_image_kind(image_source: str, custom_image_name: str | None, ex
             False,
             False,
         ),
-        (None, "snapshot-1", SNAPSHOT_KIND_FILESYSTEM, {"resume_from_run_id": "previous-run"}, False, False),
         (
+            Task.Runtime.ACP,
+            None,
+            "snapshot-1",
+            SNAPSHOT_KIND_FILESYSTEM,
+            {"resume_from_run_id": "previous-run"},
+            False,
+            False,
+        ),
+        (
+            Task.Runtime.ACP,
             "snapshot-row-1",
             None,
             SNAPSHOT_KIND_FILESYSTEM,
@@ -193,9 +205,19 @@ def test_sandbox_image_kind(image_source: str, custom_image_name: str | None, ex
             True,
         ),
         (
+            Task.Runtime.ACP,
             "snapshot-row-1",
             None,
             SNAPSHOT_KIND_DIRECTORY,
+            {"prewarmed": True, "resume_from_run_id": "previous-run"},
+            False,
+            False,
+        ),
+        (
+            Task.Runtime.PI,
+            None,
+            "snapshot-1",
+            SNAPSHOT_KIND_FILESYSTEM,
             {"prewarmed": True, "resume_from_run_id": "previous-run"},
             False,
             False,
@@ -203,9 +225,10 @@ def test_sandbox_image_kind(image_source: str, custom_image_name: str | None, ex
     ],
 )
 def test_old_full_snapshot_agent_is_rejected_only_for_prewarmed_resume(
-    mocker, snapshot_id, snapshot_external_id, snapshot_kind, state, capability, expected
+    mocker, task_runtime, snapshot_id, snapshot_external_id, snapshot_kind, state, capability, expected
 ):
     context = _context_for_desktop_bootstrap()
+    context.task_runtime = task_runtime
     context.state = state
     prepared = PrepareSandboxForRepositoryOutput(
         sandbox_name="task-sandbox-task-id",


### PR DESCRIPTION
## Problem

PostHog AI can still start an extra turn after inactivity when a restored snapshot contains an older agent.
The agent fix in #96752 needs a matching snapshot compatibility check.

## Changes

- Prewarmed resumes use the existing fresh-agent fallback when a snapshot lacks message-driven resume support.
- The capability probe changes mechanically; regression cases and rollout documentation accompany it.

```diff
- prewarmedResumeIdle
+ prewarmedResumeMessageDriven
```

> [!WARNING]
> Merge only after the agent from #96752 is released and the sandbox image rebuild finishes.

## How did you test this code?

The Docker sandbox suite covers missing, older, and compatible capabilities through the executable probe. Local preflight also ran.
The release and image rollout remain unverified.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated `docs/published/handbook/engineering/ai/sandboxed-agents.md` with snapshot compatibility and release order.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used Git, gh stack, Flox, and pytest to extract this layer from #96752 and rebase it onto fresh master.
The code and fixtures already exist in that public PR. PR #96810 changes system prompts and does not replace this gate.

Skills: `debugging-ci-failures`, `posthog-desktop`, `stacking-prs`, `writing-tests`, `writing-code-comments`, `writing-user-facing-copy`, `running-ci-preflight`, `writing-pr-descriptions`.
