### PR TITLE
docs(stamphog): repoint the engine-details link at the real agent README

### DIFF
--- a/products/stamphog/README.md
+++ b/products/stamphog/README.md
@@ -39,7 +39,7 @@ The sandbox clones and checks out the PR head for every review, so the reviewer'
 The engine is told the checkout is the head (`head_checkout=True`) so it never builds the Action's separate head worktree, and the prompt flags the PR as stacked (`PRData.stacked`, keyed on the repo's actual default branch).
 The diff stays scoped `base...head`.
 When the parent merges and GitHub retargets the child onto the default branch, the diff changes without a push: the webhook path retracts the standing approval and queues a fresh run, and `post_verdict` rechecks the live base (ref and SHA) against the reviewed one before posting.
-Engine details: [`tools/pr-approval-agent/README.md`](../../tools/pr-approval-agent/README.md#stacked-prs-graphite--git-stacks).
+Engine details: [`packages/pr-approval-agent/README.md`](packages/pr-approval-agent/README.md#stacked-prs-graphite--git-stacks).
 
 ## Configuration
 


### PR DESCRIPTION
`products/stamphog/README.md`'s "Engine details" line linked `tools/pr-approval-agent/README.md#stacked-prs-graphite--git-stacks` — `tools/` has no such directory. The agent lives at `products/stamphog/packages/pr-approval-agent/`, whose README carries the referenced 'Stacked PRs (Graphite / git stacks)' section. Link repointed there (both path and anchor verified).