### PR TITLE
fix(desktop): keep the x64 release build on the boot smoke

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -246,12 +246,20 @@ jobs:
 
             # The PR gate runs the Electron suite on Linux, so this is the only macOS
             # run left in the pipeline. It carries the boot and IPC coverage for the
-            # signed build, so it runs the whole suite instead of the smoke spec.
+            # signed build, so the native arm64 build runs the whole suite. Under
+            # Rosetta the suite takes ten times longer and its navigation tests time
+            # out, so the x64 build keeps the boot smoke only.
             - name: Run the Electron e2e suite against the packaged app
               env:
                   CI: true
                   E2E_APP_ARCH: ${{ matrix.arch }}
-              run: pnpm --filter code exec playwright test --config=tests/e2e/playwright.config.ts
+                  MATRIX_ARCH: ${{ matrix.arch }}
+              run: |
+                  SPECS=""
+                  if [[ "$MATRIX_ARCH" == "x64" ]]; then
+                    SPECS="tests/e2e/tests/smoke.spec.ts"
+                  fi
+                  pnpm --filter code exec playwright test --config=tests/e2e/playwright.config.ts $SPECS
 
             - name: Upload Playwright report
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Problem

- The 01:00 UTC release today tagged `desktop-v0.61.295` but never shipped: the x64 macOS build failed and finalize skipped ([run](https://github.com/PostHog/posthog/actions/runs/34298858904)).
- #96677 made the release job run the full Electron suite on both macOS builds.
- The native arm64 build passes the suite in about a minute. The x64 build runs it under Rosetta, took 12.7 minutes, and timed out in the subframe navigation test.

## Changes

- The arm64 build keeps the full suite. The x64 build runs the boot smoke spec only, as it did before #96677.
- Nothing user-visible changes. The next scheduled tag ships normally.

## How did you test this code?

- `actionlint` and `hogli lint:workflows` pass locally.
- Not run: the release job itself. It only runs on a `desktop-v*` tag. The 17:00 UTC schedule is the first real run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1). Skills invoked: /authoring-ci-workflows, /writing-code-comments, /writing-pr-descriptions. Follow-up to #96677 after watching its first scheduled run. The simplify pass on that PR had flagged the x64 cost; the first real run confirmed it.

https://claude.ai/code/session_01AAfrGhk4pdw6Y4X5pEnb9f
