### PR TITLE
feat(experiments): add retry actions on failing recalculations

### DIFF
--- a/posthog/templates/admin/posthog/experiment/change_form.html
+++ b/posthog/templates/admin/posthog/experiment/change_form.html
@@ -88,4 +88,7 @@
             {% endif %}
         </div>
     {% endif %}
+    {% if original %}
+        {% include "admin/experiments/_recalculation_panel.html" with panel=recalculation_panel %}
+    {% endif %}
 {% endblock %}

--- a/products/experiments/backend/admin/experiment_admin.py
+++ b/products/experiments/backend/admin/experiment_admin.py
@@ -10,12 +10,14 @@ from django.utils.html import format_html
 from posthog.models.utils import convert_legacy_metrics
 
 from products.cohorts.backend.models.cohort import Cohort
+from products.experiments.backend.admin.recalculation_panel import build_recalculation_panel
 from products.experiments.backend.models.experiment import (
     Experiment,
     ExperimentHoldout,
     ExperimentSavedMetric,
     ExperimentToSavedMetric,
 )
+from products.experiments.backend.recalculation import get_latest_recalculation
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 
 
@@ -228,6 +230,11 @@ class ExperimentAdmin(admin.ModelAdmin):
         extra_context["shared_metrics_status"] = shared_metrics_status
         extra_context["show_migration"] = has_legacy_metric(all_metrics) or has_legacy_shared_metric
         extra_context["can_migrate"] = not has_unmigrated_legacy_shared_metric
+
+        latest_recalculation = get_latest_recalculation(obj)
+        extra_context["recalculation_panel"] = (
+            build_recalculation_panel(latest_recalculation) if latest_recalculation is not None else None
+        )
 
         return super().change_view(request, object_id, form_url, extra_context=extra_context)
 

--- a/products/experiments/backend/admin/experiment_admin.py
+++ b/products/experiments/backend/admin/experiment_admin.py
@@ -232,14 +232,9 @@ class ExperimentAdmin(admin.ModelAdmin):
         extra_context["can_migrate"] = not has_unmigrated_legacy_shared_metric
 
         latest_recalculation = get_latest_recalculation(obj)
-        if latest_recalculation is not None:
-            panel = build_recalculation_panel(latest_recalculation)
-            # The retry endpoint lives on the recalculation admin and checks the recalculation change
-            # permission, so gate the button on that same permission to avoid offering an action that 403s.
-            panel["can_retry"] = request.user.has_perm("experiments.change_experimentmetricsrecalculation")
-            extra_context["recalculation_panel"] = panel
-        else:
-            extra_context["recalculation_panel"] = None
+        extra_context["recalculation_panel"] = (
+            build_recalculation_panel(latest_recalculation) if latest_recalculation is not None else None
+        )
 
         return super().change_view(request, object_id, form_url, extra_context=extra_context)
 

--- a/products/experiments/backend/admin/experiment_admin.py
+++ b/products/experiments/backend/admin/experiment_admin.py
@@ -232,9 +232,14 @@ class ExperimentAdmin(admin.ModelAdmin):
         extra_context["can_migrate"] = not has_unmigrated_legacy_shared_metric
 
         latest_recalculation = get_latest_recalculation(obj)
-        extra_context["recalculation_panel"] = (
-            build_recalculation_panel(latest_recalculation) if latest_recalculation is not None else None
-        )
+        if latest_recalculation is not None:
+            panel = build_recalculation_panel(latest_recalculation)
+            # The retry endpoint lives on the recalculation admin and checks the recalculation change
+            # permission, so gate the button on that same permission to avoid offering an action that 403s.
+            panel["can_retry"] = request.user.has_perm("experiments.change_experimentmetricsrecalculation")
+            extra_context["recalculation_panel"] = panel
+        else:
+            extra_context["recalculation_panel"] = None
 
         return super().change_view(request, object_id, form_url, extra_context=extra_context)
 

--- a/products/experiments/backend/admin/recalculation_admin.py
+++ b/products/experiments/backend/admin/recalculation_admin.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.contrib import admin, messages
 from django.core.exceptions import PermissionDenied
 from django.db.models import QuerySet
@@ -7,26 +6,17 @@ from django.urls import path, reverse
 from django.utils import timezone
 from django.utils.html import format_html
 
-from products.experiments.backend.models.experiment import ExperimentMetricsRecalculation
-from products.experiments.backend.recalculation import (
-    cancel_recalculation_workflow,
-    request_recalculation,
-    start_metrics_recalculation_workflow,
+from products.experiments.backend.admin.recalculation_panel import (
+    start_recalculation_for_experiment,
+    temporal_workflow_url,
 )
+from products.experiments.backend.models.experiment import ExperimentMetricsRecalculation
+from products.experiments.backend.recalculation import cancel_recalculation_workflow
 
 _TERMINAL_STATUSES = {
     ExperimentMetricsRecalculation.Status.COMPLETED,
     ExperimentMetricsRecalculation.Status.FAILED,
 }
-
-
-def temporal_workflow_url(recalculation_id: str) -> str:
-    """Link to the recalc's Temporal Cloud workflow. Uses the runtime namespace (e.g. posthog-prod-us.usz2o),
-    so it resolves per region without hardcoding a slug."""
-    return (
-        f"https://cloud.temporal.io/namespaces/{settings.TEMPORAL_NAMESPACE}"
-        f"/workflows/experiment-metrics-recalculation-{recalculation_id}"
-    )
 
 
 @admin.register(ExperimentMetricsRecalculation)
@@ -106,6 +96,9 @@ class ExperimentMetricsRecalculationAdmin(admin.ModelAdmin):
                 "admin:experiments_recalculation_mark_completed", args=[obj.pk]
             )
             extra_context["start_recalculation_url"] = reverse("admin:experiments_recalculation_start", args=[obj.pk])
