### PR TITLE
feat(conversations): default the support panel ticket list to unread

### DIFF
--- a/products/conversations/frontend/components/SidePanel/TicketsList.tsx
+++ b/products/conversations/frontend/components/SidePanel/TicketsList.tsx
@@ -7,7 +7,12 @@ import { LemonBadge, LemonButton, LemonSelect, LemonTag, Link, Spinner } from '@
 import { TZLabel } from 'lib/components/TZLabel'
 import { stripMarkdown } from 'lib/utils/markdown'
 
-import { statusOptions, type ConversationTicket } from '../../types'
+import {
+    type ConversationTicket,
+    type SidePanelTicketFilter,
+    sidePanelTicketFilterLabels,
+    sidePanelTicketFilterOrder,
+} from '../../types'
 import { sidepanelTicketsLogic } from './sidepanelTicketsLogic'
 
 interface TicketsListProps {
@@ -16,10 +21,20 @@ interface TicketsListProps {
 }
 
 export function TicketsList({ selectedTicketId = null }: TicketsListProps): JSX.Element {
-    const { tickets, filteredTickets, ticketsLoading, canCreateTicket, statusFilter } = useValues(sidepanelTicketsLogic)
+    const { tickets, filteredTickets, ticketsLoading, canCreateTicket, effectiveStatusFilter, ticketFilterCounts } =
+        useValues(sidepanelTicketsLogic)
     const { setCurrentTicket, setView, setStatusFilter } = useActions(sidepanelTicketsLogic)
 
     const hasIdentityMode = !!window.JS_POSTHOG_IDENTITY_DISTINCT_ID
+
+    // Unread / Active / All always show so the user can widen the view; a status only earns an
+    // entry once there's at least one ticket in it, which keeps the dropdown short.
+    const filterOptions = sidePanelTicketFilterOrder
+        .filter((filter) => ['unread', 'active', 'all'].includes(filter) || ticketFilterCounts[filter] > 0)
+        .map((filter) => ({
+            value: filter,
+            label: `${sidePanelTicketFilterLabels[filter]} (${ticketFilterCounts[filter]})`,
+        }))
 
     if (!hasIdentityMode && (!posthog.conversations || !posthog.conversations.isAvailable())) {
         return (
@@ -69,13 +84,13 @@ export function TicketsList({ selectedTicketId = null }: TicketsListProps): JSX.
                 <LemonSelect
                     size="small"
                     fullWidth
-                    value={statusFilter}
-                    onChange={(status) => {
+                    value={effectiveStatusFilter}
+                    onChange={(status: SidePanelTicketFilter | null) => {
                         if (status) {
                             setStatusFilter(status)
                         }
                     }}
-                    options={statusOptions}
+                    options={filterOptions}
                     data-attr="sidebar-ticket-status-filter"
                     className="shrink-0"
                 />
@@ -90,7 +105,29 @@ export function TicketsList({ selectedTicketId = null }: TicketsListProps): JSX.
                     </div>
                 ) : filteredTickets.length === 0 ? (
                     <div className="text-center text-muted-alt py-8">
-                        <p>No tickets with this status.</p>
+                        {effectiveStatusFilter === 'unread' ? (
+                            <>
+                                <p>You're all caught up.</p>
+                                <Link
+                                    className="text-sm"
+                                    onClick={() => setStatusFilter('active')}
+                                    data-attr="sidebar-ticket-filter-show-active"
+                                >
+                                    Show active tickets
+                                </Link>
+                            </>
+                        ) : (
+                            <>
+                                <p>No tickets match this filter.</p>
+                                <Link
+                                    className="text-sm"
+                                    onClick={() => setStatusFilter('all')}
+                                    data-attr="sidebar-ticket-filter-show-all"
+                                >
+                                    Show all tickets
+                                </Link>
+                            </>
+                        )}
                     </div>
                 ) : (
                     <div className="flex flex-col gap-1">
@@ -132,12 +169,16 @@ export function TicketsList({ selectedTicketId = null }: TicketsListProps): JSX.
                                         )}
                                     </div>
                                     {ticket.last_message && (
-                                        <p className="text-sm text-primary truncate m-0">
+                                        <p
+                                            className={`text-sm text-primary truncate m-0 ${
+                                                (ticket.unread_count ?? 0) > 0 ? 'font-semibold' : ''
+                                            }`}
+                                        >
                                             {stripMarkdown(ticket.last_message)}
                                         </p>
                                     )}
                                     <p className="text-xs text-muted-alt m-0 mt-1">
-                                        <TZLabel time={ticket.created_at} />
+                                        <TZLabel time={ticket.last_message_at ?? ticket.created_at} />
                                     </p>
                                 </div>
                                 <IconChevronRight className="text-muted-alt" />

--- a/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.test.ts
+++ b/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.test.ts
@@ -570,11 +570,60 @@ describe('sidepanelTicketsLogic', () => {
 
     // TicketsList renders filteredTickets, so a broken selector would show the wrong chats
     // (or none) once someone picks a status.
+    // Unread tickets sort first, then most recent activity, regardless of creation order.
     it.each([
-        ['all', ['t-open', 't-resolved']],
+        ['all', ['t-unread', 't-resolved', 't-open']],
+        ['active', ['t-unread', 't-open']],
+        ['unread', ['t-unread']],
         ['open', ['t-open']],
         ['resolved', ['t-resolved']],
-    ] as const)('filters the ticket list to status %s', async (status, expectedIds) => {
+    ] as const)('filters the ticket list to %s', async (filter, expectedIds) => {
+        logic = sidepanelTicketsLogic.build()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+
+        logic.actions.setTickets([
+            { id: 't-open', status: 'open', message_count: 1, created_at: '2026-07-13T00:00:00Z' },
+            { id: 't-resolved', status: 'resolved', message_count: 1, created_at: '2026-07-14T00:00:00Z' },
+            {
+                id: 't-unread',
+                status: 'pending',
+                message_count: 2,
+                unread_count: 1,
+                created_at: '2026-07-12T00:00:00Z',
+            },
+        ] as ConversationTicket[])
+        logic.actions.setStatusFilter(filter)
+
+        expect(logic.values.filteredTickets.map((ticket) => ticket.id)).toEqual(expectedIds)
+    })
+
+    it('counts tickets per filter for the dropdown labels', async () => {
+        logic = sidepanelTicketsLogic.build()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+
+        logic.actions.setTickets([
+            { id: 't-open', status: 'open', message_count: 1, unread_count: 2, created_at: '2026-07-13T00:00:00Z' },
+            { id: 't-resolved', status: 'resolved', message_count: 1, created_at: '2026-07-14T00:00:00Z' },
+            { id: 't-hold', status: 'on_hold', message_count: 1, created_at: '2026-07-12T00:00:00Z' },
+        ] as ConversationTicket[])
+
+        expect(logic.values.ticketFilterCounts).toEqual({
+            unread: 1,
+            active: 2,
+            all: 3,
+            new: 0,
+            open: 1,
+            pending: 0,
+            on_hold: 1,
+            resolved: 1,
+        })
+    })
+
+    // A long ticket history shouldn't bury the reply you're waiting on: with nothing chosen the
+    // list shows unread tickets when there are any, otherwise active ones, until the user picks.
+    it('defaults the filter to unread, then active, until the user chooses', async () => {
         logic = sidepanelTicketsLogic.build()
         logic.mount()
         await expectLogic(logic).toFinishAllListeners()
@@ -583,8 +632,17 @@ describe('sidepanelTicketsLogic', () => {
             { id: 't-open', status: 'open', message_count: 1, created_at: '2026-07-13T00:00:00Z' },
             { id: 't-resolved', status: 'resolved', message_count: 1, created_at: '2026-07-14T00:00:00Z' },
         ] as ConversationTicket[])
-        logic.actions.setStatusFilter(status)
+        expect(logic.values.effectiveStatusFilter).toBe('active')
+        expect(logic.values.filteredTickets.map((ticket) => ticket.id)).toEqual(['t-open'])
 
-        expect(logic.values.filteredTickets.map((ticket) => ticket.id)).toEqual(expectedIds)
+        logic.actions.setTickets([
+            { id: 't-open', status: 'open', message_count: 1, unread_count: 1, created_at: '2026-07-13T00:00:00Z' },
+            { id: 't-resolved', status: 'resolved', message_count: 1, created_at: '2026-07-14T00:00:00Z' },
+        ] as ConversationTicket[])
+        expect(logic.values.effectiveStatusFilter).toBe('unread')
+
+        logic.actions.setStatusFilter('all')
+        expect(logic.values.effectiveStatusFilter).toBe('all')
+        expect(logic.values.filteredTickets.map((ticket) => ticket.id)).toEqual(['t-open', 't-resolved'])
     })
 })

--- a/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.ts
+++ b/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.ts
@@ -40,9 +40,27 @@ import type {
     ConversationMessage,
     ConversationTicket,
     RestoreFlowState,
+    SidePanelTicketFilter,
     SidePanelViewState,
-    TicketStatus,
 } from '../../types'
+
+function ticketMatchesFilter(ticket: ConversationTicket, filter: SidePanelTicketFilter): boolean {
+    switch (filter) {
+        case 'all':
+            return true
+        case 'unread':
+            return (ticket.unread_count ?? 0) > 0
+        case 'active':
+            return ticket.status !== 'resolved'
+        default:
+            return ticket.status === filter
+    }
+}
+
+/** Most recent activity on a ticket, for ordering. Falls back to creation when nothing was said yet. */
+function ticketActivityTime(ticket: ConversationTicket): number {
+    return new Date(ticket.last_message_at ?? ticket.created_at).getTime() || 0
+}
 
 // Poll cadence scales with how actively the user is looking at support, so an open thread stays
 // fresh without every idle tab hammering the widget once a minute.
@@ -100,6 +118,7 @@ export interface sidepanelTicketsLogicValues {
     supportResponseTime: string | null // supportLogic
     canCreateTicket: boolean
     currentTicket: ConversationTicket | null
+    effectiveStatusFilter: SidePanelTicketFilter
     filteredTickets: ConversationTicket[]
     hasMoreMessages: boolean
     hasSupportExemption: boolean
@@ -112,7 +131,8 @@ export interface sidepanelTicketsLogicValues {
     pendingTicketId: string | null
     restoreError: string | null
     restoreState: RestoreFlowState
-    statusFilter: TicketStatus | 'all'
+    statusFilter: SidePanelTicketFilter | null
+    ticketFilterCounts: Record<SidePanelTicketFilter, number>
     tickets: ConversationTicket[]
     ticketsLoading: boolean
     totalUnreadCount: number
@@ -200,8 +220,8 @@ export interface sidepanelTicketsLogicActions {
     setRestoreState: (state: RestoreFlowState) => {
         state: RestoreFlowState
     }
-    setStatusFilter: (status: TicketStatus | 'all') => {
-        status: TicketStatus | 'all'
+    setStatusFilter: (status: SidePanelTicketFilter) => {
+        status: SidePanelTicketFilter
     }
     setTickets: (tickets: ConversationTicket[]) => {
         tickets: ConversationTicket[]
@@ -227,7 +247,15 @@ export interface sidepanelTicketsLogicActions {
 export interface sidepanelTicketsLogicMeta {
     __keaTypeGenInternalSelectorTypes: {
         totalUnreadCount: (tickets: ConversationTicket[]) => number
-        filteredTickets: (tickets: ConversationTicket[], statusFilter: TicketStatus | 'all') => ConversationTicket[]
+        effectiveStatusFilter: (
+            statusFilter: SidePanelTicketFilter | null,
+            totalUnreadCount: number
+        ) => SidePanelTicketFilter
+        ticketFilterCounts: (tickets: ConversationTicket[]) => Record<SidePanelTicketFilter, number>
+        filteredTickets: (
+            tickets: ConversationTicket[],
+            effectiveStatusFilter: SidePanelTicketFilter
+        ) => ConversationTicket[]
         canCreateTicket: (
             billing: BillingType | null,
             isCurrentOrganizationNew: boolean,
@@ -301,7 +329,7 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
         restoreFromUrlToken: (token: string) => ({ token }),
         setRestoreState: (state: RestoreFlowState) => ({ state }),
         setRestoreError: (error: string | null) => ({ error }),
-        setStatusFilter: (status: TicketStatus | 'all') => ({ status }),
+        setStatusFilter: (status: SidePanelTicketFilter) => ({ status }),
     }),
     reducers({
         view: [
@@ -390,8 +418,10 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
                 setRestoreState: () => null,
             },
         ],
+        // `null` means "not chosen yet": the list then defaults to unread tickets when there are
+        // any, otherwise to active ones, so a long history never buries what needs attention.
         statusFilter: [
-            'all' as TicketStatus | 'all',
+            null as SidePanelTicketFilter | null,
             {
                 setStatusFilter: (_, { status }) => status,
             },
@@ -412,10 +442,47 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
             (s) => [s.tickets],
             (tickets: ConversationTicket[]) => tickets.reduce((sum, t) => sum + (t.unread_count ?? 0), 0),
         ],
+        effectiveStatusFilter: [
+            (s) => [s.statusFilter, s.totalUnreadCount],
+            (statusFilter: SidePanelTicketFilter | null, totalUnreadCount: number): SidePanelTicketFilter =>
+                statusFilter ?? (totalUnreadCount > 0 ? 'unread' : 'active'),
+        ],
+        ticketFilterCounts: [
+            (s) => [s.tickets],
+            (tickets: ConversationTicket[]): Record<SidePanelTicketFilter, number> => {
+                const counts: Record<SidePanelTicketFilter, number> = {
+                    unread: 0,
+                    active: 0,
+                    all: tickets.length,
+                    new: 0,
+                    open: 0,
+                    pending: 0,
+                    on_hold: 0,
+                    resolved: 0,
+                }
+                for (const ticket of tickets) {
+                    counts[ticket.status] += 1
+                    if (ticket.status !== 'resolved') {
+                        counts.active += 1
+                    }
+                    if ((ticket.unread_count ?? 0) > 0) {
+                        counts.unread += 1
+                    }
+                }
+                return counts
+            },
+        ],
+        // Unread threads float to the top, then most recent activity, so the reply you're waiting
+        // on isn't buried under older tickets that happened to be created later.
         filteredTickets: [
-            (s) => [s.tickets, s.statusFilter],
-            (tickets: ConversationTicket[], statusFilter: TicketStatus | 'all'): ConversationTicket[] =>
-                statusFilter === 'all' ? tickets : tickets.filter((t) => t.status === statusFilter),
+            (s) => [s.tickets, s.effectiveStatusFilter],
+            (tickets: ConversationTicket[], effectiveStatusFilter: SidePanelTicketFilter): ConversationTicket[] =>
+                tickets
+                    .filter((ticket) => ticketMatchesFilter(ticket, effectiveStatusFilter))
+                    .sort((a, b) => {
+                        const unreadDelta = Number((b.unread_count ?? 0) > 0) - Number((a.unread_count ?? 0) > 0)
+                        return unreadDelta !== 0 ? unreadDelta : ticketActivityTime(b) - ticketActivityTime(a)
+                    }),
         ],
         // Opening a ticket is the paid part of support. Reading and replying to tickets already in
         // the account isn't — free plans can end up with tickets via billing questions or PostHog AI

--- a/products/conversations/frontend/types.ts
+++ b/products/conversations/frontend/types.ts
@@ -233,6 +233,35 @@ export interface ChatMessage {
     hasFullEmailContent?: boolean
 }
 
+/**
+ * Filter for the support side panel's ticket list. `unread` and `active` (everything not resolved)
+ * are the two views people actually want when they have more than a handful of tickets; the
+ * individual statuses stay available for drilling in.
+ */
+export type SidePanelTicketFilter = 'unread' | 'active' | 'all' | TicketStatus
+
+export const sidePanelTicketFilterLabels: Record<SidePanelTicketFilter, string> = {
+    unread: 'Unread',
+    active: 'Active',
+    all: 'All',
+    new: 'New',
+    open: 'Open',
+    pending: 'Pending',
+    on_hold: 'On hold',
+    resolved: 'Resolved',
+}
+
+export const sidePanelTicketFilterOrder: SidePanelTicketFilter[] = [
+    'unread',
+    'active',
+    'all',
+    'new',
+    'open',
+    'pending',
+    'on_hold',
+    'resolved',
+]
+
 export const statusOptions: { value: TicketStatus | 'all'; label: string }[] = [
     { value: 'all', label: 'All statuses' },
     { value: 'new', label: 'New' },


### PR DESCRIPTION
## Problem

- A user with a long support history opens the Support side panel and sees every ticket ever created under "All statuses", so the reply they are waiting on can sit below a screen of resolved and new tickets.
- The list sorted by creation time, so a ticket with a fresh support reply did not move up.

## Changes

- The list opens on unread tickets when there are any, otherwise on active tickets (everything not resolved). Picking a filter overrides that for as long as the panel is open.
- Unread tickets sort first, then by latest activity. Each row shows the time of the last message instead of the creation time, and the preview is bold while unread.
- The filter dropdown offers "Unread", "Active", and "All" with counts, and lists a status only when at least one ticket has it.
- Empty lists point somewhere: an empty unread view says "You're all caught up" and links to active tickets; other empty filters link to all tickets.
- The full-screen My tickets page shares this list, so it gets the same default, counts, and order. The ticket that is open stays in the list and at the top while its thread shows, because opening it marks it read and it would otherwise drop out of the unread view.
- Mechanical: a `SidePanelTicketFilter` type with its labels in the conversations frontend types. The support team's tickets scene keeps its own filter and is untouched.

Auto default rather than a fixed "Active" default: a fixed default still buries a new reply under newer active tickets. Unread first surfaces it, and the fallback to active keeps the list from opening empty.

| Before | After |
| --- | --- |
| ![support-panel-before](https://raw.githubusercontent.com/PostHog/pr-assets/6b93c101d160081c492c4c3d46ca79d4ac16d2f6/2026/09/c8015a24-9e5e-4af0-bce6-7bd16e279616.png) | ![support-panel-after](https://raw.githubusercontent.com/PostHog/pr-assets/fb1a35afde0441ec746c9bafb33afebdc1d31128/2026/09/3317ca20-eb0f-4b19-9159-26690f79d527.png) |

## How did you test this code?

- Jest, `sidepanelTicketsLogic.test.ts`: cases for the unread and active filters, the per-filter counts, the default sequence unread → active → explicit choice, and the open ticket staying listed while its thread shows. Each fails without the new selectors; the existing status cases now also assert the unread-first order.
- Rendered locally against a project seeded with 20 invented tickets across all five statuses (screenshots above).
- Not run: Playwright or Storybook for this panel, since neither covers the ticket list.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No doc under `docs/` describes the side panel ticket list.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Claude Fable 5.1) wrote the change in a local session directed by the assignee, who asked for the panel to default to open or unread tickets after seeing it with many tickets. The shipped version adds the auto default, the counted filter options, and the unread-first sort on top of that request. Skills read: writing-pr-descriptions, writing-user-facing-copy. A search of open PRs found none touching this list; #82067 and #89223 cover other support surfaces. All ticket data in the screenshots is invented seed data.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added side-panel ticket filters for unread, active, all, and individual ticket statuses.
  - Filter options now show ticket counts and automatically select the most relevant view.
  - Unread tickets are highlighted and sorted first.
  - Tickets are sorted by recent activity, using creation time as a fallback.
  - Empty filter results now provide context-specific messaging and navigation.

- **Bug Fixes**
  - The currently open ticket remains visible while it is being marked as read.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->