### PR TITLE
fix(ci): keep the restored schema's migration history consistent

### DIFF
--- a/tools/hogli-commands/hogli_commands/db_schema.py
+++ b/tools/hogli-commands/hogli_commands/db_schema.py
@@ -35,7 +35,7 @@ DOCKER_COMPOSE = ["docker", "compose", "-f", "docker-compose.dev.yml"]
 DB_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,62}$")
 PRODUCT_DB_ROUTING_PATH = Path("products/db_routing.yaml")
 APP_LABEL_RE = re.compile(r"^[a-z][a-z0-9_]*$")
-SQUASH_SCHEMA_ADDONS_NAME_PATTERN = r"%\_squash\_%\_schema\_addons"
+SQUASH_SCHEMA_ADDONS_NAME_RE = re.compile(r".*_squash_.*_schema_addons$")
 
 T = TypeVar("T")
 
@@ -172,43 +172,20 @@ def _recreate_database(target_db: str) -> None:
     _psql_admin(f"CREATE DATABASE {target_db};")
 
 
-def _ensure_migration_defaults(target_db: str) -> None:
+def _manage(target_db: str, *args: str) -> None:
+    """Run a management command against target_db."""
     _run(
-        ["python", "manage.py", "ensure_migration_defaults"],
+        ["python", "manage.py", *args],
         env={"DATABASE_URL": f"postgres://posthog:posthog@localhost:5432/{target_db}"},
     )
 
 
-def _product_routed_app_labels() -> list[str]:
-    """App labels whose tables live in their own database, per products/db_routing.yaml."""
-    config_path = _resolve_repo_path(PRODUCT_DB_ROUTING_PATH)
-    if not config_path.is_file():
-        return []
-    config = yaml.safe_load(config_path.read_text()) or {}
-    labels = {str(route.get("app_label", "")).strip() for route in config.get("routes") or []}
-    return sorted(label for label in labels if APP_LABEL_RE.fullmatch(label))
+def _ensure_migration_defaults(target_db: str) -> None:
+    _manage(target_db, "ensure_migration_defaults")
 
 
-def _forget_product_app_migrations(target_db: str) -> None:
-    """Drop the dump's claim that product-routed apps are migrated in this database.
-
-    The dump is taken from a CI database that routes those apps elsewhere, so `migrate` skipped
-    every operation in their migrations there while Django recorded them as applied anyway (it
-    records whatever the router decides). Restored verbatim, that leaves a database asserting
-    stamphog and visual_review are migrated without a single one of their tables — and an
-    environment that configures no product database then applies their NEXT migration for real
-    and dies on the missing table. Clearing the rows lets each consumer replay them under its own
-    routing: a no-op where the app is routed away, real tables where it isn't.
-
-    The squash schema-addons migrations go with them. Each one depends on the leaf squash of every
-    squashed app, the product-routed apps included, so a database that keeps an addons row while
-    its dependency row is gone fails Django's consistency check before `migrate` does anything.
-    Replay is cheap: the addons operations probe the schema and skip what is already there.
-    """
-    app_labels = _product_routed_app_labels()
-    if not app_labels:
-        return
-    in_list = ", ".join(f"'{label}'" for label in app_labels)
+def _psql_write(target_db: str, sql: str) -> None:
+    """Run a one-shot statement against target_db."""
     _run(
         [
             *DOCKER_COMPOSE,
@@ -223,10 +200,135 @@ def _forget_product_app_migrations(target_db: str) -> None:
             "posthog",
             target_db,
             "-c",
-            f"DELETE FROM django_migrations WHERE app IN ({in_list}) "
-            f"OR name LIKE '{SQUASH_SCHEMA_ADDONS_NAME_PATTERN}';",
+            sql,
         ]
     )
