### PR TITLE
fix(warehouse-sources): allow full refresh recovery without discovery

### DIFF
--- a/products/warehouse_sources/backend/presentation/views/external_data_schema.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_schema.py
@@ -74,8 +74,18 @@ from products.warehouse_sources.backend.presentation.views.source_api_versions i
     ExternalDataSourceApiVersionDeprecationSerializer,
     api_version_deprecation_payload,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql.base import SQLSource
 
 logger = structlog.get_logger(__name__)
+
+
+def schema_discovery_message(name: str) -> str:
+    return (
+        f"Could not discover schema {name}. The connection may be missing SELECT or schema access privileges, "
+        "or discovery may not support this relation type. Check that the relation exists, restore read "
+        "privileges, or expose it as a supported table or view, then try again."
+    )
 
 
 def source_supports_column_selection(source_type: str) -> bool:
@@ -796,6 +806,14 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
                     "It requires a Postgres heap table or materialized view on PostgreSQL 13+."
                 )
 
+        if self._sql_sync_type_check_applies(instance):
+            self._is_webhook_only_schema_cached(instance)
+            if not self._schema_discovery_available:
+                raise ValidationError(
+                    "Only full table replication can be saved while schema discovery is unavailable. "
+                    "Restore read privileges or expose a supported relation before selecting another sync method."
+                )
+
         # Reject non-webhook sync types for webhook-only schemas (e.g. Stripe Discount —
         # no API list endpoint, so anything other than webhook produces an empty sync).
         if self._webhook_only_check_applies():
@@ -1179,6 +1197,7 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
         return schema.api_version or schema.source.api_version
 
     def _is_webhook_only_schema(self, schema: ExternalDataSchema) -> bool:
+        self._schema_discovery_available = False
         source = schema.source
         if not source.job_inputs:
             return False
@@ -1197,7 +1216,16 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
             )
         except Exception:
             return False
+        self._schema_discovery_available = any(
+            discovered_schema.name == schema.name for discovered_schema in source_schemas
+        )
         return any(s.name == schema.name and s.webhook_only for s in source_schemas)
+
+    def _sql_sync_type_check_applies(self, schema: ExternalDataSchema) -> bool:
+        data = self.initial_data if isinstance(self.initial_data, dict) else {}
+        if data.get("sync_type") in (None, ExternalDataSchema.SyncType.FULL_REFRESH):
+            return False
+        return isinstance(SourceRegistry.get_source(ExternalDataSourceType(schema.source.source_type)), SQLSource)
 
     def _xmin_available_for_schema(self, schema: ExternalDataSchema) -> bool:
         """True when the source advertises xmin support for this table (Postgres heap table or
@@ -1230,13 +1258,14 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
         first (outside the transaction) does the network work up front; update() then reads the cached
         result and still raises per-schema, so failures stay isolated to one schema.
         """
-        if self._webhook_only_check_applies():
+        if self._webhook_only_check_applies() or self._sql_sync_type_check_applies(instance):
             self._is_webhook_only_schema_cached(instance)
 
     def seed_webhook_only_check(self, webhook_only: bool) -> None:
         """Pre-fill the webhook-only cache when the caller already discovered this table (e.g.
         bulk sync-defaults filling), so warm_webhook_only_check doesn't re-probe the source."""
         self.__dict__["_webhook_only_result"] = webhook_only
+        self._schema_discovery_available = True
 
     def _webhook_only_check_applies(self) -> bool:
         # Single source of truth for when the webhook-only check runs, so update() and the
@@ -1889,6 +1918,18 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         return Response(status=status.HTTP_200_OK)
 
+    def _full_refresh_recovery_response(self, instance: ExternalDataSchema) -> Response:
+        response = self._incremental_fields_response(
+            SourceSchema(name=instance.name, supports_incremental=False, supports_append=False), instance.source
+        )
+        response.data.update(
+            cdc_available=False,
+            xmin_available=False,
+            message=schema_discovery_message(instance.name)
+            + " You can save full table replication, but syncing still requires read access.",
+        )
+        return response
+
     @action(methods=["POST"], detail=True)
     def incremental_fields(self, request: Request, *args: Any, **kwargs: Any):
         instance: ExternalDataSchema = self.get_object()