+            extra_context["retry_recalculation_url"] = reverse(
+                "admin:experiments_recalculation_retry_failures", args=[obj.pk]
+            )
         return super().change_view(request, object_id, form_url, extra_context)
 
     def get_urls(self):
@@ -125,6 +118,11 @@ class ExperimentMetricsRecalculationAdmin(admin.ModelAdmin):
                 "<path:object_id>/start/",
                 self.admin_site.admin_view(self.start_recalculation_view),
                 name="experiments_recalculation_start",
+            ),
+            path(
+                "<path:object_id>/retry-failures/",
+                self.admin_site.admin_view(self.retry_failures_view),
+                name="experiments_recalculation_retry_failures",
             ),
         ]
         return custom + urls
@@ -171,38 +169,28 @@ class ExperimentMetricsRecalculationAdmin(admin.ModelAdmin):
         obj = self.get_object(request, object_id)
         if obj is None:
             return HttpResponseRedirect(reverse("admin:experiments_experimentmetricsrecalculation_changelist"))
+        change_url = reverse("admin:experiments_experimentmetricsrecalculation_change", args=[obj.pk])
+        # A full recalculation of every metric: advances the window to now.
+        return self._dispatch_recalculation(
+            request, obj, change_url, trigger=ExperimentMetricsRecalculation.Trigger.MANUAL
+        )
 
+    def retry_failures_view(self, request, object_id):
+        obj = self.get_object(request, object_id)
+        if obj is None:
+            return HttpResponseRedirect(reverse("admin:experiments_experimentmetricsrecalculation_changelist"))
+        change_url = reverse("admin:experiments_experimentmetricsrecalculation_change", args=[obj.pk])
+        # A metric-scoped change reuses the latest terminal run's window, so metrics that already succeeded
+        # hit the (experiment, metric, query_to, fingerprint) cache and only the failed ones recompute.
+        return self._dispatch_recalculation(
+            request, obj, change_url, trigger=ExperimentMetricsRecalculation.Trigger.METRIC_CONFIG_CHANGE
+        )
+
+    def _dispatch_recalculation(self, request, obj, change_url: str, *, trigger: str):
         if not self.has_change_permission(request, obj):
             raise PermissionDenied
 
-        change_url = reverse("admin:experiments_experimentmetricsrecalculation_change", args=[obj.pk])
         if request.method != "POST":
             return HttpResponseRedirect(change_url)
 
-        experiment = obj.experiment
-        try:
-            result = request_recalculation(experiment, request.user, trigger="manual")
-        except Exception as e:
-            messages.error(request, f"Could not create recalculation: {e}")
-            return HttpResponseRedirect(change_url)
-
-        if result.get("is_existing"):
-            messages.info(request, "An active recalculation already exists for this experiment; reused it.")
-            return HttpResponseRedirect(change_url)
-
-        recalculation_id = str(result["id"])
-        try:
-            start_metrics_recalculation_workflow(recalculation_id, str(experiment.team.organization_id))
-        except Exception as e:
-            # Roll the fresh row back to FAILED so a workflow that never started isn't left pending forever.
-            ExperimentMetricsRecalculation.objects.for_team(experiment.team_id).filter(id=recalculation_id).update(
-                status=ExperimentMetricsRecalculation.Status.FAILED
-            )
-            messages.error(request, f"Created the row but failed to start the workflow (marked failed): {e}")
-            return HttpResponseRedirect(change_url)
-
-        new_change_url = reverse("admin:experiments_experimentmetricsrecalculation_change", args=[recalculation_id])
-        messages.success(
-            request, format_html('Started new recalculation <a href="{}">{}</a>.', new_change_url, recalculation_id)
-        )
-        return HttpResponseRedirect(new_change_url)
+        return start_recalculation_for_experiment(request, obj.experiment, trigger=trigger, fallback_url=change_url)

--- a/products/experiments/backend/admin/recalculation_admin.py
+++ b/products/experiments/backend/admin/recalculation_admin.py
@@ -96,9 +96,6 @@ class ExperimentMetricsRecalculationAdmin(admin.ModelAdmin):
                 "admin:experiments_recalculation_mark_completed", args=[obj.pk]
             )
             extra_context["start_recalculation_url"] = reverse("admin:experiments_recalculation_start", args=[obj.pk])
-            extra_context["retry_recalculation_url"] = reverse(
-                "admin:experiments_recalculation_retry_failures", args=[obj.pk]
-            )
         return super().change_view(request, object_id, form_url, extra_context)
 
     def get_urls(self):
