### PR TITLE
fix(tasks): pin pnpm 10 in the local sandbox image

### DIFF
--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-local
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-local
@@ -6,6 +6,9 @@
 
 FROM posthog-sandbox-base
 
+# The base image installs the latest pnpm; pnpm 12 rejects --fetch-timeout and cannot link across the store cache mount.
+RUN npm install -g pnpm@10
+
 COPY local-workspace/.npmrc local-workspace/package.json local-workspace/pnpm-lock.yaml local-workspace/pnpm-workspace.yaml /local-workspace/
 COPY local-workspace/patches /local-workspace/patches
 COPY local-workspace/packages/agent/package.json /local-workspace/packages/agent/package.json


### PR DESCRIPTION
## Problem

Anyone building the local task sandbox image today gets a failed build, so local sandboxed eval runs and local agent tasks cannot start.

- The base image installs the latest pnpm, which is now pnpm 12.
- pnpm 12 rejects the `--fetch-timeout` flag on a tarball install and fails with `ERR_PNPM_PACKAGE_MANAGER_SYMLINK_FAILED` across the BuildKit store mount.
- The workspace install step still works because the repo pins pnpm 10 through `packageManager`; the `/scripts` install has no pin.

## Changes

- `Dockerfile.sandbox-local` installs pnpm 10 right after `FROM posthog-sandbox-base`, so both install steps use the repo's pnpm major.
- Nothing user-visible changes.

## How did you test this code?

- Built the local sandbox image through a `hogli evals` run on Docker. The build failed before the pin and completed after it.
- Not run: the cloud sandbox images, which this file does not affect.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found and fixed with Claude Code while running local evals for #97241. No skills invoked for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFBAZfbYVdHJHWS5Yw3T3g
