### PR TITLE
fix(deletions): stop crashing on person-property deletion requests

### DIFF
--- a/docs/internal/clickhouse-deletion-coverage.md
+++ b/docs/internal/clickhouse-deletion-coverage.md
@@ -109,8 +109,11 @@ The events property-removal path rewrites rows in a staging table and resets eac
 That works because `materialize()` creates columns as `DEFAULT <expr>`, which is assignable.
 
 All of that machinery (column discovery, staging rewrite, shard walk) is scoped to `events`; none of it reaches `flag_evaluations`.
-Until it does, `get_property_removal_shards` refuses to start when the table holds rows matching the request, so a request cannot complete while data it named survives.
+Until it does, `get_property_removal_shards` refuses to start when the table holds rows matching a request's event `properties`, so such a request cannot complete while data it named survives.
 The check costs nothing while the table is empty.
+
+The person-property half of a request is different, whether or not it also names event properties: `DeletionTarget.stores_person_properties` is `False` on `FLAG_EVALUATIONS`, so the gate does not build a `person_properties` predicate against the table at all, and that half of the request completes regardless of what the column holds.
+That is accurate for rows written since the producer stopped sending `person_properties` (2026-09-05, #95693), and a deliberate blind spot for whatever a row written before then still carries: those values are out of the gate's reach until the row's TTL passes.
 
 The schema stopped being a second obstacle with migration `0301_flag_evaluations_default_columns`, which recreated the nine typed columns as `DEFAULT <expr>`, the kind `materialize()` mints on events; they were true ClickHouse `MATERIALIZED` before, which is not assignable at all.
 Measured against ClickHouse 26.6.2 on the `DEFAULT` shape:
@@ -137,8 +140,9 @@ The remaining fix is pointing the events rewrite machinery at this table, with t
 #### If a request arrives before the fix lands
 
 Today the refusal costs nothing, because the table is empty.
-Once it holds rows, a property removal with `delete_all_events` refuses whenever a single flag-evaluation row carries the named property, and the operator has no way through: `delete_all_events` and `events` are mutually exclusive on the model, so the request cannot be narrowed to exclude `$feature_flag_called`, and the admin Retry button replays the same failure.
+Once it holds rows, a property removal with `delete_all_events` refuses whenever a single flag-evaluation row carries the named event property, and the operator has no way through: `delete_all_events` and `events` are mutually exclusive on the model, so the request cannot be narrowed to exclude `$feature_flag_called`, and the admin Retry button replays the same failure.
 The only exits are waiting out the TTL or shipping the fix above. The table partitions by month with `ttl_only_drop_parts = 1`, so a part drops only once its newest row expires: the real wait is up to about 120 days, not the 90-day TTL. `posthog/models/flag_evaluations/sql.py` says the same thing next to the partition clause.
+A person-property-only request is not stuck this way: as above, the gate does not check `flag_evaluations` for one at all.
 
 Refusing beats silently under-deleting, so the gate is the right default.
 If the fix has not landed by the time real traffic hits, the cheaper stopgaps are letting a request exclude event names so an operator can scope around the table, or recording an explicit, audited acknowledgement on the request so an operator can accept the residue rather than being stuck.
@@ -166,7 +170,7 @@ Keeping the fork downstream of person resolution is the contract, tracked on #81
 
 ## Adding a table
 
-Register it in `PERSONAL_DATA_TARGETS`, with capability flags reflecting what its schema can actually take and what the sweep code actually implements: `accepts_property_rewrite` needs the rewrite machinery to reach the table, not just assignable columns.
+Register it in `PERSONAL_DATA_TARGETS`, with capability flags reflecting what its schema can actually take and what the sweep code actually implements: `accepts_property_rewrite` needs the rewrite machinery to reach the table, not just assignable columns; `stores_person_properties` needs the table's `person_properties` column to actually hold reachable data, not just exist in the schema; see `FLAG_EVALUATIONS` for a table where those diverged.
 If it is not going to be swept, add it to `TTL_ONLY_TABLES` with the window you are accepting.
 If its storage lives on a cluster other than the one the deletion jobs connect to, give it a `cluster_setting` naming that cluster and mark it `optional`; see "Reach" and "Dispatching" above for which sweeps then reach it and which refuse.
 

--- a/posthog/dags/data_deletion_requests.py
+++ b/posthog/dags/data_deletion_requests.py
@@ -1,6 +1,6 @@
 import time
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from functools import partial
 
@@ -446,8 +446,7 @@ def _refuse_unsweepable(
     cluster: ClickhouseCluster,
     targets: list[DeletionTarget],
     deletion_request: DeletionRequestContext,
-    predicate: str,
-    params: dict,
+    predicate_for: Callable[[DeletionTarget], tuple[str, dict] | None],
     *,
     reason: str,
 ) -> None:
@@ -456,13 +455,40 @@ def _refuse_unsweepable(
         assert_no_unsweepable_rows(
             cluster,
             targets,
-            predicate,
-            params,
+            predicate_for,
             events=[] if deletion_request.delete_all_events else deletion_request.events,
             reason=reason,
         )
     except UnsweepableRowsError as exc:
         raise dagster.Failure(description=f"Deletion request {deletion_request.request_id}: {exc}") from exc
+
+
+def _refuse_property_removal_unsweepable(
+    cluster: ClickhouseCluster,
+    unsweepable: list[DeletionTarget],
+    deletion_request: DeletionRequestContext,
+    marker_str: str,
+) -> None:
+    """Gate a property-removal request against every unsweepable target.
+
+    A target without ``stores_person_properties`` (today only flag_evaluations) drops the
+    request's ``person_properties`` half from its presence check, since the gate cannot query that
+    column there; see the field's own comment on ``DeletionTarget`` for what that costs. A target
+    left with no criteria at all, nothing in ``properties`` either, is skipped rather than
+    queried.
+    """
+
+    def predicate_for(target: DeletionTarget) -> tuple[str, dict] | None:
+        request = (
+            deletion_request if target.stores_person_properties else replace(deletion_request, person_properties=[])
+        )
+        if not request.properties and not request.person_properties:
+            return None
+        return _property_removal_where(request, inserted_at_max=marker_str)
+
+    _refuse_unsweepable(
+        cluster, unsweepable, deletion_request, predicate_for, reason=_PROPERTY_REWRITE_UNSWEEPABLE_REASON
+    )
 
 
 def _verify_swept(
@@ -496,8 +522,10 @@ def _event_removal_placements(
 
     unsweepable = [p.target for p in placements if not p.target.accepts_hogql_predicate]
     if unsweepable:
-        predicate, params = portable_event_removal_where(deletion_request)
-        _refuse_unsweepable(cluster, unsweepable, deletion_request, predicate, params, reason=_HOGQL_UNSWEEPABLE_REASON)
+        criteria = portable_event_removal_where(deletion_request)
+        _refuse_unsweepable(
+            cluster, unsweepable, deletion_request, lambda _target: criteria, reason=_HOGQL_UNSWEEPABLE_REASON
+        )
     return [p for p in placements if p.target.accepts_hogql_predicate]
 
 
@@ -755,15 +783,7 @@ def get_property_removal_shards(
         marker_str = marker.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")
         # Bound by the same marker as the sweep and the verify gate, so a row ingested after the
         # marker — which the sweep would never touch — can't refuse the request forever.
-        presence, presence_params = _property_removal_where(deletion_request, inserted_at_max=marker_str)
-        _refuse_unsweepable(
-            cluster,
-            unsweepable,
-            deletion_request,
-            presence,
-            presence_params,
-            reason=_PROPERTY_REWRITE_UNSWEEPABLE_REASON,
-        )
+        _refuse_property_removal_unsweepable(cluster, unsweepable, deletion_request, marker_str)
 
     shards = sorted(cluster.shards)
     context.log.info(f"Fanning out property removal {deletion_request.request_id} to {len(shards)} shard op(s)")
@@ -1087,15 +1107,7 @@ def verify_property_removal(
     # Bounded by the same marker as the checks below so post-marker ingestion can't wedge the run.
     unsweepable = [t for t in resolve_targets_here(cluster) if not t.accepts_property_rewrite]
     if unsweepable:
-        presence, presence_params = _property_removal_where(deletion_request, inserted_at_max=marker_str)
-        _refuse_unsweepable(
-            cluster,
-            unsweepable,
-            deletion_request,
-            presence,
-            presence_params,
-            reason=_PROPERTY_REWRITE_UNSWEEPABLE_REASON,
-        )
+        _refuse_property_removal_unsweepable(cluster, unsweepable, deletion_request, marker_str)
 
     properties = deletion_request.properties
     person_properties = deletion_request.person_properties

--- a/posthog/dags/tests/test_data_deletion_requests.py
+++ b/posthog/dags/tests/test_data_deletion_requests.py
@@ -102,14 +102,15 @@ def _truncate_writable_events(client: Client) -> None:
     client.execute("TRUNCATE TABLE IF EXISTS sharded_events")
 
 
-def _insert_flag_evaluations_with_properties(rows: list[tuple], client: Client) -> None:
-    # Rows of (team_id, distinct_id, properties_json, uuid, timestamp, inserted_at). The event name
-    # is stamped here because a property-removal request narrows on it. inserted_at is set
-    # explicitly rather than left to its `DEFAULT timestamp` so a test can place a row before or
-    # after the removal marker, which is what the marker-bounded gate keys on.
+def _insert_flag_evaluations_with_properties(rows: list[tuple], client: Client, column: str = "properties") -> None:
+    # Rows of (team_id, distinct_id, <column>_json, uuid, timestamp, inserted_at). The event name is
+    # stamped here because a property-removal request narrows on it. inserted_at is set explicitly
+    # rather than left to its `DEFAULT timestamp` so a test can place a row before or after the
+    # removal marker, which is what the marker-bounded gate keys on. `column` selects which JSON blob
+    # column the row's properties land in: `properties` (event) or `person_properties`.
     client.execute(
-        "INSERT INTO writable_flag_evaluations "
-        "(team_id, distinct_id, properties, uuid, timestamp, inserted_at, event) VALUES",
+        f"INSERT INTO writable_flag_evaluations "
+        f"(team_id, distinct_id, {column}, uuid, timestamp, inserted_at, event) VALUES",
         [(*row, FLAG_EVALUATIONS_SOURCE_EVENT) for row in rows],
     )
 
@@ -2200,6 +2201,103 @@ def test_get_property_removal_shards_refuses_when_flag_evaluations_holds_matchin
     # unconditional block on every property removal.
     cluster.any_host(_truncate_flag_evaluations).result()
     assert list(get_property_removal_shards(build_op_context(), cluster, deletion_request))
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "properties, person_properties, insert_column, insert_value, expect_refusal",
+    [
+        pytest.param(
+            [], ["email"], "person_properties", '{"email": "a@example.com"}', False, id="person_properties_only"
+        ),
+        pytest.param(
+            ["$ip"],
+            ["email"],
+            "person_properties",
+            '{"email": "a@example.com"}',
+            False,
+            id="mixed_matches_person_property",
+        ),
+        pytest.param(["$ip"], ["email"], "properties", '{"$ip": "1.2.3.4"}', True, id="mixed_matches_event_property"),
+    ],
+)
+def test_get_property_removal_shards_narrows_person_properties_on_flag_evaluations(
+    cluster: ClickhouseCluster,
+    properties: list[str],
+    person_properties: list[str],
+    insert_column: str,
+    insert_value: str,
+    expect_refusal: bool,
+) -> None:
+    # flag_evaluations' person_properties column no longer receives real data (#95693), so the gate
+    # drops the person_properties half of its check: a row matching only that half now survives,
+    # which is the accepted cost. The target itself is still checked, so a row matching the request's
+    # event property must still refuse.
+    request = DataDeletionRequest.objects.create(
+        team_id=PROP_TEAM_ID,
+        request_type=RequestType.PROPERTY_REMOVAL,
+        events=[FLAG_EVALUATIONS_SOURCE_EVENT],
+        properties=properties,
+        person_properties=person_properties,
+        start_time=datetime.now() - timedelta(days=7),
+        end_time=datetime.now() + timedelta(days=1),
+        status=RequestStatus.APPROVED,
+    )
+    config = DataDeletionRequestConfig(request_id=str(request.pk))
+    deletion_request = load_property_removal_request(build_op_context(), config)
+    marker = deletion_request.inserted_at_marker
+    assert marker is not None
+    before_marker = marker - timedelta(minutes=1)
+
+    cluster.any_host(_truncate_flag_evaluations).result()
+    cluster.any_host(
+        partial(
+            _insert_flag_evaluations_with_properties,
+            [(PROP_TEAM_ID, "someone", insert_value, str(uuid4()), before_marker, before_marker)],
+            column=insert_column,
+        )
+    ).result()
+
+    if expect_refusal:
+        with pytest.raises(dagster.Failure, match="cannot be deleted"):
+            list(get_property_removal_shards(build_op_context(), cluster, deletion_request))
+    else:
+        assert list(get_property_removal_shards(build_op_context(), cluster, deletion_request))
+
+    cluster.any_host(_truncate_flag_evaluations).result()
+
+
+@pytest.mark.django_db
+def test_execute_event_deletion_refuses_hogql_predicate_when_flag_evaluations_holds_matching_rows(
+    cluster: ClickhouseCluster,
+) -> None:
+    # flag_evaluations has no HogQL table definition, so it cannot accept the compiled predicate
+    # and falls into the unsweepable branch of _event_removal_placements. A matching row there must
+    # refuse the request rather than let it complete while HogQL-matched rows survive.
+    now = datetime.now()
+    start_time = now - timedelta(days=7)
+    end_time = now + timedelta(minutes=1)
+
+    cluster.any_host(_truncate_flag_evaluations).result()
+    cluster.any_host(
+        partial(
+            _insert_flag_evaluations_with_properties,
+            [(PROP_TEAM_ID, "someone", '{"$browser": "Chrome"}', str(uuid4()), now, now)],
+        )
+    ).result()
+
+    deletion_ctx = DeletionRequestContext(
+        request_id=str(uuid4()),
+        team_id=PROP_TEAM_ID,
+        start_time=start_time,
+        end_time=end_time,
+        events=[FLAG_EVALUATIONS_SOURCE_EVENT],
+        hogql_predicate="properties.$browser = 'Chrome'",
+    )
+    with pytest.raises(dagster.Failure, match="cannot be deleted"):
+        execute_event_deletion(build_op_context(), cluster, deletion_ctx)
+
+    cluster.any_host(_truncate_flag_evaluations).result()
 
 
 @pytest.mark.django_db

--- a/posthog/models/deletion_targets.py
+++ b/posthog/models/deletion_targets.py
@@ -103,12 +103,29 @@ class DeletionTarget:
     # table, which today is hardcoded to the events tables. flag_evaluations satisfies only the
     # schema half, so flipping this without extending the sweep silently under-deletes.
     accepts_property_rewrite: bool = False
+    # Whether the property-removal gate may build a person_properties predicate here. False where
+    # the column has been dropped out of band on PostHog Cloud, which makes the predicate an
+    # unknown-identifier error rather than a count. The flag narrows the gate on every deployment
+    # regardless of whether the column is actually present there. The cost is a blind spot: rows
+    # this table stored before its producer stopped sending person_properties hold real values
+    # wherever the column survives, and this gate no longer sees them. Bounded by the table's TTL;
+    # see COVERAGE_DOC.
+    # accepts_property_rewrite=True implies this must stay True too, since the rewrite assumes the
+    # column holds real data; __post_init__ below enforces that pairing.
+    stores_person_properties: bool = True
     # Read uuids from this table when queueing a deferred deletion. False where the rows duplicate
     # another target's uuids, which would queue each one twice.
     queue_uuid_candidates: bool = True
     # The event names this table can hold, None meaning unconstrained. Lets a request naming other
     # events skip this table without querying it.
     stored_events: frozenset[str] | None = None
+
+    def __post_init__(self) -> None:
+        if self.accepts_property_rewrite and not self.stores_person_properties:
+            raise ValueError(
+                f"{self.data_table}: accepts_property_rewrite needs stores_person_properties, "
+                f"because the rewrite writes the person_properties column back. See {COVERAGE_DOC}."
+            )
 
     @property
     def cluster_name(self) -> str:
@@ -166,15 +183,17 @@ EVENTS_JSON = DeletionTarget(
     queue_uuid_candidates=False,
 )
 
-# Flag-evaluation telemetry carries the same person and group payload as events, so person, team
-# and queued-uuid sweeps must reach it. It takes neither of the richer sweeps; both exclusions are
-# explained in docs/internal/clickhouse-deletion-coverage.md. Its producer populates person_id
-# exactly as the events pipeline does, so a person sweep matches on person_id like every other
-# events-shaped table.
+# Flag-evaluation telemetry carries the same person_id and group payload as events, so team and
+# queued-uuid sweeps must reach it, and a person sweep matches on person_id like every other
+# events-shaped table. Its producer stopped sending person_properties on 2026-09-05 (#95693); a row
+# the table stored before then is out of the property-removal gate's reach until its TTL passes. It
+# takes neither of the richer sweeps; both exclusions are explained in
+# docs/internal/clickhouse-deletion-coverage.md.
 FLAG_EVALUATIONS = DeletionTarget(
     data_table=FLAG_EVALUATIONS_DATA_TABLE,
     read_table=FLAG_EVALUATIONS_TABLE,
     optional=True,
+    stores_person_properties=False,
     stored_events=frozenset({FLAG_EVALUATIONS_SOURCE_EVENT}),
 )
 
@@ -387,8 +406,7 @@ def count_surviving_rows(cluster: ClickhouseCluster, target: DeletionTarget, pre
 def assert_no_unsweepable_rows(
     cluster: ClickhouseCluster,
     targets: Sequence[DeletionTarget],
-    predicate: str,
-    params: dict,
+    predicate_for: Callable[[DeletionTarget], tuple[str, dict] | None],
     *,
     events: Sequence[str],
     reason: str,
@@ -397,8 +415,10 @@ def assert_no_unsweepable_rows(
 
     Pass targets already narrowed by ``resolve_targets``; this does not re-check presence.
 
-    ``predicate`` must be the portable part of the criteria — no HogQL fragment, no
-    materialized-column arms — so the count is a superset of what the deletion would have removed.
+    ``predicate_for`` returns the criteria to count on a target, or ``None`` to skip it.
+    The criteria carry no HogQL fragment and no materialized-column arms, so each count is a
+    superset of what the deletion would have removed. A caller may drop a criterion the target
+    cannot hold, and the count is then a superset of the remainder.
     ``events`` is the request's event filter, empty meaning every event.
 
     Deliberately gated on rows existing rather than on the request's shape: an unconditional
@@ -408,6 +428,11 @@ def assert_no_unsweepable_rows(
     for target in targets:
         if not target.may_hold_any_of(events):
             continue
+
+        criteria = predicate_for(target)
+        if criteria is None:
+            continue
+        predicate, params = criteria
 
         count = count_surviving_rows(cluster, target, predicate, params)
         if count:


### PR DESCRIPTION
## Problem

A property-removal deletion request that names a person property crashes the deletion job instead of completing or refusing cleanly, whenever `flag_evaluations` is in scope. The gate checks that table by querying its `person_properties` column for matching rows. That column holds no data the gate can trust: the producer stopped sending it, and production ClickHouse has already dropped the column in both regions. The gate only catches its own refusal error, so the raw ClickHouse "unknown identifier" error escapes as an unhandled job failure.

## Changes

- A property-removal request naming a person property against `flag_evaluations` now completes, or refuses cleanly on the request's event properties, instead of crashing.
- `DeletionTarget` gets a `stores_person_properties` capability flag, false on `FLAG_EVALUATIONS`. The gate drops the `person_properties` half of its predicate for a target lacking that capability, narrowing the check rather than skipping the target.
- The gate now builds its predicate per target through a callable, instead of sharing one predicate across every target in the list. This matches the shape the post-sweep verification check already uses.
- Mechanical: comments on `DeletionTarget` and the internal coverage doc explain the new flag and its dated cause.

> [!WARNING]
> The flag is a static, one-time decision, not a live schema check. A `flag_evaluations` row written before the producer stopped sending `person_properties` (2026-09-05) can still hold a real value wherever the column has not been dropped, and this gate no longer sees it. Exposure is bounded by the table's TTL, up to about 120 days.

## How did you test this code?

`test_get_property_removal_shards_narrows_person_properties_on_flag_evaluations` replaces the earlier single-case test with three parametrized cases: a person-property-only request, a mixed request that matches only on the person property, and a mixed request that matches only on the event property. Together they prove the gate narrows its check rather than skipping the target outright or suppressing the event-property half.

No test reproduces the actual production crash. The local ClickHouse schema still declares `person_properties` on `flag_evaluations`, so the unknown-identifier error this PR fixes cannot be reproduced here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None beyond the internal coverage doc already listed in Changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code implemented this from a detailed task specification, using `/writing-tests`, `/simplify`, `/comment-cleanup`, `/followup`, `/commit`, `/create-pr`, and `/writing-pr-descriptions`, plus a `code-reviewer` subagent pass. Session: https://claude.ai/code/session_017RuDFm6NFyFAFxEDM79BT4

The first implementation matched the task's own sketch: a two-branch split of unsweepable targets. A four-way parallel review (reuse, simplification, efficiency, altitude) converged independently on generalizing the existing `assert_no_unsweepable_rows`/`_refuse_unsweepable` pair to take a per-target predicate callable, the same shape `assert_sweep_complete` already uses. That refactor shipped instead of the two-bucket special case.

The `code-reviewer` pass found that an early comment claiming `flag_evaluations` "never carries real person-property data" was not backed by git history: the column held real values for about three and a half weeks before the producer change on 2026-09-05. The comments, the coverage doc, and the regression test were rewritten to state that dated window and insert a matching row, rather than assert an unqualified "never".

- No duplicate: searched open PRs for this crash and found none.
- Patch coverage: not yet checked; will review the coverage comment once it posts.
- Public artifact: nothing here beyond what's stated. The task referenced an internal review file and a sibling unmerged branch (migration `0315`); neither is quoted, and that migration is out of scope for this PR.

Follow-ups filed, not done here to keep this PR scoped: logging the gate's silent skip on the audit path, adding `flag_evaluations` coverage to the post-sweep verification gate's tests, and considering a live `system.columns` probe instead of the static capability flag.