### PR TITLE
fix(hogql): prepare saved-view types for trino transpilation

### DIFF
--- a/docs/internal/hogql-trino-compiler.md
+++ b/docs/internal/hogql-trino-compiler.md
@@ -10,6 +10,11 @@ The returned SQL uses named placeholders, with values stored in `context.values`
 
 The final Trino transpiler accepts a prepared AST plus frozen snapshots of bindings, table locators, modifiers, limits, timezone, and week start. It clones the AST and creates a fresh print context without a team, user, or schema database before final lowering, validation, and printing.
 
+Trino preparation snapshots the column metadata for expanded saved views from the existing schema before this handoff, including references reachable through aliases and nested query types.
+Each referenced view shares one column snapshot per preparation call, preserving field names, nested field metadata, and nullability without retaining saved-query callbacks or rebuilding the catalog.
+Field and table types keep their source identity and alias qualification so final lowering and type-dependent casts work with `database=None`.
+Callers of `transpile_prepared_hogql_to_trino(...)` must supply an AST prepared through `prepare_ast_for_printing(..., "trino")`; preparation includes these snapshots even when final Trino lowering is deferred.
+
 `transpile_hogql_to_trino(...)` is the restricted, manifest-backed front end. Its immutable manifest allowlists logical tables, physical Trino locators, and warehouse column types. `events` and `persons` use fixed built-in schemas. The function resolves and prints with no team, user, Django model, saved query, or lazy database callback, and its tests assert that it executes zero Django queries.
 
 Use `prepare_trino_catalog(...)` when several queries share one manifest. Preparation validates the manifest and builds its schema database and physical locator map once. Each `PreparedTrinoCatalog.transpile(...)` call creates a new AST, context, modifiers, and bound-value map, so query state does not cross compilation boundaries.

--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -424,11 +424,13 @@ class SelectSetQueryType(Type):
         return self.types[0].resolve_constant_type(context)
 
 
-@dataclass(kw_only=True, slots=True)
+@dataclass(kw_only=True, slots=True, frozen=False)
 class SelectViewType(BaseTableType):
     view_name: str
     alias: str
     select_query_type: SelectQueryType | SelectSetQueryType
+    # Trino preparation snapshots column metadata before discarding the schema context.
+    column_table: Table | None = field(default=None, repr=False, compare=False)
 
     def has_child(self, name: str, context: HogQLContext) -> bool:
         try:
@@ -438,6 +440,8 @@ class SelectViewType(BaseTableType):
             return False
 
     def resolve_database_table(self, context: HogQLContext) -> Table:
+        if self.column_table is not None:
+            return self.column_table
         if context.database is None:
             raise ResolutionError("Database must be set for queries with views")
         return context.database.get_table(self.view_name)

--- a/posthog/hogql/printer/test/test_trino_printer.py
+++ b/posthog/hogql/printer/test/test_trino_printer.py
@@ -1,5 +1,6 @@
 import sqlite3
 from contextlib import closing
+from typing import TYPE_CHECKING
 
 import pytest
 from unittest import mock
@@ -13,7 +14,14 @@ from posthog.hogql.constants import HogQLQuerySettings
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
 from posthog.hogql.database.direct_trino_table import DirectTrinoTable
-from posthog.hogql.database.models import DateTimeDatabaseField, StringDatabaseField, StringJSONDatabaseField, TableNode
+from posthog.hogql.database.models import (
+    DateDatabaseField,
+    DateTimeDatabaseField,
+    SavedQuery,
+    StringDatabaseField,
+    StringJSONDatabaseField,
+    TableNode,
+)
 from posthog.hogql.errors import QueryError
 from posthog.hogql.escape_sql import escape_trino_identifier
 from posthog.hogql.helpers.timestamp_visitor import is_time_or_interval_constant
@@ -24,6 +32,9 @@ from posthog.hogql.transforms.trino.transpiler import TrinoTranspilerInput, tran
 from posthog.hogql.trino_parameters import convert_pyformat_placeholders
 
 from posthog.schema_enums import PersonsOnEventsMode
+
+if TYPE_CHECKING:
+    from pytest_django.plugin import DjangoDbBlocker
 
 
 def _trino_modifiers() -> HogQLQueryModifiers:
@@ -110,6 +121,122 @@ def test_prepared_trino_transpiler_does_not_rebuild_the_schema_database(
         transpiled = transpile_prepared_hogql_to_trino(transpiler_input)
 
     assert (transpiled.sql, transpiled.values) == snapshot
+
+
+def _context_with_saved_views() -> HogQLContext:
+    context = _context_with_trino_table()
+    assert context.database is not None
+    for name, query in (
+        ("signup_dates", "SELECT user_id, created_at AS signed_at, toDate(created_at) AS signed_day FROM users"),
+        ("nested_dates", "SELECT user_id, signed_at, signed_day FROM signup_dates"),
+    ):
+        context.database.tables.add_child(
+            TableNode(
+                name=name,
+                table=SavedQuery(
+                    id=name,
+                    name=name,
+                    query=query,
+                    fields={
+                        "user_id": StringDatabaseField(name="user_id", nullable=False),
+                        "signed_at": DateTimeDatabaseField(name="signed_at", nullable=True),
+                        "signed_day": DateDatabaseField(name="signed_day", nullable=False),
+                    },
+                ),
+            )
+        )
+    return context
+
+
+@pytest.mark.parametrize(
+    "query, expected_predicate",
+    [
+        (
+            "SELECT signed_at FROM signup_dates WHERE signed_at > '2025-01-01'",
+            '"signup_dates"."signed_at" > CAST(%(hogql_val_0)s AS TIMESTAMP)',
+        ),
+        (
+            "SELECT v.signed_day AS day FROM nested_dates AS v WHERE '2025-01-01' = day",
+            'CAST(%(hogql_val_0)s AS DATE) = "v"."signed_day"',
+        ),
+        (
+            "SELECT renamed.moment FROM (SELECT signed_at FROM nested_dates) AS renamed(moment) "
+            "WHERE renamed.moment >= '2025-01-01'",
+            '"renamed"."moment" >= CAST(%(hogql_val_0)s AS TIMESTAMP)',
+        ),
+        (
+            "SELECT a.signed_day FROM signup_dates AS a JOIN signup_dates AS b ON a.user_id = b.user_id "
+            "WHERE a.signed_day > '2025-01-01' AND b.signed_at IS NULL",
+            '"a"."signed_day" > CAST(%(hogql_val_0)s AS DATE)',
+        ),
+    ],
+)
+def test_saved_view_types_survive_database_free_transpilation(
+    query: str, expected_predicate: str, django_db_blocker: "DjangoDbBlocker"
+) -> None:
+    preparation_context = _context_with_saved_views()
+    prepared = prepare_ast_for_printing(parse_select(query), preparation_context, "trino", _finalize_trino=False)
+    assert prepared is not None
+    assert preparation_context.database is not None
+    transpiler_input = TrinoTranspilerInput(
+        node=prepared,
+        values=tuple(preparation_context.values.items()),
+        table_locators=preparation_context.trino_table_locators,
+        persons_on_events_mode=preparation_context.modifiers.personsOnEventsMode,
+        convert_to_project_timezone=preparation_context.modifiers.convertToProjectTimezone,
+        limit_top_select=False,
+        limit_context=preparation_context.limit_context,
+        timezone=preparation_context.database.get_timezone(),
+        week_start_day=preparation_context.database.get_week_start_day(),
+    )
+    preparation_context.database = None
+
+    with (
+        django_db_blocker.block(),
+        mock.patch(
+            "posthog.hogql.database.database.Database.create_for",
+            side_effect=AssertionError("the prepared transpiler must not build a database"),
+        ),
+    ):
+        transpiled = transpile_prepared_hogql_to_trino(transpiler_input)
+
+    assert expected_predicate in transpiled.sql
+    assert 'FROM "ducklake"."analytics"."users" AS "users"' in transpiled.sql
+    assert transpiled.values == {"hogql_val_0": "2025-01-01"}
+    sql, _ = prepare_and_print_ast(parse_select(query), _context_with_saved_views(), "trino")
+    assert sql == transpiled.sql
+
+
+def test_prepared_view_metadata_preserves_nullability_and_source_identity() -> None:
+    context = _context_with_saved_views()
+    prepared = prepare_ast_for_printing(
+        parse_select("SELECT a.signed_at, b.signed_day FROM signup_dates AS a CROSS JOIN signup_dates AS b"),
+        context,
+        "trino",
+    )
+    assert prepared is not None
+    assert isinstance(prepared.type, ast.SelectQueryType)
+    first_view = prepared.type.tables["a"]
+    second_view = prepared.type.tables["b"]
+    assert isinstance(first_view, ast.SelectViewType)
+    assert isinstance(second_view, ast.SelectViewType)
+    assert first_view is not second_view
+    assert first_view.column_table is second_view.column_table
+
+    assert context.database is not None
+    source_column = context.database.get_table("signup_dates").get_field("signed_at")
+    assert isinstance(source_column, DateTimeDatabaseField)
+    source_column.nullable = False
+    context.database = None
+
+    timestamp_field = first_view.get_child("signed_at", context)
+    assert isinstance(timestamp_field, ast.FieldType)
+    assert timestamp_field.table_type is first_view
+    assert timestamp_field.is_nullable(context)
+    assert timestamp_field.resolve_constant_type(context) == ast.DateTimeType(nullable=True)
+    assert second_view.get_child("signed_day", context).resolve_constant_type(context) == ast.DateType(nullable=False)
+    assert prepared.type.columns["signed_at"].resolve_constant_type(context) == ast.DateTimeType(nullable=True)
+    assert print_prepared_ast(timestamp_field, context, "trino") == '"a"."signed_at"'
 
 
 def test_prints_trino_lambda_syntax() -> None:

--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -424,6 +424,14 @@ def prepare_ast_for_printing(
         with context.timings.measure("resolve_in_cohorts"):
             resolve_in_cohorts(node, dialect, stack, context, resolver_factory=resolver_factory)
 
+    if dialect == "trino":
+        from posthog.hogql.transforms.trino.view_types import (  # noqa: PLC0415 -- load the optional backend only for Trino compilation
+            prepare_trino_view_types,
+        )
+
+        with context.timings.measure("prepare_trino_view_types"):
+            prepare_trino_view_types(node, context, stack)
+
     if dialect == "trino" and _finalize_trino:
         from posthog.hogql.transforms.trino.validate import (  # noqa: PLC0415 — breaks validator → printer package cycle
             validate_trino_ready_ast,

--- a/posthog/hogql/transforms/trino/view_types.py
+++ b/posthog/hogql/transforms/trino/view_types.py
@@ -1,0 +1,35 @@
+from dataclasses import fields
+
+from posthog.hogql import ast
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.models import DatabaseField, Table
+
+
+def prepare_trino_view_types(node: ast.AST, context: HogQLContext, stack: list[ast.SelectQuery] | None = None) -> None:
+    pending: list[object] = [node, *(stack or [])]
+    visited: set[int] = set()
+    column_tables: dict[str, Table] = {}
+    while pending:
+        current = pending.pop()
+        if not isinstance(current, (ast.AST, dict, list, tuple)) or id(current) in visited:
+            continue
+        visited.add(id(current))
+        if isinstance(current, ast.AST):
+            if isinstance(current, ast.SelectViewType):
+                if current.view_name not in column_tables:
+                    table = current.resolve_database_table(context)
+                    column_tables[current.view_name] = Table(
+                        name=table.name,
+                        fields={
+                            name: column.model_copy(deep=True)
+                            for name, column in table.fields.items()
+                            if isinstance(column, DatabaseField)
+                        },
+                    )
+                current.column_table = column_tables[current.view_name]
+            # Expression visitors skip type edges, which can contain view references and cycles.
+            pending.extend(getattr(current, field.name) for field in fields(current))
+        elif isinstance(current, dict):
+            pending.extend(current.values())
+        elif isinstance(current, (list, tuple)):
+            pending.extend(current)


### PR DESCRIPTION
## Problem

Queries that compare columns from expanded saved views can fail during Trino compilation with `Database must be set for queries with views`.
The final transpiler deliberately discards the schema context, but residual view references still need column metadata.

## Changes

- Saved-view comparisons compile with their declared types, including date and timestamp casts.
- Trino preparation snapshots column metadata once per referenced view while preserving source identity, aliases, and nullability.
- The pure transpiler keeps its database-free context; other dialects retain their existing preparation behavior.
- Documentation and regression fixtures are supporting changes; this PR has no visual changes.

Before:

```mermaid
flowchart LR
    A[Resolve and expand] --> B[Print without view metadata]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class A phBlue;
    class B phRed;
```

After:

```mermaid
flowchart LR
    A[Resolve and expand] --> B[Snapshot view columns] --> C[Print without database]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,C phBlue;
    class B phGray;
```

## How did you test this code?

- Added regression cases for comparisons, nested and renamed aliases, repeated view references, nullable columns, and transpilation with Django queries blocked.
- Ran scoped Trino, adapter, saved-view, AST, visitor, and import-guard tests, repository-wide mypy, and preflight.
- Live Trino validation remains unchecked.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated `docs/internal/hogql-trino-compiler.md` with the preparation contract.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used shell tools and GitHub CLI. A read-only review found no actionable defects; searches found no overlapping open PR.
Regression fixtures use independently invented data.

Skills: `writing-tests`, `writing-code-comments`, `writing-dataclasses`, `writing-user-facing-copy`, `running-ci-preflight`, `writing-pr-descriptions`, and `review-agent`.