@@ -1910,6 +1951,8 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             config, self.team_id, instance.name, api_version=effective_api_version
         )
         if not credentials_valid:
+            if isinstance(new_source, SQLSource):
+                return self._full_refresh_recovery_response(instance)
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"message": credentials_error or "Invalid credentials"},
@@ -1928,18 +1971,18 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             error_text = str(e)
             if not any(pattern and pattern in error_text for pattern in new_source.get_non_retryable_errors()):
                 capture_exception(e)
+            if isinstance(new_source, SQLSource):
+                return self._full_refresh_recovery_response(instance)
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"message": str(e)},
             )
 
         if not schemas:
+            if isinstance(new_source, SQLSource):
+                return self._full_refresh_recovery_response(instance)
             return Response(
-                data={
-                    "message": f"Could not discover schema {instance.name}. The connection may be missing SELECT or "
-                    "schema access privileges, or discovery may not support this relation type. Check that the "
-                    "relation exists, restore read privileges, or expose it as a supported table or view, then try again."
-                },
+                data={"message": schema_discovery_message(instance.name)},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -1952,6 +1995,9 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST, data={"message": f"Schema with name {instance.name} not found"}
             )
 
+        return self._incremental_fields_response(schema, source)
+
+    def _incremental_fields_response(self, schema: SourceSchema, source: ExternalDataSource) -> Response:
         # job_inputs is an EncryptedJSONField: booleans round-trip as "True"/"False"
         # strings, so bool(...) would treat "False" as truthy. str_to_bool decodes both.
         source_cdc_enabled = str_to_bool(source.job_inputs.get("cdc_enabled"))

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py
@@ -949,6 +949,10 @@ class TestGetColumns:
 
         assert impl.get_columns(conn, _make_config(), names=["foo"]) == {}
 
+        with patch.object(_REDSHIFT_IMPLEMENTATION, "connect") as connect:
+            connect.return_value.__enter__.return_value = conn
+            assert RedshiftSource().get_schemas(_make_config(), team_id=1, names=["foo"]) == []
+
     def test_excludes_redshift_internal_columns(self, impl):
         # Discovery must drop the `padb_internal_*` columns Redshift stamps onto materialized
         # views — they never come back from `SELECT *`, so surfacing them desyncs the schema.

--- a/products/warehouse_sources/backend/tests/api/test_external_data_schema.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_schema.py
@@ -43,6 +43,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.bas
     WebhookSyncResult,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source import PostgresSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.redshift.source import RedshiftSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.stripe.source import StripeSource
 from products.warehouse_sources.backend.tests.api.utils import create_external_data_source_ok
