### PR TITLE
fix(desktop): poll the smoke window size until the maximize lands

### DIFF
--- a/products/desktop/apps/code/tests/e2e/tests/smoke.spec.ts
+++ b/products/desktop/apps/code/tests/e2e/tests/smoke.spec.ts
@@ -50,13 +50,21 @@ test.describe("Smoke Tests", () => {
   });
 
   test("window has correct minimum dimensions", async ({ window }) => {
-    const bounds = await window.evaluate(() => ({
-      width: window.innerWidth,
-      height: window.innerHeight,
-    }));
+    // The main process maximizes the window on ready-to-show, which can land
+    // after domcontentloaded. Poll so the assertion sees the final size, not
+    // the 600px outer frame the window opens with.
+    const bounds = () =>
+      window.evaluate(() => ({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      }));
 
-    expect(bounds.width).toBeGreaterThanOrEqual(900);
-    expect(bounds.height).toBeGreaterThanOrEqual(600);
+    await expect
+      .poll(async () => (await bounds()).width, { timeout: 10000 })
+      .toBeGreaterThanOrEqual(900);
+    await expect
+      .poll(async () => (await bounds()).height, { timeout: 10000 })
+      .toBeGreaterThanOrEqual(600);
   });
 
   test("app does not crash within 10 seconds of boot", async ({


### PR DESCRIPTION
## Problem

- Desktop PRs fail the new Linux `electron-test` job about one run in five on `Smoke Tests › window has correct minimum dimensions`, with a height of 573 instead of 600 ([run](https://github.com/PostHog/posthog/actions/runs/34326505700/job/102384937204), [run](https://github.com/PostHog/posthog/actions/runs/34324359707/job/102378130016)).
- The test reads the window size right after `domcontentloaded`. The main process maximizes the window on `ready-to-show`, which can fire later.
- The window opens at a 600px outer height. On macOS the hidden title bar makes the content the same 600px, so the race never showed. On Linux the frame takes 27px, so a read before the maximize lands sees 573.

## Changes

- The Linux Electron job stops failing on a late maximize. No user-facing change.
- The assertion polls the window size for up to ten seconds instead of reading it once. The bound starts after the app booted, so it waits for the final size only.

The deeper fix is `useContentSize: true` on the main window, so `minHeight` applies to the content on every platform. That changes window sizing for users and belongs to the desktop team, so this PR stays in the test.

## How did you test this code?

- The rewritten assertion catches the same regression as before: a `minWidth` or `minHeight` drop on the main window fails it.
- Not run locally: the desktop workspace is not installed in this checkout. The CI run on this PR is the test.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1). Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions. Found while babysitting #96681, whose desktop CI hit this. Same shape as #97145: a fixed read racing a window event.

https://claude.ai/code/session_01AAfrGhk4pdw6Y4X5pEnb9f
