### PR TITLE
fix(data-imports): stop DataForSEO's self-recovering API errors from paging error tracking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/dataforseo/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/dataforseo/source.py
@@ -129,6 +129,13 @@ Note: DataForSEO bills per API request, so every sync consumes account credits. 
             "DataForSEO API error [40203]": "Your DataForSEO daily spending limit was exceeded. Raise the limit in your DataForSEO account settings or wait for it to reset, then resync.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `_post_task`'s own tenacity retry already covers HTTP 429/5xx and the 40202/50xxx body
+        # codes (see `DataForSEORetryableError`), so one only reaches here once that budget is
+        # exhausted. Temporal retries the whole activity from there, so the failure is transient
+        # and self-recovering rather than a bug.
+        return {"DataForSEO API error (retryable)"}
+
     def get_canonical_descriptions(self) -> CanonicalDescriptions:
         from products.warehouse_sources.backend.temporal.data_imports.sources.dataforseo.canonical_descriptions import (
             CANONICAL_DESCRIPTIONS,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/dataforseo/tests/test_dataforseo_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/dataforseo/tests/test_dataforseo_source.py
@@ -7,6 +7,7 @@ from parameterized import parameterized
 
 from posthog.schema import SourceFieldInputConfig
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import error_message_matches
 from products.warehouse_sources.backend.temporal.data_imports.sources.dataforseo.settings import ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.dataforseo.source import DataForSEOSource
 
@@ -183,6 +184,21 @@ class TestDataForSEOSource:
         errors = DataForSEOSource().get_non_retryable_errors()
         assert expected_key in errors
         assert errors[expected_key]
+
+    @parameterized.expand(
+        [
+            ("http_status", "DataForSEO API error (retryable): status=500, url=https://api.dataforseo.com/v3/x"),
+            ("body_rate_limit", "DataForSEO API error (retryable) [40202]: rate limit exceeded"),
+            ("body_server_error", "DataForSEO API error (retryable) [50000]: internal error"),
+        ]
+    )
+    def test_transient_api_errors_are_retryable(self, _name: str, error_msg: str) -> None:
+        # `_post_task` already exhausted its own tenacity retry before this reaches us, so it
+        # must stay retryable (and out of the non-retryable set), so that a self-recovering
+        # blip is retried by Temporal instead of reported as an unclassified error.
+        source = DataForSEOSource()
+        assert error_message_matches(error_msg, source.get_retryable_errors())
+        assert not error_message_matches(error_msg, source.get_non_retryable_errors().keys())
 
     def test_canonical_descriptions_keyed_by_endpoint(self) -> None:
         descriptions = DataForSEOSource().get_canonical_descriptions()


### PR DESCRIPTION
## Problem

A transient DataForSEO API error, already retried by the connector and by Temporal, still opens a fresh error tracking issue instead of staying a warning. Observed on the `historical_rank_overview` table: [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a084f5-7530-7581-bb51-12f8ef30a363), a single occurrence of an upstream HTTP 500.

`_post_task` already retries HTTP 429/5xx and the 40202/50xxx body-level codes with backoff before it re-raises `DataForSEORetryableError`. That exception isn't classified as retryable at the source level, so it reaches error tracking as an unclassified issue on every occurrence, even though Temporal keeps retrying the whole activity and the condition is self-recovering.

## Changes

- `DataForSEOSource.get_retryable_errors()` now matches the `DataForSEO API error (retryable)` prefix shared by both raise sites in `dataforseo.py`. Matching errors log as a warning and let Temporal retry, instead of reporting a new error tracking issue.
- This is the same classification mechanism Apple Search Ads and Adjust already use for the identical shape: a source's own retry budget exhausted, still transient.

## How did you test this code?

Added 3 parameterized cases to `test_dataforseo_source.py` covering the HTTP-status and body-level retryable message shapes, mirroring the existing Apple Search Ads test for the same mechanism. Ran `pytest` on the source's test module (27 passed), `ruff check`/`ruff format --check`, and `mypy` on the changed files — all clean.

Not run: the full CI suite, and no integration test against DataForSEO's live API.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error tracking webhook by an automated pipeline-error triage flow. Investigated via PostHog's error tracking MCP tools (issue detail, event stack trace, sync-context properties) and by reading `dataforseo.py`/`source.py` and the shared `import_data_sync.py` error-classification path. No duplicate found: searched open PRs for "DataForSEO", "dataforseo", "DataForSEORetryableError", "historical_rank_overview", and reviewed the maintainer's open PR list — none address this.

Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/writing-code-comments`.