### PR TITLE
feat(ingestion): probe the source before a limited distinct-id move

### DIFF
--- a/nodejs/src/common/persons/repositories/person-repository-transaction.ts
+++ b/nodejs/src/common/persons/repositories/person-repository-transaction.ts
@@ -52,6 +52,8 @@ export interface PersonRepositoryTransaction {
 
     fetchPersonDistinctIds(person: InternalPerson, limit?: number): Promise<string[]>
 
+    hasMoreDistinctIdsThan(person: InternalPerson, limit: number): Promise<boolean>
+
     updateCohortsAndFeatureFlagsForMerge(
         teamId: Team['id'],
         sourcePersonID: InternalPerson['id'],

--- a/nodejs/src/common/persons/repositories/postgres-person-repository-transaction.ts
+++ b/nodejs/src/common/persons/repositories/postgres-person-repository-transaction.ts
@@ -101,6 +101,10 @@ export class PostgresPersonRepositoryTransaction implements PersonRepositoryTran
         return await this.repository.fetchPersonDistinctIds(person, limit, this.transaction)
     }
 
+    async hasMoreDistinctIdsThan(person: InternalPerson, limit: number): Promise<boolean> {
+        return await this.repository.hasMoreDistinctIdsThan(person, limit, this.transaction)
+    }
+
     async updateCohortsAndFeatureFlagsForMerge(
         teamID: Team['id'],
         sourcePersonID: InternalPerson['id'],

--- a/nodejs/src/common/persons/repositories/postgres-person-repository.test.ts
+++ b/nodejs/src/common/persons/repositories/postgres-person-repository.test.ts
@@ -1313,14 +1313,30 @@ describe('PostgresPersonRepository', () => {
 
     describe('hasMoreDistinctIdsThan()', () => {
         it.each([
+            [1, true],
             [2, true],
             [3, false],
+            [4, false],
         ])('with three live mappings and limit %i resolves %s', async (limit, expected) => {
             const person = await createTestPerson(team.id, 'probe-did-1')
             await repository.addDistinctId(person, 'probe-did-2', 1)
             await repository.addDistinctId(person, 'probe-did-3', 1)
+            const decoy = await createTestPerson(team.id, 'decoy-did-1')
+            for (const suffix of ['2', '3', '4', '5']) {
+                await repository.addDistinctId(decoy, `decoy-did-${suffix}`, 1)
+            }
 
             await expect(repository.hasMoreDistinctIdsThan(person, limit)).resolves.toBe(expected)
+        })
+
+        it('sees mappings added earlier in the same transaction', async () => {
+            const person = await createTestPerson(team.id, 'probe-tx-did-1')
+
+            await postgres.transaction(PostgresUse.PERSONS_WRITE, 'probe-in-tx', async (tx) => {
+                await expect(repository.hasMoreDistinctIdsThan(person, 1, tx)).resolves.toBe(false)
+                await repository.addDistinctId(person, 'probe-tx-did-2', 1, tx)
+                await expect(repository.hasMoreDistinctIdsThan(person, 1, tx)).resolves.toBe(true)
+            })
         })
     })
 

--- a/nodejs/src/common/persons/repositories/postgres-person-repository.test.ts
+++ b/nodejs/src/common/persons/repositories/postgres-person-repository.test.ts
@@ -288,6 +288,7 @@ describe('PostgresPersonRepository', () => {
             await expect(repository.countDistinctIdsForPersons(team.id, [person.id])).resolves.toEqual(
                 new Map([[person.id, 1]])
             )
+            await expect(repository.hasMoreDistinctIdsThan(person, 1)).resolves.toBe(false)
         })
 
         it('updatePerson does not touch a tombstoned person', async () => {
@@ -1307,6 +1308,19 @@ describe('PostgresPersonRepository', () => {
                 expect(distinctIds).toContain('tx-distinct')
                 expect(distinctIds).toContain('tx-distinct-2')
             })
+        })
+    })
+
+    describe('hasMoreDistinctIdsThan()', () => {
+        it.each([
+            [2, true],
+            [3, false],
+        ])('with three live mappings and limit %i resolves %s', async (limit, expected) => {
+            const person = await createTestPerson(team.id, 'probe-did-1')
+            await repository.addDistinctId(person, 'probe-did-2', 1)
+            await repository.addDistinctId(person, 'probe-did-3', 1)
+
+            await expect(repository.hasMoreDistinctIdsThan(person, limit)).resolves.toBe(expected)
         })
     })
 

--- a/nodejs/src/common/persons/repositories/postgres-person-repository.ts
+++ b/nodejs/src/common/persons/repositories/postgres-person-repository.ts
@@ -1851,6 +1851,22 @@ export class PostgresPersonRepository
         return rows.map((row) => row.distinct_id)
     }
 
+    async hasMoreDistinctIdsThan(person: InternalPerson, limit: number, tx?: TransactionClient): Promise<boolean> {
+        // No ORDER BY on purpose: the planner can stop after limit + 1 index entries
+        // instead of reading every mapping of the person and sorting them.
+        const { rows } = await this.postgres.query<{ found: number }>(
+            tx ?? PostgresUse.PERSONS_WRITE,
+            `SELECT 1 AS found
+             FROM posthog_persondistinctid
+             WHERE person_id = $1 AND team_id = $2 AND is_deleted = false
+             OFFSET $3
+             LIMIT 1`,
+            [person.id, person.team_id, limit],
+            'hasMoreDistinctIdsThan'
+        )
+        return rows.length > 0
+    }
+
     async personPropertiesSize(personId: string, teamId: number): Promise<number> {
         const queryString = `
             SELECT COALESCE(pg_column_size(properties)::bigint, 0::bigint) AS total_props_bytes

--- a/nodejs/src/common/persons/repositories/raw-postgres-person-repository.ts
+++ b/nodejs/src/common/persons/repositories/raw-postgres-person-repository.ts
@@ -104,6 +104,9 @@ export interface RawPostgresPersonRepository {
 
     fetchPersonDistinctIds(person: InternalPerson, limit?: number, tx?: TransactionClient): Promise<string[]>
 
+    /** True when the person owns more than `limit` live distinct ids. Reads at most `limit + 1` rows. */
+    hasMoreDistinctIdsThan(person: InternalPerson, limit: number, tx?: TransactionClient): Promise<boolean>
+
     personPropertiesSize(personId: string, teamId: number): Promise<number>
 
     updateCohortsAndFeatureFlagsForMerge(

--- a/nodejs/src/ingestion/common/persons/batch-writing-person-store.test.ts
+++ b/nodejs/src/ingestion/common/persons/batch-writing-person-store.test.ts
@@ -1622,6 +1622,20 @@ describe('BatchWritingPersonStore', () => {
         })
     })
 
+    describe('hasMoreDistinctIdsThan', () => {
+        it.each([true, false])('passes the person and limit to the transaction and returns %s', async (verdict) => {
+            const mockRepo = createMockRepository()
+            const personStore = new BatchWritingPersonsStore(mockRepo, mockIngestionWarningsOutputs)
+            const mockTransaction = createMockTransaction()
+            mockTransaction.hasMoreDistinctIdsThan.mockResolvedValue(verdict)
+
+            const result = await personStore.hasMoreDistinctIdsThan(person, 'test-distinct', 10, mockTransaction)
+
+            expect(result).toBe(verdict)
+            expect(mockTransaction.hasMoreDistinctIdsThan).toHaveBeenCalledWith(person, 10)
+        })
+    })
+
     describe('updateCohortsAndFeatureFlagsForMerge', () => {
         it('should call repository method with correct arguments', async () => {
             const mockRepo = createMockRepository()

--- a/nodejs/src/ingestion/common/persons/batch-writing-person-store.test.ts
+++ b/nodejs/src/ingestion/common/persons/batch-writing-person-store.test.ts
@@ -180,6 +180,7 @@ describe('BatchWritingPersonStore', () => {
             updateCohortsAndFeatureFlagsForMerge: jest.fn().mockResolvedValue(undefined),
             updateCohortsAndFeatureFlagsForMergeBatch: jest.fn().mockResolvedValue(undefined),
             countDistinctIdsForPersons: jest.fn().mockResolvedValue(new Map()),
+            hasMoreDistinctIdsThan: jest.fn().mockResolvedValue(false),
         }
         return mockTransaction
     }

--- a/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
+++ b/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
@@ -73,6 +73,7 @@ type MethodName =
     | 'fetchPersonsForUpdateByDistinctIds'
     | 'countDistinctIdsForPersons'
     | 'fetchPersonDistinctIds'
+    | 'hasMoreDistinctIdsThan'
     | 'updateCohortsAndFeatureFlagsForMerge'
     | 'updateCohortsAndFeatureFlagsForMergeBatch'
     | 'addPersonUpdateToBatch'
@@ -118,6 +119,8 @@ export interface BatchWritingPersonsStoreOptions {
     mergeEventsEnabled: boolean
     mergeEventsPartitionCount: number
     mergeEventsTeamAllowlist: string
+    /** Probe the source person's distinct-id count before a limited move, so an over-limit merge never writes rows it then rolls back. */
+    mergeMoveLimitPrecheck: boolean
 }
 
 const DEFAULT_OPTIONS: BatchWritingPersonsStoreOptions = {
@@ -132,6 +135,7 @@ const DEFAULT_OPTIONS: BatchWritingPersonsStoreOptions = {
     mergeEventsEnabled: false,
     mergeEventsPartitionCount: 64,
     mergeEventsTeamAllowlist: '',
+    mergeMoveLimitPrecheck: false,
 }
 
 interface CacheMetrics {
@@ -562,6 +566,7 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
         this.options = { ...DEFAULT_OPTIONS, ...options }
         this.mergePolicy = {
             updateAllProperties: this.options.updateAllProperties,
+            moveLimitPrecheck: this.options.mergeMoveLimitPrecheck,
             isTombstoneTeam: buildIntegerMatcher(this.options.mergeTombstoneTeamAllowlist, true),
             mergeEvents: {
                 enabled: this.options.mergeEventsEnabled,
@@ -1667,6 +1672,21 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
         const start = performance.now()
         const response = await tx.fetchPersonDistinctIds(person, limit)
         observeLatencyByVersion(person, start, 'fetchPersonDistinctIds')
+
+        return response
+    }
+
+    async hasMoreDistinctIdsThan(
+        person: InternalPerson,
+        distinctId: string,
+        limit: number,
+        tx: PersonRepositoryTransaction
+    ): Promise<boolean> {
+        this.incrementCount('hasMoreDistinctIdsThan', distinctId)
+        this.incrementDatabaseOperation('hasMoreDistinctIdsThan', distinctId)
+        const start = performance.now()
+        const response = await tx.hasMoreDistinctIdsThan(person, limit)
+        observeLatencyByVersion(person, start, 'hasMoreDistinctIdsThan')
 
         return response
     }

--- a/nodejs/src/ingestion/common/persons/person-merge-postgres.test.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-postgres.test.ts
@@ -38,6 +38,7 @@ describe('PostgresPersonMerge merge events', () => {
             mockOutputs as any,
             {
                 updateAllProperties: false,
+                moveLimitPrecheck: false,
                 isTombstoneTeam: () => false,
                 mergeEvents,
             },
@@ -151,6 +152,7 @@ describe('PostgresPersonMerge merge events', () => {
             mockOutputs as never,
             {
                 updateAllProperties: false,
+                moveLimitPrecheck: false,
                 isTombstoneTeam: () => false,
                 mergeEvents: { enabled: false, partitionCount: 64, isTeamEnabled: () => false },
             },
@@ -198,6 +200,7 @@ describe('PostgresPersonMerge merge events', () => {
             mockOutputs as never,
             {
                 updateAllProperties: false,
+                moveLimitPrecheck: false,
                 isTombstoneTeam: () => false,
                 mergeEvents: { enabled: false, partitionCount: 64, isTeamEnabled: () => false },
             },

--- a/nodejs/src/ingestion/common/persons/person-merge-postgres.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-postgres.ts
@@ -73,6 +73,19 @@ export const mergeDistinctIdOverrideCounter = new Counter({
     labelNames: ['call'],
 })
 
+export const mergeMoveLimitPrecheckCounter = new Counter({
+    name: 'person_merge_move_limit_precheck_total',
+    help: 'Outcomes of the pre-move distinct-id limit probe on the source person.',
+    labelNames: ['result'],
+})
+
+export const mergeMoveLimitPrecheckDurationHistogram = new Histogram({
+    name: 'person_merge_move_limit_precheck_duration_seconds',
+    help: 'Wall time of the pre-move distinct-id limit probe, by outcome. This is the cost the probe adds to every both-exist merge.',
+    labelNames: ['result'],
+    buckets: [0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+})
+
 export const personMergeEventProducedCounter = new Counter({
     name: 'person_merge_event_produced_total',
     help: 'Number of person_merge_events messages acked by the broker (gate-on merges only).',
@@ -119,6 +132,8 @@ export interface MergeEventsConfig {
 export interface PostgresMergePolicy {
     /** When true, all property changes trigger person updates; mirrors the store option of the same name. */
     updateAllProperties: boolean
+    /** Probe the source's distinct-id count before a LIMIT/ASYNC move instead of discovering the overflow after the rows are written. */
+    moveLimitPrecheck: boolean
     /** Teams on the new-world merge behavior: lifecycle-mark claims plus tombstone deletes. */
     isTombstoneTeam: ValueMatcher<number>
     mergeEvents: MergeEventsConfig
@@ -825,6 +840,8 @@ export class PostgresPersonMerge {
                         throw new SourcePersonNotFoundError('Source person was deleted concurrently')
                     }
                 }
+                await this.assertSourceWithinMoveLimit(tx, currentSourcePerson)
+
                 const [person, updatePersonMessages] = await tx.updatePersonForMerge(
                     currentTargetPerson,
                     {
@@ -943,6 +960,38 @@ export class PostgresPersonMerge {
             mergeDistinctIdOverrideCounter.labels({ call }).inc(count)
         }
         this.pendingOverrideCounts = []
+    }
+
+    /**
+     * The limited move rewrites up to `limit` rows before it can learn that more
+     * remain, and then rolls all of them back. This probe reads at most limit + 1
+     * rows instead. The post-move leftover check stays as the guard against ids
+     * that a concurrent write adds after the probe.
+     */
+    private async assertSourceWithinMoveLimit(
+        tx: PersonsStoreTransactionForBatch,
+        currentSourcePerson: InternalPerson
+    ): Promise<void> {
+        if (!this.policy.moveLimitPrecheck || this.request.mergeMode.type === 'SYNC') {
+            return
+        }
+        const limit = this.request.mergeMode.limit
+        const stopTimer = mergeMoveLimitPrecheckDurationHistogram.startTimer()
+        const overLimit = await tx.hasMoreDistinctIdsThan(currentSourcePerson, this.targetDistinctId, limit)
+        const result = overLimit ? 'over_limit' : 'within_limit'
+        stopTimer({ result })
+        mergeMoveLimitPrecheckCounter.labels({ result }).inc()
+        if (!overLimit) {
+            return
+        }
+        personMergeFailureCounter.labels({ call: this.eventName }).inc()
+        logger.warn('🤔', 'person merge move limit hit before the move', {
+            team_id: this.teamId,
+            distinct_id: this.targetDistinctId,
+            source_person_id: currentSourcePerson.id,
+            limit,
+        })
+        throw new PersonMergeLimitExceededError('person_merge_move_limit_precheck')
     }
 
     private async moveDistinctIdsBasedOnMode(

--- a/nodejs/src/ingestion/common/persons/personhog-persons-store.test.ts
+++ b/nodejs/src/ingestion/common/persons/personhog-persons-store.test.ts
@@ -50,6 +50,24 @@ describe('PersonhogPersonsStore', () => {
         store = new PersonhogPersonsStore(repository)
     })
 
+    it.each([
+        [3, 2, true],
+        [3, 3, false],
+        [0, 0, false],
+    ])('hasMoreDistinctIdsThan with %i mappings and limit %i resolves %s', async (count, limit, expected) => {
+        // The leader honors the per-person limit, so it returns at most limit + 1 ids.
+        const returned = Array.from({ length: Math.min(count, limit + 1) }, (_, i) => `d${i}`)
+        repository.getDistinctIdsForPersons.mockResolvedValue({ [person.id]: returned })
+
+        await expect(store.hasMoreDistinctIdsThan(person, 'd1', limit, {} as any)).resolves.toBe(expected)
+        expect(repository.getDistinctIdsForPersons).toHaveBeenCalledWith(
+            person.team_id,
+            [person.id],
+            limit + 1,
+            expect.any(String)
+        )
+    })
+
     it('folds a batch of ops into one leader call per person and publishes nothing', async () => {
         const bound = store.forBatch(0)
         await bound.applyEventOps(person, ops({ $set: { a: '1' }, $set_once: { first: 'x' } }), 'd1')

--- a/nodejs/src/ingestion/common/persons/personhog-persons-store.ts
+++ b/nodejs/src/ingestion/common/persons/personhog-persons-store.ts
@@ -444,6 +444,21 @@ export class PersonhogPersonsStore implements PersonsStore {
         return byPerson[person.id] ?? []
     }
 
+    async hasMoreDistinctIdsThan(
+        person: InternalPerson,
+        _distinctId: string,
+        limit: number,
+        _tx: PersonRepositoryTransaction
+    ): Promise<boolean> {
+        const byPerson = await this.repository.getDistinctIdsForPersons(
+            person.team_id,
+            [person.id],
+            limit + 1,
+            CALLER_TAG
+        )
+        return (byPerson[person.id]?.length ?? 0) > limit
+    }
+
     removeDistinctIdFromCache(teamId: number, distinctId: string): void {
         // Resolution only: the person's state may still be valid under
         // its other distinct ids; what a merge changed is which person

--- a/nodejs/src/ingestion/common/persons/persons-store-for-batch.ts
+++ b/nodejs/src/ingestion/common/persons/persons-store-for-batch.ts
@@ -97,6 +97,8 @@ export interface PersonsStoreTransactionForBatch {
     ): Promise<void>
 
     fetchPersonDistinctIds(person: InternalPerson, distinctId: string, limit?: number): Promise<string[]>
+
+    hasMoreDistinctIdsThan(person: InternalPerson, distinctId: string, limit: number): Promise<boolean>
 }
 
 /**
@@ -282,6 +284,10 @@ export class BatchBoundPersonsStoreTransaction implements PersonsStoreTransactio
 
     fetchPersonDistinctIds(person: InternalPerson, distinctId: string, limit?: number): Promise<string[]> {
         return this.tx.fetchPersonDistinctIds(person, distinctId, limit)
+    }
+
+    hasMoreDistinctIdsThan(person: InternalPerson, distinctId: string, limit: number): Promise<boolean> {
+        return this.tx.hasMoreDistinctIdsThan(person, distinctId, limit)
     }
 }
 

--- a/nodejs/src/ingestion/common/persons/persons-store-transaction.ts
+++ b/nodejs/src/ingestion/common/persons/persons-store-transaction.ts
@@ -173,4 +173,8 @@ export class PersonsStoreTransaction {
     async fetchPersonDistinctIds(person: InternalPerson, distinctId: string, limit?: number): Promise<string[]> {
         return await this.store.fetchPersonDistinctIds(person, distinctId, limit, this.tx)
     }
+
+    async hasMoreDistinctIdsThan(person: InternalPerson, distinctId: string, limit: number): Promise<boolean> {
+        return await this.store.hasMoreDistinctIdsThan(person, distinctId, limit, this.tx)
+    }
 }

--- a/nodejs/src/ingestion/config.ts
+++ b/nodejs/src/ingestion/config.ts
@@ -168,6 +168,8 @@ export type IngestionConsumerConfig = {
     PERSON_MERGE_ASYNC_TOPIC: string
     PERSON_MERGE_ASYNC_ENABLED: boolean
     PERSON_MERGE_SYNC_BATCH_SIZE: number
+    // Refuse an over-limit LIMIT/ASYNC merge before it writes the rows it would roll back.
+    PERSON_MERGE_MOVE_LIMIT_PRECHECK_ENABLED: boolean
     // Kill switch for emitting person_merge_events to the cohort-stream-processor.
     // Enable ordering: (1) create the topic, (2) set INGESTION_OUTPUT_PERSON_MERGE_EVENTS_TOPIC
     // (startup topic verification is then fatal by design), (3) flip this on. Flipping this on before
@@ -359,6 +361,7 @@ export function getDefaultIngestionConsumerConfig(): IngestionConsumerConfig {
         PERSON_MERGE_ASYNC_TOPIC: '',
         PERSON_MERGE_ASYNC_ENABLED: false,
         PERSON_MERGE_SYNC_BATCH_SIZE: 0,
+        PERSON_MERGE_MOVE_LIMIT_PRECHECK_ENABLED: false,
         PERSON_MERGE_EVENTS_ENABLED: false,
         PERSON_MERGE_EVENTS_PARTITION_COUNT: 64,
         PERSON_MERGE_EVENTS_TEAM_ALLOWLIST: '2',

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -242,6 +242,7 @@ export class IngestionConsumer {
             mergeEventsEnabled: effectivePersonMergeEventsEnabled(this.config),
             mergeEventsPartitionCount: this.config.PERSON_MERGE_EVENTS_PARTITION_COUNT,
             mergeEventsTeamAllowlist: this.config.PERSON_MERGE_EVENTS_TEAM_ALLOWLIST,
+            mergeMoveLimitPrecheck: this.config.PERSON_MERGE_MOVE_LIMIT_PRECHECK_ENABLED,
         })
 
         this.groupStore = new BatchWritingGroupStore(this.deps.groupRepository, this.deps.clickhouseGroupRepository, {

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -345,6 +345,7 @@ export class IngestionApiServer implements NodeServer {
             mergeEventsEnabled: effectivePersonMergeEventsEnabled(this.config),
             mergeEventsPartitionCount: this.config.PERSON_MERGE_EVENTS_PARTITION_COUNT,
             mergeEventsTeamAllowlist: this.config.PERSON_MERGE_EVENTS_TEAM_ALLOWLIST,
+            mergeMoveLimitPrecheck: this.config.PERSON_MERGE_MOVE_LIMIT_PRECHECK_ENABLED,
         })
         // Which backend person writes land in, deployment-wide: pg (the
         // default) builds nothing new; the other modes construct the

--- a/nodejs/tests/ingestion/common/steps/event-processing/process-persons-step.integration.test.ts
+++ b/nodejs/tests/ingestion/common/steps/event-processing/process-persons-step.integration.test.ts
@@ -277,37 +277,58 @@ describe('createProcessPersonsStep', () => {
         }
     })
 
-    it('returns DLQ result when merge limit is exceeded in LIMIT mode', async () => {
-        await createPersonWithDistinctIds('person-1')
-        await createPersonWithDistinctIds('person-2', 'person-2-extra-1', 'person-2-extra-2')
+    it.each([
+        { mode: 'LIMIT', precheck: false, expectedType: PipelineResultType.DLQ, moveCalls: 1 },
+        { mode: 'LIMIT', precheck: true, expectedType: PipelineResultType.DLQ, moveCalls: 0 },
+        { mode: 'ASYNC', precheck: false, expectedType: PipelineResultType.REDIRECT, moveCalls: 1 },
+        { mode: 'ASYNC', precheck: true, expectedType: PipelineResultType.REDIRECT, moveCalls: 0 },
+    ])(
+        'refuses an over-limit merge in $mode mode with precheck=$precheck after $moveCalls move attempts',
+        async ({ mode, precheck, expectedType, moveCalls }) => {
+            await createPersonWithDistinctIds('person-1')
+            await createPersonWithDistinctIds('person-2', 'person-2-extra-1', 'person-2-extra-2')
+            const moveSpy = jest.spyOn(personRepository, 'moveDistinctIds')
 
-        const identifyEvent: PluginEvent = {
-            ...pluginEvent,
-            event: '$identify',
-            distinct_id: 'person-1',
-            properties: {
-                $anon_distinct_id: 'person-2',
-            },
-        }
+            const identifyEvent: PluginEvent = {
+                ...pluginEvent,
+                event: '$identify',
+                distinct_id: 'person-1',
+                properties: {
+                    $anon_distinct_id: 'person-2',
+                },
+            }
 
-        const limitOptions: EventPipelineRunnerOptions = {
-            ...options,
-            PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: 2,
-        }
-
-        const step = createProcessPersonsStep(limitOptions, personOutputs)
-        const result = await step(
-            createInput({
-                normalizedEvent: identifyEvent,
-                timestamp: DateTime.fromISO(identifyEvent.timestamp!),
+            const limitOptions: EventPipelineRunnerOptions = {
+                ...options,
+                PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: 2,
+                PERSON_MERGE_ASYNC_ENABLED: mode === 'ASYNC',
+            }
+            const store = new BatchWritingPersonsStore(personRepository, personOutputs, {
+                mergeMoveLimitPrecheck: precheck,
             })
-        )
 
-        expect(result.type).toBe(PipelineResultType.DLQ)
-        if (isDlqResult(result)) {
-            expect(result.reason).toBe('Merge limit exceeded')
+            const step = createProcessPersonsStep(limitOptions, personOutputs)
+            const result = await step(
+                createInput({
+                    normalizedEvent: identifyEvent,
+                    timestamp: DateTime.fromISO(identifyEvent.timestamp!),
+                    personsStoreForBatch: new BatchBoundPersonsStore(store, 0),
+                })
+            )
+
+            expect(result.type).toBe(expectedType)
+            if (isDlqResult(result)) {
+                expect(result.reason).toBe('Merge limit exceeded')
+            }
+            if (isRedirectResult(result)) {
+                expect(result.reason).toBe('Event redirected to async merge topic')
+                expect(result.output).toBe(ASYNC_OUTPUT)
+            }
+            expect(moveSpy).toHaveBeenCalledTimes(moveCalls)
+            const persons = await fetchPostgresPersons(infra.postgres, teamId)
+            expect(persons).toHaveLength(2)
         }
-    })
+    )
 
     it('returns a refused merge before its warning is acked and defers the ack to the side effects', async () => {
         for (const distinctId of ['identified-source', 'target']) {
@@ -449,40 +470,6 @@ describe('createProcessPersonsStep', () => {
         const persons = await fetchPostgresPersons(infra.postgres, enabledTeamId)
         expect(persons).toHaveLength(1)
         expect(persons[0].last_seen_at).toEqual(futureTimestamp.startOf('hour'))
-    })
-
-    it('returns redirect result when merge limit is exceeded in ASYNC mode', async () => {
-        await createPersonWithDistinctIds('person-1')
-        await createPersonWithDistinctIds('person-2', 'person-2-extra-1', 'person-2-extra-2')
-
-        const identifyEvent: PluginEvent = {
-            ...pluginEvent,
-            event: '$identify',
-            distinct_id: 'person-1',
-            properties: {
-                $anon_distinct_id: 'person-2',
-            },
-        }
-
-        const asyncOptions: EventPipelineRunnerOptions = {
-            ...options,
-            PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: 2,
-            PERSON_MERGE_ASYNC_ENABLED: true,
-        }
-
-        const step = createProcessPersonsStep(asyncOptions, personOutputs)
-        const result = await step(
-            createInput({
-                normalizedEvent: identifyEvent,
-                timestamp: DateTime.fromISO(identifyEvent.timestamp!),
-            })
-        )
-
-        expect(result.type).toBe(PipelineResultType.REDIRECT)
-        if (isRedirectResult(result)) {
-            expect(result.reason).toBe('Event redirected to async merge topic')
-            expect(result.output).toBe(ASYNC_OUTPUT)
-        }
     })
 
     describe('merge distinct id versioning', () => {

--- a/nodejs/tests/ingestion/common/steps/event-processing/process-persons-step.integration.test.ts
+++ b/nodejs/tests/ingestion/common/steps/event-processing/process-persons-step.integration.test.ts
@@ -23,6 +23,7 @@ import { UUIDT } from '~/common/utils/utils'
 import { BatchWritingPersonsStore } from '~/ingestion/common/persons/batch-writing-person-store'
 import { PersonOutputs } from '~/ingestion/common/persons/person-context'
 import { MergeFoldPlan } from '~/ingestion/common/persons/person-merge-fold'
+import { mergeMoveLimitPrecheckCounter } from '~/ingestion/common/persons/person-merge-postgres'
 import { uuidFromDistinctId } from '~/ingestion/common/persons/person-uuid'
 import { BatchBoundPersonsStore } from '~/ingestion/common/persons/persons-store-for-batch'
 import { EventPipelineRunnerOptions } from '~/ingestion/common/steps/event-processing/event-pipeline-options'
@@ -277,58 +278,151 @@ describe('createProcessPersonsStep', () => {
         }
     })
 
-    it.each([
-        { mode: 'LIMIT', precheck: false, expectedType: PipelineResultType.DLQ, moveCalls: 1 },
-        { mode: 'LIMIT', precheck: true, expectedType: PipelineResultType.DLQ, moveCalls: 0 },
-        { mode: 'ASYNC', precheck: false, expectedType: PipelineResultType.REDIRECT, moveCalls: 1 },
-        { mode: 'ASYNC', precheck: true, expectedType: PipelineResultType.REDIRECT, moveCalls: 0 },
-    ])(
-        'refuses an over-limit merge in $mode mode with precheck=$precheck after $moveCalls move attempts',
-        async ({ mode, precheck, expectedType, moveCalls }) => {
-            await createPersonWithDistinctIds('person-1')
-            await createPersonWithDistinctIds('person-2', 'person-2-extra-1', 'person-2-extra-2')
-            const moveSpy = jest.spyOn(personRepository, 'moveDistinctIds')
+    describe('move limit precheck', () => {
+        const identifyPerson2IntoPerson1 = (): PluginEvent => ({
+            ...pluginEvent,
+            event: '$identify',
+            distinct_id: 'person-1',
+            properties: {
+                $anon_distinct_id: 'person-2',
+            },
+        })
 
-            const identifyEvent: PluginEvent = {
-                ...pluginEvent,
-                event: '$identify',
-                distinct_id: 'person-1',
-                properties: {
-                    $anon_distinct_id: 'person-2',
-                },
-            }
+        async function precheckCount(result: 'over_limit' | 'within_limit'): Promise<number> {
+            return (
+                (await mergeMoveLimitPrecheckCounter.get()).values.find((v) => v.labels.result === result)?.value ?? 0
+            )
+        }
 
-            const limitOptions: EventPipelineRunnerOptions = {
-                ...options,
-                PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: 2,
-                PERSON_MERGE_ASYNC_ENABLED: mode === 'ASYNC',
-            }
-            const store = new BatchWritingPersonsStore(personRepository, personOutputs, {
-                mergeMoveLimitPrecheck: precheck,
-            })
-
-            const step = createProcessPersonsStep(limitOptions, personOutputs)
-            const result = await step(
+        async function runIdentify(
+            stepOptions: EventPipelineRunnerOptions,
+            storeOptions: { mergeMoveLimitPrecheck: boolean; mergeTombstoneTeamAllowlist?: string }
+        ) {
+            const store = new BatchWritingPersonsStore(personRepository, personOutputs, storeOptions)
+            const step = createProcessPersonsStep(stepOptions, personOutputs)
+            const event = identifyPerson2IntoPerson1()
+            return await step(
                 createInput({
-                    normalizedEvent: identifyEvent,
-                    timestamp: DateTime.fromISO(identifyEvent.timestamp!),
+                    normalizedEvent: event,
+                    timestamp: DateTime.fromISO(event.timestamp!),
                     personsStoreForBatch: new BatchBoundPersonsStore(store, 0),
                 })
             )
+        }
 
-            expect(result.type).toBe(expectedType)
-            if (isDlqResult(result)) {
-                expect(result.reason).toBe('Merge limit exceeded')
+        it.each([
+            { mode: 'LIMIT', precheck: false, tombstone: false, expectedType: PipelineResultType.DLQ, moveCalls: 1 },
+            { mode: 'LIMIT', precheck: true, tombstone: false, expectedType: PipelineResultType.DLQ, moveCalls: 0 },
+            { mode: 'LIMIT', precheck: true, tombstone: true, expectedType: PipelineResultType.DLQ, moveCalls: 0 },
+            {
+                mode: 'ASYNC',
+                precheck: false,
+                tombstone: false,
+                expectedType: PipelineResultType.REDIRECT,
+                moveCalls: 1,
+            },
+            {
+                mode: 'ASYNC',
+                precheck: true,
+                tombstone: false,
+                expectedType: PipelineResultType.REDIRECT,
+                moveCalls: 0,
+            },
+            { mode: 'ASYNC', precheck: true, tombstone: true, expectedType: PipelineResultType.REDIRECT, moveCalls: 0 },
+        ])(
+            'refuses an over-limit merge in $mode mode with precheck=$precheck tombstone=$tombstone after $moveCalls move attempts',
+            async ({ mode, precheck, tombstone, expectedType, moveCalls }) => {
+                await createPersonWithDistinctIds('person-1')
+                await createPersonWithDistinctIds('person-2', 'person-2-extra-1', 'person-2-extra-2')
+                const moveSpy = jest.spyOn(personRepository, 'moveDistinctIds')
+                const probeSpy = jest.spyOn(personRepository, 'hasMoreDistinctIdsThan')
+                const overLimitBefore = await precheckCount('over_limit')
+
+                const result = await runIdentify(
+                    {
+                        ...options,
+                        PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: 2,
+                        PERSON_MERGE_ASYNC_ENABLED: mode === 'ASYNC',
+                    },
+                    { mergeMoveLimitPrecheck: precheck, mergeTombstoneTeamAllowlist: tombstone ? '*' : '' }
+                )
+
+                expect(result.type).toBe(expectedType)
+                if (isDlqResult(result)) {
+                    expect(result.reason).toBe('Merge limit exceeded')
+                }
+                if (isRedirectResult(result)) {
+                    expect(result.reason).toBe('Event redirected to async merge topic')
+                    expect(result.output).toBe(ASYNC_OUTPUT)
+                }
+                expect(probeSpy).toHaveBeenCalledTimes(precheck ? 1 : 0)
+                expect(moveSpy).toHaveBeenCalledTimes(moveCalls)
+                expect((await precheckCount('over_limit')) - overLimitBefore).toBe(precheck ? 1 : 0)
+                const persons = await fetchPostgresPersons(infra.postgres, teamId)
+                expect(persons).toHaveLength(2)
             }
-            if (isRedirectResult(result)) {
-                expect(result.reason).toBe('Event redirected to async merge topic')
-                expect(result.output).toBe(ASYNC_OUTPUT)
+        )
+
+        it.each([{ tombstone: false }, { tombstone: true }])(
+            'moves a source that owns exactly the limit of distinct ids (tombstone=$tombstone)',
+            async ({ tombstone }) => {
+                await createPersonWithDistinctIds('person-1')
+                await createPersonWithDistinctIds('person-2', 'person-2-extra-1')
+                const moveSpy = jest.spyOn(personRepository, 'moveDistinctIds')
+                const probeSpy = jest.spyOn(personRepository, 'hasMoreDistinctIdsThan')
+                const withinBefore = await precheckCount('within_limit')
+
+                const result = await runIdentify(
+                    { ...options, PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: 2 },
+                    { mergeMoveLimitPrecheck: true, mergeTombstoneTeamAllowlist: tombstone ? '*' : '' }
+                )
+
+                expect(result.type).toBe(PipelineResultType.OK)
+                expect(probeSpy).toHaveBeenCalledTimes(1)
+                expect(moveSpy).toHaveBeenCalledTimes(1)
+                expect((await precheckCount('within_limit')) - withinBefore).toBe(1)
+                const persons = await fetchPostgresPersons(infra.postgres, teamId)
+                expect(persons).toHaveLength(1)
+                const distinctIds = await fetchDistinctIdValues(infra.postgres, persons[0])
+                expect(distinctIds.sort()).toEqual(['person-1', 'person-2', 'person-2-extra-1'])
             }
-            expect(moveSpy).toHaveBeenCalledTimes(moveCalls)
+        )
+
+        it('skips the probe in SYNC mode, where the move is unbounded', async () => {
+            await createPersonWithDistinctIds('person-1')
+            await createPersonWithDistinctIds('person-2', 'person-2-extra-1', 'person-2-extra-2')
+            const probeSpy = jest.spyOn(personRepository, 'hasMoreDistinctIdsThan')
+
+            const result = await runIdentify(
+                { ...options, PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: 0, PERSON_MERGE_SYNC_BATCH_SIZE: 1 },
+                { mergeMoveLimitPrecheck: true }
+            )
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            expect(probeSpy).not.toHaveBeenCalled()
+            const persons = await fetchPostgresPersons(infra.postgres, teamId)
+            expect(persons).toHaveLength(1)
+            const distinctIds = await fetchDistinctIdValues(infra.postgres, persons[0])
+            expect(distinctIds.sort()).toEqual(['person-1', 'person-2', 'person-2-extra-1', 'person-2-extra-2'])
+        })
+
+        it('still refuses after the move when the probe missed ids added concurrently', async () => {
+            await createPersonWithDistinctIds('person-1')
+            await createPersonWithDistinctIds('person-2', 'person-2-extra-1', 'person-2-extra-2')
+            const moveSpy = jest.spyOn(personRepository, 'moveDistinctIds')
+            jest.spyOn(personRepository, 'hasMoreDistinctIdsThan').mockResolvedValue(false)
+
+            const result = await runIdentify(
+                { ...options, PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: 2 },
+                { mergeMoveLimitPrecheck: true }
+            )
+
+            expect(result.type).toBe(PipelineResultType.DLQ)
+            expect(moveSpy).toHaveBeenCalledTimes(1)
             const persons = await fetchPostgresPersons(infra.postgres, teamId)
             expect(persons).toHaveLength(2)
-        }
-    )
+        })
+    })
 
     it('returns a refused merge before its warning is acked and defers the ack to the side effects', async () => {
         for (const distinctId of ['identified-source', 'target']) {
@@ -577,7 +671,9 @@ describe('createProcessPersonsStep', () => {
         async function runIdentifies(
             events: PluginEvent[],
             plan: MergeFoldPlan | undefined,
-            stepOptions: EventPipelineRunnerOptions
+            stepOptions: EventPipelineRunnerOptions,
+            store: BatchWritingPersonsStore = personsStore,
+            expectOk: boolean = true
         ) {
             const step = createProcessPersonsStep(stepOptions, personOutputs)
             const results = []
@@ -586,10 +682,13 @@ describe('createProcessPersonsStep', () => {
                     createInput({
                         normalizedEvent: event,
                         timestamp: DateTime.fromISO(event.timestamp!),
+                        personsStoreForBatch: new BatchBoundPersonsStore(store, 0),
                         mergeFold: plan ? { type: 'planned', plan } : { type: 'immediate' },
                     })
                 )
-                expect(isOkResult(result)).toBe(true)
+                if (expectOk) {
+                    expect(isOkResult(result)).toBe(true)
+                }
                 results.push(result)
             }
             return results
@@ -746,31 +845,50 @@ describe('createProcessPersonsStep', () => {
             expect(distinctIds.sort()).toEqual(['anon-1', 'anon-2', 'user-1'])
         })
 
-        it('abandons the fold when a source exceeds the move limit and merges sequentially', async () => {
-            const bigSource = await createPersonWithProps('anon-1', { a: 1 })
-            await personRepository.addDistinctId(bigSource, 'anon-1-extra-1', 0)
-            await personRepository.addDistinctId(bigSource, 'anon-1-extra-2', 0)
-            await createPersonWithProps('anon-2', { b: 2 })
-            await createPersonWithProps('user-1', {})
-            const plan = planFor('user-1', 'anon-1', 'anon-2')
+        it.each([
+            { precheck: false, moveCalls: 2 },
+            { precheck: true, moveCalls: 1 },
+        ])(
+            'abandons the fold when a source exceeds the move limit and merges sequentially (precheck=$precheck)',
+            async ({ precheck, moveCalls }) => {
+                const bigSource = await createPersonWithProps('anon-1', { a: 1 })
+                await personRepository.addDistinctId(bigSource, 'anon-1-extra-1', 0)
+                await personRepository.addDistinctId(bigSource, 'anon-1-extra-2', 0)
+                await createPersonWithProps('anon-2', { b: 2 })
+                await createPersonWithProps('user-1', {})
+                const plan = planFor('user-1', 'anon-1', 'anon-2')
+                const moveSpy = jest.spyOn(personRepository, 'moveDistinctIds')
+                const store = new BatchWritingPersonsStore(personRepository, personOutputs, {
+                    mergeMoveLimitPrecheck: precheck,
+                })
 
-            // LIMIT mode with a limit of 2: anon-1 owns 3 distinct ids, so the
-            // fold must roll back; the sequential path then DLQs anon-1's merge
-            // per-event while anon-2 still merges normally.
-            await runIdentifies([identifyEvent('anon-2', 'user-1')], plan, {
-                ...options,
-                PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: 2,
-                PERSON_MERGE_FOLD_ENABLED: true,
-            })
+                // LIMIT mode with a limit of 2: anon-1 owns 3 distinct ids, so the
+                // fold must roll back; the sequential path then DLQs anon-1's merge
+                // per-event while anon-2 still merges normally. With the precheck
+                // on, anon-1's sequential attempt is refused before it moves rows.
+                const results = await runIdentifies(
+                    [identifyEvent('anon-1', 'user-1'), identifyEvent('anon-2', 'user-1')],
+                    plan,
+                    {
+                        ...options,
+                        PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: 2,
+                        PERSON_MERGE_FOLD_ENABLED: true,
+                    },
+                    store,
+                    false
+                )
 
-            expect(plan.status).toBe('abandoned')
-            const persons = await fetchPostgresPersons(infra.postgres, teamId)
-            // anon-1's person survives untouched; anon-2 merged into user-1
-            expect(persons).toHaveLength(2)
-            const target = persons.find((p) => p.id !== bigSource.id)!
-            const distinctIds = await fetchDistinctIdValues(infra.postgres, target)
-            expect(distinctIds.sort()).toEqual(['anon-2', 'user-1'])
-        })
+                expect(plan.status).toBe('abandoned')
+                expect(results.map((r) => r.type)).toEqual([PipelineResultType.DLQ, PipelineResultType.OK])
+                expect(moveSpy).toHaveBeenCalledTimes(moveCalls)
+                const persons = await fetchPostgresPersons(infra.postgres, teamId)
+                // anon-1's person survives untouched; anon-2 merged into user-1
+                expect(persons).toHaveLength(2)
+                const target = persons.find((p) => p.id !== bigSource.id)!
+                const distinctIds = await fetchDistinctIdValues(infra.postgres, target)
+                expect(distinctIds.sort()).toEqual(['anon-2', 'user-1'])
+            }
+        )
 
         it('merges sequentially after a mid-transaction fold failure poisons the batch caches', async () => {
             await createPersonWithProps('anon-1', { a: 1 })


### PR DESCRIPTION
## Problem

- An `$identify` whose anonymous person owns more distinct ids than the merge limit stalls its ingestion partition for tens of seconds, and then merges nothing.
- In LIMIT and ASYNC mode the move rewrites up to `limit` mapping rows first, then probes for leftovers, throws, and rolls the whole transaction back.
- That write is I/O-bound. Every rewritten row is a non-HOT update into three large indexes, and `ORDER BY id` makes the planner read every mapping of the source before it picks the batch.
- The event is then redirected or sent to the DLQ exactly as it would have been without the writes.

Coupling the writes with the limit check, results in a lot of wasted work when we do exceed the limit. To properly employ the ASYNC merge lane, we could probe all these and redirect to the ASYNC lane before attempting any writes.

## Changes

- Behind `PERSON_MERGE_MOVE_LIMIT_PRECHECK_ENABLED` (default off), an over-limit merge is refused before its first write, so the same redirect or DLQ result arrives without the rolled-back rows.
- The transaction runs a bounded probe on the source right after the lifecycle claims: `SELECT 1 ... OFFSET limit LIMIT 1`. It reads at most `limit + 1` index entries and never sorts.
- The post-move leftover check stays, so ids added concurrently after the probe are still caught.
- Only the both-persons-exist path (`mergePeople`) probes. The one-exists and neither-exist paths never move rows, and the fold path already counts before it moves.
- New metrics: `person_merge_move_limit_precheck_total{result}` and `person_merge_move_limit_precheck_duration_seconds{result}`. The duration histogram is the cost the probe adds to every both-exist merge. An over-limit refusal still increments `person_merge_failure_total`.
- A full `count(*)` was rejected as the probe because it is O(N) on exactly the persons the check exists to catch.
- Mechanical: the probe is a new `hasMoreDistinctIdsThan` verb threaded through the repository, transaction, and store layers, mirroring `fetchPersonDistinctIds`.

> [!NOTE]
> With the flag off nothing changes. With it on, an over-limit merge logs "person merge move limit hit before the move" at warn level instead of the post-move error line, and the outcome is the same redirect or DLQ.

## How did you test this code?

Each group names the regression it catches. All ran locally against the dev Postgres, and a mutation that skips the probe call fails seven of the cases below.

- `postgres-person-repository.test.ts`: limits 1 to 4 against a source with three mappings and a decoy person with five. Catches an off-by-one in the `OFFSET` and a dropped `person_id` predicate. One case runs inside a transaction and sees a mapping added earlier in it, which catches a wrapper that drops the transaction handle. One assertion that tombstoned mappings do not count.
- `process-persons-step.integration.test.ts`, over-limit matrix: LIMIT and ASYNC, precheck on and off, tombstone teams on and off. Asserts the outcome, that the probe runs only with the flag, that `moveDistinctIds` never runs with the flag and runs once without it, and that the `over_limit` counter moves. The tombstone rows matter because production merges run on that path.
- Same file, within-limit: a source with exactly the limit of mappings still merges completely with the flag on, in both tombstone modes. Catches an inverted comparison or a `>=` where `>` is meant.
- Same file, SYNC mode with the flag on: the probe never runs and the batched move completes. Catches reading `.limit` off a mode that has none.
- Same file, probe mocked to say within limit while the source is over it: the post-move check still refuses. Catches removing the leftover check on the theory that the probe suffices.
- Same file, fold fallback: when the fold aborts on the limit and falls back to sequential merges, the flag stops the sequential attempt before it moves rows. Catches a probe placed where the fallback path skips it.
- `batch-writing-person-store.test.ts` and `personhog-persons-store.test.ts`: the store verbs pass the person and limit through, and the personhog one asks the leader for `limit + 1` ids. Catches an argument swap and an off-by-one against the leader.
- Not run: nothing exercises the personhog verb against a live leader.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The merge env vars are not documented under `docs/`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, session linked below. Skills invoked: `/monitoring-ingestion-pipeline`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The change came out of a production investigation into outlier merge latency, where the rolled-back limited move was the dominant cost of every outlier transaction. Nothing from that investigation is in the diff. Test data is invented and the description is written from the code.

Decisions across the session: the probe runs inside the transaction after the lifecycle claims rather than before the transaction, so the tombstone-team liveness checks still precede it and the existing transaction verb set is reused. The probe drops `ORDER BY` so the planner can stop early. A latency histogram was added after the outcome counter so the probe's own cost is visible, not only its result. Duplicate search: `gh pr list --state open --search "merge limit precheck distinct id move"` found nothing related.

https://claude.ai/code/session_01T46AiHXVrk5TnQBbwCc7xc

