### PR TITLE
feat(personhog): add GetDistinctIdMappings to the identity service

### DIFF
--- a/nodejs/src/common/generated/personhog/personhog/identity/v1/identity_pb.ts
+++ b/nodejs/src/common/generated/personhog/personhog/identity/v1/identity_pb.ts
@@ -13,7 +13,7 @@ import { file_personhog_types_v1_person } from '../../types/v1/person_pb'
 export const file_personhog_identity_v1_identity: GenFile =
     /*@__PURE__*/
     fileDesc(
-        'CiRwZXJzb25ob2cvaWRlbnRpdHkvdjEvaWRlbnRpdHkucHJvdG8SFXBlcnNvbmhvZy5pZGVudGl0eS52MSLOAQoWR2V0T3JDcmVhdGVQZXJzb25FbnRyeRIPCgd0ZWFtX2lkGAEgASgDEhMKC2Rpc3RpbmN0X2lkGAIgASgJEhoKEmV4dHJhX2Rpc3RpbmN0X2lkcxgDIAMoCRISCgpldmVudF9uYW1lGAQgASgJEhYKDnNldF9wcm9wZXJ0aWVzGAUgASgMEhsKE3NldF9vbmNlX3Byb3BlcnRpZXMYBiABKAwSEgoKY3JlYXRlZF9hdBgHIAEoAxIVCg1pc19pZGVudGlmaWVkGAggASgIImQKJEdldE9yQ3JlYXRlUGVyc29uQnlEaXN0aW5jdElkUmVxdWVzdBI8CgVlbnRyeRgBIAEoCzItLnBlcnNvbmhvZy5pZGVudGl0eS52MS5HZXRPckNyZWF0ZVBlcnNvbkVudHJ5ImQKJUdldE9yQ3JlYXRlUGVyc29uQnlEaXN0aW5jdElkUmVzcG9uc2USKgoGcGVyc29uGAEgASgLMhoucGVyc29uaG9nLnR5cGVzLnYxLlBlcnNvbhIPCgdjcmVhdGVkGAIgASgIImgKJkdldE9yQ3JlYXRlUGVyc29uc0J5RGlzdGluY3RJZHNSZXF1ZXN0Ej4KB2VudHJpZXMYASADKAsyLS5wZXJzb25ob2cuaWRlbnRpdHkudjEuR2V0T3JDcmVhdGVQZXJzb25FbnRyeSKqAQoXR2V0T3JDcmVhdGVQZXJzb25SZXN1bHQSDwoHdGVhbV9pZBgBIAEoAxITCgtkaXN0aW5jdF9pZBgCIAEoCRIvCgZwZXJzb24YAyABKAsyGi5wZXJzb25ob2cudHlwZXMudjEuUGVyc29uSACIAQESDwoHY3JlYXRlZBgEIAEoCBISCgVlcnJvchgFIAEoCUgBiAEBQgkKB19wZXJzb25CCAoGX2Vycm9yImoKJ0dldE9yQ3JlYXRlUGVyc29uc0J5RGlzdGluY3RJZHNSZXNwb25zZRI/CgdyZXN1bHRzGAEgAygLMi4ucGVyc29uaG9nLmlkZW50aXR5LnYxLkdldE9yQ3JlYXRlUGVyc29uUmVzdWx0IjEKCVBlcnNvbktleRIPCgd0ZWFtX2lkGAEgASgDEhMKC2Rpc3RpbmN0X2lkGAIgASgJIlAKHkdldFBlcnNvbnNCeURpc3RpbmN0SWRzUmVxdWVzdBIuCgRrZXlzGAEgAygLMiAucGVyc29uaG9nLmlkZW50aXR5LnYxLlBlcnNvbktleSJ/ChtHZXRQZXJzb25CeURpc3RpbmN0SWRSZXN1bHQSDwoHdGVhbV9pZBgBIAEoAxITCgtkaXN0aW5jdF9pZBgCIAEoCRIvCgZwZXJzb24YAyABKAsyGi5wZXJzb25ob2cudHlwZXMudjEuUGVyc29uSACIAQFCCQoHX3BlcnNvbiJmCh9HZXRQZXJzb25zQnlEaXN0aW5jdElkc1Jlc3BvbnNlEkMKB3Jlc3VsdHMYASADKAsyMi5wZXJzb25ob2cuaWRlbnRpdHkudjEuR2V0UGVyc29uQnlEaXN0aW5jdElkUmVzdWx0InoKH0dldERpc3RpbmN0SWRzRm9yUGVyc29uc1JlcXVlc3QSDwoHdGVhbV9pZBgBIAEoAxISCgpwZXJzb25faWRzGAIgAygDEh0KEGxpbWl0X3Blcl9wZXJzb24YAyABKANIAIgBAUITChFfbGltaXRfcGVyX3BlcnNvbiJmCiBHZXREaXN0aW5jdElkc0ZvclBlcnNvbnNSZXNwb25zZRJCChNwZXJzb25fZGlzdGluY3RfaWRzGAEgAygLMiUucGVyc29uaG9nLnR5cGVzLnYxLlBlcnNvbkRpc3RpbmN0SWRzIj0KC01lcmdlU291cmNlEhoKEnNvdXJjZV9kaXN0aW5jdF9pZBgBIAEoCRISCgpldmVudF91dWlkGAIgASgJIqsCChNNZXJnZVBlcnNvbnNSZXF1ZXN0Eg8KB3RlYW1faWQYASABKAMSGgoSdGFyZ2V0X2Rpc3RpbmN0X2lkGAIgASgJEjMKB3NvdXJjZXMYAyADKAsyIi5wZXJzb25ob2cuaWRlbnRpdHkudjEuTWVyZ2VTb3VyY2USEQoJZXZlbnRfc2V0GAQgASgMEhYKDmV2ZW50X3NldF9vbmNlGAUgASgMEg0KBW9wX2lkGAYgASgJEiAKGGFsbG93X2lkZW50aWZpZWRfc291cmNlcxgHIAEoCBIXCgptb3ZlX2xpbWl0GAggASgDSACIAQESEgoKY3JlYXRlZF9hdBgJIAEoAxIaChJjcmVhdG9yX2V2ZW50X3V1aWQYCiABKAlCDQoLX21vdmVfbGltaXQisAEKEU1lcmdlU291cmNlUmVzdWx0EhoKEnNvdXJjZV9kaXN0aW5jdF9pZBgBIAEoCRI6CgdvdXRjb21lGAIgASgOMikucGVyc29uaG9nLmlkZW50aXR5LnYxLk1lcmdlU291cmNlT3V0Y29tZRIdChBzb3VyY2VfcGVyc29uX2lkGAMgASgDSACIAQESDwoHc2V0dGxlZBgEIAEoCEITChFfc291cmNlX3BlcnNvbl9pZCKgAQoUTWVyZ2VQZXJzb25zUmVzcG9uc2USDQoFb3BfaWQYASABKAkSMQoIc3Vydml2b3IYAiABKAsyGi5wZXJzb25ob2cudHlwZXMudjEuUGVyc29uSACIAQESOQoHcmVzdWx0cxgDIAMoCzIoLnBlcnNvbmhvZy5pZGVudGl0eS52MS5NZXJnZVNvdXJjZVJlc3VsdEILCglfc3Vydml2b3IqqgMKEk1lcmdlU291cmNlT3V0Y29tZRIkCiBNRVJHRV9TT1VSQ0VfT1VUQ09NRV9VTlNQRUNJRklFRBAAEh8KG01FUkdFX1NPVVJDRV9PVVRDT01FX01FUkdFRBABEikKJU1FUkdFX1NPVVJDRV9PVVRDT01FX05PT1BfU0FNRV9QRVJTT04QAhIhCh1NRVJHRV9TT1VSQ0VfT1VUQ09NRV9BVFRBQ0hFRBADEigKJE1FUkdFX1NPVVJDRV9PVVRDT01FX1NLSVBQRURfSUxMRUdBTBAEEjMKL01FUkdFX1NPVVJDRV9PVVRDT01FX1NLSVBQRURfQUxSRUFEWV9JREVOVElGSUVEEAUSKQolTUVSR0VfU09VUkNFX09VVENPTUVfU0tJUFBFRF9DT05GTElDVBAGEisKJ01FUkdFX1NPVVJDRV9PVVRDT01FX1NLSVBQRURfTU9WRV9MSU1JVBAHEh4KGk1FUkdFX1NPVVJDRV9PVVRDT01FX0VSUk9SEAgSKAokTUVSR0VfU09VUkNFX09VVENPTUVfU0tJUFBFRF9SRUZVU0VEEAky1QUKEVBlcnNvbkhvZ0lkZW50aXR5EpoBCh1HZXRPckNyZWF0ZVBlcnNvbkJ5RGlzdGluY3RJZBI7LnBlcnNvbmhvZy5pZGVudGl0eS52MS5HZXRPckNyZWF0ZVBlcnNvbkJ5RGlzdGluY3RJZFJlcXVlc3QaPC5wZXJzb25ob2cuaWRlbnRpdHkudjEuR2V0T3JDcmVhdGVQZXJzb25CeURpc3RpbmN0SWRSZXNwb25zZRKgAQofR2V0T3JDcmVhdGVQZXJzb25zQnlEaXN0aW5jdElkcxI9LnBlcnNvbmhvZy5pZGVudGl0eS52MS5HZXRPckNyZWF0ZVBlcnNvbnNCeURpc3RpbmN0SWRzUmVxdWVzdBo+LnBlcnNvbmhvZy5pZGVudGl0eS52MS5HZXRPckNyZWF0ZVBlcnNvbnNCeURpc3RpbmN0SWRzUmVzcG9uc2USiAEKF0dldFBlcnNvbnNCeURpc3RpbmN0SWRzEjUucGVyc29uaG9nLmlkZW50aXR5LnYxLkdldFBlcnNvbnNCeURpc3RpbmN0SWRzUmVxdWVzdBo2LnBlcnNvbmhvZy5pZGVudGl0eS52MS5HZXRQZXJzb25zQnlEaXN0aW5jdElkc1Jlc3BvbnNlEosBChhHZXREaXN0aW5jdElkc0ZvclBlcnNvbnMSNi5wZXJzb25ob2cuaWRlbnRpdHkudjEuR2V0RGlzdGluY3RJZHNGb3JQZXJzb25zUmVxdWVzdBo3LnBlcnNvbmhvZy5pZGVudGl0eS52MS5HZXREaXN0aW5jdElkc0ZvclBlcnNvbnNSZXNwb25zZRJnCgxNZXJnZVBlcnNvbnMSKi5wZXJzb25ob2cuaWRlbnRpdHkudjEuTWVyZ2VQZXJzb25zUmVxdWVzdBorLnBlcnNvbmhvZy5pZGVudGl0eS52MS5NZXJnZVBlcnNvbnNSZXNwb25zZWIGcHJvdG8z',
+        'CiRwZXJzb25ob2cvaWRlbnRpdHkvdjEvaWRlbnRpdHkucHJvdG8SFXBlcnNvbmhvZy5pZGVudGl0eS52MSLOAQoWR2V0T3JDcmVhdGVQZXJzb25FbnRyeRIPCgd0ZWFtX2lkGAEgASgDEhMKC2Rpc3RpbmN0X2lkGAIgASgJEhoKEmV4dHJhX2Rpc3RpbmN0X2lkcxgDIAMoCRISCgpldmVudF9uYW1lGAQgASgJEhYKDnNldF9wcm9wZXJ0aWVzGAUgASgMEhsKE3NldF9vbmNlX3Byb3BlcnRpZXMYBiABKAwSEgoKY3JlYXRlZF9hdBgHIAEoAxIVCg1pc19pZGVudGlmaWVkGAggASgIImQKJEdldE9yQ3JlYXRlUGVyc29uQnlEaXN0aW5jdElkUmVxdWVzdBI8CgVlbnRyeRgBIAEoCzItLnBlcnNvbmhvZy5pZGVudGl0eS52MS5HZXRPckNyZWF0ZVBlcnNvbkVudHJ5ImQKJUdldE9yQ3JlYXRlUGVyc29uQnlEaXN0aW5jdElkUmVzcG9uc2USKgoGcGVyc29uGAEgASgLMhoucGVyc29uaG9nLnR5cGVzLnYxLlBlcnNvbhIPCgdjcmVhdGVkGAIgASgIImgKJkdldE9yQ3JlYXRlUGVyc29uc0J5RGlzdGluY3RJZHNSZXF1ZXN0Ej4KB2VudHJpZXMYASADKAsyLS5wZXJzb25ob2cuaWRlbnRpdHkudjEuR2V0T3JDcmVhdGVQZXJzb25FbnRyeSKqAQoXR2V0T3JDcmVhdGVQZXJzb25SZXN1bHQSDwoHdGVhbV9pZBgBIAEoAxITCgtkaXN0aW5jdF9pZBgCIAEoCRIvCgZwZXJzb24YAyABKAsyGi5wZXJzb25ob2cudHlwZXMudjEuUGVyc29uSACIAQESDwoHY3JlYXRlZBgEIAEoCBISCgVlcnJvchgFIAEoCUgBiAEBQgkKB19wZXJzb25CCAoGX2Vycm9yImoKJ0dldE9yQ3JlYXRlUGVyc29uc0J5RGlzdGluY3RJZHNSZXNwb25zZRI/CgdyZXN1bHRzGAEgAygLMi4ucGVyc29uaG9nLmlkZW50aXR5LnYxLkdldE9yQ3JlYXRlUGVyc29uUmVzdWx0IjEKCVBlcnNvbktleRIPCgd0ZWFtX2lkGAEgASgDEhMKC2Rpc3RpbmN0X2lkGAIgASgJIlAKHkdldFBlcnNvbnNCeURpc3RpbmN0SWRzUmVxdWVzdBIuCgRrZXlzGAEgAygLMiAucGVyc29uaG9nLmlkZW50aXR5LnYxLlBlcnNvbktleSJ/ChtHZXRQZXJzb25CeURpc3RpbmN0SWRSZXN1bHQSDwoHdGVhbV9pZBgBIAEoAxITCgtkaXN0aW5jdF9pZBgCIAEoCRIvCgZwZXJzb24YAyABKAsyGi5wZXJzb25ob2cudHlwZXMudjEuUGVyc29uSACIAQFCCQoHX3BlcnNvbiJmCh9HZXRQZXJzb25zQnlEaXN0aW5jdElkc1Jlc3BvbnNlEkMKB3Jlc3VsdHMYASADKAsyMi5wZXJzb25ob2cuaWRlbnRpdHkudjEuR2V0UGVyc29uQnlEaXN0aW5jdElkUmVzdWx0IkUKHEdldERpc3RpbmN0SWRNYXBwaW5nc1JlcXVlc3QSDwoHdGVhbV9pZBgBIAEoAxIUCgxkaXN0aW5jdF9pZHMYAiADKAkiUQoURGlzdGluY3RJZE1hcHBpbmdSb3cSEwoLZGlzdGluY3RfaWQYASABKAkSEwoLcGVyc29uX3V1aWQYAiABKAkSDwoHdmVyc2lvbhgDIAEoAyJeCh1HZXREaXN0aW5jdElkTWFwcGluZ3NSZXNwb25zZRI9CghtYXBwaW5ncxgBIAMoCzIrLnBlcnNvbmhvZy5pZGVudGl0eS52MS5EaXN0aW5jdElkTWFwcGluZ1JvdyJ6Ch9HZXREaXN0aW5jdElkc0ZvclBlcnNvbnNSZXF1ZXN0Eg8KB3RlYW1faWQYASABKAMSEgoKcGVyc29uX2lkcxgCIAMoAxIdChBsaW1pdF9wZXJfcGVyc29uGAMgASgDSACIAQFCEwoRX2xpbWl0X3Blcl9wZXJzb24iZgogR2V0RGlzdGluY3RJZHNGb3JQZXJzb25zUmVzcG9uc2USQgoTcGVyc29uX2Rpc3RpbmN0X2lkcxgBIAMoCzIlLnBlcnNvbmhvZy50eXBlcy52MS5QZXJzb25EaXN0aW5jdElkcyI9CgtNZXJnZVNvdXJjZRIaChJzb3VyY2VfZGlzdGluY3RfaWQYASABKAkSEgoKZXZlbnRfdXVpZBgCIAEoCSKrAgoTTWVyZ2VQZXJzb25zUmVxdWVzdBIPCgd0ZWFtX2lkGAEgASgDEhoKEnRhcmdldF9kaXN0aW5jdF9pZBgCIAEoCRIzCgdzb3VyY2VzGAMgAygLMiIucGVyc29uaG9nLmlkZW50aXR5LnYxLk1lcmdlU291cmNlEhEKCWV2ZW50X3NldBgEIAEoDBIWCg5ldmVudF9zZXRfb25jZRgFIAEoDBINCgVvcF9pZBgGIAEoCRIgChhhbGxvd19pZGVudGlmaWVkX3NvdXJjZXMYByABKAgSFwoKbW92ZV9saW1pdBgIIAEoA0gAiAEBEhIKCmNyZWF0ZWRfYXQYCSABKAMSGgoSY3JlYXRvcl9ldmVudF91dWlkGAogASgJQg0KC19tb3ZlX2xpbWl0IrABChFNZXJnZVNvdXJjZVJlc3VsdBIaChJzb3VyY2VfZGlzdGluY3RfaWQYASABKAkSOgoHb3V0Y29tZRgCIAEoDjIpLnBlcnNvbmhvZy5pZGVudGl0eS52MS5NZXJnZVNvdXJjZU91dGNvbWUSHQoQc291cmNlX3BlcnNvbl9pZBgDIAEoA0gAiAEBEg8KB3NldHRsZWQYBCABKAhCEwoRX3NvdXJjZV9wZXJzb25faWQioAEKFE1lcmdlUGVyc29uc1Jlc3BvbnNlEg0KBW9wX2lkGAEgASgJEjEKCHN1cnZpdm9yGAIgASgLMhoucGVyc29uaG9nLnR5cGVzLnYxLlBlcnNvbkgAiAEBEjkKB3Jlc3VsdHMYAyADKAsyKC5wZXJzb25ob2cuaWRlbnRpdHkudjEuTWVyZ2VTb3VyY2VSZXN1bHRCCwoJX3N1cnZpdm9yKqoDChJNZXJnZVNvdXJjZU91dGNvbWUSJAogTUVSR0VfU09VUkNFX09VVENPTUVfVU5TUEVDSUZJRUQQABIfChtNRVJHRV9TT1VSQ0VfT1VUQ09NRV9NRVJHRUQQARIpCiVNRVJHRV9TT1VSQ0VfT1VUQ09NRV9OT09QX1NBTUVfUEVSU09OEAISIQodTUVSR0VfU09VUkNFX09VVENPTUVfQVRUQUNIRUQQAxIoCiRNRVJHRV9TT1VSQ0VfT1VUQ09NRV9TS0lQUEVEX0lMTEVHQUwQBBIzCi9NRVJHRV9TT1VSQ0VfT1VUQ09NRV9TS0lQUEVEX0FMUkVBRFlfSURFTlRJRklFRBAFEikKJU1FUkdFX1NPVVJDRV9PVVRDT01FX1NLSVBQRURfQ09ORkxJQ1QQBhIrCidNRVJHRV9TT1VSQ0VfT1VUQ09NRV9TS0lQUEVEX01PVkVfTElNSVQQBxIeChpNRVJHRV9TT1VSQ0VfT1VUQ09NRV9FUlJPUhAIEigKJE1FUkdFX1NPVVJDRV9PVVRDT01FX1NLSVBQRURfUkVGVVNFRBAJMtoGChFQZXJzb25Ib2dJZGVudGl0eRKaAQodR2V0T3JDcmVhdGVQZXJzb25CeURpc3RpbmN0SWQSOy5wZXJzb25ob2cuaWRlbnRpdHkudjEuR2V0T3JDcmVhdGVQZXJzb25CeURpc3RpbmN0SWRSZXF1ZXN0GjwucGVyc29uaG9nLmlkZW50aXR5LnYxLkdldE9yQ3JlYXRlUGVyc29uQnlEaXN0aW5jdElkUmVzcG9uc2USoAEKH0dldE9yQ3JlYXRlUGVyc29uc0J5RGlzdGluY3RJZHMSPS5wZXJzb25ob2cuaWRlbnRpdHkudjEuR2V0T3JDcmVhdGVQZXJzb25zQnlEaXN0aW5jdElkc1JlcXVlc3QaPi5wZXJzb25ob2cuaWRlbnRpdHkudjEuR2V0T3JDcmVhdGVQZXJzb25zQnlEaXN0aW5jdElkc1Jlc3BvbnNlEogBChdHZXRQZXJzb25zQnlEaXN0aW5jdElkcxI1LnBlcnNvbmhvZy5pZGVudGl0eS52MS5HZXRQZXJzb25zQnlEaXN0aW5jdElkc1JlcXVlc3QaNi5wZXJzb25ob2cuaWRlbnRpdHkudjEuR2V0UGVyc29uc0J5RGlzdGluY3RJZHNSZXNwb25zZRKCAQoVR2V0RGlzdGluY3RJZE1hcHBpbmdzEjMucGVyc29uaG9nLmlkZW50aXR5LnYxLkdldERpc3RpbmN0SWRNYXBwaW5nc1JlcXVlc3QaNC5wZXJzb25ob2cuaWRlbnRpdHkudjEuR2V0RGlzdGluY3RJZE1hcHBpbmdzUmVzcG9uc2USiwEKGEdldERpc3RpbmN0SWRzRm9yUGVyc29ucxI2LnBlcnNvbmhvZy5pZGVudGl0eS52MS5HZXREaXN0aW5jdElkc0ZvclBlcnNvbnNSZXF1ZXN0GjcucGVyc29uaG9nLmlkZW50aXR5LnYxLkdldERpc3RpbmN0SWRzRm9yUGVyc29uc1Jlc3BvbnNlEmcKDE1lcmdlUGVyc29ucxIqLnBlcnNvbmhvZy5pZGVudGl0eS52MS5NZXJnZVBlcnNvbnNSZXF1ZXN0GisucGVyc29uaG9nLmlkZW50aXR5LnYxLk1lcmdlUGVyc29uc1Jlc3BvbnNlYgZwcm90bzM',
         [file_personhog_types_v1_person]
     )
 
