### PR TITLE
feat(owners): map every Postgres table to its owning team

### DIFF
--- a/hogli.yaml
+++ b/hogli.yaml
@@ -1074,6 +1074,9 @@ owners:
     owners:who:
         click: posthog_owners.cli:cmd_who
         description: Show who owns a single path (owners, status, slack, source)
+    owners:tables:
+        cmd: python manage.py generate_table_owners
+        description: Regenerate rust/pgcollector/ownership/table_owners.json (Postgres table -> owning team); --report lists unowned tables
     owners:census:
         click: posthog_owners.cli:cmd_census
         description: Count test files per owning team (optional PREFIX; --json for machine output)

--- a/posthog/management/commands/generate_table_owners.py
+++ b/posthog/management/commands/generate_table_owners.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from posthog.ownership.table_owners import OUTPUT_PATH, render_json, table_owners, unowned_report
+
+
+class Command(BaseCommand):
+    help = "Write rust/pgcollector/ownership/table_owners.json from the Django model registry and owners.yaml"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--report", action="store_true", help="List tables with no owner instead of writing")
+
+    def handle(self, *args, **options):
+        repo_root = Path(settings.BASE_DIR)
+        records = table_owners(repo_root)
+        unowned = unowned_report(records)
+        if options["report"]:
+            self.stdout.write("\n".join(unowned))
+            return
+        out = repo_root / OUTPUT_PATH
+        out.write_text(render_json(records))
+        self.stdout.write(f"wrote {out} ({len(records)} tables, {len(unowned)} unowned)")

--- a/posthog/ownership/table_owners.py
+++ b/posthog/ownership/table_owners.py
@@ -1,0 +1,101 @@
+"""Map every Postgres table Django knows about to the team that owns its model.
+
+The output is embedded in pgcollector so slow queries can be attributed to a team.
+Only the app registry is read; no database connection is needed.
+"""
+
+import json
+import inspect
+from pathlib import Path
+from typing import Literal
+
+from django.apps import apps
+
+from posthog_owners.resolver import OwnersResolver
+
+from posthog.dataclasses import frozen
+from posthog.product_db_config import load_product_db_routes
+
+OUTPUT_PATH = "rust/pgcollector/ownership/table_owners.json"
+
+TableKind = Literal["django", "through", "third_party"]
+
+
+@frozen
+class TableOwner:
+    db_table: str
+    model: str
+    app_label: str
+    database: str
+    kind: TableKind
+    owners: tuple[str, ...]
+    slack: str | None
+    notifications: str | None
+    source: str | None
+
+
+def table_owners(repo_root: Path) -> list[TableOwner]:
+    routes = {r.app_label: r.database for r in load_product_db_routes(repo_root)}
+    people = OwnersResolver(repo_root=repo_root, purpose="slack")
+    automation = OwnersResolver(repo_root=repo_root, purpose="notifications")
+    records: dict[str, TableOwner] = {}
+    for model in apps.get_models(include_auto_created=True):
+        meta = model._meta
+        # An auto-created M2M through table has no source file of its own; the model that
+        # declares the relation owns it.
+        # django-stubs types auto_created as bool, but Django stores the declaring model there.
+        auto_created: object = meta.auto_created
+        origin = auto_created if isinstance(auto_created, type) else model
+        kind: TableKind = "through" if isinstance(auto_created, type) else "django"
+        source = _repo_relative_source(origin, repo_root)
+        if source is None:
+            kind = "third_party"
+        resolution = people.resolve(source) if source else None
+        records[meta.db_table] = TableOwner(
+            db_table=meta.db_table,
+            model=f"{meta.app_label}.{model.__name__}",
+            app_label=meta.app_label,
+            database=routes.get(meta.app_label, "default"),
+            kind=kind,
+            owners=tuple(resolution.owners or ()) if resolution else (),
+            slack=resolution.slack if resolution else None,
+            notifications=automation.resolve(source).slack if source else None,
+            source=source,
+        )
+    return [records[t] for t in sorted(records)]
+
+
+def _repo_relative_source(model: type, repo_root: Path) -> str | None:
+    path = inspect.getsourcefile(model)
+    if path is None:
+        return None
+    resolved = Path(path).resolve()
+    # The dev venv can live under the repo root (.flox, .venv), so a relative path alone
+    # does not prove the model is ours.
+    if "site-packages" in resolved.parts:
+        return None
+    try:
+        return resolved.relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return None
+
+
+def render_json(records: list[TableOwner]) -> str:
+    tables = {
+        r.db_table: {
+            "model": r.model,
+            "app_label": r.app_label,
+            "database": r.database,
+            "kind": r.kind,
+            "owners": list(r.owners),
+            "slack": r.slack,
+            "notifications": r.notifications,
+            "source": r.source,
+        }
+        for r in records
+    }
+    return json.dumps({"version": 1, "tables": tables}, indent=2, sort_keys=False) + "\n"
+
+
+def unowned_report(records: list[TableOwner]) -> list[str]:
+    return [f"{r.db_table}\t{r.kind}\t{r.source or r.model}" for r in records if not r.owners]

--- a/posthog/test/repo_invariants/test_table_owners_json.py
+++ b/posthog/test/repo_invariants/test_table_owners_json.py
@@ -1,0 +1,23 @@
+"""pgcollector embeds rust/pgcollector/ownership/table_owners.json to attribute slow queries
+to teams. It is generated from the model registry and owners.yaml, so a new model, a moved
+model, or an ownership change makes it stale.
+
+Regenerate:
+
+    bin/hogli owners:tables
+"""
+
+from pathlib import Path
+
+from django.conf import settings
+
+from posthog.ownership.table_owners import OUTPUT_PATH, render_json, table_owners
+
+REGENERATE = "bin/hogli owners:tables"
+
+
+def test_table_owners_json_is_fresh() -> None:
+    repo_root = Path(settings.BASE_DIR)
+    expected = render_json(table_owners(repo_root))
+    actual = (repo_root / OUTPUT_PATH).read_text()
+    assert actual == expected, f"{OUTPUT_PATH} is stale; run `{REGENERATE}` and commit the result"

