### PR TITLE
fix(experiments): Add note for 'hide' setting on an empty list

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentRecordingsListEmptyState.test.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentRecordingsListEmptyState.test.tsx
@@ -8,7 +8,7 @@ import { expectLogic } from 'kea-test-utils'
 
 import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
-import { playerSettingsLogic } from 'scenes/session-recordings/player/playerSettingsLogic'
+import { HideViewedRecordingsOptions, playerSettingsLogic } from 'scenes/session-recordings/player/playerSettingsLogic'
 import {
     DEFAULT_RECORDING_FILTERS,
     SessionRecordingPlaylistLogicProps,
@@ -302,6 +302,38 @@ describe('ExperimentRecordingsListEmptyState', () => {
 
         logic.unmount()
     })
+
+    // The server removes the recordings this setting hides before it answers, so they never reach
+    // the browser, `hiddenRecordingsCount` stays zero, and the reason reads as if nothing were
+    // hidden. The note is the only thing that tells the viewer otherwise. 'any-user' hides what the
+    // whole project watched, so copy about this viewer's own watching would be false there.
+    it.each([
+        ['current-user', 214, 'Recordings you have already watched are hidden'],
+        ['any-user', 215, 'Recordings anyone on your team has already watched are hidden'],
+    ] as [HideViewedRecordingsOptions, number, string][])(
+        'notes the %s setting next to the reason it could account for',
+        async (mode, experimentId, copy) => {
+            teamLogic.actions.loadCurrentTeamSuccess(MOCK_DEFAULT_TEAM)
+            playerSettingsLogic.actions.setHideViewedRecordings(mode)
+            const experiment = {
+                ...EXPERIMENT,
+                id: experimentId,
+                start_date: daysAgo(10),
+                end_date: daysAgo(2),
+            } as Experiment
+            const logic = experimentReplayTabLogic({ experiment })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+
+            renderEmptyState(experiment)
+
+            const emptyState = screen.getByTestId('experiment-recordings-empty-state')
+            expect(emptyState).toHaveTextContent('A session can be missing for a few reasons')
+            expect(emptyState).toHaveTextContent(copy)
+
+            logic.unmount()
+        }
+    )
 
     it('answers with the hidden recordings instead of a reason when the list only looks empty', async () => {
         teamLogic.actions.loadCurrentTeamSuccess(MOCK_DEFAULT_TEAM)

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentRecordingsListEmptyState.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentRecordingsListEmptyState.tsx
@@ -236,7 +236,21 @@ export function ExperimentRecordingsListEmptyState({ experiment }: { experiment:
                 would claim an answer the request has not given yet. The caption above the playlist
                 carries the wait. */}
             {hiddenRecordingsCount === 0 && !sessionBucketLoading && (
-                <ReasonBanner reason={listEmptyReason} context={listEmptyContext} onAction={runAction} />
+                <>
+                    <ReasonBanner reason={listEmptyReason} context={listEmptyContext} onAction={runAction} />
+                    {/* The reason above is a guess from an empty list, and this setting can empty the
+                        list on its own. The server removes the recordings it hides before it answers,
+                        so they never reach the browser and the count above stays zero for them.
+                        'any-user' hides what the whole project watched, so the copy has to say whose
+                        watching emptied the list. */}
+                    {recordingsAreHidden && (
+                        <p className="text-secondary text-xs">
+                            {hideViewedRecordings === 'any-user'
+                                ? 'Recordings anyone on your team has already watched are hidden, so this list can be empty for that reason alone.'
+                                : 'Recordings you have already watched are hidden, so this list can be empty for that reason alone.'}
+                        </p>
+                    )}
+                </>
             )}
         </div>
     )


### PR DESCRIPTION
## Problem

A viewer on an experiment's Recordings tab who hides recordings they have already watched can read a guess as a fact.

- The empty state names a cause: no recordings for the variant, a narrowed filter, an ad blocker, or a retention window.
- The hide-viewed setting is applied server-side, so the rows it removes never reach the browser.
- Nothing in the tab accounts for those rows, so the reason renders as if none were hidden.
- The setting is off by default, so this reaches only the viewers who chose it.

## Changes

- The empty state keeps its reason and adds one line under it: "Recordings you have already watched are hidden, so this list can be empty for that reason alone."
- "Hide all viewed recordings" excludes what anyone in the project watched, so that mode names the team rather than the viewer.
- The note is secondary text, not a second banner, so it reads as a caveat instead of competing with the reason.

It is gated on the setting alone, which the browser already knows. No API field and no new state.

> [!NOTE]
> No screenshot: this sandbox has no dev stack, so the tab was never rendered in a browser. The new cases assert the copy in jsdom instead.

## How did you test this code?

One parameterized test in `ExperimentRecordingsListEmptyState.test.tsx`, a row per hide-viewed mode.

It catches the note going missing, and the two modes swapping copy. A viewer in "Hide all viewed recordings" mode would otherwise read a false claim about their own watching. The nearest existing case covers the opposite branch, where the browser hid the rows itself. Reverting the component change fails both rows.

Ran that suite, oxlint, and oxfmt. No backend, kea logic, or generated type changed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No page under `docs/` describes this empty state.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code in a PostHog cloud task. Skills invoked: `/writing-tests`.

An earlier version added a `viewed_recordings_hidden` field to the recordings list response and plumbed it through the playlist logic. It withheld the reason entirely whenever the server reported hidden rows. That was cut to the client-side note above, and the branch rebuilt as one commit.

The tradeoff: the note shows for every viewer with the setting on, whether or not this query lost rows. Only the server can tell the difference, and asking it cost the plumbing.

No duplicate: `gh pr list --state open --search "hide_viewed_recordings"` returns only this PR.

Public artifact: nothing here carries material from the session.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
