### PR TITLE
fix(lemon-ui): let an undefined activeKey leave LemonCollapse uncontrolled

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonCollapse/LemonCollapse.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCollapse/LemonCollapse.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom'
 
 import { render, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { LemonCollapse } from './LemonCollapse'
 
@@ -14,6 +15,18 @@ describe('LemonCollapse', () => {
         const { container } = render(<LemonCollapse panels={panels} defaultActiveKey="only" activeKey={null} />)
 
         expect(within(container).queryByText('Body')).not.toBeInTheDocument()
+    })
+
+    // Many callers pass `activeKey={condition ? key : undefined}` and give no `onChange`. If
+    // `undefined` made the panel controlled, a click would have nothing to update and the panel
+    // could never open.
+    it('opens on click when activeKey is undefined', async () => {
+        const { container } = render(<LemonCollapse panels={panels} activeKey={undefined} />)
+        expect(within(container).queryByText('Body')).not.toBeInTheDocument()
+
+        await userEvent.click(container.querySelector<HTMLElement>('.LemonCollapsePanel__header')!)
+
+        expect(within(container).getByText('Body')).toBeInTheDocument()
     })
 
     it('still seeds itself from defaultActiveKey when left uncontrolled', () => {

--- a/frontend/src/lib/lemon-ui/LemonCollapse/LemonCollapse.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCollapse/LemonCollapse.tsx
@@ -28,7 +28,7 @@ interface LemonCollapsePropsBase<K extends React.Key> {
 }
 
 interface LemonCollapsePropsSingle<K extends React.Key> extends LemonCollapsePropsBase<K> {
-    /** Pass this to control the panel. `null` or `undefined` then means closed, not uncontrolled. */
+    /** Pass a key to control the panel, or `null` to control it closed. Leave it `undefined` to let the panel keep its own state. */
     activeKey?: K | null
     defaultActiveKey?: K
     onChange?: (activeKey: K | null) => void
@@ -77,10 +77,10 @@ export function LemonCollapse<K extends React.Key>({
     } else {
         // eslint-disable-next-line react-hooks/rules-of-hooks
         const [localActiveKey, setLocalActiveKey] = useState<K | null>(props.defaultActiveKey ?? null)
-        // Read the presence of `activeKey` rather than its value. A caller that controls the panel
-        // has no other way to say "closed", so falling back on a nullish value would reopen the
-        // panel from whatever the user last clicked.
-        const effectiveActiveKey = 'activeKey' in props ? (props.activeKey ?? null) : localActiveKey
+        // `null` is a controlled value that means closed, because a caller that controls the panel
+        // has no other way to say so. `undefined` stays uncontrolled, because many callers pass a
+        // key only some of the time and let a click open the panel the rest of the time.
+        const effectiveActiveKey = props.activeKey !== undefined ? props.activeKey : localActiveKey
         isPanelExpanded = (key: K) => key === effectiveActiveKey
         onPanelChange = (key: K, isExpanded: boolean): void => {
             props.onChange?.(isExpanded ? key : null)

--- a/frontend/src/scenes/feature-flags/FeatureFlagTemplates.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagTemplates.tsx
@@ -28,10 +28,7 @@ export function FeatureFlagTemplates(): JSX.Element | null {
         <>
             <div className="mb-4">
                 <LemonCollapse
-                    // Use a non-matching key instead of null/undefined to force closed state,
-                    // because LemonCollapse uses `activeKey ?? localActiveKey` which falls back
-                    // to internal state when activeKey is nullish
-                    activeKey={templateExpanded ? 'templates' : '__closed__'}
+                    activeKey={templateExpanded ? 'templates' : null}
                     onChange={(key) => setTemplateExpanded(key === 'templates')}
                     panels={[
                         {


### PR DESCRIPTION
## Problem

A person editing a no-code web experiment in the toolbar cannot open a transformation panel once a variant has two or more transformations. The same latent break applies to any other caller of `LemonCollapse`.

**Why:** [#89785](https://github.com/PostHog/posthog/pull/89785) changed `LemonCollapse` to decide controlled mode from the presence of `activeKey` instead of its value. Callers that pass `activeKey={condition ? key : undefined}` and no `onChange` became permanently controlled at closed, so a click had nothing to update.

## Changes

- A panel whose caller passes `activeKey={undefined}` opens on click again.
- `null` still controls a panel closed, so the feature flag form's advanced panel keeps working.
- `FeatureFlagTemplates` drops its `'__closed__'` sentinel key and passes `null`. Mechanical.

## How did you test this code?

`frontend/src/lib/lemon-ui/LemonCollapse/LemonCollapse.test.tsx` gains one case: a panel with `activeKey={undefined}` and no `onChange` opens on click. The case fails against the component on `master` and passes with this change; no existing case covered a click.

Also run: the existing `LemonCollapse` suite and `frontend/src/scenes/feature-flags`. `pnpm --filter=@posthog/frontend typescript:check` reports no error in the three touched files; the errors it does report come from workspace packages this sandbox has not built, and none sit on a path this change touches. No manual testing in a running app.

**No duplicate:** [#95268](https://github.com/PostHog/posthog/pull/95268) fixes the same symptom at one caller, by moving `WebExperimentVariant` to `defaultActiveKey`. This change fixes the shared component, so every other caller is covered and the sentinel-key workaround can go. The two do not conflict. Pick one, or land both.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code in a PostHog Desktop cloud task, from a request to verify a suspected regression in [#89785](https://github.com/PostHog/posthog/pull/89785) and fix it. Skills invoked: `/writing-tests`.

Every single-mode `LemonCollapse` caller was checked for `activeKey` without `onChange`; `WebExperimentVariant` is the only one that breaks today. The caller-side fix was the smaller diff, but the component contract is what regressed, and `undefined` meaning uncontrolled is the React convention the other callers already assume.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
