### PR TITLE
feat(tasks): expose task run default preferences via MCP

### DIFF
--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -395,10 +395,32 @@ tools:
         enabled: false
     tasks-config-create:
         operation: tasks_config_create
-        enabled: false
+        enabled: true
+        scopes:
+            - task:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Set project task run defaults
+        description: >
+            Set the project-wide default AI run preferences (runtime adapter, model, reasoning effort) applied to task
+            runs created without an explicit runtime selection. Requires project admin. `runtime_adapter` and `model`
+            must be set together; send all three fields as null to clear the project default. Use tasks-models-retrieve
+            to list valid model identifiers.
     tasks-config-list:
         operation: tasks_config_list
-        enabled: false
+        enabled: true
+        scopes:
+            - task:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get project task run defaults
+        description: >
+            Get the project-wide default AI run preferences (runtime adapter, model, reasoning effort) applied to task
+            runs created without an explicit runtime selection. All fields are null when no project default is stored.
     tasks-create:
         operation: tasks_create
         enabled: true
@@ -482,13 +504,47 @@ tools:
                 - updated_at
     tasks-me-config-create:
         operation: tasks_me_config_create
-        enabled: false
+        enabled: true
+        scopes:
+            - task:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Set my task run defaults
+        description: >
+            Set the caller's per-project default AI run preferences (runtime adapter, model, reasoning effort). They
+            override the project default wholesale. `runtime_adapter` and `model` must be set together; send all three
+            fields as null to clear and inherit the project default. Returns the stored preferences plus the resolved
+            defaults a new run will use. Use tasks-models-retrieve to list valid model identifiers.
     tasks-me-config-list:
         operation: tasks_me_config_list
-        enabled: false
+        enabled: true
+        scopes:
+            - task:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get my task run defaults
+        description: >
+            Get the caller's per-project default AI run preferences, plus the resolved defaults a new run will use when
+            no explicit runtime selection is sent (the caller's preference wins over the project default; `source` says
+            which level supplied it).
     tasks-models-retrieve:
         operation: tasks_models_retrieve
-        enabled: false
+        enabled: true
+        scopes:
+            - task:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: List available task run models
+        description: >
+            List the models a task run may use, each with its runtime adapter and the reasoning efforts it supports.
+            Use the returned identifiers when setting task run default preferences or creating a run. An empty list
+            means the model catalogue is temporarily unavailable, not that no models exist.
     tasks-partial-update:
         operation: tasks_partial_update
         enabled: false

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -408,6 +408,7 @@ tools:
             runs created without an explicit runtime selection. Requires project admin. `runtime_adapter` and `model`
             must be set together; send all three fields as null to clear the project default. Use tasks-models-retrieve
             to list valid model identifiers.
+        feature_flag: tasks
     tasks-config-list:
         operation: tasks_config_list
         enabled: true
@@ -421,6 +422,7 @@ tools:
         description: >
             Get the project-wide default AI run preferences (runtime adapter, model, reasoning effort) applied to task
             runs created without an explicit runtime selection. All fields are null when no project default is stored.
+        feature_flag: tasks
     tasks-create:
         operation: tasks_create
         enabled: true
@@ -517,6 +519,7 @@ tools:
             override the project default wholesale. `runtime_adapter` and `model` must be set together; send all three
             fields as null to clear and inherit the project default. Returns the stored preferences plus the resolved
             defaults a new run will use. Use tasks-models-retrieve to list valid model identifiers.
+        feature_flag: tasks
     tasks-me-config-list:
         operation: tasks_me_config_list
         enabled: true
@@ -531,6 +534,7 @@ tools:
             Get the caller's per-project default AI run preferences, plus the resolved defaults a new run will use when
             no explicit runtime selection is sent (the caller's preference wins over the project default; `source` says
             which level supplied it).
+        feature_flag: tasks
     tasks-models-retrieve:
         operation: tasks_models_retrieve
         enabled: true
@@ -545,6 +549,7 @@ tools:
             List the models a task run may use, each with its runtime adapter and the reasoning efforts it supports. Use
             the returned identifiers when setting task run default preferences or creating a run. An empty list means
             the model catalogue is temporarily unavailable, not that no models exist.