--- a/rust/pgcollector/ownership/table_owners.json
+++ b/rust/pgcollector/ownership/table_owners.json
@@ -1,0 +1,6499 @@
+{
+  "version": 1,
+  "tables": {
+    "access_control_propertyaccesscontrol": {
+      "model": "access_control.PropertyAccessControl",
+      "app_label": "access_control",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "products/access_control/backend/models/property_access_control.py"
+    },
+    "ai_observability_parserrecipe": {
+      "model": "ai_observability.ParserRecipe",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/parser_recipe.py"
+    },
+    "analytics_platform_preaggregationjob": {
+      "model": "analytics_platform.PreaggregationJob",
+      "app_label": "analytics_platform",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/analytics_platform/backend/models/preaggregation_job.py"
+    },
+    "auth_group": {
+      "model": "auth.Group",
+      "app_label": "auth",
+      "database": "default",
+      "kind": "third_party",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": null
+    },
+    "auth_group_permissions": {
+      "model": "auth.Group_permissions",
+      "app_label": "auth",
+      "database": "default",
+      "kind": "third_party",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": null
+    },
+    "auth_permission": {
+      "model": "auth.Permission",
+      "app_label": "auth",
+      "database": "default",
+      "kind": "third_party",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": null
+    },
+    "autoresearch_autoresearchiteration": {
+      "model": "autoresearch.AutoresearchIteration",
+      "app_label": "autoresearch",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "products/autoresearch/backend/models.py"
+    },
+    "autoresearch_autoresearchmodel": {
+      "model": "autoresearch.AutoresearchModel",
+      "app_label": "autoresearch",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "products/autoresearch/backend/models.py"
+    },
+    "autoresearch_autoresearchpipeline": {
+      "model": "autoresearch.AutoresearchPipeline",
+      "app_label": "autoresearch",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "products/autoresearch/backend/models.py"
+    },
+    "autoresearch_autoresearchrun": {
+      "model": "autoresearch.AutoresearchRun",
+      "app_label": "autoresearch",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "products/autoresearch/backend/models.py"
+    },
+    "autoresearch_autoresearchsuggestion": {
+      "model": "autoresearch.AutoresearchSuggestion",
+      "app_label": "autoresearch",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "products/autoresearch/backend/models.py"
+    },
+    "autoresearch_autoresearchtrainingrun": {
+      "model": "autoresearch.AutoresearchTrainingRun",
+      "app_label": "autoresearch",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "products/autoresearch/backend/models.py"
+    },
+    "axes_accessattempt": {
+      "model": "axes.AccessAttempt",
+      "app_label": "axes",
+      "database": "default",
+      "kind": "third_party",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": null
+    },
+    "axes_accessattemptexpiration": {
+      "model": "axes.AccessAttemptExpiration",
+      "app_label": "axes",
+      "database": "default",
+      "kind": "third_party",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": null
+    },
+    "axes_accessfailurelog": {
+      "model": "axes.AccessFailureLog",
+      "app_label": "axes",
+      "database": "default",
+      "kind": "third_party",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": null
+    },
+    "axes_accesslog": {
+      "model": "axes.AccessLog",
+      "app_label": "axes",
+      "database": "default",
+      "kind": "third_party",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": null
+    },
+    "billing_alerts_configuration": {
+      "model": "billing_alerts.BillingAlertConfiguration",
+      "app_label": "billing_alerts",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-billing"
+      ],
+      "slack": "#team-billing",
+      "notifications": "#team-billing",
+      "source": "products/billing_alerts/backend/models.py"
+    },
+    "billing_alerts_evaluation_claim": {
+      "model": "billing_alerts.BillingAlertEvaluationClaim",
+      "app_label": "billing_alerts",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-billing"
+      ],
+      "slack": "#team-billing",
+      "notifications": "#team-billing",
+      "source": "products/billing_alerts/backend/models.py"
+    },
+    "billing_alerts_event": {
+      "model": "billing_alerts.BillingAlertEvent",
+      "app_label": "billing_alerts",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-billing"
+      ],
+      "slack": "#team-billing",
+      "notifications": "#team-billing",
+      "source": "products/billing_alerts/backend/models.py"
+    },
+    "cdp_hogfunctionrevision": {
+      "model": "cdp.HogFunctionRevision",
+      "app_label": "cdp",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/cdp/backend/models/hog_functions/hog_function_revision.py"
+    },
+    "cohort_backfill_chunks": {
+      "model": "cohorts.CohortBackfillChunk",
+      "app_label": "cohorts",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/cohorts/backend/models/backfill.py"
+    },
+    "cohort_backfill_run_cohorts": {
+      "model": "cohorts.CohortBackfillRunCohort",
+      "app_label": "cohorts",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/cohorts/backend/models/backfill.py"
+    },
+    "cohort_backfill_runs": {
+      "model": "cohorts.CohortBackfillRun",
+      "app_label": "cohorts",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/cohorts/backend/models/backfill.py"
+    },
+    "context_layer_config": {
+      "model": "context_layer.ContextLayerConfig",
+      "app_label": "context_layer",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/context_layer/backend/models.py"
+    },
+    "customer_analytics_account": {
+      "model": "customer_analytics.Account",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/account.py"
+    },
+    "customer_analytics_accountchannelsummary": {
+      "model": "customer_analytics.AccountChannelSummary",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/account_channel_summary.py"
+    },
+    "customer_analytics_accountrelationship": {
+      "model": "customer_analytics.AccountRelationship",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/relationship.py"
+    },
+    "customer_analytics_accountrelationshipdefinition": {
+      "model": "customer_analytics.AccountRelationshipDefinition",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/relationship.py"
+    },
+    "customer_analytics_accounttrackrulerun": {
+      "model": "customer_analytics.AccountTrackRuleRun",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/account_track_rule_run.py"
+    },
+    "customer_analytics_announcement": {
+      "model": "customer_analytics.Announcement",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/announcement.py"
+    },
+    "customer_analytics_announcementdelivery": {
+      "model": "customer_analytics.AnnouncementDelivery",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/announcement_delivery.py"
+    },
+    "customer_analytics_customerjourney": {
+      "model": "customer_analytics.CustomerJourney",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/customer_journey.py"
+    },
+    "customer_analytics_customerprofileconfig": {
+      "model": "customer_analytics.CustomerProfileConfig",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/customer_profile_config.py"
+    },
+    "customer_analytics_customertask": {
+      "model": "customer_analytics.CustomerTask",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/customer_task.py"
+    },
+    "customer_analytics_customertaskactivity": {
+      "model": "customer_analytics.CustomerTaskActivity",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/customer_task.py"
+    },
+    "customer_analytics_custompropertydefinition": {
+      "model": "customer_analytics.CustomPropertyDefinition",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/custom_property_definition.py"
+    },
+    "customer_analytics_custompropertysource": {
+      "model": "customer_analytics.CustomPropertySource",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/custom_property_source.py"
+    },
+    "customer_analytics_custompropertysyncrun": {
+      "model": "customer_analytics.CustomPropertySyncRun",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/custom_property_sync_run.py"
+    },
+    "customer_analytics_custompropertyvalue": {
+      "model": "customer_analytics.CustomPropertyValue",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/custom_property_value.py"
+    },
+    "customer_analytics_eventstream": {
+      "model": "customer_analytics.EventStream",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/event_stream.py"
+    },
+    "customer_analytics_eventstreammember": {
+      "model": "customer_analytics.EventStreamMember",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/event_stream.py"
+    },
+    "customer_analytics_featurerequest": {
+      "model": "customer_analytics.FeatureRequest",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/feature_request.py"
+    },
+    "customer_analytics_featurerequestaccountlink": {
+      "model": "customer_analytics.FeatureRequestAccountLink",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/feature_request.py"
+    },
+    "customer_analytics_featurerequestevidence": {
+      "model": "customer_analytics.FeatureRequestEvidence",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/feature_request.py"
+    },
+    "customer_analytics_featurerequesthistory": {
+      "model": "customer_analytics.FeatureRequestHistory",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/feature_request.py"
+    },
+    "customer_analytics_featurerequestproductarea": {
+      "model": "customer_analytics.FeatureRequestProductArea",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/feature_request.py"
+    },
+    "customer_analytics_featurerequestproductarealink": {
+      "model": "customer_analytics.FeatureRequestProductAreaLink",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/feature_request.py"
+    },
+    "customer_analytics_meeting": {
+      "model": "customer_analytics.Meeting",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/meeting.py"
+    },
+    "customer_analytics_meetingparticipant": {
+      "model": "customer_analytics.MeetingParticipant",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/meeting.py"
+    },
+    "customer_analytics_teamcustomeranalyticsconfig": {
+      "model": "customer_analytics.TeamCustomerAnalyticsConfig",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/team_customer_analytics_config.py"
+    },
+    "customer_analytics_usercustomeranalyticsconfig": {
+      "model": "customer_analytics.UserCustomerAnalyticsConfig",
+      "app_label": "customer_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/customer_analytics/backend/models/user_customer_analytics_config.py"
+    },
+    "data_catalog_metric": {
+      "model": "data_catalog.Metric",
+      "app_label": "data_catalog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/data_catalog/backend/models/metric.py"
+    },
+    "data_catalog_relationshipproposal": {
+      "model": "data_catalog.RelationshipProposal",
+      "app_label": "data_catalog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/data_catalog/backend/models/relationship_proposal.py"
+    },
+    "data_catalog_tablecertification": {
+      "model": "data_catalog.TableCertification",
+      "app_label": "data_catalog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/data_catalog/backend/models/certification.py"
+    },
+    "data_modeling_datawarehousesavedquerycolumnannotation": {
+      "model": "data_modeling.DataWarehouseSavedQueryColumnAnnotation",
+      "app_label": "data_modeling",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/data_modeling/backend/models/datawarehouse_saved_query_column_annotation.py"
+    },
+    "data_quality_dataqualitycheck": {
+      "model": "data_quality.DataQualityCheck",
+      "app_label": "data_quality",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/data_quality/backend/models/check.py"
+    },
+    "data_quality_dataqualitycheckrun": {
+      "model": "data_quality.DataQualityCheckRun",
+      "app_label": "data_quality",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/data_quality/backend/models/check_run.py"
+    },
+    "data_quality_dataqualitysuiterun": {
+      "model": "data_quality.DataQualitySuiteRun",
+      "app_label": "data_quality",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/data_quality/backend/models/check_run.py"
+    },
+    "data_quality_teamdataqualityconfig": {
+      "model": "data_quality.TeamDataQualityConfig",
+      "app_label": "data_quality",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/data_quality/backend/models/team_data_quality_config.py"
+    },
+    "data_tools_datawarehouseexpression": {
+      "model": "data_tools.DataWarehouseExpression",
+      "app_label": "data_tools",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-managed-warehouse"
+      ],
+      "slack": "#team-managed-warehouse",
+      "notifications": "#team-managed-warehouse",
+      "source": "products/data_tools/backend/models/expression.py"
+    },
+    "data_warehouse_managedwarehousebackfillpartition": {
+      "model": "data_warehouse.ManagedWarehouseBackfillPartition",
+      "app_label": "data_warehouse",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-managed-warehouse"
+      ],
+      "slack": "#team-managed-warehouse",
+      "notifications": "#team-managed-warehouse",
+      "source": "products/data_warehouse/backend/models/managed_warehouse_backfill_partition.py"
+    },
+    "data_warehouse_teamdatawarehouseconfig": {
+      "model": "data_warehouse.TeamDataWarehouseConfig",
+      "app_label": "data_warehouse",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-managed-warehouse"
+      ],
+      "slack": "#team-managed-warehouse",
+      "notifications": "#team-managed-warehouse",
+      "source": "products/data_warehouse/backend/models/team_data_warehouse_config.py"
+    },
+    "data_warehouse_teamdatawarehouseconfig_overview_dashboards": {
+      "model": "data_warehouse.TeamDataWarehouseConfig_overview_dashboards",
+      "app_label": "data_warehouse",
+      "database": "default",
+      "kind": "through",
+      "owners": [
+        "team-managed-warehouse"
+      ],
+      "slack": "#team-managed-warehouse",
+      "notifications": "#team-managed-warehouse",
+      "source": "products/data_warehouse/backend/models/team_data_warehouse_config.py"
+    },
+    "django_admin_log": {
+      "model": "admin.LogEntry",
+      "app_label": "admin",
+      "database": "default",
+      "kind": "third_party",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": null
+    },
+    "django_content_type": {
+      "model": "contenttypes.ContentType",
+      "app_label": "contenttypes",
+      "database": "default",
+      "kind": "third_party",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": null
+    },
+    "django_session": {
+      "model": "posthog_session.Session",
+      "app_label": "posthog_session",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/session/models.py"
+    },
+    "ee_accesscontrol": {
+      "model": "ee.AccessControl",
+      "app_label": "ee",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "products/access_control/backend/models/access_control.py"
+    },
+    "ee_agentartifact": {
+      "model": "posthog_ai.AgentArtifact",
+      "app_label": "posthog_ai",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/posthog_ai/backend/models/assistant.py"
+    },
+    "ee_conversation": {
+      "model": "posthog_ai.Conversation",
+      "app_label": "posthog_ai",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/posthog_ai/backend/models/assistant.py"
+    },
+    "ee_conversationcheckpoint": {
+      "model": "posthog_ai.ConversationCheckpoint",
+      "app_label": "posthog_ai",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/posthog_ai/backend/models/assistant.py"
+    },
+    "ee_conversationcheckpointblob": {
+      "model": "posthog_ai.ConversationCheckpointBlob",
+      "app_label": "posthog_ai",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/posthog_ai/backend/models/assistant.py"
+    },
+    "ee_conversationcheckpointwrite": {
+      "model": "posthog_ai.ConversationCheckpointWrite",
+      "app_label": "posthog_ai",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/posthog_ai/backend/models/assistant.py"
+    },
+    "ee_corememory": {
+      "model": "posthog_ai.CoreMemory",
+      "app_label": "posthog_ai",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/posthog_ai/backend/models/assistant.py"
+    },
+    "ee_dashboardprivilege": {
+      "model": "ee.DashboardPrivilege",
+      "app_label": "ee",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "ee/models/dashboard_privilege.py"
+    },
+    "ee_enterpriseeventdefinition": {
+      "model": "ee.EnterpriseEventDefinition",
+      "app_label": "ee",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "ee/models/event_definition.py"
+    },
+    "ee_enterprisepropertydefinition": {
+      "model": "ee.EnterprisePropertyDefinition",
+      "app_label": "ee",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "ee/models/property_definition.py"
+    },
+    "ee_explicitteammembership": {
+      "model": "ee.ExplicitTeamMembership",
+      "app_label": "ee",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "ee/models/explicit_team_membership.py"
+    },
+    "ee_featureflagroleaccess": {
+      "model": "ee.FeatureFlagRoleAccess",
+      "app_label": "ee",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "products/access_control/backend/models/feature_flag_role_access.py"
+    },
+    "ee_hook": {
+      "model": "cdp.Hook",
+      "app_label": "cdp",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/cdp/backend/models/hook.py"
+    },
+    "ee_license": {
+      "model": "ee.License",
+      "app_label": "ee",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "ee/models/license.py"
+    },
+    "ee_llmtracesummary": {
+      "model": "ai_observability.LLMTraceSummary",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/llm_traces_summaries.py"
+    },
+    "ee_organizationresourceaccess": {
+      "model": "ee.OrganizationResourceAccess",
+      "app_label": "ee",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "products/access_control/backend/models/organization_resource_access.py"
+    },
+    "ee_role": {
+      "model": "ee.Role",
+      "app_label": "ee",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "products/access_control/backend/models/role.py"
+    },
+    "ee_rolemembership": {
+      "model": "ee.RoleMembership",
+      "app_label": "ee",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "products/access_control/backend/models/role.py"
+    },
+    "ee_scimprovisioneduser": {
+      "model": "ee.SCIMProvisionedUser",
+      "app_label": "ee",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "ee/models/scim_provisioned_user.py"
+    },
+    "ee_scimrequestlog": {
+      "model": "ee.SCIMRequestLog",
+      "app_label": "ee",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "ee/models/scim_request_log.py"
+    },
+    "endpoints_endpoint": {
+      "model": "endpoints.Endpoint",
+      "app_label": "endpoints",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/endpoints/backend/models.py"
+    },
+    "endpoints_endpointversion": {
+      "model": "endpoints.EndpointVersion",
+      "app_label": "endpoints",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/endpoints/backend/models.py"
+    },
+    "experiments_teamexperimentsconfig": {
+      "model": "experiments.TeamExperimentsConfig",
+      "app_label": "experiments",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-experiments"
+      ],
+      "slack": "#team-experiments",
+      "notifications": "#team-experiments",
+      "source": "products/experiments/backend/models/team_experiments_config.py"
+    },
+    "feature_flags_teamfeatureflagdefaultsconfig": {
+      "model": "feature_flags.TeamFeatureFlagDefaultsConfig",
+      "app_label": "feature_flags",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/feature_flags/backend/models/team_feature_flag_defaults_config.py"
+    },
+    "feature_flags_teamfeatureflagpolicyconfig": {
+      "model": "feature_flags.TeamFeatureFlagPolicyConfig",
+      "app_label": "feature_flags",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/feature_flags/backend/models/team_feature_flag_policy_config.py"
+    },
+    "feature_flags_teamfeatureflagsconfig": {
+      "model": "feature_flags.TeamFeatureFlagsConfig",
+      "app_label": "feature_flags",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/feature_flags/backend/models/team_feature_flags_config.py"
+    },
+    "growth_enrichmentlabelresult": {
+      "model": "growth.EnrichmentLabelResult",
+      "app_label": "growth",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-growth"
+      ],
+      "slack": "#team-growth",
+      "notifications": "#team-growth",
+      "source": "products/growth/backend/models.py"
+    },
+    "growth_enrichmentpromptconfig": {
+      "model": "growth.EnrichmentPromptConfig",
+      "app_label": "growth",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-growth"
+      ],
+      "slack": "#team-growth",
+      "notifications": "#team-growth",
+      "source": "products/growth/backend/models.py"
+    },
+    "growth_enrichmentsignupsnapshot": {
+      "model": "growth.EnrichmentSignupSnapshot",
+      "app_label": "growth",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-growth"
+      ],
+      "slack": "#team-growth",
+      "notifications": "#team-growth",
+      "source": "products/growth/backend/models.py"
+    },
+    "growth_icpscoringconfig": {
+      "model": "growth.IcpScoringConfig",
+      "app_label": "growth",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-growth"
+      ],
+      "slack": "#team-growth",
+      "notifications": "#team-growth",
+      "source": "products/growth/backend/models.py"
+    },
+    "growth_organizationenrichment": {
+      "model": "growth.OrganizationEnrichment",
+      "app_label": "growth",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-growth"
+      ],
+      "slack": "#team-growth",
+      "notifications": "#team-growth",
+      "source": "products/growth/backend/models.py"
+    },
+    "growth_organizationenrichmentfetch": {
+      "model": "growth.OrganizationEnrichmentFetch",
+      "app_label": "growth",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-growth"
+      ],
+      "slack": "#team-growth",
+      "notifications": "#team-growth",
+      "source": "products/growth/backend/models.py"
+    },
+    "growth_productpushcampaign": {
+      "model": "growth.ProductPushCampaign",
+      "app_label": "growth",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-growth"
+      ],
+      "slack": "#team-growth",
+      "notifications": "#team-growth",
+      "source": "products/growth/backend/models.py"
+    },
+    "hogflow_templates": {
+      "model": "workflows.HogFlowTemplate",
+      "app_label": "workflows",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/workflows/backend/models/hog_flow/hog_flow_template.py"
+    },
+    "legal_documents_legaldocument": {
+      "model": "legal_documents.LegalDocument",
+      "app_label": "legal_documents",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-growth"
+      ],
+      "slack": "#team-growth",
+      "notifications": "#team-growth",
+      "source": "products/legal_documents/backend/models.py"
+    },
+    "llm_analytics_checklistitemstate": {
+      "model": "ai_observability.AIObservabilityChecklistItemState",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/instrumentation_checklist.py"
+    },
+    "llm_analytics_clusteringconfig": {
+      "model": "ai_observability.ClusteringConfig",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/clustering_config.py"
+    },
+    "llm_analytics_clusteringjob": {
+      "model": "ai_observability.ClusteringJob",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/clustering_job.py"
+    },
+    "llm_analytics_communityskill": {
+      "model": "skills.CommunitySkill",
+      "app_label": "skills",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/skills/backend/models/community_skills.py"
+    },
+    "llm_analytics_communityskillfile": {
+      "model": "skills.CommunitySkillFile",
+      "app_label": "skills",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/skills/backend/models/community_skills.py"
+    },
+    "llm_analytics_communityskillvote": {
+      "model": "skills.CommunitySkillVote",
+      "app_label": "skills",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/skills/backend/models/community_skills.py"
+    },
+    "llm_analytics_dataset_v2": {
+      "model": "ai_observability.Dataset",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/datasets.py"
+    },
+    "llm_analytics_datasetitem_v2": {
+      "model": "ai_observability.DatasetItem",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/datasets.py"
+    },
+    "llm_analytics_datasetitemversion_v2": {
+      "model": "ai_observability.DatasetItemVersion",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/datasets.py"
+    },
+    "llm_analytics_datasetrevision_v2": {
+      "model": "ai_observability.DatasetRevision",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/datasets.py"
+    },
+    "llm_analytics_evaluation": {
+      "model": "ai_observability.Evaluation",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/evaluations.py"
+    },
+    "llm_analytics_evaluationconfig": {
+      "model": "ai_observability.EvaluationConfig",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/evaluation_config.py"
+    },
+    "llm_analytics_evaluationdirectory": {
+      "model": "ai_observability.EvaluationDirectory",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/evaluation_directories.py"
+    },
+    "llm_analytics_evaluationreport": {
+      "model": "ai_observability.EvaluationReport",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/evaluation_reports.py"
+    },
+    "llm_analytics_evaluationreportrun": {
+      "model": "ai_observability.EvaluationReportRun",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/evaluation_reports.py"
+    },
+    "llm_analytics_llmmodelconfiguration": {
+      "model": "ai_observability.LLMModelConfiguration",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/model_configuration.py"
+    },
+    "llm_analytics_llmproviderkey": {
+      "model": "ai_observability.LLMProviderKey",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/provider_keys.py"
+    },
+    "llm_analytics_llmskill": {
+      "model": "skills.LLMSkill",
+      "app_label": "skills",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/skills/backend/models/skills.py"
+    },
+    "llm_analytics_llmskillfile": {
+      "model": "skills.LLMSkillFile",
+      "app_label": "skills",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/skills/backend/models/skills.py"
+    },
+    "llm_analytics_llmskillowner": {
+      "model": "skills.LLMSkillOwner",
+      "app_label": "skills",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/skills/backend/models/skills.py"
+    },
+    "llm_analytics_reviewqueue": {
+      "model": "ai_observability.ReviewQueue",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/review_queues.py"
+    },
+    "llm_analytics_reviewqueueitem": {
+      "model": "ai_observability.ReviewQueueItem",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/review_queues.py"
+    },
+    "llm_analytics_scoredefinition": {
+      "model": "ai_observability.ScoreDefinition",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/score_definitions.py"
+    },
+    "llm_analytics_scoredefinitionversion": {
+      "model": "ai_observability.ScoreDefinitionVersion",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/score_definitions.py"
+    },
+    "llm_analytics_tagger": {
+      "model": "ai_observability.Tagger",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/taggers.py"
+    },
+    "llm_analytics_tracereview": {
+      "model": "ai_observability.TraceReview",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/trace_reviews.py"
+    },
+    "llm_analytics_tracereviewscore": {
+      "model": "ai_observability.TraceReviewScore",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/trace_reviews.py"
+    },
+    "logs_logsalertcheck": {
+      "model": "logs.LogsAlertCheck",
+      "app_label": "logs",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-apm"
+      ],
+      "slack": "#team-apm",
+      "notifications": "#team-apm",
+      "source": "products/logs/backend/models.py"
+    },
+    "logs_logsalertconfiguration": {
+      "model": "logs.LogsAlertConfiguration",
+      "app_label": "logs",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-apm"
+      ],
+      "slack": "#team-apm",
+      "notifications": "#team-apm",
+      "source": "products/logs/backend/models.py"
+    },
+    "logs_logsalertevent": {
+      "model": "logs.LogsAlertEvent",
+      "app_label": "logs",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-apm"
+      ],
+      "slack": "#team-apm",
+      "notifications": "#team-apm",
+      "source": "products/logs/backend/models.py"
+    },
+    "logs_logsexclusionrule": {
+      "model": "logs.LogsExclusionRule",
+      "app_label": "logs",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-apm"
+      ],
+      "slack": "#team-apm",
+      "notifications": "#team-apm",
+      "source": "products/logs/backend/models.py"
+    },
+    "logs_logsmetricrule": {
+      "model": "logs.LogsMetricRule",
+      "app_label": "logs",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-apm"
+      ],
+      "slack": "#team-apm",
+      "notifications": "#team-apm",
+      "source": "products/logs/backend/models.py"
+    },
+    "logs_logsretentionrule": {
+      "model": "logs.LogsRetentionRule",
+      "app_label": "logs",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-apm"
+      ],
+      "slack": "#team-apm",
+      "notifications": "#team-apm",
+      "source": "products/logs/backend/models.py"
+    },
+    "logs_logsview": {
+      "model": "logs.LogsView",
+      "app_label": "logs",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-apm"
+      ],
+      "slack": "#team-apm",
+      "notifications": "#team-apm",
+      "source": "products/logs/backend/models.py"
+    },
+    "logs_teamlogsconfig": {
+      "model": "logs.TeamLogsConfig",
+      "app_label": "logs",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-apm"
+      ],
+      "slack": "#team-apm",
+      "notifications": "#team-apm",
+      "source": "products/logs/backend/models.py"
+    },
+    "mcp_registry_measured_stats": {
+      "model": "mcp_registry.MCPMeasuredStats",
+      "app_label": "mcp_registry",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "mcp-analytics"
+      ],
+      "slack": "#team-mcp-analytics",
+      "notifications": "#team-mcp-analytics",
+      "source": "products/mcp_registry/backend/models.py"
+    },
+    "mcp_registry_ranking_run": {
+      "model": "mcp_registry.MCPRankingRun",
+      "app_label": "mcp_registry",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "mcp-analytics"
+      ],
+      "slack": "#team-mcp-analytics",
+      "notifications": "#team-mcp-analytics",
+      "source": "products/mcp_registry/backend/models.py"
+    },
+    "mcp_registry_ranking_score": {
+      "model": "mcp_registry.MCPRankingScore",
+      "app_label": "mcp_registry",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "mcp-analytics"
+      ],
+      "slack": "#team-mcp-analytics",
+      "notifications": "#team-mcp-analytics",
+      "source": "products/mcp_registry/backend/models.py"
+    },
+    "mcp_registry_server": {
+      "model": "mcp_registry.MCPRegistryServer",
+      "app_label": "mcp_registry",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "mcp-analytics"
+      ],
+      "slack": "#team-mcp-analytics",
+      "notifications": "#team-mcp-analytics",
+      "source": "products/mcp_registry/backend/models.py"
+    },
+    "mcp_registry_tool": {
+      "model": "mcp_registry.MCPRegistryTool",
+      "app_label": "mcp_registry",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "mcp-analytics"
+      ],
+      "slack": "#team-mcp-analytics",
+      "notifications": "#team-mcp-analytics",
+      "source": "products/mcp_registry/backend/models.py"
+    },
+    "mcp_store_mcpauditevent": {
+      "model": "mcp_store.MCPAuditEvent",
+      "app_label": "mcp_store",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/mcp_store/backend/models.py"
+    },
+    "mcp_store_mcpgatewayserver": {
+      "model": "mcp_store.MCPGatewayServer",
+      "app_label": "mcp_store",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/mcp_store/backend/models.py"
+    },
+    "mcp_store_mcpmemberserverrevocation": {
+      "model": "mcp_store.MCPMemberServerRevocation",
+      "app_label": "mcp_store",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/mcp_store/backend/models.py"
+    },
+    "mcp_store_mcpoauthstate": {
+      "model": "mcp_store.MCPOAuthState",
+      "app_label": "mcp_store",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/mcp_store/backend/models.py"
+    },
+    "mcp_store_mcporgrule": {
+      "model": "mcp_store.MCPOrgRule",
+      "app_label": "mcp_store",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/mcp_store/backend/models.py"
+    },
+    "mcp_store_mcpserverinstallation": {
+      "model": "mcp_store.MCPServerInstallation",
+      "app_label": "mcp_store",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/mcp_store/backend/models.py"
+    },
+    "mcp_store_mcpserverinstallationtool": {
+      "model": "mcp_store.MCPServerInstallationTool",
+      "app_label": "mcp_store",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/mcp_store/backend/models.py"
+    },
+    "mcp_store_mcpservertemplate": {
+      "model": "mcp_store.MCPServerTemplate",
+      "app_label": "mcp_store",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/mcp_store/backend/models.py"
+    },
+    "mcp_store_mcpserviceaccount": {
+      "model": "mcp_store.MCPServiceAccount",
+      "app_label": "mcp_store",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/mcp_store/backend/models.py"
+    },
+    "mcp_store_mcpserviceaccountserveraccess": {
+      "model": "mcp_store.MCPServiceAccountServerAccess",
+      "app_label": "mcp_store",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/mcp_store/backend/models.py"
+    },
+    "mcp_store_mcptoolpolicy": {
+      "model": "mcp_store.MCPToolPolicy",
+      "app_label": "mcp_store",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/mcp_store/backend/models.py"
+    },
+    "mcp_store_teammcpgatewayconfig": {
+      "model": "mcp_store.TeamMCPGatewayConfig",
+      "app_label": "mcp_store",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/mcp_store/backend/models.py"
+    },
+    "notifications_notificationarchivestate": {
+      "model": "notifications.NotificationArchiveState",
+      "app_label": "notifications",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "products/notifications/backend/models.py"
+    },
+    "notifications_notificationevent": {
+      "model": "notifications.NotificationEvent",
+      "app_label": "notifications",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "products/notifications/backend/models.py"
+    },
+    "notifications_notificationreadstate": {
+      "model": "notifications.NotificationReadState",
+      "app_label": "notifications",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "products/notifications/backend/models.py"
+    },
+    "oauth2_provider_devicegrant": {
+      "model": "oauth2_provider.DeviceGrant",
+      "app_label": "oauth2_provider",
+      "database": "default",
+      "kind": "third_party",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": null
+    },
+    "otp_static_staticdevice": {
+      "model": "otp_static.StaticDevice",
+      "app_label": "otp_static",
+      "database": "default",
+      "kind": "third_party",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": null
+    },
+    "otp_static_statictoken": {
+      "model": "otp_static.StaticToken",
+      "app_label": "otp_static",
+      "database": "default",
+      "kind": "third_party",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": null
+    },
+    "otp_totp_totpdevice": {
+      "model": "otp_totp.TOTPDevice",
+      "app_label": "otp_totp",
+      "database": "default",
+      "kind": "third_party",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": null
+    },
+    "posthog_action": {
+      "model": "actions.Action",
+      "app_label": "actions",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-product-analytics"
+      ],
+      "slack": "#team-product-analytics",
+      "notifications": "#team-product-analytics",
+      "source": "products/actions/backend/models/action.py"
+    },
+    "posthog_action_events": {
+      "model": "actions.Action_events",
+      "app_label": "actions",
+      "database": "default",
+      "kind": "through",
+      "owners": [
+        "team-product-analytics"
+      ],
+      "slack": "#team-product-analytics",
+      "notifications": "#team-product-analytics",
+      "source": "products/actions/backend/models/action.py"
+    },
+    "posthog_actionstep": {
+      "model": "actions.ActionStep",
+      "app_label": "actions",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-product-analytics"
+      ],
+      "slack": "#team-product-analytics",
+      "notifications": "#team-product-analytics",
+      "source": "products/actions/backend/models/action_step.py"
+    },
+    "posthog_activitylog": {
+      "model": "posthog.ActivityLog",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "posthog/models/activity_logging/activity_log.py"
+    },
+    "posthog_agent_peer_message": {
+      "model": "tasks.AgentPeerMessage",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_ai_agentmemory": {
+      "model": "posthog_ai.AgentMemory",
+      "app_label": "posthog_ai",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/posthog_ai/backend/models/agent_memory.py"
+    },
+    "posthog_alert": {
+      "model": "alerts.Alert",
+      "app_label": "alerts",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/alerts/backend/models/alert.py"
+    },
+    "posthog_alertcheck": {
+      "model": "alerts.AlertCheck",
+      "app_label": "alerts",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/alerts/backend/models/alert.py"
+    },
+    "posthog_alertconfiguration": {
+      "model": "alerts.AlertConfiguration",
+      "app_label": "alerts",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/alerts/backend/models/alert.py"
+    },
+    "posthog_alertsubscription": {
+      "model": "alerts.AlertSubscription",
+      "app_label": "alerts",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/alerts/backend/models/alert.py"
+    },
+    "posthog_annotation": {
+      "model": "annotations.Annotation",
+      "app_label": "annotations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-product-analytics"
+      ],
+      "slack": "#team-product-analytics",
+      "notifications": "#team-product-analytics",
+      "source": "products/annotations/backend/models/annotation.py"
+    },
+    "posthog_approval": {
+      "model": "approvals.Approval",
+      "app_label": "approvals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/approvals/backend/models.py"
+    },
+    "posthog_approvalpolicy": {
+      "model": "approvals.ApprovalPolicy",
+      "app_label": "approvals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/approvals/backend/models.py"
+    },
+    "posthog_approvalpolicy_bypass_roles": {
+      "model": "approvals.ApprovalPolicy_bypass_roles",
+      "app_label": "approvals",
+      "database": "default",
+      "kind": "through",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/approvals/backend/models.py"
+    },
+    "posthog_asyncdeletion": {
+      "model": "posthog.AsyncDeletion",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/async_deletion/async_deletion.py"
+    },
+    "posthog_asyncmigration": {
+      "model": "posthog.AsyncMigration",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/async_migration.py"
+    },
+    "posthog_asyncmigrationerror": {
+      "model": "posthog.AsyncMigrationError",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/async_migration.py"
+    },
+    "posthog_batchexport": {
+      "model": "batch_exports.BatchExport",
+      "app_label": "batch_exports",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "batch-exports"
+      ],
+      "slack": "#team-batch-exports",
+      "notifications": "#team-batch-exports",
+      "source": "products/batch_exports/backend/models/batch_export.py"
+    },
+    "posthog_batchexportbackfill": {
+      "model": "batch_exports.BatchExportBackfill",
+      "app_label": "batch_exports",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "batch-exports"
+      ],
+      "slack": "#team-batch-exports",
+      "notifications": "#team-batch-exports",
+      "source": "products/batch_exports/backend/models/batch_export.py"
+    },
+    "posthog_batchexportdestination": {
+      "model": "batch_exports.BatchExportDestination",
+      "app_label": "batch_exports",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "batch-exports"
+      ],
+      "slack": "#team-batch-exports",
+      "notifications": "#team-batch-exports",
+      "source": "products/batch_exports/backend/models/batch_export.py"
+    },
+    "posthog_batchexportfiledownload": {
+      "model": "batch_exports.BatchExportFileDownload",
+      "app_label": "batch_exports",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "batch-exports"
+      ],
+      "slack": "#team-batch-exports",
+      "notifications": "#team-batch-exports",
+      "source": "products/batch_exports/backend/models/batch_export.py"
+    },
+    "posthog_batchexportondemand": {
+      "model": "batch_exports.BatchExportOnDemand",
+      "app_label": "batch_exports",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "batch-exports"
+      ],
+      "slack": "#team-batch-exports",
+      "notifications": "#team-batch-exports",
+      "source": "products/batch_exports/backend/models/batch_export.py"
+    },
+    "posthog_batchexportrun": {
+      "model": "batch_exports.BatchExportRun",
+      "app_label": "batch_exports",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "batch-exports"
+      ],
+      "slack": "#team-batch-exports",
+      "notifications": "#team-batch-exports",
+      "source": "products/batch_exports/backend/models/batch_export.py"
+    },
+    "posthog_batchexportsource": {
+      "model": "batch_exports.BatchExportSource",
+      "app_label": "batch_exports",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "batch-exports"
+      ],
+      "slack": "#team-batch-exports",
+      "notifications": "#team-batch-exports",
+      "source": "products/batch_exports/backend/models/batch_export.py"
+    },
+    "posthog_batchimport": {
+      "model": "managed_migrations.BatchImport",
+      "app_label": "managed_migrations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ingestion"
+      ],
+      "slack": "#team-ingestion",
+      "notifications": "#team-ingestion",
+      "source": "products/managed_migrations/backend/models/batch_imports.py"
+    },
+    "posthog_business_knowledge_knowledgechunk": {
+      "model": "business_knowledge.KnowledgeChunk",
+      "app_label": "business_knowledge",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/business_knowledge/backend/models/knowledge_chunk.py"
+    },
+    "posthog_business_knowledge_knowledgedocument": {
+      "model": "business_knowledge.KnowledgeDocument",
+      "app_label": "business_knowledge",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/business_knowledge/backend/models/knowledge_document.py"
+    },
+    "posthog_business_knowledge_knowledgegapsuggestion": {
+      "model": "business_knowledge.KnowledgeGapSuggestion",
+      "app_label": "business_knowledge",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/business_knowledge/backend/models/knowledge_gap_suggestion.py"
+    },
+    "posthog_business_knowledge_knowledgesource": {
+      "model": "business_knowledge.KnowledgeSource",
+      "app_label": "business_knowledge",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/business_knowledge/backend/models/knowledge_source.py"
+    },
+    "posthog_buttontile": {
+      "model": "dashboards.ButtonTile",
+      "app_label": "dashboards",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/dashboards/backend/models/dashboard_tile.py"
+    },
+    "posthog_canvas": {
+      "model": "canvas.Canvas",
+      "app_label": "canvas",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/canvas/backend/models.py"
+    },
+    "posthog_canvas_build": {
+      "model": "canvas.CanvasBuild",
+      "app_label": "canvas",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/canvas/backend/models.py"
+    },
+    "posthog_canvas_home_preference": {
+      "model": "canvas.CanvasHomePreference",
+      "app_label": "canvas",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/canvas/backend/models.py"
+    },
+    "posthog_canvas_source_version": {
+      "model": "canvas.CanvasSourceVersion",
+      "app_label": "canvas",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/canvas/backend/models.py"
+    },
+    "posthog_canvas_state": {
+      "model": "canvas.CanvasState",
+      "app_label": "canvas",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/canvas/backend/models.py"
+    },
+    "posthog_changerequest": {
+      "model": "approvals.ChangeRequest",
+      "app_label": "approvals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/approvals/backend/models.py"
+    },
+    "posthog_cimdverificationtoken": {
+      "model": "posthog.CIMDVerificationToken",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/oauth.py"
+    },
+    "posthog_cohort": {
+      "model": "cohorts.Cohort",
+      "app_label": "cohorts",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/cohorts/backend/models/cohort.py"
+    },
+    "posthog_cohortcalculationhistory": {
+      "model": "cohorts.CohortCalculationHistory",
+      "app_label": "cohorts",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/cohorts/backend/models/calculation_history.py"
+    },
+    "posthog_cohortpeople": {
+      "model": "cohorts.CohortPeople",
+      "app_label": "cohorts",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/cohorts/backend/models/cohort.py"
+    },
+    "posthog_columnconfiguration": {
+      "model": "posthog.ColumnConfiguration",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/column_configuration.py"
+    },
+    "posthog_comment": {
+      "model": "posthog.Comment",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "posthog/models/comment/comment.py"
+    },
+    "posthog_commentslackthread": {
+      "model": "posthog.CommentSlackThread",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "posthog/models/comment/slack_thread.py"
+    },
+    "posthog_contentautopilotproposal": {
+      "model": "web_analytics.ContentAutopilotProposal",
+      "app_label": "web_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/web_analytics/backend/models/content_autopilot.py"
+    },
+    "posthog_contentautopilotrun": {
+      "model": "web_analytics.ContentAutopilotRun",
+      "app_label": "web_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/web_analytics/backend/models/content_autopilot.py"
+    },
+    "posthog_contentautopilotsiteprofile": {
+      "model": "web_analytics.ContentAutopilotSiteProfile",
+      "app_label": "web_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/web_analytics/backend/models/content_autopilot.py"
+    },
+    "posthog_conversations_email_channel": {
+      "model": "conversations.EmailChannel",
+      "app_label": "conversations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/conversations/backend/models/team_conversations_email_config.py"
+    },
+    "posthog_conversations_email_channel_setup": {
+      "model": "conversations.EmailChannelSetup",
+      "app_label": "conversations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/conversations/backend/models/email_channel_setup.py"
+    },
+    "posthog_conversations_email_message_mapping": {
+      "model": "conversations.EmailMessageMapping",
+      "app_label": "conversations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/conversations/backend/models/email_message_mapping.py"
+    },
+    "posthog_conversations_email_outbox_message": {
+      "model": "conversations.EmailOutboxMessage",
+      "app_label": "conversations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/conversations/backend/models/email_outbox_message.py"
+    },
+    "posthog_conversations_email_thread": {
+      "model": "conversations.EmailThread",
+      "app_label": "conversations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/conversations/backend/models/email_thread.py"
+    },
+    "posthog_conversations_email_thread_account_link": {
+      "model": "conversations.EmailThreadAccountLink",
+      "app_label": "conversations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/conversations/backend/models/email_thread.py"
+    },
+    "posthog_conversations_email_thread_message": {
+      "model": "conversations.EmailThreadMessage",
+      "app_label": "conversations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/conversations/backend/models/email_thread.py"
+    },
+    "posthog_conversations_email_thread_participant": {
+      "model": "conversations.EmailThreadParticipant",
+      "app_label": "conversations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/conversations/backend/models/email_thread.py"
+    },
+    "posthog_conversations_github_comment_mapping": {
+      "model": "conversations.GithubCommentMapping",
+      "app_label": "conversations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/conversations/backend/models/github_comment_mapping.py"
+    },
+    "posthog_conversations_restore_token": {
+      "model": "conversations.ConversationRestoreToken",
+      "app_label": "conversations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/conversations/backend/models/restore_token.py"
+    },
+    "posthog_conversations_signing_secret": {
+      "model": "conversations.SigningSecret",
+      "app_label": "conversations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/conversations/backend/models/signing_secret.py"
+    },
+    "posthog_conversations_slack_config": {
+      "model": "conversations.TeamConversationsSlackConfig",
+      "app_label": "conversations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/conversations/backend/models/team_conversations_slack_config.py"
+    },
+    "posthog_conversations_teams_channel_sync": {
+      "model": "conversations.TeamConversationsTeamsChannelSync",
+      "app_label": "conversations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/conversations/backend/models/team_conversations_teams_channel_sync.py"
+    },
+    "posthog_conversations_teams_config": {
+      "model": "conversations.TeamConversationsTeamsConfig",
+      "app_label": "conversations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/conversations/backend/models/team_conversations_teams_config.py"
+    },
+    "posthog_conversations_ticket": {
+      "model": "conversations.Ticket",
+      "app_label": "conversations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/conversations/backend/models/ticket.py"
+    },
+    "posthog_conversations_ticket_assignment": {
+      "model": "conversations.TicketAssignment",
+      "app_label": "conversations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/conversations/backend/models/assignment.py"
+    },
+    "posthog_conversations_ticket_view_favorites": {
+      "model": "conversations.TicketViewFavorite",
+      "app_label": "conversations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/conversations/backend/models/ticket_view_favorite.py"
+    },
+    "posthog_conversations_tickets_views": {
+      "model": "conversations.TicketView",
+      "app_label": "conversations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/conversations/backend/models/ticket_view.py"
+    },
+    "posthog_conversations_zendesk_import_job": {
+      "model": "conversations.ZendeskImportJob",
+      "app_label": "conversations",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "conversations"
+      ],
+      "slack": "#team-conversations",
+      "notifications": "#support-conversations",
+      "source": "products/conversations/backend/models/zendesk_import_job.py"
+    },
+    "posthog_coreevent": {
+      "model": "posthog.CoreEvent",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/core_event.py"
+    },
+    "posthog_dashboard": {
+      "model": "dashboards.Dashboard",
+      "app_label": "dashboards",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/dashboards/backend/models/dashboard.py"
+    },
+    "posthog_dashboard_saved_view": {
+      "model": "dashboards.DashboardSavedView",
+      "app_label": "dashboards",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/dashboards/backend/models/dashboard_saved_view.py"
+    },
+    "posthog_dashboarditem": {
+      "model": "product_analytics.Insight",
+      "app_label": "product_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-product-analytics"
+      ],
+      "slack": "#team-product-analytics",
+      "notifications": "#team-product-analytics",
+      "source": "products/product_analytics/backend/models/insight.py"
+    },
+    "posthog_dashboardtemplate": {
+      "model": "dashboards.DashboardTemplate",
+      "app_label": "dashboards",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/dashboards/backend/models/dashboard_templates.py"
+    },
+    "posthog_dashboardtile": {
+      "model": "dashboards.DashboardTile",
+      "app_label": "dashboards",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/dashboards/backend/models/dashboard_tile.py"
+    },
+    "posthog_dashboardwidget": {
+      "model": "dashboards.DashboardWidget",
+      "app_label": "dashboards",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/dashboards/backend/models/dashboard_widget.py"
+    },
+    "posthog_datacolortheme": {
+      "model": "posthog.DataColorTheme",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/data_color_theme.py"
+    },
+    "posthog_datadeletionrequest": {
+      "model": "posthog.DataDeletionRequest",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/data_deletion_request.py"
+    },
+    "posthog_datamodelingdag": {
+      "model": "data_modeling.DAG",
+      "app_label": "data_modeling",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/data_modeling/backend/models/dag.py"
+    },
+    "posthog_datamodelingedge": {
+      "model": "data_modeling.Edge",
+      "app_label": "data_modeling",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/data_modeling/backend/models/edge.py"
+    },
+    "posthog_datamodelinggithubsyncconfig": {
+      "model": "data_modeling.GitHubSyncConfig",
+      "app_label": "data_modeling",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/data_modeling/backend/models/github_sync_config.py"
+    },
+    "posthog_datamodelinggithubsyncedmodel": {
+      "model": "data_modeling.GitHubSyncedModel",
+      "app_label": "data_modeling",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/data_modeling/backend/models/github_synced_model.py"
+    },
+    "posthog_datamodelinggithubsyncplan": {
+      "model": "data_modeling.GitHubSyncPlan",
+      "app_label": "data_modeling",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/data_modeling/backend/models/github_sync_plan.py"
+    },
+    "posthog_datamodelingjob": {
+      "model": "data_modeling.DataModelingJob",
+      "app_label": "data_modeling",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/data_modeling/backend/models/data_modeling_job.py"
+    },
+    "posthog_datamodelingnode": {
+      "model": "data_modeling.Node",
+      "app_label": "data_modeling",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/data_modeling/backend/models/node.py"
+    },
+    "posthog_datawarehousecredential": {
+      "model": "warehouse_sources.DataWarehouseCredential",
+      "app_label": "warehouse_sources",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-warehouse-sources"
+      ],
+      "slack": "#team-warehouse-sources",
+      "notifications": "#team-warehouse-sources",
+      "source": "products/warehouse_sources/backend/models/credential.py"
+    },
+    "posthog_datawarehousejoin": {
+      "model": "data_tools.DataWarehouseJoin",
+      "app_label": "data_tools",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-managed-warehouse"
+      ],
+      "slack": "#team-managed-warehouse",
+      "notifications": "#team-managed-warehouse",
+      "source": "products/data_tools/backend/models/join.py"
+    },
+    "posthog_datawarehousemanagedviewset": {
+      "model": "data_modeling.DataWarehouseManagedViewSet",
+      "app_label": "data_modeling",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/data_modeling/backend/models/datawarehouse_managed_viewset.py"
+    },
+    "posthog_datawarehousemodelpath": {
+      "model": "data_modeling.DataWarehouseModelPath",
+      "app_label": "data_modeling",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/data_modeling/backend/models/modeling.py"
+    },
+    "posthog_datawarehousesavedquery": {
+      "model": "data_modeling.DataWarehouseSavedQuery",
+      "app_label": "data_modeling",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/data_modeling/backend/models/datawarehouse_saved_query.py"
+    },
+    "posthog_datawarehousesavedquerydraft": {
+      "model": "data_modeling.DataWarehouseSavedQueryDraft",
+      "app_label": "data_modeling",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-modeling"
+      ],
+      "slack": "#team-data-modeling",
+      "notifications": "#team-data-modeling",
+      "source": "products/data_modeling/backend/models/datawarehouse_saved_query_draft.py"
+    },
+    "posthog_datawarehousesavedqueryfolder": {
+      "model": "data_tools.DataWarehouseSavedQueryFolder",
+      "app_label": "data_tools",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-managed-warehouse"
+      ],
+      "slack": "#team-managed-warehouse",
+      "notifications": "#team-managed-warehouse",
+      "source": "products/data_tools/backend/models/datawarehouse_saved_query_folder.py"
+    },
+    "posthog_datawarehousetable": {
+      "model": "warehouse_sources.DataWarehouseTable",
+      "app_label": "warehouse_sources",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-warehouse-sources"
+      ],
+      "slack": "#team-warehouse-sources",
+      "notifications": "#team-warehouse-sources",
+      "source": "products/warehouse_sources/backend/models/table.py"
+    },
+    "posthog_datawarehouseviewlink": {
+      "model": "data_tools.DataWarehouseViewLink",
+      "app_label": "data_tools",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-managed-warehouse"
+      ],
+      "slack": "#team-managed-warehouse",
+      "notifications": "#team-managed-warehouse",
+      "source": "products/data_tools/backend/models/join.py"
+    },
+    "posthog_duckgresserver": {
+      "model": "managed_warehouse.DuckgresServer",
+      "app_label": "managed_warehouse",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-managed-warehouse"
+      ],
+      "slack": "#team-managed-warehouse",
+      "notifications": "#team-managed-warehouse",
+      "source": "products/managed_warehouse/backend/models.py"
+    },
+    "posthog_earlyaccessfeature": {
+      "model": "early_access_features.EarlyAccessFeature",
+      "app_label": "early_access_features",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/early_access_features/backend/models.py"
+    },
+    "posthog_element": {
+      "model": "posthog.Element",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/element/element.py"
+    },
+    "posthog_elementgroup": {
+      "model": "posthog.ElementGroup",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/element_group.py"
+    },
+    "posthog_errortrackingalert": {
+      "model": "error_tracking.ErrorTrackingAlert",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackingalertdestination": {
+      "model": "error_tracking.ErrorTrackingAlertDestination",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackingalertthread": {
+      "model": "error_tracking.ErrorTrackingAlertThread",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackingassignmentrule": {
+      "model": "error_tracking.ErrorTrackingAssignmentRule",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackingautocapturecontrols": {
+      "model": "error_tracking.ErrorTrackingAutoCaptureControls",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackingbypassrule": {
+      "model": "error_tracking.ErrorTrackingBypassRule",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackingexternalreference": {
+      "model": "error_tracking.ErrorTrackingExternalReference",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackinggroup": {
+      "model": "error_tracking.ErrorTrackingGroup",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackinggroupingrule": {
+      "model": "error_tracking.ErrorTrackingGroupingRule",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackingissue": {
+      "model": "error_tracking.ErrorTrackingIssue",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackingissueassignment": {
+      "model": "error_tracking.ErrorTrackingIssueAssignment",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackingissuecohort": {
+      "model": "error_tracking.ErrorTrackingIssueCohort",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackingissuefingerprint": {
+      "model": "error_tracking.ErrorTrackingIssueFingerprint",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackingissuefingerprintv2": {
+      "model": "error_tracking.ErrorTrackingIssueFingerprintV2",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackingrecommendation": {
+      "model": "error_tracking.ErrorTrackingRecommendation",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackingrelease": {
+      "model": "error_tracking.ErrorTrackingRelease",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackingsettings": {
+      "model": "error_tracking.ErrorTrackingSettings",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackingseverityrule": {
+      "model": "error_tracking.ErrorTrackingSeverityRule",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackingspikedetectionconfig": {
+      "model": "error_tracking.ErrorTrackingSpikeDetectionConfig",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackingspikeevent": {
+      "model": "error_tracking.ErrorTrackingSpikeEvent",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackingstackframe": {
+      "model": "error_tracking.ErrorTrackingStackFrame",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackingsuppressionrule": {
+      "model": "error_tracking.ErrorTrackingSuppressionRule",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_errortrackingsymbolset": {
+      "model": "error_tracking.ErrorTrackingSymbolSet",
+      "app_label": "error_tracking",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-error-tracking"
+      ],
+      "slack": "#team-error-tracking",
+      "notifications": "#team-error-tracking",
+      "source": "products/error_tracking/backend/models.py"
+    },
+    "posthog_evaluationcontext": {
+      "model": "feature_flags.EvaluationContext",
+      "app_label": "feature_flags",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/feature_flags/backend/models/evaluation_context.py"
+    },
+    "posthog_event": {
+      "model": "posthog.Event",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/event/event.py"
+    },
+    "posthog_eventbuffer": {
+      "model": "posthog.EventBuffer",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/event_buffer.py"
+    },
+    "posthog_eventdefinition": {
+      "model": "event_definitions.EventDefinition",
+      "app_label": "event_definitions",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-product-analytics"
+      ],
+      "slack": "#team-product-analytics",
+      "notifications": "#team-product-analytics",
+      "source": "products/event_definitions/backend/models/event_definition.py"
+    },
+    "posthog_eventfilterconfig": {
+      "model": "posthog.EventFilterConfig",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/event_filter_config.py"
+    },
+    "posthog_eventingestionrestrictionconfig": {
+      "model": "posthog.EventIngestionRestrictionConfig",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/event_ingestion_restriction_config.py"
+    },
+    "posthog_eventproperty": {
+      "model": "event_definitions.EventProperty",
+      "app_label": "event_definitions",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-product-analytics"
+      ],
+      "slack": "#team-product-analytics",
+      "notifications": "#team-product-analytics",
+      "source": "products/event_definitions/backend/models/event_property.py"
+    },
+    "posthog_eventschema": {
+      "model": "event_definitions.EventSchema",
+      "app_label": "event_definitions",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-product-analytics"
+      ],
+      "slack": "#team-product-analytics",
+      "notifications": "#team-product-analytics",
+      "source": "products/event_definitions/backend/models/schema.py"
+    },
+    "posthog_experiment": {
+      "model": "experiments.WebExperiment",
+      "app_label": "experiments",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-experiments"
+      ],
+      "slack": "#team-experiments",
+      "notifications": "#team-experiments",
+      "source": "products/experiments/backend/models/web_experiment.py"
+    },
+    "posthog_experimentholdout": {
+      "model": "experiments.ExperimentHoldout",
+      "app_label": "experiments",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-experiments"
+      ],
+      "slack": "#team-experiments",
+      "notifications": "#team-experiments",
+      "source": "products/experiments/backend/models/experiment.py"
+    },
+    "posthog_experimentmetricresult": {
+      "model": "experiments.ExperimentMetricResult",
+      "app_label": "experiments",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-experiments"
+      ],
+      "slack": "#team-experiments",
+      "notifications": "#team-experiments",
+      "source": "products/experiments/backend/models/experiment.py"
+    },
+    "posthog_experimentmetricsrecalculation": {
+      "model": "experiments.ExperimentMetricsRecalculation",
+      "app_label": "experiments",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-experiments"
+      ],
+      "slack": "#team-experiments",
+      "notifications": "#team-experiments",
+      "source": "products/experiments/backend/models/experiment.py"
+    },
+    "posthog_experimentsavedmetric": {
+      "model": "experiments.ExperimentSavedMetric",
+      "app_label": "experiments",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-experiments"
+      ],
+      "slack": "#team-experiments",
+      "notifications": "#team-experiments",
+      "source": "products/experiments/backend/models/experiment.py"
+    },
+    "posthog_experimenttimeseriesrecalculation": {
+      "model": "experiments.ExperimentTimeseriesRecalculation",
+      "app_label": "experiments",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-experiments"
+      ],
+      "slack": "#team-experiments",
+      "notifications": "#team-experiments",
+      "source": "products/experiments/backend/models/experiment.py"
+    },
+    "posthog_experimenttosavedmetric": {
+      "model": "experiments.ExperimentToSavedMetric",
+      "app_label": "experiments",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-experiments"
+      ],
+      "slack": "#team-experiments",
+      "notifications": "#team-experiments",
+      "source": "products/experiments/backend/models/experiment.py"
+    },
+    "posthog_exportedasset": {
+      "model": "exports.ExportedAsset",
+      "app_label": "exports",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/exports/backend/models/exported_asset.py"
+    },
+    "posthog_exportedrecording": {
+      "model": "replay.ExportedRecording",
+      "app_label": "replay",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-replay"
+      ],
+      "slack": "#team-replay",
+      "notifications": "#team-replay",
+      "source": "products/replay/backend/models/exported_recording.py"
+    },
+    "posthog_externaldatadestination": {
+      "model": "warehouse_sources.ExternalDataDestination",
+      "app_label": "warehouse_sources",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-warehouse-sources"
+      ],
+      "slack": "#team-warehouse-sources",
+      "notifications": "#team-warehouse-sources",
+      "source": "products/warehouse_sources/backend/models/external_data_destination.py"
+    },
+    "posthog_externaldatajob": {
+      "model": "warehouse_sources.ExternalDataJob",
+      "app_label": "warehouse_sources",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-warehouse-sources"
+      ],
+      "slack": "#team-warehouse-sources",
+      "notifications": "#team-warehouse-sources",
+      "source": "products/warehouse_sources/backend/models/external_data_job.py"
+    },
+    "posthog_externaldataschema": {
+      "model": "warehouse_sources.ExternalDataSchema",
+      "app_label": "warehouse_sources",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-warehouse-sources"
+      ],
+      "slack": "#team-warehouse-sources",
+      "notifications": "#team-warehouse-sources",
+      "source": "products/warehouse_sources/backend/models/external_data_schema.py"
+    },
+    "posthog_externaldataschemadestination": {
+      "model": "warehouse_sources.ExternalDataSchemaDestination",
+      "app_label": "warehouse_sources",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-warehouse-sources"
+      ],
+      "slack": "#team-warehouse-sources",
+      "notifications": "#team-warehouse-sources",
+      "source": "products/warehouse_sources/backend/models/external_data_destination.py"
+    },
+    "posthog_externaldatasource": {
+      "model": "warehouse_sources.ExternalDataSource",
+      "app_label": "warehouse_sources",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-warehouse-sources"
+      ],
+      "slack": "#team-warehouse-sources",
+      "notifications": "#team-warehouse-sources",
+      "source": "products/warehouse_sources/backend/models/external_data_source.py"
+    },
+    "posthog_externaldatasourcedestination": {
+      "model": "warehouse_sources.ExternalDataSourceDestination",
+      "app_label": "warehouse_sources",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-warehouse-sources"
+      ],
+      "slack": "#team-warehouse-sources",
+      "notifications": "#team-warehouse-sources",
+      "source": "products/warehouse_sources/backend/models/external_data_destination.py"
+    },
+    "posthog_externaldatasourcerevenueanalyticsconfig": {
+      "model": "data_warehouse.ExternalDataSourceRevenueAnalyticsConfig",
+      "app_label": "data_warehouse",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-managed-warehouse"
+      ],
+      "slack": "#team-managed-warehouse",
+      "notifications": "#team-managed-warehouse",
+      "source": "products/data_warehouse/backend/models/revenue_analytics_config.py"
+    },
+    "posthog_featureflag": {
+      "model": "feature_flags.FeatureFlag",
+      "app_label": "feature_flags",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/feature_flags/backend/models/feature_flag.py"
+    },
+    "posthog_featureflagdashboards": {
+      "model": "feature_flags.FeatureFlagDashboards",
+      "app_label": "feature_flags",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/feature_flags/backend/models/feature_flag.py"
+    },
+    "posthog_featureflagevaluationcontext": {
+      "model": "feature_flags.FeatureFlagEvaluationContext",
+      "app_label": "feature_flags",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/feature_flags/backend/models/evaluation_context.py"
+    },
+    "posthog_featureflaghashkeyoverride": {
+      "model": "feature_flags.FeatureFlagHashKeyOverride",
+      "app_label": "feature_flags",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/feature_flags/backend/models/feature_flag.py"
+    },
+    "posthog_featureflagoverride": {
+      "model": "feature_flags.FeatureFlagOverride",
+      "app_label": "feature_flags",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/feature_flags/backend/models/feature_flag.py"
+    },
+    "posthog_field_note": {
+      "model": "field_notes.FieldNote",
+      "app_label": "field_notes",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-surveys"
+      ],
+      "slack": "#team-surveys",
+      "notifications": "#team-surveys",
+      "source": "products/field_notes/backend/models.py"
+    },
+    "posthog_filesystem": {
+      "model": "posthog.FileSystem",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/file_system/file_system.py"
+    },
+    "posthog_filesystemshortcut": {
+      "model": "posthog.FileSystemShortcut",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/file_system/file_system_shortcut.py"
+    },
+    "posthog_filesystemviewlog": {
+      "model": "posthog.FileSystemViewLog",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/file_system/file_system_view_log.py"
+    },
+    "posthog_flatpersonoverride": {
+      "model": "posthog.FlatPersonOverride",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ingestion"
+      ],
+      "slack": "#team-ingestion",
+      "notifications": "#team-ingestion",
+      "source": "posthog/models/person/person.py"
+    },
+    "posthog_generated_widget": {
+      "model": "notebooks.GeneratedWidget",
+      "app_label": "notebooks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-tools"
+      ],
+      "slack": "#team-data-tools",
+      "notifications": "#team-data-tools",
+      "source": "products/notebooks/backend/models.py"
+    },
+    "posthog_generated_widget_generation_job": {
+      "model": "notebooks.GeneratedWidgetGenerationJob",
+      "app_label": "notebooks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-tools"
+      ],
+      "slack": "#team-data-tools",
+      "notifications": "#team-data-tools",
+      "source": "products/notebooks/backend/models.py"
+    },
+    "posthog_generated_widget_version": {
+      "model": "notebooks.GeneratedWidgetVersion",
+      "app_label": "notebooks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-tools"
+      ],
+      "slack": "#team-data-tools",
+      "notifications": "#team-data-tools",
+      "source": "products/notebooks/backend/models.py"
+    },
+    "posthog_github_install_request": {
+      "model": "posthog.GitHubInstallRequest",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/user_integration.py"
+    },
+    "posthog_globalratelimitthresholdconfig": {
+      "model": "posthog.GlobalRateLimitThresholdConfig",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/global_rate_limit_threshold_config.py"
+    },
+    "posthog_group": {
+      "model": "posthog.Group",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/group/group.py"
+    },
+    "posthog_grouptypemapping": {
+      "model": "posthog.GroupTypeMapping",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/group_type_mapping.py"
+    },
+    "posthog_groupusagemetric": {
+      "model": "posthog.GroupUsageMetric",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/group_usage_metric.py"
+    },
+    "posthog_healthissue": {
+      "model": "posthog.HealthIssue",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/health_issue.py"
+    },
+    "posthog_heatmapsaved": {
+      "model": "web_analytics.SavedHeatmap",
+      "app_label": "web_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/web_analytics/backend/models/heatmap_saved.py"
+    },
+    "posthog_heatmapsnapshot": {
+      "model": "web_analytics.HeatmapSnapshot",
+      "app_label": "web_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/web_analytics/backend/models/heatmap_saved.py"
+    },
+    "posthog_hogflow": {
+      "model": "workflows.HogFlow",
+      "app_label": "workflows",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/workflows/backend/models/hog_flow/hog_flow.py"
+    },
+    "posthog_hogfunction": {
+      "model": "cdp.HogFunction",
+      "app_label": "cdp",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/cdp/backend/models/hog_functions/hog_function.py"
+    },
+    "posthog_hogfunctiontemplate": {
+      "model": "cdp.HogFunctionTemplate",
+      "app_label": "cdp",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/cdp/backend/models/hog_function_template.py"
+    },
+    "posthog_hostdefinition": {
+      "model": "posthog.HostDefinition",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/host_definition.py"
+    },
+    "posthog_identityproviderconfig": {
+      "model": "posthog.IdentityProviderConfig",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/identity_provider_config.py"
+    },
+    "posthog_insightvariable": {
+      "model": "product_analytics.InsightVariable",
+      "app_label": "product_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-product-analytics"
+      ],
+      "slack": "#team-product-analytics",
+      "notifications": "#team-product-analytics",
+      "source": "products/product_analytics/backend/models/insight_variable.py"
+    },
+    "posthog_insightviewed": {
+      "model": "product_analytics.InsightViewed",
+      "app_label": "product_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-product-analytics"
+      ],
+      "slack": "#team-product-analytics",
+      "notifications": "#team-product-analytics",
+      "source": "products/product_analytics/backend/models/insight.py"
+    },
+    "posthog_instancesetting": {
+      "model": "posthog.InstanceSetting",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/instance_setting.py"
+    },
+    "posthog_integration": {
+      "model": "posthog.Integration",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/integration/model.py"
+    },
+    "posthog_integrationrepositorycacheentry": {
+      "model": "posthog.IntegrationRepositoryCacheEntry",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/integration_repository_cache.py"
+    },
+    "posthog_kernelruntime": {
+      "model": "notebooks.KernelRuntime",
+      "app_label": "notebooks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-tools"
+      ],
+      "slack": "#team-data-tools",
+      "notifications": "#team-data-tools",
+      "source": "products/notebooks/backend/models.py"
+    },
+    "posthog_link": {
+      "model": "links.Link",
+      "app_label": "links",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "products/links/backend/models.py"
+    },
+    "posthog_linkedidentityproviderconfig": {
+      "model": "posthog.LinkedIdentityProviderConfig",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/linked_identity_provider_config.py"
+    },
+    "posthog_livedebuggerbreakpoint": {
+      "model": "live_debugger.LiveDebuggerBreakpoint",
+      "app_label": "live_debugger",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "clickhouse"
+      ],
+      "slack": "#team-clickhouse",
+      "notifications": "#team-clickhouse",
+      "source": "products/live_debugger/backend/models.py"
+    },
+    "posthog_llmprompt": {
+      "model": "ai_observability.LLMPrompt",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability",
+        "team-experiments"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/llm_prompt.py"
+    },
+    "posthog_llmpromptlabel": {
+      "model": "ai_observability.LLMPromptLabel",
+      "app_label": "ai_observability",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ai-observability",
+        "team-experiments"
+      ],
+      "slack": "#team-ai-observability",
+      "notifications": "#team-ai-observability",
+      "source": "products/ai_observability/backend/models/llm_prompt.py"
+    },
+    "posthog_managedwarehousesourcejob": {
+      "model": "managed_warehouse.ManagedWarehouseSourceJob",
+      "app_label": "managed_warehouse",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-managed-warehouse"
+      ],
+      "slack": "#team-managed-warehouse",
+      "notifications": "#team-managed-warehouse",
+      "source": "products/managed_warehouse/backend/models.py"
+    },
+    "posthog_managedwarehousesourcelifecycle": {
+      "model": "managed_warehouse.ManagedWarehouseSourceLifecycle",
+      "app_label": "managed_warehouse",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-managed-warehouse"
+      ],
+      "slack": "#team-managed-warehouse",
+      "notifications": "#team-managed-warehouse",
+      "source": "products/managed_warehouse/backend/models.py"
+    },
+    "posthog_managedwarehouseviewtranslationjob": {
+      "model": "managed_warehouse.ManagedWarehouseViewTranslationJob",
+      "app_label": "managed_warehouse",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-managed-warehouse"
+      ],
+      "slack": "#team-managed-warehouse",
+      "notifications": "#team-managed-warehouse",
+      "source": "products/managed_warehouse/backend/models.py"
+    },
+    "posthog_managedwarehouseviewtranslationresult": {
+      "model": "managed_warehouse.ManagedWarehouseViewTranslationResult",
+      "app_label": "managed_warehouse",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-managed-warehouse"
+      ],
+      "slack": "#team-managed-warehouse",
+      "notifications": "#team-managed-warehouse",
+      "source": "products/managed_warehouse/backend/models.py"
+    },
+    "posthog_marketinganalyticsgoalmapping": {
+      "model": "marketing_analytics.MarketingAnalyticsGoalMapping",
+      "app_label": "marketing_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/marketing_analytics/backend/models/marketing_analytics_goal_mapping.py"
+    },
+    "posthog_materializedcolumnslot": {
+      "model": "posthog.MaterializedColumnSlot",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/materialized_column_slots.py"
+    },
+    "posthog_mcp_analytics_intent_cluster_snapshot": {
+      "model": "mcp_analytics.MCPIntentClusterSnapshot",
+      "app_label": "mcp_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "mcp-analytics"
+      ],
+      "slack": "#team-mcp-analytics",
+      "notifications": "#team-mcp-analytics",
+      "source": "products/mcp_analytics/backend/models.py"
+    },
+    "posthog_mcp_analytics_intent_embedding_cache": {
+      "model": "mcp_analytics.MCPIntentEmbeddingCache",
+      "app_label": "mcp_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "mcp-analytics"
+      ],
+      "slack": "#team-mcp-analytics",
+      "notifications": "#team-mcp-analytics",
+      "source": "products/mcp_analytics/backend/models.py"
+    },
+    "posthog_mcp_analytics_submission": {
+      "model": "mcp_analytics.MCPAnalyticsSubmission",
+      "app_label": "mcp_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "mcp-analytics"
+      ],
+      "slack": "#team-mcp-analytics",
+      "notifications": "#team-mcp-analytics",
+      "source": "products/mcp_analytics/backend/models.py"
+    },
+    "posthog_mcp_session": {
+      "model": "mcp_analytics.MCPSession",
+      "app_label": "mcp_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "mcp-analytics"
+      ],
+      "slack": "#team-mcp-analytics",
+      "notifications": "#team-mcp-analytics",
+      "source": "products/mcp_analytics/backend/models.py"
+    },
+    "posthog_messagecategory": {
+      "model": "messaging.MessageCategory",
+      "app_label": "messaging",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/messaging/backend/models/message_category.py"
+    },
+    "posthog_messagerecipientpreference": {
+      "model": "messaging.MessageRecipientPreference",
+      "app_label": "messaging",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/messaging/backend/models/message_preferences.py"
+    },
+    "posthog_messagesuppression": {
+      "model": "messaging.MessageSuppression",
+      "app_label": "messaging",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/messaging/backend/models/message_suppression.py"
+    },
+    "posthog_messagetemplate": {
+      "model": "messaging.MessageTemplate",
+      "app_label": "messaging",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/messaging/backend/models/message_template.py"
+    },
+    "posthog_messaging_optout_sync_config": {
+      "model": "messaging.OptOutSyncConfig",
+      "app_label": "messaging",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/messaging/backend/models/optout_sync_config.py"
+    },
+    "posthog_messagingrecord": {
+      "model": "posthog.MessagingRecord",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "posthog/models/messaging.py"
+    },
+    "posthog_notebook": {
+      "model": "notebooks.Notebook",
+      "app_label": "notebooks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-tools"
+      ],
+      "slack": "#team-data-tools",
+      "notifications": "#team-data-tools",
+      "source": "products/notebooks/backend/models.py"
+    },
+    "posthog_notebook_widget_instance": {
+      "model": "notebooks.NotebookWidgetInstance",
+      "app_label": "notebooks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-tools"
+      ],
+      "slack": "#team-data-tools",
+      "notifications": "#team-data-tools",
+      "source": "products/notebooks/backend/models.py"
+    },
+    "posthog_notebooknoderun": {
+      "model": "notebooks.NotebookNodeRun",
+      "app_label": "notebooks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-tools"
+      ],
+      "slack": "#team-data-tools",
+      "notifications": "#team-data-tools",
+      "source": "products/notebooks/backend/models.py"
+    },
+    "posthog_notificationviewed": {
+      "model": "posthog.NotificationViewed",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "posthog/models/activity_logging/notification_viewed.py"
+    },
+    "posthog_oauthaccesstoken": {
+      "model": "posthog.OAuthAccessToken",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/oauth.py"
+    },
+    "posthog_oauthapplication": {
+      "model": "posthog.OAuthApplication",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/oauth.py"
+    },
+    "posthog_oauthgrant": {
+      "model": "posthog.OAuthGrant",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/oauth.py"
+    },
+    "posthog_oauthidtoken": {
+      "model": "posthog.OAuthIDToken",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/oauth.py"
+    },
+    "posthog_oauthrefreshtoken": {
+      "model": "posthog.OAuthRefreshToken",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/oauth.py"
+    },
+    "posthog_objectmediapreview": {
+      "model": "posthog.ObjectMediaPreview",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/object_media_preview.py"
+    },
+    "posthog_organization": {
+      "model": "posthog.Organization",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/organization.py"
+    },
+    "posthog_organizationdomain": {
+      "model": "posthog.OrganizationDomain",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/organization_domain.py"
+    },
+    "posthog_organizationintegration": {
+      "model": "posthog.OrganizationIntegration",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/organization_integration.py"
+    },
+    "posthog_organizationinvite": {
+      "model": "posthog.OrganizationInvite",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/organization_invite.py"
+    },
+    "posthog_organizationmembernotificationlock": {
+      "model": "posthog.OrganizationMemberNotificationLock",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/organization_notification_lock.py"
+    },
+    "posthog_organizationmembership": {
+      "model": "posthog.OrganizationMembership",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/organization.py"
+    },
+    "posthog_pendingpersonoverride": {
+      "model": "posthog.PendingPersonOverride",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ingestion"
+      ],
+      "slack": "#team-ingestion",
+      "notifications": "#team-ingestion",
+      "source": "posthog/models/person/person.py"
+    },
+    "posthog_persistedfolder": {
+      "model": "posthog.PersistedFolder",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/file_system/persisted_folder.py"
+    },
+    "posthog_person": {
+      "model": "posthog.Person",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ingestion"
+      ],
+      "slack": "#team-ingestion",
+      "notifications": "#team-ingestion",
+      "source": "posthog/models/person/person.py"
+    },
+    "posthog_personalapikey": {
+      "model": "posthog.PersonalAPIKey",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/personal_api_key.py"
+    },
+    "posthog_persondistinctid": {
+      "model": "posthog.PersonDistinctId",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ingestion"
+      ],
+      "slack": "#team-ingestion",
+      "notifications": "#team-ingestion",
+      "source": "posthog/models/person/person.py"
+    },
+    "posthog_personoverride": {
+      "model": "posthog.PersonOverride",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ingestion"
+      ],
+      "slack": "#team-ingestion",
+      "notifications": "#team-ingestion",
+      "source": "posthog/models/person/person.py"
+    },
+    "posthog_personoverridemapping": {
+      "model": "posthog.PersonOverrideMapping",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-ingestion"
+      ],
+      "slack": "#team-ingestion",
+      "notifications": "#team-ingestion",
+      "source": "posthog/models/person/person.py"
+    },
+    "posthog_plugin": {
+      "model": "cdp.Plugin",
+      "app_label": "cdp",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/cdp/backend/models/plugin.py"
+    },
+    "posthog_plugin_has_private_access": {
+      "model": "cdp.Plugin_has_private_access",
+      "app_label": "cdp",
+      "database": "default",
+      "kind": "through",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/cdp/backend/models/plugin.py"
+    },
+    "posthog_pluginattachment": {
+      "model": "cdp.PluginAttachment",
+      "app_label": "cdp",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/cdp/backend/models/plugin.py"
+    },
+    "posthog_pluginconfig": {
+      "model": "cdp.PluginConfig",
+      "app_label": "cdp",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/cdp/backend/models/plugin.py"
+    },
+    "posthog_pluginsourcefile": {
+      "model": "cdp.PluginSourceFile",
+      "app_label": "cdp",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/cdp/backend/models/plugin.py"
+    },
+    "posthog_pluginstorage": {
+      "model": "cdp.PluginStorage",
+      "app_label": "cdp",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/cdp/backend/models/plugin.py"
+    },
+    "posthog_productintent": {
+      "model": "posthog.ProductIntent",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/product_intent/product_intent.py"
+    },
+    "posthog_project": {
+      "model": "posthog.Project",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/project.py"
+    },
+    "posthog_projectsecretapikey": {
+      "model": "posthog.ProjectSecretAPIKey",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/project_secret_api_key.py"
+    },
+    "posthog_prompt": {
+      "model": "posthog.Prompt",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/_deprecated_prompts.py"
+    },
+    "posthog_promptsequence": {
+      "model": "posthog.PromptSequence",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/_deprecated_prompts.py"
+    },
+    "posthog_promptsequence_must_have_completed": {
+      "model": "posthog.PromptSequence_must_have_completed",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "through",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/_deprecated_prompts.py"
+    },
+    "posthog_promptsequence_prompts": {
+      "model": "posthog.PromptSequence_prompts",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "through",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/_deprecated_prompts.py"
+    },
+    "posthog_propertydefinition": {
+      "model": "event_definitions.PropertyDefinition",
+      "app_label": "event_definitions",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-product-analytics"
+      ],
+      "slack": "#team-product-analytics",
+      "notifications": "#team-product-analytics",
+      "source": "products/event_definitions/backend/models/property_definition.py"
+    },
+    "posthog_proxyrecord": {
+      "model": "posthog.ProxyRecord",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "posthog/models/proxy_record.py"
+    },
+    "posthog_querytabstate": {
+      "model": "data_tools.QueryTabState",
+      "app_label": "data_tools",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-managed-warehouse"
+      ],
+      "slack": "#team-managed-warehouse",
+      "notifications": "#team-managed-warehouse",
+      "source": "products/data_tools/backend/models/query_tab_state.py"
+    },
+    "posthog_quickfilter": {
+      "model": "posthog.QuickFilter",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/quick_filter.py"
+    },
+    "posthog_quickfiltercontext": {
+      "model": "posthog.QuickFilterContext",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/quick_filter.py"
+    },
+    "posthog_remoteconfig": {
+      "model": "posthog.RemoteConfig",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/remote_config.py"
+    },
+    "posthog_reporoutingrule": {
+      "model": "posthog.RepoRoutingRule",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/repo_routing_rule.py"
+    },
+    "posthog_resourcenotebook": {
+      "model": "notebooks.ResourceNotebook",
+      "app_label": "notebooks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-tools"
+      ],
+      "slack": "#team-data-tools",
+      "notifications": "#team-data-tools",
+      "source": "products/notebooks/backend/models.py"
+    },
+    "posthog_resourcetransfer": {
+      "model": "posthog.ResourceTransfer",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "posthog/models/resource_transfer/resource_transfer.py"
+    },
+    "posthog_roleexternalreference": {
+      "model": "posthog.RoleExternalReference",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "products/access_control/backend/models/role_external_reference.py"
+    },
+    "posthog_sandbox_custom_image": {
+      "model": "tasks.SandboxCustomImage",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_sandbox_environment": {
+      "model": "tasks.SandboxEnvironment",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_sandbox_snapshot": {
+      "model": "tasks.SandboxSnapshot",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_scheduledchange": {
+      "model": "feature_flags.ScheduledChange",
+      "app_label": "feature_flags",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/feature_flags/backend/models/scheduled_change.py"
+    },
+    "posthog_schemapropertygroup": {
+      "model": "event_definitions.SchemaPropertyGroup",
+      "app_label": "event_definitions",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-product-analytics"
+      ],
+      "slack": "#team-product-analytics",
+      "notifications": "#team-product-analytics",
+      "source": "products/event_definitions/backend/models/schema.py"
+    },
+    "posthog_schemapropertygroupproperty": {
+      "model": "event_definitions.SchemaPropertyGroupProperty",
+      "app_label": "event_definitions",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-product-analytics"
+      ],
+      "slack": "#team-product-analytics",
+      "notifications": "#team-product-analytics",
+      "source": "products/event_definitions/backend/models/schema.py"
+    },
+    "posthog_sessionrecording": {
+      "model": "posthog.SessionRecording",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-replay"
+      ],
+      "slack": "#team-replay",
+      "notifications": "#team-replay",
+      "source": "posthog/session_recordings/models/session_recording.py"
+    },
+    "posthog_sessionrecordingevent": {
+      "model": "posthog.SessionRecordingEvent",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-replay"
+      ],
+      "slack": "#team-replay",
+      "notifications": "#team-replay",
+      "source": "posthog/session_recordings/models/session_recording_event.py"
+    },
+    "posthog_sessionrecordingexternalreference": {
+      "model": "posthog.SessionRecordingExternalReference",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-replay"
+      ],
+      "slack": "#team-replay",
+      "notifications": "#team-replay",
+      "source": "posthog/session_recordings/models/session_recording_external_reference.py"
+    },
+    "posthog_sessionrecordingplaylist": {
+      "model": "posthog.SessionRecordingPlaylist",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-replay"
+      ],
+      "slack": "#team-replay",
+      "notifications": "#team-replay",
+      "source": "posthog/session_recordings/models/session_recording_playlist.py"
+    },
+    "posthog_sessionrecordingplaylistitem": {
+      "model": "posthog.SessionRecordingPlaylistItem",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-replay"
+      ],
+      "slack": "#team-replay",
+      "notifications": "#team-replay",
+      "source": "posthog/session_recordings/models/session_recording_playlist_item.py"
+    },
+    "posthog_sessionrecordingplaylistviewed": {
+      "model": "posthog.SessionRecordingPlaylistViewed",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-replay"
+      ],
+      "slack": "#team-replay",
+      "notifications": "#team-replay",
+      "source": "posthog/session_recordings/models/session_recording_playlist.py"
+    },
+    "posthog_sessionrecordingviewed": {
+      "model": "posthog.SessionRecordingViewed",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-replay"
+      ],
+      "slack": "#team-replay",
+      "notifications": "#team-replay",
+      "source": "posthog/session_recordings/models/session_recording_event.py"
+    },
+    "posthog_sharepassword": {
+      "model": "posthog.SharePassword",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/share_password.py"
+    },
+    "posthog_sharingconfiguration": {
+      "model": "posthog.SharingConfiguration",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/sharing_configuration.py"
+    },
+    "posthog_subscription": {
+      "model": "exports.Subscription",
+      "app_label": "exports",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/exports/backend/models/subscription.py"
+    },
+    "posthog_subscription_dashboard_export_insights": {
+      "model": "exports.Subscription_dashboard_export_insights",
+      "app_label": "exports",
+      "database": "default",
+      "kind": "through",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/exports/backend/models/subscription.py"
+    },
+    "posthog_subscription_delivery": {
+      "model": "exports.SubscriptionDelivery",
+      "app_label": "exports",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/exports/backend/models/subscription.py"
+    },
+    "posthog_survey": {
+      "model": "surveys.Survey",
+      "app_label": "surveys",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-surveys"
+      ],
+      "slack": "#team-surveys",
+      "notifications": "#team-surveys",
+      "source": "products/surveys/backend/models.py"
+    },
+    "posthog_survey_actions": {
+      "model": "surveys.Survey_actions",
+      "app_label": "surveys",
+      "database": "default",
+      "kind": "through",
+      "owners": [
+        "team-surveys"
+      ],
+      "slack": "#team-surveys",
+      "notifications": "#team-surveys",
+      "source": "products/surveys/backend/models.py"
+    },
+    "posthog_surveyresponsearchive": {
+      "model": "surveys.SurveyResponseArchive",
+      "app_label": "surveys",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-surveys"
+      ],
+      "slack": "#team-surveys",
+      "notifications": "#team-surveys",
+      "source": "products/surveys/backend/models.py"
+    },
+    "posthog_tag": {
+      "model": "posthog.Tag",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/tag.py"
+    },
+    "posthog_taggeditem": {
+      "model": "posthog.TaggedItem",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/tagged_item.py"
+    },
+    "posthog_task": {
+      "model": "tasks.Task",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_task_activity": {
+      "model": "tasks.TaskActivity",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_task_artifact": {
+      "model": "tasks.TaskArtifact",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_task_channel": {
+      "model": "tasks.Channel",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_task_channel_context_generation": {
+      "model": "tasks.ChannelContextGeneration",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_task_channel_feed_message": {
+      "model": "tasks.ChannelFeedMessage",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_task_channel_instructions": {
+      "model": "tasks.ChannelInstructions",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_task_channel_membership": {
+      "model": "tasks.ChannelMembership",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_task_channel_star": {
+      "model": "tasks.ChannelStar",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_task_comment_activity": {
+      "model": "tasks.TaskCommentActivity",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_task_loop": {
+      "model": "tasks.Loop",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_task_loop_fire": {
+      "model": "tasks.LoopFire",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_task_loop_trigger": {
+      "model": "tasks.LoopTrigger",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_task_pin": {
+      "model": "tasks.TaskPin",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_task_presence": {
+      "model": "tasks.TaskPresence",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_task_run": {
+      "model": "tasks.TaskRun",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_task_sandbox_session": {
+      "model": "tasks.SandboxSession",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_task_search_document": {
+      "model": "tasks.TaskSearchDocument",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_task_session": {
+      "model": "tasks.TaskSession",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_task_thread_message": {
+      "model": "tasks.TaskThreadMessage",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_task_thread_message_mention": {
+      "model": "tasks.TaskThreadMessageMention",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_taskworkflowdispatch": {
+      "model": "tasks.TaskWorkflowDispatch",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "posthog_team": {
+      "model": "posthog.Team",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/team/team.py"
+    },
+    "posthog_teamdefaultevaluationcontext": {
+      "model": "feature_flags.TeamDefaultEvaluationContext",
+      "app_label": "feature_flags",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-feature-flags"
+      ],
+      "slack": "#team-feature-flags",
+      "notifications": "#team-feature-flags",
+      "source": "products/feature_flags/backend/models/evaluation_context.py"
+    },
+    "posthog_teamjssnippetconfig": {
+      "model": "posthog.TeamJsSnippetConfig",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/team/js_snippet_config.py"
+    },
+    "posthog_teammarketinganalyticsconfig": {
+      "model": "posthog.TeamMarketingAnalyticsConfig",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/team/team_marketing_analytics_config.py"
+    },
+    "posthog_teamprovisioningconfig": {
+      "model": "posthog.TeamProvisioningConfig",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/team/team_provisioning_config.py"
+    },
+    "posthog_teamrevenueanalyticsconfig": {
+      "model": "posthog.TeamRevenueAnalyticsConfig",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/team/team_revenue_analytics_config.py"
+    },
+    "posthog_text": {
+      "model": "dashboards.Text",
+      "app_label": "dashboards",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/dashboards/backend/models/dashboard_tile.py"
+    },
+    "posthog_threshold": {
+      "model": "alerts.Threshold",
+      "app_label": "alerts",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/alerts/backend/models/alert.py"
+    },
+    "posthog_uploadedmedia": {
+      "model": "posthog.UploadedMedia",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/uploaded_media.py"
+    },
+    "posthog_user": {
+      "model": "posthog.User",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/user.py"
+    },
+    "posthog_user_groups": {
+      "model": "posthog.User_groups",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "through",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/user.py"
+    },
+    "posthog_user_integration": {
+      "model": "posthog.UserIntegration",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/user_integration.py"
+    },
+    "posthog_user_push_token": {
+      "model": "posthog.UserPushToken",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/user_push_token.py"
+    },
+    "posthog_user_user_permissions": {
+      "model": "posthog.User_user_permissions",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "through",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/user.py"
+    },
+    "posthog_userfacetsettings": {
+      "model": "posthog.UserFacetSettings",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/user_facet_settings.py"
+    },
+    "posthog_usergroup": {
+      "model": "posthog.UserGroup",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/user_group/user_group.py"
+    },
+    "posthog_usergroupmembership": {
+      "model": "posthog.UserGroupMembership",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/user_group/user_group.py"
+    },
+    "posthog_userhomesettings": {
+      "model": "posthog.UserHomeSettings",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/user_home_settings.py"
+    },
+    "posthog_userproductlist": {
+      "model": "posthog.UserProductList",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/file_system/user_product_list.py"
+    },
+    "posthog_userpromptstate": {
+      "model": "posthog.UserPromptState",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/_deprecated_prompts.py"
+    },
+    "posthog_userrepopreference": {
+      "model": "posthog.UserRepoPreference",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/user_repo_preference.py"
+    },
+    "posthog_userscenepersonalisation": {
+      "model": "posthog.UserScenePersonalisation",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/user_scene_personalisation.py"
+    },
+    "posthog_webanalyticsachievementprogress": {
+      "model": "web_analytics.WebAnalyticsAchievementProgress",
+      "app_label": "web_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/web_analytics/backend/models/web_analytics_achievement_progress.py"
+    },
+    "posthog_webanalyticsfilterpreset": {
+      "model": "web_analytics.WebAnalyticsFilterPreset",
+      "app_label": "web_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/web_analytics/backend/models/web_analytics_filter_preset.py"
+    },
+    "posthog_webanalyticsinteraction": {
+      "model": "web_analytics.WebAnalyticsInteraction",
+      "app_label": "web_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/web_analytics/backend/models/web_analytics_interaction.py"
+    },
+    "posthog_webanalyticsuserconfig": {
+      "model": "web_analytics.WebAnalyticsUserConfig",
+      "app_label": "web_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/web_analytics/backend/models/web_analytics_user_config.py"
+    },
+    "posthog_webanalyticsvisit": {
+      "model": "web_analytics.WebAnalyticsVisit",
+      "app_label": "web_analytics",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-web-analytics"
+      ],
+      "slack": "#team-web-analytics",
+      "notifications": "#team-web-analytics",
+      "source": "products/web_analytics/backend/models/web_analytics_visit.py"
+    },
+    "posthog_webauthncredential": {
+      "model": "posthog.WebauthnCredential",
+      "app_label": "posthog",
+      "database": "default",
+      "kind": "django",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": "posthog/models/webauthn_credential.py"
+    },
+    "product_tours_producttour": {
+      "model": "product_tours.ProductTour",
+      "app_label": "product_tours",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-surveys"
+      ],
+      "slack": "#team-surveys",
+      "notifications": "#team-surveys",
+      "source": "products/product_tours/backend/models.py"
+    },
+    "product_tours_producttour_linked_surveys": {
+      "model": "product_tours.ProductTour_linked_surveys",
+      "app_label": "product_tours",
+      "database": "default",
+      "kind": "through",
+      "owners": [
+        "team-surveys"
+      ],
+      "slack": "#team-surveys",
+      "notifications": "#team-surveys",
+      "source": "products/product_tours/backend/models.py"
+    },
+    "pulse_briefconfig": {
+      "model": "pulse.BriefConfig",
+      "app_label": "pulse",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/pulse/backend/models.py"
+    },
+    "pulse_opportunity": {
+      "model": "pulse.Opportunity",
+      "app_label": "pulse",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/pulse/backend/models.py"
+    },
+    "pulse_productbrief": {
+      "model": "pulse.ProductBrief",
+      "app_label": "pulse",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/pulse/backend/models.py"
+    },
+    "pulse_resourcelink": {
+      "model": "pulse.ResourceLink",
+      "app_label": "pulse",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-analytics-platform"
+      ],
+      "slack": "#team-analytics-platform",
+      "notifications": "#team-analytics-platform",
+      "source": "products/pulse/backend/models.py"
+    },
+    "reminders_reminder": {
+      "model": "reminders.Reminder",
+      "app_label": "reminders",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-platform-features"
+      ],
+      "slack": "#team-platform-features",
+      "notifications": "#team-platform-features",
+      "source": "products/reminders/backend/models/reminder.py"
+    },
+    "replay_vision_replayobservation": {
+      "model": "replay_vision.ReplayObservation",
+      "app_label": "replay_vision",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-replay"
+      ],
+      "slack": "#team-replay",
+      "notifications": "#team-replay",
+      "source": "products/replay_vision/backend/models/replay_observation.py"
+    },
+    "replay_vision_replayobservationlabel": {
+      "model": "replay_vision.ReplayObservationLabel",
+      "app_label": "replay_vision",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-replay"
+      ],
+      "slack": "#team-replay",
+      "notifications": "#team-replay",
+      "source": "products/replay_vision/backend/models/replay_observation_label.py"
+    },
+    "replay_vision_replayobservationusage": {
+      "model": "replay_vision.ReplayObservationUsage",
+      "app_label": "replay_vision",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-replay"
+      ],
+      "slack": "#team-replay",
+      "notifications": "#team-replay",
+      "source": "products/replay_vision/backend/models/replay_observation_usage.py"
+    },
+    "replay_vision_replayscanner": {
+      "model": "replay_vision.ReplayScanner",
+      "app_label": "replay_vision",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-replay"
+      ],
+      "slack": "#team-replay",
+      "notifications": "#team-replay",
+      "source": "products/replay_vision/backend/models/replay_scanner.py"
+    },
+    "replay_vision_replayscannerbackfill": {
+      "model": "replay_vision.ReplayScannerBackfill",
+      "app_label": "replay_vision",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-replay"
+      ],
+      "slack": "#team-replay",
+      "notifications": "#team-replay",
+      "source": "products/replay_vision/backend/models/replay_scanner_backfill.py"
+    },
+    "replay_vision_replayscannerpromptsuggestion": {
+      "model": "replay_vision.ReplayScannerPromptSuggestion",
+      "app_label": "replay_vision",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-replay"
+      ],
+      "slack": "#team-replay",
+      "notifications": "#team-replay",
+      "source": "products/replay_vision/backend/models/replay_scanner_prompt_suggestion.py"
+    },
+    "replay_vision_visionalertconfiguration": {
+      "model": "replay_vision.VisionAlertConfiguration",
+      "app_label": "replay_vision",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-replay"
+      ],
+      "slack": "#team-replay",
+      "notifications": "#team-replay",
+      "source": "products/replay_vision/backend/models/vision_alert.py"
+    },
+    "replay_vision_visionalertevent": {
+      "model": "replay_vision.VisionAlertEvent",
+      "app_label": "replay_vision",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-replay"
+      ],
+      "slack": "#team-replay",
+      "notifications": "#team-replay",
+      "source": "products/replay_vision/backend/models/vision_alert.py"
+    },
+    "replay_vision_visionalertmatch": {
+      "model": "replay_vision.VisionAlertMatch",
+      "app_label": "replay_vision",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-replay"
+      ],
+      "slack": "#team-replay",
+      "notifications": "#team-replay",
+      "source": "products/replay_vision/backend/models/vision_alert.py"
+    },
+    "review_hog_reviewreport": {
+      "model": "review_hog.ReviewReport",
+      "app_label": "review_hog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/review_hog/backend/models.py"
+    },
+    "review_hog_reviewreportartefact": {
+      "model": "review_hog.ReviewReportArtefact",
+      "app_label": "review_hog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/review_hog/backend/models.py"
+    },
+    "review_hog_reviewskillconfig": {
+      "model": "review_hog.ReviewSkillConfig",
+      "app_label": "review_hog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/review_hog/backend/models.py"
+    },
+    "review_hog_reviewusersettings": {
+      "model": "review_hog.ReviewUserSettings",
+      "app_label": "review_hog",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/review_hog/backend/models.py"
+    },
+    "signals_signalemissionrecord": {
+      "model": "signals.SignalEmissionRecord",
+      "app_label": "signals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/signals/backend/models.py"
+    },
+    "signals_signalprojectprofile": {
+      "model": "signals.SignalProjectProfile",
+      "app_label": "signals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/signals/backend/models.py"
+    },
+    "signals_signalreport": {
+      "model": "signals.SignalReport",
+      "app_label": "signals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/signals/backend/models.py"
+    },
+    "signals_signalreportaction": {
+      "model": "signals.SignalReportAction",
+      "app_label": "signals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/signals/backend/models.py"
+    },
+    "signals_signalreportartefact": {
+      "model": "signals.SignalReportArtefact",
+      "app_label": "signals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/signals/backend/models.py"
+    },
+    "signals_signalreportassignment": {
+      "model": "signals.SignalReportAssignment",
+      "app_label": "signals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/signals/backend/models.py"
+    },
+    "signals_signalreportrefund": {
+      "model": "signals.SignalReportRefund",
+      "app_label": "signals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/signals/backend/models.py"
+    },
+    "signals_signalreporttask": {
+      "model": "signals.SignalReportTask",
+      "app_label": "signals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/signals/backend/models.py"
+    },
+    "signals_signalrepositoryareaactivity": {
+      "model": "signals.SignalRepositoryAreaActivity",
+      "app_label": "signals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/signals/backend/models.py"
+    },
+    "signals_signalscoutconfig": {
+      "model": "signals.SignalScoutConfig",
+      "app_label": "signals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/signals/backend/models.py"
+    },
+    "signals_signalscoutemission": {
+      "model": "signals.SignalScoutEmission",
+      "app_label": "signals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/signals/backend/models.py"
+    },
+    "signals_signalscoutnote": {
+      "model": "signals.SignalScoutNote",
+      "app_label": "signals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/signals/backend/models.py"
+    },
+    "signals_signalscoutrun": {
+      "model": "signals.SignalScoutRun",
+      "app_label": "signals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/signals/backend/models.py"
+    },
+    "signals_signalscoutsuggestionset": {
+      "model": "signals.SignalScoutSuggestionSet",
+      "app_label": "signals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/signals/backend/models.py"
+    },
+    "signals_signalscratchpad": {
+      "model": "signals.SignalScratchpad",
+      "app_label": "signals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/signals/backend/models.py"
+    },
+    "signals_signalsourceconfig": {
+      "model": "signals.SignalSourceConfig",
+      "app_label": "signals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/signals/backend/models.py"
+    },
+    "signals_signalteamconfig": {
+      "model": "signals.SignalTeamConfig",
+      "app_label": "signals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/signals/backend/models.py"
+    },
+    "signals_signaluserautonomyconfig": {
+      "model": "signals.SignalUserAutonomyConfig",
+      "app_label": "signals",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/signals/backend/models.py"
+    },
+    "slack_app_slackchannel": {
+      "model": "slack_app.SlackChannel",
+      "app_label": "slack_app",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/slack_app/backend/models.py"
+    },
+    "slack_app_slacksettings": {
+      "model": "slack_app.SlackSettings",
+      "app_label": "slack_app",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/slack_app/backend/models.py"
+    },
+    "slack_app_slackthreadtaskmapping": {
+      "model": "slack_app.SlackThreadTaskMapping",
+      "app_label": "slack_app",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/slack_app/backend/models.py"
+    },
+    "slack_app_slackuserprofilecache": {
+      "model": "slack_app.SlackUserProfileCache",
+      "app_label": "slack_app",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-self-driving"
+      ],
+      "slack": "#team-self-driving",
+      "notifications": "#team-self-driving",
+      "source": "products/slack_app/backend/models.py"
+    },
+    "social_auth_association": {
+      "model": "social_django.Association",
+      "app_label": "social_django",
+      "database": "default",
+      "kind": "third_party",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": null
+    },
+    "social_auth_code": {
+      "model": "social_django.Code",
+      "app_label": "social_django",
+      "database": "default",
+      "kind": "third_party",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": null
+    },
+    "social_auth_nonce": {
+      "model": "social_django.Nonce",
+      "app_label": "social_django",
+      "database": "default",
+      "kind": "third_party",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": null
+    },
+    "social_auth_partial": {
+      "model": "social_django.Partial",
+      "app_label": "social_django",
+      "database": "default",
+      "kind": "third_party",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": null
+    },
+    "social_auth_usersocialauth": {
+      "model": "social_django.UserSocialAuth",
+      "app_label": "social_django",
+      "database": "default",
+      "kind": "third_party",
+      "owners": [],
+      "slack": null,
+      "notifications": null,
+      "source": null
+    },
+    "sourcebatch": {
+      "model": "warehouse_sources_queue.SourceBatch",
+      "app_label": "warehouse_sources_queue",
+      "database": "warehouse_sources_queue",
+      "kind": "django",
+      "owners": [
+        "team-warehouse-sources"
+      ],
+      "slack": "#team-warehouse-sources",
+      "notifications": "#team-warehouse-sources",
+      "source": "products/warehouse_sources_queue/backend/models.py"
+    },
+    "sourcebatchstatus": {
+      "model": "warehouse_sources_queue.SourceBatchStatus",
+      "app_label": "warehouse_sources_queue",
+      "database": "warehouse_sources_queue",
+      "kind": "django",
+      "owners": [
+        "team-warehouse-sources"
+      ],
+      "slack": "#team-warehouse-sources",
+      "notifications": "#team-warehouse-sources",
+      "source": "products/warehouse_sources_queue/backend/models.py"
+    },
+    "sourcegrouplease": {
+      "model": "warehouse_sources_queue.SourceGroupLease",
+      "app_label": "warehouse_sources_queue",
+      "database": "warehouse_sources_queue",
+      "kind": "django",
+      "owners": [
+        "team-warehouse-sources"
+      ],
+      "slack": "#team-warehouse-sources",
+      "notifications": "#team-warehouse-sources",
+      "source": "products/warehouse_sources_queue/backend/models.py"
+    },
+    "stamphog_digestrun": {
+      "model": "stamphog.DigestRun",
+      "app_label": "stamphog",
+      "database": "stamphog",
+      "kind": "django",
+      "owners": [
+        "team-devex"
+      ],
+      "slack": "#team-devex",
+      "notifications": "#team-devex",
+      "source": "products/stamphog/backend/models.py"
+    },
+    "stamphog_pullrequest": {
+      "model": "stamphog.PullRequest",
+      "app_label": "stamphog",
+      "database": "stamphog",
+      "kind": "django",
+      "owners": [
+        "team-devex"
+      ],
+      "slack": "#team-devex",
+      "notifications": "#team-devex",
+      "source": "products/stamphog/backend/models.py"
+    },
+    "stamphog_pullrequestaudience": {
+      "model": "stamphog.PullRequestAudience",
+      "app_label": "stamphog",
+      "database": "stamphog",
+      "kind": "django",
+      "owners": [
+        "team-devex"
+      ],
+      "slack": "#team-devex",
+      "notifications": "#team-devex",
+      "source": "products/stamphog/backend/models.py"
+    },
+    "stamphog_reviewrun": {
+      "model": "stamphog.ReviewRun",
+      "app_label": "stamphog",
+      "database": "stamphog",
+      "kind": "django",
+      "owners": [
+        "team-devex"
+      ],
+      "slack": "#team-devex",
+      "notifications": "#team-devex",
+      "source": "products/stamphog/backend/models.py"
+    },
+    "stamphog_stamphogrepoconfig": {
+      "model": "stamphog.StamphogRepoConfig",
+      "app_label": "stamphog",
+      "database": "stamphog",
+      "kind": "django",
+      "owners": [
+        "team-devex"
+      ],
+      "slack": "#team-devex",
+      "notifications": "#team-devex",
+      "source": "products/stamphog/backend/models.py"
+    },
+    "streamlit_apps_streamlitapp": {
+      "model": "streamlit_apps.StreamlitApp",
+      "app_label": "streamlit_apps",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-tools"
+      ],
+      "slack": "#team-data-tools",
+      "notifications": "#team-data-tools",
+      "source": "products/streamlit_apps/backend/models.py"
+    },
+    "streamlit_apps_streamlitappsandbox": {
+      "model": "streamlit_apps.StreamlitAppSandbox",
+      "app_label": "streamlit_apps",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-tools"
+      ],
+      "slack": "#team-data-tools",
+      "notifications": "#team-data-tools",
+      "source": "products/streamlit_apps/backend/models.py"
+    },
+    "streamlit_apps_streamlitappversion": {
+      "model": "streamlit_apps.StreamlitAppVersion",
+      "app_label": "streamlit_apps",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-data-tools"
+      ],
+      "slack": "#team-data-tools",
+      "notifications": "#team-data-tools",
+      "source": "products/streamlit_apps/backend/models.py"
+    },
+    "tasks_desktopbetatermsacceptance": {
+      "model": "tasks.DesktopBetaTermsAcceptance",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "tasks_teamtasksconfig": {
+      "model": "tasks.TeamTasksConfig",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "tasks_usertasksconfig": {
+      "model": "tasks.UserTasksConfig",
+      "app_label": "tasks",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-posthog-desktop"
+      ],
+      "slack": "#team-desktop",
+      "notifications": "#team-desktop",
+      "source": "products/tasks/backend/models.py"
+    },
+    "tracing_teamtracingconfig": {
+      "model": "tracing.TeamTracingConfig",
+      "app_label": "tracing",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-apm"
+      ],
+      "slack": "#team-apm",
+      "notifications": "#team-apm",
+      "source": "products/tracing/backend/models.py"
+    },
+    "tracing_tracingview": {
+      "model": "tracing.TracingView",
+      "app_label": "tracing",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-apm"
+      ],
+      "slack": "#team-apm",
+      "notifications": "#team-apm",
+      "source": "products/tracing/backend/models.py"
+    },
+    "user_interviews_intervieweecontext": {
+      "model": "user_interviews.IntervieweeContext",
+      "app_label": "user_interviews",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "@pauldambra",
+        "@fivestarspicy",
+        "@ksvat"
+      ],
+      "slack": null,
+      "notifications": null,
+      "source": "products/user_interviews/backend/models.py"
+    },
+    "user_interviews_userinterview": {
+      "model": "user_interviews.UserInterview",
+      "app_label": "user_interviews",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "@pauldambra",
+        "@fivestarspicy",
+        "@ksvat"
+      ],
+      "slack": null,
+      "notifications": null,
+      "source": "products/user_interviews/backend/models.py"
+    },
+    "user_interviews_userinterviewtopic": {
+      "model": "user_interviews.UserInterviewTopic",
+      "app_label": "user_interviews",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "@pauldambra",
+        "@fivestarspicy",
+        "@ksvat"
+      ],
+      "slack": null,
+      "notifications": null,
+      "source": "products/user_interviews/backend/models.py"
+    },
+    "visual_review_artifact": {
+      "model": "visual_review.Artifact",
+      "app_label": "visual_review",
+      "database": "visual_review",
+      "kind": "django",
+      "owners": [
+        "team-devex"
+      ],
+      "slack": "#team-devex",
+      "notifications": "#team-devex",
+      "source": "products/visual_review/backend/models.py"
+    },
+    "visual_review_quarantinedidentifier": {
+      "model": "visual_review.QuarantinedIdentifier",
+      "app_label": "visual_review",
+      "database": "visual_review",
+      "kind": "django",
+      "owners": [
+        "team-devex"
+      ],
+      "slack": "#team-devex",
+      "notifications": "#team-devex",
+      "source": "products/visual_review/backend/models.py"
+    },
+    "visual_review_repo": {
+      "model": "visual_review.Repo",
+      "app_label": "visual_review",
+      "database": "visual_review",
+      "kind": "django",
+      "owners": [
+        "team-devex"
+      ],
+      "slack": "#team-devex",
+      "notifications": "#team-devex",
+      "source": "products/visual_review/backend/models.py"
+    },
+    "visual_review_run": {
+      "model": "visual_review.Run",
+      "app_label": "visual_review",
+      "database": "visual_review",
+      "kind": "django",
+      "owners": [
+        "team-devex"
+      ],
+      "slack": "#team-devex",
+      "notifications": "#team-devex",
+      "source": "products/visual_review/backend/models.py"
+    },
+    "visual_review_runsnapshot": {
+      "model": "visual_review.RunSnapshot",
+      "app_label": "visual_review",
+      "database": "visual_review",
+      "kind": "django",
+      "owners": [
+        "team-devex"
+      ],
+      "slack": "#team-devex",
+      "notifications": "#team-devex",
+      "source": "products/visual_review/backend/models.py"
+    },
+    "visual_review_toleratedhash": {
+      "model": "visual_review.ToleratedHash",
+      "app_label": "visual_review",
+      "database": "visual_review",
+      "kind": "django",
+      "owners": [
+        "team-devex"
+      ],
+      "slack": "#team-devex",
+      "notifications": "#team-devex",
+      "source": "products/visual_review/backend/models.py"
+    },
+    "warehouse_sources_customoauth2integration": {
+      "model": "warehouse_sources.CustomOAuth2Integration",
+      "app_label": "warehouse_sources",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-warehouse-sources"
+      ],
+      "slack": "#team-warehouse-sources",
+      "notifications": "#team-warehouse-sources",
+      "source": "products/warehouse_sources/backend/models/custom_oauth2_integration.py"
+    },
+    "warehouse_sources_externaldataschemaoomevent": {
+      "model": "warehouse_sources.ExternalDataSchemaOOMEvent",
+      "app_label": "warehouse_sources",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-warehouse-sources"
+      ],
+      "slack": "#team-warehouse-sources",
+      "notifications": "#team-warehouse-sources",
+      "source": "products/warehouse_sources/backend/models/oom_event.py"
+    },
+    "warehouse_sources_pendingsourcecredential": {
+      "model": "warehouse_sources.PendingSourceCredential",
+      "app_label": "warehouse_sources",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-warehouse-sources"
+      ],
+      "slack": "#team-warehouse-sources",
+      "notifications": "#team-warehouse-sources",
+      "source": "products/warehouse_sources/backend/models/pending_source_credential.py"
+    },
+    "warehouse_sources_warehousecolumnannotation": {
+      "model": "warehouse_sources.WarehouseColumnAnnotation",
+      "app_label": "warehouse_sources",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-warehouse-sources"
+      ],
+      "slack": "#team-warehouse-sources",
+      "notifications": "#team-warehouse-sources",
+      "source": "products/warehouse_sources/backend/models/column_annotation.py"
+    },
+    "warehouse_sources_warehousecolumnstatistics": {
+      "model": "warehouse_sources.WarehouseColumnStatistics",
+      "app_label": "warehouse_sources",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-warehouse-sources"
+      ],
+      "slack": "#team-warehouse-sources",
+      "notifications": "#team-warehouse-sources",
+      "source": "products/warehouse_sources/backend/models/column_statistics.py"
+    },
+    "wizard_wizardrun": {
+      "model": "wizard.WizardRun",
+      "app_label": "wizard",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-growth"
+      ],
+      "slack": "#team-growth",
+      "notifications": "#team-growth",
+      "source": "products/wizard/backend/models.py"
+    },
+    "wizard_wizardrunartifact": {
+      "model": "wizard.WizardRunArtifact",
+      "app_label": "wizard",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-growth"
+      ],
+      "slack": "#team-growth",
+      "notifications": "#team-growth",
+      "source": "products/wizard/backend/models.py"
+    },
+    "wizard_wizardsession": {
+      "model": "wizard.WizardSession",
+      "app_label": "wizard",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-growth"
+      ],
+      "slack": "#team-growth",
+      "notifications": "#team-growth",
+      "source": "products/wizard/backend/models.py"
+    },
+    "wizard_wizardworker": {
+      "model": "wizard.WizardWorker",
+      "app_label": "wizard",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-growth"
+      ],
+      "slack": "#team-growth",
+      "notifications": "#team-growth",
+      "source": "products/wizard/backend/models.py"
+    },
+    "workflows_hogflowbatchjob": {
+      "model": "workflows.HogFlowBatchJob",
+      "app_label": "workflows",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/workflows/backend/models/hog_flow_batch_job/hog_flow_batch_job.py"
+    },
+    "workflows_hogflowrevision": {
+      "model": "workflows.HogFlowRevision",
+      "app_label": "workflows",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/workflows/backend/models/hog_flow_revision.py"
+    },
+    "workflows_hogflowschedule": {
+      "model": "workflows.HogFlowSchedule",
+      "app_label": "workflows",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/workflows/backend/models/hog_flow_schedule/hog_flow_schedule.py"
+    },
+    "workflows_teamworkflowsconfig": {
+      "model": "workflows.TeamWorkflowsConfig",
+      "app_label": "workflows",
+      "database": "default",
+      "kind": "django",
+      "owners": [
+        "team-workflows"
+      ],
+      "slack": "#team-workflows",
+      "notifications": "#team-workflows",
+      "source": "products/workflows/backend/models/team_workflows_config.py"
+    }
+  }
+}