@@ -492,7 +493,7 @@ class TestExternalDataSchema(APIBaseTest):
         [
             (
                 "empty_discovery",
-                RedshiftSource,
+                StripeSource,
                 [],
                 "Could not discover schema C999. The connection may be missing SELECT or schema access privileges, "
                 "or discovery may not support this relation type. Check that the relation exists, restore read "
@@ -975,6 +976,11 @@ class TestExternalDataSchema(APIBaseTest):
             request_body["primary_key_columns"] = payload_pk
 
         with (
+            mock.patch.object(
+                PostgresSource,
+                "get_schemas",
+                return_value=[SourceSchema(name=schema.name, supports_incremental=True, supports_append=True)],
+            ),
             mock.patch(
                 "products.warehouse_sources.backend.presentation.views.external_data_schema.is_cdc_enabled_for_team",
                 return_value=True,
@@ -1021,9 +1027,12 @@ class TestExternalDataSchema(APIBaseTest):
             table=table,
         )
 
-        with mock.patch(
-            "products.warehouse_sources.backend.presentation.views.external_data_schema.is_cdc_enabled_for_team",
-            return_value=True,
+        with (
+            mock.patch(
+                "products.warehouse_sources.backend.presentation.views.external_data_schema.is_cdc_enabled_for_team",
+                return_value=True,
+            ),
+            self._xmin_discovery_patch(),
         ):
             response = self.client.patch(
                 f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
@@ -1265,6 +1274,7 @@ class TestExternalDataSchema(APIBaseTest):
         )
 
         with (
+            self._xmin_discovery_patch(),
             mock.patch(
                 "products.warehouse_sources.backend.presentation.views.external_data_schema.trigger_external_data_workflow"
             ) as mock_trigger,
@@ -2051,6 +2061,11 @@ class TestExternalDataSchema(APIBaseTest):
         )
 
         with (
+            mock.patch.object(
+                PostgresSource,
+                "get_schemas",
+                return_value=[SourceSchema(name=schema.name, supports_incremental=False, supports_append=False)],
+            ),
             mock.patch(
                 "products.warehouse_sources.backend.presentation.views.external_data_schema.external_data_workflow_exists",
                 return_value=False,
@@ -2106,6 +2121,211 @@ class TestExternalDataSchema(APIBaseTest):
 
         assert response.status_code == 200
         mock_get_or_create.assert_not_called()
+
+
+class TestSQLSchemaRecovery(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_type=ExternalDataSourceType.REDSHIFT,
+            job_inputs={
+                "host": "localhost",
+                "port": 5439,
+                "database": "dev",
+                "user": "test",
+                "password": "test",
+                "schema": "public",
+            },
+        )
+        self.schema = ExternalDataSchema.objects.create(
+            name="public.orders",
+            team=self.team,
+            source=self.source,
+            should_sync=False,
+            sync_type=ExternalDataSchema.SyncType.INCREMENTAL,
+            sync_type_config={"primary_key_columns": ["id"], "incremental_field": "updated_at"},
+        )
+
+    @parameterized.expand(
+        [
+            ("empty", True, None),
+            ("discovery_error", True, psycopg.errors.InsufficientPrivilege("permission denied for relation")),
+            ("invalid_credentials", False, None),
+        ]
+    )
+    def test_discovery_unavailable_offers_and_saves_only_full_refresh(self, _name, valid_credentials, discovery_error):
+        original_config = self.schema.sync_type_config.copy()
+        with (
+            mock.patch.object(RedshiftSource, "validate_credentials", return_value=(valid_credentials, "Read denied")),
+            mock.patch.object(RedshiftSource, "get_schemas", return_value=[], side_effect=discovery_error),
+            mock.patch(
+                "products.warehouse_sources.backend.presentation.views.external_data_schema.sync_external_data_job_workflow"
+            ),
+            mock.patch(
+                "products.warehouse_sources.backend.presentation.views.external_data_schema.external_data_workflow_exists",
+                return_value=False,
+            ),
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.pk}/external_data_schemas/{self.schema.id}/incremental_fields"
+            )
+            assert response.status_code == 200
+            payload = response.json()
+            assert payload.pop("message") == (
+                "Could not discover schema public.orders. The connection may be missing SELECT or schema access "
+                "privileges, or discovery may not support this relation type. Check that the relation exists, "
+                "restore read privileges, or expose it as a supported table or view, then try again. "
+                "You can save full table replication, but syncing still requires read access."
+            )
+            assert payload == {
+                "incremental_fields": [],
+                "incremental_available": False,
+                "append_available": False,
+                "cdc_available": False,
+                "xmin_available": False,
+                "full_refresh_available": True,
+                "supports_webhooks": False,
+                "webhook_only": False,
+                "available_columns": [],
+                "detected_primary_keys": None,
+            }
+            self.schema.refresh_from_db()
+            assert self.schema.sync_type == ExternalDataSchema.SyncType.INCREMENTAL
+            assert self.schema.should_sync is False
+            assert self.schema.sync_type_config == original_config
+
+            response = self.client.patch(
+                f"/api/environments/{self.team.pk}/external_data_schemas/{self.schema.id}/",
+                data={
+                    "should_sync": True,
+                    "sync_type": "full_refresh",
+                    "incremental_field": None,
+                    "incremental_field_type": None,
+                    "incremental_field_lookback_seconds": None,
+                    "primary_key_columns": None,
+                },
+            )
+            assert response.status_code == 200, response.json()
+        self.schema.refresh_from_db()
+        assert self.schema.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH
+        assert self.schema.should_sync is True
+
+    @parameterized.expand(
+        [
+            (sync_type, raises)
+            for sync_type in ("incremental", "append", "cdc", "webhook", "xmin")
+            for raises in (False, True)
+        ]
+    )
+    def test_discovery_unavailable_blocks_unverified_sync_types(self, sync_type, raises):
+        self.schema.sync_type = ExternalDataSchema.SyncType.FULL_REFRESH
+        self.schema.save()
+        with (
+            mock.patch.object(
+                RedshiftSource,
+                "get_schemas",
+                return_value=[],
+                side_effect=RuntimeError("Discovery unavailable") if raises else None,
+            ),
+            mock.patch(
+                "products.warehouse_sources.backend.presentation.views.external_data_schema.is_cdc_enabled_for_team",
+                return_value=True,
+            ),
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.pk}/external_data_schemas/{self.schema.id}/",
+                data={
+                    "sync_type": sync_type,
+                    "incremental_field": "id",
+                    "incremental_field_type": "integer",
+                    "primary_key_columns": ["id"],
+                },
+            )
+        assert response.status_code == 400
+        expected_error = (
+            "xmin replication is only available for Postgres sources"
+            if sync_type == "xmin"
+            else "Only full table replication can be saved while schema discovery is unavailable"
+        )
+        assert expected_error in str(response.json())
+        self.schema.refresh_from_db()
+        assert self.schema.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH
+
+    def test_successful_discovery_preserves_capabilities_and_incremental_save(self):
+        discovered = SourceSchema(
+            name=self.schema.name,
+            supports_incremental=True,
+            supports_append=True,
+            incremental_fields=[{"field": "id", "label": "id", "type": "integer", "field_type": "integer"}],
+            columns=[("id", "integer", False)],
+            detected_primary_keys=["id"],
+        )
+        with (
+            mock.patch.object(RedshiftSource, "validate_credentials", return_value=(True, None)),
+            mock.patch.object(RedshiftSource, "get_schemas", return_value=[discovered]),
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.pk}/external_data_schemas/{self.schema.id}/incremental_fields"
+            )
+            assert response.status_code == 200
+            assert response.json() == {
+                "incremental_fields": discovered.incremental_fields,
+                "incremental_available": True,
+                "append_available": True,
+                "cdc_available": None,
+                "xmin_available": None,
+                "full_refresh_available": True,
+                "supports_webhooks": False,
+                "webhook_only": False,
+                "available_columns": [{"field": "id", "label": "id", "type": "integer", "nullable": False}],
+                "detected_primary_keys": ["id"],
+            }
+            response = self.client.patch(
+                f"/api/environments/{self.team.pk}/external_data_schemas/{self.schema.id}/",
+                data={"sync_type": "incremental", "incremental_field": "id", "incremental_field_type": "integer"},
+            )
+            assert response.status_code == 200, response.json()
+        self.schema.refresh_from_db()
+        assert self.schema.incremental_field == "id"
+
+    @parameterized.expand([("full_refresh", 200), ("append", 400), ("webhook", 400)])
+    def test_bulk_update_reuses_failed_discovery(self, sync_type, expected_status):
+        with mock.patch.object(RedshiftSource, "get_schemas", return_value=[]) as discovery:
+            response = self.client.patch(
+                f"/api/environments/{self.team.pk}/external_data_sources/{self.source.id}/bulk_update_schemas",
+                data={"schemas": [{"id": str(self.schema.id), "sync_type": sync_type}]},
+                format="json",
+            )
+        assert response.status_code == expected_status, response.json()
+        discovery.assert_called_once()
+        self.schema.refresh_from_db()
+        assert self.schema.sync_type == (
+            ExternalDataSchema.SyncType.FULL_REFRESH
+            if expected_status == 200
+            else ExternalDataSchema.SyncType.INCREMENTAL
+        )
+
+    def test_bulk_defaults_reuse_successful_discovery(self):
+        self.schema.sync_type = None
+        self.schema.save()
+        discovered = SourceSchema(
+            name=self.schema.name,
+            supports_incremental=True,
+            supports_append=True,
+            incremental_fields=[{"field": "id", "label": "id", "type": "integer", "field_type": "integer"}],
+            detected_primary_keys=["id"],
+        )
+        with mock.patch.object(RedshiftSource, "get_schemas", return_value=[discovered]) as discovery:
+            response = self.client.patch(
+                f"/api/environments/{self.team.pk}/external_data_sources/{self.source.id}/bulk_update_schemas",
+                data={"schemas": [{"id": str(self.schema.id), "apply_sync_defaults": True}]},
+                format="json",
+            )
+        assert response.status_code == 200, response.json()
+        discovery.assert_called_once()
+        self.schema.refresh_from_db()
+        assert self.schema.sync_type == ExternalDataSchema.SyncType.INCREMENTAL
 
 
 class TestUpdateExternalDataSchema:
@@ -2569,6 +2789,11 @@ class TestUpdateExternalDataSchema:
             status=ExternalDataSource.Status.RUNNING,
             source_type=ExternalDataSourceType.POSTGRES,
             job_inputs={
+                "host": "localhost",
+                "port": 5432,
+                "database": "dev",
+                "user": "test",
+                "password": "test",
                 "schema": "",
                 "cdc_enabled": True,
                 "cdc_management_mode": "posthog",
@@ -2594,6 +2819,11 @@ class TestUpdateExternalDataSchema:
         )
 
         with (
+            mock.patch.object(
+                PostgresSource,
+                "get_schemas",
+                return_value=[SourceSchema(name=schema.name, supports_incremental=True, supports_append=True)],
+            ),
             mock.patch(
                 "products.warehouse_sources.backend.presentation.views.external_data_schema.is_cdc_enabled_for_team",
                 return_value=True,


### PR DESCRIPTION
## Problem

**Why:** Existing SQL schemas cannot leave a failing incremental sync when live discovery blocks the sync-method editor.

Refs #96903. Builds on [#96905](https://github.com/PostHog/posthog/pull/96905), which closes the issue for the diagnostic split; recovery criterion 3 lands here.

## Changes

The editor receives full-refresh-only capabilities when SQL discovery is empty, raises, or credential validation fails. Successful discovery and nonempty unmatched-name errors retain their behavior.

Raw saves cannot select unverified broader sync modes. Bulk saves reuse discovery outside their write transactions.

> [!WARNING]
> This changes product behavior. Product sign-off requested before merge: allow full-refresh configuration without live discovery. Syncing still requires read access.
> The existing form offers a usable save path without frontend edits, but does not display the recovery response's optional diagnostic message.

Before:
```mermaid
flowchart LR
    Schema[Existing SQL schema] --> Discovery[Discovery unavailable] --> Blocked[Editor blocked]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class Schema,Blocked phYellow;
    class Discovery phRed;
```

After:
```mermaid
flowchart LR
    Schema[Existing SQL schema] --> Discovery[Discovery unavailable] --> Recovery[Full refresh only] --> Save[Save configuration]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    class Schema,Save phYellow;
    class Discovery phRed;
    class Recovery phBlue;
```

Scope: schema view, adjacent API tests, and Redshift tests only. No pipeline kernel, merge strategy, SQL source base, or base source contract changes.

## How did you test this code?

Real pytest red/green runs cover recovery responses, the form's exact save payload, raw/bulk capability guards, and successful discovery. The schema-view, Redshift, SQL-base, and access-control test files pass locally. Ruff lint/fix and formatting pass.

Frontend consumers were inspected, not browser-tested. No live Redshift cluster verification.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None pending product sign-off.

## Agent context

**Autonomy:** Human-driven (agent-assisted).

Codex used shell, GitHub CLI, and PostHog signed-commit tools. Skills: improving-drf-endpoints, writing-tests, writing-user-facing-copy, writing-pr-descriptions, announcing-behavior-changes, investigating-ci-failures. Tests use invented inputs only. This layer updates PR1's SQL empty-state expectation; the stack keeps diagnostics reviewable separately.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