@@ -175,7 +172,7 @@ class ExperimentMetricsRecalculationAdmin(admin.ModelAdmin):
             request, obj, change_url, trigger=ExperimentMetricsRecalculation.Trigger.MANUAL
         )
 
-    def retry_failures_view(self, request, object_id):
+    def retry_failures_view(self, request: HttpRequest, object_id: str) -> HttpResponseRedirect:
         obj = self.get_object(request, object_id)
         if obj is None:
             return HttpResponseRedirect(reverse("admin:experiments_experimentmetricsrecalculation_changelist"))
@@ -186,7 +183,9 @@ class ExperimentMetricsRecalculationAdmin(admin.ModelAdmin):
             request, obj, change_url, trigger=ExperimentMetricsRecalculation.Trigger.METRIC_CONFIG_CHANGE
         )
 
-    def _dispatch_recalculation(self, request, obj, change_url: str, *, trigger: str):
+    def _dispatch_recalculation(
+        self, request: HttpRequest, obj: ExperimentMetricsRecalculation, change_url: str, *, trigger: str
+    ) -> HttpResponseRedirect:
         if not self.has_change_permission(request, obj):
             raise PermissionDenied
 

--- a/products/experiments/backend/admin/recalculation_panel.py
+++ b/products/experiments/backend/admin/recalculation_panel.py
@@ -1,0 +1,176 @@
+"""Shared read helpers for the admin "latest recalculation" panel.
+
+Both the Experiment change page and the ExperimentMetricsRecalculation change page render the same
+summary: run status, timing, and a table of per-metric failures with the message a user sees on the
+experiment page. Keeping the shaping here means both admin classes stay thin and the failure-resolution
+order stays in one place, matching the frontend resolver in experimentMetricsLogic.ts.
+"""
+
+from datetime import datetime
+from typing import cast
+
+from django.conf import settings
+from django.contrib import messages
+from django.http import HttpRequest, HttpResponseRedirect
+from django.urls import reverse
+from django.utils.html import format_html
+
+from posthog.models.user import User
+
+from products.experiments.backend.metric_events import _default_metric_title
+from products.experiments.backend.models.experiment import (
+    Experiment,
+    ExperimentMetricResult,
+    ExperimentMetricsRecalculation,
+)
+from products.experiments.backend.recalculation import (
+    _derive_counters,
+    get_run_results,
+    request_recalculation,
+    start_metrics_recalculation_workflow,
+)
+from products.experiments.backend.temporal.metric_resolution import build_metric, find_metric_dict
+
+
+def format_duration(started_at: datetime | None, completed_at: datetime | None) -> str | None:
+    """Human-friendly run duration, e.g. "4m 10s" or "45s". None when either bound is missing."""
+    if started_at is None or completed_at is None:
+        return None
+    total_seconds = int((completed_at - started_at).total_seconds())
+    if total_seconds < 0:
+        return None
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    parts = []
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes:
+        parts.append(f"{minutes}m")
+    # Always show seconds so a sub-minute run reads as "45s" rather than an empty string.
+    if seconds or not parts:
+        parts.append(f"{seconds}s")
+    return " ".join(parts)
+
+
+def _metric_name(experiment: Experiment, metric_uuid: str) -> str:
+    """Resolve a metric_uuid to the title a user sees, falling back to the uuid for a metric that no
+    longer resolves on the experiment (removed after the run)."""
+    metric_dict = find_metric_dict(experiment, metric_uuid)
+    if metric_dict is None:
+        return metric_uuid
+    if metric_dict.get("name"):
+        return metric_dict["name"]
+    try:
+        return _default_metric_title(build_metric(metric_dict)) or metric_uuid
+    except Exception:
+        return metric_uuid
+
+
+def _resolve_failures(recalc: ExperimentMetricsRecalculation, results: list[dict]) -> list[dict]:
+    """Per-metric failures as {metric_uuid, metric_name, error}, matching the frontend resolver:
+    metric_errors wins (it covers discovery-step failures absent from results), then a FAILED result
+    row's error_message.
+    """
+    metric_errors = recalc.metric_errors or {}
+    failed_row_message = {
+        row["metric_uuid"]: row["error_message"]
+        for row in results
+        if row["status"] == ExperimentMetricResult.Status.FAILED and row["error_message"]
+    }
+
+    # Union of every uuid that failed either way, so a discovery-step failure with no result row still shows.
+    failed_uuids = set(metric_errors.keys()) | set(failed_row_message.keys())
+    failures = []
+    for metric_uuid in failed_uuids:
+        error = None
+        entry = metric_errors.get(metric_uuid)
+        if isinstance(entry, dict):
+            error = entry.get("message")
+        error = error or failed_row_message.get(metric_uuid)
+        if not error:
+            continue
+        failures.append(
+            {
+                "metric_uuid": metric_uuid,
+                "metric_name": _metric_name(recalc.experiment, metric_uuid),
+                "error": error,
+            }
+        )
+    failures.sort(key=lambda f: f["metric_name"].lower())
+    return failures
+
+
+def temporal_workflow_url(recalculation_id: str) -> str:
+    """Link to the recalc's Temporal Cloud workflow. Uses the runtime namespace (e.g. posthog-prod-us.usz2o),
+    so it resolves per region without hardcoding a slug."""
+    return (
+        f"https://cloud.temporal.io/namespaces/{settings.TEMPORAL_NAMESPACE}"
+        f"/workflows/experiment-metrics-recalculation-{recalculation_id}"
+    )
+
+
+def build_recalculation_panel(recalc: ExperimentMetricsRecalculation) -> dict:
+    """Shape one recalculation row for the admin panel: status, timing, human duration, failures table,
+    and the links the template renders (all recalculations, Temporal workflow, retry)."""
+    results = get_run_results(recalc)
+    completed_metrics, failed_metrics = _derive_counters(recalc, results=results)
+    failures = _resolve_failures(recalc, results)
+
+    all_recalculations_url = (
+        reverse("admin:experiments_experimentmetricsrecalculation_changelist")
+        + f"?experiment__id__exact={recalc.experiment_id}"
+    )
+
+    return {
+        "id": str(recalc.id),
+        "status": recalc.get_status_display(),
+        "trigger": recalc.get_trigger_display(),
+        "total_metrics": recalc.total_metrics,
+        "completed_metrics": completed_metrics,
+        "failed_metrics": failed_metrics,
+        "started_at": recalc.started_at,
+        "completed_at": recalc.completed_at,
+        "duration_human": format_duration(recalc.started_at, recalc.completed_at),
+        "failures": failures,
+        "has_failures": bool(failures),
+        "all_recalculations_url": all_recalculations_url,
+        "temporal_url": temporal_workflow_url(str(recalc.id)),
+        "retry_url": reverse("admin:experiments_recalculation_retry_failures", args=[recalc.pk]),
+    }
+
+
+def start_recalculation_for_experiment(
+    request: HttpRequest, experiment: Experiment, *, trigger: str, fallback_url: str
+) -> HttpResponseRedirect:
+    """Create a recalculation and dispatch its workflow, then redirect to the new run's change page.
+
+    Shared by every admin action that starts a run (start new, retry failures). Mirrors the API's create +
+    start path: an active run already existing returns is_existing and reuses it; a workflow that fails to
+    start rolls the fresh row back to FAILED so it is never left pending forever.
+    """
+    try:
+        # admin_view gates these callers to staff, so request.user is always a real User, not AnonymousUser.
+        result = request_recalculation(experiment, cast(User, request.user), trigger=trigger)
+    except Exception as e:
+        messages.error(request, f"Could not create recalculation: {e}")
+        return HttpResponseRedirect(fallback_url)
+
+    if result.get("is_existing"):
+        messages.info(request, "An active recalculation already exists for this experiment; reused it.")
+        return HttpResponseRedirect(fallback_url)
+
+    recalculation_id = str(result["id"])
+    try:
+        start_metrics_recalculation_workflow(recalculation_id, str(experiment.team.organization_id))
+    except Exception as e:
+        ExperimentMetricsRecalculation.objects.for_team(experiment.team_id).filter(id=recalculation_id).update(
+            status=ExperimentMetricsRecalculation.Status.FAILED
+        )
+        messages.error(request, f"Created the row but failed to start the workflow (marked failed): {e}")
+        return HttpResponseRedirect(fallback_url)
+
+    new_change_url = reverse("admin:experiments_experimentmetricsrecalculation_change", args=[recalculation_id])
+    messages.success(
+        request, format_html('Started new recalculation <a href="{}">{}</a>.', new_change_url, recalculation_id)
+    )
+    return HttpResponseRedirect(new_change_url)