+
+
+def _psql_rows(target_db: str, sql: str) -> list[list[str]]:
+    """Run a query against target_db and return its rows as lists of column values."""
+    result = subprocess.run(
+        [
+            *DOCKER_COMPOSE,
+            "exec",
+            "-T",
+            "db",
+            "psql",
+            "-At",
+            "-F",
+            "\t",
+            "-v",
+            "ON_ERROR_STOP=1",
+            "-U",
+            "posthog",
+            target_db,
+            "-c",
+            sql,
+        ],
+        cwd=REPO_ROOT,
+        env=os.environ.copy(),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line.split("\t") for line in result.stdout.splitlines() if line]
+
+
+def _product_routed_app_labels() -> list[str]:
+    """App labels whose tables live in their own database, per products/db_routing.yaml."""
+    config_path = _resolve_repo_path(PRODUCT_DB_ROUTING_PATH)
+    if not config_path.is_file():
+        return []
+    config = yaml.safe_load(config_path.read_text()) or {}
+    labels = {str(route.get("app_label", "")).strip() for route in config.get("routes") or []}
+    return sorted(label for label in labels if APP_LABEL_RE.fullmatch(label))
+
+
+@dataclass(frozen=True)
+class MigrationRecordPlan:
+    """What a restore does to the django_migrations rows the dump carries."""
+
+    forget: tuple[tuple[str, str], ...]
+    replay: tuple[tuple[str, str], ...]
+    refake: tuple[tuple[str, str], ...]
+
+
+def plan_migration_records(
+    recorded: Iterable[tuple[str, str]], product_app_labels: Iterable[str]
+) -> MigrationRecordPlan:
+    """Decide which of the dump's migration records to forget, replay for real, and re-record.
+
+    The dump is taken from a CI database that routes product apps elsewhere, so `migrate` skipped
+    every operation in their migrations there while Django recorded them as applied anyway (it
+    records whatever the router decides). Restored verbatim, that leaves a database asserting
+    stamphog and visual_review are migrated without a single one of their tables — and an
+    environment that configures no product database then applies their NEXT migration for real
+    and dies on the missing table. Forgetting the rows lets each consumer replay them under its
+    own routing: a no-op where the app is routed away, real tables where it isn't.
+
+    The squash schema-addons migrations go with them. Each one depends on the leaf squash of every
+    squashed app, the product-routed apps included, so a database that keeps an addons row while
+    its dependency row is gone fails Django's consistency check before `migrate` does anything.
+    Replaying one is cheap: its operations probe the schema and skip what is already there.
+
+    Everything an app records after its addons migration depends on that addons migration, so it
+    fails the same check for the same reason and has to be forgotten too. Those migrations are
+    already in the restored schema though, so replaying one would add a column that exists. They
+    are re-recorded with `--fake` instead. The repo keeps one migration line per app, so a name
+    that sorts after the addons migration is a descendant of it, and faking up to the last one
+    re-records the whole run.
+    """
+    routed = set(product_app_labels)
+    by_app: dict[str, list[str]] = {}
+    for app, name in recorded:
+        by_app.setdefault(app, []).append(name)
+
+    forget: list[tuple[str, str]] = []
+    replay: list[tuple[str, str]] = []
+    refake: list[tuple[str, str]] = []
+    for app, recorded_names in sorted(by_app.items()):
+        names = sorted(recorded_names)
+        if app in routed:
+            forget.extend((app, name) for name in names)
+            continue
+        addons = next((name for name in names if SQUASH_SCHEMA_ADDONS_NAME_RE.fullmatch(name)), None)
+        if addons is None:
+            continue
+        trailing = [name for name in names if name > addons]
+        forget.append((app, addons))
+        forget.extend((app, name) for name in trailing)
+        replay.append((app, addons))
+        if trailing:
+            refake.append((app, trailing[-1]))
+
+    return MigrationRecordPlan(forget=tuple(forget), replay=tuple(replay), refake=tuple(refake))
+
+
+def _sql_string(value: str) -> str:
+    escaped = value.replace("'", "''")
+    return f"'{escaped}'"
+
+
+def _forget_product_app_migrations(target_db: str) -> None:
+    """Re-record the dump's migrations the way this database can honor them.
+
+    See `plan_migration_records` for what moves and why.
+    """
+    app_labels = _product_routed_app_labels()
+    if not app_labels:
+        return
+    recorded = [(row[0], row[1]) for row in _psql_rows(target_db, "SELECT app, name FROM django_migrations;")]
+    plan = plan_migration_records(recorded, app_labels)
+    if not plan.forget:
+        return
+
+    pairs = ", ".join(f"({_sql_string(app)}, {_sql_string(name)})" for app, name in plan.forget)
+    _psql_write(target_db, f"DELETE FROM django_migrations WHERE (app, name) IN ({pairs});")
+
+    for app, name in plan.replay:
+        _manage(target_db, "migrate", app, name, "--noinput")
+    for app, name in plan.refake:
+        _manage(target_db, "migrate", app, name, "--noinput", "--fake")
 
 
 def restore_schema_dump(

--- a/tools/hogli-commands/hogli_commands/tests/test_db_schema.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_db_schema.py
@@ -295,6 +295,7 @@ def test_restore_schema_dump_recreate_drops_and_creates(tmp_path: Path, monkeypa
         lambda gzip_path, target_db: restored.append((gzip_path, target_db)),
     )
     monkeypatch.setattr(db_schema, "_ensure_migration_defaults", lambda target_db: defaults.append(target_db))
+    monkeypatch.setattr(db_schema, "_psql_rows", lambda target_db, sql: [])
 
     db_schema.restore_schema_dump(target_db="test_posthog", recreate=True, schema_path=schema_path)
 
@@ -304,12 +305,46 @@ def test_restore_schema_dump_recreate_drops_and_creates(tmp_path: Path, monkeypa
     assert defaults == ["test_posthog"]
 
 
+_RECORDED = [
+    ("stamphog", "0001_squash_2026_09_07_initial"),
+    ("stamphog", "0002_later"),
+    ("posthog", "0001_squash_2026_09_07_initial"),
+    ("posthog", "1345_squash_2026_09_07_schema_addons"),
+    ("posthog", "1346_untrack_organization_is_hipaa"),
+    ("posthog", "1347_add_a_column"),
+    ("cdp", "0005_no_addons_migration_here"),
+]
+
+
+@pytest.mark.parametrize(
+    "attribute,expected",
+    [
+        (
+            "forget",
+            (
+                # A product-routed app is replayed in full under the consumer's own routing.
+                ("posthog", "1345_squash_2026_09_07_schema_addons"),
+                ("posthog", "1346_untrack_organization_is_hipaa"),
+                ("posthog", "1347_add_a_column"),
+                ("stamphog", "0001_squash_2026_09_07_initial"),
+                ("stamphog", "0002_later"),
+            ),
+        ),
+        # The addons migration probes the schema, so replaying it for real is safe.
+        ("replay", (("posthog", "1345_squash_2026_09_07_schema_addons"),)),
+        # Its descendants are already in the restored schema, so they are re-recorded, not re-run.
+        ("refake", (("posthog", "1347_add_a_column"),)),
+    ],
+)
+def test_plan_migration_records(attribute: str, expected: tuple[tuple[str, str], ...]) -> None:
+    plan = db_schema.plan_migration_records(_RECORDED, ["stamphog"])
+
+    assert getattr(plan, attribute) == expected
+
+
 def test_restore_schema_dump_forgets_product_app_migrations(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # The dump comes from a database that routes product apps elsewhere, so it records their
-    # migrations as applied without ever creating their tables. Left in place, the next product
-    # migration is applied for real here and fails on the missing table. The squash schema-addons
-    # rows must go too: they depend on the product apps' leaf squashes, so keeping them while the
-    # product rows are gone fails Django's migration consistency check.
+    # Every migration the plan forgets has to leave the table, or the restored database asserts a
+    # migration applied before its dependency and Django refuses to migrate at all.
     schema_path = tmp_path / "schema.sql.gz"
     _write_schema(schema_path)
     commands: list[list[str]] = []
@@ -317,16 +352,20 @@ def test_restore_schema_dump_forgets_product_app_migrations(tmp_path: Path, monk
     monkeypatch.setattr(db_schema, "_run", lambda command, env=None: commands.append(command))
     monkeypatch.setattr(db_schema, "_run_psql_with_gzip_input", lambda gzip_path, target_db: None)
     monkeypatch.setattr(db_schema, "_ensure_migration_defaults", lambda target_db: None)
+    monkeypatch.setattr(db_schema, "_product_routed_app_labels", lambda: ["stamphog"])
+    monkeypatch.setattr(db_schema, "_psql_rows", lambda target_db, sql: [list(row) for row in _RECORDED])
 
     db_schema.restore_schema_dump(target_db="test_posthog", recreate=False, schema_path=schema_path)
 
     deletes = [command[-1] for command in commands if "DELETE FROM django_migrations" in command[-1]]
     assert len(deletes) == 1
-    app_labels = db_schema._product_routed_app_labels()
-    assert app_labels, "expected products/db_routing.yaml to route at least one app"
-    for app_label in app_labels:
-        assert f"'{app_label}'" in deletes[0]
-    assert r"name LIKE '%\_squash\_%\_schema\_addons'" in deletes[0]
+    for app, name in db_schema.plan_migration_records(_RECORDED, ["stamphog"]).forget:
+        assert f"('{app}', '{name}')" in deletes[0]
+    migrates = [command for command in commands if command[:3] == ["python", "manage.py", "migrate"]]
+    assert migrates == [
+        ["python", "manage.py", "migrate", "posthog", "1345_squash_2026_09_07_schema_addons", "--noinput"],
+        ["python", "manage.py", "migrate", "posthog", "1347_add_a_column", "--noinput", "--fake"],
+    ]
 
 
 def test_restore_schema_dump_recreate_cleans_up_after_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -372,6 +411,7 @@ def test_restore_schema_dump_without_recreate_does_not_drop(tmp_path: Path, monk
     monkeypatch.setattr(db_schema, "_run", lambda command, env=None: commands.append(command))
     monkeypatch.setattr(db_schema, "_run_psql_with_gzip_input", lambda gzip_path, target_db: None)
     monkeypatch.setattr(db_schema, "_ensure_migration_defaults", lambda target_db: None)
+    monkeypatch.setattr(db_schema, "_psql_rows", lambda target_db, sql: [])
 
     db_schema.restore_schema_dump(target_db="posthog", recreate=False, schema_path=schema_path)
 


### PR DESCRIPTION
## Problem

- Every PR that rebases onto current master now fails Playwright E2E before a single test runs. The job stops in "Apply postgres and clickhouse migrations and setup dev" with `InconsistentMigrationHistory: Migration posthog.1346_untrack_organization_is_hipaa is applied before its dependency posthog.1345_squash_2026_09_07_schema_addons`. Example: [this run](https://github.com/PostHog/posthog/actions/runs/34308765094/job/102331236876).
- The job primes its database from master's cached schema dump. The restore forgets the dump's product-routed app rows, and the squash schema-addons rows with them, because the addons migrations depend on those apps' leaf squashes.
- The restore kept every row recorded after an addons migration. `posthog.1346` depends on `posthog.1345`, so the restored database claims a child applied without its parent, and Django refuses to migrate.
- The break arrives with the first migration that lands on top of an addons migration. Runs still pass only where the cache holds an older dump.

## Changes

- The restore now forgets the trailing rows too, so `migrate` runs again after the dump is primed.
- It replays each app up to its addons migration for real, then re-records the trailing migrations with `--fake`. Their schema is already in the dump, so replaying one would add a column that exists.
- `plan_migration_records` decides all of this as a pure function over the recorded rows. The rule is now testable without a database, which is where the missing case would have shown up.
- Mechanical: the delete moves from a `LIKE` pattern to explicit `(app, name)` pairs, and the psql read and write calls get named helpers.
- Nothing a user sees changes. This is CI and local dev tooling, so there is no screenshot to show.

## How did you test this code?

- Added `test_plan_migration_records` and extended `test_restore_schema_dump_forgets_product_app_migrations` in `tools/hogli-commands/hogli_commands/tests/test_db_schema.py`. The regression they catch: forgetting a migration row while leaving a row that depends on it, which no existing case covered.
- Ran `plan_migration_records` over the 2799 rows in master's own [schema dump artifact](https://github.com/PostHog/posthog/actions/runs/34307329841). It forgets 46 rows, replays the 13 addons migrations, and re-records `posthog.1346_untrack_organization_is_hipaa` with `--fake`.
- Not run: the E2E job itself, and any suite needing the dev stack. This sandbox has no Postgres or Docker.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior, API, or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by the PostHog Slack app from a report that master was broken with conflicting migrations, raised in a Slack thread.
- No duplicate: `gh pr list --state open --search` over the migration and schema-restore keywords found no open PR fixing this.
- The first search found no conflict. Django's own `detect_conflicts()`, the leaf-vs-`max_migration.txt` check, and `makemigrations --check` are all clean on master, and the "Validate migrations" job passes. The failure lives in the cached-schema restore, not in the migration files.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- The obvious alternative was to forget the trailing rows and let them replay with everything else. That works for `1346`, which only changes Django's state, and breaks on the next migration that adds a column. Re-recording them with `--fake` holds for both.
- Nothing in this PR carries non-public material.
