### PR TITLE
fix(desktop): stop the subframe navigation e2e racing a fixed timer

### DIFF
--- a/products/desktop/apps/code/tests/e2e/tests/main-process.spec.ts
+++ b/products/desktop/apps/code/tests/e2e/tests/main-process.spec.ts
@@ -44,35 +44,31 @@ test.describe("Main Process", () => {
     window,
   }) => {
     const targetUrl = "custom-scheme://sandbox-navigation-test/payload";
-    const navigationResult = electronApp.evaluate(
-      async ({ BrowserWindow }, expectedUrl) => {
-        const mainWindow = BrowserWindow.getAllWindows()[0];
-        if (!mainWindow) throw new Error("Main window not found");
+    type NavigationRecord = { defaultPrevented: boolean; isMainFrame: boolean };
+    type NavigationProbe = typeof globalThis & {
+      __e2eSubframeNavigation?: NavigationRecord;
+    };
 
-        return await new Promise<{
-          defaultPrevented: boolean;
-          isMainFrame: boolean;
-        }>((resolve, reject) => {
-          const timeout = setTimeout(() => {
-            mainWindow.webContents.off("will-frame-navigate", listener);
-            reject(new Error("Timed out waiting for subframe navigation"));
-          }, 5000);
-          const listener = (
-            event: Electron.Event<Electron.WebContentsWillFrameNavigateEventParams>,
-          ): void => {
-            if (event.url !== expectedUrl) return;
-            clearTimeout(timeout);
-            mainWindow.webContents.off("will-frame-navigate", listener);
-            resolve({
-              defaultPrevented: event.defaultPrevented,
-              isMainFrame: event.isMainFrame,
-            });
-          };
-          mainWindow.webContents.on("will-frame-navigate", listener);
-        });
-      },
-      targetUrl,
-    );
+    // The listener records the event instead of racing a timer against the
+    // renderer setup below, which takes tens of seconds under Rosetta.
+    await electronApp.evaluate(({ BrowserWindow }, expectedUrl) => {
+      const mainWindow = BrowserWindow.getAllWindows()[0];
+      if (!mainWindow) throw new Error("Main window not found");
+
+      const probe = globalThis as NavigationProbe;
+      probe.__e2eSubframeNavigation = undefined;
+      const listener = (
+        event: Electron.Event<Electron.WebContentsWillFrameNavigateEventParams>,
+      ): void => {
+        if (event.url !== expectedUrl) return;
+        mainWindow.webContents.off("will-frame-navigate", listener);
+        probe.__e2eSubframeNavigation = {
+          defaultPrevented: event.defaultPrevented,
+          isMainFrame: event.isMainFrame,
+        };
+      };
+      mainWindow.webContents.on("will-frame-navigate", listener);
+    }, targetUrl);
 
     const frameHandle = await window.evaluateHandle(() => {
       const iframe = document.createElement("iframe");
@@ -93,9 +89,19 @@ test.describe("Main Process", () => {
 
     await frame.getByText("Navigate externally").click();
 
-    await expect(navigationResult).resolves.toEqual({
-      defaultPrevented: true,
-      isMainFrame: false,
-    });
+    // Each poll is a main-process round trip, so the wait scales with the test
+    // timeout rather than the 5s default that expect.poll would apply.
+    await expect
+      .poll(
+        () =>
+          electronApp.evaluate(
+            () => (globalThis as NavigationProbe).__e2eSubframeNavigation,
+          ),
+        { timeout: test.info().timeout / 2 },
+      )
+      .toEqual({
+        defaultPrevented: true,
+        isMainFrame: false,
+      });
   });
 });

--- a/products/desktop/apps/code/tests/e2e/tests/main-process.spec.ts
+++ b/products/desktop/apps/code/tests/e2e/tests/main-process.spec.ts
@@ -89,15 +89,15 @@ test.describe("Main Process", () => {
 
     await frame.getByText("Navigate externally").click();
 
-    // Each poll is a main-process round trip, so the wait scales with the test
-    // timeout rather than the 5s default that expect.poll would apply.
+    // The event fires as soon as the click lands, so this only bounds the
+    // delivery. It starts after the setup above, which is the slow part.
     await expect
       .poll(
         () =>
           electronApp.evaluate(
             () => (globalThis as NavigationProbe).__e2eSubframeNavigation,
           ),
-        { timeout: test.info().timeout / 2 },
+        { timeout: 30000 },
       )
       .toEqual({
         defaultPrevented: true,


### PR DESCRIPTION
## Problem

- Every desktop release has failed since [#96677](https://github.com/PostHog/posthog/pull/96677) landed. The x64 macOS leg fails, so no x64 build reaches the update feed and `finalize-release` skips.
- One test fails, three attempts in a row, on three different runners: `main-process.spec.ts › blocks external protocol navigation from a renderer subframe` ([run 34298858904](https://github.com/PostHog/posthog/actions/runs/34298858904)).
- The test arms a `will-frame-navigate` listener behind a fixed 5 s timer, then builds an iframe in the renderer, then clicks. The timer measures the setup, not the behavior.
- The x64 build runs under Rosetta on an Apple silicon runner. The trace from attempt 2 shows the iframe creation alone took 16 s, so the timer expired about 10 s before the click could happen.
- #96677 was the first time this test ran under Rosetta. Before it, the x64 leg ran only the smoke spec.

## Changes

- The x64 release leg passes again. No user-facing change.
- The listener now records the matching event on `globalThis` in the main process instead of rejecting after 5 s. The test polls for the record after the click with `expect.poll`, bounded to 30 s. That bound starts after the setup, so it measures event delivery alone and cannot be beaten by slow setup.
- The listener keeps an explicit `on`/`off` pair rather than `once`. The app can emit unrelated subframe navigations during boot, so a match filter is required.
- The app code under test, `setupExternalLinkHandlers` in `external-links.ts`, is unchanged.

> [!NOTE]
> The release run cannot be re-run to green. The failure is deterministic, so this fix must ship in a new tag.

## How did you test this code?

- Packaged the Linux app and ran the full Electron suite under xvfb the way `desktop-test.yml` does. 15 of 15 pass, including the rewritten test.
- Not run: the x64 macOS leg under Rosetta. This sandbox is Linux. The next release run is the real check for that leg.
- The regression this guards: a slow environment failing the test before the navigation is ever attempted.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code in PostHog Desktop, directed to find why the release failed and fix the root cause.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- The investigation covered all three attempts of the failing run and the Playwright trace artifact. A timeout bump was rejected because it only moves the cliff. Limiting the x64 leg to the smoke spec was discussed and deferred to a separate decision.
- Duplicate search found no open PR for this fix.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