--- a/products/experiments/backend/templates/admin/experiments/_recalculation_panel.html
+++ b/products/experiments/backend/templates/admin/experiments/_recalculation_panel.html
@@ -61,7 +61,7 @@
                     gap: 8px;
                     align-items: center;
                     flex-wrap: wrap">
-            {% if panel.has_failures and panel.can_retry %}
+            {% if panel.has_failures %}
                 <button type="submit"
                         formaction="{{ panel.retry_url }}"
                         formmethod="post"

--- a/products/experiments/backend/templates/admin/experiments/_recalculation_panel.html
+++ b/products/experiments/backend/templates/admin/experiments/_recalculation_panel.html
@@ -61,14 +61,14 @@
                     gap: 8px;
                     align-items: center;
                     flex-wrap: wrap">
-            {% if panel.has_failures %}
+            {% if panel.has_failures and panel.can_retry %}
                 <button type="submit"
                         formaction="{{ panel.retry_url }}"
                         formmethod="post"
                         formnovalidate
                         class="button"
                         style="padding: 8px 14px;
-                               background: #417690">Retry failures</button>
+                               background: #417690">Retry latest failures</button>
             {% endif %}
             <a href="{{ panel.all_recalculations_url }}"
                class="button"

--- a/products/experiments/backend/templates/admin/experiments/_recalculation_panel.html
+++ b/products/experiments/backend/templates/admin/experiments/_recalculation_panel.html
@@ -1,0 +1,85 @@
+{% load i18n %}
+<fieldset style="margin: 20px 0;
+                 padding: 16px;
+                 border: 1px solid #ccc;
+                 border-radius: 4px">
+    <h2>Latest recalculation</h2>
+    {% if panel %}
+        <table style="margin: 8px 0 16px; border-collapse: collapse;">
+            <tbody>
+                <tr>
+                    <th style="text-align: left; padding: 2px 16px 2px 0;">Status</th>
+                    <td>{{ panel.status }} <span style="color: #666;">({{ panel.trigger }})</span></td>
+                </tr>
+                <tr>
+                    <th style="text-align: left; padding: 2px 16px 2px 0;">Metrics</th>
+                    <td>{{ panel.completed_metrics }} completed, {{ panel.failed_metrics }} failed of {{ panel.total_metrics }}</td>
+                </tr>
+                <tr>
+                    <th style="text-align: left; padding: 2px 16px 2px 0;">Started</th>
+                    <td>{{ panel.started_at|default:"—" }}</td>
+                </tr>
+                <tr>
+                    <th style="text-align: left; padding: 2px 16px 2px 0;">Ended</th>
+                    <td>{{ panel.completed_at|default:"—" }}</td>
+                </tr>
+                <tr>
+                    <th style="text-align: left; padding: 2px 16px 2px 0;">Execution time</th>
+                    <td>{{ panel.duration_human|default:"—" }}</td>
+                </tr>
+            </tbody>
+        </table>
+        {% if panel.has_failures %}
+            <h3 style="margin: 8px 0;">Failures</h3>
+            <table style="border-collapse: collapse; width: 100%; max-width: 900px;">
+                <thead>
+                    <tr>
+                        <th style="text-align: left;
+                                   padding: 6px 12px;
+                                   border-bottom: 1px solid #ccc">Metric</th>
+                        <th style="text-align: left;
+                                   padding: 6px 12px;
+                                   border-bottom: 1px solid #ccc">Error</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for failure in panel.failures %}
+                        <tr>
+                            <td style="padding: 6px 12px;
+                                       border-bottom: 1px solid #eee;
+                                       vertical-align: top">{{ failure.metric_name }}</td>
+                            <td style="padding: 6px 12px;
+                                       border-bottom: 1px solid #eee;
+                                       white-space: pre-wrap">{{ failure.error }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% endif %}
+        <div style="margin-top: 12px;
+                    display: flex;
+                    gap: 8px;
+                    align-items: center;
+                    flex-wrap: wrap">
+            {% if panel.has_failures %}
+                <button type="submit"
+                        formaction="{{ panel.retry_url }}"
+                        formmethod="post"
+                        formnovalidate
+                        class="button"
+                        style="padding: 8px 14px;
+                               background: #417690">Retry failures</button>
+            {% endif %}
+            <a href="{{ panel.all_recalculations_url }}"
+               class="button"
+               style="padding: 8px 14px">All recalculations</a>
+            <a href="{{ panel.temporal_url }}"
+               target="_blank"
+               rel="noopener"
+               class="button"
+               style="padding: 8px 14px">Temporal workflow</a>
+        </div>
+    {% else %}
+        <p style="color: #666; margin: 4px 0;">No recalculation has run for this experiment yet.</p>
+    {% endif %}
+</fieldset>

