### PR TITLE
chore(tasks): give stream token tests their own signing key

### DIFF
--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -8272,7 +8272,10 @@ class TestTaskRunAPI(BaseTaskAPITest):
         self.assertNotIn("user_id", decoded)
         self.assertIn("exp", decoded)
 
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     def test_stream_token_returns_proxy_url_when_configured_and_flag_enabled(self):
+        reset_sandbox_jwt_key_cache()
+
         task = self.create_task()
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
 
@@ -8285,9 +8288,12 @@ class TestTaskRunAPI(BaseTaskAPITest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["stream_base_url"], "https://agent-proxy.example.com")
 
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     def test_stream_token_omits_proxy_url_for_thin_tail_run(self):
         # Only the Django read leg serves the durable backlog, so a thin-tail run must
         # never be routed to the agent-proxy even with the proxy flag enabled.
+        reset_sandbox_jwt_key_cache()
+
         task = self.create_task()
         run = TaskRun.objects.create(
             task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS, state={"stream_thin_tail": True}
@@ -8302,7 +8308,10 @@ class TestTaskRunAPI(BaseTaskAPITest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsNone(response.json()["stream_base_url"])
 
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     def test_stream_token_omits_proxy_url_when_flag_disabled(self):
+        reset_sandbox_jwt_key_cache()
+
         task = self.create_task()
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
 
@@ -8323,7 +8332,10 @@ class TestTaskRunAPI(BaseTaskAPITest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsNone(response.json()["stream_base_url"])
 
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     def test_stream_token_returns_proxy_url_for_pi_when_flag_disabled(self):
+        reset_sandbox_jwt_key_cache()
+
         task = self.create_task(runtime=Task.Runtime.PI)
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
 
@@ -8342,8 +8354,11 @@ class TestTaskRunAPI(BaseTaskAPITest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["stream_base_url"], "https://agent-proxy.example.com")
 
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     def test_stream_token_returns_proxy_url_in_debug_without_flag(self):
         # Local dev (DEBUG) disables the analytics SDK, so the URL setting alone opts in.
+        reset_sandbox_jwt_key_cache()
+
         task = self.create_task()
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
 
@@ -8353,8 +8368,11 @@ class TestTaskRunAPI(BaseTaskAPITest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["stream_base_url"], "http://localhost:8003")
 
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     def test_stream_token_omits_proxy_url_when_flag_evaluation_fails(self):
         # A flag-service outage must fall back to reading from Django, not break token issuance.
+        reset_sandbox_jwt_key_cache()
+
         task = self.create_task()
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
 


### PR DESCRIPTION
## Problem

An external contributor sees six backend tests fail on their pull request, and they cannot fix it from their fork. [PR #84625](https://github.com/PostHog/posthog/pull/84625) is the current example, in the `products/tasks` shard of [this run](https://github.com/PostHog/posthog/actions/runs/34266901157/job/102206546069).

- A fork pull request gets no repository variables, so `SANDBOX_JWT_PRIVATE_KEY` in `.github/workflows/ci-backend.yml` resolves to an empty string. The same run reports `RUNS_ON_INTERNAL_PR: false`, and an internal run from the same minute resolves the variable to the fake key.
- Six stream token tests in `TestTaskRunAPI` read that setting from the environment instead of supplying a key.
- `_key_registry` then raises `ValueError: SANDBOX_JWT_PRIVATE_KEY setting is required`, and `stream_token` answers 500.

## Changes

- Nothing user-visible changes. This is a test-only change.
- The six tests now carry `@override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)` and call `reset_sandbox_jwt_key_cache()`, the same as every sibling token test. Each test is now hermetic, so no CI variable and no test ordering can decide the result.
- The workflow still hands fork runs an empty key. This PR removes the tests' dependence on it rather than changing how CI supplies it.

## How did you test this code?

Ran the six tests with `SANDBOX_JWT_PRIVATE_KEY` unset, which reproduces the fork condition. Before the change all six fail with the CI error; after it all six pass.

<details>
<summary>Local run</summary>

```
$ unset SANDBOX_JWT_PRIVATE_KEY
$ pytest products/tasks/backend/tests/test_api.py -k "stream_token and proxy_url" -q -p no:randomly

# on master
6 failed, 937 deselected
ValueError: SANDBOX_JWT_PRIVATE_KEY setting is required

# with this change
6 passed, 937 deselected
```

</details>

The change adds no coverage; it removes an environment dependency from existing setup. The regression it guards is a test that passes only because CI exports a key.

Not checked: the rest of the `products/tasks` suite, and the frontend. The local dev stack served Postgres, ClickHouse and Redis, while its Celery and ingestion processes crashed and stayed down.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The PostHog Slack app diagnosed the failure from a Slack thread and wrote this change under human direction. It compared the job environment of the failing fork run against an internal run to identify the empty variable, then reproduced and fixed the failure locally.

Skills invoked: `/writing-tests` and `/writing-pr-descriptions`.

No duplicate: `gh pr list --state open --search "SANDBOX_JWT_PRIVATE_KEY"` found no open pull request for this.

Public artifact: the work started from a Slack thread. The diff, the commit message, and this description carry no thread contents.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09ADEV3AJD/p1788896166177649?thread_ts=1788896166.177649&cid=C09ADEV3AJD)*