+        feature_flag: tasks
     tasks-partial-update:
         operation: tasks_partial_update
         enabled: false

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -542,9 +542,9 @@ tools:
             idempotent: true
         title: List available task run models
         description: >
-            List the models a task run may use, each with its runtime adapter and the reasoning efforts it supports.
-            Use the returned identifiers when setting task run default preferences or creating a run. An empty list
-            means the model catalogue is temporarily unavailable, not that no models exist.
+            List the models a task run may use, each with its runtime adapter and the reasoning efforts it supports. Use
+            the returned identifiers when setting task run default preferences or creating a run. An empty list means
+            the model catalogue is temporarily unavailable, not that no models exist.
     tasks-partial-update:
         operation: tasks_partial_update
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -11018,7 +11018,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false
-        }
+        },
+        "feature_flag": "tasks"
     },
     "tasks-config-list": {
         "description": "Get the project-wide default AI run preferences (runtime adapter, model, reasoning effort) applied to task runs created without an explicit runtime selection. All fields are null when no project default is stored.",
@@ -11032,7 +11033,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_flag": "tasks"
     },
     "tasks-create": {
         "description": "Create an agent task in the current project — a unit of work an AI agent picks up and actions, such as investigating an inbox report, fixing an error, or opening a pull request. `description` is the prompt handed to the agent, so make it specific and actionable. Pass `repository` in `organization/repo` format for code tasks so the agent knows where to work; omit it for investigation-only tasks. This creates the task record only — it does not start the agent. Returns the created task including its URL; open that URL to start the run. Requires the calling token's organization to have Tasks access enabled.",
@@ -11076,7 +11078,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false
-        }
+        },
+        "feature_flag": "tasks"
     },
     "tasks-me-config-list": {
         "description": "Get the caller's per-project default AI run preferences, plus the resolved defaults a new run will use when no explicit runtime selection is sent (the caller's preference wins over the project default; `source` says which level supplied it).",
@@ -11090,7 +11093,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_flag": "tasks"
     },
     "tasks-models-retrieve": {
         "description": "List the models a task run may use, each with its runtime adapter and the reasoning efforts it supports. Use the returned identifiers when setting task run default preferences or creating a run. An empty list means the model catalogue is temporarily unavailable, not that no models exist.",
@@ -11104,7 +11108,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_flag": "tasks"
     },
     "tasks-retrieve": {
         "description": "Get a specific task by ID, including its description, repository, origin product, current stage, and latest run summary. Sandbox connection credentials and the presigned log URL are omitted from the embedded `latest_run`. Use tasks-runs-list or tasks-runs-retrieve to inspect past executions.",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -11006,6 +11006,34 @@
         },
         "feature_flag": "context-layer"
     },