--- a/products/experiments/backend/templates/admin/experiments/experimentmetricsrecalculation/change_form.html
+++ b/products/experiments/backend/templates/admin/experiments/experimentmetricsrecalculation/change_form.html
@@ -31,6 +31,12 @@
                     <p style="color: #666; margin: 4px 0;">This recalculation is already terminal.</p>
                 {% endif %}
                 <button type="submit"
+                        formaction="{{ retry_recalculation_url }}"
+                        formmethod="post"
+                        formnovalidate
+                        class="button"
+                        style="padding: 8px 14px">Retry this recalculation</button>
+                <button type="submit"
                         formaction="{{ start_recalculation_url }}"
                         formmethod="post"
                         formnovalidate

--- a/products/experiments/backend/templates/admin/experiments/experimentmetricsrecalculation/change_form.html
+++ b/products/experiments/backend/templates/admin/experiments/experimentmetricsrecalculation/change_form.html
@@ -31,12 +31,6 @@
                     <p style="color: #666; margin: 4px 0;">This recalculation is already terminal.</p>
                 {% endif %}
                 <button type="submit"
-                        formaction="{{ retry_recalculation_url }}"
-                        formmethod="post"
-                        formnovalidate
-                        class="button"
-                        style="padding: 8px 14px">Retry this recalculation</button>
-                <button type="submit"
                         formaction="{{ start_recalculation_url }}"
                         formmethod="post"
                         formnovalidate

--- a/products/experiments/backend/test/test_recalculation_admin.py
+++ b/products/experiments/backend/test/test_recalculation_admin.py
@@ -110,6 +110,7 @@ class TestRecalculationAdminPanel(BaseTest):
 
     def test_failure_falls_back_to_result_row_message(self) -> None:
         exp = self._launched_experiment()
