### PR TITLE
chore(wizard): snapshot cloud worker commands

### DIFF
--- a/products/wizard/backend/tests/runs/__snapshots__/test_wizard_command/test_wizard_command[audit-eu].txt
+++ b/products/wizard/backend/tests/runs/__snapshots__/test_wizard_command/test_wizard_command[audit-eu].txt
@@ -1,0 +1,10 @@
+timeout -k 30 2700 sh -c 'rm -rf /tmp/posthog-wizard-package && mkdir -p /tmp/posthog-wizard-package && rm -f /tmp/posthog-wizard-global.npmrc && touch /tmp/posthog-wizard-global.npmrc && npm --userconfig=/dev/null --globalconfig=/tmp/posthog-wizard-global.npmrc install --ignore-scripts --no-package-lock --no-save --prefix /tmp/posthog-wizard-package --registry=https://registry.npmjs.org @posthog/wizard@2.67.0 && cd '"'"'/workspace/example user'"'"'"'"'"'"'"'"'s project'"'"' && node /tmp/posthog-wizard-package/node_modules/@posthog/wizard/dist/bin.js audit web-analytics --headless-DONOTUSE-EXPERIMENTAL --install-dir . --region eu --project-id 7'
+
+Shell script:
+rm -rf /tmp/posthog-wizard-package
+mkdir -p /tmp/posthog-wizard-package
+rm -f /tmp/posthog-wizard-global.npmrc
+touch /tmp/posthog-wizard-global.npmrc
+npm --userconfig=/dev/null --globalconfig=/tmp/posthog-wizard-global.npmrc install --ignore-scripts --no-package-lock --no-save --prefix /tmp/posthog-wizard-package --registry=https://registry.npmjs.org @posthog/wizard@2.67.0
+cd '/workspace/example user'"'"'s project'
+node /tmp/posthog-wizard-package/node_modules/@posthog/wizard/dist/bin.js audit web-analytics --headless-DONOTUSE-EXPERIMENTAL --install-dir . --region eu --project-id 7

--- a/products/wizard/backend/tests/runs/__snapshots__/test_wizard_command/test_wizard_command[debug-local].txt
+++ b/products/wizard/backend/tests/runs/__snapshots__/test_wizard_command/test_wizard_command[debug-local].txt
@@ -1,0 +1,5 @@
+timeout -k 30 2700 sh -c 'cd '"'"'/workspace/example user'"'"'"'"'"'"'"'"'s project'"'"' && node /tmp/posthog-local-wizard/dist/bin.js audit web-analytics --headless-DONOTUSE-EXPERIMENTAL --install-dir . --region eu --project-id 7 --base-url "$POSTHOG_API_URL"'
+
+Shell script:
+cd '/workspace/example user'"'"'s project'
+node /tmp/posthog-local-wizard/dist/bin.js audit web-analytics --headless-DONOTUSE-EXPERIMENTAL --install-dir . --region eu --project-id 7 --base-url "$POSTHOG_API_URL"

--- a/products/wizard/backend/tests/runs/__snapshots__/test_wizard_command/test_wizard_command[debug-package].txt
+++ b/products/wizard/backend/tests/runs/__snapshots__/test_wizard_command/test_wizard_command[debug-package].txt
@@ -1,0 +1,10 @@
+timeout -k 30 2700 sh -c 'rm -rf /tmp/posthog-wizard-package && mkdir -p /tmp/posthog-wizard-package && rm -f /tmp/posthog-wizard-global.npmrc && touch /tmp/posthog-wizard-global.npmrc && npm --userconfig=/dev/null --globalconfig=/tmp/posthog-wizard-global.npmrc install --ignore-scripts --no-package-lock --no-save --prefix /tmp/posthog-wizard-package --registry=https://registry.npmjs.org @posthog/wizard@2.67.0 && cd '"'"'/workspace/example user'"'"'"'"'"'"'"'"'s project'"'"' && node /tmp/posthog-wizard-package/node_modules/@posthog/wizard/dist/bin.js --headless-DONOTUSE-EXPERIMENTAL --install-dir . --region us --project-id 7 --base-url "$POSTHOG_API_URL"'
+
+Shell script:
+rm -rf /tmp/posthog-wizard-package
+mkdir -p /tmp/posthog-wizard-package
+rm -f /tmp/posthog-wizard-global.npmrc
+touch /tmp/posthog-wizard-global.npmrc
+npm --userconfig=/dev/null --globalconfig=/tmp/posthog-wizard-global.npmrc install --ignore-scripts --no-package-lock --no-save --prefix /tmp/posthog-wizard-package --registry=https://registry.npmjs.org @posthog/wizard@2.67.0
+cd '/workspace/example user'"'"'s project'
+node /tmp/posthog-wizard-package/node_modules/@posthog/wizard/dist/bin.js --headless-DONOTUSE-EXPERIMENTAL --install-dir . --region us --project-id 7 --base-url "$POSTHOG_API_URL"

