### PR TITLE
fix(data-warehouse): hide the firewall hint on the DynamoDB setup step

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceScene.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceScene.tsx
@@ -519,9 +519,9 @@ function FirstStep({ allowedSources }: NewSourcesWizardProps): JSX.Element {
 }
 
 // Connectors in the "Databases" category that PostHog reaches over the provider's public HTTPS API
-// with a service account key. The customer has no network path in front of them, so the firewall
-// hint would name a setup step that does not exist.
-const SOURCES_WITHOUT_NETWORK_ALLOWLIST: ExternalDataSourceType[] = ['BigQuery', 'Firebase']
+// with a key the provider issues. The customer has no network path in front of them, so the
+// firewall hint would name a setup step that does not exist.
+const SOURCES_WITHOUT_NETWORK_ALLOWLIST: ExternalDataSourceType[] = ['BigQuery', 'DynamoDB', 'Firebase']
 
 // Firewall allowlisting only applies to self-hosted databases PostHog dials out to, so the hint is
 // scoped to that category rather than shown for OAuth/API connectors.


### PR DESCRIPTION
## Problem

Someone setting up a DynamoDB source is told to add PostHog's IP addresses to their database firewall allowlist. DynamoDB has no such firewall. PostHog reaches it over the AWS API with a request signed by the access key entered on the same form, so there is nothing to allowlist.

Session scans of the new-source wizard show people stalling on the DynamoDB setup step and leaving without connecting. The banner sends them looking for an AWS setting that does not exist.

BigQuery and Firebase already skip this banner for the same reason.

## Changes

- The DynamoDB setup step no longer shows the firewall allowlist banner. Every other field and instruction on the step is unchanged.
- `DynamoDB` joins `BigQuery` and `Firebase` in `SOURCES_WITHOUT_NETWORK_ALLOWLIST`, the existing exclusion list.
- The comment above that list now says "a key the provider issues" rather than "a service account key", since DynamoDB uses an AWS access key.

No screenshot: this sandbox has no `node_modules`, so the app was not built. The visible change is the removal of one info banner between the connector caption and the connection form.

## How did you test this code?

- Not run: the frontend test suites, because this sandbox has no `node_modules`.
- No new test. The banner has no test today, and the change is one entry in a list a rendering test would restate rather than protect.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code while reviewing Replay Vision summaries of the data warehouse new-source flow for recurring friction. Two of those sessions stalled on the DynamoDB setup step.

Skills invoked: `/writing-user-facing-copy`, `/writing-pr-descriptions`.

No duplicate: `gh pr list --state open --search` for "DynamoDB", "firewall" and "allowlist", plus the full list of open PRs on this area, found nothing that touches this banner.

Public artifact: the diff, the commit message and this description carry no material from the session that produced them. The connector name is the only detail taken from it, and it names a public PostHog connector.
