### PR TITLE
fix(warehouse-sources): explain empty schema discovery

### DIFF
--- a/products/warehouse_sources/backend/presentation/views/external_data_schema.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_schema.py
@@ -1933,6 +1933,16 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 data={"message": str(e)},
             )
 
+        if not schemas:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={
+                    "message": f"Could not discover schema {instance.name}. The connection may be missing SELECT or "
+                    "schema access privileges, or discovery may not support this relation type. Check that the "
+                    "relation exists, restore read privileges, or expose it as a supported table or view, then try again."
+                },
+            )
+
         # Not every source honors the `names` filter (e.g. Slack returns all schemas regardless), so
         # `schemas` may contain unrelated tables in any order. Pick the one that matches this schema
         # instead of trusting `schemas[0]`, whose metadata could belong to a different table.

--- a/products/warehouse_sources/backend/presentation/views/external_data_schema.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_schema.py
@@ -1935,12 +1935,12 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         if not schemas:
             return Response(
-                status=status.HTTP_400_BAD_REQUEST,
                 data={
                     "message": f"Could not discover schema {instance.name}. The connection may be missing SELECT or "
                     "schema access privileges, or discovery may not support this relation type. Check that the "
                     "relation exists, restore read privileges, or expose it as a supported table or view, then try again."
                 },
+                status=status.HTTP_400_BAD_REQUEST,
             )
 
         # Not every source honors the `names` filter (e.g. Slack returns all schemas regardless), so

--- a/products/warehouse_sources/backend/tests/api/test_external_data_schema.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_schema.py
@@ -43,6 +43,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.bas
     WebhookSyncResult,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.redshift.source import RedshiftSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.stripe.source import StripeSource
 from products.warehouse_sources.backend.tests.api.utils import create_external_data_source_ok
 
@@ -487,9 +488,46 @@ class TestExternalDataSchema(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["supports_webhooks"] is True
 
-    def test_incremental_fields_returns_400_when_schema_name_absent(self):
+    @parameterized.expand(
+        [
+            (
+                "empty_discovery",
+                RedshiftSource,
+                [],
+                "Could not discover schema C999. The connection may be missing SELECT or schema access privileges, "
+                "or discovery may not support this relation type. Check that the relation exists, restore read "
+                "privileges, or expose it as a supported table or view, then try again.",
+            ),
+            (
+                "nonempty_discovery",
+                RedshiftSource,
+                [SourceSchema(name="$channels", supports_incremental=False, supports_append=False)],
+                "Schema with name C999 not found",
+            ),
+            (
+                "nonempty_api_discovery",
+                StripeSource,
+                [SourceSchema(name="$channels", supports_incremental=False, supports_append=False)],
+                "Schema with name C999 not found",
+            ),
+        ]
+    )
+    def test_incremental_fields_returns_400_when_schema_name_absent(
+        self, _name, source_class, discovered_schemas, expected_message
+    ):
         source = ExternalDataSource.objects.create(
-            team=self.team, source_type=ExternalDataSourceType.STRIPE, job_inputs={"stripe_secret_key": "test_key"}
+            team=self.team,
+            source_type=source_class().source_type,
+            job_inputs={
+                "host": "localhost",
+                "port": 5439,
+                "database": "dev",
+                "user": "test",
+                "password": "test",
+                "schema": "public",
+            }
+            if source_class is RedshiftSource
+            else {"stripe_secret_key": "test_key"},
         )
         schema = ExternalDataSchema.objects.create(
             name="C999",
@@ -500,19 +538,16 @@ class TestExternalDataSchema(APIBaseTest):
             sync_type=ExternalDataSchema.SyncType.WEBHOOK,
         )
 
-        other_schemas = [
-            SourceSchema(name="$channels", supports_incremental=False, supports_append=False, supports_webhooks=False),
-        ]
-
         with (
-            mock.patch.object(StripeSource, "validate_credentials", return_value=(True, None)),
-            mock.patch.object(StripeSource, "get_schemas", return_value=other_schemas),
+            mock.patch.object(source_class, "validate_credentials", return_value=(True, None)),
+            mock.patch.object(source_class, "get_schemas", return_value=discovered_schemas),
         ):
             response = self.client.post(
                 f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}/incremental_fields",
             )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {"message": expected_message}
 
     def test_update_schema_change_sync_type(self):
         source = ExternalDataSource.objects.create(


### PR DESCRIPTION
## Problem

**Why:** The sync-method editor reports an unreadable relation as missing, without explaining how to restore discovery.

Closes #96903. This diagnostic-only PR addresses criteria 1, 2, and 4; criterion 3 remains for a separate recovery PR.

## Changes

Empty discovery now suggests checking relation existence, SELECT/schema privileges, and supported relation types. Nonempty unmatched discovery retains its existing error.

Scope stays inside the schema view and adjacent tests. No pipeline kernel, merge strategy, SQL source base, or base source contract changes.

## How did you test this code?

The new empty-discovery regression failed before the fix; both unmatched-name cases passed. The schema-view and Redshift pytest files pass locally, as do `ruff check --fix` and `ruff format`. No live Redshift cluster or browser verification.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## Agent context

**Autonomy:** Human-driven (agent-assisted).

Codex used shell, GitHub CLI, and PostHog signed-commit tools. Skills: improving-drf-endpoints, writing-tests, writing-user-facing-copy, writing-pr-descriptions, investigating-ci-failures. Duplicate search found no matching fix. Test inputs are invented; no private source material is included.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

