### PR TITLE
feat(pgcollector): resolve which team owns a table or a SQL statement

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9045,6 +9045,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "shellexpand",
+ "sqlparser",
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
@@ -11850,6 +11851,18 @@ checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
 dependencies = [
  "log",
  "recursive",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/rust/pgcollector/Cargo.toml
+++ b/rust/pgcollector/Cargo.toml
@@ -30,6 +30,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = "0.9"
 shellexpand = "3"
+sqlparser = { version = "0.61", features = ["visitor"] }
 tokio = { workspace = true }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
 tokio-postgres-rustls = "0.13"

--- a/rust/pgcollector/README.md
+++ b/rust/pgcollector/README.md
@@ -59,6 +59,28 @@ diffs) are Rust in `src/collectors/` implementing the same `Collector` trait.
 Validate a `log_line_prefix` against a log file:
 `pgcollector --parse-log postgresql.log --log-line-prefix '%t:%r:%u@%d:[%p]:%Q:'`.
 
+## Table ownership
+
+`src/ownership/` maps a table, and from there a SQL statement, to the PostHog
+team that owns it, so a finding can reach the right rotation and Slack channel.
+
+`ownership/table_owners.json` is generated from the Django model registry and
+the repo's `owners.yaml` files: run `hogli owners:tables` after adding or
+moving a model (a repo invariant test fails when it is stale; `--report` lists
+unowned tables). `ownership/overrides.yaml` adds hubs, tables created by Rust
+migrations, the team -> incident.io rotation map, and channel overrides. Both
+are compiled into the binary; `[ownership] dir` replaces them at runtime.
+
+Attribution of a statement, first match wins: `databases` in `overrides.yaml`
+(whole database or server), an `owner='team-x'` marker in a leading SQL
+comment, then the tables the statement touches. The DML target wins, else the
+driving table of the outermost `FROM`, joins after it; hub tables (`posthog_team`,
+`posthog_user`, ...) only decide when nothing else does. Ask it directly:
+
+```sh
+pgcollector --attribute "SELECT * FROM posthog_survey WHERE team_id = 1" --datname posthog
+```
+
 ## Local testing
 
 `test/setup-local.sh` starts a throwaway PG16 with `pg_stat_statements`,

--- a/rust/pgcollector/deploy/pgcollector.example.toml
+++ b/rust/pgcollector/deploy/pgcollector.example.toml
@@ -23,3 +23,10 @@ databases = ["posthog"]
 [servers.overrides]
 activity = { interval = "5s" }
 sizes = { enabled = false }
+
+# Table -> team ownership, used to route findings. The compiled-in map comes from
+# `hogli owners:tables` plus ownership/overrides.yaml; `dir` replaces both at runtime.
+[ownership]
+fallback_rotation = "infra"
+# dir = "/etc/pgcollector/ownership"   # table_owners.json + overrides.yaml overlay
+

--- a/rust/pgcollector/ownership/overrides.yaml
+++ b/rust/pgcollector/ownership/overrides.yaml
@@ -1,0 +1,85 @@
+# Hand-written ownership on top of the generated table_owners.json. Later entries win.
+#
+# databases: a whole database (or every database on a server) belongs to one team.
+# tables:    glob on the table name. kind: owner (default) | hub | ignore.
+#            hub = a table joined from everywhere (teams, users, persons); it never decides
+#            the owner of a query on its own, so the driving table of the query wins.
+# rotations: team slug -> incident.io rotation, when it is not the slug minus "team-".
+# channels:  team slug -> Slack channel, when the owners.yaml registry is wrong or missing.
+
+databases:
+  - server: persons
+    team: team-ingestion
+  - datname: posthog_stamphog
+    team: team-self-driving
+  - datname: posthog_visual_review
+    team: team-self-driving
+  - datname: posthog_warehouse_sources_queue
+    team: team-warehouse-sources
+
+tables:
+  # Hubs: every product joins these.
+  - match: posthog_team
+    kind: hub
+  - match: posthog_project
+    kind: hub
+  - match: "posthog_organization*"
+    kind: hub
+  - match: posthog_user
+    kind: hub
+  - match: "posthog_person*"
+    kind: hub
+    team: team-ingestion
+  - match: "posthog_tag*"
+    kind: hub
+  - match: "django_*"
+    kind: hub
+  - match: "auth_*"
+    kind: hub
+  - match: "social_auth_*"
+    kind: hub
+  - match: "axes_*"
+    kind: hub
+  - match: "otp_*"
+    kind: hub
+  - match: "oauth2_provider_*"
+    kind: hub
+  # Tables created by Rust sqlx migrations, not Django.
+  - match: "personhog_*"
+    team: team-ingestion
+  - match: "lifecycle_op*"
+    team: team-ingestion
+  - match: person_pg_cleanup_queue
+    team: team-ingestion
+  - match: "cohort_membership*"
+    team: team-feature-flags
+  - match: "cyclotron_*"
+    team: team-workflows
+  - match: "flags_*"
+    team: team-feature-flags
+  # The stats DB itself, if it is ever monitored.
+  - match: "ts_*"
+    team: team-ingestion
+  - match: "cur_*"
+    team: team-ingestion
+  - match: query_findings
+    team: team-ingestion
+  # Core tables without an owners.yaml entry yet. Claim them in posthog/models/owners.yaml
+  # and drop the line here.
+  - match: posthog_asyncdeletion
+    team: team-ingestion
+
+rotations:
+  team-ai-observability: llm-analytics
+  team-self-driving: max-ai
+  team-error-tracking: error-tracking
+  team-platform-features: platform-features
+  team-web-analytics: product-analytics
+  team-analytics-platform: analytics-platform
+  team-data-modeling: data-modeling
+  team-warehouse-sources: data-modeling
+  conversations: max-ai
+  clickhouse: clickhouse
+  ai-research: ai-research
+
+channels: {}