@@ -330,6 +330,84 @@ export const GetPersonsByDistinctIdsResponseSchema: GenMessage<GetPersonsByDisti
     messageDesc(file_personhog_identity_v1_identity, 9)
 
 /**
+ * @generated from message personhog.identity.v1.GetDistinctIdMappingsRequest
+ */
+export type GetDistinctIdMappingsRequest = Message<'personhog.identity.v1.GetDistinctIdMappingsRequest'> & {
+    /**
+     * @generated from field: int64 team_id = 1;
+     */
+    teamId: bigint
+
+    /**
+     * Max 250 per request.
+     *
+     * @generated from field: repeated string distinct_ids = 2;
+     */
+    distinctIds: string[]
+}
+
+/**
+ * Describes the message personhog.identity.v1.GetDistinctIdMappingsRequest.
+ * Use `create(GetDistinctIdMappingsRequestSchema)` to create a new message.
+ */
+export const GetDistinctIdMappingsRequestSchema: GenMessage<GetDistinctIdMappingsRequest> =
+    /*@__PURE__*/
+    messageDesc(file_personhog_identity_v1_identity, 10)
+
+/**
+ * One live mapping row, shaped for re-emission to ClickHouse: the person
+ * uuid (ClickHouse keys persons by uuid, not row id) and the mapping row's
+ * own version (not the person's).
+ *
+ * @generated from message personhog.identity.v1.DistinctIdMappingRow
+ */
+export type DistinctIdMappingRow = Message<'personhog.identity.v1.DistinctIdMappingRow'> & {
+    /**
+     * @generated from field: string distinct_id = 1;
+     */
+    distinctId: string
+
+    /**
+     * @generated from field: string person_uuid = 2;
+     */
+    personUuid: string
+
+    /**
+     * @generated from field: int64 version = 3;
+     */
+    version: bigint
+}
+
+/**
+ * Describes the message personhog.identity.v1.DistinctIdMappingRow.
+ * Use `create(DistinctIdMappingRowSchema)` to create a new message.
+ */
+export const DistinctIdMappingRowSchema: GenMessage<DistinctIdMappingRow> =
+    /*@__PURE__*/
+    messageDesc(file_personhog_identity_v1_identity, 11)
+
+/**
+ * @generated from message personhog.identity.v1.GetDistinctIdMappingsResponse
+ */
+export type GetDistinctIdMappingsResponse = Message<'personhog.identity.v1.GetDistinctIdMappingsResponse'> & {
+    /**
+     * Distinct ids without a live mapping (unknown, tombstoned, or their
+     * person deleted) are absent.
+     *
+     * @generated from field: repeated personhog.identity.v1.DistinctIdMappingRow mappings = 1;
+     */
+    mappings: DistinctIdMappingRow[]
+}
+
+/**
+ * Describes the message personhog.identity.v1.GetDistinctIdMappingsResponse.
+ * Use `create(GetDistinctIdMappingsResponseSchema)` to create a new message.
+ */
+export const GetDistinctIdMappingsResponseSchema: GenMessage<GetDistinctIdMappingsResponse> =
+    /*@__PURE__*/
+    messageDesc(file_personhog_identity_v1_identity, 12)
+
+/**
  * The identity-side twin of the service RPC of the same name, minus
  * ReadOptions: identity always reads the primary, so there is no
  * consistency to choose.
@@ -364,7 +442,7 @@ export type GetDistinctIdsForPersonsRequest = Message<'personhog.identity.v1.Get
  */
 export const GetDistinctIdsForPersonsRequestSchema: GenMessage<GetDistinctIdsForPersonsRequest> =
     /*@__PURE__*/
-    messageDesc(file_personhog_identity_v1_identity, 10)
+    messageDesc(file_personhog_identity_v1_identity, 13)
 
 /**
  * @generated from message personhog.identity.v1.GetDistinctIdsForPersonsResponse
@@ -382,7 +460,7 @@ export type GetDistinctIdsForPersonsResponse = Message<'personhog.identity.v1.Ge
  */
 export const GetDistinctIdsForPersonsResponseSchema: GenMessage<GetDistinctIdsForPersonsResponse> =
     /*@__PURE__*/
-    messageDesc(file_personhog_identity_v1_identity, 11)
+    messageDesc(file_personhog_identity_v1_identity, 14)
 
 /**
  * One source pair of a MergePersons call.
@@ -410,7 +488,7 @@ export type MergeSource = Message<'personhog.identity.v1.MergeSource'> & {
  */
 export const MergeSourceSchema: GenMessage<MergeSource> =
     /*@__PURE__*/
-    messageDesc(file_personhog_identity_v1_identity, 12)
+    messageDesc(file_personhog_identity_v1_identity, 15)
 
 /**
  * MergePersonsRequest merges every source distinct id's person into the
@@ -510,7 +588,7 @@ export type MergePersonsRequest = Message<'personhog.identity.v1.MergePersonsReq
  */
 export const MergePersonsRequestSchema: GenMessage<MergePersonsRequest> =
     /*@__PURE__*/