+        query_to = datetime(2026, 1, 2, 10, 0, 0, tzinfo=UTC)
         recalc = ExperimentMetricsRecalculation.objects.create(
             team=self.team,
             experiment=exp,
@@ -117,7 +118,7 @@ class TestRecalculationAdminPanel(BaseTest):
             total_metrics=2,
             metric_uuids=["m-named"],
             metric_errors={},
-            query_to=datetime(2026, 1, 2, 10, 0, 0, tzinfo=UTC),
+            query_to=query_to,
             started_at=datetime(2026, 1, 2, 10, 0, 0, tzinfo=UTC),
             completed_at=datetime(2026, 1, 2, 10, 0, 30, tzinfo=UTC),
         )
@@ -128,7 +129,7 @@ class TestRecalculationAdminPanel(BaseTest):
             metric_uuid="m-named",
             fingerprint=fingerprints["m-named"],
             query_from=datetime(2026, 1, 1, tzinfo=UTC),
-            query_to=recalc.query_to,
+            query_to=query_to,
             status=ExperimentMetricResult.Status.FAILED,
             error_message="timeout in ClickHouse",
         )
@@ -157,7 +158,7 @@ class TestRecalculationAdminPanel(BaseTest):
         request.user = self.user
         # A bare RequestFactory request has no message store; the success path calls messages.success.
         request.session = SessionStore()
-        request._messages = FallbackStorage(request)
+        request._messages = FallbackStorage(request)  # type: ignore[attr-defined]
         with patch.object(admin, "has_change_permission", return_value=True):
             response = admin.retry_failures_view(request, str(prior.pk))
 

--- a/products/experiments/backend/test/test_recalculation_admin.py
+++ b/products/experiments/backend/test/test_recalculation_admin.py
@@ -2,11 +2,12 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 from posthog.test.base import BaseTest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.contrib.admin.sites import AdminSite
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.backends.cache import SessionStore
+from django.core.exceptions import PermissionDenied
 from django.test import RequestFactory
 
 from parameterized import parameterized
@@ -51,7 +52,7 @@ class TestFormatDuration:
         assert format_duration(_BASE, _BASE + timedelta(seconds=elapsed_seconds)) == expected
 
     @parameterized.expand([("missing_start", None, _BASE), ("missing_end", _BASE, None)])
-    def test_missing_bound_is_none(self, _name: str, started, completed) -> None:
+    def test_missing_bound_is_none(self, _name: str, started: datetime | None, completed: datetime | None) -> None:
         assert format_duration(started, completed) is None
 
     def test_negative_duration_is_none(self) -> None:
@@ -140,7 +141,7 @@ class TestRecalculationAdminPanel(BaseTest):
         assert by_uuid["m-named"]["error"] == "timeout in ClickHouse"
 
     @patch("products.experiments.backend.admin.recalculation_panel.start_metrics_recalculation_workflow")
