### PR TITLE
feat(wizard): connect cloud and UI run analytics

### DIFF
--- a/docs/internal/wizard-runs.md
+++ b/docs/internal/wizard-runs.md
@@ -92,6 +92,32 @@ Tokens do not enter Temporal inputs, workflow history, run metadata, or logs.
 Wizard owns the Worker command, environment, credentials, resource limits, timeouts, and diff behavior.
 Tasks provides only generic repository-token and sandbox helpers through public facades.
 
+## Analytics compatibility
+
+Cloud lifecycle events keep their existing names and deterministic event UUIDs.
+They add the legacy properties `run_surface`, `project_id`, `version`, and `command`.
+The existing `environment`, `team_id`, `wizard_version`, and `wizard_run_id` properties remain available.
+`event_source` distinguishes `wizard_run_service` events from `wizard_ui` events.
+
+The pinned Wizard CLI reads `POSTHOG_TASK_RUN_ID` and attaches it as `task_run_id` to its events.
+Cloud workers pass the Wizard run ID through this existing variable.
+Cloud service and UI events also include this `task_run_id` alias, so these events can join the CLI events.
+The alias does not refer to a Tasks record. No `POSTHOG_TASK_ID` is supplied.
+Local runs do not get the cloud alias.
+The CLI keeps its separate, process-level `run_id`.
+
+The CLI remains the only source of `setup wizard finished`.
+Its `status` values remain `success`, `error`, and `cancelled`.
+Service completion events describe the full cloud lifecycle, including failures before CLI startup and failures during repository publication.
+Do not add the CLI and service completion events together when counting runs.
+
+The UI records library opens, successful command copies, create requests and outcomes, retry selections, run views, and diff opens.
+It also records confirmed cancellation requests and outcomes.
+Polling does not create more view events. Clipboard failures do not count as command copies.
+Use `wizard run create requested` and `wizard run create failed` to measure request failures, including limit responses.
+Use `wizard_run_id` to join successful creation to existing lifecycle events, `wizard pull request created`, and `wizard run diff opened`.
+Events omit repository names, paths, full shell commands, diff contents, tokens, and raw error messages.
+
 ## Deployment configuration
 
 The production rollout depends on the [Wizard Worker chart](https://github.com/PostHog/charts/pull/14662) and [cloud infrastructure](https://github.com/PostHog/posthog-cloud-infra/pull/10081) changes.

--- a/products/wizard/backend/logic/workers/service.py
+++ b/products/wizard/backend/logic/workers/service.py
@@ -350,6 +350,7 @@ def _build_sandbox_config(request: WizardWorkerProvisionRequest, wizard_token: s
         "POSTHOG_API_URL": settings.SANDBOX_API_URL or settings.SITE_URL,
         "POSTHOG_PROJECT_ID": str(request.team_id),
         "POSTHOG_WIZARD_API_KEY": wizard_token,
+        "POSTHOG_TASK_RUN_ID": str(request.run_id),
         "POSTHOG_HANDOFF_OUTPUT_PATH": wizard_handoff_output_path(request.run_id),
     }
     if settings.DEBUG and settings.SANDBOX_MCP_URL:

--- a/products/wizard/backend/observability/events.py
+++ b/products/wizard/backend/observability/events.py
@@ -4,7 +4,7 @@ from posthog.models import User
 from posthog.ph_client import ph_background_capture
 
 from products.wizard.backend.facade.contracts import WizardRunDTO
-from products.wizard.backend.facade.enums import WizardRunStage
+from products.wizard.backend.facade.enums import WizardRunEnvironment, WizardRunStage
 from products.wizard.backend.observability.config import (
     WIZARD_PULL_REQUEST_CREATED_EVENT,
     WIZARD_RUN_CREATED_EVENT,
@@ -81,11 +81,19 @@ def _enqueue_run_event(
 ) -> None:
     event_uuid = uuid5(NAMESPACE_URL, f"wizard:{run.id}:{event_key}")
     event_properties: WizardEventProperties = {
+        "event_source": "wizard_run_service",
+        "project_id": str(run.team_id),
         "environment": run.environment.value,
+        "run_surface": run.environment.value,
         "workspace_type": run.workspace.type,
         "program_id": run.program.id,
         "wizard_version": run.program.wizard_version,
+        "version": run.program.wizard_version,
+        "command": run.program.command[0] if run.program.command else "default",
     }
+
+    if run.environment == WizardRunEnvironment.CLOUD:
+        event_properties["task_run_id"] = str(run.id)
 
     if properties is not None:
         event_properties.update(properties)

--- a/products/wizard/backend/tests/runs/test_cloud_worker.py
+++ b/products/wizard/backend/tests/runs/test_cloud_worker.py
@@ -75,6 +75,8 @@ def test_provision_worker_configures_wizard_environment(
     assert config.environment_variables["POSTHOG_WIZARD_API_KEY"] == "wizard-secret"
     assert config.environment_variables["MCP_URL"] == "http://host.docker.internal:8787/mcp"
     assert "POSTHOG_WIZARD_RUN_ID" not in config.environment_variables
+    assert config.environment_variables["POSTHOG_TASK_RUN_ID"] == str(request.run_id)
+    assert "POSTHOG_TASK_ID" not in config.environment_variables
     assert config.environment_variables["POSTHOG_HANDOFF_OUTPUT_PATH"] == wizard_handoff_output_path(request.run_id)
     assert config.ttl_seconds == 75 * 60
 

--- a/products/wizard/backend/tests/runs/test_observability.py
+++ b/products/wizard/backend/tests/runs/test_observability.py
@@ -446,8 +446,11 @@ def test_reliability_metrics_record_artifacts_cleanup_and_deadlines() -> None:
 
 
 @pytest.mark.parametrize("user_distinct_id", ["example-user", None])
-def test_stage_event_has_deterministic_identity_and_run_properties(user_distinct_id: str | None) -> None:
-    run = replace(_cloud_run(), stage=WizardRunStage.PROVISIONING)
+@pytest.mark.parametrize("environment", [WizardRunEnvironment.CLOUD, WizardRunEnvironment.LOCAL])
+def test_stage_event_has_deterministic_identity_and_run_properties(
+    user_distinct_id: str | None, environment: WizardRunEnvironment
+) -> None:
+    run = replace(_cloud_run(), stage=WizardRunStage.PROVISIONING, environment=environment)
 
     with (
         patch.object(events, "ph_background_capture") as background_capture,
@@ -465,9 +468,15 @@ def test_stage_event_has_deterministic_identity_and_run_properties(user_distinct
     assert first_args["properties"] == {
         "team_id": run.team_id,
         "wizard_run_id": str(run.id),
-        "environment": "cloud",
+        "event_source": "wizard_run_service",
+        "project_id": str(run.team_id),
+        "environment": environment.value,
+        "run_surface": environment.value,
         "workspace_type": "git_repository",
         "program_id": "posthog-integration",
         "wizard_version": POSTHOG_INTEGRATION_PROGRAM.wizard_version,
+        "version": POSTHOG_INTEGRATION_PROGRAM.wizard_version,
+        "command": "default",
+        **({"task_run_id": str(run.id)} if environment == WizardRunEnvironment.CLOUD else {}),
         "stage": "provisioning",
     }

--- a/products/wizard/frontend/wizardAnalytics.ts
+++ b/products/wizard/frontend/wizardAnalytics.ts
@@ -1,0 +1,27 @@
+import type { RunEnvironmentEnumApi, WizardRunApi } from './generated/api.schemas'
+
+export function wizardEventProperties(
+    projectId: number | string | null,
+    environment: RunEnvironmentEnumApi
+): Record<string, string | null> {
+    return {
+        event_source: 'wizard_ui',
+        project_id: projectId === null ? null : String(projectId),
+        environment,
+        run_surface: environment,
+    }
+}
+
+export function wizardRunEventProperties(run: WizardRunApi): Record<string, string | null> {
+    return {
+        ...wizardEventProperties(run.team_id, run.environment),
+        wizard_run_id: run.id,
+        ...(run.environment === 'cloud' ? { task_run_id: run.id } : {}),
+        program_id: run.program.id,
+        wizard_version: run.program.wizard_version,
+        version: run.program.wizard_version,
+        command: run.program.command[0] ?? 'default',
+        workspace_type: run.workspace.type,
+        status: run.status,
+    }
+}

--- a/products/wizard/frontend/wizardLibraryLogic.test.ts
+++ b/products/wizard/frontend/wizardLibraryLogic.test.ts
@@ -1,6 +1,9 @@
 import { expectLogic } from 'kea-test-utils'
+import posthog from 'posthog-js'
 
+import { ApiError } from 'lib/api'
 import { preflightLogic } from 'lib/logic/preflightLogic'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { projectLogic } from 'scenes/projectLogic'
 
 import { useMocks } from '~/mocks/jest'
@@ -10,6 +13,10 @@ import { wizardRegistryList, wizardRunsCreate } from './generated/api'
 import type { WizardProgramApi, WizardRunApi } from './generated/api.schemas'
 import { wizardLibraryLogic } from './wizardLibraryLogic'
 import { wizardRunDetailsLogic } from './wizardRunDetailsLogic'
+
+jest.mock('lib/utils/copyToClipboard', () => ({
+    copyToClipboard: jest.fn(),
+}))
 
 jest.mock('./generated/api', () => ({
     wizardRegistryList: jest.fn(),
@@ -37,6 +44,26 @@ const localProgram: WizardProgramApi = {
     name: 'Local program',
     supported_environments: ['local'],
 }
+function makeRun(overrides: Partial<WizardRunApi> = {}): WizardRunApi {
+    return {
+        id: 'run-new',
+        team_id: 1,
+        created_by_id: 1,
+        environment: 'cloud',
+        workspace: { type: 'git_repository', repository: 'example/private-project' },
+        program,
+        status: 'created',
+        error_code: null,
+        error_message: null,
+        stage: 'dispatching',
+        created_at: '2026-08-26T10:00:00Z',
+        updated_at: null,
+        started_at: null,
+        finished_at: null,
+        deadline_at: null,
+        ...overrides,
+    }
+}
 
 describe('wizardLibraryLogic', () => {
     let logic: ReturnType<typeof wizardLibraryLogic.build>
@@ -55,7 +82,9 @@ describe('wizardLibraryLogic', () => {
             previous: null,
             results: [program, localProgram],
         })
-        mockWizardRunsCreate.mockReset()
+        mockWizardRunsCreate.mockReset().mockResolvedValue(makeRun())
+        jest.spyOn(posthog, 'capture').mockClear()
+        jest.mocked(copyToClipboard).mockReset().mockResolvedValue(true)
         await expectLogic(projectLogic).toMatchValues({ currentProjectId: expect.any(Number) })
         logic = wizardLibraryLogic()
         logic.mount()
@@ -72,8 +101,30 @@ describe('wizardLibraryLogic', () => {
         expect(logic.values.filteredPrograms).toEqual([program])
     })
 
+    it.each([true, false])('tracks command copies only when the clipboard succeeds: %s', async (copied) => {
+        jest.mocked(copyToClipboard).mockResolvedValue(copied)
+        logic.actions.selectProgram(program)
+        logic.actions.copyCommand()
+        await expectLogic(logic).toFinishAllListeners()
+
+        const events = jest.mocked(posthog.capture).mock.calls.filter(([event]) => event === 'wizard command copied')
+        expect(events).toHaveLength(copied ? 1 : 0)
+        if (copied) {
+            expect(events[0][1]).toEqual(
+                expect.objectContaining({
+                    program_id: program.id,
+                    version: '2.67.0',
+                    run_surface: 'local',
+                    command: 'default',
+                })
+            )
+            expect(events[0][1]).not.toHaveProperty('task_run_id')
+            expect(JSON.stringify(events)).not.toContain('npx')
+        }
+    })
+
     it('reuses the idempotency key after a failed cloud request', async () => {
-        mockWizardRunsCreate.mockRejectedValue(new Error('request failed'))
+        mockWizardRunsCreate.mockRejectedValue(new ApiError('private response content', 429))
         logic.actions.openLibrary('stable-key')
         logic.actions.selectProgram(program)
         logic.actions.setRepository('posthog/posthog')
@@ -86,6 +137,20 @@ describe('wizardLibraryLogic', () => {
         expect(mockWizardRunsCreate).toHaveBeenCalledTimes(2)
         expect(mockWizardRunsCreate.mock.calls[0][1].idempotency_key).toBe('stable-key')
         expect(mockWizardRunsCreate.mock.calls[1][1].idempotency_key).toBe('stable-key')
+        const events = jest
+            .mocked(posthog.capture)
+            .mock.calls.filter(([event]) => event.startsWith('wizard run create'))
+        expect(events.map(([event]) => event)).toEqual([
+            'wizard run create requested',
+            'wizard run create failed',
+            'wizard run create requested',
+            'wizard run create failed',
+        ])
+        expect(events[1][1]).toEqual(
+            expect.objectContaining({ http_status: 429, run_surface: 'cloud', version: '2.67.0' })
+        )
+        expect(JSON.stringify(events)).not.toContain('private response content')
+        expect(JSON.stringify(events)).not.toContain('posthog/posthog')
     })
 
     it('does not create a server run for local execution', async () => {
@@ -97,6 +162,7 @@ describe('wizardLibraryLogic', () => {
         await expectLogic(logic).toFinishAllListeners()
 
         expect(mockWizardRunsCreate).not.toHaveBeenCalled()
+        expect(posthog.capture).not.toHaveBeenCalledWith('wizard run create requested', expect.anything())
     })
 
     it('runs the program version shown in the Library', async () => {
@@ -121,7 +187,7 @@ describe('wizardLibraryLogic', () => {
     })
 
     it('follows the new run after a successful start', async () => {
-        const createdRun = { id: 'run-new' } as WizardRunApi
+        const createdRun = makeRun()
         mockWizardRunsCreate.mockResolvedValueOnce(createdRun)
         const detailsLogic = wizardRunDetailsLogic()
         detailsLogic.mount()
@@ -133,6 +199,23 @@ describe('wizardLibraryLogic', () => {
         await expectLogic(logic).toFinishAllListeners()
 
         expect(detailsLogic.values.selectedRunSummary?.id).toBe('run-new')
+        expect(posthog.capture).toHaveBeenCalledWith('wizard run create succeeded', {
+            event_source: 'wizard_ui',
+            project_id: '1',
+            environment: 'cloud',
+            run_surface: 'cloud',
+            wizard_run_id: 'run-new',
+            task_run_id: 'run-new',
+            program_id: program.id,
+            wizard_version: '2.67.0',
+            version: '2.67.0',
+            command: 'default',
+            workspace_type: 'git_repository',
+            status: 'created',
+        })
+        expect(posthog.capture).not.toHaveBeenCalledWith('setup wizard finished', expect.anything())
+        expect(JSON.stringify(jest.mocked(posthog.capture).mock.calls)).not.toContain('example/private-project')
+        detailsLogic.unmount()
     })
 
     it('selects the retried program after the registry reloads', async () => {
@@ -142,12 +225,7 @@ describe('wizardLibraryLogic', () => {
             previous: null,
             results: [program, localProgram],
         })
-        const run = {
-            id: 'run-old',
-            program: { id: 'posthog-integration' },
-            environment: 'cloud',
-            workspace: { type: 'git_repository', repository: 'posthog/posthog' },
-        }
+        const run = makeRun({ id: 'run-old' })
 
         logic.actions.runAgain(run as any)
         await expectLogic(logic).toFinishAllListeners()
@@ -163,12 +241,7 @@ describe('wizardLibraryLogic', () => {
             previous: null,
             results: [localProgram],
         })
-        const run = {
-            id: 'run-old',
-            program: { id: 'posthog-integration' },
-            environment: 'cloud',
-            workspace: { type: 'git_repository', repository: 'posthog/posthog' },
-        }
+        const run = makeRun({ id: 'run-old' })
 
         logic.actions.runAgain(run as any)
         await expectLogic(logic).toFinishAllListeners()

--- a/products/wizard/frontend/wizardLibraryLogic.ts
+++ b/products/wizard/frontend/wizardLibraryLogic.ts
@@ -1,5 +1,6 @@
 import { MakeLogicType, actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import posthog from 'posthog-js'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
@@ -19,6 +20,7 @@ import type {
     WizardRunApi,
     WizardRunCreateRequestApi,
 } from './generated/api.schemas'
+import { wizardEventProperties, wizardRunEventProperties } from './wizardAnalytics'
 import { wizardRunDetailsLogic } from './wizardRunDetailsLogic'
 import { WIZARD_LOCAL_RUNS_VISIBLE, wizardCommand } from './wizardRunDisplay'
 import { wizardRunsLogic } from './wizardRunsLogic'
@@ -209,8 +211,33 @@ export const wizardLibraryLogic = kea<wizardLibraryLogicType>([
         createRunRequest: [
             null as WizardRunApi | null,
             {
-                createRunRequest: async ({ projectId, body }: { projectId: string; body: WizardRunCreateRequestApi }) =>
-                    wizardRunsCreate(projectId, body),
+                createRunRequest: async ({
+                    projectId,
+                    body,
+                }: {
+                    projectId: string
+                    body: WizardRunCreateRequestApi
+                }) => {
+                    const properties = {
+                        ...wizardEventProperties(projectId, body.environment),
+                        program_id: body.program_id,
+                        wizard_version: body.wizard_version,
+                        version: body.wizard_version,
+                        workspace_type: body.workspace.type,
+                    }
+                    posthog.capture('wizard run create requested', properties)
+                    try {
+                        const run = await wizardRunsCreate(projectId, body)
+                        posthog.capture('wizard run create succeeded', wizardRunEventProperties(run))
+                        return run
+                    } catch (error) {
+                        posthog.capture('wizard run create failed', {
+                            ...properties,
+                            http_status: error instanceof ApiError ? error.status : null,
+                        })
+                        throw error
+                    }
+                },
             },
         ],
     })),
@@ -290,6 +317,13 @@ export const wizardLibraryLogic = kea<wizardLibraryLogicType>([
                 return
             }
 
+            posthog.capture(
+                'wizard library opened',
+                wizardEventProperties(
+                    values.currentProjectId,
+                    WIZARD_LOCAL_RUNS_VISIBLE ? values.libraryEnvironment : 'cloud'
+                )
+            )
             actions.loadRegistry()
             actions.loadIntegrations()
 
@@ -308,9 +342,17 @@ export const wizardLibraryLogic = kea<wizardLibraryLogicType>([
             actions.setLibraryEnvironment(environment)
         },
         copyCommand: () => {
+            const program = values.selectedProgram
             if (values.selectedProgramCommand) {
                 void copyToClipboard(values.selectedProgramCommand, 'Wizard command').then((copied) => {
                     if (copied) {
+                        posthog.capture('wizard command copied', {
+                            ...wizardEventProperties(values.currentProjectId, 'local'),
+                            program_id: program?.id,
+                            wizard_version: program?.wizard_version,
+                            version: program?.wizard_version,
+                            command: program?.command[0] ?? 'default',
+                        })
                         actions.markCommandCopied()
                     }
                 })
@@ -321,6 +363,7 @@ export const wizardLibraryLogic = kea<wizardLibraryLogicType>([
                 return
             }
 
+            posthog.capture('wizard run retry selected', wizardRunEventProperties(run))
             // Resolve the program only after the registry (re)loads, so a stale or absent
             // selection can never start an unrelated program.
             cache.pendingRunAgainProgramId = run.program.id

--- a/products/wizard/frontend/wizardRunDetailsLogic.test.ts
+++ b/products/wizard/frontend/wizardRunDetailsLogic.test.ts
@@ -1,12 +1,14 @@
 import { expectLogic } from 'kea-test-utils'
+import posthog from 'posthog-js'
 
 import { LemonDialog } from '@posthog/lemon-ui'
 
+import { ApiError } from 'lib/api'
 import { projectLogic } from 'scenes/projectLogic'
 
 import { initKeaTests } from '~/test/init'
 
-import { wizardRunsRetrieve } from './generated/api'
+import { wizardRunsPartialUpdate, wizardRunsRetrieve } from './generated/api'
 import type { WizardRunApi, WizardRunGitDiffArtifactApi } from './generated/api.schemas'
 import { loadWizardRunArtifactContent, loadWizardRunArtifacts } from './wizardApi'
 import { wizardRunDetailsLogic } from './wizardRunDetailsLogic'
@@ -72,6 +74,7 @@ describe('wizardRunDetailsLogic', () => {
 
     beforeEach(async () => {
         initKeaTests()
+        jest.spyOn(posthog, 'capture').mockClear()
         mockWizardRunsRetrieve.mockReset()
         mockLoadWizardRunArtifactContent.mockReset()
         mockLoadWizardRunArtifacts.mockReset()
@@ -102,6 +105,15 @@ describe('wizardRunDetailsLogic', () => {
         expect(mockWizardRunsRetrieve).toHaveBeenCalledWith(expect.any(String), 'run-1')
         expect(mockLoadWizardRunArtifacts).toHaveBeenCalledWith(expect.any(String), 'run-1')
         expect(mockLoadWizardRunArtifactContent).not.toHaveBeenCalled()
+        expect(posthog.capture).toHaveBeenCalledWith(
+            'wizard run viewed',
+            expect.objectContaining({
+                wizard_run_id: 'run-1',
+                task_run_id: 'run-1',
+                run_surface: 'cloud',
+                version: '2.6.0',
+            })
+        )
     })
 
     it('loads git diff content only after the artifact is opened', async () => {
@@ -119,6 +131,14 @@ describe('wizardRunDetailsLogic', () => {
             runDiffLoading: false,
         })
         expect(mockLoadWizardRunArtifactContent).toHaveBeenCalledWith(expect.any(String), 'run-1', 'artifact-1')
+        expect(posthog.capture).toHaveBeenCalledWith(
+            'wizard run diff opened',
+            expect.objectContaining({
+                wizard_run_id: 'run-1',
+                artifact_type: 'git_diff',
+            })
+        )
+        expect(JSON.stringify(jest.mocked(posthog.capture).mock.calls)).not.toContain('diff content')
     })
 
     it('reuses downloaded diff content when the same artifact is reopened', async () => {
@@ -154,6 +174,9 @@ describe('wizardRunDetailsLogic', () => {
         logic.actions.loadRunDetails({ runId: 'run-1' })
         await expectLogic(logic).toFinishAllListeners()
         expect(mockLoadWizardRunArtifacts).toHaveBeenCalledTimes(2)
+        expect(jest.mocked(posthog.capture).mock.calls.filter(([event]) => event === 'wizard run viewed')).toHaveLength(
+            1
+        )
     })
 
     it('does not download a diff that is too large to render', async () => {
@@ -177,6 +200,33 @@ describe('wizardRunDetailsLogic', () => {
                 primaryButton: expect.objectContaining({ children: 'Cancel run', status: 'danger' }),
             })
         )
+        expect(posthog.capture).not.toHaveBeenCalledWith('wizard run cancel requested', expect.anything())
+    })
+
+    it.each([true, false])('tracks the confirmed cancellation outcome: %s', async (succeeded) => {
+        jest.spyOn(console, 'error').mockImplementation()
+        if (succeeded) {
+            jest.mocked(wizardRunsPartialUpdate).mockResolvedValue({ ...makeRun(), status: 'cancelled' })
+        } else {
+            jest.mocked(wizardRunsPartialUpdate).mockRejectedValue(new ApiError('private response content', 503))
+        }
+
+        logic.actions.cancelRunRequest({ runId: 'run-1' })
+        await expectLogic(logic).toFinishAllListeners()
+
+        const events = jest
+            .mocked(posthog.capture)
+            .mock.calls.filter(([event]) => event.startsWith('wizard run cancel'))
+        expect(events.map(([event]) => event)).toEqual([
+            'wizard run cancel requested',
+            succeeded ? 'wizard run cancel succeeded' : 'wizard run cancel failed',
+        ])
+        expect(events[1][1]).toEqual(expect.objectContaining({ wizard_run_id: 'run-1' }))
+        if (!succeeded) {
+            expect(events[1][1]).toEqual(expect.objectContaining({ http_status: 503 }))
+        }
+        expect(JSON.stringify(events)).not.toContain('private response content')
+        expect(posthog.capture).not.toHaveBeenCalledWith('setup wizard finished', expect.anything())
     })
 
     it('prefers a newer run summary over stale cached details', async () => {

--- a/products/wizard/frontend/wizardRunDetailsLogic.ts
+++ b/products/wizard/frontend/wizardRunDetailsLogic.ts
@@ -1,6 +1,7 @@
 import { MakeLogicType, actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import type { BreakPointFunction } from 'kea'
 import { loaders } from 'kea-loaders'
+import posthog from 'posthog-js'
 
 import { LemonDialog, lemonToast } from '@posthog/lemon-ui'
 
@@ -11,6 +12,7 @@ import { projectLogic } from 'scenes/projectLogic'
 
 import { wizardRunsPartialUpdate, wizardRunsRetrieve } from './generated/api'
 import type { WizardRunApi, WizardRunArtifactApi, WizardRunGitDiffArtifactApi } from './generated/api.schemas'
+import { wizardRunEventProperties } from './wizardAnalytics'
 import { loadWizardRunArtifactContent, loadWizardRunArtifacts } from './wizardApi'
 import { wizardRunDiffCanRender, wizardRunIsActive } from './wizardRunDisplay'
 import { wizardRunsLogic } from './wizardRunsLogic'
@@ -274,7 +276,25 @@ export const wizardRunDetailsLogic = kea<wizardRunDetailsLogicType>([
                         return null
                     }
 
-                    return wizardRunsPartialUpdate(String(values.currentProjectId), runId, { status: 'cancelled' })
+                    const properties = {
+                        event_source: 'wizard_ui',
+                        project_id: String(values.currentProjectId),
+                        wizard_run_id: runId,
+                    }
+                    posthog.capture('wizard run cancel requested', properties)
+                    try {
+                        const run = await wizardRunsPartialUpdate(String(values.currentProjectId), runId, {
+                            status: 'cancelled',
+                        })
+                        posthog.capture('wizard run cancel succeeded', wizardRunEventProperties(run))
+                        return run
+                    } catch (error) {
+                        posthog.capture('wizard run cancel failed', {
+                            ...properties,
+                            http_status: error instanceof ApiError ? error.status : null,
+                        })
+                        throw error
+                    }
                 },
             },
         ],
@@ -323,6 +343,7 @@ export const wizardRunDetailsLogic = kea<wizardRunDetailsLogicType>([
                 return
             }
 
+            posthog.capture('wizard run viewed', wizardRunEventProperties(run))
             actions.loadRunDetails({ runId: run.id })
             actions.loadRunArtifacts({ runId: run.id })
 
@@ -341,6 +362,13 @@ export const wizardRunDetailsLogic = kea<wizardRunDetailsLogicType>([
             if (!wizardRunDiffCanRender(artifact.size_bytes)) {
                 return
             }
+
+            posthog.capture('wizard run diff opened', {
+                ...(values.selectedRun?.id === artifact.run_id
+                    ? wizardRunEventProperties(values.selectedRun)
+                    : { event_source: 'wizard_ui', wizard_run_id: artifact.run_id }),
+                artifact_type: artifact.artifact_type,
+            })
 
             // Artifacts are immutable, so reuse the cached content instead of re-downloading it.
             if (values.runDiff?.artifactId !== artifact.id) {


### PR DESCRIPTION
## Problem

Wizard usage cannot be followed from the new UI through CLI execution to the cloud result.

**Why:** The new run system needs compatible event properties without counting legacy completion events twice.

Refs #85854

## Changes

- Connects CLI, cloud, and UI events through the existing `task_run_id` property while preserving `wizard_run_id`.
- Keeps `setup wizard finished` and its status values under CLI ownership.
- Records UI actions and request outcomes without repository names, diff contents, tokens, or raw error messages.
- Changes no visible UI. Documents the event contract and measurement boundaries.

Before:
```mermaid
flowchart LR
    Cloud[Cloud events]:::data
    CLI[CLI events]:::data
    classDef data fill:#e5e7eb,stroke:#c7ccd1,color:#000;
```

After:
```mermaid
flowchart LR
    UI[UI events]:::data --> Run[Shared cloud run key]:::path
    Cloud[Cloud events]:::data --> Run
    CLI[CLI events]:::data --> Run
    classDef data fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    classDef path fill:#1d4aff,stroke:#1d4aff,color:#fff;
```

## How did you test this code?

Ran the worker and observability tests through `hogli test`, plus both affected Kea test files through Jest.

Lint, formatting, preflight, and a strict type check of the new analytics helper passed. Both full frontend type-check attempts exceeded memory.

Tests cover event identity, cloud-only correlation, request failures, clipboard failures, cancellation confirmation, polling, and sensitive-content exclusion. No live cloud run was tested.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Adds analytics compatibility and measurement guidance to `docs/internal/wizard-runs.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Codex used GitHub, shell tools, and PostHog MCP. The compatibility check used the pinned CLI source and existing event definitions.

Skills: `/instrument-product-analytics`, `/writing-kea-logics`, `/writing-tests`, `/stacking-prs`, `/writing-pr-descriptions`, and `/asd-ste100`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