-    messageDesc(file_personhog_identity_v1_identity, 13)
+    messageDesc(file_personhog_identity_v1_identity, 16)
 
 /**
  * @generated from message personhog.identity.v1.MergeSourceResult
@@ -550,7 +628,7 @@ export type MergeSourceResult = Message<'personhog.identity.v1.MergeSourceResult
  */
 export const MergeSourceResultSchema: GenMessage<MergeSourceResult> =
     /*@__PURE__*/
-    messageDesc(file_personhog_identity_v1_identity, 14)
+    messageDesc(file_personhog_identity_v1_identity, 17)
 
 /**
  * @generated from message personhog.identity.v1.MergePersonsResponse
@@ -587,7 +665,7 @@ export type MergePersonsResponse = Message<'personhog.identity.v1.MergePersonsRe
  */
 export const MergePersonsResponseSchema: GenMessage<MergePersonsResponse> =
     /*@__PURE__*/
-    messageDesc(file_personhog_identity_v1_identity, 15)
+    messageDesc(file_personhog_identity_v1_identity, 18)
 
 /**
  * @generated from enum personhog.identity.v1.MergeSourceOutcome
@@ -732,6 +810,18 @@ export const PersonHogIdentity: GenService<{
         methodKind: 'unary'
         input: typeof GetPersonsByDistinctIdsRequestSchema
         output: typeof GetPersonsByDistinctIdsResponseSchema
+    }
+    /**
+     * Committed mapping rows for the given distinct ids on the primary, with
+     * the person uuid and mapping-row version, for re-emission to ClickHouse
+     * by merge paths that find their request already satisfied.
+     *
+     * @generated from rpc personhog.identity.v1.PersonHogIdentity.GetDistinctIdMappings
+     */
+    getDistinctIdMappings: {
+        methodKind: 'unary'
+        input: typeof GetDistinctIdMappingsRequestSchema
+        output: typeof GetDistinctIdMappingsResponseSchema
     }
     /**
      * Person-id to distinct-ids expansion on the primary; the strong twin

--- a/nodejs/src/common/generated/personhog/personhog/identity/v1/identity_pb.ts
+++ b/nodejs/src/common/generated/personhog/personhog/identity/v1/identity_pb.ts
@@ -355,9 +355,8 @@ export const GetDistinctIdMappingsRequestSchema: GenMessage<GetDistinctIdMapping
     messageDesc(file_personhog_identity_v1_identity, 10)
 
 /**
- * One live mapping row, shaped for re-emission to ClickHouse: the person
- * uuid (ClickHouse keys persons by uuid, not row id) and the mapping row's
- * own version (not the person's).
+ * One live mapping row: the person uuid (ClickHouse keys persons by uuid,
+ * not row id) and the mapping row's own version (not the person's).
  *
  * @generated from message personhog.identity.v1.DistinctIdMappingRow
  */
@@ -812,9 +811,8 @@ export const PersonHogIdentity: GenService<{
         output: typeof GetPersonsByDistinctIdsResponseSchema
     }
     /**
-     * Committed mapping rows for the given distinct ids on the primary, with
-     * the person uuid and mapping-row version, for re-emission to ClickHouse
-     * by merge paths that find their request already satisfied.
+     * Committed mapping rows on the primary, for re-emission to ClickHouse by
+     * merge paths that find their request already satisfied.
      *
      * @generated from rpc personhog.identity.v1.PersonHogIdentity.GetDistinctIdMappings
      */

