### PR TITLE
fix(flags): point the feedback buttons at open-feedback surveys instead of NPS

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -69,9 +69,9 @@ import { BULK_ARCHIVE_MAX_FLAGS, flagSelectionLogic } from './flagSelectionLogic
 import { OverlayForNewFeatureFlagMenu } from './NewFeatureFlagMenu'
 import ProjectsGrid from './projects-grid/ProjectsGrid'
 
-// "NPS - Feature Flags" in project 2: https://us.posthog.com/project/2/surveys/018bcec8-6cf5-0000-c724-a51a86a4e8b1
-// The survey also self-triggers as a popover on feature flag URLs; this is the on-demand path.
-const FEATURE_FLAGS_NPS_SURVEY_ID = '018bcec8-6cf5-0000-c724-a51a86a4e8b1'
+// "Feature Flags open feedback" in project 2: https://us.posthog.com/project/2/surveys/01a08364-0b1f-0000-5d00-170b29838bc5
+// Button-only: its URL condition never matches, so this button is the survey's sole entry point.
+const FEATURE_FLAGS_FEEDBACK_SURVEY_ID = '01a08364-0b1f-0000-5d00-170b29838bc5'
 
 function FlagDescription({ name }: { name: string }): JSX.Element {
     const ref = useRef<HTMLDivElement | null>(null)
@@ -789,7 +789,7 @@ export function FeatureFlags(): JSX.Element {
                 actions={
                     <>
                         <FeedbackSurveyButton
-                            surveyId={FEATURE_FLAGS_NPS_SURVEY_ID}
+                            surveyId={FEATURE_FLAGS_FEEDBACK_SURVEY_ID}
                             data-attr="feature-flags-feedback-button"
                         />
                         <AccessControlAction

--- a/products/experiments/frontend/scenes/ExperimentsScene.tsx
+++ b/products/experiments/frontend/scenes/ExperimentsScene.tsx
@@ -74,9 +74,9 @@ import {
 import { ExperimentsSettingsScene } from 'products/experiments/frontend/scenes/ExperimentsSettingsScene'
 import { ExperimentsSharedMetricsScene } from 'products/experiments/frontend/scenes/ExperimentsSharedMetricsScene'
 
-// "NPS - Experiments" in project 2: https://us.posthog.com/project/2/surveys/01902c1f-6675-0000-913b-686c40c3a957
-// The survey also self-triggers as a popover on experiment URLs; this is the on-demand path.
-const EXPERIMENTS_NPS_SURVEY_ID = '01902c1f-6675-0000-913b-686c40c3a957'
+// "Experiments open feedback" in project 2: https://us.posthog.com/project/2/surveys/01a08364-270e-0000-585b-147d32bf96ed
+// Button-only: its URL condition never matches, so this button is the survey's sole entry point.
+const EXPERIMENTS_FEEDBACK_SURVEY_ID = '01a08364-270e-0000-585b-147d32bf96ed'
 
 export const scene: SceneExport = {
     component: ExperimentsScene,
@@ -577,7 +577,7 @@ export function ExperimentsScene(): JSX.Element {
                 actions={
                     <>
                         <FeedbackSurveyButton
-                            surveyId={EXPERIMENTS_NPS_SURVEY_ID}
+                            surveyId={EXPERIMENTS_FEEDBACK_SURVEY_ID}
                             data-attr="experiments-feedback-button"
                         />
                         {tab !== ExperimentsTabs.SharedMetrics && tab !== ExperimentsTabs.Holdouts ? (


### PR DESCRIPTION
## Problem

- A user who clicks the Feedback button on the feature flags or experiments pages gets the 0-10 NPS survey - - Every clicker opened the survey and none submitted it; almost all dismissed it.
- Someone who clicks "Feedback" has something to write, so we want to capture that with an open-text survey.

## Changes

- Each button now opens a dedicated open-feedback survey ("Feature Flags open feedback" / "Experiments open feedback" in the PostHog cloud project): one open-text question, `schedule: always` so repeat feedback works.
- The new surveys carry a URL condition that never matches, so the button's `displaySurvey` call is their only entry point; they never auto-show.
- The NPS surveys are untouched and keep collecting through their passive popovers.
- No visual change: same button, a different survey opens on click.

## How did you test this code?

- Not run: the app. The diff is a two-constant swap plus comment updates; the pre-commit prettier/eslint pass is the only local check.
- The two new surveys are created and launched in the cloud project, so the IDs resolve in production the moment this deploys.
- No tests added: no logic changed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code, directed by the PM for feature flags. Skills invoked: `writing-pr-descriptions`.
- Decision trail: the buttons originally targeted the product NPS surveys. Production click data showed clickers open and dismiss without submitting, so the PM asked for dedicated open-feedback surveys; the agent created and launched them via MCP, then made this swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