--- a/products/wizard/backend/tests/runs/__snapshots__/test_wizard_command/test_wizard_command[default-us].txt
+++ b/products/wizard/backend/tests/runs/__snapshots__/test_wizard_command/test_wizard_command[default-us].txt
@@ -1,0 +1,10 @@
+timeout -k 30 2700 sh -c 'rm -rf /tmp/posthog-wizard-package && mkdir -p /tmp/posthog-wizard-package && rm -f /tmp/posthog-wizard-global.npmrc && touch /tmp/posthog-wizard-global.npmrc && npm --userconfig=/dev/null --globalconfig=/tmp/posthog-wizard-global.npmrc install --ignore-scripts --no-package-lock --no-save --prefix /tmp/posthog-wizard-package --registry=https://registry.npmjs.org @posthog/wizard@2.67.0 && cd '"'"'/workspace/example user'"'"'"'"'"'"'"'"'s project'"'"' && node /tmp/posthog-wizard-package/node_modules/@posthog/wizard/dist/bin.js --headless-DONOTUSE-EXPERIMENTAL --install-dir . --region us --project-id 7'
+
+Shell script:
+rm -rf /tmp/posthog-wizard-package
+mkdir -p /tmp/posthog-wizard-package
+rm -f /tmp/posthog-wizard-global.npmrc
+touch /tmp/posthog-wizard-global.npmrc
+npm --userconfig=/dev/null --globalconfig=/tmp/posthog-wizard-global.npmrc install --ignore-scripts --no-package-lock --no-save --prefix /tmp/posthog-wizard-package --registry=https://registry.npmjs.org @posthog/wizard@2.67.0
+cd '/workspace/example user'"'"'s project'
+node /tmp/posthog-wizard-package/node_modules/@posthog/wizard/dist/bin.js --headless-DONOTUSE-EXPERIMENTAL --install-dir . --region us --project-id 7

--- a/products/wizard/backend/tests/runs/test_wizard_command.py
+++ b/products/wizard/backend/tests/runs/test_wizard_command.py
@@ -1,0 +1,49 @@
+import shlex
+
+import pytest
+from unittest.mock import patch
+
+from django.test import override_settings
+
+from syrupy.assertion import SnapshotAssertion
+from syrupy.extensions.single_file import SingleFileSnapshotExtension, WriteMode
+
+from products.wizard.backend.logic.workers.commands import build_wizard_command
+
+
+class CommandSnapshotExtension(SingleFileSnapshotExtension):
+    _file_extension = "txt"
+    _write_mode = WriteMode.TEXT
+
+
+@pytest.mark.parametrize(
+    "region,debug,use_local_wizard_source,program_command",
+    [
+        pytest.param("US", False, False, (), id="default-us"),
+        pytest.param("EU", False, False, ("audit", "web-analytics"), id="audit-eu"),
+        pytest.param("US", True, False, (), id="debug-package"),
+        pytest.param("EU", True, True, ("audit", "web-analytics"), id="debug-local"),
+    ],
+)
+def test_wizard_command(
+    snapshot: SnapshotAssertion,
+    region: str,
+    debug: bool,
+    use_local_wizard_source: bool,
+    program_command: tuple[str, ...],
+) -> None:
+    with (
+        override_settings(DEBUG=debug),
+        patch("products.wizard.backend.logic.workers.commands.get_instance_region", return_value=region),
+    ):
+        command = build_wizard_command(
+            "/workspace/example user's project",
+            7,
+            "2.67.0",
+            program_command,
+            use_local_wizard_source=use_local_wizard_source,
+        )
+
+    script = shlex.split(command)[-1]
+    readable_script = script.replace(" && ", "\n")
+    assert f"{command}\n\nShell script:\n{readable_script}\n" == snapshot(extension_class=CommandSnapshotExtension)


### PR DESCRIPTION
## Problem

Reviewers need readable snapshots to check changes to the cloud Wizard command.

**Why:** This addresses the [command review request](https://github.com/PostHog/posthog/pull/91821#discussion_r3929006069). It follows the [Wizard UI layer](https://github.com/PostHog/posthog/pull/89523).

Refs #85854

## Changes

- Adds text snapshots for default, audit, debug, and local-source commands.
- Shows the exact command and its decoded script, including paths with spaces and quotes.
- Changes no runtime behavior.

## How did you test this code?

Ran `hogli test products/wizard/backend/tests/runs/test_wizard_command.py` and `hogli ci:preflight --fix`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This change adds tests only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Codex used GitHub, shell tools, and PostHog MCP. Skills: `/writing-tests`, `/stacking-prs`, `/writing-pr-descriptions`, and `/asd-ste100`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
