### PR TITLE
feat(pgcollector): attribute heavy new queries and regressions to owning teams

### DIFF
--- a/rust/pgapi/README.md
+++ b/rust/pgapi/README.md
@@ -14,10 +14,14 @@ curl "localhost:3400/api/v1/servers/<id>/queries?since=1h&order=total_exec_time"
 ```
 
 MCP client config (Claude Code / Desktop): `{"type": "http", "url": "http://localhost:3400/mcp"}`.
-17 tools: `list_servers`, `server_overview`, `top_queries`, `query_detail`,
+18 tools: `list_servers`, `server_overview`, `top_queries`, `query_detail`,
 `wait_events`, `current_activity`, `table_stats`, `index_stats`,
 `vacuum_status`, `events`, `settings`, `schema`, `log_errors`, `system_stats`,
+`query_findings` (slow queries attributed to teams by the collector's checks job),
 `collector_health`, `describe_stats_schema`, `query_stats_db` (guarded raw SQL).
+
+Findings over REST: `/api/v1/findings?team=team-x&status=open&since=7d`,
+`/api/v1/servers/<id>/findings`, `/api/v1/findings/<id>`; the UI has a Findings page.
 
 ## Authentication
 

--- a/rust/pgapi/src/api.rs
+++ b/rust/pgapi/src/api.rs
@@ -52,6 +52,9 @@ pub fn router() -> Router<Arc<AppState>> {
         .route("/servers/:server/schema", get(schema))
         .route("/servers/:server/logs", get(logs))
         .route("/servers/:server/system", get(system))
+        .route("/findings", get(findings))
+        .route("/findings/:id", get(finding_detail))
+        .route("/servers/:server/findings", get(server_findings))
         .route("/collector/health", get(collector_health))
         .route("/sql", get(sql))
         .route("/stats-schema", get(stats_schema))
@@ -198,6 +201,49 @@ async fn logs(State(s): S, Path(server): Path<String>, Query(p): Query<OptDbQ>) 
 async fn system(State(s): S, Path(server): Path<String>, Query(r): Query<Range>) -> R {
     let (f, t) = r.resolve()?;
     Ok(Json(q::system(&s.db, &server, f, t).await?))
+}
+#[derive(Deserialize)]
+struct FindingsQ {
+    #[serde(flatten)]
+    range: Range,
+    server: Option<String>,
+    team: Option<String>,
+    status: Option<String>,
+    #[serde(default = "d_limit")]
+    limit: i64,
+}
+async fn findings(State(s): S, Query(p): Query<FindingsQ>) -> R {
+    let (f, t) = p.range.resolve()?;
+    Ok(Json(
+        q::findings(
+            &s.db,
+            p.server.as_deref(),
+            p.team.as_deref(),
+            p.status.as_deref(),
+            f,
+            t,
+            p.limit.clamp(1, 1000),
+        )
+        .await?,
+    ))
+}
+async fn server_findings(State(s): S, Path(server): Path<String>, Query(p): Query<FindingsQ>) -> R {
+    let (f, t) = p.range.resolve()?;
+    Ok(Json(
+        q::findings(
+            &s.db,
+            Some(&server),
+            p.team.as_deref(),
+            p.status.as_deref(),
+            f,
+            t,
+            p.limit.clamp(1, 1000),
+        )
+        .await?,
+    ))
+}
+async fn finding_detail(State(s): S, Path(id): Path<i64>) -> R {
+    Ok(Json(q::finding_detail(&s.db, id).await?))
 }
 async fn collector_health(State(s): S) -> R {
     Ok(Json(q::collector_health(&s.db).await?))

--- a/rust/pgapi/src/mcp.rs
+++ b/rust/pgapi/src/mcp.rs
@@ -105,6 +105,18 @@ pub struct SettingsArg {
     pub non_default_only: Option<bool>,
 }
 #[derive(Deserialize, schemars::JsonSchema)]
+pub struct FindingsArg {
+    /// Restrict to one server; default all.
+    pub server: Option<String>,
+    /// Team slug as in owners.yaml (e.g. "team-ingestion"), or "unowned".
+    pub team: Option<String>,
+    /// pending | open | resolved. Default: everything not resolved.
+    pub status: Option<String>,
+    /// Look-back on last detection, e.g. "24h", "7d". Default 24h.
+    pub since: Option<String>,
+    pub limit: Option<i64>,
+}
+#[derive(Deserialize, schemars::JsonSchema)]
 pub struct SqlArg {
     /// A single read-only SELECT/WITH statement against the stats database. Call describe_stats_schema first for table shapes.
     pub sql: String,
@@ -321,6 +333,26 @@ impl PgMcp {
     async fn collector_health(&self) -> Result<CallToolResult, McpError> {
         ok(q::collector_health(&self.state.db).await.map_err(err)?)
     }
+    #[tool(
+        description = "Slow-query findings: new heavy queries and regressions the collector attributed to a team (rule, why it fired, which tables decided the owner, stats, query text). Use to answer \"what has my team been alerted about\" or to check a query before shipping it."
+    )]
+    async fn query_findings(
+        &self,
+        Parameters(a): Parameters<FindingsArg>,
+    ) -> Result<CallToolResult, McpError> {
+        let (f, t) = range(&a.since.clone().or_else(|| Some("24h".into())))?;
+        ok(q::findings(
+            &self.state.db,
+            a.server.as_deref(),
+            a.team.as_deref(),
+            a.status.as_deref(),
+            f,
+            t,
+            a.limit.unwrap_or(50).clamp(1, 500),
+        )
+        .await
+        .map_err(err)?)
+    }
     #[tool(description = "Tables and columns of the stats database, for use with query_stats_db.")]
     async fn describe_stats_schema(&self) -> Result<CallToolResult, McpError> {
         ok(q::schema_of_stats_db(&self.state.db).await.map_err(err)?)
@@ -343,7 +375,7 @@ impl ServerHandler for PgMcp {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::from_build_env())
-            .with_instructions("Read-only access to PostHog's Postgres telemetry (pgcollector). Start with list_servers, then server_overview; drill into top_queries / query_detail for performance, current_activity for live issues, vacuum_status and events for maintenance. query_stats_db runs arbitrary read-only SQL against the stats database.")
+            .with_instructions("Read-only access to PostHog's Postgres telemetry (pgcollector). Start with list_servers, then server_overview; drill into top_queries / query_detail for performance, query_findings for slow queries attributed to teams, current_activity for live issues, vacuum_status and events for maintenance. query_stats_db runs arbitrary read-only SQL against the stats database.")
     }
 }
 

--- a/rust/pgapi/src/queries.rs
+++ b/rust/pgapi/src/queries.rs
@@ -100,6 +100,7 @@ pub async fn top_queries(
                   count(DISTINCT s.instance)::bigint AS instances
            FROM ts_query_stats s
            WHERE s.server_id = $1 AND s.collected_at >= $2 AND s.collected_at < $3 AND ($4::text IS NULL OR s.datname = $4)
+             AND s.toplevel
            GROUP BY 1, 2, 3)
          SELECT a.*, q.query, q.fingerprint,
                 round((a.total_ms / nullif(sum(a.total_ms) OVER (), 0) * 100)::numeric, 2)::float8 AS pct_of_total_time
@@ -263,6 +264,41 @@ async fn log_sampling_settings(db: &Db, server: &str) -> Result<LogSampling> {
         hard_threshold_ms: get("log_min_duration_statement", -1.0),
         enabled: sample_floor_ms >= 0.0 && rate > 0.0,
     })
+}
+
+/// Slow-query findings the pgcollector checks job persisted: what fired, for which team,
+/// and why. `status` is pending | open | resolved, or None for everything but resolved.
+pub async fn findings(
+    db: &Db,
+    server: Option<&str>,
+    team: Option<&str>,
+    status: Option<&str>,
+    from: Ts,
+    to: Ts,
+    limit: i64,
+) -> Result<Value> {
+    Ok(json!(opt(db,
+        "SELECT f.id, f.server_id, f.datname, f.rule, f.severity, f.status, f.team, f.rotation, f.slack_channel, f.method,
+                f.queryid, f.fingerprint, f.attribution, f.stats, f.seen_count, f.miss_count,
+                f.first_detected, f.last_detected, f.resolved_at, left(q.query, 500) AS query
+         FROM query_findings f
+         LEFT JOIN LATERAL (SELECT query FROM cur_queries q WHERE q.server_id = f.server_id AND q.queryid = f.queryid AND q.datname = f.datname LIMIT 1) q ON true
+         WHERE ($1::text IS NULL OR f.server_id = $1) AND ($2::text IS NULL OR f.team = $2)
+           AND (CASE WHEN $3::text IS NULL THEN f.status <> 'resolved' ELSE f.status = $3 END)
+           AND f.last_detected >= $4 AND f.last_detected < $5
+         ORDER BY f.status = 'open' DESC, f.last_detected DESC LIMIT $6",
+        &[&server, &team, &status, &from, &to, &limit]).await?))
+}
+
+pub async fn finding_detail(db: &Db, id: i64) -> Result<Value> {
+    let rows = opt(db,
+        "SELECT f.*, q.query, q.fingerprint AS query_fingerprint, q.first_seen AS query_first_seen
+         FROM query_findings f
+         LEFT JOIN LATERAL (SELECT query, fingerprint, first_seen FROM cur_queries q WHERE q.server_id = f.server_id AND q.queryid = f.queryid AND q.datname = f.datname ORDER BY first_seen LIMIT 1) q ON true
+         WHERE f.id = $1", &[&id]).await?;
+    rows.into_iter()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("finding {id} not found"))
 }
 
 pub async fn wait_events(db: &Db, server: &str, from: Ts, to: Ts, bucket: &str) -> Result<Value> {

--- a/rust/pgapi/src/ui/index.html
+++ b/rust/pgapi/src/ui/index.html
@@ -73,7 +73,7 @@
   const PAGES = [
     ['overview', 'Overview'], ['queries', 'Queries'], ['activity', 'Activity'], ['waits', 'Wait events'],
     ['tables', 'Tables'], ['indexes', 'Indexes'], ['vacuum', 'Vacuum'], ['events', 'Events'], ['logs', 'Logs'],
-    ['system', 'System'], ['schema', 'Schema'], ['settings', 'Settings'], ['collector', 'Collector health'],
+    ['system', 'System'], ['schema', 'Schema'], ['settings', 'Settings'], ['findings', 'Findings'], ['collector', 'Collector health'],
   ];
   const state = { servers: [], server: null, page: 'overview', params: {}, range: '1h' };
   const $ = (s, r = document) => r.querySelector(s);
@@ -343,6 +343,21 @@
         { key: 'at', label: 'time', fmt: fmt.ts }, { key: 'kind', label: 'kind', render: r => el('span', { class: 'pill' }, r.kind) }, { key: 'datname', label: 'db' }, { key: 'subject', label: 'subject', cls: 'mono' },
         { key: 'after', label: 'details', render: r => el('details', {}, el('summary', {}, summarize(r)), el('pre', {}, JSON.stringify({ before: r.before, after: r.after }, null, 2))) },
       ], { empty: 'no events in range' })),
+    ];
+  };
+  pages.findings = async () => {
+    const status = state.params.status || '';
+    const rows = await api(`/servers/${state.server}/findings`, { since: state.range === '1h' ? '24h' : state.range, status, limit: 500 });
+    const statuses = ['', 'open', 'pending', 'resolved'];
+    return [
+      el('h1', {}, 'Findings', el('span', { class: 'sub' }, 'heavy new queries and regressions, attributed to the team that owns the tables they touch')),
+      el('div', { class: 'toolbar' }, el('label', {}, 'status ', el('select', { onchange: e => go('findings', { status: e.target.value }) }, statuses.map(k => el('option', { value: k, selected: k === status ? '' : null }, k || 'not resolved'))))),
+      panel(null, table(rows, [
+        { key: 'last_detected', label: 'last seen', fmt: fmt.ts }, { key: 'status', label: 'status', render: r => el('span', { class: r.status === 'open' ? 'pill warn' : 'pill' }, r.status) },
+        { key: 'rule', label: 'rule', cls: 'mono' }, { key: 'team', label: 'team', render: r => el('span', { title: `${r.method}: ${(r.attribution || {}).reason || ''}` }, r.team) },
+        { key: 'datname', label: 'db' }, { key: 'queryid', label: 'query', render: r => el('a', { href: `#/${state.server}/query?queryid=${r.queryid}` }, queryCell(r.query || String(r.queryid))) },
+        { key: 'attribution', label: 'why', render: r => el('details', {}, el('summary', {}, ((r.attribution || {}).reasons || []).join('; ')), el('pre', {}, JSON.stringify({ attribution: r.attribution, stats: r.stats }, null, 2))) },
+      ], { empty: 'no findings in range' })),
     ];
   };
   function summarize(e) {

--- a/rust/pgcollector/DESIGN.md
+++ b/rust/pgcollector/DESIGN.md
@@ -134,6 +134,7 @@ Planned Tier B collectors:
 | 60s | memory contexts (Aurora) | A | `aurora_stat_memctx_usage()` — backends > 64 MB |
 | 60s | system cpu / memory / disk | A | `pg_proctab`: `pg_cputime`, `pg_memusage`, `pg_loadavg`, `pg_diskusage` |
 | 60s | backend cpu | A | `pg_proctab()` per pid joined to `pg_stat_activity` |
+| 10m | query checks | job | `ts_query_stats` + `cur_queries` in the stats DB: heavy new queries and regressions, attributed to a team via table ownership; `query_findings`, `ts_query_stats_1h`, `pgcollector_query_finding` gauges |
 | 30s | logs | B | CloudWatch Logs (RDS) or files: `ts_query_durations` (latency quantiles), `ts_log_plans` (auto_explain), `ts_autovacuum_runs`, `ts_checkpoints`, `ts_temp_files`, `ts_log_errors`, `ts_logs` counts, deadlock/lock-wait/cancel events |
 
 On Aurora, `query_stats` reads `aurora_stat_statements` (adds Aurora-storage I/O
@@ -213,8 +214,9 @@ Hand-written tables (Tier B): `ts_query_stats`, `cur_queries`,
 `ts_activity_samples`, `ts_activity_sessions`, `ts_lock_waits`,
 `cur_relations`, `cur_indexes`, `cur_settings`, `events`, `collector_state`,
 `collector_runs` (self-metrics: per collector/server tick duration, rows,
-error). Roll-ups (`ts_query_stats_1h`) are done by a periodic job in the sink,
-not by the collector.
+error). The hourly roll-up `ts_query_stats_1h` / `ts_server_stats_1h` is filled
+by the checks job (`migrations/0002_query_findings.sql`), which also owns
+`query_findings` and `checks_state`.
 
 Migrations: `migrations/*.sql`, applied by the sink on startup (`sqlx` migrate).
 
@@ -296,7 +298,11 @@ Secrets come from env (`${VAR}` expansion in URLs).
 6. ✅ **`pgapi`** — REST + MCP (17 tools) over the stats DB; edge-provided
    identity (Tailscale whois / ALB Cognito JWT / auth gateway), domain
    allowlist, read-only. UI still to come.
-7. UI on top of `pgapi` on top of the stats DB (separate design).
+7. ✅ UI on top of `pgapi`.
+8. ✅ **Slow-query checks** — `[checks]` job in the collector: `new_heavy` /
+   `regression` rules over the stats DB, attribution to a team through the
+   generated table ownership map, `query_findings` + gauges for the alerting
+   path (vmalert -> alertmanager -> incident.io rotation). See README.
 
 ## 9. Non-goals (for now)
 

--- a/rust/pgcollector/README.md
+++ b/rust/pgcollector/README.md
@@ -81,6 +81,38 @@ driving table of the outermost `FROM`, joins after it; hub tables (`posthog_team
 pgcollector --attribute "SELECT * FROM posthog_survey WHERE team_id = 1" --datname posthog
 ```
 
+## Slow-query checks
+
+`[checks]` (off by default) runs a job every 10 minutes that finds heavy new
+queries and regressions in the stats DB, attributes each to the team that owns
+the tables it touches, and stores the result in `query_findings`. With
+`alerting = true` every open finding is a `pgcollector_query_finding` gauge
+labelled `team` / `rotation` / `slack_channel`; the vmalert rule in the charts
+repo turns those into per-rotation alerts. Leave `alerting = false` (shadow
+mode) until the thresholds are tuned; pgapi shows the findings either way.
+
+Rules, all over the last `window` (1h) and thresholds in `[checks.thresholds]`:
+
+* `new_heavy`: a query first seen within 24h that already takes >= 2% of the
+  server's exec time, >= 60 s in total, has a mean >= 500 ms over >= 10 calls,
+  or reads/spills a lot. Skipped while a server is younger than 48h or after a
+  stats reset. More than 5 new shapes on one table collapse into one
+  `new_heavy_burst` finding (a deploy).
+* `regression`: a query with >= 7 days of history whose mean or share of server
+  time over the window is over 3x the median and 1.5x the p95 of the same
+  hour-of-day on the previous 7 days (read from the hourly roll-up
+  `ts_query_stats_1h`, which this job also fills).
+
+A finding opens after 2 consecutive matching runs and resolves after 6 clean
+runs. Utility statements, catalog-only queries, `ignore_roles` and `mute`
+fingerprints never produce findings.
+
+Each finding is attributed to a team through [table ownership](#table-ownership);
+unowned queries route to `[ownership] fallback_rotation`.
+
+`pgcollector --checks-once` evaluates once and prints the candidates as JSON
+lines without writing findings or gauges.
+
 ## Local testing
 
 `test/setup-local.sh` starts a throwaway PG16 with `pg_stat_statements`,

--- a/rust/pgcollector/deploy/pgcollector.example.toml
+++ b/rust/pgcollector/deploy/pgcollector.example.toml
@@ -30,3 +30,14 @@ sizes = { enabled = false }
 fallback_rotation = "infra"
 # dir = "/etc/pgcollector/ownership"   # table_owners.json + overrides.yaml overlay
 
+# Slow-query checks: attribute heavy new queries and regressions to the owning team.
+# Off by default. With alerting = false findings are only persisted (shadow mode).
+[checks]
+enabled = true
+interval = "10m"
+window = "1h"
+alerting = false
+# mute = [1234567890]                            # fingerprints that never produce findings
+[checks.thresholds]
+share_pct = 2.0
+mean_ms = 500

--- a/rust/pgcollector/migrations/0002_query_findings.sql
+++ b/rust/pgcollector/migrations/0002_query_findings.sql
@@ -1,0 +1,56 @@
+-- Hourly roll-up of ts_query_stats, filled by the checks job so the 7-day regression
+-- baseline reads 168 rows per query instead of rescanning the raw minute data.
+CREATE TABLE IF NOT EXISTS ts_query_stats_1h (
+    server_id          text NOT NULL,
+    datname            text NOT NULL,
+    queryid            bigint NOT NULL,
+    hour               timestamptz NOT NULL,
+    calls              bigint NOT NULL,
+    total_ms           double precision NOT NULL,
+    sumsq              double precision NOT NULL,
+    rows               bigint NOT NULL,
+    shared_blks_read   bigint NOT NULL,
+    temp_blks_written  bigint NOT NULL,
+    wal_bytes          bigint NOT NULL,
+    instances          int NOT NULL,
+    PRIMARY KEY (server_id, datname, queryid, hour)
+);
+CREATE INDEX IF NOT EXISTS ts_query_stats_1h_server_hour ON ts_query_stats_1h (server_id, hour);
+
+CREATE TABLE IF NOT EXISTS ts_server_stats_1h (
+    server_id  text NOT NULL,
+    hour       timestamptz NOT NULL,
+    total_ms   double precision NOT NULL,
+    calls      bigint NOT NULL,
+    PRIMARY KEY (server_id, hour)
+);
+
+CREATE TABLE IF NOT EXISTS query_findings (
+    id             bigserial PRIMARY KEY,
+    server_id      text NOT NULL,
+    datname        text NOT NULL,
+    fingerprint    bigint NOT NULL,
+    queryid        bigint NOT NULL,
+    rule           text NOT NULL,           -- new_heavy | new_heavy_burst | regression
+    severity       text NOT NULL,           -- warning | critical
+    status         text NOT NULL,           -- pending | open | resolved
+    team           text NOT NULL,
+    rotation       text NOT NULL,
+    slack_channel  text,
+    method         text NOT NULL,           -- database | comment | table | unowned
+    attribution    jsonb NOT NULL,
+    stats          jsonb NOT NULL,
+    seen_count     int NOT NULL DEFAULT 0,
+    miss_count     int NOT NULL DEFAULT 0,
+    first_detected timestamptz NOT NULL,
+    last_detected  timestamptz NOT NULL,
+    resolved_at    timestamptz,
+    UNIQUE (server_id, datname, fingerprint, rule)
+);
+CREATE INDEX IF NOT EXISTS query_findings_status ON query_findings (status, last_detected DESC);
+
+CREATE TABLE IF NOT EXISTS checks_state (
+    key        text PRIMARY KEY,
+    value      jsonb NOT NULL,
+    updated_at timestamptz NOT NULL
+);

--- a/rust/pgcollector/src/checks/findings.rs
+++ b/rust/pgcollector/src/checks/findings.rs
@@ -1,0 +1,146 @@
+//! Findings: the persisted, debounced form of a candidate, and the gauges that alert on it.
+
+use super::rules::Candidate;
+use crate::config::Thresholds;
+use crate::http::METRICS;
+use crate::ownership::{Attribution, Ownership};
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use deadpool_postgres::Client;
+use serde::Serialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Finding {
+    pub server_id: String,
+    pub datname: String,
+    pub fingerprint: i64,
+    pub queryid: i64,
+    pub rule: &'static str,
+    pub severity: &'static str,
+    pub team: String,
+    pub rotation: String,
+    pub slack_channel: Option<String>,
+    pub method: &'static str,
+    pub attribution: serde_json::Value,
+    pub stats: serde_json::Value,
+}
+
+pub fn build(server: &str, cand: &Candidate, attr: &Attribution, own: &Ownership) -> Finding {
+    let mut attribution = serde_json::to_value(attr).unwrap_or_default();
+    attribution["reasons"] = serde_json::json!(cand.reasons);
+    attribution["rolnames"] = serde_json::json!(cand.rolnames);
+    Finding {
+        server_id: server.to_string(),
+        datname: cand.datname.clone(),
+        fingerprint: cand.fingerprint,
+        queryid: cand.queryid,
+        rule: cand.rule.as_str(),
+        severity: "warning",
+        team: attr.team.clone(),
+        rotation: own.rotation(&attr.team),
+        slack_channel: own.slack_channel(&attr.team),
+        method: attr.method,
+        attribution,
+        stats: cand.stats.clone(),
+    }
+}
+
+/// Write this run's candidates for one server and age out the rest. Returns the
+/// findings that reached `open` on this run.
+pub async fn apply(
+    c: &Client,
+    server: &str,
+    findings: &[Finding],
+    th: &Thresholds,
+    now: DateTime<Utc>,
+) -> Result<Vec<Finding>> {
+    let before: HashMap<i64, String> = c
+        .query(
+            "SELECT id, status FROM query_findings WHERE server_id = $1 AND status <> 'resolved'",
+            &[&server],
+        )
+        .await?
+        .into_iter()
+        .map(|r| (r.get::<_, i64>(0), r.get::<_, String>(1)))
+        .collect();
+    let mut matched_ids: Vec<i64> = Vec::new();
+    let mut opened = Vec::new();
+    for f in findings {
+        let row = c
+            .query_one(
+                "INSERT INTO query_findings (server_id, datname, fingerprint, queryid, rule, severity, status, team, rotation, slack_channel, method,
+                                             attribution, stats, seen_count, miss_count, first_detected, last_detected)
+                 VALUES ($1, $2, $3, $4, $5, $6, CASE WHEN 1 >= $14 THEN 'open' ELSE 'pending' END, $7, $8, $9, $10, $11, $12, 1, 0, $13, $13)
+                 ON CONFLICT (server_id, datname, fingerprint, rule) DO UPDATE SET
+                   seen_count = CASE WHEN query_findings.status = 'resolved' THEN 1 ELSE query_findings.seen_count + 1 END,
+                   miss_count = 0,
+                   status = CASE WHEN query_findings.status = 'open' THEN 'open'
+                                 WHEN (CASE WHEN query_findings.status = 'resolved' THEN 1 ELSE query_findings.seen_count + 1 END) >= $14 THEN 'open'
+                                 ELSE 'pending' END,
+                   first_detected = CASE WHEN query_findings.status = 'resolved' THEN EXCLUDED.first_detected ELSE query_findings.first_detected END,
+                   last_detected = EXCLUDED.last_detected, resolved_at = NULL,
+                   queryid = EXCLUDED.queryid, severity = EXCLUDED.severity, team = EXCLUDED.team, rotation = EXCLUDED.rotation,
+                   slack_channel = EXCLUDED.slack_channel, method = EXCLUDED.method, attribution = EXCLUDED.attribution, stats = EXCLUDED.stats
+                 RETURNING id, status",
+                &[
+                    &f.server_id, &f.datname, &f.fingerprint, &f.queryid, &f.rule, &f.severity, &f.team, &f.rotation,
+                    &f.slack_channel, &f.method, &f.attribution, &f.stats, &now, &th.open_after_runs,
+                ],
+            )
+            .await?;
+        let (id, status): (i64, String) = (row.get(0), row.get(1));
+        matched_ids.push(id);
+        if status == "open" && before.get(&id).map(String::as_str) != Some("open") {
+            opened.push(f.clone());
+        }
+    }
+    c.execute(
+        "UPDATE query_findings
+         SET miss_count = miss_count + 1,
+             status = CASE WHEN miss_count + 1 >= $3 THEN 'resolved' ELSE status END,
+             resolved_at = CASE WHEN miss_count + 1 >= $3 THEN $4 ELSE resolved_at END
+         WHERE server_id = $1 AND status <> 'resolved' AND NOT (id = ANY($2))",
+        &[&server, &matched_ids, &th.resolve_after_runs, &now],
+    )
+    .await?;
+    for f in &opened {
+        METRICS
+            .checks_findings
+            .with_label_values(&[f.rule, &f.team])
+            .inc();
+    }
+    Ok(opened)
+}
+
+/// Rebuild the `pgcollector_query_finding` gauge from every open finding.
+pub async fn export_gauges(c: &Client) -> Result<usize> {
+    let rows = c
+        .query(
+            "SELECT server_id, datname, rule, severity, team, rotation, coalesce(slack_channel, ''), method, queryid, fingerprint
+             FROM query_findings WHERE status = 'open'",
+            &[],
+        )
+        .await?;
+    METRICS.query_finding.reset();
+    for r in &rows {
+        let queryid: i64 = r.get(8);
+        let fingerprint: i64 = r.get(9);
+        METRICS
+            .query_finding
+            .with_label_values(&[
+                r.get::<_, &str>(0),
+                r.get::<_, &str>(1),
+                r.get::<_, &str>(2),
+                r.get::<_, &str>(3),
+                r.get::<_, &str>(4),
+                r.get::<_, &str>(5),
+                r.get::<_, &str>(6),
+                r.get::<_, &str>(7),
+                &queryid.to_string(),
+                &fingerprint.to_string(),
+            ])
+            .set(1);
+    }
+    Ok(rows.len())
+}

--- a/rust/pgcollector/src/checks/mod.rs
+++ b/rust/pgcollector/src/checks/mod.rs
@@ -1,0 +1,317 @@
+//! The slow-query checks job. Every `checks.interval` it rolls raw stats into hourly
+//! buckets, evaluates the rules over the last window per server, attributes each
+//! candidate to a team, and persists the result as a debounced finding. Open findings
+//! become `pgcollector_query_finding` gauges when `alerting` is on; the vmalert rule
+//! in the charts repo turns those into per-rotation alerts.
+
+pub mod findings;
+pub mod rules;
+pub mod sql;
+
+use crate::config::{ChecksConfig, SinkConfig};
+use crate::http::METRICS;
+use crate::ownership::{extract, Ownership, UNOWNED};
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use deadpool_postgres::{Manager, ManagerConfig, Pool, RecyclingMethod};
+use findings::Finding;
+use rules::{Candidate, Rule};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+pub fn pool(sink: &SinkConfig) -> Result<Pool> {
+    let mut pg_cfg: tokio_postgres::Config =
+        sink.database_url.parse().context("parsing sink url")?;
+    pg_cfg.ssl_mode(crate::pg::tls_policy(&sink.database_url));
+    pg_cfg.application_name("pgcollector-checks");
+    let mgr = Manager::from_config(
+        pg_cfg,
+        crate::pg::tls_connector(),
+        ManagerConfig {
+            recycling_method: RecyclingMethod::Fast,
+        },
+    );
+    Ok(Pool::builder(mgr).max_size(2).build()?)
+}
+
+pub async fn run(cfg: Arc<crate::config::Config>) {
+    let own = match Ownership::load(&cfg.ownership) {
+        Ok(o) => o,
+        Err(e) => {
+            tracing::error!(error = %format!("{e:#}"), "checks: cannot load ownership; job disabled");
+            return;
+        }
+    };
+    let pool = match pool(&cfg.sink) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(error = %format!("{e:#}"), "checks: cannot build pool; job disabled");
+            return;
+        }
+    };
+    tracing::info!(
+        tables = own.table_count(),
+        alerting = cfg.checks.alerting,
+        "checks job started"
+    );
+    let mut t = tokio::time::interval(cfg.checks.interval);
+    loop {
+        t.tick().await;
+        let started = Instant::now();
+        match run_once(&pool, &cfg.checks, &own, Utc::now(), true).await {
+            Ok(Some(report)) => tracing::info!(
+                candidates = report.candidates.len(),
+                opened = report.opened.len(),
+                exported = report.exported,
+                rollup_hours = report.rollup_hours,
+                "checks run"
+            ),
+            Ok(None) => tracing::debug!("checks: another runner holds the lock"),
+            Err(e) => tracing::warn!(error = %format!("{e:#}"), "checks run failed"),
+        }
+        METRICS
+            .checks_run_seconds
+            .observe(started.elapsed().as_secs_f64());
+    }
+}
+
+pub struct Report {
+    pub candidates: Vec<(String, Candidate, Finding)>,
+    pub opened: Vec<Finding>,
+    pub exported: usize,
+    pub rollup_hours: i64,
+}
+
+/// One evaluation. `persist = false` (the `--checks-once` CLI path) still fills the
+/// roll-up, which is idempotent, but neither writes findings nor touches gauges.
+pub async fn run_once(
+    pool: &Pool,
+    cfg: &ChecksConfig,
+    own: &Ownership,
+    now: DateTime<Utc>,
+    persist: bool,
+) -> Result<Option<Report>> {
+    let c = pool.get().await?;
+    if !sql::try_lock(&c).await? {
+        return Ok(None);
+    }
+    let result = evaluate_all(&c, cfg, own, now, persist).await;
+    if let Err(e) = sql::unlock(&c).await {
+        tracing::warn!(error = %e, "checks: advisory unlock failed; the session will release it");
+    }
+    result.map(Some)
+}
+
+async fn evaluate_all(
+    c: &deadpool_postgres::Client,
+    cfg: &ChecksConfig,
+    own: &Ownership,
+    now: DateTime<Utc>,
+    persist: bool,
+) -> Result<Report> {
+    let rollup_hours = sql::fill_rollup(c, now, cfg.baseline_days, &cfg.ignore_roles).await?;
+    let mut all = Vec::new();
+    let mut opened = Vec::new();
+    let window_len = chrono::Duration::from_std(cfg.window)?;
+    for server in sql::servers(c).await? {
+        let ctx = sql::server_context(c, &server).await?;
+        let w = sql::window(c, &server, now - window_len, now, &cfg.ignore_roles).await?;
+        let wanted: Vec<i64> = w
+            .rows
+            .iter()
+            .filter(|r| rules::needs_baseline(r, &w, &cfg.thresholds, now))
+            .map(|r| r.queryid)
+            .collect();
+        let baselines = sql::baselines(c, &server, &wanted, now, cfg.baseline_days).await?;
+        let cands = rules::evaluate(&w, &baselines, &ctx, &cfg.thresholds, &cfg.mute, now);
+        let attributed: Vec<(Candidate, Finding)> = cands
+            .into_iter()
+            .filter_map(|cand| {
+                let ex = extract(&cand.query);
+                if ex.catalog_only() {
+                    return None;
+                }
+                let attr = own.attribute(&server, &cand.datname, &ex);
+                let f = findings::build(&server, &cand, &attr, own);
+                Some((cand, f))
+            })
+            .collect();
+        let collapsed = collapse_bursts(attributed, cfg.thresholds.burst_shapes);
+        let fs: Vec<Finding> = collapsed.iter().map(|(_, f)| f.clone()).collect();
+        if persist {
+            opened.extend(findings::apply(c, &server, &fs, &cfg.thresholds, now).await?);
+        }
+        all.extend(
+            collapsed
+                .into_iter()
+                .map(|(cand, f)| (server.clone(), cand, f)),
+        );
+    }
+    let exported = if persist && cfg.alerting {
+        findings::export_gauges(c).await?
+    } else {
+        0
+    };
+    for f in &opened {
+        tracing::info!(
+            server = f.server_id,
+            datname = f.datname,
+            rule = f.rule,
+            team = f.team,
+            rotation = f.rotation,
+            method = f.method,
+            queryid = f.queryid,
+            fingerprint = f.fingerprint,
+            "finding opened"
+        );
+    }
+    Ok(Report {
+        candidates: all,
+        opened,
+        exported,
+        rollup_hours,
+    })
+}
+
+/// A deploy that touches one model can produce dozens of new query shapes on one table
+/// at once. Above `burst_shapes` new_heavy candidates on the same (team, table), keep
+/// one grouped finding instead of one per shape.
+pub fn collapse_bursts(
+    items: Vec<(Candidate, Finding)>,
+    burst_shapes: usize,
+) -> Vec<(Candidate, Finding)> {
+    let mut groups: BTreeMap<(String, String, String), Vec<usize>> = BTreeMap::new();
+    for (i, (cand, f)) in items.iter().enumerate() {
+        if cand.rule != Rule::NewHeavy || f.team == UNOWNED {
+            continue;
+        }
+        let table = f.attribution["primary_table"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        if table.is_empty() {
+            continue;
+        }
+        groups
+            .entry((f.datname.clone(), f.team.clone(), table))
+            .or_default()
+            .push(i);
+    }
+    let mut drop = vec![false; items.len()];
+    let mut merged = Vec::new();
+    for ((datname, team, table), idx) in groups {
+        if idx.len() <= burst_shapes {
+            continue;
+        }
+        let total_ms: f64 = idx.iter().map(|&i| items[i].cand_total_ms()).sum();
+        let share: f64 = idx.iter().map(|&i| items[i].cand_share()).sum();
+        let top = idx
+            .iter()
+            .copied()
+            .max_by(|&a, &b| {
+                items[a]
+                    .cand_total_ms()
+                    .total_cmp(&items[b].cand_total_ms())
+            })
+            .unwrap();
+        for &i in &idx {
+            drop[i] = true;
+        }
+        let (cand, f) = &items[top];
+        let mut c = cand.clone();
+        c.rule = Rule::NewHeavyBurst;
+        c.fingerprint = crate::logs::fingerprint::fingerprint(&format!("burst:{datname}:{table}"));
+        c.query = format!(
+            "{} new query shapes on {table}; heaviest: {}",
+            idx.len(),
+            cand.query
+        );
+        c.reasons = vec![format!(
+            "{} new query shapes on {table} in one window, {total_ms:.0} ms total ({share:.1}% of server time); likely one deploy",
+            idx.len()
+        )];
+        c.stats = serde_json::json!({ "shapes": idx.len(), "total_ms": total_ms, "share_pct": share, "heaviest": cand.stats });
+        let mut nf = f.clone();
+        nf.rule = c.rule.as_str();
+        nf.fingerprint = c.fingerprint;
+        nf.stats = c.stats.clone();
+        nf.attribution["reasons"] = serde_json::json!(c.reasons);
+        nf.team = team;
+        merged.push((c, nf));
+    }
+    let mut out: Vec<(Candidate, Finding)> = items
+        .into_iter()
+        .enumerate()
+        .filter(|(i, _)| !drop[*i])
+        .map(|(_, x)| x)
+        .collect();
+    out.extend(merged);
+    out
+}
+
+trait CandStats {
+    fn cand_total_ms(&self) -> f64;
+    fn cand_share(&self) -> f64;
+}
+impl CandStats for (Candidate, Finding) {
+    fn cand_total_ms(&self) -> f64 {
+        self.0.stats["total_ms"].as_f64().unwrap_or(0.0)
+    }
+    fn cand_share(&self) -> f64 {
+        self.0.stats["share_pct"].as_f64().unwrap_or(0.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(queryid: i64, table: &str, total_ms: f64) -> (Candidate, Finding) {
+        let cand = Candidate {
+            rule: Rule::NewHeavy,
+            datname: "posthog".into(),
+            queryid,
+            fingerprint: queryid,
+            query: format!("SELECT {queryid} FROM {table}"),
+            rolnames: vec![],
+            stats: serde_json::json!({ "total_ms": total_ms, "share_pct": 1.0 }),
+            reasons: vec!["x".into()],
+        };
+        let f = Finding {
+            server_id: "cloud".into(),
+            datname: "posthog".into(),
+            fingerprint: queryid,
+            queryid,
+            rule: "new_heavy",
+            severity: "warning",
+            team: "team-a".into(),
+            rotation: "a".into(),
+            slack_channel: None,
+            method: "table",
+            attribution: serde_json::json!({ "primary_table": table }),
+            stats: cand.stats.clone(),
+        };
+        (cand, f)
+    }
+
+    #[test]
+    fn many_new_shapes_on_one_table_become_one_burst_finding() {
+        let mut items: Vec<_> = (1..=4).map(|i| item(i, "posthog_a", i as f64)).collect();
+        items.push(item(9, "posthog_b", 1.0));
+        let out = collapse_bursts(items.clone(), 3);
+        assert_eq!(out.len(), 2);
+        let burst = out
+            .iter()
+            .find(|(c, _)| c.rule == Rule::NewHeavyBurst)
+            .unwrap();
+        assert_eq!(burst.0.queryid, 4);
+        assert_eq!(burst.1.rule, "new_heavy_burst");
+        assert_eq!(burst.0.stats["shapes"], 4);
+        assert_eq!(burst.0.stats["total_ms"], 10.0);
+        assert!(out
+            .iter()
+            .any(|(c, _)| c.queryid == 9 && c.rule == Rule::NewHeavy));
+        assert_eq!(collapse_bursts(items, 4).len(), 5);
+    }
+}

--- a/rust/pgcollector/src/checks/rules.rs
+++ b/rust/pgcollector/src/checks/rules.rs
@@ -1,0 +1,428 @@
+//! The rules, as pure functions over aggregates the SQL layer returns.
+
+use crate::config::Thresholds;
+use chrono::{DateTime, Utc};
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde::Serialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct WindowRow {
+    pub datname: String,
+    pub queryid: i64,
+    pub calls: i64,
+    pub total_ms: f64,
+    pub rows: i64,
+    pub shared_blks_read: i64,
+    pub temp_blks_written: i64,
+    pub rolnames: Vec<String>,
+    pub query: Option<String>,
+    pub fingerprint: Option<i64>,
+    pub first_seen: Option<DateTime<Utc>>,
+}
+
+impl WindowRow {
+    pub fn mean_ms(&self) -> f64 {
+        if self.calls > 0 {
+            self.total_ms / self.calls as f64
+        } else {
+            0.0
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Window {
+    pub rows: Vec<WindowRow>,
+    pub server_total_ms: f64,
+    /// Distinct sample timestamps in the window: how much data the aggregates rest on.
+    pub samples: i64,
+    pub from: DateTime<Utc>,
+    pub to: DateTime<Utc>,
+}
+
+impl Window {
+    pub fn share_pct(&self, total_ms: f64) -> f64 {
+        if self.server_total_ms > 0.0 {
+            total_ms / self.server_total_ms * 100.0
+        } else {
+            0.0
+        }
+    }
+}
+
+/// One baseline hour for one query: the same hour-of-day on an earlier day.
+#[derive(Debug, Clone, Copy)]
+pub struct BaselinePoint {
+    pub mean_ms: f64,
+    pub share_pct: f64,
+}
+
+pub type Baselines = HashMap<(String, i64), Vec<BaselinePoint>>;
+
+#[derive(Debug, Clone, Default)]
+pub struct ServerContext {
+    pub first_seen: Option<DateTime<Utc>>,
+    pub stats_reset_recent: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Rule {
+    NewHeavy,
+    NewHeavyBurst,
+    Regression,
+}
+
+impl Rule {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Rule::NewHeavy => "new_heavy",
+            Rule::NewHeavyBurst => "new_heavy_burst",
+            Rule::Regression => "regression",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Candidate {
+    pub rule: Rule,
+    pub datname: String,
+    pub queryid: i64,
+    pub fingerprint: i64,
+    pub query: String,
+    pub rolnames: Vec<String>,
+    pub stats: serde_json::Value,
+    pub reasons: Vec<String>,
+}
+
+static UTILITY: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)^\s*(?:/\*.*?\*/\s*)*(?:BEGIN|COMMIT|ROLLBACK|SET|SHOW|SAVEPOINT|RELEASE|DEALLOCATE|DISCARD|LISTEN|COPY|VACUUM|ANALYZE|CREATE|ALTER|DROP|REINDEX|CLUSTER|REFRESH|EXPLAIN|LOCK|FETCH|DECLARE|CLOSE)\b").unwrap()
+});
+
+pub fn is_utility(sql: &str) -> bool {
+    UTILITY.is_match(sql)
+}
+
+/// Whether a row is worth fetching a 7-day baseline for.
+pub fn needs_baseline(row: &WindowRow, w: &Window, th: &Thresholds, now: DateTime<Utc>) -> bool {
+    let old_enough = row
+        .first_seen
+        .is_some_and(|f| now - f >= chrono::Duration::days(th.baseline_days_floor()));
+    old_enough
+        && ((row.mean_ms() >= th.regression_min_mean_ms && row.calls >= th.regression_min_calls)
+            || w.share_pct(row.total_ms) >= th.regression_share_pct)
+}
+
+impl Thresholds {
+    fn baseline_days_floor(&self) -> i64 {
+        self.baseline_min_days as i64
+    }
+}
+
+pub fn evaluate(
+    w: &Window,
+    baselines: &Baselines,
+    ctx: &ServerContext,
+    th: &Thresholds,
+    mute: &[i64],
+    now: DateTime<Utc>,
+) -> Vec<Candidate> {
+    let mut out = Vec::new();
+    if w.samples < th.min_samples {
+        return out;
+    }
+    let warming_up = ctx.stats_reset_recent
+        || ctx
+            .first_seen
+            .is_some_and(|f| now - f < chrono::Duration::from_std(th.warmup).unwrap_or_default());
+    for row in &w.rows {
+        let (Some(query), Some(fp)) = (&row.query, row.fingerprint) else {
+            continue;
+        };
+        if mute.contains(&fp) || is_utility(query) {
+            continue;
+        }
+        let share = w.share_pct(row.total_ms);
+        let mean = row.mean_ms();
+        let is_new = row.first_seen.is_some_and(|f| {
+            now - f < chrono::Duration::from_std(th.new_query_age).unwrap_or_default()
+        });
+        if is_new && !warming_up {
+            let mut reasons = Vec::new();
+            if share >= th.share_pct {
+                reasons.push(format!(
+                    "{share:.1}% of server exec time (floor {}%)",
+                    th.share_pct
+                ));
+            }
+            if row.total_ms >= th.total_ms {
+                reasons.push(format!(
+                    "{:.0} ms total in the window (floor {:.0})",
+                    row.total_ms, th.total_ms
+                ));
+            }
+            if mean >= th.mean_ms && row.calls >= th.mean_min_calls {
+                reasons.push(format!(
+                    "mean {mean:.0} ms over {} calls (floor {:.0} ms)",
+                    row.calls, th.mean_ms
+                ));
+            }
+            if row.shared_blks_read >= th.shared_blks_read {
+                reasons.push(format!(
+                    "{} shared blocks read (floor {})",
+                    row.shared_blks_read, th.shared_blks_read
+                ));
+            }
+            if row.temp_blks_written >= th.temp_blks_written {
+                reasons.push(format!(
+                    "{} temp blocks written (floor {})",
+                    row.temp_blks_written, th.temp_blks_written
+                ));
+            }
+            if !reasons.is_empty() {
+                out.push(Candidate {
+                    rule: Rule::NewHeavy,
+                    datname: row.datname.clone(),
+                    queryid: row.queryid,
+                    fingerprint: fp,
+                    query: query.clone(),
+                    rolnames: row.rolnames.clone(),
+                    stats: stats_json(row, w, share, mean, None),
+                    reasons,
+                });
+                continue;
+            }
+        }
+        if let Some(points) = baselines.get(&(row.datname.clone(), row.queryid)) {
+            if let Some((reasons, base)) = regression(row, share, mean, points, th) {
+                out.push(Candidate {
+                    rule: Rule::Regression,
+                    datname: row.datname.clone(),
+                    queryid: row.queryid,
+                    fingerprint: fp,
+                    query: query.clone(),
+                    rolnames: row.rolnames.clone(),
+                    stats: stats_json(row, w, share, mean, Some(base)),
+                    reasons,
+                });
+            }
+        }
+    }
+    out
+}
+
+fn regression(
+    row: &WindowRow,
+    share: f64,
+    mean: f64,
+    points: &[BaselinePoint],
+    th: &Thresholds,
+) -> Option<(Vec<String>, serde_json::Value)> {
+    if points.len() < th.baseline_min_days {
+        return None;
+    }
+    let mut means: Vec<f64> = points.iter().map(|p| p.mean_ms).collect();
+    let mut shares: Vec<f64> = points.iter().map(|p| p.share_pct).collect();
+    let (mean_med, mean_p95) = (median(&mut means), p95(&mut means));
+    let (share_med, share_p95) = (median(&mut shares), p95(&mut shares));
+    let mut reasons = Vec::new();
+    let mean_floor = (th.regression_multiple * mean_med).max(th.regression_p95_multiple * mean_p95);
+    if mean >= th.regression_min_mean_ms
+        && row.calls >= th.regression_min_calls
+        && mean > mean_floor
+    {
+        reasons.push(format!(
+            "mean {mean:.0} ms vs {mean_med:.0} ms median / {mean_p95:.0} ms p95 at this hour over {} days",
+            points.len()
+        ));
+    }
+    let share_floor =
+        (th.regression_multiple * share_med).max(th.regression_p95_multiple * share_p95);
+    if share >= th.regression_share_pct && share > share_floor {
+        reasons.push(format!(
+            "{share:.1}% of server time vs {share_med:.1}% median / {share_p95:.1}% p95 at this hour over {} days",
+            points.len()
+        ));
+    }
+    if reasons.is_empty() {
+        return None;
+    }
+    Some((
+        reasons,
+        serde_json::json!({ "days": points.len(), "mean_ms_median": mean_med, "mean_ms_p95": mean_p95, "share_pct_median": share_med, "share_pct_p95": share_p95 }),
+    ))
+}
+
+fn stats_json(
+    row: &WindowRow,
+    w: &Window,
+    share: f64,
+    mean: f64,
+    baseline: Option<serde_json::Value>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "window_from": w.from, "window_to": w.to, "samples": w.samples,
+        "calls": row.calls, "total_ms": row.total_ms, "mean_ms": mean, "share_pct": share,
+        "rows": row.rows, "shared_blks_read": row.shared_blks_read, "temp_blks_written": row.temp_blks_written,
+        "first_seen": row.first_seen, "rolnames": row.rolnames, "baseline": baseline,
+    })
+}
+
+fn median(v: &mut [f64]) -> f64 {
+    v.sort_by(|a, b| a.total_cmp(b));
+    let n = v.len();
+    if n == 0 {
+        0.0
+    } else if n % 2 == 1 {
+        v[n / 2]
+    } else {
+        (v[n / 2 - 1] + v[n / 2]) / 2.0
+    }
+}
+
+fn p95(v: &mut [f64]) -> f64 {
+    v.sort_by(|a, b| a.total_cmp(b));
+    if v.is_empty() {
+        return 0.0;
+    }
+    let idx = ((v.len() as f64 * 0.95).ceil() as usize).clamp(1, v.len()) - 1;
+    v[idx]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    fn now() -> DateTime<Utc> {
+        "2026-09-03T12:00:00Z".parse().unwrap()
+    }
+
+    fn row(queryid: i64, calls: i64, total_ms: f64, age: Duration) -> WindowRow {
+        WindowRow {
+            datname: "posthog".into(),
+            queryid,
+            calls,
+            total_ms,
+            rows: 0,
+            shared_blks_read: 0,
+            temp_blks_written: 0,
+            rolnames: vec!["posthog".into()],
+            query: Some(format!("SELECT {queryid} FROM posthog_dashboard")),
+            fingerprint: Some(queryid * 10),
+            first_seen: Some(now() - age),
+        }
+    }
+
+    fn window(rows: Vec<WindowRow>) -> Window {
+        Window {
+            rows,
+            server_total_ms: 1_000_000.0,
+            samples: 60,
+            from: now() - Duration::hours(1),
+            to: now(),
+        }
+    }
+
+    fn th() -> Thresholds {
+        Thresholds::default()
+    }
+
+    #[test]
+    fn new_heavy_fires_on_any_floor_and_names_the_reason() {
+        let w = window(vec![
+            row(1, 1000, 30_000.0, Duration::hours(2)),
+            row(2, 5, 4_000.0, Duration::hours(2)),
+            row(3, 20, 12_000.0, Duration::hours(2)),
+            row(4, 1000, 30_000.0, Duration::days(3)),
+        ]);
+        let c = evaluate(
+            &w,
+            &Baselines::new(),
+            &ServerContext::default(),
+            &th(),
+            &[],
+            now(),
+        );
+        let ids: Vec<i64> = c.iter().map(|c| c.queryid).collect();
+        assert_eq!(ids, vec![1, 3]);
+        assert!(c[0].reasons[0].contains("3.0% of server exec time"));
+        assert!(c[1].reasons[0].contains("mean 600 ms over 20 calls"));
+        assert_eq!(c[0].rule, Rule::NewHeavy);
+    }
+
+    #[test]
+    fn new_heavy_is_suppressed_while_the_server_warms_up_or_with_little_data() {
+        let mut w = window(vec![row(1, 1000, 30_000.0, Duration::hours(2))]);
+        let ctx = ServerContext {
+            first_seen: Some(now() - Duration::hours(3)),
+            stats_reset_recent: false,
+        };
+        assert!(evaluate(&w, &Baselines::new(), &ctx, &th(), &[], now()).is_empty());
+        let ctx = ServerContext {
+            first_seen: Some(now() - Duration::days(30)),
+            stats_reset_recent: true,
+        };
+        assert!(evaluate(&w, &Baselines::new(), &ctx, &th(), &[], now()).is_empty());
+        w.samples = 5;
+        assert!(evaluate(
+            &w,
+            &Baselines::new(),
+            &ServerContext::default(),
+            &th(),
+            &[],
+            now()
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn muted_utility_and_textless_rows_are_skipped() {
+        let mut r = row(1, 1000, 30_000.0, Duration::hours(2));
+        r.query = Some("VACUUM ANALYZE posthog_person".into());
+        let mut no_text = row(2, 1000, 30_000.0, Duration::hours(2));
+        no_text.query = None;
+        let w = window(vec![r, no_text, row(3, 1000, 30_000.0, Duration::hours(2))]);
+        let c = evaluate(
+            &w,
+            &Baselines::new(),
+            &ServerContext::default(),
+            &th(),
+            &[30],
+            now(),
+        );
+        assert!(c.is_empty());
+    }
+
+    #[test]
+    fn regression_needs_enough_days_and_beats_median_and_p95() {
+        let old = row(7, 500, 100_000.0, Duration::days(20)); // mean 200 ms, share 10%
+        let w = window(vec![old.clone()]);
+        assert!(needs_baseline(&old, &w, &th(), now()));
+        let point = |mean_ms, share_pct| BaselinePoint { mean_ms, share_pct };
+        let mut b = Baselines::new();
+        b.insert(("posthog".into(), 7), vec![point(50.0, 3.0); 4]);
+        assert!(evaluate(&w, &b, &ServerContext::default(), &th(), &[], now()).is_empty());
+        b.insert(("posthog".into(), 7), vec![point(50.0, 3.0); 7]);
+        let c = evaluate(&w, &b, &ServerContext::default(), &th(), &[], now());
+        assert_eq!(c.len(), 1);
+        assert_eq!(c[0].rule, Rule::Regression);
+        assert_eq!(c[0].reasons.len(), 2);
+        // One noisy day lifts the p95 floor above the window mean.
+        let mut noisy = vec![point(50.0, 3.0); 6];
+        noisy.push(point(150.0, 8.0));
+        b.insert(("posthog".into(), 7), noisy);
+        let c = evaluate(&w, &b, &ServerContext::default(), &th(), &[], now());
+        assert!(c.is_empty());
+    }
+
+    #[test]
+    fn quantiles() {
+        assert_eq!(median(&mut [3.0, 1.0, 2.0]), 2.0);
+        assert_eq!(median(&mut [4.0, 1.0, 2.0, 3.0]), 2.5);
+        assert_eq!(p95(&mut [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 100.0]), 100.0);
+        assert_eq!(p95(&mut []), 0.0);
+    }
+}

--- a/rust/pgcollector/src/checks/sql.rs
+++ b/rust/pgcollector/src/checks/sql.rs
@@ -1,0 +1,231 @@
+//! Every query the checks job runs against the stats DB.
+
+use super::rules::{BaselinePoint, Baselines, ServerContext, Window, WindowRow};
+use anyhow::{Context, Result};
+use chrono::{DateTime, Duration, DurationRound, Timelike, Utc};
+use deadpool_postgres::Client;
+
+const ROLLUP_STATE_KEY: &str = "rollup_through";
+/// Hours of raw data one rollup statement covers; bounds the cost of a catch-up.
+const ROLLUP_CHUNK_HOURS: i64 = 6;
+
+pub async fn try_lock(c: &Client) -> Result<bool> {
+    let r = c
+        .query_one(
+            "SELECT pg_try_advisory_lock(hashtext('pgcollector:checks'))",
+            &[],
+        )
+        .await?;
+    Ok(r.get(0))
+}
+
+pub async fn unlock(c: &Client) -> Result<()> {
+    c.execute(
+        "SELECT pg_advisory_unlock(hashtext('pgcollector:checks'))",
+        &[],
+    )
+    .await?;
+    Ok(())
+}
+
+pub async fn servers(c: &Client) -> Result<Vec<String>> {
+    Ok(c.query("SELECT server_id FROM cur_servers ORDER BY 1", &[])
+        .await?
+        .into_iter()
+        .map(|r| r.get(0))
+        .collect())
+}
+
+/// Roll completed hours of `ts_query_stats` into `ts_query_stats_1h` / `ts_server_stats_1h`,
+/// continuing from where the last run stopped. Returns the number of hours processed.
+pub async fn fill_rollup(
+    c: &Client,
+    now: DateTime<Utc>,
+    baseline_days: u32,
+    ignore_roles: &[String],
+) -> Result<i64> {
+    let end = now.duration_trunc(Duration::hours(1))?;
+    let earliest = end - Duration::days(baseline_days as i64 + 1);
+    let through: Option<DateTime<Utc>> = c
+        .query_opt(
+            "SELECT (value->>'through')::timestamptz FROM checks_state WHERE key = $1",
+            &[&ROLLUP_STATE_KEY],
+        )
+        .await?
+        .map(|r| r.get(0));
+    let mut from = through.unwrap_or(earliest).max(earliest);
+    let mut hours = 0;
+    while from < end {
+        let to = (from + Duration::hours(ROLLUP_CHUNK_HOURS)).min(end);
+        c.execute(
+            "INSERT INTO ts_query_stats_1h (server_id, datname, queryid, hour, calls, total_ms, sumsq, rows, shared_blks_read, temp_blks_written, wal_bytes, instances)
+             SELECT server_id, datname, queryid, date_trunc('hour', collected_at),
+                    sum(calls)::bigint, sum(total_exec_time)::float8, sum(sumsq_exec_time)::float8, sum(rows)::bigint,
+                    sum(shared_blks_read)::bigint, sum(temp_blks_written)::bigint, sum(wal_bytes)::bigint, count(DISTINCT instance)::int
+             FROM ts_query_stats
+             WHERE collected_at >= $1 AND collected_at < $2 AND toplevel AND datname IS NOT NULL AND NOT (rolname = ANY($3))
+             GROUP BY 1, 2, 3, 4
+             ON CONFLICT (server_id, datname, queryid, hour) DO UPDATE SET
+               calls = EXCLUDED.calls, total_ms = EXCLUDED.total_ms, sumsq = EXCLUDED.sumsq, rows = EXCLUDED.rows,
+               shared_blks_read = EXCLUDED.shared_blks_read, temp_blks_written = EXCLUDED.temp_blks_written,
+               wal_bytes = EXCLUDED.wal_bytes, instances = EXCLUDED.instances",
+            &[&from, &to, &ignore_roles],
+        )
+        .await
+        .context("rollup")?;
+        c.execute(
+            "INSERT INTO ts_server_stats_1h (server_id, hour, total_ms, calls)
+             SELECT server_id, hour, sum(total_ms), sum(calls) FROM ts_query_stats_1h
+             WHERE hour >= $1 AND hour < $2 GROUP BY 1, 2
+             ON CONFLICT (server_id, hour) DO UPDATE SET total_ms = EXCLUDED.total_ms, calls = EXCLUDED.calls",
+            &[&from, &to],
+        )
+        .await?;
+        c.execute(
+            "INSERT INTO checks_state (key, value, updated_at) VALUES ($1, jsonb_build_object('through', $2::timestamptz), now())
+             ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at",
+            &[&ROLLUP_STATE_KEY, &to],
+        )
+        .await?;
+        hours += (to - from).num_hours();
+        from = to;
+    }
+    c.execute(
+        "DELETE FROM ts_query_stats_1h WHERE hour < $1",
+        &[&earliest],
+    )
+    .await?;
+    c.execute(
+        "DELETE FROM ts_server_stats_1h WHERE hour < $1",
+        &[&earliest],
+    )
+    .await?;
+    Ok(hours)
+}
+
+pub async fn server_context(c: &Client, server: &str) -> Result<ServerContext> {
+    let first_seen: Option<DateTime<Utc>> = c
+        .query_opt(
+            "SELECT first_seen FROM cur_servers WHERE server_id = $1",
+            &[&server],
+        )
+        .await?
+        .map(|r| r.get(0));
+    let resets: i64 = c
+        .query_one(
+            "SELECT count(*) FROM events WHERE server_id = $1 AND kind = 'stats_reset' AND at >= now() - interval '24 hours'",
+            &[&server],
+        )
+        .await?
+        .get(0);
+    Ok(ServerContext {
+        first_seen,
+        stats_reset_recent: resets > 0,
+    })
+}
+
+pub async fn window(
+    c: &Client,
+    server: &str,
+    from: DateTime<Utc>,
+    to: DateTime<Utc>,
+    ignore_roles: &[String],
+) -> Result<Window> {
+    let rows = c
+        .query(
+            "WITH w AS (
+               SELECT datname, queryid, sum(calls)::bigint AS calls, sum(total_exec_time)::float8 AS total_ms,
+                      sum(rows)::bigint AS rows, sum(shared_blks_read)::bigint AS shared_blks_read,
+                      sum(temp_blks_written)::bigint AS temp_blks_written,
+                      array_agg(DISTINCT rolname) AS rolnames
+               FROM ts_query_stats
+               WHERE server_id = $1 AND collected_at >= $2 AND collected_at < $3 AND toplevel
+                 AND datname IS NOT NULL AND NOT (rolname = ANY($4))
+               GROUP BY 1, 2),
+             q AS (
+               SELECT DISTINCT ON (datname, queryid) datname, queryid, query, fingerprint, first_seen
+               FROM cur_queries WHERE server_id = $1 ORDER BY datname, queryid, first_seen)
+             SELECT w.datname, w.queryid, w.calls, w.total_ms, w.rows, w.shared_blks_read, w.temp_blks_written, w.rolnames,
+                    q.query, q.fingerprint, q.first_seen
+             FROM w LEFT JOIN q USING (datname, queryid)
+             WHERE w.total_ms > 0",
+            &[&server, &from, &to, &ignore_roles],
+        )
+        .await
+        .context("window")?;
+    let totals = c
+        .query_one(
+            "SELECT coalesce(sum(total_exec_time), 0)::float8, count(DISTINCT collected_at)::bigint
+             FROM ts_query_stats WHERE server_id = $1 AND collected_at >= $2 AND collected_at < $3 AND toplevel",
+            &[&server, &from, &to],
+        )
+        .await?;
+    Ok(Window {
+        rows: rows
+            .iter()
+            .map(|r| WindowRow {
+                datname: r.get(0),
+                queryid: r.get(1),
+                calls: r.get(2),
+                total_ms: r.get(3),
+                rows: r.get(4),
+                shared_blks_read: r.get(5),
+                temp_blks_written: r.get(6),
+                rolnames: r
+                    .get::<_, Option<Vec<Option<String>>>>(7)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .flatten()
+                    .collect(),
+                query: r.get(8),
+                fingerprint: r.get(9),
+                first_seen: r.get(10),
+            })
+            .collect(),
+        server_total_ms: totals.get(0),
+        samples: totals.get(1),
+        from,
+        to,
+    })
+}
+
+/// Same hour-of-day as `at` on each of the previous `days` days, per (datname, queryid).
+pub async fn baselines(
+    c: &Client,
+    server: &str,
+    queryids: &[i64],
+    at: DateTime<Utc>,
+    days: u32,
+) -> Result<Baselines> {
+    let mut out = Baselines::new();
+    if queryids.is_empty() {
+        return Ok(out);
+    }
+    let hour = at.duration_trunc(Duration::hours(1))?;
+    let from = hour - Duration::days(days as i64);
+    let rows = c
+        .query(
+            "SELECT s.datname, s.queryid, s.calls, s.total_ms, t.total_ms
+             FROM ts_query_stats_1h s JOIN ts_server_stats_1h t USING (server_id, hour)
+             WHERE s.server_id = $1 AND s.queryid = ANY($2) AND s.hour >= $3 AND s.hour < $4
+               AND extract(hour FROM s.hour AT TIME ZONE 'UTC') = $5 AND s.calls > 0",
+            &[&server, &queryids, &from, &hour, &(hour.hour() as f64)],
+        )
+        .await
+        .context("baselines")?;
+    for r in rows {
+        let (datname, queryid, calls, total_ms, server_ms): (String, i64, i64, f64, f64) =
+            (r.get(0), r.get(1), r.get(2), r.get(3), r.get(4));
+        out.entry((datname, queryid))
+            .or_default()
+            .push(BaselinePoint {
+                mean_ms: total_ms / calls as f64,
+                share_pct: if server_ms > 0.0 {
+                    total_ms / server_ms * 100.0
+                } else {
+                    0.0
+                },
+            });
+    }
+    Ok(out)
+}

--- a/rust/pgcollector/src/config.rs
+++ b/rust/pgcollector/src/config.rs
@@ -15,6 +15,8 @@ pub struct Config {
     pub servers: Vec<ServerConfig>,
     #[serde(default)]
     pub ownership: OwnershipConfig,
+    #[serde(default)]
+    pub checks: ChecksConfig,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -142,6 +144,127 @@ impl Default for OwnershipConfig {
 }
 fn ownership_fallback_rotation() -> String {
     "infra".into()
+}
+
+/// The slow-query checks job: finds heavy new queries and regressions in the stats DB,
+/// attributes them to a team and exposes them as findings (and gauges when `alerting`).
+#[derive(Debug, Deserialize, Clone)]
+pub struct ChecksConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(with = "humantime_serde", default = "checks_interval")]
+    pub interval: Duration,
+    /// Recent window every rule looks at.
+    #[serde(with = "humantime_serde", default = "checks_window")]
+    pub window: Duration,
+    /// Days of hourly roll-up the regression baseline compares against.
+    #[serde(default = "checks_baseline_days")]
+    pub baseline_days: u32,
+    /// Export open findings as `pgcollector_query_finding` gauges. Off = shadow mode:
+    /// findings are still persisted and visible in pgapi.
+    #[serde(default)]
+    pub alerting: bool,
+    /// Roles whose statements never produce findings (monitoring, RDS internals).
+    #[serde(default = "checks_ignore_roles")]
+    pub ignore_roles: Vec<String>,
+    /// Query fingerprints that never produce findings.
+    #[serde(default)]
+    pub mute: Vec<i64>,
+    #[serde(default)]
+    pub thresholds: Thresholds,
+}
+impl Default for ChecksConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            interval: checks_interval(),
+            window: checks_window(),
+            baseline_days: checks_baseline_days(),
+            alerting: false,
+            ignore_roles: checks_ignore_roles(),
+            mute: vec![],
+            thresholds: Thresholds::default(),
+        }
+    }
+}
+fn checks_interval() -> Duration {
+    Duration::from_secs(600)
+}
+fn checks_window() -> Duration {
+    Duration::from_secs(3600)
+}
+fn checks_baseline_days() -> u32 {
+    7
+}
+fn checks_ignore_roles() -> Vec<String> {
+    [
+        "pgcollector",
+        "pgapi",
+        "pganalyze",
+        "rdsadmin",
+        "rdstopmgr",
+        "rdsrepladmin",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect()
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct Thresholds {
+    /// A query first seen more recently than this is "new".
+    #[serde(with = "humantime_serde")]
+    pub new_query_age: Duration,
+    /// A server younger than this has every query "new"; new_heavy is skipped.
+    #[serde(with = "humantime_serde")]
+    pub warmup: Duration,
+    /// new_heavy floors: any one of them opens a candidate.
+    pub share_pct: f64,
+    pub total_ms: f64,
+    pub mean_ms: f64,
+    pub mean_min_calls: i64,
+    pub shared_blks_read: i64,
+    pub temp_blks_written: i64,
+    /// regression: mean over the window vs the same hour-of-day over the baseline days.
+    pub regression_multiple: f64,
+    pub regression_p95_multiple: f64,
+    pub regression_min_mean_ms: f64,
+    pub regression_min_calls: i64,
+    pub regression_share_pct: f64,
+    pub baseline_min_days: usize,
+    /// Consecutive runs a candidate must match before a finding opens, and clean runs
+    /// before it resolves.
+    pub open_after_runs: i32,
+    pub resolve_after_runs: i32,
+    /// More new shapes than this on one table in one run collapse into one finding.
+    pub burst_shapes: usize,
+    /// Fewer distinct sample timestamps than this in the window = not enough data.
+    pub min_samples: i64,
+}
+impl Default for Thresholds {
+    fn default() -> Self {
+        Self {
+            new_query_age: Duration::from_secs(24 * 3600),
+            warmup: Duration::from_secs(48 * 3600),
+            share_pct: 2.0,
+            total_ms: 60_000.0,
+            mean_ms: 500.0,
+            mean_min_calls: 10,
+            shared_blks_read: 1_280_000,
+            temp_blks_written: 12_800,
+            regression_multiple: 3.0,
+            regression_p95_multiple: 1.5,
+            regression_min_mean_ms: 50.0,
+            regression_min_calls: 100,
+            regression_share_pct: 1.0,
+            baseline_min_days: 5,
+            open_after_runs: 2,
+            resolve_after_runs: 6,
+            burst_shapes: 5,
+            min_samples: 30,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]

--- a/rust/pgcollector/src/http.rs
+++ b/rust/pgcollector/src/http.rs
@@ -4,7 +4,8 @@
 use axum::{extract::State, http::StatusCode, routing::get, Router};
 use once_cell::sync::Lazy;
 use prometheus::{
-    Encoder, HistogramVec, IntCounterVec, IntGaugeVec, Registry as PromRegistry, TextEncoder,
+    Encoder, Histogram, HistogramVec, IntCounterVec, IntGaugeVec, Registry as PromRegistry,
+    TextEncoder,
 };
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -17,6 +18,10 @@ pub struct Metrics {
     pub rows: IntCounterVec,
     pub errors: IntCounterVec,
     pub targets: IntGaugeVec,
+    /// 1 per open finding; the vmalert rule fires on these.
+    pub query_finding: IntGaugeVec,
+    pub checks_findings: IntCounterVec,
+    pub checks_run_seconds: Histogram,
 }
 
 impl Metrics {
@@ -56,6 +61,45 @@ impl Metrics {
         build_info
             .with_label_values(&[env!("CARGO_PKG_VERSION")])
             .set(1);
+        let query_finding = IntGaugeVec::new(
+            prometheus::opts!(
+                "pgcollector_query_finding",
+                "open slow-query finding attributed to a team"
+            ),
+            &[
+                "server",
+                "datname",
+                "rule",
+                "severity",
+                "team",
+                "rotation",
+                "slack_channel",
+                "method",
+                "queryid",
+                "fingerprint",
+            ],
+        )
+        .unwrap();
+        let checks_findings = IntCounterVec::new(
+            prometheus::opts!(
+                "pgcollector_checks_findings_total",
+                "findings that reached open"
+            ),
+            &["rule", "team"],
+        )
+        .unwrap();
+        let checks_run_seconds = Histogram::with_opts(
+            prometheus::histogram_opts!("pgcollector_checks_run_seconds", "checks run duration")
+                .buckets(vec![0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0]),
+        )
+        .unwrap();
+        registry.register(Box::new(query_finding.clone())).unwrap();
+        registry
+            .register(Box::new(checks_findings.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(checks_run_seconds.clone()))
+            .unwrap();
         registry.register(Box::new(tick_seconds.clone())).unwrap();
         registry.register(Box::new(rows.clone())).unwrap();
         registry.register(Box::new(errors.clone())).unwrap();
@@ -68,6 +112,9 @@ impl Metrics {
             rows,
             errors,
             targets,
+            query_finding,
+            checks_findings,
+            checks_run_seconds,
         }
     }
 }

--- a/rust/pgcollector/src/main.rs
+++ b/rust/pgcollector/src/main.rs
@@ -1,3 +1,4 @@
+mod checks;
 mod collector;
 mod collectors;
 mod config;
@@ -34,6 +35,10 @@ struct Cli {
     /// Run every collector once against every server, print row counts, exit (no sink writes)
     #[arg(long)]
     once: bool,
+    /// Evaluate the slow-query checks once against the stats DB, print the candidates as
+    /// JSON lines, exit (no findings written, no gauges)
+    #[arg(long)]
+    checks_once: bool,
     /// Print which team owns a SQL statement (per [ownership]) as JSON, then exit
     #[arg(long, value_name = "SQL")]
     attribute: Option<String>,
@@ -114,6 +119,10 @@ async fn main() -> Result<()> {
         return attribute(&cfg, &cli.server, &cli.datname, sql);
     }
 
+    if cli.checks_once {
+        return checks_once(&cfg).await;
+    }
+
     let sink: Arc<dyn sink::Sink> = if cli.once {
         Arc::new(sink::StdoutSink)
     } else {
@@ -130,7 +139,11 @@ async fn main() -> Result<()> {
         });
     }
 
-    scheduler::run(Arc::new(cfg), Arc::new(registry), sink, ready, cli.once).await
+    let cfg = Arc::new(cfg);
+    if cfg.checks.enabled && !cli.once {
+        tokio::spawn(checks::run(cfg.clone()));
+    }
+    scheduler::run(cfg, Arc::new(registry), sink, ready, cli.once).await
 }
 
 fn attribute(cfg: &config::Config, server: &str, datname: &str, sql: &str) -> Result<()> {
@@ -150,6 +163,31 @@ fn attribute(cfg: &config::Config, server: &str, datname: &str, sql: &str) -> Re
         "tables_known": own.table_count(),
     });
     println!("{}", serde_json::to_string_pretty(&out)?);
+    Ok(())
+}
+
+async fn checks_once(cfg: &config::Config) -> Result<()> {
+    let own = ownership::Ownership::load(&cfg.ownership)?;
+    let pool = checks::pool(&cfg.sink)?;
+    let Some(report) =
+        checks::run_once(&pool, &cfg.checks, &own, chrono::Utc::now(), false).await?
+    else {
+        anyhow::bail!("another checks runner holds the advisory lock");
+    };
+    for (server, cand, f) in &report.candidates {
+        println!(
+            "{}",
+            serde_json::json!({ "server": server, "rule": cand.rule, "datname": cand.datname, "queryid": cand.queryid,
+                "fingerprint": cand.fingerprint, "team": f.team, "rotation": f.rotation, "method": f.method,
+                "reasons": cand.reasons, "attribution": f.attribution, "stats": cand.stats,
+                "query": cand.query.chars().take(300).collect::<String>() })
+        );
+    }
+    eprintln!(
+        "{} candidates, rollup advanced {} hours",
+        report.candidates.len(),
+        report.rollup_hours
+    );
     Ok(())
 }
 

--- a/rust/pgcollector/src/ownership/mod.rs
+++ b/rust/pgcollector/src/ownership/mod.rs
@@ -1,5 +1,5 @@
 pub mod owners;
 pub mod tables;
 
-pub use owners::Ownership;
+pub use owners::{Attribution, Ownership, UNOWNED};
 pub use tables::extract;

--- a/rust/pgcollector/src/sink/postgres.rs
+++ b/rust/pgcollector/src/sink/postgres.rs
@@ -49,8 +49,13 @@ fn datname_for(snap: &Snapshot, row: &crate::collector::Row) -> Option<String> {
         })
 }
 
-const MIGRATIONS: &[(&str, &str)] =
-    &[("0001_base", include_str!("../../migrations/0001_base.sql"))];
+const MIGRATIONS: &[(&str, &str)] = &[
+    ("0001_base", include_str!("../../migrations/0001_base.sql")),
+    (
+        "0002_query_findings",
+        include_str!("../../migrations/0002_query_findings.sql"),
+    ),
+];
 
 impl PostgresSink {
     pub async fn connect(cfg: &SinkConfig) -> Result<Self> {


### PR DESCRIPTION
## Problem

- A team that ships a heavy new query, or slows an existing one, does not hear about it. Someone on infra notices later in a dashboard and works out who to tell by hand.
- pgcollector already collects `pg_stat_statements` deltas per minute, and #97068 can say which team a statement belongs to. Nothing joins the two.
- This is the top layer of the stack: #97067 generates the table-to-team map, #97068 resolves a statement to a team, and this PR evaluates the rules and produces the findings.

## Changes

- Teams get a per-query finding, attributed to them, when a new query is heavy or an old one regresses. The finding names the rule, the team, the rotation, the Slack channel, and the reasons.
- pgapi shows the findings on a new Findings page, filterable by status, and serves them over `/api/v1/findings` and the `query_findings` MCP tool.

![pgapi-findings-page](https://raw.githubusercontent.com/PostHog/pr-assets/7eb5853894dccd797fffa0041c16e8804902307a/2026/09/aeb3bce5-a0e1-440f-92b3-840562df292f.png)

- A `[checks]` job in pgcollector, off by default, runs every 10 minutes over the last hour of stats in the stats database.
- `new_heavy` fires for a query first seen within 24 hours that takes at least 2% of the server's execution time, 60 seconds in total, a mean of 500 ms over 10 calls, or reads or spills a lot. More than 5 new shapes on one table collapse into one `new_heavy_burst` finding, which is what a deploy looks like.
- `regression` fires for a query with 7 days of history whose mean or share of server time is over 3x the median and 1.5x the p95 of the same hour of day over the previous 7 days.
- A finding opens after 2 consecutive matching runs and resolves after 6 clean runs, so one noisy window never alerts. Rules skip a server younger than 48 hours, a recent stats reset, utility statements, catalog-only queries, monitoring roles, and muted fingerprints.
- With `alerting = true` every open finding is a `pgcollector_query_finding` gauge labelled with team, rotation and Slack channel. The default is shadow mode: findings persist and show in pgapi, no gauge is exported. The vmalert rule that turns the gauge into an alert lands in the charts repo separately.
- The job also fills an hourly roll-up, `ts_query_stats_1h`, so the 7-day baseline reads 168 rows per query instead of rescanning minute data.
- `pgcollector --checks-once` evaluates once and prints the candidates as JSON lines without writing findings or gauges, for tuning thresholds.
- Mechanical: migration `0002_query_findings.sql`, the three new Prometheus metrics, and the README and DESIGN updates.

Before, the stats database was read only by people:

```mermaid
flowchart LR
  PG[pg_stat_statements] --> C[pgcollector] --> DB[(stats DB)] --> API[pgapi] --> P{{person}}
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
  classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
  class C,API phBlue;
  class PG,DB phGray;
  class P phYellow;
```

After, the checks job reads it back and routes what it finds:

```mermaid
flowchart LR
  PG[pg_stat_statements] --> C[pgcollector] --> DB[(stats DB)]
  DB --> J[checks job] --> O[ownership map] --> F[(query_findings)]
  F --> API[pgapi] --> P{{person}}
  F -->|alerting = true| G[gauge] --> V[vmalert] --> R{{team rotation / Slack}}
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
  classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
  classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
  class C,J,API phBlue;
  class V phRed;
  class PG,DB,O,F,G phGray;
  class P,R phYellow;
```

> [!NOTE]
> Rollout is shadow mode first: enable `[checks]` with `alerting = false`, tune thresholds and `ownership/overrides.yaml` from the Findings page for a week, land the charts alert rule, then flip `alerting`.

## How did you test this code?

- Unit tests in `src/checks/rules.rs` catch threshold regressions: `new_heavy` fires on any one floor and names the reason, is suppressed during warmup or with too few samples, skips muted, utility and textless rows, and `regression` needs enough baseline days and must beat both the median and the p95.
- A unit test in `src/checks/mod.rs` catches the burst collapse regressing to one finding per shape.
- The screenshot above comes from pgapi on a local throwaway stats database, with the two findings inserted by hand from invented numbers. The checks job itself did not run against a database in this session.
- Not checked: the SQL in `src/checks/sql.rs` (window, baselines, roll-up) ran only through the migration in the local database, not through the job.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`rust/pgcollector/README.md` gains a "Slow-query checks" section and `DESIGN.md` records the job, in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5.1). Skills invoked: /stacking-prs, /writing-pr-descriptions.
- Top layer of one larger branch split into three. Compared with the original branch, the ownership settings moved from `[checks]` to `[ownership]` (see #97068); the rules, findings and pgapi code are unchanged.

https://claude.ai/code/session_019YJkcNok1ZzR6iBXES1Cmi
