### PR TITLE
feat(warehouse-sources): promote the Close source to GA

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/close/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/close/source.py
@@ -133,7 +133,7 @@ class CloseSource(ResumableSource[CloseSourceConfig, CloseResumeConfig]):
             ),
             iconPath="/static/services/close.png",
             docsUrl="https://posthog.com/docs/cdp/sources/close",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.GA,
             fields=cast(
                 list[FieldType],
                 [


### PR DESCRIPTION
## Problem

People connecting Close in the data warehouse wizard see it labelled Alpha, which reads as "new and lightly tested" and discourages anyone from picking it for real work. The connector has outgrown that label.

It now clears both promotion bars:

- Live for 3.1 months (the bar is 100+ teams or 3 months).
- Import error rate of 0.0% over the last 7 days (the bar is under 2.5%).

## Changes

- The Close source now shows as generally available instead of Alpha in the source catalog and on its docs page.
- `releaseStatus` moves from `ReleaseStatus.ALPHA` to `ReleaseStatus.GA` in the source config. One line, no behavior change.

Nothing else was touched. Close carries no `unreleasedSource` flag and no `dwh-close` feature flag, so there is no gating to remove alongside the status. `SOURCES.md` records transport, not release stage, so it needed no edit.

## How did you test this code?

No tests were added or changed. The diff is a single enum value in a declarative config, and the repo's source-test guidance rules out tests that only read back a declaration.

Sync logic, schemas, and endpoints are untouched, so existing Close coverage still applies unchanged. Nothing was verified against a live Close account.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The posthog.com docs page renders release status from the `public_source_configs` API, so it picks this up with no doc edit.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code (Opus 5) from a promotion request that supplied the qualifying metrics quoted above. Invoked `/implementing-warehouse-sources` for the release-status conventions, which is where the `ReleaseStatus` enum rule and the "no gating flag left behind" check come from, and `/writing-pr-descriptions` for this body.

No duplicate: searched open PRs for the source name, `releaseStatus`, `promote`, and `GA`, and listed every open PR by the warehouse-sources maintainer. Nothing addresses the Close promotion. The one nearby PR, #91695, changes Close's search field list rather than its release stage.

Public artifact: the change draws on aggregate usage and error-rate figures only, described qualitatively here. No customer material is in the diff or this description.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