### PR DESCRIPTION
## Problem

- Nobody can answer "which team owns this Postgres table" from the repo. The owners resolver behind `hogli owners:who` answers for files and directories, not tables.
- pgcollector wants to route a database finding, such as a slow query or a table nearing a size limit, to the team that owns the table. The next layer of this stack, #97068, consumes the map this PR generates.

## Changes

- `hogli owners:tables` writes `rust/pgcollector/ownership/table_owners.json`: one entry per table Django knows about, with the owning team, Slack channel, database, and the model's source file.
- A table is owned by whoever owns the file that declares its model. The command joins Django's model registry to the existing owners resolver and needs no database connection.
- Auto-created M2M through tables inherit the declaring model's owner. Models from site-packages are marked third party.
- `hogli owners:tables --report` lists the tables with no owner. Today that is 105 of 558, mostly core models under `posthog/models/` with no `owners.yaml` entry yet.
- A repo invariant test regenerates the map in CI and fails when the committed file is stale, so a new or moved model has to rerun the command.
- The generated JSON is the mechanical part of the diff. Nothing user-visible changes.

## How did you test this code?

- `posthog/test/repo_invariants/test_table_owners_json.py` catches a committed map that drifts from the model registry or the ownership files. It passes locally.
- Not checked: the map was not compared against a live database. It reads the model registry only.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The pgcollector README in #97068 documents the command. None needed here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5.1). Skills invoked: /stacking-prs, /writing-pr-descriptions.
- This is the bottom layer of one larger branch split into three. The split moved no logic. A search of open PRs found nothing covering it.

https://claude.ai/code/session_019YJkcNok1ZzR6iBXES1Cmi
