### PR TITLE
feat(cohorts): add realtime cohorts waitlist banner

### DIFF
--- a/frontend/src/layout/scenes/components/FeaturePreviewSceneGate.test.tsx
+++ b/frontend/src/layout/scenes/components/FeaturePreviewSceneGate.test.tsx
@@ -361,7 +361,7 @@ describe('FeaturePreviewSceneGate', () => {
 
             render(<FeaturePreviewSceneGate config={BASE_CONFIG}>{CHILDREN}</FeaturePreviewSceneGate>)
 
-            expect(screen.getByText(/Thanks — we'll email you when it's ready/)).toBeInTheDocument()
+            expect(screen.getByText(/Thanks, we'll email you when it's ready/)).toBeInTheDocument()
             expect(screen.queryByRole('switch')).not.toBeInTheDocument()
         })
 

--- a/frontend/src/layout/scenes/components/FeaturePreviewSceneGate.tsx
+++ b/frontend/src/layout/scenes/components/FeaturePreviewSceneGate.tsx
@@ -1,10 +1,10 @@
 import { useActions, useValues } from 'kea'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 
-import { IconCheck } from '@posthog/icons'
-import { LemonButton, LemonInput, LemonSwitch } from '@posthog/lemon-ui'
+import { LemonButton, LemonSwitch } from '@posthog/lemon-ui'
 
