### PR TITLE
fix(data-imports): retry redis connection before falling back in idempotency check

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/idempotency.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/idempotency.py
@@ -2,8 +2,10 @@ from contextlib import contextmanager
 
 from django.conf import settings
 
+import redis
 import structlog
 from asgiref.sync import async_to_sync
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from posthog.exceptions_capture import capture_exception
 from posthog.redis import get_client
@@ -18,9 +20,24 @@ IDEMPOTENCY_KEY_PREFIX = "warehouse_pipelines:processed"
 IDEMPOTENCY_TTL_SECONDS = 72 * 60 * 60  # 3 days (72 hours) same as the topic retention period
 
 
+@retry(
+    retry=retry_if_exception_type((redis.exceptions.ConnectionError, redis.exceptions.TimeoutError)),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential_jitter(initial=0.1, max=1),
+    reraise=True,
+)
+def _connect_and_ping(redis_client: redis.Redis) -> None:
+    redis_client.ping()
+
+
 @contextmanager
 def get_redis_client():
-    """Get a Redis client for the data warehouse Redis instance."""
+    """Get a Redis client for the data warehouse Redis instance.
+
+    A bare connection blip here would fall through to the delta history scan on
+    every batch until it clears, which is not cheap (see `is_batch_already_processed`).
+    Absorb a few quick retries first, same as `sync_lock._get_redis_client`.
+    """
     redis_client = None
     try:
         if not settings.DATA_WAREHOUSE_REDIS_HOST or not settings.DATA_WAREHOUSE_REDIS_PORT:
@@ -29,7 +46,7 @@ def get_redis_client():
             )
 
         redis_client = get_client(f"redis://{settings.DATA_WAREHOUSE_REDIS_HOST}:{settings.DATA_WAREHOUSE_REDIS_PORT}/")
-        redis_client.ping()
+        _connect_and_ping(redis_client)
     except Exception as e:
         logger.warning(
             "Redis unavailable for idempotency check — falling back to delta history scan",

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/test_idempotency.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/test_idempotency.py
@@ -1,12 +1,14 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import redis
 from parameterized import parameterized
 
 from posthog.temporal.common.errors import NonReportableError
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.load.idempotency import (
     get_idempotency_key,
+    get_redis_client,
     is_batch_already_processed,
     mark_batch_as_processed,
 )
@@ -197,3 +199,29 @@ class TestMarkBatchAsProcessed:
             mock_get_client.return_value.__enter__.return_value = None
             mark_batch_as_processed(team_id=1, schema_id="s", run_uuid="r", batch_index=0)
             # No exception — the function logs a warning and returns
+
+
+class TestGetRedisClient:
+    """A bare connection blip previously fell through to the delta history scan on
+    every batch with no retry (see `sync_lock.TestGetRedisClient` for the sibling
+    fix this mirrors)."""
+
+    @patch(f"{_IDEMPOTENCY_MODULE}.get_client")
+    def test_recovers_from_transient_connection_error(self, mock_get_client: MagicMock) -> None:
+        mock_redis = MagicMock()
+        mock_redis.ping.side_effect = [redis.exceptions.TimeoutError("Timeout connecting to server"), None]
+        mock_get_client.return_value = mock_redis
+
+        with get_redis_client() as client:
+            assert client is mock_redis
+        assert mock_redis.ping.call_count == 2
+
+    @patch(f"{_IDEMPOTENCY_MODULE}.get_client")
+    def test_fails_closed_after_exhausting_retries(self, mock_get_client: MagicMock) -> None:
+        mock_redis = MagicMock()
+        mock_redis.ping.side_effect = redis.exceptions.TimeoutError("Timeout connecting to server")
+        mock_get_client.return_value = mock_redis
+
+        with get_redis_client() as client:
+            assert client is None
+        assert mock_redis.ping.call_count == 3


### PR DESCRIPTION
## Problem

A brief Redis connectivity blip during a data warehouse sync sends every in-flight batch straight to the delta-commit history scan fallback instead of retrying the cheap Redis check first. That scan opens the destination table and reads up to 50 commits per batch, so a blip during a long first sync pays that cost repeatedly instead of once.

Error tracking surfaced this as a `TimeoutError: Timeout connecting to server` raised from `get_redis_client` in the load pipeline's idempotency check ([issue](https://us.posthog.com/project/2/error_tracking/01a08302-43d0-7cb0-a436-07414f2fc857)). The exception is already caught and reported for visibility, so no sync failed, but the fallback got taken more often than it needed to be.

## Changes

- `get_redis_client` retries the initial ping up to 3 times, with exponential backoff and jitter, before falling back to the delta history scan.
- The retry mirrors `sync_lock._get_redis_client`, which already applies the same pattern to the same failure mode elsewhere in this package.
- Mechanical: two new tests cover the retry-then-recover and retry-then-fail-closed paths.

## How did you test this code?

Added `TestGetRedisClient` in `test_idempotency.py`, covering a transient ping failure that recovers on retry and one that exhausts all 3 retries and falls back. Ran the full file locally: 21 passed. Ran `mypy` on the changed file: clean.

Not run: the pipeline end-to-end against a real Redis outage.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- No duplicate: searched open PRs for `idempotency.py`, `get_redis_client`, and `warehouse redis timeout` — no match. No open PR touches this code path.
- Patch coverage: both changed lines in `idempotency.py` are exercised by the new tests.
- Public artifact: the error tracking issue is linked, not quoted; no customer data, tickets, or internal thread content is included in this PR.

Investigated via PostHog error tracking (issue linked above) and fixed with Claude Code. Skills invoked: `triaging-error-issues`, `investigating-error-issue`, `writing-pr-descriptions`.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
