### PR TITLE
ci: bump the schema cache epoch to abandon a stale dump

### DIFF
--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -115,7 +115,7 @@ jobs:
                   IS_PR: ${{ github.event_name == 'pull_request' }}
                   # Manual cache-bust knob. Keep in sync with SCHEMA_CACHE_EPOCH in
                   # ci-backend.yml, which saves these caches on master pushes.
-                  SCHEMA_CACHE_EPOCH: v2
+                  SCHEMA_CACHE_EPOCH: v3
               run: |
                   if [ "$IS_PR" != "true" ]; then
                       # Pushed or dispatched commit is checked out directly: no merge

--- a/.github/workflows/cd-tasks-golden-snapshot.yml
+++ b/.github/workflows/cd-tasks-golden-snapshot.yml
@@ -169,7 +169,7 @@ jobs:
                   IS_PR: ${{ github.event_name == 'pull_request' }}
                   # Manual cache-bust knob. Keep in sync with SCHEMA_CACHE_EPOCH in
                   # ci-backend.yml, which saves these caches on master pushes.
-                  SCHEMA_CACHE_EPOCH: v2
+                  SCHEMA_CACHE_EPOCH: v3
               run: |
                   if [ "$IS_PR" != "true" ]; then
                       # Pushed or dispatched commit is checked out directly: no merge

--- a/.github/workflows/ci-agent-skills.yml
+++ b/.github/workflows/ci-agent-skills.yml
@@ -94,7 +94,7 @@ jobs:
                   IS_PUSH: ${{ github.event_name == 'push' }}
                   # Manual cache-bust knob. Keep in sync with SCHEMA_CACHE_EPOCH in
                   # ci-backend.yml, which saves these caches on master pushes.
-                  SCHEMA_CACHE_EPOCH: v2
+                  SCHEMA_CACHE_EPOCH: v3
               run: |
                   if [ "$IS_PUSH" = "true" ]; then
                       # Pushed commit is checked out directly: no merge commit, no base ref.
@@ -320,7 +320,7 @@ jobs:
               env:
                   # Manual cache-bust knob. Keep in sync with SCHEMA_CACHE_EPOCH in
                   # ci-backend.yml, which saves these caches on master pushes.
-                  SCHEMA_CACHE_EPOCH: v2
+                  SCHEMA_CACHE_EPOCH: v3
               run: |
                   # Must match ci-backend.yml's save-side computation byte for byte or the key never hits.
                   MIG_FILES=$(git ls-tree -r --format='%(objectname) %(path)' HEAD \

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -54,8 +54,9 @@ env:
     # Schema cache epoch. Bump to abandon every shared schema cache entry at once
     # (key is posthog-schema-mig-<epoch>-<hash>). Single-sourced so it can't drift
     # between the merge-base (PR) and HEAD (push) key computations below.
-    # ci-e2e-playwright.yml, ci-dagster.yml, ci-mcp.yml and ci-rust-flags-integration.yml restore by the same key; keep their copies in sync when bumping.
-    SCHEMA_CACHE_EPOCH: v2
+    # Other workflows declare their own copy and restore by the same key, so bump
+    # every one together: grep SCHEMA_CACHE_EPOCH across .github/workflows.
+    SCHEMA_CACHE_EPOCH: v3
     # Hypothesis constants cache epoch. Bump to abandon every shared entry at once
     # (key is posthog-hypothesis-constants-<version>-<epoch>-<isoyear>-<isoweek>); used by
     # the Django test shards below.

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -28,7 +28,7 @@ permissions:
 
 env:
     # Manual cache-bust knob. Keep in sync with SCHEMA_CACHE_EPOCH in ci-backend.yml, which saves these caches on master pushes.
-    SCHEMA_CACHE_EPOCH: v2
+    SCHEMA_CACHE_EPOCH: v3
     SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
     DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
     REDIS_URL: 'redis://localhost'

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -288,7 +288,7 @@ jobs:
                   IS_PUSH: ${{ github.event_name == 'push' }}
                   # Manual cache-bust knob — keep in sync with SCHEMA_CACHE_EPOCH in
                   # ci-backend.yml, which saves these caches on master pushes.
-                  SCHEMA_CACHE_EPOCH: v2
+                  SCHEMA_CACHE_EPOCH: v3
               run: |
                   if [ "$IS_PUSH" = "true" ]; then
                       # Pushed commit is checked out directly — no merge commit, no base ref.

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -33,7 +33,7 @@ permissions:
 
 env:
     # Manual cache-bust knob. Keep in sync with SCHEMA_CACHE_EPOCH in ci-backend.yml, which saves these caches on master pushes.
-    SCHEMA_CACHE_EPOCH: v2
+    SCHEMA_CACHE_EPOCH: v3
     RUNS_ON_INTERNAL_PR: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
 
 jobs:

--- a/.github/workflows/ci-rust-flags-integration.yml
+++ b/.github/workflows/ci-rust-flags-integration.yml
@@ -38,7 +38,7 @@ concurrency:
 
 env:
     # Cache-bust knob. Keep in sync with ci-backend.yml, which saves these caches.
-    SCHEMA_CACHE_EPOCH: v2
+    SCHEMA_CACHE_EPOCH: v3
     # Django SECRET_KEY for cryptographic signing (sessions, CSRF, etc.) - test-only, not used in production
     SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461b81b72'
     DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/test_posthog'


### PR DESCRIPTION
Every Django and product shard on a PR branched from the current master tip dies before it runs a test:

```
django.db.migrations.exceptions.InconsistentMigrationHistory:
Migration posthog.1346_untrack_organization_is_hipaa is applied before
its dependency posthog.1345_squash_2026_09_07_schema_addons
```

7,611 occurrences in one job, 52 failing shards, no test-logic failures among them.

## What happens

The schema cache key is computed from the merge-base. A PR whose merge-base has no saved dump misses its exact key, and the `restore-keys` prefix then hands it the newest `posthog-schema-mig-v2-` entry of any migration set. The job log shows both lines together:

```
Cache restored from key: posthog-schema-mig-v2-5fae852071be...
::notice::Schema cache miss; the migrate step will build test_posthog
```

The restored dump primes `test_posthog` with 1346 recorded applied and 1345 not, and `check_consistent_history` refuses it. The workflow already anticipates this shape: the prefix key carries a comment that migrate top-ups "only apply forward, so they cannot repair a dump that is newer than the code."

It cannot clear on its own, because a failed run saves no dump for the merge-base that missed.

## Changes

Bump `SCHEMA_CACHE_EPOCH` from `v2` to `v3`, the documented knob for abandoning every shared entry at once. The next run rebuilds from a full migrate.

Nine declarations move together across eight workflows, since they restore by the same key. The sync comment in `ci-backend.yml` named four of them, and there are eight, so it now points at a grep instead of a list that goes stale.

## Risk

The first run after this merges pays a full migrate on each shard rather than a cache restore. That cost is one round, and it is what the shards are already paying today, except they fail at the end of it.
