### PR TITLE
fix(tasks): stop bot comments waking the PR babysit loop

### DIFF
--- a/posthog/models/github_integration_base.py
+++ b/posthog/models/github_integration_base.py
@@ -1776,22 +1776,19 @@ class GitHubIntegrationBase:
                 {**item, "id": node.get("id"), "path": node.get("path"), "last_comment_id": item["id"] or ""}
             )
 
-        # A woken agent pushes, and a push ejects the PR from the merge queue whose bot was
-        # reporting on it, taking the whole batch with it (PostHog/posthog#96393). Review
-        # threads are exempt — an unresolved one is work somebody is waiting on.
         feedback: list[dict[str, Any]] = []
         for connection in ("comments", "reviews"):
             for node in ((pr.get(connection) or {}).get("nodes")) or []:
                 if not isinstance(node, dict):
                     continue
                 item = self._feedback_item(node)
-                if (
-                    item["id"]
-                    and item["body"].strip()
-                    and item["author"] != author_login
-                    and not self._is_bot_author(node)
-                ):
-                    feedback.append(item)
+                if not (item["id"] and item["body"].strip() and item["author"] != author_login):
+                    continue
+                # A bot review is code feedback. A bot comment is merge-queue and CI chatter,
+                # and waking on it makes the agent push the PR out of the queue (#96393).
+                if connection == "comments" and self._is_bot_author(node):
+                    continue
+                feedback.append(item)
 
         rollup_nodes = ((pr.get("commits") or {}).get("nodes")) or []
         rollup = ((rollup_nodes[0] or {}).get("commit") or {}).get("statusCheckRollup") if rollup_nodes else None

