### PR TITLE
fix(instagram): say what to enter when no professional account is listed

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instagram/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instagram/source.py
@@ -97,6 +97,14 @@ Connect your Instagram account, then pick the professional account you want to s
                         label="Instagram professional account",
                         integrationField="instagram_integration_id",
                         integrationKind="instagram",
+                        placeholder="17841400000000000",
+                        # An account a Business portfolio owns is missing from the list even when the
+                        # page is linked (see `list_professional_accounts`), so name the fallback here
+                        # rather than after a save fails.
+                        caption=(
+                            "Only professional accounts linked to a Facebook page are listed. If yours is missing, "
+                            "enter its numeric Instagram account ID from your Meta business settings."
+                        ),
                         required=True,
                     ),
                     SourceFieldInputConfig(


### PR DESCRIPTION
## Problem

People connect Instagram, land on the "Instagram professional account" picker, and find it empty. The field is required, so the connection stops there. Session scans of the new-source wizard show this three times, with people reconnecting the integration several times and then giving up.

An empty list is expected in a case the form never mentions. The picker lists only professional accounts linked to a Facebook page, and an account owned by a Business portfolio stays hidden even when the page really is linked, because Meta omits it without the `business_management` scope this integration deliberately does not request. Such an account syncs fine once its numeric ID is typed in.

Today the only place that says so is the validation error raised after the field is saved with a username in it.

## Changes

- The account field now carries guidance under its label: only linked professional accounts are listed, and a missing one is reached by its numeric account ID from Meta business settings.
- The field's placeholder now shows the shape of that ID, so a username no longer looks like the expected value.
- No behavior change. Both are fields on the connector's `SourceConfig`, rendered by the existing form component. Google Search Console's account field already carries the same pair.

No screenshot: this sandbox has no `node_modules`, so the app was not built. The visible change is two lines of static text on one field, in the same positions the Search Console field uses them.

## How did you test this code?

- Ran: `ruff format --check` and `ruff check` over the changed file.
- Not run: the Instagram test suite, because it was not reachable from this sandbox.
- No new test. The change is two static strings on a config object, and a test asserting them would restate the constant.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code while reviewing Replay Vision summaries of the data warehouse new-source flow for recurring friction. An empty Instagram account picker after a successful connection was the most repeated blocking step in that set.

An earlier draft added the same guidance to the generic empty-account hint in `IntegrationAccountSelector`. That put one connector's rules into a component every OAuth source shares, so the guidance moved onto the connector's own field config instead.

Skills invoked: `/writing-user-facing-copy`, `/writing-pr-descriptions`.

No duplicate: `gh pr list --state open --search` for "Instagram", "instagram professional", "numeric ID" and "account select", plus the full list of open PRs on this area, found nothing that touches this field.

Public artifact: the diff, the commit message and this description carry no material from the session that produced them. The placeholder ID is invented, not a value read from any account.