--- a/nodejs/src/common/personhog/identity.test.ts
+++ b/nodejs/src/common/personhog/identity.test.ts
@@ -1,6 +1,7 @@
 import { createClient, createRouterTransport } from '@connectrpc/connect'
 
 import {
+    GetDistinctIdMappingsRequest,
     GetDistinctIdsForPersonsRequest,
     GetPersonsByDistinctIdsRequest,
     PersonHogIdentity,
@@ -9,7 +10,11 @@ import {
 import { PersonhogIdentityOperations } from './identity'
 
 describe('PersonhogIdentityOperations', () => {
-    function makeOps(handlers: { getPersonsByDistinctIds?: jest.Mock; getDistinctIdsForPersons?: jest.Mock }) {
+    function makeOps(handlers: {
+        getPersonsByDistinctIds?: jest.Mock
+        getDistinctIdsForPersons?: jest.Mock
+        getDistinctIdMappings?: jest.Mock
+    }) {
         const transport = createRouterTransport(({ service }) => {
             service(PersonHogIdentity, {
                 getOrCreatePersonByDistinctId: jest.fn(() => ({ person: undefined, created: false })),
@@ -17,6 +22,7 @@ describe('PersonhogIdentityOperations', () => {
                 getPersonsByDistinctIds: handlers.getPersonsByDistinctIds ?? jest.fn(() => ({ results: [] })),
                 getDistinctIdsForPersons:
                     handlers.getDistinctIdsForPersons ?? jest.fn(() => ({ personDistinctIds: [] })),
+                getDistinctIdMappings: handlers.getDistinctIdMappings ?? jest.fn(() => ({ mappings: [] })),
             })
         })
         return new PersonhogIdentityOperations(createClient(PersonHogIdentity, transport))
@@ -38,6 +44,26 @@ describe('PersonhogIdentityOperations', () => {
         expect(handler.mock.calls[0][0].keys).toHaveLength(250)
         expect(handler.mock.calls[1][0].keys).toHaveLength(1)
         expect(results).toHaveLength(251)
+    })
+
+    // The mapping version feeds the ClickHouse message builder as a JSON
+    // number; a BigInt leaking through would throw in JSON.stringify.
+    it('decodes mapping rows to plain numbers and strings', async () => {
+        const handler = jest.fn((req: GetDistinctIdMappingsRequest) => ({
+            mappings: req.distinctIds.map((distinctId) => ({
+                distinctId,
+                personUuid: '01928aaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+                version: BigInt(1),
+            })),
+        }))
+        const ops = makeOps({ getDistinctIdMappings: handler })
+
+        const mappings = await ops.getDistinctIdMappings(1, ['anon'])
+
+        expect(handler.mock.calls[0][0].teamId).toBe(BigInt(1))
+        expect(mappings).toEqual([
+            { distinctId: 'anon', personUuid: '01928aaa-bbbb-cccc-dddd-eeeeeeeeeeee', version: 1 },
+        ])
     })
 
     it('chunks expansion requests to the service batch cap', async () => {

--- a/nodejs/src/common/personhog/identity.ts
+++ b/nodejs/src/common/personhog/identity.ts
@@ -2,6 +2,7 @@ import { create } from '@bufbuild/protobuf'
 import { Client, Code, ConnectError } from '@connectrpc/connect'
 
 import {
+    GetDistinctIdMappingsRequestSchema,
     GetDistinctIdsForPersonsRequestSchema,
     GetOrCreatePersonByDistinctIdRequestSchema,
     GetPersonsByDistinctIdsRequestSchema,
@@ -117,6 +118,40 @@ export class PersonhogIdentityOperations {
             }
         }
         return byPerson
+    }
+
+    /**
+     * Committed mapping rows for the given distinct ids on the primary,
+     * with the person uuid and mapping-row version, for re-emission to
+     * ClickHouse. Ids without a live mapping are absent from the result.
+     */
+    async getDistinctIdMappings(
+        teamId: number,
+        distinctIds: string[],
+        callerTag?: string
+    ): Promise<{ distinctId: string; personUuid: string; version: number }[]> {
+        if (distinctIds.length === 0) {
+            return []
+        }
+        const out: { distinctId: string; personUuid: string; version: number }[] = []
+        for (let i = 0; i < distinctIds.length; i += IDENTITY_BATCH_SIZE) {
+            const chunk = distinctIds.slice(i, i + IDENTITY_BATCH_SIZE)
+            const response = await this.client.getDistinctIdMappings(
+                create(GetDistinctIdMappingsRequestSchema, {
+                    teamId: BigInt(teamId),
+                    distinctIds: chunk,
+                }),
+                callerTag ? { headers: { 'x-caller-tag': callerTag } } : undefined
+            )
+            for (const mapping of response.mappings) {
+                out.push({
+                    distinctId: mapping.distinctId,
+                    personUuid: mapping.personUuid,
+                    version: Number(mapping.version),
+                })
+            }
+        }
+        return out
     }
 
     /**

--- a/nodejs/src/common/personhog/identity.ts
+++ b/nodejs/src/common/personhog/identity.ts
@@ -121,9 +121,8 @@ export class PersonhogIdentityOperations {
     }
 
     /**
-     * Committed mapping rows for the given distinct ids on the primary,
-     * with the person uuid and mapping-row version, for re-emission to
-     * ClickHouse. Ids without a live mapping are absent from the result.
+     * Committed mapping rows on the primary, for re-emission to ClickHouse.
+     * Ids without a live mapping are absent from the result.
      */
     async getDistinctIdMappings(
         teamId: number,

--- a/nodejs/src/common/personhog/personhog-person-repository.test.ts
+++ b/nodejs/src/common/personhog/personhog-person-repository.test.ts
@@ -76,6 +76,7 @@ function createMockPostgres(): jest.Mocked<PersonRepository> {
         fetchPersonsByPersonIds: jest.fn(),
         fetchPersonsForUpdateByDistinctIds: jest.fn(),
         fetchDistinctIdsForPersons: jest.fn(),
+        fetchPersonDistinctIdMappings: jest.fn(),
         deletePersons: jest.fn(),
         claimLifecycleMarks: jest.fn(),
         releaseLifecycleMarks: jest.fn(),

--- a/nodejs/src/common/personhog/personhog-person-repository.ts
+++ b/nodejs/src/common/personhog/personhog-person-repository.ts
@@ -5,6 +5,7 @@ import { PersonUpdate } from '~/common/persons/person-update-batch'
 import {
     InternalPersonWithDistinctId,
     LifecycleMarkPerson,
+    PersonDistinctIdMapping,
     PersonRepository,
 } from '~/common/persons/repositories/person-repository'
 import { PersonRepositoryTransaction } from '~/common/persons/repositories/person-repository-transaction'
@@ -164,6 +165,10 @@ export class PersonHogPersonRepository implements PersonRepository {
                 this.postgres.fetchDistinctIdsForPersons(teamId, personIntIds, options)
             )
         }
+    }
+
+    fetchPersonDistinctIdMappings(_teamId: TeamId, _distinctIds: string[]): Promise<PersonDistinctIdMapping[]> {
+        return Promise.reject(new Error('fetchPersonDistinctIdMappings is not implemented for personhog'))
     }
 
     // All write operations delegate directly to Postgres

--- a/nodejs/src/common/persons/repositories/person-repository.ts
+++ b/nodejs/src/common/persons/repositories/person-repository.ts
@@ -21,6 +21,12 @@ export type InternalPersonWithDistinctId = InternalPerson & {
     distinct_id: string
 }
 
+/** A distinct id's committed mapping row, shaped for re-emission to ClickHouse. */
+export type PersonDistinctIdMapping = {
+    distinctId: string
+    message: PersonMessage
+}
+
 export class PersonPropertiesSizeViolationError extends Error {
     constructor(
         message: string,
@@ -158,6 +164,15 @@ export interface PersonRepository {
         personIntIds: string[],
         options?: { limitPerPerson?: number; useReadReplica?: boolean }
     ): Promise<Record<string, string[]>>
+
+    /**
+     * Fetch the committed mapping rows for the given distinct ids, as ready-to-produce
+     * ClickHouse messages carrying the current person uuid and mapping-row version.
+     * Reads the authoritative side: emitted rows must reflect committed truth, since a
+     * stale pairing re-emitted with its version would overwrite a newer mapping.
+     * Distinct ids without a live mapping are absent from the result.
+     */
+    fetchPersonDistinctIdMappings(teamId: TeamId, distinctIds: string[]): Promise<PersonDistinctIdMapping[]>
 
     createPerson(
         createdAt: DateTime,

--- a/nodejs/src/common/persons/repositories/person-repository.ts
+++ b/nodejs/src/common/persons/repositories/person-repository.ts
@@ -166,11 +166,8 @@ export interface PersonRepository {
     ): Promise<Record<string, string[]>>
 
     /**
-     * Fetch the committed mapping rows for the given distinct ids, as ready-to-produce
-     * ClickHouse messages carrying the current person uuid and mapping-row version.
-     * Reads the authoritative side: emitted rows must reflect committed truth, since a
-     * stale pairing re-emitted with its version would overwrite a newer mapping.
-     * Distinct ids without a live mapping are absent from the result.
+     * Reads the authoritative side: a stale pairing re-emitted with its version would
+     * overwrite a newer mapping. Ids without a live mapping are absent from the result.
      */
     fetchPersonDistinctIdMappings(teamId: TeamId, distinctIds: string[]): Promise<PersonDistinctIdMapping[]>
 

--- a/nodejs/src/common/persons/repositories/postgres-person-repository.test.ts
+++ b/nodejs/src/common/persons/repositories/postgres-person-repository.test.ts
@@ -979,6 +979,51 @@ describe('PostgresPersonRepository', () => {
         })
     })
 
+    describe('fetchPersonDistinctIdMappings()', () => {
+        // Re-emission healing depends on this read carrying the committed pairing:
+        // a stale uuid or version 0 would overwrite or fail to repair ClickHouse.
+        it('returns the committed uuid and version per mapping, skipping deleted and missing ids', async () => {
+            const sourcePerson = await createTestPerson(team.id, 'anon')
+            const targetPerson = await createTestPerson(team.id, 'main')
+            const moveResult = await repository.moveDistinctIds(sourcePerson, targetPerson, undefined)
+            expect(moveResult.success).toBe(true)
+            await repository.addDistinctId(targetPerson, 'deleted-id', 1)
+            await postgres.query(
+                PostgresUse.PERSONS_WRITE,
+                'UPDATE posthog_persondistinctid SET is_deleted = true WHERE team_id = $1 AND distinct_id = $2',
+                [team.id, 'deleted-id'],
+                'markDeletedForTest'
+            )
+
+            const mappings = await repository.fetchPersonDistinctIdMappings(team.id, [
+                'anon',
+                'main',
+                'deleted-id',
+                'never-seen',
+            ])
+
+            const byDistinctId = Object.fromEntries(
+                mappings.map((mapping) => [mapping.distinctId, parseJSON(mapping.message.value!.toString())])
+            )
+            expect(Object.keys(byDistinctId).sort()).toEqual(['anon', 'main'])
+            expect(byDistinctId['anon']).toEqual({
+                team_id: team.id,
+                distinct_id: 'anon',
+                person_id: targetPerson.uuid,
+                version: 1,
+                is_deleted: 0,
+            })
+            expect(byDistinctId['main']).toEqual({
+                team_id: team.id,
+                distinct_id: 'main',
+                person_id: targetPerson.uuid,
+                version: 0,
+                is_deleted: 0,
+            })
+            expect(mappings.every((mapping) => mapping.message.output === PERSON_DISTINCT_IDS_OUTPUT)).toBe(true)
+        })
+    })
+
     describe('moveDistinctIds()', () => {
         it('should move distinct IDs from source to target person', async () => {
             const sourcePerson = await createTestPerson(team.id, 'source-distinct-id', { name: 'Source Person' })

--- a/nodejs/src/common/persons/repositories/postgres-person-repository.ts
+++ b/nodejs/src/common/persons/repositories/postgres-person-repository.ts
@@ -39,6 +39,7 @@ import {
     InternalPersonWithDistinctId,
     LifecycleMarkPerson,
     PersonClaimedByLifecycleOpError,
+    PersonDistinctIdMapping,
     PersonMessage,
     PersonPropertiesSizeViolationError,
     PersonRepository,
@@ -1849,6 +1850,41 @@ export class PostgresPersonRepository
         )
 
         return rows.map((row) => row.distinct_id)
+    }
+
+    async fetchPersonDistinctIdMappings(teamId: number, distinctIds: string[]): Promise<PersonDistinctIdMapping[]> {
+        if (distinctIds.length === 0) {
+            return []
+        }
+
+        const { rows } = await this.postgres.query<{ distinct_id: string; version: string | null; uuid: string }>(
+            PostgresUse.PERSONS_WRITE,
+            `SELECT pd.distinct_id, pd.version, p.uuid
+                FROM posthog_persondistinctid pd
+                JOIN posthog_person p ON p.id = pd.person_id AND p.team_id = pd.team_id
+                WHERE pd.team_id = $1 AND pd.distinct_id = ANY($2) AND pd.is_deleted = false`,
+            [teamId, distinctIds],
+            'fetchPersonDistinctIdMappings'
+        )
+
+        return rows.map((row) => {
+            const version = Number(row.version || 0)
+            return {
+                distinctId: row.distinct_id,
+                message: {
+                    output: PERSON_DISTINCT_IDS_OUTPUT,
+                    value: Buffer.from(
+                        JSON.stringify({
+                            team_id: teamId,
+                            distinct_id: row.distinct_id,
+                            person_id: row.uuid,
+                            version,
+                            is_deleted: 0,
+                        })
+                    ),
+                },
+            }
+        })
     }
 
     async personPropertiesSize(personId: string, teamId: number): Promise<number> {

--- a/nodejs/src/ingestion/common/persons/batch-writing-person-store.test.ts
+++ b/nodejs/src/ingestion/common/persons/batch-writing-person-store.test.ts
@@ -126,6 +126,7 @@ describe('BatchWritingPersonStore', () => {
         const mockRepo = {
             fetchPerson: jest.fn().mockResolvedValue(person),
             fetchPersonDistinctIds: jest.fn().mockResolvedValue([]),
+            fetchPersonDistinctIdMappings: jest.fn().mockResolvedValue([]),
             fetchPersonsByDistinctIds: jest.fn().mockResolvedValue([]),
             fetchPersonsByPersonIds: jest.fn().mockResolvedValue([]),
             fetchPersonsForUpdateByDistinctIds: jest.fn().mockResolvedValue([]),

--- a/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
+++ b/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
@@ -1292,9 +1292,8 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
     }
 
     /**
-     * Uncached authoritative read of committed mapping rows, for re-emitting them to
-     * ClickHouse. The batch caches are bypassed on purpose: a healing emission must
-     * carry the committed version, not an optimistic in-batch state.
+     * Bypasses the batch caches on purpose: a healing emission must carry the
+     * committed version, not an optimistic in-batch state.
      */
     fetchPersonDistinctIdMappings(teamId: Team['id'], distinctIds: string[]): Promise<PersonDistinctIdMapping[]> {
         return this.personRepository.fetchPersonDistinctIdMappings(teamId, distinctIds)

--- a/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
+++ b/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
@@ -42,6 +42,7 @@ import { PersonBatchWritingDbWriteMode } from '~/ingestion/config'
 import { Properties } from '~/plugin-scaffold'
 import { InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team } from '~/types'
 
+import { MergeMappingDebounce } from './merge-mapping-debounce'
 import { PersonOutputs } from './person-context'
 import { PostgresMergePolicy, PostgresPersonMerge } from './person-merge-postgres'
 import {
@@ -119,6 +120,10 @@ export interface BatchWritingPersonsStoreOptions {
     mergeEventsEnabled: boolean
     mergeEventsPartitionCount: number
     mergeEventsTeamAllowlist: string
+    /** Gate and debounce sizing for re-emitting mappings on already-satisfied merges. */
+    mergeNoopMappingEmissionEnabled: boolean
+    mergeNoopMappingEmissionCacheSize: number
+    mergeNoopMappingEmissionTtlMs: number
 }
 
 const DEFAULT_OPTIONS: BatchWritingPersonsStoreOptions = {
@@ -133,6 +138,9 @@ const DEFAULT_OPTIONS: BatchWritingPersonsStoreOptions = {
     mergeEventsEnabled: false,
     mergeEventsPartitionCount: 64,
     mergeEventsTeamAllowlist: '',
+    mergeNoopMappingEmissionEnabled: false,
+    mergeNoopMappingEmissionCacheSize: 500_000,
+    mergeNoopMappingEmissionTtlMs: 15 * 60 * 1000,
 }
 
 interface CacheMetrics {
@@ -569,6 +577,12 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
                 partitionCount: this.options.mergeEventsPartitionCount,
                 isTeamEnabled: buildIntegerMatcher(this.options.mergeEventsTeamAllowlist, true),
             },
+            noopMappingDebounce: this.options.mergeNoopMappingEmissionEnabled
+                ? new MergeMappingDebounce(
+                      this.options.mergeNoopMappingEmissionCacheSize,
+                      this.options.mergeNoopMappingEmissionTtlMs
+                  )
+                : undefined,
         }
         this.personCache = new BatchWritingPersonsCache()
         Object.defineProperties(this, {

--- a/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
+++ b/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
@@ -140,7 +140,7 @@ const DEFAULT_OPTIONS: BatchWritingPersonsStoreOptions = {
     mergeEventsTeamAllowlist: '',
     mergeNoopMappingEmissionEnabled: false,
     mergeNoopMappingEmissionCacheSize: 500_000,
-    mergeNoopMappingEmissionTtlMs: 15 * 60 * 1000,
+    mergeNoopMappingEmissionTtlMs: 60 * 60 * 1000,
 }
 
 interface CacheMetrics {

--- a/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
+++ b/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
@@ -25,6 +25,7 @@ import { PersonUpdate, fromInternalPerson, toInternalPerson } from '~/common/per
 import {
     InternalPersonWithDistinctId,
     LifecycleMarkPerson,
+    PersonDistinctIdMapping,
     PersonMessage,
     PersonPropertiesSizeViolationError,
     PersonRepository,
@@ -1274,6 +1275,15 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
             }
             throw error
         })
+    }
+
+    /**
+     * Uncached authoritative read of committed mapping rows, for re-emitting them to
+     * ClickHouse. The batch caches are bypassed on purpose: a healing emission must
+     * carry the committed version, not an optimistic in-batch state.
+     */
+    fetchPersonDistinctIdMappings(teamId: Team['id'], distinctIds: string[]): Promise<PersonDistinctIdMapping[]> {
+        return this.personRepository.fetchPersonDistinctIdMappings(teamId, distinctIds)
     }
 
     async fetchForUpdate(teamId: Team['id'], distinctId: string, batchId: number): Promise<InternalPerson | null> {

--- a/nodejs/src/ingestion/common/persons/merge-mapping-debounce.ts
+++ b/nodejs/src/ingestion/common/persons/merge-mapping-debounce.ts
@@ -13,19 +13,16 @@ export class MergeMappingDebounce {
         this.cache = new LRUCache({ max: maxEntries, ttl: ttlMs })
     }
 
-    /** Returns the distinct ids not seen within the TTL, marking them seen. */
-    claim(teamId: number, distinctIds: string[]): string[] {
-        return distinctIds.filter((distinctId) => {
-            const key = `${teamId}:${distinctId}`
-            if (this.cache.has(key)) {
-                return false
-            }
-            this.cache.set(key, true)
-            return true
-        })
+    /**
+     * Returns the distinct ids not seen within the TTL, without marking them:
+     * callers mark via touch only after their emission succeeds, so a failed
+     * read or produce leaves the ids eligible for the retry to heal.
+     */
+    unseen(teamId: number, distinctIds: string[]): string[] {
+        return distinctIds.filter((distinctId) => !this.cache.has(`${teamId}:${distinctId}`))
     }
 
-    /** Marks freshly written mappings so an immediately following no-op does not re-emit them. */
+    /** Marks handled mappings so a following no-op does not re-emit them. */
     touch(teamId: number, distinctIds: string[]): void {
         for (const distinctId of distinctIds) {
             this.cache.set(`${teamId}:${distinctId}`, true)

--- a/nodejs/src/ingestion/common/persons/merge-mapping-debounce.ts
+++ b/nodejs/src/ingestion/common/persons/merge-mapping-debounce.ts
@@ -1,0 +1,34 @@
+import { LRUCache } from 'lru-cache'
+
+/**
+ * Debounces re-emission of already-satisfied merge mappings. The cache is
+ * process-local on purpose: a healing emission is only needed when an event
+ * replays after a crash, and the crash restart empties the cache, so replays
+ * always emit while steady-state duplicate merges stay suppressed.
+ */
+export class MergeMappingDebounce {
+    private readonly cache: LRUCache<string, true>
+
+    constructor(maxEntries: number, ttlMs: number) {
+        this.cache = new LRUCache({ max: maxEntries, ttl: ttlMs })
+    }
+
+    /** Returns the distinct ids not seen within the TTL, marking them seen. */
+    claim(teamId: number, distinctIds: string[]): string[] {
+        return distinctIds.filter((distinctId) => {
+            const key = `${teamId}:${distinctId}`
+            if (this.cache.has(key)) {
+                return false
+            }
+            this.cache.set(key, true)
+            return true
+        })
+    }
+
+    /** Marks freshly written mappings so an immediately following no-op does not re-emit them. */
+    touch(teamId: number, distinctIds: string[]): void {
+        for (const distinctId of distinctIds) {
+            this.cache.set(`${teamId}:${distinctId}`, true)
+        }
+    }
+}

--- a/nodejs/src/ingestion/common/persons/person-create-service.test.ts
+++ b/nodejs/src/ingestion/common/persons/person-create-service.test.ts
@@ -94,7 +94,7 @@ describe('PersonCreateService', () => {
 
             mockPersonStore.createPerson.mockResolvedValue(mockResult)
 
-            const [person, created] = await personCreateService.createPerson(
+            const [person, created, messages] = await personCreateService.createPerson(
                 createdAt,
                 properties,
                 propertiesOnce,
@@ -107,11 +107,9 @@ describe('PersonCreateService', () => {
 
             expect(person).toEqual(mockPerson)
             expect(created).toBe(true)
-            expect(mockOutputs.produce).toHaveBeenCalledWith('persons', {
-                value: Buffer.from('test'),
-                key: null,
-                teamId,
-            })
+            // The caller owns the produce, so a transactional caller can defer it past commit.
+            expect(messages).toEqual(mockResult.messages)
+            expect(mockOutputs.produce).not.toHaveBeenCalled()
         })
 
         it('should handle PersonPropertiesSizeViolationError and log ingestion warning', async () => {

--- a/nodejs/src/ingestion/common/persons/person-create-service.ts
+++ b/nodejs/src/ingestion/common/persons/person-create-service.ts
@@ -1,6 +1,7 @@
 import { DateTime } from 'luxon'
 
 import { personCreateConflictResolvedCounter } from '~/common/persons/metrics'
+import { PersonMessage } from '~/common/persons/person-message'
 import { PersonPropertiesSizeViolationError } from '~/common/persons/repositories/person-repository'
 import { emitIngestionWarning } from '~/ingestion/common/ingestion-warnings'
 import { uuidFromDistinctId } from '~/ingestion/common/persons/person-uuid'
@@ -17,7 +18,11 @@ export class PersonCreateService {
     ) {}
 
     /**
-     * @returns [Person, boolean that indicates if person was created or not, true if person was created by this call, false if found existing person from concurrent creation]
+     * Creation messages are returned, never produced here: the caller owns the
+     * produce, so a transactional caller can defer it past commit instead of
+     * holding the transaction open across the Kafka roundtrip.
+     *
+     * @returns [Person, true if person was created by this call (false if found existing person from concurrent creation), ClickHouse messages to produce]
      */
     async createPerson(
         createdAt: DateTime,
@@ -30,7 +35,7 @@ export class PersonCreateService {
         primaryDistinctId: { distinctId: string; version?: number },
         extraDistinctIds?: { distinctId: string; version?: number }[],
         tx?: PersonsStoreTransactionForBatch
-    ): Promise<[InternalPerson, boolean]> {
+    ): Promise<[InternalPerson, boolean, PersonMessage[]]> {
         const uuid = uuidFromDistinctId(teamId, primaryDistinctId.distinctId)
 
         const props = { ...propertiesOnce, ...properties, ...{ $creator_event_uuid: creatorEventUuid } }
@@ -60,12 +65,7 @@ export class PersonCreateService {
             )
 
             if (result.success) {
-                await Promise.all(
-                    result.messages.map((msg) =>
-                        this.outputs.produce(msg.output, { value: msg.value, key: null, teamId })
-                    )
-                )
-                return [result.person, result.created]
+                return [result.person, result.created, result.messages]
             }
 
             // Handle creation conflict - another process created the person concurrently
@@ -75,7 +75,7 @@ export class PersonCreateService {
                 for (const distinctIdInfo of allDistinctIds) {
                     const existingPerson = await this.store.fetchForUpdate(teamId, distinctIdInfo.distinctId)
                     if (existingPerson) {
-                        return [existingPerson, false]
+                        return [existingPerson, false, []]
                     }
                 }
 
@@ -86,7 +86,7 @@ export class PersonCreateService {
                 // mapping, so no two identities are silently merged.
                 if (result.conflictingPerson) {
                     personCreateConflictResolvedCounter.labels({ resolved_by: 'uuid' }).inc()
-                    return [result.conflictingPerson, false]
+                    return [result.conflictingPerson, false, []]
                 }
 
                 // The holder vanished between the failed write and the lookup, so there is

--- a/nodejs/src/ingestion/common/persons/person-merge-postgres.test.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-postgres.test.ts
@@ -1,5 +1,5 @@
 import { buildIntegerMatcher } from '~/common/config/config'
-import { PERSON_MERGE_EVENTS_OUTPUT } from '~/common/outputs'
+import { PERSON_DISTINCT_IDS_OUTPUT, PERSON_MERGE_EVENTS_OUTPUT } from '~/common/outputs'
 import { UUIDT } from '~/common/utils/utils'
 import { InternalPerson } from '~/types'
 
@@ -126,6 +126,49 @@ describe('PostgresPersonMerge merge events', () => {
 
         expect(store.removeDistinctIdFromCache).toHaveBeenCalledWith(2, 'd')
         expect(store.removeDistinctIdFromCache).toHaveBeenCalledWith(2, 'anon')
+    })
+
+    // A produce awaited inside the merge transaction holds row locks and lifecycle
+    // marks across the Kafka roundtrip, and its ack escapes the batch-end await.
+    it('a one-exists merge produces the mapping after the transaction and surfaces the ack', async () => {
+        const order: string[] = []
+        mockOutputs = {
+            produce: jest.fn().mockImplementation(() => {
+                order.push('produce')
+                return Promise.resolve()
+            }),
+        }
+        const existingPerson = { id: 'p1', uuid: targetPerson.uuid, team_id: 2 } as unknown as InternalPerson
+        const mappingMessage = {
+            output: PERSON_DISTINCT_IDS_OUTPUT,
+            value: Buffer.from('{}'),
+        }
+        const tx = { addDistinctId: jest.fn().mockResolvedValue([mappingMessage]) }
+        const store = {
+            fetchForUpdate: jest
+                .fn()
+                .mockImplementation((_teamId: number, distinctId: string) =>
+                    Promise.resolve(distinctId === 'd' ? existingPerson : null)
+                ),
+            inTransaction: jest
+                .fn()
+                .mockImplementation(async (_description: string, body: (tx: unknown) => Promise<unknown>) => {
+                    const result = await body(tx)
+                    order.push('commit')
+                    return result
+                }),
+        }
+        const merge = buildSingleSourceMerge(store, new UUIDT().toString())
+
+        const result = await merge.execute()
+
+        expect(order).toEqual(['commit', 'produce'])
+        expect(mockOutputs.produce).toHaveBeenCalledWith(
+            PERSON_DISTINCT_IDS_OUTPUT,
+            expect.objectContaining({ teamId: 2, value: mappingMessage.value })
+        )
+        expect(result.results).toEqual([{ sourceDistinctId: 'anon', outcome: 'attached' }])
+        await expect(result.kafkaAck).resolves.toBeUndefined()
     })
 
     function buildSingleSourceMerge(store: object, eventUuid: string): PostgresPersonMerge {

--- a/nodejs/src/ingestion/common/persons/person-merge-postgres.test.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-postgres.test.ts
@@ -3,7 +3,13 @@ import { PERSON_DISTINCT_IDS_OUTPUT, PERSON_MERGE_EVENTS_OUTPUT } from '~/common
 import { UUIDT } from '~/common/utils/utils'
 import { InternalPerson } from '~/types'
 
-import { MergeEventsConfig, PostgresPersonMerge, personMergeEventProducedCounter } from './person-merge-postgres'
+import { MergeMappingDebounce } from './merge-mapping-debounce'
+import {
+    MergeEventsConfig,
+    PostgresMergePolicy,
+    PostgresPersonMerge,
+    personMergeEventProducedCounter,
+} from './person-merge-postgres'
 import { createDefaultSyncMergeMode } from './person-merge-types'
 import { MergePersonsRequest } from './persons-store'
 
@@ -171,7 +177,50 @@ describe('PostgresPersonMerge merge events', () => {
         await expect(result.kafkaAck).resolves.toBeUndefined()
     })
 
-    function buildSingleSourceMerge(store: object, eventUuid: string): PostgresPersonMerge {
+    // A crash between a merge's commit and its produce loses the mapping message; the
+    // replayed event lands in the noop branch, which must re-emit the committed mapping
+    // exactly once per debounce window (unbounded re-emission would flood the topic and
+    // keep the ClickHouse overrides table from converging).
+    it('an already-satisfied merge re-emits the committed mappings once per debounce window', async () => {
+        mockOutputs = { produce: jest.fn().mockResolvedValue(undefined) }
+        const person = { id: 'p1', uuid: targetPerson.uuid, team_id: 2 } as unknown as InternalPerson
+        const mapping = {
+            distinctId: 'anon',
+            message: { output: PERSON_DISTINCT_IDS_OUTPUT, value: Buffer.from('{"version":1}') },
+        }
+        const store = {
+            fetchForUpdate: jest.fn().mockResolvedValue(person),
+            fetchPersonDistinctIdMappings: jest.fn().mockResolvedValue([mapping]),
+        }
+        const debounce = new MergeMappingDebounce(100, 60_000)
+
+        const cold = await buildSingleSourceMerge(store, new UUIDT().toString(), {
+            noopMappingDebounce: debounce,
+        }).execute()
+        await cold.kafkaAck
+
+        expect(cold.results[0].outcome).toBe('noop_same_person')
+        expect(store.fetchPersonDistinctIdMappings).toHaveBeenCalledWith(2, ['anon', 'd'])
+        expect(mockOutputs.produce).toHaveBeenCalledTimes(1)
+        expect(mockOutputs.produce).toHaveBeenCalledWith(
+            PERSON_DISTINCT_IDS_OUTPUT,
+            expect.objectContaining({ teamId: 2, value: mapping.message.value })
+        )
+
+        const warm = await buildSingleSourceMerge(store, new UUIDT().toString(), {
+            noopMappingDebounce: debounce,
+        }).execute()
+        await warm.kafkaAck
+
+        expect(store.fetchPersonDistinctIdMappings).toHaveBeenCalledTimes(1)
+        expect(mockOutputs.produce).toHaveBeenCalledTimes(1)
+    })
+
+    function buildSingleSourceMerge(
+        store: object,
+        eventUuid: string,
+        policyOverrides: Partial<PostgresMergePolicy> = {}
+    ): PostgresPersonMerge {
         const request: MergePersonsRequest = {
             teamId: 2,
             targetDistinctId: 'd',
@@ -196,6 +245,7 @@ describe('PostgresPersonMerge merge events', () => {
                 updateAllProperties: false,
                 isTombstoneTeam: () => false,
                 mergeEvents: { enabled: false, partitionCount: 64, isTeamEnabled: () => false },
+                ...policyOverrides,
             },
             request,
             0

--- a/nodejs/src/ingestion/common/persons/person-merge-postgres.test.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-postgres.test.ts
@@ -177,6 +177,52 @@ describe('PostgresPersonMerge merge events', () => {
         await expect(result.kafkaAck).resolves.toBeUndefined()
     })
 
+    // Same contract as the one-exists case: createPerson returns its messages and the
+    // branch produces after commit, so the creation transaction never spans Kafka.
+    it('a neither-exists merge produces the creation messages after the transaction', async () => {
+        const order: string[] = []
+        mockOutputs = {
+            produce: jest.fn().mockImplementation(() => {
+                order.push('produce')
+                return Promise.resolve()
+            }),
+        }
+        const createdPerson = { id: 'p1', uuid: targetPerson.uuid, team_id: 2, is_identified: true } as InternalPerson
+        const creationMessage = {
+            output: PERSON_DISTINCT_IDS_OUTPUT,
+            value: Buffer.from('{}'),
+        }
+        const tx = {
+            createPerson: jest.fn().mockResolvedValue({
+                success: true,
+                person: createdPerson,
+                created: true,
+                messages: [creationMessage],
+            }),
+        }
+        const store = {
+            fetchForUpdate: jest.fn().mockResolvedValue(null),
+            inTransaction: jest
+                .fn()
+                .mockImplementation(async (_description: string, body: (tx: unknown) => Promise<unknown>) => {
+                    const result = await body(tx)
+                    order.push('commit')
+                    return result
+                }),
+        }
+        const merge = buildSingleSourceMerge(store, new UUIDT().toString())
+
+        const result = await merge.execute()
+
+        expect(order).toEqual(['commit', 'produce'])
+        expect(mockOutputs.produce).toHaveBeenCalledWith(
+            PERSON_DISTINCT_IDS_OUTPUT,
+            expect.objectContaining({ teamId: 2, value: creationMessage.value })
+        )
+        expect(result.results).toEqual([{ sourceDistinctId: 'anon', outcome: 'attached' }])
+        await expect(result.kafkaAck).resolves.toBeUndefined()
+    })
+
     // Both directions matter: never emitting loses the healing, and emitting on every
     // duplicate $identify floods the topic and keeps the overrides table from converging.
     it('an already-satisfied merge re-emits the committed mappings once per debounce window', async () => {

--- a/nodejs/src/ingestion/common/persons/person-merge-postgres.test.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-postgres.test.ts
@@ -177,10 +177,8 @@ describe('PostgresPersonMerge merge events', () => {
         await expect(result.kafkaAck).resolves.toBeUndefined()
     })
 
-    // A crash between a merge's commit and its produce loses the mapping message; the
-    // replayed event lands in the noop branch, which must re-emit the committed mapping
-    // exactly once per debounce window (unbounded re-emission would flood the topic and
-    // keep the ClickHouse overrides table from converging).
+    // Both directions matter: never emitting loses the healing, and emitting on every
+    // duplicate $identify floods the topic and keeps the overrides table from converging.
     it('an already-satisfied merge re-emits the committed mappings once per debounce window', async () => {
         mockOutputs = { produce: jest.fn().mockResolvedValue(undefined) }
         const person = { id: 'p1', uuid: targetPerson.uuid, team_id: 2 } as unknown as InternalPerson

--- a/nodejs/src/ingestion/common/persons/person-merge-postgres.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-postgres.ts
@@ -408,7 +408,7 @@ export class PostgresPersonMerge {
             const distinctId2 = otherPersonDistinctId
 
             this.discardOverrideCounts()
-            const [person, needsPersonUpdate] = await this.inTransaction(
+            const [person, needsPersonUpdate, kafkaMessages] = await this.inTransaction(
                 'mergeDistinctIds-NeitherExist',
                 async (tx) => {
                     // See comment above about `distinctIdVersion`: the first Distinct ID derives the
@@ -417,7 +417,7 @@ export class PostgresPersonMerge {
                     const distinctId2Version = 1
                     this.recordOverrideCount('neitherExist')
 
-                    const [created, wasCreated] = await this.createService.createPerson(
+                    const [created, wasCreated, messages] = await this.createService.createPerson(
                         this.timestamp,
                         this.request.eventOps.set,
                         this.request.eventOps.setOnce,
@@ -431,14 +431,16 @@ export class PostgresPersonMerge {
                     )
                     // If person was not created (creation conflict) and is not identified,
                     // we need to update it later
-                    return [created, !wasCreated && !created.is_identified] as const
+                    return [created, !wasCreated && !created.is_identified, messages] as const
                 }
             )
             this.flushOverrideCounts()
+            const kafkaAck = this.produceMessages(kafkaMessages)
             return {
                 survivor: person,
                 results: [{ sourceDistinctId: otherPersonDistinctId, outcome: 'attached' }],
                 survivorNeedsUpdate: needsPersonUpdate,
+                kafkaAck,
             }
         }
     }

--- a/nodejs/src/ingestion/common/persons/person-merge-postgres.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-postgres.ts
@@ -282,7 +282,7 @@ export class PostgresPersonMerge {
 
             this.discardOverrideCounts()
             const lifecycleOpId = lifecycleOpIdFromEvent(teamId, this.request.eventUuid)
-            const result = await this.inTransaction('mergeDistinctIds-OneExists', async (tx) => {
+            const [result, kafkaMessages] = await this.inTransaction('mergeDistinctIds-OneExists', async (tx) => {
                 // New-world merges claim the person's lifecycle mark, which keeps a concurrent
                 // tombstone from landing between this check and the distinct id insert (an
                 // orphaned mapping); old-world merges rely on the delete's FK violation instead.
@@ -308,17 +308,20 @@ export class PostgresPersonMerge {
                 const distinctIdVersion = 1
                 this.recordOverrideCount('oneExists')
 
-                const kafkaMessages = await tx.addDistinctId(existingPerson, distinctIdToAdd, distinctIdVersion)
-                await this.produceMessages(kafkaMessages)
+                const messages = await tx.addDistinctId(existingPerson, distinctIdToAdd, distinctIdVersion)
                 if (this.tombstoneEnabled()) {
                     await tx.releaseLifecycleMarks(lifecycleOpId, teamId, this.targetDistinctId)
                 }
-                return existingPerson
+                return [existingPerson, messages] as const
             })
             this.flushOverrideCounts()
+            // Produce only after the transaction commits: a produce awaited inside the
+            // transaction holds row locks and lifecycle marks across the Kafka roundtrip.
+            const kafkaAck = this.produceMessages(kafkaMessages)
             return {
                 survivor: result,
                 results: [{ sourceDistinctId: otherPersonDistinctId, outcome: 'attached' }],
+                kafkaAck,
             }
         } else if (otherPerson && mergeIntoPerson) {
             // Both Distinct IDs point at an existing Person

--- a/nodejs/src/ingestion/common/persons/person-merge-postgres.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-postgres.ts
@@ -15,6 +15,7 @@ import { Properties } from '~/plugin-scaffold'
 import { InternalPerson, ValueMatcher } from '~/types'
 
 import type { BatchWritingPersonsStore } from './batch-writing-person-store'
+import { MergeMappingDebounce } from './merge-mapping-debounce'
 import { PersonOutputs } from './person-context'
 import { PersonCreateService } from './person-create-service'
 import { buildPersonMergeEventMessage } from './person-merge-event'
@@ -78,6 +79,12 @@ export const personMergeEventProducedCounter = new Counter({
     help: 'Number of person_merge_events messages acked by the broker (gate-on merges only).',
 })
 
+export const mergeNoopMappingEmissionCounter = new Counter({
+    name: 'person_merge_noop_mapping_emission_total',
+    help: 'Distinct ids considered for mapping re-emission on already-satisfied merges.',
+    labelNames: ['action'],
+})
+
 /** Thrown inside the fold transaction to roll it back when merge-mode move bounds would be exceeded. */
 class MergeFoldLimitError extends Error {}
 
@@ -122,6 +129,12 @@ export interface PostgresMergePolicy {
     /** Teams on the new-world merge behavior: lifecycle-mark claims plus tombstone deletes. */
     isTombstoneTeam: ValueMatcher<number>
     mergeEvents: MergeEventsConfig
+    /**
+     * When set, merges that find their request already satisfied re-emit the committed
+     * mappings to ClickHouse (debounced), healing rows lost to a crash between a prior
+     * merge's commit and its produce. Absent means the behavior is off.
+     */
+    noopMappingDebounce?: MergeMappingDebounce
 }
 
 /**
@@ -173,10 +186,27 @@ export class PostgresPersonMerge {
         if (this.request.sources.length === 0) {
             throw new Error('mergePersons requires at least one source')
         }
-        if (this.request.sources.length > 1) {
-            return await this.executeFold()
+        const result =
+            this.request.sources.length > 1
+                ? await this.executeFold()
+                : await this.mergeSingleWithCachePurge(this.request.sources[0])
+        this.touchWrittenMappings(result)
+        return result
+    }
+
+    /** Marks written mappings in the debounce so a following duplicate no-op does not re-emit them. */
+    private touchWrittenMappings(result: MergePersonsResult): void {
+        const debounce = this.policy.noopMappingDebounce
+        if (!debounce) {
+            return
         }
-        return await this.mergeSingleWithCachePurge(this.request.sources[0])
+        const written = result.results
+            .filter((source) => source.outcome === 'attached' || source.outcome === 'merged')
+            .map((source) => source.sourceDistinctId)
+        if (written.length === 0) {
+            return
+        }
+        debounce.touch(this.teamId, [this.targetDistinctId, ...written])
     }
 
     /**
@@ -202,6 +232,31 @@ export class PostgresPersonMerge {
         return this.store.inTransaction(description, (tx) =>
             body(new BatchBoundPersonsStoreTransaction(tx, this.batchId))
         )
+    }
+
+    /**
+     * Re-emits the committed mappings for a merge request found already satisfied,
+     * debounced per (team, distinct id). A crash between a prior merge's commit and
+     * its produce loses the mapping message for good, because the replayed event
+     * lands here and would otherwise produce nothing. Returns the produce ack to
+     * chain on the result; resolved when disabled or everything was debounced.
+     */
+    private async reemitSatisfiedMappings(distinctIds: string[]): Promise<{ kafkaAck: Promise<void> }> {
+        const debounce = this.policy.noopMappingDebounce
+        if (!debounce) {
+            return { kafkaAck: Promise.resolve() }
+        }
+        const toEmit = debounce.claim(this.teamId, distinctIds)
+        mergeNoopMappingEmissionCounter.labels({ action: 'debounced' }).inc(distinctIds.length - toEmit.length)
+        if (toEmit.length === 0) {
+            return { kafkaAck: Promise.resolve() }
+        }
+        const mappings = await this.store.fetchPersonDistinctIdMappings(this.teamId, toEmit)
+        mergeNoopMappingEmissionCounter.labels({ action: 'emitted' }).inc(mappings.length)
+        if (mappings.length === 0) {
+            return { kafkaAck: Promise.resolve() }
+        }
+        return { kafkaAck: this.produceMessages(mappings.map((mapping) => mapping.message)) }
     }
 
     private async produceMessages(messages: PersonMessage[]): Promise<void> {
@@ -327,7 +382,9 @@ export class PostgresPersonMerge {
             // Both Distinct IDs point at an existing Person
 
             if (otherPerson.id == mergeIntoPerson.id) {
-                // Nothing to do, they are the same Person
+                // Nothing to do in Postgres, but the pair may carry a mapping whose
+                // ClickHouse message a crashed prior merge never produced.
+                const { kafkaAck } = await this.reemitSatisfiedMappings([otherPersonDistinctId, mergeIntoDistinctId])
                 return {
                     survivor: mergeIntoPerson,
                     results: [
@@ -337,6 +394,7 @@ export class PostgresPersonMerge {
                             sourcePersonUuid: otherPerson.uuid,
                         },
                     ],
+                    kafkaAck,
                 }
             }
 
@@ -503,6 +561,7 @@ export class PostgresPersonMerge {
         const mergedSourceOutcomes: MergePersonsSourceResult[] = []
         const seenSourceIds = new Set<string>([target.id])
         const missingSources: MergePersonsSource[] = []
+        const noopSourceDistinctIds: string[] = []
         for (const pair of sourcesToFold) {
             if (isDistinctIdUnmergeable(pair.distinctId)) {
                 outcomes.push({ sourceDistinctId: pair.distinctId, outcome: 'skipped_illegal' })
@@ -514,6 +573,7 @@ export class PostgresPersonMerge {
                 continue
             }
             if (seenSourceIds.has(source.id)) {
+                noopSourceDistinctIds.push(pair.distinctId)
                 outcomes.push({
                     sourceDistinctId: pair.distinctId,
                     outcome: 'noop_same_person',
@@ -539,7 +599,9 @@ export class PostgresPersonMerge {
         }
 
         if (mergeSources.length === 0 && missingSources.length === 0) {
-            return { survivor: target, results: outcomes, kafkaAck: bootstrapAck }
+            const { kafkaAck: reemitAck } = await this.reemitSatisfiedMappings(noopSourceDistinctIds)
+            const kafkaAck = bootstrapAck ? joinAcks(bootstrapAck, reemitAck) : reemitAck
+            return { survivor: target, results: outcomes, kafkaAck }
         }
 
         // Sequential property precedence: each source merges its properties
@@ -646,7 +708,8 @@ export class PostgresPersonMerge {
         // The bootstrap's produce, when there was one, joins the fold's own
         // ack so the caller observes every message this merge produced.
         const foldAck = this.produceMessages(kafkaMessages)
-        const kafkaAck = bootstrapAck ? joinAcks(bootstrapAck, foldAck) : foldAck
+        const { kafkaAck: reemitAck } = await this.reemitSatisfiedMappings(noopSourceDistinctIds)
+        const kafkaAck = bootstrapAck ? joinAcks(bootstrapAck, foldAck, reemitAck) : joinAcks(foldAck, reemitAck)
         for (const source of mergeSources) {
             // Same fire-and-forget contract as executeTransaction.
             void this.producePersonMergeEvent(source, mergedPerson).catch(() => {})
@@ -1097,7 +1160,10 @@ export class PostgresPersonMerge {
                     )
 
                     if (!refreshedPerson) {
-                        return mergeSuccess(currentTargetPerson, Promise.resolve(), true)
+                        // A concurrent merge absorbed the source; its mapping messages may
+                        // be lost if that consumer crashed before producing, so re-emit.
+                        const { kafkaAck } = await this.reemitSatisfiedMappings([sourceDistinctId, targetDistinctId])
+                        return mergeSuccess(currentTargetPerson, kafkaAck, true)
                     }
 
                     currentSourcePerson = refreshedPerson
@@ -1111,7 +1177,10 @@ export class PostgresPersonMerge {
                     )
 
                     if (!refreshedPerson) {
-                        return mergeSuccess(currentTargetPerson, Promise.resolve(), true)
+                        // Same as the source case: the target went away to a concurrent
+                        // merge whose produce may have been lost, so re-emit.
+                        const { kafkaAck } = await this.reemitSatisfiedMappings([sourceDistinctId, targetDistinctId])
+                        return mergeSuccess(currentTargetPerson, kafkaAck, true)
                     }
 
                     currentTargetPerson = refreshedPerson

--- a/nodejs/src/ingestion/common/persons/person-merge-postgres.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-postgres.ts
@@ -243,7 +243,7 @@ export class PostgresPersonMerge {
         if (!debounce) {
             return { kafkaAck: Promise.resolve() }
         }
-        const toEmit = debounce.claim(this.teamId, distinctIds)
+        const toEmit = debounce.unseen(this.teamId, distinctIds)
         mergeNoopMappingEmissionCounter.labels({ action: 'debounced' }).inc(distinctIds.length - toEmit.length)
         if (toEmit.length === 0) {
             return { kafkaAck: Promise.resolve() }
@@ -251,9 +251,15 @@ export class PostgresPersonMerge {
         const mappings = await this.store.fetchPersonDistinctIdMappings(this.teamId, toEmit)
         mergeNoopMappingEmissionCounter.labels({ action: 'emitted' }).inc(mappings.length)
         if (mappings.length === 0) {
+            debounce.touch(this.teamId, toEmit)
             return { kafkaAck: Promise.resolve() }
         }
-        return { kafkaAck: this.produceMessages(mappings.map((mapping) => mapping.message)) }
+        // Mark only on delivery: a failed read or produce replays the event, and the
+        // replay must find the ids unmarked to heal them.
+        const kafkaAck = this.produceMessages(mappings.map((mapping) => mapping.message)).then(() =>
+            debounce.touch(this.teamId, toEmit)
+        )
+        return { kafkaAck }
     }
 
     private async produceMessages(messages: PersonMessage[]): Promise<void> {

--- a/nodejs/src/ingestion/common/persons/person-merge-postgres.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-postgres.ts
@@ -130,9 +130,8 @@ export interface PostgresMergePolicy {
     isTombstoneTeam: ValueMatcher<number>
     mergeEvents: MergeEventsConfig
     /**
-     * When set, merges that find their request already satisfied re-emit the committed
-     * mappings to ClickHouse (debounced), healing rows lost to a crash between a prior
-     * merge's commit and its produce. Absent means the behavior is off.
+     * When set, already-satisfied merges re-emit the committed mappings (debounced),
+     * healing ClickHouse rows lost between a prior merge's commit and its produce.
      */
     noopMappingDebounce?: MergeMappingDebounce
 }
@@ -235,11 +234,9 @@ export class PostgresPersonMerge {
     }
 
     /**
-     * Re-emits the committed mappings for a merge request found already satisfied,
-     * debounced per (team, distinct id). A crash between a prior merge's commit and
-     * its produce loses the mapping message for good, because the replayed event
-     * lands here and would otherwise produce nothing. Returns the produce ack to
-     * chain on the result; resolved when disabled or everything was debounced.
+     * A crash between a prior merge's commit and its produce loses the mapping message
+     * for good, because the replayed event lands in a satisfied branch and would
+     * otherwise produce nothing. Re-emit the committed mappings, debounced.
      */
     private async reemitSatisfiedMappings(distinctIds: string[]): Promise<{ kafkaAck: Promise<void> }> {
         const debounce = this.policy.noopMappingDebounce
@@ -382,8 +379,8 @@ export class PostgresPersonMerge {
             // Both Distinct IDs point at an existing Person
 
             if (otherPerson.id == mergeIntoPerson.id) {
-                // Nothing to do in Postgres, but the pair may carry a mapping whose
-                // ClickHouse message a crashed prior merge never produced.
+                // Same person already; re-emit in case a crashed prior merge never
+                // produced the pair's mapping.
                 const { kafkaAck } = await this.reemitSatisfiedMappings([otherPersonDistinctId, mergeIntoDistinctId])
                 return {
                     survivor: mergeIntoPerson,
@@ -1160,8 +1157,8 @@ export class PostgresPersonMerge {
                     )
 
                     if (!refreshedPerson) {
-                        // A concurrent merge absorbed the source; its mapping messages may
-                        // be lost if that consumer crashed before producing, so re-emit.
+                        // A concurrent merge absorbed the source; re-emit in case its
+                        // produce was lost to a crash.
                         const { kafkaAck } = await this.reemitSatisfiedMappings([sourceDistinctId, targetDistinctId])
                         return mergeSuccess(currentTargetPerson, kafkaAck, true)
                     }
@@ -1177,8 +1174,7 @@ export class PostgresPersonMerge {
                     )
 
                     if (!refreshedPerson) {
-                        // Same as the source case: the target went away to a concurrent
-                        // merge whose produce may have been lost, so re-emit.
+                        // Same as the source case above.
                         const { kafkaAck } = await this.reemitSatisfiedMappings([sourceDistinctId, targetDistinctId])
                         return mergeSuccess(currentTargetPerson, kafkaAck, true)
                     }

--- a/nodejs/src/ingestion/common/persons/person-property-service.ts
+++ b/nodejs/src/ingestion/common/persons/person-property-service.ts
@@ -32,20 +32,21 @@ export class PersonPropertyService {
     }
 
     async updateProperties(): Promise<[InternalPerson, Promise<void>]> {
-        const [person, propertiesHandled] = await this.createOrGetPerson()
+        const [person, propertiesHandled, createAck] = await this.createOrGetPerson()
         if (propertiesHandled) {
-            return [person, Promise.resolve()]
+            return [person, createAck]
         }
-        return await this.updatePersonProperties(person)
+        const [updatedPerson, updateAck] = await this.updatePersonProperties(person)
+        return [updatedPerson, Promise.all([createAck, updateAck]).then(() => undefined)]
     }
 
     /**
-     * @returns [Person, boolean that indicates if properties were already handled or not]
+     * @returns [Person, boolean that indicates if properties were already handled or not, creation messages' produce ack]
      */
-    private async createOrGetPerson(): Promise<[InternalPerson, boolean]> {
+    private async createOrGetPerson(): Promise<[InternalPerson, boolean, Promise<void>]> {
         const person = await this.context.personStore.fetchForUpdate(this.context.team.id, this.context.distinctId)
         if (person) {
-            return [person, false]
+            return [person, false, Promise.resolve()]
         }
 
         let properties = {}
@@ -55,7 +56,7 @@ export class PersonPropertyService {
             propertiesOnce = this.context.eventProperties['$set_once']
         }
 
-        return await this.personCreateService.createPerson(
+        const [createdPerson, created, kafkaMessages] = await this.personCreateService.createPerson(
             this.context.timestamp,
             properties || {},
             propertiesOnce || {},
@@ -66,6 +67,7 @@ export class PersonPropertyService {
             this.context.event.uuid,
             { distinctId: this.context.distinctId }
         )
+        return [createdPerson, created, this.context.produceMessages(kafkaMessages)]
     }
 
     async updatePersonProperties(person: InternalPerson): Promise<[InternalPerson, Promise<void>]> {

--- a/nodejs/src/ingestion/config.ts
+++ b/nodejs/src/ingestion/config.ts
@@ -373,7 +373,7 @@ export function getDefaultIngestionConsumerConfig(): IngestionConsumerConfig {
         PERSON_MERGE_TOMBSTONE_TEAM_ALLOWLIST: '',
         PERSON_MERGE_NOOP_MAPPING_EMISSION_ENABLED: false,
         PERSON_MERGE_NOOP_MAPPING_EMISSION_CACHE_SIZE: 500_000,
-        PERSON_MERGE_NOOP_MAPPING_EMISSION_TTL_MS: 15 * 60 * 1000,
+        PERSON_MERGE_NOOP_MAPPING_EMISSION_TTL_MS: 60 * 60 * 1000,
         PERSON_CREATE_CLAIM_TEAM_ALLOWLIST: '',
 
         // Group batch writing config

--- a/nodejs/src/ingestion/config.ts
+++ b/nodejs/src/ingestion/config.ts
@@ -192,6 +192,12 @@ export type IngestionConsumerConfig = {
     // recreated person revives above its own tombstone. Comma-separated team IDs, or '*' for all
     // teams; empty means no teams.
     PERSON_MERGE_TOMBSTONE_TEAM_ALLOWLIST: string
+    // Re-emit committed distinct id mappings for merge events that arrive already satisfied,
+    // debounced per (team, distinct id). Heals ClickHouse mapping rows lost to a crash between
+    // a merge's commit and its produce; see MergeMappingDebounce for why the cache is in-memory.
+    PERSON_MERGE_NOOP_MAPPING_EMISSION_ENABLED: boolean
+    PERSON_MERGE_NOOP_MAPPING_EMISSION_CACHE_SIZE: number
+    PERSON_MERGE_NOOP_MAPPING_EMISSION_TTL_MS: number
     // Teams whose person creation claims an existing unreachable posthog_person row holding
     // the same deterministic (team_id, uuid) instead of inserting a duplicate row. Scope to
     // teams whose distinct-ID mappings were destroyed outside the write path (stranded rows);
@@ -365,6 +371,9 @@ export function getDefaultIngestionConsumerConfig(): IngestionConsumerConfig {
         PERSON_MERGE_FOLD_ENABLED: false,
         PERSON_MERGE_FOLD_TEAM_ALLOWLIST: '*',
         PERSON_MERGE_TOMBSTONE_TEAM_ALLOWLIST: '',
+        PERSON_MERGE_NOOP_MAPPING_EMISSION_ENABLED: false,
+        PERSON_MERGE_NOOP_MAPPING_EMISSION_CACHE_SIZE: 500_000,
+        PERSON_MERGE_NOOP_MAPPING_EMISSION_TTL_MS: 15 * 60 * 1000,
         PERSON_CREATE_CLAIM_TEAM_ALLOWLIST: '',
 
         // Group batch writing config

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -242,6 +242,9 @@ export class IngestionConsumer {
             mergeEventsEnabled: effectivePersonMergeEventsEnabled(this.config),
             mergeEventsPartitionCount: this.config.PERSON_MERGE_EVENTS_PARTITION_COUNT,
             mergeEventsTeamAllowlist: this.config.PERSON_MERGE_EVENTS_TEAM_ALLOWLIST,
+            mergeNoopMappingEmissionEnabled: this.config.PERSON_MERGE_NOOP_MAPPING_EMISSION_ENABLED,
+            mergeNoopMappingEmissionCacheSize: this.config.PERSON_MERGE_NOOP_MAPPING_EMISSION_CACHE_SIZE,
+            mergeNoopMappingEmissionTtlMs: this.config.PERSON_MERGE_NOOP_MAPPING_EMISSION_TTL_MS,
         })
 
         this.groupStore = new BatchWritingGroupStore(this.deps.groupRepository, this.deps.clickhouseGroupRepository, {

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -345,6 +345,9 @@ export class IngestionApiServer implements NodeServer {
             mergeEventsEnabled: effectivePersonMergeEventsEnabled(this.config),
             mergeEventsPartitionCount: this.config.PERSON_MERGE_EVENTS_PARTITION_COUNT,
             mergeEventsTeamAllowlist: this.config.PERSON_MERGE_EVENTS_TEAM_ALLOWLIST,
+            mergeNoopMappingEmissionEnabled: this.config.PERSON_MERGE_NOOP_MAPPING_EMISSION_ENABLED,
+            mergeNoopMappingEmissionCacheSize: this.config.PERSON_MERGE_NOOP_MAPPING_EMISSION_CACHE_SIZE,
+            mergeNoopMappingEmissionTtlMs: this.config.PERSON_MERGE_NOOP_MAPPING_EMISSION_TTL_MS,
         })
         // Which backend person writes land in, deployment-wide: pg (the
         // default) builds nothing new; the other modes construct the

--- a/proto/personhog/identity/v1/identity.proto
+++ b/proto/personhog/identity/v1/identity.proto
@@ -95,6 +95,27 @@ message GetPersonsByDistinctIdsResponse {
   repeated GetPersonByDistinctIdResult results = 1;
 }
 
+message GetDistinctIdMappingsRequest {
+  int64 team_id = 1;
+  // Max 250 per request.
+  repeated string distinct_ids = 2;
+}
+
+// One live mapping row, shaped for re-emission to ClickHouse: the person
+// uuid (ClickHouse keys persons by uuid, not row id) and the mapping row's
+// own version (not the person's).
+message DistinctIdMappingRow {
+  string distinct_id = 1;
+  string person_uuid = 2;
+  int64 version = 3;
+}
+
+message GetDistinctIdMappingsResponse {
+  // Distinct ids without a live mapping (unknown, tombstoned, or their
+  // person deleted) are absent.
+  repeated DistinctIdMappingRow mappings = 1;
+}
+
 // The identity-side twin of the service RPC of the same name, minus
 // ReadOptions: identity always reads the primary, so there is no
 // consistency to choose.
@@ -245,6 +266,10 @@ service PersonHogIdentity {
   // resolve — the router's GetPersonsByDistinctIds reads the replica and
   // its consistency option does not change that.
   rpc GetPersonsByDistinctIds(GetPersonsByDistinctIdsRequest) returns (GetPersonsByDistinctIdsResponse);
+  // Committed mapping rows for the given distinct ids on the primary, with
+  // the person uuid and mapping-row version, for re-emission to ClickHouse
+  // by merge paths that find their request already satisfied.
+  rpc GetDistinctIdMappings(GetDistinctIdMappingsRequest) returns (GetDistinctIdMappingsResponse);
   // Person-id to distinct-ids expansion on the primary; the strong twin
   // of the router RPC of the same name (which reads the replica).
   rpc GetDistinctIdsForPersons(GetDistinctIdsForPersonsRequest) returns (GetDistinctIdsForPersonsResponse);

--- a/proto/personhog/identity/v1/identity.proto
+++ b/proto/personhog/identity/v1/identity.proto
@@ -101,9 +101,8 @@ message GetDistinctIdMappingsRequest {
   repeated string distinct_ids = 2;
 }
 
-// One live mapping row, shaped for re-emission to ClickHouse: the person
-// uuid (ClickHouse keys persons by uuid, not row id) and the mapping row's
-// own version (not the person's).
+// One live mapping row: the person uuid (ClickHouse keys persons by uuid,
+// not row id) and the mapping row's own version (not the person's).
 message DistinctIdMappingRow {
   string distinct_id = 1;
   string person_uuid = 2;
@@ -266,9 +265,8 @@ service PersonHogIdentity {
   // resolve — the router's GetPersonsByDistinctIds reads the replica and
   // its consistency option does not change that.
   rpc GetPersonsByDistinctIds(GetPersonsByDistinctIdsRequest) returns (GetPersonsByDistinctIdsResponse);
-  // Committed mapping rows for the given distinct ids on the primary, with
-  // the person uuid and mapping-row version, for re-emission to ClickHouse
-  // by merge paths that find their request already satisfied.
+  // Committed mapping rows on the primary, for re-emission to ClickHouse by
+  // merge paths that find their request already satisfied.
   rpc GetDistinctIdMappings(GetDistinctIdMappingsRequest) returns (GetDistinctIdMappingsResponse);
   // Person-id to distinct-ids expansion on the primary; the strong twin
   // of the router RPC of the same name (which reads the replica).

--- a/rust/personhog-identity/src/service/mod.rs
+++ b/rust/personhog-identity/src/service/mod.rs
@@ -15,6 +15,7 @@ use tonic::{Request, Response, Status};
 
 use personhog_proto::personhog::identity::v1::person_hog_identity_server::PersonHogIdentity;
 use personhog_proto::personhog::identity::v1::{
+    DistinctIdMappingRow, GetDistinctIdMappingsRequest, GetDistinctIdMappingsResponse,
     GetDistinctIdsForPersonsRequest, GetDistinctIdsForPersonsResponse,
     GetOrCreatePersonByDistinctIdRequest, GetOrCreatePersonByDistinctIdResponse,
     GetOrCreatePersonResult, GetOrCreatePersonsByDistinctIdsRequest,
@@ -150,6 +151,37 @@ impl PersonHogIdentity for PersonHogIdentityService {
             })
             .collect();
         Ok(Response::new(GetPersonsByDistinctIdsResponse { results }))
+    }
+
+    async fn get_distinct_id_mappings(
+        &self,
+        request: Request<GetDistinctIdMappingsRequest>,
+    ) -> Result<Response<GetDistinctIdMappingsResponse>, Status> {
+        let req = request.into_inner();
+        validate_team_id(req.team_id)?;
+        validate_batch_size(&self.limits, req.distinct_ids.len())?;
+
+        let mut distinct_ids = req.distinct_ids;
+        distinct_ids.sort_unstable();
+        distinct_ids.dedup();
+
+        let mappings = self
+            .storage
+            .get_distinct_id_mappings(req.team_id, &distinct_ids)
+            .await
+            .map_err(|e| {
+                crate::service::error::log_and_convert_error(e, "get_distinct_id_mappings")
+            })?;
+
+        let mappings = mappings
+            .into_iter()
+            .map(|mapping| DistinctIdMappingRow {
+                distinct_id: mapping.distinct_id,
+                person_uuid: mapping.person_uuid.to_string(),
+                version: mapping.version.unwrap_or(0),
+            })
+            .collect();
+        Ok(Response::new(GetDistinctIdMappingsResponse { mappings }))
     }
 
     async fn get_distinct_ids_for_persons(

--- a/rust/personhog-identity/src/storage/mod.rs
+++ b/rust/personhog-identity/src/storage/mod.rs
@@ -7,7 +7,9 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 
 pub use error::{StorageError, StorageResult};
-pub use types::{AttachOutcome, DistinctIdMapping, Person, PersonStub, StubOutcome};
+pub use types::{
+    AttachOutcome, DistinctIdMapping, DistinctIdPersonMapping, Person, PersonStub, StubOutcome,
+};
 
 pub const DB_QUERY_DURATION: &str = "personhog_identity_db_query_duration_ms";
 
@@ -33,6 +35,16 @@ pub trait IdentityStorage: Send + Sync {
         person_ids: &[i64],
         limit_per_person: Option<i64>,
     ) -> StorageResult<Vec<DistinctIdMapping>>;
+
+    /// Live mapping rows for the given distinct ids on the primary, joined
+    /// to the person's uuid for re-emission to ClickHouse. Mappings to
+    /// tombstoned persons are invisible; ids without a live mapping are
+    /// absent from the result.
+    async fn get_distinct_id_mappings(
+        &self,
+        team_id: i64,
+        distinct_ids: &[String],
+    ) -> StorageResult<Vec<DistinctIdPersonMapping>>;
 
     /// Create person stubs (uuidv5 from team_id:distinct_id, version 0, empty
     /// properties) plus their distinct id rows in one multi-row transaction.

--- a/rust/personhog-identity/src/storage/mod.rs
+++ b/rust/personhog-identity/src/storage/mod.rs
@@ -37,9 +37,7 @@ pub trait IdentityStorage: Send + Sync {
     ) -> StorageResult<Vec<DistinctIdMapping>>;
 
     /// Live mapping rows for the given distinct ids on the primary, joined
-    /// to the person's uuid for re-emission to ClickHouse. Mappings to
-    /// tombstoned persons are invisible; ids without a live mapping are
-    /// absent from the result.
+    /// to the person's uuid. Ids without a live mapping are absent.
     async fn get_distinct_id_mappings(
         &self,
         team_id: i64,

--- a/rust/personhog-identity/src/storage/postgres/distinct_ids.rs
+++ b/rust/personhog-identity/src/storage/postgres/distinct_ids.rs
@@ -1,8 +1,9 @@
 use sqlx::postgres::PgPool;
 use sqlx::Row;
 
+use crate::config::IdentityTables;
 use crate::storage::error::StorageResult;
-use crate::storage::types::DistinctIdMapping;
+use crate::storage::types::{DistinctIdMapping, DistinctIdPersonMapping};
 
 /// Expand person ids to live distinct id rows on the primary. With a
 /// per-person limit, identified ids survive the cut (the regex mirrors
@@ -66,6 +67,48 @@ pub(super) async fn get_distinct_ids_for_persons(
             Ok(DistinctIdMapping {
                 person_id: row.try_get("person_id")?,
                 distinct_id: row.try_get("distinct_id")?,
+                version: row.try_get("version")?,
+            })
+        })
+        .collect()
+}
+
+/// Live mapping rows for the given distinct ids on the primary, joined to
+/// the person's uuid. Mappings to tombstoned persons are invisible, like
+/// `resolve_distinct_ids`.
+pub(super) async fn get_distinct_id_mappings(
+    pool: &PgPool,
+    tables: &IdentityTables,
+    team_id: i64,
+    distinct_ids: &[String],
+) -> StorageResult<Vec<DistinctIdPersonMapping>> {
+    if distinct_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let sql = format!(
+        r#"
+        SELECT pdi.distinct_id, pdi.version, p.uuid AS person_uuid
+        FROM {pdi_table} pdi
+        JOIN {person_table} p
+          ON p.team_id = pdi.team_id AND p.id = pdi.person_id
+         AND p.is_deleted = false
+        WHERE pdi.team_id = $1 AND pdi.distinct_id = ANY($2) AND pdi.is_deleted = false
+        "#,
+        pdi_table = tables.person_distinct_id,
+        person_table = tables.person,
+    );
+    let rows = sqlx::query(&sql)
+        .bind(team_id as i32)
+        .bind(distinct_ids)
+        .fetch_all(pool)
+        .await?;
+
+    rows.into_iter()
+        .map(|row| {
+            Ok(DistinctIdPersonMapping {
+                distinct_id: row.try_get("distinct_id")?,
+                person_uuid: row.try_get("person_uuid")?,
                 version: row.try_get("version")?,
             })
         })

--- a/rust/personhog-identity/src/storage/postgres/distinct_ids.rs
+++ b/rust/personhog-identity/src/storage/postgres/distinct_ids.rs
@@ -73,9 +73,7 @@ pub(super) async fn get_distinct_ids_for_persons(
         .collect()
 }
 
-/// Live mapping rows for the given distinct ids on the primary, joined to
-/// the person's uuid. Mappings to tombstoned persons are invisible, like
-/// `resolve_distinct_ids`.
+/// Mappings to tombstoned persons are invisible, like `resolve_distinct_ids`.
 pub(super) async fn get_distinct_id_mappings(
     pool: &PgPool,
     tables: &IdentityTables,

--- a/rust/personhog-identity/src/storage/postgres/mod.rs
+++ b/rust/personhog-identity/src/storage/postgres/mod.rs
@@ -17,7 +17,9 @@ use personhog_common::grpc::{current_client_name, current_method_name};
 
 use crate::config::IdentityTables;
 use crate::storage::error::StorageResult;
-use crate::storage::types::{AttachOutcome, DistinctIdMapping, Person, PersonStub, StubOutcome};
+use crate::storage::types::{
+    AttachOutcome, DistinctIdMapping, DistinctIdPersonMapping, Person, PersonStub, StubOutcome,
+};
 use crate::storage::{IdentityStorage, DB_QUERY_DURATION};
 
 const POOL_LABEL: &str = "primary";
@@ -106,6 +108,22 @@ impl IdentityStorage for PostgresIdentityStorage {
             team_id,
             person_ids,
             limit_per_person,
+        )
+        .await
+    }
+
+    async fn get_distinct_id_mappings(
+        &self,
+        team_id: i64,
+        distinct_ids: &[String],
+    ) -> StorageResult<Vec<DistinctIdPersonMapping>> {
+        let labels = Self::query_labels("get_distinct_id_mappings");
+        let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
+        distinct_ids::get_distinct_id_mappings(
+            &self.primary_pool,
+            &self.tables,
+            team_id,
+            distinct_ids,
         )
         .await
     }

--- a/rust/personhog-identity/src/storage/types.rs
+++ b/rust/personhog-identity/src/storage/types.rs
@@ -40,3 +40,12 @@ pub struct DistinctIdMapping {
     pub distinct_id: String,
     pub version: Option<i64>,
 }
+
+/// One live mapping row joined to its person's uuid, because ClickHouse
+/// keys persons by uuid, not row id.
+#[derive(Debug, Clone)]
+pub struct DistinctIdPersonMapping {
+    pub distinct_id: String,
+    pub person_uuid: uuid::Uuid,
+    pub version: Option<i64>,
+}

--- a/rust/personhog-identity/src/storage/types.rs
+++ b/rust/personhog-identity/src/storage/types.rs
@@ -41,8 +41,7 @@ pub struct DistinctIdMapping {
     pub version: Option<i64>,
 }
 
-/// One live mapping row joined to its person's uuid, because ClickHouse
-/// keys persons by uuid, not row id.
+/// One live mapping row joined to its person's uuid.
 #[derive(Debug, Clone)]
 pub struct DistinctIdPersonMapping {
     pub distinct_id: String,

--- a/rust/personhog-identity/tests/common/mod.rs
+++ b/rust/personhog-identity/tests/common/mod.rs
@@ -277,6 +277,16 @@ impl personhog_identity::storage::IdentityStorage for UnusedStorage {
         panic!("not exercised by this test")
     }
 
+    async fn get_distinct_id_mappings(
+        &self,
+        _team_id: i64,
+        _distinct_ids: &[String],
+    ) -> personhog_identity::storage::StorageResult<
+        Vec<personhog_identity::storage::DistinctIdPersonMapping>,
+    > {
+        panic!("not exercised by this test")
+    }
+
     async fn create_person_stubs(
         &self,
         _stubs: &[personhog_identity::storage::PersonStub],
@@ -355,6 +365,18 @@ impl personhog_identity::storage::IdentityStorage for RacingStorage {
     > {
         self.inner
             .get_distinct_ids_for_persons(team_id, person_ids, limit_per_person)
+            .await
+    }
+
+    async fn get_distinct_id_mappings(
+        &self,
+        team_id: i64,
+        distinct_ids: &[String],
+    ) -> personhog_identity::storage::StorageResult<
+        Vec<personhog_identity::storage::DistinctIdPersonMapping>,
+    > {
+        self.inner
+            .get_distinct_id_mappings(team_id, distinct_ids)
             .await
     }
 

--- a/rust/personhog-identity/tests/service_tests.rs
+++ b/rust/personhog-identity/tests/service_tests.rs
@@ -14,7 +14,8 @@ use personhog_identity::service::validation::RequestLimits;
 use personhog_identity::service::PersonHogIdentityService;
 use personhog_proto::personhog::identity::v1::person_hog_identity_server::PersonHogIdentity;
 use personhog_proto::personhog::identity::v1::{
-    GetDistinctIdsForPersonsRequest, GetOrCreatePersonByDistinctIdRequest, GetOrCreatePersonEntry,
+    GetDistinctIdMappingsRequest, GetDistinctIdsForPersonsRequest,
+    GetOrCreatePersonByDistinctIdRequest, GetOrCreatePersonEntry,
     GetOrCreatePersonsByDistinctIdsRequest, GetPersonsByDistinctIdsRequest, PersonKey,
 };
 use personhog_proto::personhog::types::v1::{
@@ -477,4 +478,41 @@ async fn repeated_person_ids_do_not_exceed_the_per_person_limit() {
         1,
         "the per-person limit must hold under repeated ids"
     );
+}
+
+/// The mapping read backs ClickHouse re-emission: it must carry the
+/// mapping row's own version (extras are born at version 1, primaries at
+/// 0) and the person's uuid, and hide unknown ids.
+#[tokio::test]
+async fn distinct_id_mappings_carry_uuid_and_mapping_version() {
+    let t = ServiceTestContext::new().await;
+    let mut entry = t.entry("mapping-primary");
+    entry.extra_distinct_ids = vec!["mapping-extra".to_string()];
+    t.get_or_create_single(entry).await.expect("seed person");
+
+    let response = t
+        .service
+        .get_distinct_id_mappings(Request::new(GetDistinctIdMappingsRequest {
+            team_id: t.ctx.team_id,
+            distinct_ids: vec![
+                "mapping-primary".to_string(),
+                "mapping-extra".to_string(),
+                "never-seen".to_string(),
+            ],
+        }))
+        .await
+        .expect("mappings read must succeed")
+        .into_inner();
+
+    let expected_uuid =
+        personhog_common::persons::person_uuid(t.ctx.team_id, "mapping-primary").to_string();
+    let mut mappings = response.mappings;
+    mappings.sort_by(|a, b| a.distinct_id.cmp(&b.distinct_id));
+    assert_eq!(mappings.len(), 2, "unknown ids yield no row");
+    assert_eq!(mappings[0].distinct_id, "mapping-extra");
+    assert_eq!(mappings[0].person_uuid, expected_uuid);
+    assert_eq!(mappings[0].version, 1);
+    assert_eq!(mappings[1].distinct_id, "mapping-primary");
+    assert_eq!(mappings[1].person_uuid, expected_uuid);
+    assert_eq!(mappings[1].version, 0);
 }

--- a/rust/personhog-identity/tests/service_tests.rs
+++ b/rust/personhog-identity/tests/service_tests.rs
@@ -480,9 +480,8 @@ async fn repeated_person_ids_do_not_exceed_the_per_person_limit() {
     );
 }
 
-/// The mapping read backs ClickHouse re-emission: it must carry the
-/// mapping row's own version (extras are born at version 1, primaries at
-/// 0) and the person's uuid, and hide unknown ids.
+/// The read must carry the mapping row's own version (extras are born at
+/// version 1, primaries at 0), not the person's, and hide unknown ids.
 #[tokio::test]
 async fn distinct_id_mappings_carry_uuid_and_mapping_version() {
     let t = ServiceTestContext::new().await;


### PR DESCRIPTION
## Problem

The Postgres merge path re-emits committed distinct id mappings to ClickHouse when a merge arrives already satisfied (#96917). The personhog backend cannot do that yet: its repository has no way to read a mapping row's version and person uuid, so `fetchPersonDistinctIdMappings` throws.

- The identity service resolves distinct ids to persons on the primary, but no RPC returns the mapping row itself.
- Re-emission needs exactly that row: the person uuid (ClickHouse keys persons by uuid) and the mapping's own version, read from the authoritative side.

## Changes

Nothing is user-visible: this adds an API and its client, with no caller yet.

- The identity service gains `GetDistinctIdMappings(team_id, distinct_ids)`: committed mapping rows on the primary, carrying the person uuid and mapping-row version. Ids without a live mapping, or mapped to tombstoned persons, are absent.
- The Node client gains `PersonhogIdentityOperations.getDistinctIdMappings`, chunked to the 250-key batch cap like its siblings.
- The personhog repository returns no mapping rows: its identity service produces the ClickHouse messages itself, so re-emission is a safe no-op there.
- Mechanical: regenerated `identity_pb.ts`, trait stubs in the identity test doubles.

## How did you test this code?

- New identity service test seeds a person with an extra distinct id and asserts the RPC returns the mapping-row versions (primary 0, extra 1), the deterministic person uuid, and no row for unknown ids.
- New Node wrapper test asserts the response decodes to plain numbers and strings; a BigInt version leaking through would throw in the downstream JSON message builder.
- Ran the full `personhog-identity` crate suite locally against the persons database.
- Not run locally: router and replica suites; the RPC touches neither.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: internal service API, documented in the proto.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session, continuing the #96917 work; skills invoked: /adding-personhog-rpc, /stacking-prs, /writing-tests, /writing-pr-descriptions, /writing-code-comments.
- The RPC went on the identity service rather than the replica/router pair because re-emission requires an authoritative read, and identity always reads the primary.
- All fixtures and sample data are invented; no session-sensitive material is included.