--- a/rust/pgcollector/src/config.rs
+++ b/rust/pgcollector/src/config.rs
@@ -13,6 +13,8 @@ pub struct Config {
     pub http: HttpConfig,
     #[serde(default)]
     pub servers: Vec<ServerConfig>,
+    #[serde(default)]
+    pub ownership: OwnershipConfig,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -118,6 +120,28 @@ pub struct LogsConfig {
 }
 fn default_prefix() -> String {
     "%t:%r:%u@%d:[%p]:".into()
+}
+
+/// Table -> team ownership: the generated `table_owners.json` plus `overrides.yaml`,
+/// compiled in unless `dir` points at replacements.
+#[derive(Debug, Deserialize, Clone)]
+pub struct OwnershipConfig {
+    /// Directory with `table_owners.json` / `overrides.yaml` replacing the compiled-in ones.
+    pub dir: Option<std::path::PathBuf>,
+    /// Rotation for anything no team owns.
+    #[serde(default = "ownership_fallback_rotation")]
+    pub fallback_rotation: String,
+}
+impl Default for OwnershipConfig {
+    fn default() -> Self {
+        Self {
+            dir: None,
+            fallback_rotation: ownership_fallback_rotation(),
+        }
+    }
+}
+fn ownership_fallback_rotation() -> String {
+    "infra".into()
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]

--- a/rust/pgcollector/src/main.rs
+++ b/rust/pgcollector/src/main.rs
@@ -3,6 +3,7 @@ mod collectors;
 mod config;
 mod http;
 mod logs;
+mod ownership;
 mod pg;
 mod scheduler;
 mod sink;
@@ -33,6 +34,15 @@ struct Cli {
     /// Run every collector once against every server, print row counts, exit (no sink writes)
     #[arg(long)]
     once: bool,
+    /// Print which team owns a SQL statement (per [ownership]) as JSON, then exit
+    #[arg(long, value_name = "SQL")]
+    attribute: Option<String>,
+    /// Server id the --attribute statement runs on ([ownership] database rules match on it)
+    #[arg(long, default_value = "")]
+    server: String,
+    /// Database the --attribute statement runs in
+    #[arg(long, default_value = "posthog")]
+    datname: String,
     /// Parse a Postgres log file with --log-line-prefix and print what was classified, then exit
     #[arg(long)]
     parse_log: Option<PathBuf>,
@@ -100,6 +110,10 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
+    if let Some(sql) = &cli.attribute {
+        return attribute(&cfg, &cli.server, &cli.datname, sql);
+    }
+
     let sink: Arc<dyn sink::Sink> = if cli.once {
         Arc::new(sink::StdoutSink)
     } else {
@@ -117,6 +131,26 @@ async fn main() -> Result<()> {
     }
 
     scheduler::run(Arc::new(cfg), Arc::new(registry), sink, ready, cli.once).await
+}
+
+fn attribute(cfg: &config::Config, server: &str, datname: &str, sql: &str) -> Result<()> {
+    let own = ownership::Ownership::load(&cfg.ownership)?;
+    let ex = ownership::extract(sql);
+    let attr = own.attribute(server, datname, &ex);
+    let out = serde_json::json!({
+        "team": attr.team,
+        "rotation": own.rotation(&attr.team),
+        "slack_channel": own.slack_channel(&attr.team),
+        "method": attr.method,
+        "reason": attr.reason,
+        "primary_table": attr.primary_table,
+        "tables": attr.tables,
+        "parser": attr.parser,
+        "catalog_only": ex.catalog_only(),
+        "tables_known": own.table_count(),
+    });
+    println!("{}", serde_json::to_string_pretty(&out)?);
+    Ok(())
 }
 
 fn parse_log(path: &std::path::Path, prefix: &str) -> Result<()> {

--- a/rust/pgcollector/src/ownership/mod.rs
+++ b/rust/pgcollector/src/ownership/mod.rs
@@ -1,0 +1,5 @@
+pub mod owners;
+pub mod tables;
+
+pub use owners::Ownership;
+pub use tables::extract;

--- a/rust/pgcollector/src/ownership/owners.rs
+++ b/rust/pgcollector/src/ownership/owners.rs
@@ -1,0 +1,375 @@
+//! Table -> team, from the generated `table_owners.json` plus hand-written `overrides.yaml`.
+
+use super::tables::{is_catalog, Extracted};
+use crate::config::OwnershipConfig;
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap};
+
+const TABLE_OWNERS_JSON: &str = include_str!("../../ownership/table_owners.json");
+const OVERRIDES_YAML: &str = include_str!("../../ownership/overrides.yaml");
+
+pub const UNOWNED: &str = "unowned";
+
+#[derive(Deserialize)]
+struct TableOwnersFile {
+    tables: BTreeMap<String, TableRecord>,
+}
+#[derive(Deserialize)]
+struct TableRecord {
+    #[serde(default)]
+    owners: Vec<String>,
+    #[serde(default)]
+    slack: Option<String>,
+    #[serde(default)]
+    notifications: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct Overrides {
+    #[serde(default)]
+    databases: Vec<DatabaseRule>,
+    #[serde(default)]
+    tables: Vec<TableRule>,
+    #[serde(default)]
+    rotations: HashMap<String, String>,
+    #[serde(default)]
+    channels: HashMap<String, String>,
+}
+#[derive(Deserialize)]
+struct DatabaseRule {
+    server: Option<String>,
+    datname: Option<String>,
+    team: String,
+}
+#[derive(Deserialize)]
+struct TableRule {
+    #[serde(rename = "match")]
+    pattern: String,
+    team: Option<String>,
+    #[serde(default)]
+    kind: RuleKind,
+}
+#[derive(Deserialize, Default, Clone, Copy, PartialEq, Eq, Debug)]
+#[serde(rename_all = "lowercase")]
+enum RuleKind {
+    #[default]
+    Owner,
+    Hub,
+    Ignore,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct TableTeam {
+    pub table: String,
+    pub team: Option<String>,
+    pub hub: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct Attribution {
+    pub team: String,
+    /// database | comment | table | unowned
+    pub method: &'static str,
+    pub primary_table: Option<String>,
+    pub tables: Vec<TableTeam>,
+    pub parser: &'static str,
+    pub reason: String,
+}
+
+pub struct Ownership {
+    tables: HashMap<String, (Option<String>, bool)>,
+    globs: Vec<(glob::Pattern, Option<String>, RuleKind)>,
+    databases: Vec<DatabaseRule>,
+    rotations: HashMap<String, String>,
+    channels: HashMap<String, String>,
+    fallback_rotation: String,
+}
+
+impl Ownership {
+    pub fn load(cfg: &OwnershipConfig) -> Result<Self> {
+        let (json, yaml) = match cfg.dir.as_deref() {
+            Some(d) => (
+                std::fs::read_to_string(d.join("table_owners.json"))
+                    .with_context(|| format!("reading {}", d.display()))?,
+                std::fs::read_to_string(d.join("overrides.yaml")).unwrap_or_default(),
+            ),
+            None => (TABLE_OWNERS_JSON.to_string(), OVERRIDES_YAML.to_string()),
+        };
+        Self::from_sources(&json, &yaml, &cfg.fallback_rotation)
+    }
+
+    pub fn from_sources(json: &str, yaml: &str, fallback_rotation: &str) -> Result<Self> {
+        let file: TableOwnersFile = serde_json::from_str(json).context("table_owners.json")?;
+        let ov: Overrides = if yaml.trim().is_empty() {
+            Overrides::default()
+        } else {
+            serde_yaml::from_str(yaml).context("overrides.yaml")?
+        };
+        let mut channels = ov.channels;
+        let mut tables = HashMap::new();
+        for (t, r) in file.tables {
+            let team = r.owners.first().cloned().filter(|o| !o.starts_with('@'));
+            if let (Some(team), Some(ch)) = (&team, r.notifications.or(r.slack)) {
+                channels.entry(team.clone()).or_insert(ch);
+            }
+            tables.insert(t, (team, false));
+        }
+        let mut globs = Vec::new();
+        for r in ov.tables {
+            let p = glob::Pattern::new(&r.pattern)
+                .with_context(|| format!("overrides.yaml pattern {}", r.pattern))?;
+            globs.push((p, r.team, r.kind));
+        }
+        Ok(Self {
+            tables,
+            globs,
+            databases: ov.databases,
+            rotations: ov.rotations,
+            channels,
+            fallback_rotation: fallback_rotation.to_string(),
+        })
+    }
+
+    pub fn table_count(&self) -> usize {
+        self.tables.len()
+    }
+
+    /// (team, hub) for one table. Globs from overrides beat the generated map.
+    fn lookup(&self, table: &str) -> Option<(Option<String>, bool)> {
+        let mut found = self.tables.get(table).cloned();
+        for (p, team, kind) in &self.globs {
+            if !p.matches(table) {
+                continue;
+            }
+            match kind {
+                RuleKind::Ignore => return None,
+                RuleKind::Hub => {
+                    let t = team
+                        .clone()
+                        .or_else(|| found.as_ref().and_then(|f| f.0.clone()));
+                    found = Some((t, true));
+                }
+                RuleKind::Owner => found = Some((team.clone(), false)),
+            }
+        }
+        found
+    }
+
+    pub fn attribute(&self, server: &str, datname: &str, ex: &Extracted) -> Attribution {
+        let tables: Vec<TableTeam> = ex
+            .ranked()
+            .into_iter()
+            .filter(|t| !is_catalog(t))
+            .filter_map(|t| {
+                self.lookup(t).map(|(team, hub)| TableTeam {
+                    table: t.to_string(),
+                    team,
+                    hub,
+                })
+            })
+            .collect();
+        let base = |team: String, method: &'static str, primary: Option<String>, reason: String| {
+            Attribution {
+                team,
+                method,
+                primary_table: primary,
+                tables: tables.clone(),
+                parser: ex.parser,
+                reason,
+            }
+        };
+        if let Some(r) = self.databases.iter().find(|r| {
+            r.server.as_deref().is_none_or(|s| s == server)
+                && r.datname.as_deref().is_none_or(|d| d == datname)
+        }) {
+            return base(
+                r.team.clone(),
+                "database",
+                None,
+                format!("database {datname} on {server} belongs to {}", r.team),
+            );
+        }
+        if let Some(m) = &ex.marker {
+            return base(
+                m.clone(),
+                "comment",
+                None,
+                format!("owner='{m}' marker in the query text"),
+            );
+        }
+        // Driving table first; hubs only when nothing else names a team.
+        let pick = tables
+            .iter()
+            .find(|t| !t.hub && t.team.is_some())
+            .or_else(|| tables.iter().find(|t| t.team.is_some()));
+        match pick {
+            Some(t) => {
+                let team = t.team.clone().unwrap_or_default();
+                let why = if t.hub {
+                    format!("only hub tables referenced; {} is owned by {team}", t.table)
+                } else if Some(&t.table) == ex.target.as_ref() {
+                    format!("writes {} (owned by {team})", t.table)
+                } else {
+                    format!("reads {} (owned by {team})", t.table)
+                };
+                base(team, "table", Some(t.table.clone()), why)
+            }
+            None => {
+                let named: Vec<&str> = tables.iter().map(|t| t.table.as_str()).collect();
+                let why = if named.is_empty() {
+                    "no known table referenced".to_string()
+                } else {
+                    format!("no owner for {}", named.join(", "))
+                };
+                base(
+                    UNOWNED.into(),
+                    "unowned",
+                    tables.first().map(|t| t.table.clone()),
+                    why,
+                )
+            }
+        }
+    }
+
+    pub fn rotation(&self, team: &str) -> String {
+        if team == UNOWNED {
+            return self.fallback_rotation.clone();
+        }
+        self.rotations
+            .get(team)
+            .cloned()
+            .unwrap_or_else(|| team.strip_prefix("team-").unwrap_or(team).to_string())
+    }
+
+    /// Channel name without the leading `#`, as incident.io expects in `slack_channel`.
+    pub fn slack_channel(&self, team: &str) -> Option<String> {
+        self.channels
+            .get(team)
+            .map(|c| c.trim_start_matches('#').to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tables::extract;
+    use super::*;
+
+    const JSON: &str = r##"{"version":1,"tables":{
+        "posthog_dashboard":{"owners":["team-analytics-platform"],"slack":"#team-analytics-platform","notifications":"#alerts-analytics"},
+        "posthog_team":{"owners":[]},
+        "posthog_person":{"owners":["team-ingestion"],"slack":"#team-ingestion"},
+        "posthog_featureflag":{"owners":["team-feature-flags"],"slack":"#team-feature-flags"},
+        "posthog_thing":{"owners":["@someone"]}
+    }}"##;
+    const YAML: &str = r#"
+databases:
+  - server: persons
+    team: team-ingestion
+tables:
+  - match: posthog_team
+    kind: hub
+  - match: "posthog_person*"
+    kind: hub
+    team: team-ingestion
+  - match: "personhog_*"
+    team: team-ingestion
+  - match: "django_*"
+    kind: ignore
+rotations:
+  team-analytics-platform: analytics
+"#;
+
+    fn own() -> Ownership {
+        Ownership::from_sources(JSON, YAML, "infra").unwrap()
+    }
+
+    #[test]
+    fn driving_table_beats_joined_hub() {
+        let a = own().attribute("cloud", "posthog", &extract(r#"SELECT 1 FROM "posthog_dashboard" INNER JOIN "posthog_team" ON true WHERE "posthog_dashboard"."id" = $1"#));
+        assert_eq!(a.team, "team-analytics-platform");
+        assert_eq!(a.method, "table");
+        assert_eq!(a.primary_table.as_deref(), Some("posthog_dashboard"));
+        assert_eq!(a.tables.len(), 2);
+        assert!(a.tables[1].hub);
+    }
+
+    #[test]
+    fn dml_target_and_hub_only_queries() {
+        let a = own().attribute(
+            "cloud",
+            "posthog",
+            &extract(
+                r#"UPDATE "posthog_featureflag" SET "active" = $1 FROM "posthog_team" WHERE 1=1"#,
+            ),
+        );
+        assert_eq!(a.team, "team-feature-flags");
+        assert!(a.reason.starts_with("writes posthog_featureflag"));
+        let a = own().attribute(
+            "cloud",
+            "posthog",
+            &extract(r#"SELECT 1 FROM "posthog_team" WHERE id = $1"#),
+        );
+        assert_eq!(a.team, UNOWNED);
+        assert_eq!(a.method, "unowned");
+        let a = own().attribute(
+            "cloud",
+            "posthog",
+            &extract(r#"SELECT 1 FROM "posthog_person" WHERE id = $1"#),
+        );
+        assert_eq!((a.team.as_str(), a.method), ("team-ingestion", "table"));
+        assert!(a.reason.starts_with("only hub tables"));
+    }
+
+    #[test]
+    fn database_rule_marker_and_globs_take_precedence() {
+        let o = own();
+        let a = o.attribute("persons", "d63d9", &extract("SELECT 1 FROM whatever"));
+        assert_eq!((a.team.as_str(), a.method), ("team-ingestion", "database"));
+        let a = o.attribute(
+            "cloud",
+            "posthog",
+            &extract("/*owner='team-x'*/ SELECT 1 FROM posthog_dashboard"),
+        );
+        assert_eq!((a.team.as_str(), a.method), ("team-x", "comment"));
+        let a = o.attribute(
+            "cloud",
+            "posthog",
+            &extract("SELECT 1 FROM personhog_lease"),
+        );
+        assert_eq!(a.team, "team-ingestion");
+        let a = o.attribute("cloud", "posthog", &extract("SELECT 1 FROM django_session"));
+        assert_eq!(a.method, "unowned");
+        assert!(a.tables.is_empty());
+    }
+
+    #[test]
+    fn handles_are_not_teams_and_channels_come_from_the_registry() {
+        let o = own();
+        let a = o.attribute("cloud", "posthog", &extract("SELECT 1 FROM posthog_thing"));
+        assert_eq!(a.team, UNOWNED);
+        assert_eq!(
+            o.slack_channel("team-analytics-platform").as_deref(),
+            Some("alerts-analytics")
+        );
+        assert_eq!(
+            o.slack_channel("team-ingestion").as_deref(),
+            Some("team-ingestion")
+        );
+        assert_eq!(o.rotation("team-analytics-platform"), "analytics");
+        assert_eq!(o.rotation("team-ingestion"), "ingestion");
+        assert_eq!(o.rotation(UNOWNED), "infra");
+    }
+
+    #[test]
+    fn compiled_in_files_load() {
+        let o = Ownership::load(&OwnershipConfig::default()).unwrap();
+        assert!(o.table_count() > 100);
+        let a = o.attribute(
+            "cloud",
+            "posthog",
+            &extract(r#"SELECT 1 FROM "posthog_person" INNER JOIN "posthog_team" ON true"#),
+        );
+        assert_eq!(a.team, "team-ingestion");
+    }
+}

--- a/rust/pgcollector/src/ownership/tables.rs
+++ b/rust/pgcollector/src/ownership/tables.rs
@@ -1,0 +1,304 @@
+//! Which relations a statement touches, and which one drives it.
+//!
+//! sqlparser handles the Django/ORM shapes we see in pg_stat_statements text (`$1`
+//! placeholders, `= ANY($1)`, `::jsonb`, quoted identifiers). Text is capped at 10 KiB
+//! in `cur_queries` and may be truncated mid-statement, so a regex over the leading
+//! keywords is the fallback.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use sqlparser::ast::{
+    visit_relations, Delete, FromTable, Insert, ObjectName, Query, SetExpr, Statement, TableFactor,
+    TableObject, TableWithJoins, Update,
+};
+use sqlparser::dialect::PostgreSqlDialect;
+use sqlparser::parser::Parser;
+use std::ops::ControlFlow;
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Extracted {
+    /// The DML target of an INSERT/UPDATE/DELETE.
+    pub target: Option<String>,
+    /// Relations of the outermost FROM, driving table first, joins after it.
+    pub outer: Vec<String>,
+    /// Relations only referenced from subqueries or CTEs.
+    pub inner: Vec<String>,
+    pub parser: &'static str,
+    /// `owner='team-x'` from a sqlcommenter-style leading comment.
+    pub marker: Option<String>,
+}
+
+impl Extracted {
+    /// Every relation, most authoritative first, without duplicates.
+    pub fn ranked(&self) -> Vec<&str> {
+        let mut out: Vec<&str> = Vec::new();
+        for t in self
+            .target
+            .iter()
+            .chain(self.outer.iter())
+            .chain(self.inner.iter())
+        {
+            if !out.contains(&t.as_str()) {
+                out.push(t);
+            }
+        }
+        out
+    }
+
+    /// Only `pg_catalog` / `information_schema` relations: introspection, not workload.
+    pub fn catalog_only(&self) -> bool {
+        let all = self.ranked();
+        !all.is_empty() && all.iter().all(|t| is_catalog(t))
+    }
+}
+
+pub fn is_catalog(table: &str) -> bool {
+    table.starts_with("pg_") || table.starts_with("information_schema.")
+}
+
+static MARKER: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"(?i)/\*.*?\bowner\s*[=:]\s*'?([a-z0-9@_-]+)'?.*?\*/"#).unwrap());
+static FALLBACK: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"(?i)\b(?:FROM|JOIN|UPDATE|INTO|DELETE\s+FROM)\s+((?:"[^"]+"|[a-z_][a-z0-9_]*)(?:\.(?:"[^"]+"|[a-z_][a-z0-9_]*))?)"#).unwrap()
+});
+static DML: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"(?i)^\s*(?:/\*.*?\*/\s*)*(?:INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+((?:"[^"]+"|[a-z_][a-z0-9_]*)(?:\.(?:"[^"]+"|[a-z_][a-z0-9_]*))?)"#).unwrap()
+});
+
+pub fn extract(sql: &str) -> Extracted {
+    let marker = MARKER.captures(sql).map(|c| c[1].to_ascii_lowercase());
+    let mut ex = match Parser::parse_sql(&PostgreSqlDialect {}, sql) {
+        Ok(stmts) if !stmts.is_empty() => from_ast(&stmts[0]),
+        _ => from_regex(sql),
+    };
+    ex.marker = marker;
+    ex
+}
+
+fn from_ast(stmt: &Statement) -> Extracted {
+    let mut ex = Extracted {
+        parser: "sqlparser",
+        ..Default::default()
+    };
+    match stmt {
+        Statement::Query(q) => outer_from_query(q, &mut ex.outer),
+        Statement::Insert(Insert { table, source, .. }) => {
+            if let TableObject::TableName(n) = table {
+                ex.target = Some(name(n));
+            }
+            if let Some(q) = source {
+                outer_from_query(q, &mut ex.outer);
+            }
+        }
+        Statement::Update(Update { table, from, .. }) => {
+            let mut t = Vec::new();
+            twj(table, &mut t);
+            ex.target = t.into_iter().next();
+            if let Some(f) = from {
+                for x in from_tables(f) {
+                    twj(x, &mut ex.outer);
+                }
+            }
+        }
+        Statement::Delete(Delete { from, using, .. }) => {
+            let (FromTable::WithFromKeyword(v) | FromTable::WithoutKeyword(v)) = from;
+            let mut t = Vec::new();
+            for x in v {
+                twj(x, &mut t);
+            }
+            ex.target = t.into_iter().next();
+            if let Some(u) = using {
+                for x in u {
+                    twj(x, &mut ex.outer);
+                }
+            }
+        }
+        _ => {}
+    }
+    let mut all = Vec::new();
+    let _: ControlFlow<()> = visit_relations(stmt, |n| {
+        all.push(name(n));
+        ControlFlow::Continue(())
+    });
+    for t in all {
+        if ex.target.as_deref() != Some(t.as_str())
+            && !ex.outer.contains(&t)
+            && !ex.inner.contains(&t)
+        {
+            ex.inner.push(t);
+        }
+    }
+    ex
+}
+
+fn from_tables(f: &sqlparser::ast::UpdateTableFromKind) -> &[TableWithJoins] {
+    use sqlparser::ast::UpdateTableFromKind::{AfterSet, BeforeSet};
+    match f {
+        BeforeSet(v) | AfterSet(v) => v,
+    }
+}
+
+fn outer_from_query(q: &Query, out: &mut Vec<String>) {
+    match q.body.as_ref() {
+        SetExpr::Select(s) => {
+            for f in &s.from {
+                twj(f, out);
+            }
+        }
+        SetExpr::Query(inner) => outer_from_query(inner, out),
+        SetExpr::SetOperation { left, .. } => {
+            if let SetExpr::Select(s) = left.as_ref() {
+                for f in &s.from {
+                    twj(f, out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn twj(t: &TableWithJoins, out: &mut Vec<String>) {
+    factor(&t.relation, out);
+    for j in &t.joins {
+        factor(&j.relation, out);
+    }
+}
+
+fn factor(f: &TableFactor, out: &mut Vec<String>) {
+    if let TableFactor::Table { name: n, .. } = f {
+        let n = name(n);
+        if !out.contains(&n) {
+            out.push(n);
+        }
+    }
+}
+
+/// `"public"."posthog_team"` -> `posthog_team`; `pg_catalog.pg_class` keeps its prefix so
+/// catalog queries stay recognisable.
+fn name(n: &ObjectName) -> String {
+    let parts: Vec<String> =
+        n.0.iter()
+            .filter_map(|p| p.as_ident())
+            .map(|i| i.value.to_ascii_lowercase())
+            .collect();
+    normalize(&parts.join("."))
+}
+
+fn normalize(s: &str) -> String {
+    let s = s.replace('"', "");
+    match s.rsplit_once('.') {
+        Some(("public", table)) => table.to_string(),
+        Some(("pg_catalog", table)) => format!("pg_{}", table.trim_start_matches("pg_")),
+        _ => s,
+    }
+}
+
+fn from_regex(sql: &str) -> Extracted {
+    let mut ex = Extracted {
+        parser: "regex",
+        ..Default::default()
+    };
+    ex.target = DML
+        .captures(sql)
+        .map(|c| normalize(&c[1].to_ascii_lowercase()));
+    for c in FALLBACK.captures_iter(sql) {
+        let t = normalize(&c[1].to_ascii_lowercase());
+        if ex.target.as_deref() != Some(t.as_str()) && !ex.outer.contains(&t) {
+            ex.outer.push(t);
+        }
+    }
+    ex
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ex(sql: &str) -> Extracted {
+        extract(sql)
+    }
+
+    #[test]
+    fn django_select_related_join_keeps_driving_table_first() {
+        let e = ex(
+            r#"SELECT "posthog_dashboard"."id", "posthog_team"."name" FROM "posthog_dashboard" INNER JOIN "posthog_team" ON ("posthog_dashboard"."team_id" = "posthog_team"."id") WHERE "posthog_dashboard"."id" = $1 LIMIT $2"#,
+        );
+        assert_eq!(e.parser, "sqlparser");
+        assert_eq!(e.outer, vec!["posthog_dashboard", "posthog_team"]);
+        assert_eq!(e.target, None);
+    }
+
+    #[test]
+    fn subquery_tables_rank_after_outer_ones() {
+        let e = ex(
+            r#"SELECT * FROM "posthog_insight" WHERE "posthog_insight"."team_id" IN (SELECT U0."team_id" FROM "posthog_organizationmembership" U0 WHERE U0."user_id" = $1) AND "posthog_insight"."id" = ANY($2)"#,
+        );
+        assert_eq!(e.outer, vec!["posthog_insight"]);
+        assert_eq!(e.inner, vec!["posthog_organizationmembership"]);
+        assert_eq!(
+            e.ranked(),
+            vec!["posthog_insight", "posthog_organizationmembership"]
+        );
+    }
+
+    #[test]
+    fn dml_target_wins_over_joined_tables() {
+        let e = ex(
+            r#"UPDATE "posthog_cohort" SET "is_calculating" = $1 FROM "posthog_team" WHERE "posthog_cohort"."team_id" = "posthog_team"."id""#,
+        );
+        assert_eq!(e.target.as_deref(), Some("posthog_cohort"));
+        assert_eq!(e.ranked()[0], "posthog_cohort");
+        let e = ex(
+            r#"INSERT INTO "posthog_persondistinctid" ("distinct_id", "person_id", "team_id") VALUES ($1, $2, $3) RETURNING "posthog_persondistinctid"."id""#,
+        );
+        assert_eq!(e.target.as_deref(), Some("posthog_persondistinctid"));
+        let e = ex(
+            r#"DELETE FROM "posthog_element" USING "posthog_elementgroup" WHERE "posthog_element"."group_id" = "posthog_elementgroup"."id""#,
+        );
+        assert_eq!(e.target.as_deref(), Some("posthog_element"));
+        assert_eq!(e.outer, vec!["posthog_elementgroup"]);
+    }
+
+    #[test]
+    fn cte_relations_are_inner() {
+        let e = ex("WITH recent AS (SELECT id FROM posthog_event WHERE ts > $1) SELECT count(*) FROM posthog_person p JOIN recent r ON r.id = p.id");
+        assert_eq!(e.outer, vec!["posthog_person", "recent"]);
+        assert_eq!(e.inner, vec!["posthog_event"]);
+    }
+
+    #[test]
+    fn truncated_text_falls_back_to_regex() {
+        let e = ex(
+            r#"SELECT "posthog_featureflag"."id" FROM "posthog_featureflag" INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id") WHERE "posthog_featureflag"."key" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $1"#,
+        );
+        assert_eq!(e.parser, "regex");
+        assert_eq!(e.outer, vec!["posthog_featureflag", "posthog_team"]);
+        let e = ex(
+            r#"UPDATE "posthog_team" SET "updated_at" = $1 WHERE "posthog_team"."id" IN ($1, $2, $3, $"#,
+        );
+        assert_eq!(e.parser, "regex");
+        assert_eq!(e.target.as_deref(), Some("posthog_team"));
+    }
+
+    #[test]
+    fn schema_prefix_and_catalog_detection() {
+        let e = ex(
+            r#"SELECT c.relname FROM pg_catalog.pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace"#,
+        );
+        assert!(e.catalog_only());
+        let e = ex(r#"SELECT 1 FROM "public"."posthog_team" t, other_schema.audit a"#);
+        assert_eq!(e.outer, vec!["posthog_team", "other_schema.audit"]);
+        assert!(!e.catalog_only());
+        assert!(!ex("SELECT 1").catalog_only());
+    }
+
+    #[test]
+    fn owner_marker_is_read_from_a_leading_comment() {
+        let e = ex(
+            "/*owner='team-feature-flags',route='/api/flags'*/ SELECT 1 FROM posthog_featureflag",
+        );
+        assert_eq!(e.marker.as_deref(), Some("team-feature-flags"));
+        assert_eq!(e.outer, vec!["posthog_featureflag"]);
+        assert_eq!(ex("SELECT 1 FROM posthog_featureflag").marker, None);
+    }
+}


### PR DESCRIPTION
## Problem

- #97067 generates a table-to-team map, but nothing reads it. pgcollector has no way to say which team a statement belongs to, so a finding cannot reach a rotation or a Slack channel.
- This layer adds the resolver and a CLI to query it. The slow-query checks that use it come in #97069.

## Changes

- `pgcollector --attribute "<SQL>"` prints the owning team, its incident.io rotation, its Slack channel, and which table decided it. Use it to see where a query would route, and to tune the overrides.
- Attribution order, first match wins: a `databases` rule in `overrides.yaml` (a whole database or server belongs to one team), an `owner='team-x'` marker in a leading SQL comment, then the tables the statement touches.
- Among tables, the DML target wins, then the driving table of the outermost FROM, then the joins. Hub tables such as `posthog_team` and `posthog_user` only decide when nothing else names a team, so a product query joined to `posthog_team` goes to the product's team.
- `ownership/overrides.yaml` holds what the generated map cannot know: hubs, tables created by Rust sqlx migrations, the team to rotation map, and channel overrides.
- New `[ownership]` config section. `dir` points at replacement copies of both files for a runtime overlay. `fallback_rotation`, default `infra`, receives anything unowned.
- Both files are compiled into the binary, so the image needs no repo checkout. A new mapping ships with the next image build, or sooner through the overlay.
- Statements are parsed with sqlparser, with a regex fallback for text that does not parse, such as `pg_stat_statements` text truncated at `track_activity_query_size`.
- Nothing user-visible changes for PostHog users. The rest of the diff is the `sqlparser` dependency.

## How did you test this code?

- Unit tests in `src/ownership/tables.rs` catch ranking regressions: a Django `select_related` join keeps the driving table first, a DML target beats the joins, CTE and subquery tables rank last, truncated text falls back to the regex, and the comment marker is read.
- Unit tests in `src/ownership/owners.rs` catch precedence regressions: the driving table beats a joined hub, database rules and markers and globs beat the table lookup, `@handles` are not teams, and the compiled-in files load.
- `pgcollector --attribute` on a survey query joined to `posthog_team` attributes it to team-surveys with the hub deferring:

<details>
<summary>Output</summary>

```json
{
  "team": "team-surveys",
  "rotation": "surveys",
  "slack_channel": "team-surveys",
  "method": "table",
  "reason": "reads posthog_survey (owned by team-surveys)",
  "primary_table": "posthog_survey",
  "tables": [
    { "table": "posthog_survey", "team": "team-surveys", "hub": false },
    { "table": "posthog_team", "team": null, "hub": true }
  ],
  "parser": "sqlparser",
  "catalog_only": false,
  "tables_known": 557
}
```

</details>

- Not checked: the `dir` overlay was not exercised, and nothing ran in a deployed pod.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`rust/pgcollector/README.md` gains a "Table ownership" section in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5.1). Skills invoked: /stacking-prs, /writing-pr-descriptions.
- Middle layer of one larger branch split into three. Two things changed in the split: the resolver moved from under the checks job to a top-level `src/ownership/` module, since table-level checks will use it too, and its settings moved out of `[checks]` into `[ownership]`. The `--attribute` CLI was added so this layer has a caller.

https://claude.ai/code/session_019YJkcNok1ZzR6iBXES1Cmi