--- a/posthog/models/github_integration_base.py
+++ b/posthog/models/github_integration_base.py
@@ -1667,15 +1667,15 @@ class GitHubIntegrationBase:
             nodes {
               id isResolved path
               comments(last: 1) {
-                nodes { id url body author { login } authorAssociation }
+                nodes { id url body author { login __typename } authorAssociation }
               }
             }
           }
           comments(last: 30) {
-            nodes { id url body author { login } authorAssociation }
+            nodes { id url body author { login __typename } authorAssociation }
           }
           reviews(last: 10) {
-            nodes { id url body author { login } authorAssociation }
+            nodes { id url body author { login __typename } authorAssociation }
           }
           commits(last: 1) {
             nodes {
@@ -1741,6 +1741,12 @@ class GitHubIntegrationBase:
             "url": node.get("url"),
         }
 
+    @staticmethod
+    def _is_bot_author(node: dict[str, Any]) -> bool:
+        # GraphQL drops the `[bot]` login suffix REST adds, and authorAssociation says
+        # nothing about whether an author is automated.
+        return ((node.get("author") or {}).get("__typename")) == "Bot"
+
     def get_pull_request_babysit_snapshot(self, pr_url: str) -> dict[str, Any]:
         """Fetch the per-item PR state the babysit loop dispatches on: every unresolved
         review thread with its latest comment, top-level comments and review bodies,
@@ -1770,13 +1776,21 @@ class GitHubIntegrationBase:
                 {**item, "id": node.get("id"), "path": node.get("path"), "last_comment_id": item["id"] or ""}
             )
 
+        # A woken agent pushes, and a push ejects the PR from the merge queue whose bot was
+        # reporting on it, taking the whole batch with it (PostHog/posthog#96393). Review
+        # threads are exempt — an unresolved one is work somebody is waiting on.
         feedback: list[dict[str, Any]] = []
         for connection in ("comments", "reviews"):
             for node in ((pr.get(connection) or {}).get("nodes")) or []:
                 if not isinstance(node, dict):
                     continue
                 item = self._feedback_item(node)
-                if item["id"] and item["body"].strip() and item["author"] != author_login:
+                if (
+                    item["id"]
+                    and item["body"].strip()
+                    and item["author"] != author_login
+                    and not self._is_bot_author(node)
+                ):
                     feedback.append(item)
 
         rollup_nodes = ((pr.get("commits") or {}).get("nodes")) or []

--- a/posthog/models/test/integration/test_github.py
+++ b/posthog/models/test/integration/test_github.py
@@ -2122,7 +2122,14 @@ class TestGitHubIntegrationGraphQL(BaseTest):
 BABYSIT_PR_URL = "https://github.com/acme/widgets/pull/7"
 
 
-def _babysit_thread(thread_id: str, *, is_resolved: bool = False, author: str = "reviewer", body: str = "fix this"):
+def _babysit_thread(
+    thread_id: str,
+    *,
+    is_resolved: bool = False,
+    author: str = "reviewer",
+    body: str = "fix this",
+    is_bot: bool = False,
+):
     return {
         "id": thread_id,
         "isResolved": is_resolved,
@@ -2133,7 +2140,7 @@ def _babysit_thread(thread_id: str, *, is_resolved: bool = False, author: str = 
                     "id": f"{thread_id}-C1",
                     "url": f"{BABYSIT_PR_URL}#discussion_{thread_id}",
                     "body": body,
-                    "author": {"login": author},
+                    "author": {"login": author, "__typename": "Bot" if is_bot else "User"},
                     "authorAssociation": "MEMBER",
                 }
             ]
@@ -2141,12 +2148,12 @@ def _babysit_thread(thread_id: str, *, is_resolved: bool = False, author: str = 
     }
 
 
-def _babysit_feedback(node_id: str, *, author: str = "reviewer", body: str = "please rename"):
+def _babysit_feedback(node_id: str, *, author: str = "reviewer", body: str = "please rename", is_bot: bool = False):
     return {
         "id": node_id,
         "url": f"{BABYSIT_PR_URL}#issuecomment-{node_id}",
         "body": body,
-        "author": {"login": author},
+        "author": {"login": author, "__typename": "Bot" if is_bot else "User"},
         "authorAssociation": "MEMBER",
     }
 
@@ -2198,6 +2205,36 @@ class TestGitHubIntegrationPullRequestBabysitSnapshot(BaseTest):
 
         assert [thread["id"] for thread in result["unresolved_threads"]] == ["T2"]
         assert [comment["id"] for comment in result["comments"]] == ["M3", "R2"]
+
+    def test_bot_comments_and_review_bodies_are_dropped(self):
+        """A merge-queue or CI bot comments once per event, each with a fresh id, so every one
+        of them would wake the babysit loop — and the push that follows ejects the PR from the
+        very queue the bot was reporting on."""
+        payload = self._payload(
+            comments={
+                "nodes": [
+                    _babysit_feedback("M1", author="talyn-app", body="/trunk merge", is_bot=True),
+                    _babysit_feedback("M2", author="github-actions", body="## 🤖 CI report", is_bot=True),
+                    _babysit_feedback("M3"),
+                ]
+            },
+            reviews={"nodes": [_babysit_feedback("R1", author="stamphog", body="Approved.", is_bot=True)]},
+        )
+
+        with patch.object(GitHubIntegration, "_gh_graphql", return_value=payload):
+            result = self._github().get_pull_request_babysit_snapshot(BABYSIT_PR_URL)
+
+        assert [comment["id"] for comment in result["comments"]] == ["M3"]
+
+    def test_a_bot_review_thread_is_still_an_item_to_address(self):
+        """Deliberately not symmetric with the comment rule: an unresolved inline thread is work
+        somebody is waiting on, and it is keyed by its last comment id rather than re-arriving."""
+        payload = self._payload(reviewThreads={"nodes": [_babysit_thread("T1", author="review-bot", is_bot=True)]})
+
+        with patch.object(GitHubIntegration, "_gh_graphql", return_value=payload):
+            result = self._github().get_pull_request_babysit_snapshot(BABYSIT_PR_URL)
+
+        assert [thread["id"] for thread in result["unresolved_threads"]] == ["T1"]
 
     @parameterized.expand(
         [

--- a/posthog/models/test/integration/test_github.py
+++ b/posthog/models/test/integration/test_github.py
@@ -2206,30 +2206,28 @@ class TestGitHubIntegrationPullRequestBabysitSnapshot(BaseTest):
         assert [thread["id"] for thread in result["unresolved_threads"]] == ["T2"]
         assert [comment["id"] for comment in result["comments"]] == ["M3", "R2"]
 
-    def test_bot_comments_and_review_bodies_are_dropped(self):
-        """A merge-queue or CI bot comments once per event, each with a fresh id, so every one
-        of them would wake the babysit loop — and the push that follows ejects the PR from the
-        very queue the bot was reporting on."""
+    def test_bot_comments_are_dropped_and_bot_reviews_are_kept(self):
+        """A merge-queue bot comments once per submission, each with a fresh id, so every one
+        wakes the loop. A review bot writes the feedback the loop exists to act on."""
         payload = self._payload(
             comments={
                 "nodes": [
                     _babysit_feedback("M1", author="talyn-app", body="/trunk merge", is_bot=True),
-                    _babysit_feedback("M2", author="github-actions", body="## 🤖 CI report", is_bot=True),
+                    _babysit_feedback("M2", author="github-actions", body="CI report", is_bot=True),
                     _babysit_feedback("M3"),
                 ]
             },
-            reviews={"nodes": [_babysit_feedback("R1", author="stamphog", body="Approved.", is_bot=True)]},
+            reviews={"nodes": [_babysit_feedback("R1", author="review-hog", body="rename this", is_bot=True)]},
         )
 
         with patch.object(GitHubIntegration, "_gh_graphql", return_value=payload):
             result = self._github().get_pull_request_babysit_snapshot(BABYSIT_PR_URL)
 
-        assert [comment["id"] for comment in result["comments"]] == ["M3"]
+        assert [comment["id"] for comment in result["comments"]] == ["M3", "R1"]
 
-    def test_a_bot_review_thread_is_still_an_item_to_address(self):
-        """Deliberately not symmetric with the comment rule: an unresolved inline thread is work
-        somebody is waiting on, and it is keyed by its last comment id rather than re-arriving."""
-        payload = self._payload(reviewThreads={"nodes": [_babysit_thread("T1", author="review-bot", is_bot=True)]})
+    def test_a_bot_review_thread_is_kept(self):
+        """An unresolved inline thread is work somebody waits on, whoever opened it."""
+        payload = self._payload(reviewThreads={"nodes": [_babysit_thread("T1", author="review-hog", is_bot=True)]})
 
         with patch.object(GitHubIntegration, "_gh_graphql", return_value=payload):
             result = self._github().get_pull_request_babysit_snapshot(BABYSIT_PR_URL)


### PR DESCRIPTION
## Problem

- A PR sitting in the Trunk merge queue is knocked out of it when a bot comments, and every PR batched alongside it goes back too.
- The babysit loop wakes on any comment id it has not journalled yet. It filtered only the PR author's own comments, so merge-queue submissions, CI reports and auto-approvals all woke it.
- A woken agent works the PR and pushes. Trunk drops a PR on push: "removed from the merge queue because it was pushed to".
- A queue bot that comments once per submission drives the loop that undoes its own queue. #96393 shows it: a `/trunk merge` comment, a server-side branch update twelve seconds later, a resubmit eight seconds after that.

## Changes

- Bot comments no longer wake the loop. `get_pull_request_babysit_snapshot` drops top-level comments written by a GitHub App.
- Bot reviews still wake it. A review bot's body is the feedback the loop exists to act on, so the filter covers the `comments` connection only.
- Bot review threads still wake it. An unresolved thread is work somebody waits on, and it is keyed by its last comment id rather than arriving fresh per event.
- `__typename` identifies a bot, because GraphQL drops the `[bot]` login suffix that REST adds, and `authorAssociation` says nothing about automation.
- Mechanical: three author selections in the query gain `__typename`, and the test fixtures gain an `is_bot` flag.

> [!NOTE]
> This closes the wake path only. Nothing yet tells a woken agent to leave a PR alone while a merge queue holds it: `MERGE_PROHIBITION` forbids merging, enqueuing and approving, but not updating the branch. The repo's pre-push hook guards humans and CLI agents, not the sandbox loop.

## How did you test this code?

- Two cases in the babysit snapshot suite. One covers bot comments dropped with a bot review kept, the other a bot review thread kept.
- The first case was checked against both wrong versions. It fails with no filter, because the bot comments leak in. It fails with the filter applied to reviews too, because the bot review is lost.
- Not run: anything needing ClickHouse, and the wider Django suite. CI covers those.
- No manual testing. The behaviour is only reachable from a live Temporal babysit run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5). The work started from a person investigating a PR that left the merge queue without explanation.
- Skills invoked: `/writing-pr-descriptions`.
- The first version of this branch dropped bot reviews alongside bot comments. That removed real review feedback, so the filter was narrowed to top-level comments.
- No duplicate: `gh pr list --state open` searches for "babysit bot comments" and "babysit snapshot" return only this PR.
- Public artifact: the diff, its comments and this description come from public GitHub data on this repo. No customer or session material.

https://claude.ai/code/session_01XUh4zGKpX5L9mJc32RzqBP