+    "tasks-config-create": {
+        "description": "Set the project-wide default AI run preferences (runtime adapter, model, reasoning effort) applied to task runs created without an explicit runtime selection. Requires project admin. `runtime_adapter` and `model` must be set together; send all three fields as null to clear the project default. Use tasks-models-retrieve to list valid model identifiers.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Set project task run defaults",
+        "title": "Set project task run defaults",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "tasks-config-list": {
+        "description": "Get the project-wide default AI run preferences (runtime adapter, model, reasoning effort) applied to task runs created without an explicit runtime selection. All fields are null when no project default is stored.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Get project task run defaults",
+        "title": "Get project task run defaults",
+        "required_scopes": ["task:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "tasks-create": {
         "description": "Create an agent task in the current project — a unit of work an AI agent picks up and actions, such as investigating an inbox report, fixing an error, or opening a pull request. `description` is the prompt handed to the agent, so make it specific and actionable. Pass `repository` in `organization/repo` format for code tasks so the agent knows where to work; omit it for investigation-only tasks. This creates the task record only — it does not start the agent. Returns the created task including its URL; open that URL to start the run. Requires the calling token's organization to have Tasks access enabled.",
         "category": "Tasks",
@@ -11035,6 +11063,48 @@
             "readOnlyHint": true
         },
         "feature_flag": "tasks"
+    },
+    "tasks-me-config-create": {
+        "description": "Set the caller's per-project default AI run preferences (runtime adapter, model, reasoning effort). They override the project default wholesale. `runtime_adapter` and `model` must be set together; send all three fields as null to clear and inherit the project default. Returns the stored preferences plus the resolved defaults a new run will use. Use tasks-models-retrieve to list valid model identifiers.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Set my task run defaults",
+        "title": "Set my task run defaults",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "tasks-me-config-list": {
+        "description": "Get the caller's per-project default AI run preferences, plus the resolved defaults a new run will use when no explicit runtime selection is sent (the caller's preference wins over the project default; `source` says which level supplied it).",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Get my task run defaults",
+        "title": "Get my task run defaults",
+        "required_scopes": ["task:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "tasks-models-retrieve": {
+        "description": "List the models a task run may use, each with its runtime adapter and the reasoning efforts it supports. Use the returned identifiers when setting task run default preferences or creating a run. An empty list means the model catalogue is temporarily unavailable, not that no models exist.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "List available task run models",
+        "title": "List available task run models",
+        "required_scopes": ["task:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
     },
     "tasks-retrieve": {
         "description": "Get a specific task by ID, including its description, repository, origin product, current stage, and latest run summary. Sandbox connection credentials and the presigned log URL are omitted from the embedded `latest_run`. Use tasks-runs-list or tasks-runs-retrieve to inspect past executions.",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -11663,7 +11663,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false
-        }
+        },
+        "feature_flag": "tasks"
     },
     "tasks-config-list": {
         "description": "Get the project-wide default AI run preferences (runtime adapter, model, reasoning effort) applied to task runs created without an explicit runtime selection. All fields are null when no project default is stored.",
@@ -11677,7 +11678,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_flag": "tasks"
     },
     "tasks-create": {
         "description": "Create an agent task in the current project — a unit of work an AI agent picks up and actions, such as investigating an inbox report, fixing an error, or opening a pull request. `description` is the prompt handed to the agent, so make it specific and actionable. Pass `repository` in `organization/repo` format for code tasks so the agent knows where to work; omit it for investigation-only tasks. This creates the task record only — it does not start the agent. Returns the created task including its URL; open that URL to start the run. Requires the calling token's organization to have Tasks access enabled.",
@@ -11721,7 +11723,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false
-        }
+        },
+        "feature_flag": "tasks"
     },
     "tasks-me-config-list": {
         "description": "Get the caller's per-project default AI run preferences, plus the resolved defaults a new run will use when no explicit runtime selection is sent (the caller's preference wins over the project default; `source` says which level supplied it).",
@@ -11735,7 +11738,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_flag": "tasks"
     },
     "tasks-models-retrieve": {
         "description": "List the models a task run may use, each with its runtime adapter and the reasoning efforts it supports. Use the returned identifiers when setting task run default preferences or creating a run. An empty list means the model catalogue is temporarily unavailable, not that no models exist.",
@@ -11749,7 +11753,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_flag": "tasks"
     },
     "tasks-retrieve": {
         "description": "Get a specific task by ID, including its description, repository, origin product, current stage, and latest run summary. Sandbox connection credentials and the presigned log URL are omitted from the embedded `latest_run`. Use tasks-runs-list or tasks-runs-retrieve to inspect past executions.",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -11651,6 +11651,34 @@
             "readOnlyHint": true
         }
     },
