### PR TITLE
fix(ci): stop re-recording product app migrations on schema restore

### DIFF
--- a/tools/hogli-commands/hogli_commands/db_schema.py
+++ b/tools/hogli-commands/hogli_commands/db_schema.py
@@ -244,39 +244,30 @@ def _product_routed_app_labels() -> list[str]:
     return sorted(label for label in labels if APP_LABEL_RE.fullmatch(label))
 
 
-@dataclass(frozen=True)
-class MigrationRecordPlan:
-    """What a restore does to the django_migrations rows the dump carries."""
-
-    forget: tuple[tuple[str, str], ...]
-    replay: tuple[tuple[str, str], ...]
-    refake: tuple[tuple[str, str], ...]
-
-
-def plan_migration_records(
+def migrations_to_forget(
     recorded: Iterable[tuple[str, str]], product_app_labels: Iterable[str]
-) -> MigrationRecordPlan:
-    """Decide which of the dump's migration records to forget, replay for real, and re-record.
+) -> tuple[tuple[str, str], ...]:
+    """Pick the dump's migration records this database cannot honor.
 
     The dump is taken from a CI database that routes product apps elsewhere, so `migrate` skipped
     every operation in their migrations there while Django recorded them as applied anyway (it
     records whatever the router decides). Restored verbatim, that leaves a database asserting
     stamphog and visual_review are migrated without a single one of their tables — and an
     environment that configures no product database then applies their NEXT migration for real
-    and dies on the missing table. Forgetting the rows lets each consumer replay them under its
-    own routing: a no-op where the app is routed away, real tables where it isn't.
+    and dies on the missing table. Forgetting the rows lets each consumer apply them under its own
+    routing: a no-op where the app is routed away, real tables where it isn't.
 
     The squash schema-addons migrations go with them. Each one depends on the leaf squash of every
     squashed app, the product-routed apps included, so a database that keeps an addons row while
     its dependency row is gone fails Django's consistency check before `migrate` does anything.
-    Replaying one is cheap: its operations probe the schema and skip what is already there.
+    Re-applying one is cheap: its operations probe the schema and skip what is already there.
 
     Everything an app records after its addons migration depends on that addons migration, so it
-    fails the same check for the same reason and has to be forgotten too. Those migrations are
-    already in the restored schema though, so replaying one would add a column that exists. They
-    are re-recorded with `--fake` instead. The repo keeps one migration line per app, so a name
-    that sorts after the addons migration is a descendant of it, and faking up to the last one
-    re-records the whole run.
+    fails the same check for the same reason and has to be forgotten too. The repo keeps one
+    migration line per app, so a name that sorts after the addons migration is a descendant of it.
+
+    Nothing is re-recorded here. The caller's own `migrate` applies every forgotten migration
+    against the restored schema, which is the only pass that sees this database's routing.
     """
     routed = set(product_app_labels)
     by_app: dict[str, list[str]] = {}
@@ -284,8 +275,6 @@ def plan_migration_records(
         by_app.setdefault(app, []).append(name)
 
     forget: list[tuple[str, str]] = []
-    replay: list[tuple[str, str]] = []
-    refake: list[tuple[str, str]] = []
     for app, recorded_names in sorted(by_app.items()):
         names = sorted(recorded_names)
         if app in routed:
@@ -294,14 +283,9 @@ def plan_migration_records(
         addons = next((name for name in names if SQUASH_SCHEMA_ADDONS_NAME_RE.fullmatch(name)), None)
         if addons is None:
             continue
-        trailing = [name for name in names if name > addons]
-        forget.append((app, addons))
-        forget.extend((app, name) for name in trailing)
-        replay.append((app, addons))
-        if trailing:
-            refake.append((app, trailing[-1]))
+        forget.extend((app, name) for name in names if name >= addons)
 
-    return MigrationRecordPlan(forget=tuple(forget), replay=tuple(replay), refake=tuple(refake))
+    return tuple(forget)
 
 
 def _sql_string(value: str) -> str:
@@ -310,25 +294,20 @@ def _sql_string(value: str) -> str:
 
 
 def _forget_product_app_migrations(target_db: str) -> None:
-    """Re-record the dump's migrations the way this database can honor them.
+    """Drop the dump's migration records this database cannot honor.
 
-    See `plan_migration_records` for what moves and why.
+    See `migrations_to_forget` for what goes and why.
     """
     app_labels = _product_routed_app_labels()
     if not app_labels:
         return
     recorded = [(row[0], row[1]) for row in _psql_rows(target_db, "SELECT app, name FROM django_migrations;")]
-    plan = plan_migration_records(recorded, app_labels)
-    if not plan.forget:
+    forget = migrations_to_forget(recorded, app_labels)
+    if not forget:
         return
 
-    pairs = ", ".join(f"({_sql_string(app)}, {_sql_string(name)})" for app, name in plan.forget)
+    pairs = ", ".join(f"({_sql_string(app)}, {_sql_string(name)})" for app, name in forget)
     _psql_write(target_db, f"DELETE FROM django_migrations WHERE (app, name) IN ({pairs});")
-
-    for app, name in plan.replay:
-        _manage(target_db, "migrate", app, name, "--noinput")
-    for app, name in plan.refake:
-        _manage(target_db, "migrate", app, name, "--noinput", "--fake")
 
 
 def restore_schema_dump(

--- a/tools/hogli-commands/hogli_commands/db_schema.py
+++ b/tools/hogli-commands/hogli_commands/db_schema.py
@@ -244,9 +244,17 @@ def _product_routed_app_labels() -> list[str]:
     return sorted(label for label in labels if APP_LABEL_RE.fullmatch(label))
 
 
+@dataclass(frozen=True, kw_only=True)
+class MigrationRecord:
+    """One row of django_migrations."""
+
+    app: str
+    name: str
+
+
 def migrations_to_forget(
-    recorded: Iterable[tuple[str, str]], product_app_labels: Iterable[str]
-) -> tuple[tuple[str, str], ...]:
+    recorded: Iterable[MigrationRecord], product_app_labels: Iterable[str]
+) -> tuple[MigrationRecord, ...]:
     """Pick the dump's migration records this database cannot honor.
 
     The dump is taken from a CI database that routes product apps elsewhere, so `migrate` skipped
@@ -271,19 +279,19 @@ def migrations_to_forget(
     """
     routed = set(product_app_labels)
     by_app: dict[str, list[str]] = {}
-    for app, name in recorded:
-        by_app.setdefault(app, []).append(name)
+    for record in recorded:
+        by_app.setdefault(record.app, []).append(record.name)
 
-    forget: list[tuple[str, str]] = []
+    forget: list[MigrationRecord] = []
     for app, recorded_names in sorted(by_app.items()):
         names = sorted(recorded_names)
         if app in routed:
-            forget.extend((app, name) for name in names)
+            forget.extend(MigrationRecord(app=app, name=name) for name in names)
             continue
         addons = next((name for name in names if SQUASH_SCHEMA_ADDONS_NAME_RE.fullmatch(name)), None)
         if addons is None:
             continue
-        forget.extend((app, name) for name in names if name >= addons)
+        forget.extend(MigrationRecord(app=app, name=name) for name in names if name >= addons)
 
     return tuple(forget)
 
@@ -301,12 +309,15 @@ def _forget_product_app_migrations(target_db: str) -> None:
     app_labels = _product_routed_app_labels()
     if not app_labels:
         return
-    recorded = [(row[0], row[1]) for row in _psql_rows(target_db, "SELECT app, name FROM django_migrations;")]
+    recorded = [
+        MigrationRecord(app=row[0], name=row[1])
+        for row in _psql_rows(target_db, "SELECT app, name FROM django_migrations;")
+    ]
     forget = migrations_to_forget(recorded, app_labels)
     if not forget:
         return
 
-    pairs = ", ".join(f"({_sql_string(app)}, {_sql_string(name)})" for app, name in forget)
+    pairs = ", ".join(f"({_sql_string(r.app)}, {_sql_string(r.name)})" for r in forget)
     _psql_write(target_db, f"DELETE FROM django_migrations WHERE (app, name) IN ({pairs});")
 
 

--- a/tools/hogli-commands/hogli_commands/tests/test_db_schema.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_db_schema.py
@@ -316,35 +316,22 @@ _RECORDED = [
 ]
 
 
-@pytest.mark.parametrize(
-    "attribute,expected",
-    [
-        (
-            "forget",
-            (
-                # A product-routed app is replayed in full under the consumer's own routing.
-                ("posthog", "1345_squash_2026_09_07_schema_addons"),
-                ("posthog", "1346_untrack_organization_is_hipaa"),
-                ("posthog", "1347_add_a_column"),
-                ("stamphog", "0001_squash_2026_09_07_initial"),
-                ("stamphog", "0002_later"),
-            ),
-        ),
-        # The addons migration probes the schema, so replaying it for real is safe.
-        ("replay", (("posthog", "1345_squash_2026_09_07_schema_addons"),)),
-        # Its descendants are already in the restored schema, so they are re-recorded, not re-run.
-        ("refake", (("posthog", "1347_add_a_column"),)),
-    ],
-)
-def test_plan_migration_records(attribute: str, expected: tuple[tuple[str, str], ...]) -> None:
-    plan = db_schema.plan_migration_records(_RECORDED, ["stamphog"])
-
-    assert getattr(plan, attribute) == expected
+def test_migrations_to_forget() -> None:
+    # A product-routed app goes in full. Elsewhere the addons migration and everything recorded
+    # after it go, because each of those depends on a row that is about to disappear.
+    assert db_schema.migrations_to_forget(_RECORDED, ["stamphog"]) == (
+        ("posthog", "1345_squash_2026_09_07_schema_addons"),
+        ("posthog", "1346_untrack_organization_is_hipaa"),
+        ("posthog", "1347_add_a_column"),
+        ("stamphog", "0001_squash_2026_09_07_initial"),
+        ("stamphog", "0002_later"),
+    )
 
 
 def test_restore_schema_dump_forgets_product_app_migrations(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # Every migration the plan forgets has to leave the table, or the restored database asserts a
-    # migration applied before its dependency and Django refuses to migrate at all.
+    # Two regressions live here. Leaving a forgotten migration's descendant behind makes Django
+    # refuse to migrate at all. Re-recording any of them here marks a product app migrated on a
+    # database that never got its tables, which breaks its next migration instead.
     schema_path = tmp_path / "schema.sql.gz"
     _write_schema(schema_path)
     commands: list[list[str]] = []
@@ -359,13 +346,9 @@ def test_restore_schema_dump_forgets_product_app_migrations(tmp_path: Path, monk
 
     deletes = [command[-1] for command in commands if "DELETE FROM django_migrations" in command[-1]]
     assert len(deletes) == 1
-    for app, name in db_schema.plan_migration_records(_RECORDED, ["stamphog"]).forget:
+    for app, name in db_schema.migrations_to_forget(_RECORDED, ["stamphog"]):
         assert f"('{app}', '{name}')" in deletes[0]
-    migrates = [command for command in commands if command[:3] == ["python", "manage.py", "migrate"]]
-    assert migrates == [
-        ["python", "manage.py", "migrate", "posthog", "1345_squash_2026_09_07_schema_addons", "--noinput"],
-        ["python", "manage.py", "migrate", "posthog", "1347_add_a_column", "--noinput", "--fake"],
-    ]
+    assert not [command for command in commands if command[:3] == ["python", "manage.py", "migrate"]]
 
 
 def test_restore_schema_dump_recreate_cleans_up_after_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tools/hogli-commands/hogli_commands/tests/test_db_schema.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_db_schema.py
@@ -305,14 +305,18 @@ def test_restore_schema_dump_recreate_drops_and_creates(tmp_path: Path, monkeypa
     assert defaults == ["test_posthog"]
 
 
+def _record(app: str, name: str) -> db_schema.MigrationRecord:
+    return db_schema.MigrationRecord(app=app, name=name)
+
+
 _RECORDED = [
-    ("stamphog", "0001_squash_2026_09_07_initial"),
-    ("stamphog", "0002_later"),
-    ("posthog", "0001_squash_2026_09_07_initial"),
-    ("posthog", "1345_squash_2026_09_07_schema_addons"),
-    ("posthog", "1346_untrack_organization_is_hipaa"),
-    ("posthog", "1347_add_a_column"),
-    ("cdp", "0005_no_addons_migration_here"),
+    _record("stamphog", "0001_squash_2026_09_07_initial"),
+    _record("stamphog", "0002_later"),
+    _record("posthog", "0001_squash_2026_09_07_initial"),
+    _record("posthog", "1345_squash_2026_09_07_schema_addons"),
+    _record("posthog", "1346_untrack_organization_is_hipaa"),
+    _record("posthog", "1347_add_a_column"),
+    _record("cdp", "0005_no_addons_migration_here"),
 ]
 
 
@@ -320,11 +324,11 @@ def test_migrations_to_forget() -> None:
     # A product-routed app goes in full. Elsewhere the addons migration and everything recorded
     # after it go, because each of those depends on a row that is about to disappear.
     assert db_schema.migrations_to_forget(_RECORDED, ["stamphog"]) == (
-        ("posthog", "1345_squash_2026_09_07_schema_addons"),
-        ("posthog", "1346_untrack_organization_is_hipaa"),
-        ("posthog", "1347_add_a_column"),
-        ("stamphog", "0001_squash_2026_09_07_initial"),
-        ("stamphog", "0002_later"),
+        _record("posthog", "1345_squash_2026_09_07_schema_addons"),
+        _record("posthog", "1346_untrack_organization_is_hipaa"),
+        _record("posthog", "1347_add_a_column"),
+        _record("stamphog", "0001_squash_2026_09_07_initial"),
+        _record("stamphog", "0002_later"),
     )
 
 
@@ -340,14 +344,14 @@ def test_restore_schema_dump_forgets_product_app_migrations(tmp_path: Path, monk
     monkeypatch.setattr(db_schema, "_run_psql_with_gzip_input", lambda gzip_path, target_db: None)
     monkeypatch.setattr(db_schema, "_ensure_migration_defaults", lambda target_db: None)
     monkeypatch.setattr(db_schema, "_product_routed_app_labels", lambda: ["stamphog"])
-    monkeypatch.setattr(db_schema, "_psql_rows", lambda target_db, sql: [list(row) for row in _RECORDED])
+    monkeypatch.setattr(db_schema, "_psql_rows", lambda target_db, sql: [[r.app, r.name] for r in _RECORDED])
 
     db_schema.restore_schema_dump(target_db="test_posthog", recreate=False, schema_path=schema_path)
 
     deletes = [command[-1] for command in commands if "DELETE FROM django_migrations" in command[-1]]
     assert len(deletes) == 1
-    for app, name in db_schema.migrations_to_forget(_RECORDED, ["stamphog"]):
-        assert f"('{app}', '{name}')" in deletes[0]
+    for record in db_schema.migrations_to_forget(_RECORDED, ["stamphog"]):
+        assert f"('{record.app}', '{record.name}')" in deletes[0]
     assert not [command for command in commands if command[:3] == ["python", "manage.py", "migrate"]]
 
 


### PR DESCRIPTION
## Problem

- Playwright E2E fails on master and on every branch that rebases onto it. The job stops in "Apply postgres and clickhouse migrations and setup dev" with `relation "stamphog_digestrun" does not exist`, applying `stamphog.0005_index_digest_runs_by_audience`. Example: [the master run](https://github.com/PostHog/posthog/actions/runs/34312805145/job/102342787966).
- This is the second failure in that step today. [#97123](https://github.com/PostHog/posthog/pull/97123) cleared the first one and introduced this one.
- That PR made the schema restore replay each app's squash schema-addons migration. Replaying one pulls the product-routed apps' squashes into the plan, because every addons migration depends on them.
- On a database that configures no product database, `migrate` records those squashes as applied. The cached dump carries no product tables, so nothing creates them, and the next product migration runs against a table that was never made.

## Changes

- The restore forgets the migration records it cannot honor and stops there. It no longer runs `migrate` at all.
- The caller's own `migrate` applies every forgotten migration. That pass is the only one that sees the database's real routing, so a product app gets real tables where it is not routed away.
- `plan_migration_records` becomes `migrations_to_forget`, returning one list instead of three. The replay and re-record lists are gone.

## How did you test this code?

- Ran the planner over the 2799 migration records in master's own [schema dump](https://github.com/PostHog/posthog/actions/runs/34312805126). It forgets the same 46 records as before and re-records none.
- `tools/hogli-commands/hogli_commands/tests/test_db_schema.py` passes. The restore test now asserts no `migrate` runs during the restore — the regression that no test caught, and the one this PR is about.
- Not run: the E2E job itself. This sandbox has no Postgres or Docker, so CI on this PR is the real proof.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior, API, or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by the PostHog Slack app, following up on [#97123](https://github.com/PostHog/posthog/pull/97123) after a Slack thread asked whether the new master failure was related to it. It was.
- No duplicate: `gh pr list --state open --search` over the schema-restore and migration keywords found no open PR fixing this.
- The replay in the previous PR was there to cover a trailing migration that carries real DDL, which would fail if re-applied against a schema that already has it. No such migration exists today (`posthog.1346` only changes Django state), and letting the caller's `migrate` handle every forgotten record is what CI was green on for weeks. The narrower behavior wins until a case actually needs more.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Nothing in this PR carries non-public material.