-import { EnrichedEarlyAccessFeature, featurePreviewsLogic } from 'lib/components/FeaturePreviews/featurePreviewsLogic'
+import { ConceptWaitlistCTA } from 'lib/components/FeaturePreviews/ConceptWaitlistCTA'
+import { featurePreviewsLogic } from 'lib/components/FeaturePreviews/featurePreviewsLogic'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { supportLogic } from 'lib/components/Support/supportLogic'
 import {
@@ -40,7 +40,8 @@ export function FeaturePreviewSceneGate({
 
 function FeaturePreviewGateContent({ config }: { config: FeaturePreviewGateConfig }): JSX.Element {
     const { earlyAccessFeatures } = useValues(featurePreviewsLogic)
-    const { loadEarlyAccessFeatures, updateEarlyAccessFeatureEnrollment } = useActions(featurePreviewsLogic)
+    const { loadEarlyAccessFeatures, updateEarlyAccessFeatureEnrollment, addProductIntentForCrossSell } =
+        useActions(featurePreviewsLogic)
     const { activeSceneId } = useValues(sceneLogic)
     const { preflight } = useValues(preflightLogic)
     const { openSupportForm } = useActions(supportLogic)
@@ -72,7 +73,21 @@ function FeaturePreviewGateContent({ config }: { config: FeaturePreviewGateConfi
                     titleOverride={config.title}
                     description={config.description}
                     isEmpty
-                    actionElementOverride={<ConceptWaitlistForm feature={feature} config={config} />}
+                    actionElementOverride={
+                        <ConceptWaitlistCTA
+                            feature={feature}
+                            size="medium"
+                            onSignUp={() => {
+                                if (config.productIntent) {
+                                    void addProductIntentForCrossSell({
+                                        from: ProductKey.EARLY_ACCESS_FEATURES,
+                                        to: config.productIntent,
+                                        intent_context: ProductIntentContext.FEATURE_PREVIEW_ENABLED,
+                                    })
+                                }
+                            }}
+                        />
+                    }
                     docsURL={config.docsURL}
                 />
             </SceneContent>
@@ -142,83 +157,5 @@ function FeaturePreviewGateContent({ config }: { config: FeaturePreviewGateConfi
                 docsURL={config.docsURL}
             />
         </SceneContent>
-    )
-}
-
-function ConceptWaitlistForm({
-    feature,
-    config,
-}: {
-    feature: EnrichedEarlyAccessFeature
-    config: FeaturePreviewGateConfig
-}): JSX.Element {
-    const { waitlistSurveysEnabled, conceptSurveySubmissions } = useValues(featurePreviewsLogic)
-    const { submitConceptSurvey, updateEarlyAccessFeatureEnrollment, addProductIntentForCrossSell } =
-        useActions(featurePreviewsLogic)
-    const [email, setEmail] = useState('')
-
-    const surveySubmitted = !!conceptSurveySubmissions[feature.flagKey] || feature.enabled
-
-    // Mirrors the previews page's ConceptPreview: email collection only when the waitlist
-    // surveys gate is on, otherwise the plain one-click registration.
-    const hasWaitlistSurvey = waitlistSurveysEnabled
-
-    const recordIntent = (): void => {
-        // submitConceptSurvey refuses impersonated sessions; skip the intent too so a
-        // rejected signup never records a false adoption signal.
-        if (config.productIntent && !window.IMPERSONATED_SESSION) {
-            void addProductIntentForCrossSell({
-                from: ProductKey.EARLY_ACCESS_FEATURES,
-                to: config.productIntent,
-                intent_context: ProductIntentContext.FEATURE_PREVIEW_ENABLED,
-            })
-        }
-    }
-
-    if (surveySubmitted) {
-        return (
-            <span role="status" className="flex items-center gap-1 text-success font-medium">
-                <IconCheck /> Thanks — we'll email you when it's ready.
-            </span>
-        )
-    }
-
-    if (hasWaitlistSurvey) {
-        return (
-            <form
-                className="flex items-center gap-2"
-                onSubmit={(e) => {
-                    e.preventDefault()
-                    if (email) {
-                        submitConceptSurvey(feature.flagKey, email)
-                        recordIntent()
-                    }
-                }}
-            >
-                <LemonInput
-                    type="email"
-                    value={email}
-                    onChange={setEmail}
-                    placeholder="email@yourcompany.com"
-                    aria-label="Email address"
-                    autoComplete="email"
-                />
-                <LemonButton type="primary" htmlType="submit" disabledReason={!email ? 'Enter your email' : undefined}>
-                    Get notified
-                </LemonButton>
-            </form>
-        )
-    }
-
-    return (
-        <LemonButton
-            type="primary"
-            onClick={() => {
-                updateEarlyAccessFeatureEnrollment(feature.flagKey, true, feature.stage)
-                recordIntent()
-            }}
-        >
-            Get notified
-        </LemonButton>
     )
 }

--- a/frontend/src/lib/components/FeaturePreviews/ConceptWaitlistCTA.tsx
+++ b/frontend/src/lib/components/FeaturePreviews/ConceptWaitlistCTA.tsx
@@ -1,0 +1,98 @@
+import { useActions, useValues } from 'kea'
+import { useState } from 'react'
+
+import { IconBell, IconCheck } from '@posthog/icons'
+import { LemonButton, LemonInput } from '@posthog/lemon-ui'
+
+import { EnrichedEarlyAccessFeature, featurePreviewsLogic } from './featurePreviewsLogic'
+
+export interface ConceptWaitlistCTAProps {
+    feature: EnrichedEarlyAccessFeature
+    size?: 'small' | 'medium'
+    /** Runs after a sign-up the backend will accept, for callers that record their own product intent. */
+    onSignUp?: () => void
+}
+
+/** Waitlist sign-up for a concept ("Coming soon") early access feature. */
+export function ConceptWaitlistCTA({ feature, size = 'small', onSignUp }: ConceptWaitlistCTAProps): JSX.Element {
+    const { waitlistSurveysEnabled, conceptSurveySubmissions } = useValues(featurePreviewsLogic)
+    const { submitConceptSurvey, updateEarlyAccessFeatureEnrollment } = useActions(featurePreviewsLogic)
+    const [email, setEmail] = useState('')
+
+    const { flagKey, enabled } = feature
+
+    // When the gate is on and the feature has a linked waitlist survey, collect an email
+    // (recorded as a survey response) instead of the one-click, login-tied enrollment.
+    const hasWaitlistSurvey = waitlistSurveysEnabled && !!feature.payload?.survey_id
+
+    const signUp = (): void => {
+        // submitConceptSurvey and the enrollment listener both refuse impersonated sessions, so
+        // skip the callback too: a rejected sign-up must not record a false adoption signal.
+        if (!window.IMPERSONATED_SESSION) {
+            onSignUp?.()
+        }
+    }
+
+    if (!hasWaitlistSurvey) {
+        return (
+            <LemonButton
+                type="primary"
+                disabledReason={
+                    enabled && "You have already expressed your interest. We'll contact you when it's ready"
+                }
+                onClick={() => {
+                    updateEarlyAccessFeatureEnrollment(flagKey, true, feature.stage)
+                    signUp()
+                }}
+                size={size}
+                sideIcon={enabled ? <IconCheck /> : <IconBell />}
+                className="w-fit"
+            >
+                {enabled ? 'Registered' : 'Get notified'}
+            </LemonButton>
+        )
+    }
+
+    // `enabled` covers users who registered interest before the survey era. The migration
+    // command moves them into the survey, so do not ask them again.
+    if (!!conceptSurveySubmissions[flagKey] || enabled) {
+        // role="status" makes the confirmation a live region: the form (and its focused
+        // button) unmounts on submit, so without it screen readers announce nothing.
+        return (
+            <span role="status" className="flex items-center gap-1 text-success font-medium">
+                <IconCheck /> Thanks, we'll email you when it's ready.
+            </span>
+        )
+    }
+
+    return (
+        <form
+            className="flex items-center gap-2"
+            onSubmit={(e) => {
+                e.preventDefault()
+                if (email) {
+                    submitConceptSurvey(flagKey, email)
+                    signUp()
+                }
+            }}
+        >
+            <LemonInput
+                type="email"
+                value={email}
+                onChange={setEmail}
+                placeholder="email@yourcompany.com"
+                aria-label="Email address"
+                autoComplete="email"
+                size={size}
+            />
+            <LemonButton
+                type="primary"
+                size={size}
+                htmlType="submit"
+                disabledReason={!email ? 'Enter your email' : undefined}
+            >
+                Get notified
+            </LemonButton>
+        </form>
+    )
+}

--- a/frontend/src/lib/components/FeaturePreviews/FeaturePreviews.tsx
+++ b/frontend/src/lib/components/FeaturePreviews/FeaturePreviews.tsx
@@ -1,7 +1,6 @@
 import { useActions, useAsyncActions, useValues } from 'kea'
 import { useEffect, useLayoutEffect, useState } from 'react'
 
-import { IconBell, IconCheck } from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonInput, LemonSwitch, LemonTextArea, Link } from '@posthog/lemon-ui'
 
 import { BasicCard } from 'lib/components/Cards/BasicCard'
@@ -16,6 +15,7 @@ import { userLogic } from 'scenes/userLogic'
 
 import { AvailableFeature } from '~/types'
 
+import { ConceptWaitlistCTA } from './ConceptWaitlistCTA'
 import { EnrichedEarlyAccessFeature, featurePreviewsLogic } from './featurePreviewsLogic'
 
 type AvailableFeatureChecker = (feature: AvailableFeature) => boolean
@@ -172,74 +172,9 @@ function PreviewCard({ feature, title, description, actions, children }: Preview
 }
 
 function ConceptPreview({ feature }: { feature: EnrichedEarlyAccessFeature }): JSX.Element {
-    const { updateEarlyAccessFeatureEnrollment, copyExternalFeaturePreviewLink, submitConceptSurvey } =
-        useActions(featurePreviewsLogic)
-    const { waitlistSurveysEnabled, conceptSurveySubmissions } = useValues(featurePreviewsLogic)
+    const { copyExternalFeaturePreviewLink } = useActions(featurePreviewsLogic)
 
-    const { flagKey, enabled, name, description } = feature
-    const [email, setEmail] = useState('')
-
-    // When the gate is on and the feature has a linked waitlist survey, collect an email
-    // (recorded as a survey response) instead of the one-click, login-tied enrollment.
-    const surveyId = feature.payload?.survey_id
-    const hasWaitlistSurvey = waitlistSurveysEnabled && !!surveyId
-    // `enabled` covers users who registered interest before the survey era — the
-    // migration command moves them into the survey, so don't ask them again.
-    const surveySubmitted = !!conceptSurveySubmissions[flagKey] || enabled
-
-    let actions: JSX.Element
-    if (hasWaitlistSurvey) {
-        actions = surveySubmitted ? (
-            // role="status" makes the confirmation a live region: the form (and its focused
-            // button) unmounts on submit, so without it screen readers announce nothing.
-            <span role="status" className="flex items-center gap-1 text-success font-medium">
-                <IconCheck /> Thanks — we'll email you when it's ready.
-            </span>
-        ) : (
-            <form
-                className="flex items-center gap-2"
-                onSubmit={(e) => {
-                    e.preventDefault()
-                    if (email) {
-                        submitConceptSurvey(flagKey, email)
-                    }
-                }}
-            >
-                <LemonInput
-                    type="email"
-                    value={email}
-                    onChange={setEmail}
-                    placeholder="email@yourcompany.com"
-                    aria-label="Email address"
-                    autoComplete="email"
-                    size="small"
-                />
-                <LemonButton
-                    type="primary"
-                    size="small"
-                    htmlType="submit"
-                    disabledReason={!email ? 'Enter your email' : undefined}
-                >
-                    Get notified
-                </LemonButton>
-            </form>
-        )
-    } else {
-        actions = (
-            <LemonButton
-                type="primary"
-                disabledReason={
-                    enabled && "You have already expressed your interest. We'll contact you when it's ready"
-                }
-                onClick={() => updateEarlyAccessFeatureEnrollment(flagKey, true, feature.stage)}
-                size="small"
-                sideIcon={enabled ? <IconCheck /> : <IconBell />}
-                className="w-fit"
-            >
-                {enabled ? 'Registered' : 'Get notified'}
-            </LemonButton>
-        )
-    }
+    const { flagKey, name, description } = feature
 
     return (
         <PreviewCard
@@ -259,7 +194,7 @@ function ConceptPreview({ feature }: { feature: EnrichedEarlyAccessFeature }): J
                     {description || <span className="text-tertiary">No description</span>}
                 </p>
             }
-            actions={actions}
+            actions={<ConceptWaitlistCTA feature={feature} />}
         />
     )
 }

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -261,6 +261,7 @@ export const FEATURE_FLAGS = {
     AUTORESEARCH: 'autoresearch', // owner: @andrewm4894 #team-platform-features
     AVERAGE_PAGE_VIEW_COLUMN: 'average-page-view-column', // owner: @jordanm-posthog #team-web-analytics
     BACKFILL_WORKFLOWS_DESTINATION: 'backfill-workflows-destination', // owner: #team-batch-exports
+    BEHAVIORAL_COHORTS: 'behavioral-cohorts', // owner: #team-feature-flags, links the cohorts list waitlist banner to its early access feature
     BILLING_ALERTS: 'billing-alerts', // owner: #team-billing, gates the Billing > Alerts tab
     BILLING_REAL_TIME_USAGE: 'billing-real-time-usage', // owner: #team-billing, gates the Real-time usage scene
     CDP_DWH_TABLE_SOURCE: 'cdp-dwh-table-source', // owner: #team-workflows-cdp

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -261,7 +261,6 @@ export const FEATURE_FLAGS = {
     AUTORESEARCH: 'autoresearch', // owner: @andrewm4894 #team-platform-features
     AVERAGE_PAGE_VIEW_COLUMN: 'average-page-view-column', // owner: @jordanm-posthog #team-web-analytics
     BACKFILL_WORKFLOWS_DESTINATION: 'backfill-workflows-destination', // owner: #team-batch-exports
-    BEHAVIORAL_COHORTS: 'behavioral-cohorts', // owner: #team-feature-flags, links the cohorts list waitlist banner to its early access feature
     BILLING_ALERTS: 'billing-alerts', // owner: #team-billing, gates the Billing > Alerts tab
     BILLING_REAL_TIME_USAGE: 'billing-real-time-usage', // owner: #team-billing, gates the Real-time usage scene
     CDP_DWH_TABLE_SOURCE: 'cdp-dwh-table-source', // owner: #team-workflows-cdp
@@ -468,6 +467,7 @@ export const FEATURE_FLAGS = {
     QUILL_DATE_PICKER: 'quill-date-picker', // owner: @pauldambra, flips the lib/components/DatePicker seam from LemonUI to Quill
     REAL_TIME_NOTIFICATIONS: 'real-time-notifications', // owner: #team-platform-features
     REALTIME_COHORT_FLAG_TARGETING: 'realtime-cohort-flag-targeting', // owner: @dmarticus #team-feature-flags
+    REALTIME_COHORTS: 'realtime-cohorts', // owner: #team-feature-flags, links the cohorts list waitlist banner to its early access feature
     RECORDINGS_PLAYER_EVENT_PROPERTY_EXPANSION: 'recordings-player-event-property-expansion', // owner: @pauldambra #team-replay
     REMOTE_CONFIG: 'remote-config', // owner: #team-platform-features
     REPLAY_COLLAPSE_INSPECTOR_ITEMS: 'replay-collapse-inspector-items', // owner: @fasyy612 #team-replay

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -36,8 +36,8 @@ import {
     PropertyOperator,
 } from '~/types'
 
-import { BehavioralCohortsWaitlistBanner } from 'products/cohorts/frontend/BehavioralCohortsWaitlistBanner'
 import { cohortsEmptyState } from 'products/cohorts/frontend/emptyState/cohortsEmptyState'
+import { RealtimeCohortsWaitlistBanner } from 'products/cohorts/frontend/RealtimeCohortsWaitlistBanner'
 
 export const scene: SceneExport = {
     component: Cohorts,
@@ -294,7 +294,7 @@ export function Cohorts(): JSX.Element {
                 }
             />
 
-            <BehavioralCohortsWaitlistBanner />
+            <RealtimeCohortsWaitlistBanner />
 
             <div>{filtersSection}</div>
             <LemonTable

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -36,6 +36,7 @@ import {
     PropertyOperator,
 } from '~/types'
 
+import { BehavioralCohortsWaitlistBanner } from 'products/cohorts/frontend/BehavioralCohortsWaitlistBanner'
 import { cohortsEmptyState } from 'products/cohorts/frontend/emptyState/cohortsEmptyState'
 
 export const scene: SceneExport = {
@@ -292,6 +293,8 @@ export function Cohorts(): JSX.Element {
                     </Shortcut>
                 }
             />
+
+            <BehavioralCohortsWaitlistBanner />
 
             <div>{filtersSection}</div>
             <LemonTable

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2705,6 +2705,9 @@ importers:
       '@posthog/icons':
         specifier: 'catalog:'
         version: 0.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/jest-dom':
+        specifier: '*'
+        version: 5.17.0
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -2730,6 +2733,9 @@ importers:
       '@storybook/react':
         specifier: 'catalog:'
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
+      '@testing-library/react':
+        specifier: ^14.3.1
+        version: 14.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       kea-test-utils:
         specifier: 'catalog:'
         version: 0.2.4(kea@4.0.0-pre.6(patch_hash=139b8d1f1304f9d9da452a9a1244c94ea679dbcb85687d8999563146879fb6f5)(react@18.3.1))

--- a/products/cohorts/frontend/BehavioralCohortsWaitlistBanner.test.tsx
+++ b/products/cohorts/frontend/BehavioralCohortsWaitlistBanner.test.tsx
@@ -1,0 +1,80 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { useActions, useValues } from 'kea'
+
+import { featurePreviewsLogic } from 'lib/components/FeaturePreviews/featurePreviewsLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
+
+import { BehavioralCohortsWaitlistBanner } from './BehavioralCohortsWaitlistBanner'
+
+jest.mock('kea', () => ({
+    ...jest.requireActual('kea'),
+    useValues: jest.fn(),
+    useActions: jest.fn(),
+}))
+
+const mockedUseValues = useValues as jest.Mock
+const mockedUseActions = useActions as jest.Mock
+
+const CONCEPT_FEATURE = {
+    flagKey: FEATURE_FLAGS.BEHAVIORAL_COHORTS,
+    name: 'Behavioral cohorts',
+    enabled: false,
+    stage: 'concept',
+    payload: { survey_id: 'survey-1' },
+}
+
+function setupMocks(
+    earlyAccessFeatures: Array<{
+        flagKey: string
+        enabled: boolean
+        stage?: string
+        payload?: Record<string, unknown>
+    }>
+): void {
+    mockedUseValues.mockImplementation((logic: unknown) =>
+        logic === featurePreviewsLogic
+            ? { earlyAccessFeatures, waitlistSurveysEnabled: true, conceptSurveySubmissions: {} }
+            : // Anything else is the banner's own dismissal logic, which must report "not dismissed"
+              { isDismissed: false }
+    )
+    mockedUseActions.mockImplementation((logic: unknown) =>
+        logic === featurePreviewsLogic
+            ? {
+                  loadEarlyAccessFeatures: jest.fn(),
+                  submitConceptSurvey: jest.fn(),
+                  updateEarlyAccessFeatureEnrollment: jest.fn(),
+              }
+            : { dismiss: jest.fn() }
+    )
+}
+
+describe('BehavioralCohortsWaitlistBanner', () => {
+    afterEach(() => {
+        cleanup()
+        jest.clearAllMocks()
+    })
+
+    it('offers the waitlist while the feature is at the concept stage', () => {
+        setupMocks([CONCEPT_FEATURE])
+
+        render(<BehavioralCohortsWaitlistBanner />)
+
+        expect(screen.getByText('Behavioral cohorts are coming soon')).toBeInTheDocument()
+        expect(screen.getByText('Beta')).toBeInTheDocument()
+        expect(screen.getByPlaceholderText('email@yourcompany.com')).toBeInTheDocument()
+        expect(screen.getByText('Get notified')).toBeInTheDocument()
+    })
+
+    it.each([
+        ['the feature preview does not exist', []],
+        ['the feature has moved past concept', [{ ...CONCEPT_FEATURE, stage: 'beta' }]],
+    ])('renders nothing when %s', (_label, earlyAccessFeatures) => {
+        setupMocks(earlyAccessFeatures)
+
+        const { container } = render(<BehavioralCohortsWaitlistBanner />)
+
+        expect(container).toBeEmptyDOMElement()
+    })
+})

--- a/products/cohorts/frontend/BehavioralCohortsWaitlistBanner.tsx
+++ b/products/cohorts/frontend/BehavioralCohortsWaitlistBanner.tsx
@@ -1,0 +1,44 @@
+import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
+
+import { LemonBanner, LemonTag } from '@posthog/lemon-ui'
+
+import { ConceptWaitlistCTA } from 'lib/components/FeaturePreviews/ConceptWaitlistCTA'
+import { featurePreviewsLogic } from 'lib/components/FeaturePreviews/featurePreviewsLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
+
+// pinned: localStorage key, because renaming it shows the banner again to everyone who closed it
+const DISMISS_KEY = 'behavioral-cohorts-waitlist'
+
+export function BehavioralCohortsWaitlistBanner(): JSX.Element | null {
+    const { earlyAccessFeatures } = useValues(featurePreviewsLogic)
+    const { loadEarlyAccessFeatures } = useActions(featurePreviewsLogic)
+
+    useEffect(() => {
+        loadEarlyAccessFeatures()
+    }, [loadEarlyAccessFeatures])
+
+    // The early access feature decides whether the banner shows. It appears once the concept
+    // feature exists, and stops showing when the feature leaves the concept ("coming soon")
+    // stage, so shipping behavioral cohorts does not need a second frontend change.
+    const feature = earlyAccessFeatures.find((f) => f.flagKey === FEATURE_FLAGS.BEHAVIORAL_COHORTS)
+    if (feature?.stage !== 'concept') {
+        return null
+    }
+
+    return (
+        <LemonBanner type="info" dismissKey={DISMISS_KEY}>
+            <div className="flex flex-col gap-2">
+                <div className="flex flex-wrap items-center gap-1.5">
+                    <span className="font-semibold">Behavioral cohorts are coming soon</span>
+                    <LemonTag type="completion">Beta</LemonTag>
+                </div>
+                <p className="m-0">
+                    Group people by the actions they took, and keep the group up to date as they take them. Join the
+                    waitlist to try it first.
+                </p>
+                <ConceptWaitlistCTA feature={feature} />
+            </div>
+        </LemonBanner>
+    )
+}

--- a/products/cohorts/frontend/RealtimeCohortsWaitlistBanner.test.tsx
+++ b/products/cohorts/frontend/RealtimeCohortsWaitlistBanner.test.tsx
@@ -6,7 +6,7 @@ import { useActions, useValues } from 'kea'
 import { featurePreviewsLogic } from 'lib/components/FeaturePreviews/featurePreviewsLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 
-import { BehavioralCohortsWaitlistBanner } from './BehavioralCohortsWaitlistBanner'
+import { RealtimeCohortsWaitlistBanner } from './RealtimeCohortsWaitlistBanner'
 
 jest.mock('kea', () => ({
     ...jest.requireActual('kea'),
@@ -18,8 +18,8 @@ const mockedUseValues = useValues as jest.Mock
 const mockedUseActions = useActions as jest.Mock
 
 const CONCEPT_FEATURE = {
-    flagKey: FEATURE_FLAGS.BEHAVIORAL_COHORTS,
-    name: 'Behavioral cohorts',
+    flagKey: FEATURE_FLAGS.REALTIME_COHORTS,
+    name: 'Realtime cohorts',
     enabled: false,
     stage: 'concept',
     payload: { survey_id: 'survey-1' },
@@ -50,7 +50,7 @@ function setupMocks(
     )
 }
 
-describe('BehavioralCohortsWaitlistBanner', () => {
+describe('RealtimeCohortsWaitlistBanner', () => {
     afterEach(() => {
         cleanup()
         jest.clearAllMocks()
@@ -59,9 +59,9 @@ describe('BehavioralCohortsWaitlistBanner', () => {
     it('offers the waitlist while the feature is at the concept stage', () => {
         setupMocks([CONCEPT_FEATURE])
 
-        render(<BehavioralCohortsWaitlistBanner />)
+        render(<RealtimeCohortsWaitlistBanner />)
 
-        expect(screen.getByText('Behavioral cohorts are coming soon')).toBeInTheDocument()
+        expect(screen.getByText('Realtime cohorts are coming soon')).toBeInTheDocument()
         expect(screen.getByText('Beta')).toBeInTheDocument()
         expect(screen.getByPlaceholderText('email@yourcompany.com')).toBeInTheDocument()
         expect(screen.getByText('Get notified')).toBeInTheDocument()
@@ -73,7 +73,7 @@ describe('BehavioralCohortsWaitlistBanner', () => {
     ])('renders nothing when %s', (_label, earlyAccessFeatures) => {
         setupMocks(earlyAccessFeatures)
 
-        const { container } = render(<BehavioralCohortsWaitlistBanner />)
+        const { container } = render(<RealtimeCohortsWaitlistBanner />)
 
         expect(container).toBeEmptyDOMElement()
     })

--- a/products/cohorts/frontend/RealtimeCohortsWaitlistBanner.tsx
+++ b/products/cohorts/frontend/RealtimeCohortsWaitlistBanner.tsx
@@ -8,9 +8,9 @@ import { featurePreviewsLogic } from 'lib/components/FeaturePreviews/featurePrev
 import { FEATURE_FLAGS } from 'lib/constants'
 
 // pinned: localStorage key, because renaming it shows the banner again to everyone who closed it
-const DISMISS_KEY = 'behavioral-cohorts-waitlist'
+const DISMISS_KEY = 'realtime-cohorts-waitlist'
 
-export function BehavioralCohortsWaitlistBanner(): JSX.Element | null {
+export function RealtimeCohortsWaitlistBanner(): JSX.Element | null {
     const { earlyAccessFeatures } = useValues(featurePreviewsLogic)
     const { loadEarlyAccessFeatures } = useActions(featurePreviewsLogic)
 
@@ -20,8 +20,8 @@ export function BehavioralCohortsWaitlistBanner(): JSX.Element | null {
 
     // The early access feature decides whether the banner shows. It appears once the concept
     // feature exists, and stops showing when the feature leaves the concept ("coming soon")
-    // stage, so shipping behavioral cohorts does not need a second frontend change.
-    const feature = earlyAccessFeatures.find((f) => f.flagKey === FEATURE_FLAGS.BEHAVIORAL_COHORTS)
+    // stage, so shipping realtime cohorts does not need a second frontend change.
+    const feature = earlyAccessFeatures.find((f) => f.flagKey === FEATURE_FLAGS.REALTIME_COHORTS)
     if (feature?.stage !== 'concept') {
         return null
     }
@@ -30,7 +30,7 @@ export function BehavioralCohortsWaitlistBanner(): JSX.Element | null {
         <LemonBanner type="info" dismissKey={DISMISS_KEY}>
             <div className="flex flex-col gap-2">
                 <div className="flex flex-wrap items-center gap-1.5">
-                    <span className="font-semibold">Behavioral cohorts are coming soon</span>
+                    <span className="font-semibold">Realtime cohorts are coming soon</span>
                     <LemonTag type="completion">Beta</LemonTag>
                 </div>
                 <p className="m-0">

--- a/products/cohorts/package.json
+++ b/products/cohorts/package.json
@@ -10,11 +10,14 @@
     },
     "devDependencies": {
         "@storybook/react": "catalog:",
+        "@testing-library/react": "^14.3.1",
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
         "@posthog/brand": "catalog:",
         "@posthog/icons": "catalog:",
+        "@testing-library/jest-dom": "*",
+        "@testing-library/react": "*",
         "@types/react": "*",
         "clsx": "*",
         "fuse.js": "*",


### PR DESCRIPTION
## Problem

Someone browsing the cohorts list has no way to register interest in realtime cohorts. The waitlist sign-up lives on the feature previews page in user settings, so nobody looking at cohorts finds it and the team gets no waitlist and no early feedback.

## Changes

- Dismissible banner with beta tag, and get notified button on cohorts page. Only visible if already using cohorts and does not show to users of realtime cohorts.
- Adds the logged-in user to the waitlist, with no email to type, like other in-app waitlists.
-  Enrolls the user in the `realtime-cohorts` early access feature, so the enrolled persons are the waitlist.
- Only shows whilst in early access feature, so will need no cleanup PR.
- Signing up hides the banner for good and confirms with a toast.
- The banner captures `realtime-cohorts-waitlist-banner-shown` when it renders, so sign-ups have a denominator.
- The early access fetch runs only when the banner can render. It is skipped for dismissed banners, teams with no cohorts, and people this browser already knows joined.
- The scene gate has one behavior change: with waitlist surveys off, a user who already registered sees a disabled "Registered" button instead of the thanks line. This matches the feature previews page.

### Screenshots

These replace the earlier single screenshot of the banner, which showed an email field. They come from Storybook with mocked data.

**Cohorts list with the banner**

![Cohorts list with the realtime cohorts waitlist banner](https://raw.githubusercontent.com/PostHog/pr-assets/b6b085430069724ff0885307ff77ad1aa798facd/2026/09/1bd75654-0bf7-44eb-9b1c-7c7dffc4d6a2.png)

**A project with no cohorts: setup screen, no banner**

![Cohorts setup screen with no banner](https://raw.githubusercontent.com/PostHog/pr-assets/14a68026455a138860b209e15522d51374dcd5dc/2026/09/3f3dc9bc-629f-4049-a3be-60d875f0ccb8.png)

**After sign-up: the banner is gone and a toast confirms it**

![Cohorts list after sign-up with a confirmation toast](https://raw.githubusercontent.com/PostHog/pr-assets/440984fd245b979793a2cc01564d4c9a014aeba5/2026/09/ac54f86c-350d-4a63-ab98-4ad36a95dd35.png)

> [!NOTE]
> The Beta tag was requested; the feature is not in beta yet, so the heading says "coming soon" next to it. The banner stays hidden until someone creates the early access feature at concept stage with flag key `realtime-cohorts`. No survey is needed.

## How did you test this code?

- `RealtimeCohortsWaitlistBanner.test.tsx` covers the concept-stage render and the impression wrapper. It also covers one-click sign-up with no email field, even when the feature links a survey: the click enrolls the user, sends no survey response, and shows the toast.
- The same file checks that nothing renders once the feature passes concept or the user is on the waitlist.
- The same file checks that the banner renders nothing and skips the fetch in five cases: dismissed, realtime targeting, no cohorts, cohort detection still loading, and joined in this browser.
- `FeaturePreviewSceneGate.test.tsx` covers both registered states: the thanks line with waitlist surveys on, and the disabled "Registered" button with them off.
- The screenshots above come from a Storybook run of the cohorts scene with mocked cohorts and a mocked early access feature. That run exercised the sign-up flow in a browser.
- Not run: a check against a real early access feature on a local stack.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1, earlier commits Opus 5) from a request in Slack. Skills invoked: `/writing-ui-components`, `/placing-product-frontend-code`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-pr-descriptions`, `/review-code` (eight agents, no blocking findings; applied: skip the fetch and render when dismissed, hide for teams with targeting, the tests above, `data-attr` and feature-named labels, the move into `realtime/`; declined: replacing the Beta tag, since it was requested). Review follow-up by Claude Code (Opus 5) with `/writing-code-comments` and `/writing-pr-descriptions`. The first version named the feature "behavioral cohorts"; a later commit renamed the component, copy, flag key and dismiss key, and the branch name still carries the old word.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07Q2U4BH4L/p1788909399537419?thread_ts=1788909399.537419&cid=C07Q2U4BH4L)*