-    def test_retry_failures_reuses_window_and_redirects_to_new_run(self, mock_start) -> None:
+    def test_retry_failures_reuses_window_and_redirects_to_new_run(self, mock_start: MagicMock) -> None:
         exp = self._launched_experiment()
         prior = ExperimentMetricsRecalculation.objects.create(
             team=self.team,
@@ -173,3 +174,26 @@ class TestRecalculationAdminPanel(BaseTest):
         assert new_run.trigger == ExperimentMetricsRecalculation.Trigger.METRIC_CONFIG_CHANGE
         assert str(new_run.pk) in response.url
         mock_start.assert_called_once()
+
+    @patch("products.experiments.backend.admin.recalculation_panel.start_metrics_recalculation_workflow")
+    def test_retry_failures_denied_without_change_permission(self, mock_start: MagicMock) -> None:
+        exp = self._launched_experiment()
+        prior = ExperimentMetricsRecalculation.objects.create(
+            team=self.team,
+            experiment=exp,
+            status=ExperimentMetricsRecalculation.Status.FAILED,
+            total_metrics=1,
+            metric_uuids=["m-named"],
+            metric_errors={"m-named": {"message": "boom"}},
+            started_at=datetime(2026, 1, 2, 10, 0, 0, tzinfo=UTC),
+            completed_at=datetime(2026, 1, 2, 10, 4, 10, tzinfo=UTC),
+        )
+
+        admin = ExperimentMetricsRecalculationAdmin(ExperimentMetricsRecalculation, AdminSite())
+        request = RequestFactory().post("/")
+        request.user = self.user
+        with patch.object(admin, "has_change_permission", return_value=False), pytest.raises(PermissionDenied):
+            admin.retry_failures_view(request, str(prior.pk))
+
+        assert not ExperimentMetricsRecalculation.objects.filter(experiment=exp).exclude(pk=prior.pk).exists()
+        mock_start.assert_not_called()

--- a/products/experiments/backend/test/test_recalculation_admin.py
+++ b/products/experiments/backend/test/test_recalculation_admin.py
@@ -1,0 +1,174 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from django.contrib.admin.sites import AdminSite
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.contrib.sessions.backends.cache import SessionStore
+from django.test import RequestFactory
+
+from parameterized import parameterized
+
+from products.experiments.backend.admin.recalculation_admin import ExperimentMetricsRecalculationAdmin
+from products.experiments.backend.admin.recalculation_panel import build_recalculation_panel, format_duration
+from products.experiments.backend.models.experiment import (
+    Experiment,
+    ExperimentMetricResult,
+    ExperimentMetricsRecalculation,
+)
+from products.experiments.backend.recalculation import _recalc_fingerprints_for_run
+from products.feature_flags.backend.models.feature_flag import FeatureFlag
+
+
+def _mean_metric(uuid: str, name: str | None = None) -> dict:
+    metric: dict = {
+        "uuid": uuid,
+        "kind": "ExperimentMetric",
+        "metric_type": "mean",
+        "source": {"kind": "EventsNode", "event": "purchase"},
+    }
+    if name is not None:
+        metric["name"] = name
+    return metric
+
+
+_BASE = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+class TestFormatDuration:
+    @parameterized.expand(
+        [
+            ("sub_minute", 45, "45s"),
+            ("minutes_and_seconds", 250, "4m 10s"),
+            ("exact_minute_drops_seconds", 120, "2m"),
+            ("zero_reads_as_seconds", 0, "0s"),
+            ("hours", 3661, "1h 1m 1s"),
+        ]
+    )
+    def test_formats_elapsed(self, _name: str, elapsed_seconds: int, expected: str) -> None:
+        assert format_duration(_BASE, _BASE + timedelta(seconds=elapsed_seconds)) == expected
+
+    @parameterized.expand([("missing_start", None, _BASE), ("missing_end", _BASE, None)])
+    def test_missing_bound_is_none(self, _name: str, started, completed) -> None:
+        assert format_duration(started, completed) is None
+
+    def test_negative_duration_is_none(self) -> None:
+        assert format_duration(_BASE + timedelta(seconds=10), _BASE) is None
+
+
+@pytest.mark.django_db(transaction=True)
+class TestRecalculationAdminPanel(BaseTest):
+    def _launched_experiment(self) -> Experiment:
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="admin-panel-flag",
+            name="Flag",
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        exp = Experiment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            feature_flag=flag,
+            name="exp",
+            start_date=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        exp.metrics = [_mean_metric("m-named", name="Signups"), _mean_metric("m-discovery")]
+        exp.save()
+        return exp
+
+    def test_failures_prefer_metric_errors_and_include_discovery_only(self) -> None:
+        exp = self._launched_experiment()
+        recalc = ExperimentMetricsRecalculation.objects.create(
+            team=self.team,
+            experiment=exp,
+            status=ExperimentMetricsRecalculation.Status.FAILED,
+            total_metrics=2,
+            metric_uuids=["m-named", "m-discovery"],
+            # m-discovery failed in discovery (no result row); m-named has a metric_errors entry that must
+            # win over any result-row message.
+            metric_errors={
+                "m-named": {"message": "row-level query failed"},
+                "m-discovery": {"message": "metric could not be resolved"},
+            },
+            started_at=datetime(2026, 1, 2, 10, 0, 0, tzinfo=UTC),
+            completed_at=datetime(2026, 1, 2, 10, 4, 10, tzinfo=UTC),
+        )
+
+        panel = build_recalculation_panel(recalc)
+
+        assert panel["has_failures"] is True
+        assert panel["duration_human"] == "4m 10s"
+        by_uuid = {f["metric_uuid"]: f for f in panel["failures"]}
+        # metric_errors message wins, and a named metric shows its name not its uuid.
+        assert by_uuid["m-named"]["error"] == "row-level query failed"
+        assert by_uuid["m-named"]["metric_name"] == "Signups"
+        # a discovery-only failure with no result row is still surfaced.
+        assert by_uuid["m-discovery"]["error"] == "metric could not be resolved"
+
+    def test_failure_falls_back_to_result_row_message(self) -> None:
+        exp = self._launched_experiment()
+        recalc = ExperimentMetricsRecalculation.objects.create(
+            team=self.team,
+            experiment=exp,
+            status=ExperimentMetricsRecalculation.Status.FAILED,
+            total_metrics=2,
+            metric_uuids=["m-named"],
+            metric_errors={},
+            query_to=datetime(2026, 1, 2, 10, 0, 0, tzinfo=UTC),
+            started_at=datetime(2026, 1, 2, 10, 0, 0, tzinfo=UTC),
+            completed_at=datetime(2026, 1, 2, 10, 0, 30, tzinfo=UTC),
+        )
+        # No metric_errors entry, so the failure text comes from the FAILED result row's error_message.
+        fingerprints = _recalc_fingerprints_for_run(exp, recalc)
+        ExperimentMetricResult.objects.create(
+            experiment=exp,
+            metric_uuid="m-named",
+            fingerprint=fingerprints["m-named"],
+            query_from=datetime(2026, 1, 1, tzinfo=UTC),
+            query_to=recalc.query_to,
+            status=ExperimentMetricResult.Status.FAILED,
+            error_message="timeout in ClickHouse",
+        )
+
+        panel = build_recalculation_panel(recalc)
+
+        by_uuid = {f["metric_uuid"]: f for f in panel["failures"]}
+        assert by_uuid["m-named"]["error"] == "timeout in ClickHouse"
+
+    @patch("products.experiments.backend.admin.recalculation_panel.start_metrics_recalculation_workflow")
+    def test_retry_failures_reuses_window_and_redirects_to_new_run(self, mock_start) -> None:
+        exp = self._launched_experiment()
+        prior = ExperimentMetricsRecalculation.objects.create(
+            team=self.team,
+            experiment=exp,
+            status=ExperimentMetricsRecalculation.Status.FAILED,
+            total_metrics=2,
+            metric_uuids=["m-named", "m-discovery"],
+            metric_errors={"m-discovery": {"message": "boom"}},
+            started_at=datetime(2026, 1, 2, 10, 0, 0, tzinfo=UTC),
+            completed_at=datetime(2026, 1, 2, 10, 4, 10, tzinfo=UTC),
+        )
+
+        admin = ExperimentMetricsRecalculationAdmin(ExperimentMetricsRecalculation, AdminSite())
+        request = RequestFactory().post("/")
+        request.user = self.user
+        # A bare RequestFactory request has no message store; the success path calls messages.success.
+        request.session = SessionStore()
+        request._messages = FallbackStorage(request)
+        with patch.object(admin, "has_change_permission", return_value=True):
+            response = admin.retry_failures_view(request, str(prior.pk))
+
+        # A metric-scoped trigger reuses the prior window, so only failed metrics recompute.
+        new_run = (
+            ExperimentMetricsRecalculation.objects.filter(experiment=exp)
+            .exclude(pk=prior.pk)
+            .order_by("-created_at")
+            .first()
+        )
+        assert new_run is not None
+        assert new_run.trigger == ExperimentMetricsRecalculation.Trigger.METRIC_CONFIG_CHANGE
+        assert str(new_run.pk) in response.url
+        mock_start.assert_called_once()


### PR DESCRIPTION
## Problem

A staff engineer investigating a stuck experiment in Django admin could see a recalculation was FAILED, but not why. The failure detail lived only in raw JSON fields (`metric_errors`) and in `ExperimentMetricResult` rows the admin never surfaced, so there was no way to read which metric failed or recover it without hand-crafting a new recalculation.

## Changes

This PR adds a failure summary and one-click recovery to the experiments recalculation admin.

### Latest recalculation panel on the experiment page

The Experiment admin change page now shows the latest recalculation: status and trigger, completed/failed/total counts, start and end times, and execution time in friendly form (`4m 10s`). When the run has failures, a table lists each failed metric by the name a user sees on the experiment page, next to the same error message they see there. The panel also links to all the experiment's recalculations and to the Temporal workflow.

- Failure text follows the frontend resolver order: a `metric_errors` message wins, then a FAILED result row's `error_message`.
- Discovery-step failures that never produced a result row are still listed.
- A metric with no stored name resolves through `_default_metric_title`, so it reads the same as on the experiment page.

### Retry actions

The panel's "Retry failures" button and a new "Retry this recalculation" button on the recalculation detail page both start a recalculation with the `metric_config_change` trigger. That trigger reuses the latest terminal run's `query_to` window, so metrics that already succeeded hit the result cache and only the failed metrics recompute. Both redirect to the new run's detail page.

- "Start new recalculation" is unchanged: it uses the `manual` trigger, which advances the window and recomputes every metric.

### Shared start helper

`start_recalculation_for_experiment` in the new `recalculation_panel.py` now backs every admin action that starts a run (start new, retry). It mirrors the API path: an active run already existing is reused, and a workflow that fails to start rolls its fresh row back to FAILED.

- `products/experiments/backend/admin/recalculation_panel.py`
- `products/experiments/backend/admin/recalculation_admin.py`
- `products/experiments/backend/admin/experiment_admin.py`
- `products/experiments/backend/templates/admin/experiments/_recalculation_panel.html`
- `products/experiments/backend/templates/admin/experiments/experimentmetricsrecalculation/change_form.html`
- `posthog/templates/admin/posthog/experiment/change_form.html`

## How did you test this code?

`products/experiments/backend/test/test_recalculation_admin.py` (new):

- `format_duration`: elapsed formatting including sub-minute, exact-minute, hours, and None on a missing or negative bound. Catches a regression that mis-renders execution time.
- Panel failure merge: `metric_errors` message wins over a result-row message, a discovery-only failure with no result row is still shown, and a named metric resolves to its name not its uuid. Catches the failures table showing the wrong text or dropping a failure.
- `retry_failures_view`: the created run carries the `metric_config_change` trigger and the response redirects to the new run. Catches retry silently becoming a full recalculation, or not redirecting.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Agent: Claude Code (Opus 4.8).

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/asd-ste100`.

Decisions:

- Retry reuses the window instead of recomputing everything. The window-reuse behavior of `metric_config_change` was verified against the calc activity's `already_computed` cache check, so a retry only reruns metrics without a COMPLETED result row.
- The panel builder and start logic live in a shared `recalculation_panel.py` so the experiment admin and recalculation admin stay thin and the failure-resolution order stays in one place.
- The panel renders only on the experiment page. An earlier revision also rendered it on the recalculation detail page; that was removed because it duplicated the run the reviewer already had open.

![cat-type-small](https://github.com/user-attachments/assets/082cec3e-4f24-4da2-8161-61f357b9d9e4)