+    "tasks-config-create": {
+        "description": "Set the project-wide default AI run preferences (runtime adapter, model, reasoning effort) applied to task runs created without an explicit runtime selection. Requires project admin. `runtime_adapter` and `model` must be set together; send all three fields as null to clear the project default. Use tasks-models-retrieve to list valid model identifiers.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Set project task run defaults",
+        "title": "Set project task run defaults",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "tasks-config-list": {
+        "description": "Get the project-wide default AI run preferences (runtime adapter, model, reasoning effort) applied to task runs created without an explicit runtime selection. All fields are null when no project default is stored.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Get project task run defaults",
+        "title": "Get project task run defaults",
+        "required_scopes": ["task:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "tasks-create": {
         "description": "Create an agent task in the current project — a unit of work an AI agent picks up and actions, such as investigating an inbox report, fixing an error, or opening a pull request. `description` is the prompt handed to the agent, so make it specific and actionable. Pass `repository` in `organization/repo` format for code tasks so the agent knows where to work; omit it for investigation-only tasks. This creates the task record only — it does not start the agent. Returns the created task including its URL; open that URL to start the run. Requires the calling token's organization to have Tasks access enabled.",
         "category": "Tasks",
@@ -11680,6 +11708,48 @@
             "readOnlyHint": true
         },
         "feature_flag": "tasks"
+    },
+    "tasks-me-config-create": {
+        "description": "Set the caller's per-project default AI run preferences (runtime adapter, model, reasoning effort). They override the project default wholesale. `runtime_adapter` and `model` must be set together; send all three fields as null to clear and inherit the project default. Returns the stored preferences plus the resolved defaults a new run will use. Use tasks-models-retrieve to list valid model identifiers.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Set my task run defaults",
+        "title": "Set my task run defaults",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "tasks-me-config-list": {
+        "description": "Get the caller's per-project default AI run preferences, plus the resolved defaults a new run will use when no explicit runtime selection is sent (the caller's preference wins over the project default; `source` says which level supplied it).",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Get my task run defaults",
+        "title": "Get my task run defaults",
+        "required_scopes": ["task:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "tasks-models-retrieve": {
+        "description": "List the models a task run may use, each with its runtime adapter and the reasoning efforts it supports. Use the returned identifiers when setting task run default preferences or creating a run. An empty list means the model catalogue is temporarily unavailable, not that no models exist.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "List available task run models",
+        "title": "List available task run models",
+        "required_scopes": ["task:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
     },
     "tasks-retrieve": {
         "description": "Get a specific task by ID, including its description, repository, origin product, current stage, and latest run summary. Sandbox connection credentials and the presigned log URL are omitted from the embedded `latest_run`. Use tasks-runs-list or tasks-runs-retrieve to inspect past executions.",

--- a/services/mcp/src/generated/tasks/api.ts
+++ b/services/mcp/src/generated/tasks/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 19 enabled ops
+ * PostHog API - MCP 24 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -1279,4 +1279,130 @@ export const TasksRunsSessionLogsRetrieveQueryParams = () => zod.object({
         .min(tasksRunsSessionLogsRetrieveQueryOffsetMin)
         .default(tasksRunsSessionLogsRetrieveQueryOffsetDefault)
         .describe('Zero-based offset into the filtered log entries'),
+})
+
+/**
+ * Retrieve your per-project default AI run preferences, plus the resolved defaults a new run will use when no explicit runtime selection is sent (your preference over the project default).
+ */
+export const TasksMeConfigListParams = () => zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const TasksMeConfigListQueryParams = () => zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})
+
+/**
+ * Set your per-project default AI run preferences; they override the project default wholesale. Send all fields as null to clear and inherit the project default.
+ */
+export const TasksMeConfigCreateParams = () => zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const TasksMeConfigCreateBody = () => zod
+    .object({
+        runtime_adapter: zod
+            .union([zod.enum(['claude', 'codex']).describe('\* `claude` - claude\n\* `codex` - codex'), zod.null()])
+            .optional()
+            .describe(
+                "Default agent runtime adapter for new task runs. Use 'claude' for the Claude runtime or 'codex' for the Codex runtime. Must be set together with `model`.\n\n\* `claude` - claude\n\* `codex` - codex"
+            ),
+        model: zod
+            .string()
+            .nullish()
+            .describe('Default LLM model identifier for new task runs. Must be set together with `runtime_adapter`.'),
+        reasoning_effort: zod
+            .union([
+                zod
+                    .enum(['low', 'medium', 'high', 'xhigh', 'max', 'ultracode'])
+                    .describe(
+                        '\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max\n\* `ultracode` - ultracode'
+                    ),
+                zod.null(),
+            ])
+            .optional()
+            .describe(
+                'Default reasoning effort for models that expose an effort control.\n\n\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max\n\* `ultracode` - ultracode'
+            ),
+    })
+    .describe(
+        'The default AI run triple stored at team or user level.\n\nWrite payload for the tasks config endpoints and the `ai_run_preferences` block of\ntheir responses. `runtime_adapter` and `model` must be set together; send all three\nas null to clear a stored preference.'
+    )
+
+/**
+ * Retrieve the project-wide default AI run preferences for task runs.
+ */
+export const TasksConfigListParams = () => zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const TasksConfigListQueryParams = () => zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})
+
+/**
+ * Set the project-wide default AI run preferences applied to task runs created without an explicit runtime selection. Send all fields as null to clear.
+ */
+export const TasksConfigCreateParams = () => zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const TasksConfigCreateBody = () => zod
+    .object({
+        runtime_adapter: zod
+            .union([zod.enum(['claude', 'codex']).describe('\* `claude` - claude\n\* `codex` - codex'), zod.null()])
+            .optional()
+            .describe(
+                "Default agent runtime adapter for new task runs. Use 'claude' for the Claude runtime or 'codex' for the Codex runtime. Must be set together with `model`.\n\n\* `claude` - claude\n\* `codex` - codex"
+            ),
+        model: zod
+            .string()
+            .nullish()
+            .describe('Default LLM model identifier for new task runs. Must be set together with `runtime_adapter`.'),
+        reasoning_effort: zod
+            .union([
+                zod
+                    .enum(['low', 'medium', 'high', 'xhigh', 'max', 'ultracode'])
+                    .describe(
+                        '\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max\n\* `ultracode` - ultracode'
+                    ),
+                zod.null(),
+            ])
+            .optional()
+            .describe(
+                'Default reasoning effort for models that expose an effort control.\n\n\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max\n\* `ultracode` - ultracode'
+            ),
+    })
+    .describe(
+        'The default AI run triple stored at team or user level.\n\nWrite payload for the tasks config endpoints and the `ai_run_preferences` block of\ntheir responses. `runtime_adapter` and `model` must be set together; send all three\nas null to clear a stored preference.'
+    )
+
+/**
+ * Return the models a task run may use, with the reasoning efforts each one supports. Derived from the live LLM gateway catalogue, so a newly released model appears without a client change. An empty list means the gateway is unreachable — clients should fall back to their own default rather than treating it as 'no models exist'.
+ * @summary List available models
+ */
+export const TasksModelsRetrieveParams = () => zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
 })

--- a/services/mcp/src/tools/generated/tasks.ts
+++ b/services/mcp/src/tools/generated/tasks.ts
@@ -528,6 +528,60 @@ const loopsRunsRetrieve = (): ToolBase<
     },
 })
 
+const TasksConfigCreateSchema = () => {
+    const TasksConfigCreateBody = orvalSchemas.TasksConfigCreateBody()
+    return TasksConfigCreateBody
+}
+
+const tasksConfigCreate = (): ToolBase<
+    ReturnType<typeof TasksConfigCreateSchema>,
+    Schemas.TasksTeamConfigResponse
+> => ({
+    name: 'tasks-config-create',
+    schema: TasksConfigCreateSchema(),
+    handler: async (context: Context, params: z.infer<ReturnType<typeof TasksConfigCreateSchema>>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.runtime_adapter !== undefined) {
+            body['runtime_adapter'] = params.runtime_adapter
+        }
+        if (params.model !== undefined) {
+            body['model'] = params.model
+        }
+        if (params.reasoning_effort !== undefined) {
+            body['reasoning_effort'] = params.reasoning_effort
+        }
+        const result = await context.api.request<Schemas.TasksTeamConfigResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/tasks/config/`,
+            body,
+        })
+        return result
+    },
+})
+
+const TasksConfigListSchema = () => {
+    const TasksConfigListQueryParams = orvalSchemas.TasksConfigListQueryParams()
+    return TasksConfigListQueryParams
+}
+
+const tasksConfigList = (): ToolBase<ReturnType<typeof TasksConfigListSchema>, Schemas.TasksTeamConfigResponse> => ({
+    name: 'tasks-config-list',
+    schema: TasksConfigListSchema(),
+    handler: async (context: Context, params: z.infer<ReturnType<typeof TasksConfigListSchema>>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.TasksTeamConfigResponse>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/tasks/config/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+            },
+        })
+        return result
+    },
+})
+
 const TasksCreateSchema = () => {
     const TasksCreateBody = orvalSchemas.TasksCreateBody()
     return TasksCreateBody.omit({
@@ -674,6 +728,81 @@ const tasksList = (): ToolBase<
     },
 })
 
+const TasksMeConfigCreateSchema = () => {
+    const TasksMeConfigCreateBody = orvalSchemas.TasksMeConfigCreateBody()
+    return TasksMeConfigCreateBody
+}
+
+const tasksMeConfigCreate = (): ToolBase<
+    ReturnType<typeof TasksMeConfigCreateSchema>,
+    Schemas.TasksUserConfigResponse
+> => ({
+    name: 'tasks-me-config-create',
+    schema: TasksMeConfigCreateSchema(),
+    handler: async (context: Context, params: z.infer<ReturnType<typeof TasksMeConfigCreateSchema>>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.runtime_adapter !== undefined) {
+            body['runtime_adapter'] = params.runtime_adapter
+        }
+        if (params.model !== undefined) {
+            body['model'] = params.model
+        }
+        if (params.reasoning_effort !== undefined) {
+            body['reasoning_effort'] = params.reasoning_effort
+        }
+        const result = await context.api.request<Schemas.TasksUserConfigResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/tasks/@me/config/`,
+            body,
+        })
+        return result
+    },
+})
+
+const TasksMeConfigListSchema = () => {
+    const TasksMeConfigListQueryParams = orvalSchemas.TasksMeConfigListQueryParams()
+    return TasksMeConfigListQueryParams
+}
+
+const tasksMeConfigList = (): ToolBase<
+    ReturnType<typeof TasksMeConfigListSchema>,
+    Schemas.TasksUserConfigResponse
+> => ({
+    name: 'tasks-me-config-list',
+    schema: TasksMeConfigListSchema(),
+    handler: async (context: Context, params: z.infer<ReturnType<typeof TasksMeConfigListSchema>>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.TasksUserConfigResponse>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/tasks/@me/config/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+            },
+        })
+        return result
+    },
+})
+
+const TasksModelsRetrieveSchema = () => z.object({})
+
+const tasksModelsRetrieve = (): ToolBase<
+    ReturnType<typeof TasksModelsRetrieveSchema>,
+    Schemas.ModelCatalogueResponse
+> => ({
+    name: 'tasks-models-retrieve',
+    schema: TasksModelsRetrieveSchema(),
+    handler: async (context: Context, _params: z.infer<ReturnType<typeof TasksModelsRetrieveSchema>>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.ModelCatalogueResponse>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/tasks/models/`,
+        })
+        return result
+    },
+})
+
 const TasksRetrieveSchema = () => {
     const TasksRetrieveParams = orvalSchemas.TasksRetrieveParams()
     return TasksRetrieveParams.omit({ project_id: true })
@@ -814,8 +943,13 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'loops-retrieve': loopsRetrieve,
     'loops-run-create': loopsRunCreate,
     'loops-runs-retrieve': loopsRunsRetrieve,
+    'tasks-config-create': tasksConfigCreate,
+    'tasks-config-list': tasksConfigList,
     'tasks-create': tasksCreate,
     'tasks-list': tasksList,
+    'tasks-me-config-create': tasksMeConfigCreate,
+    'tasks-me-config-list': tasksMeConfigList,
+    'tasks-models-retrieve': tasksModelsRetrieve,
     'tasks-retrieve': tasksRetrieve,
     'tasks-runs-list': tasksRunsList,
     'tasks-runs-retrieve': tasksRunsRetrieve,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-config-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-config-create.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "The default AI run triple stored at team or user level.\n\nWrite payload for the tasks config endpoints and the `ai_run_preferences` block of\ntheir responses. `runtime_adapter` and `model` must be set together; send all three\nas null to clear a stored preference.",
+    "properties": {
+        "model": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Default LLM model identifier for new task runs. Must be set together with `runtime_adapter`."
+        },
+        "reasoning_effort": {
+            "anyOf": [
+                {
+                    "description": "* `low` - low\n* `medium` - medium\n* `high` - high\n* `xhigh` - xhigh\n* `max` - max\n* `ultracode` - ultracode",
+                    "enum": ["low", "medium", "high", "xhigh", "max", "ultracode"],
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Default reasoning effort for models that expose an effort control.\n\n* `low` - low\n* `medium` - medium\n* `high` - high\n* `xhigh` - xhigh\n* `max` - max\n* `ultracode` - ultracode"
+        },
+        "runtime_adapter": {
+            "anyOf": [
+                {
+                    "description": "* `claude` - claude\n* `codex` - codex",
+                    "enum": ["claude", "codex"],
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Default agent runtime adapter for new task runs. Use 'claude' for the Claude runtime or 'codex' for the Codex runtime. Must be set together with `model`.\n\n* `claude` - claude\n* `codex` - codex"
+        }
+    },
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-config-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-config-list.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "limit": {
+            "description": "Number of results to return per page.",
+            "type": "number"
+        },
+        "offset": {
+            "description": "The initial index from which to return the results.",
+            "type": "number"
+        }
+    },
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-me-config-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-me-config-create.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "The default AI run triple stored at team or user level.\n\nWrite payload for the tasks config endpoints and the `ai_run_preferences` block of\ntheir responses. `runtime_adapter` and `model` must be set together; send all three\nas null to clear a stored preference.",
+    "properties": {
+        "model": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Default LLM model identifier for new task runs. Must be set together with `runtime_adapter`."
+        },
+        "reasoning_effort": {
+            "anyOf": [
+                {
+                    "description": "* `low` - low\n* `medium` - medium\n* `high` - high\n* `xhigh` - xhigh\n* `max` - max\n* `ultracode` - ultracode",
+                    "enum": ["low", "medium", "high", "xhigh", "max", "ultracode"],
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Default reasoning effort for models that expose an effort control.\n\n* `low` - low\n* `medium` - medium\n* `high` - high\n* `xhigh` - xhigh\n* `max` - max\n* `ultracode` - ultracode"
+        },
+        "runtime_adapter": {
+            "anyOf": [
+                {
+                    "description": "* `claude` - claude\n* `codex` - codex",
+                    "enum": ["claude", "codex"],
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Default agent runtime adapter for new task runs. Use 'claude' for the Claude runtime or 'codex' for the Codex runtime. Must be set together with `model`.\n\n* `claude` - claude\n* `codex` - codex"
+        }
+    },
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-me-config-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-me-config-list.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "limit": {
+            "description": "Number of results to return per page.",
+            "type": "number"
+        },
+        "offset": {
+            "description": "The initial index from which to return the results.",
+            "type": "number"
+        }
+    },
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-models-retrieve.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-models-retrieve.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {},
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

Projects and users can store default AI run preferences for task runs (runtime adapter, model, reasoning effort), but only through the web settings. Agents connected over MCP cannot read or change them.

## Changes

- Agents can now read and set the project-wide default and their own per-project task run preferences over MCP.
- Agents can also list the available models with their supported reasoning efforts, to pick valid identifiers.
- Mechanically: enables the five scaffolded tools in `products/tasks/mcp/tools.yaml` and commits the regenerated handlers, schemas, and snapshots. No backend changes.

> [!NOTE]
> The project-wide write stays admin-only; the endpoint enforces it and the tool description says so.

## How did you test this code?

- Tested end to end against a local MCP server and dev stack: all five tools listed, both config reads returned the stored and resolved triples, and both writes (user preference, project default) stored and resolved correctly.
- Ran the MCP unit suite locally; it wrote the five new tool-schema snapshots included here.
- The endpoints themselves are unchanged and keep their existing test coverage.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Skills invoked: `/implementing-mcp-tools`, `/writing-pr-descriptions`. The work was YAML enablement plus `hogli build:openapi` codegen; the serializers already carried typed fields and help_text, so the generated schemas came out complete without Django changes. No HogQL system table was added: the my-config read resolves per requesting user, which a table cannot express.
