### PR TITLE
feat(wizard): require a verified email for the AI gateway

### DIFF
--- a/posthog/api/email_verification.py
+++ b/posthog/api/email_verification.py
@@ -4,32 +4,24 @@ import structlog
 from rest_framework import exceptions
 
 from posthog.exceptions_capture import capture_exception
+from posthog.helpers.email_verification_state import VERIFICATION_DISABLED_FLAG, is_email_verification_disabled
 from posthog.helpers.two_factor_session import (
     CODE_MAX_ATTEMPTS,
     CODE_TTL_SECONDS,
     code_based_verification_token_generator,
 )
 from posthog.models.user import User
-from posthog.ph_client import feature_enabled_or_false
 from posthog.redis import get_client
 from posthog.tasks.email import send_email_verification_code
 
 logger = structlog.get_logger(__name__)
 
-VERIFICATION_DISABLED_FLAG = "email-verification-disabled"
+# Re-exported: both moved to a module the early-loading callers can import, and
+# this is still where the rest of the codebase asks for them.
+__all__ = ["VERIFICATION_DISABLED_FLAG", "is_email_verification_disabled"]
 
 EMAIL_CODE_STATE_REDIS_KEY_PREFIX = "email_verification_code_state"
 EMAIL_CODE_ATTEMPTS_REDIS_KEY_PREFIX = "email_verification_code_attempts"
-
-
-def is_email_verification_disabled(user: User) -> bool:
-    # using disabled here so that the default state (if no flag exists) is that verification defaults to ON.
-    return user.organization is not None and feature_enabled_or_false(
-        VERIFICATION_DISABLED_FLAG,
-        str(user.organization.id),
-        groups={"organization": str(user.organization.id)},
-        group_properties={"organization": {"id": str(user.organization.id)}},
-    )
 
 
 class EmailVerificationCodeVerifier:

--- a/posthog/api/oauth/test_views.py
+++ b/posthog/api/oauth/test_views.py
@@ -3207,6 +3207,30 @@ class TestOAuthAPI(APIBaseTest):
         self.assertEqual(response.json()["error"], "access_denied")
         self.assertFalse(OAuthGrant.objects.filter(application=app).exists())
 
+    @patch("posthog.api.oauth.views.wizard_email_unverified", return_value=True)
+    def test_authorize_refuses_an_unverified_identity_a_gateway_scope(self, mock_unverified):
+        # An unverified address is the cheapest identity to mint at scale, so the
+        # grant has to be refused, not only its later use.
+        app = self._create_first_party_app_with_ceiling("insight:read", "llm_gateway:read")
+        url = self.replace_param_in_url(self.base_authorization_url, "client_id", app.client_id)
+
+        response = self.client.get(f"{url}&scope=insight:read llm_gateway:read")
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.content)
+        self.assertEqual(response.json()["error"], "access_denied")
+        self.assertFalse(OAuthGrant.objects.filter(application=app).exists())
+        self.assertEqual(mock_unverified.call_args.kwargs["surface"], "oauth_authorize")
+
+    @patch("posthog.api.oauth.views.wizard_email_unverified", return_value=True)
+    def test_authorize_still_grants_an_unverified_identity_scopes_without_the_gateway(self, mock_unverified):
+        # Same scope-keying as the ban: verification gates the gateway, not sign-in.
+        app = self._create_first_party_app_with_ceiling("insight:read")
+
+        grant = self._first_party_authorize_grant(app, "insight:read")
+
+        self.assertEqual(set(grant.scope.split()), {"insight:read"})
+        mock_unverified.assert_not_called()
+
     @patch("posthog.api.oauth.views.wizard_identity_blocked", return_value=True)
     def test_authorize_still_grants_a_blocklisted_identity_scopes_without_the_gateway(self, mock_blocked):
         app = self._create_first_party_app_with_ceiling("insight:read")

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -62,6 +62,7 @@ from posthog.api.oauth.client_auth import verify_client_secret
 from posthog.api.oauth.mcp_resource_scopes import build_oauth_mcp_consent_context
 from posthog.helpers.impersonation import get_original_user_from_session, is_impersonated_session
 from posthog.llm.wizard_blocklist import GATEWAY_BEARING_SCOPES, WIZARD_BLOCKED_DETAIL, wizard_identity_blocked
+from posthog.llm.wizard_email_verification import WIZARD_EMAIL_UNVERIFIED_DETAIL, wizard_email_unverified
 from posthog.middleware import is_read_only_impersonation
 from posthog.models import OAuthAccessToken, OAuthApplication, Organization, Team, User
 from posthog.models.oauth import (
@@ -302,7 +303,7 @@ def _impersonation_ai_processing_block(
     )
 
 
-def _gateway_blocklist_block(
+def _gateway_access_block(
     request,
     scopes: str | Iterable[str],
     *,
@@ -310,7 +311,8 @@ def _gateway_blocklist_block(
     scoped_organization_ids: list[str] | None = None,
     scoped_team_ids: list[int] | None = None,
 ) -> Response | None:
-    """Refuse a blocklisted identity a grant carrying an LLM gateway scope.
+    """Refuse a grant carrying an LLM gateway scope: to a blocklisted identity, or
+    to one that never verified its address.
 
     Keyed on the scope rather than the wizard's client id, so another first-party
     app whose ceiling includes it is not an evasion route.
@@ -328,6 +330,11 @@ def _gateway_blocklist_block(
     requested = set(scopes.split() if isinstance(scopes, str) else scopes)
     if not GATEWAY_BEARING_SCOPES & requested:
         return None
+    if wizard_email_unverified(user=request.user, surface="oauth_authorize"):
+        return Response(
+            {"error": "access_denied", "error_description": WIZARD_EMAIL_UNVERIFIED_DETAIL},
+            status=status.HTTP_403_FORBIDDEN,
+        )
     organization_ids = _scoped_organization_ids(request.user, access_level, scoped_organization_ids, scoped_team_ids)
     if not wizard_identity_blocked(
         distinct_id=str(request.user.distinct_id),
@@ -1445,7 +1452,7 @@ class OAuthAuthorizationView(OAuthLibMixin, APIView):
         if application.is_first_party:
             if block := _impersonation_ai_processing_block(request):
                 return block
-            if block := _gateway_blocklist_block(request, scope_str.split()):
+            if block := _gateway_access_block(request, scope_str.split()):
                 return block
             try:
                 org_ids = request.user.organizations.values_list("id", flat=True)
@@ -1484,7 +1491,7 @@ class OAuthAuthorizationView(OAuthLibMixin, APIView):
                         # matched token's scope through — the precise check lives in the POST path.
                         if block := _impersonation_ai_processing_block(request):
                             return block
-                        if block := _gateway_blocklist_block(request, scope_str.split()):
+                        if block := _gateway_access_block(request, scope_str.split()):
                             return block
                         uri, headers, body, status_code = self.create_authorization_response(
                             request=request, scopes=scope_str, credentials=credentials, allow=True
@@ -1604,7 +1611,7 @@ class OAuthAuthorizationView(OAuthLibMixin, APIView):
             ):
                 return block
 
-            if block := _gateway_blocklist_block(
+            if block := _gateway_access_block(
                 request,
                 scopes,
                 access_level=serializer.validated_data.get("access_level"),

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -33,6 +33,7 @@ from posthog.auth import OAuthAccessTokenAuthentication, SessionAuthentication
 from posthog.cloud_utils import get_api_host
 from posthog.exceptions_capture import capture_exception
 from posthog.llm.wizard_blocklist import WIZARD_BLOCKED_DETAIL, wizard_identity_blocked
+from posthog.llm.wizard_email_verification import WIZARD_EMAIL_UNVERIFIED_DETAIL, wizard_email_unverified
 from posthog.llm.wizard_gateway_token import (
     WizardGatewayMintError,
     mint_wizard_gateway_token,
@@ -83,8 +84,8 @@ WIZARD_CLOUD_RUN_DAILY_ATTEMPT_CAP = 15
 WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL = Counter(
     "posthog_wizard_gateway_token_requests_total",
     "Wizard gateway-token mint requests, by outcome (minted/unconfigured/not_wizard_app/"
-    "scope_missing/team_ambiguous/team_missing/unauthorized/blocked/program_unknown/"
-    "not_rolled_out/mint_failed)",
+    "scope_missing/team_ambiguous/team_missing/unauthorized/blocked/email_unverified/"
+    "program_unknown/not_rolled_out/mint_failed)",
     labelnames=["outcome"],
 )
 
@@ -358,6 +359,8 @@ class SetupWizardViewSet(viewsets.ViewSet):
             # No outcome label: query labels no other exit, and the blocklist
             # counter already carries this surface with its own denominator.
             raise exceptions.PermissionDenied(WIZARD_BLOCKED_DETAIL)
+        if wizard_email_unverified(user=blocklist_user, surface="query"):
+            raise exceptions.PermissionDenied(WIZARD_EMAIL_UNVERIFIED_DETAIL)
 
         posthog_client = posthoganalytics.default_client
 
@@ -577,6 +580,9 @@ class SetupWizardViewSet(viewsets.ViewSet):
             # Ahead of the rollout gate, so a ban reads as a ban whatever the flag says.
             refuse("blocked", exceptions.PermissionDenied(WIZARD_BLOCKED_DETAIL), user=user)
 
+        if wizard_email_unverified(user=user, surface="gateway_token"):
+            refuse("email_unverified", exceptions.PermissionDenied(WIZARD_EMAIL_UNVERIFIED_DETAIL), user=user)
+
         # A kill switch, not a rollout gate: only a literal False refuses. With the
         # legacy product off there is no second path, so reading an outage as "not
         # rolled out" turns a flag-service blip into a global wizard outage.
@@ -795,6 +801,10 @@ class SetupWizardViewSet(viewsets.ViewSet):
             # No outcome label: `cloud_run` already counts every PermissionDenied as
             # permission_denied.
             raise exceptions.PermissionDenied(WIZARD_BLOCKED_DETAIL)
+        # Refused before the attempt is reserved too, so an unverified address does
+        # not also cost a daily slot.
+        if wizard_email_unverified(user=user, surface="cloud_run"):
+            raise exceptions.PermissionDenied(WIZARD_EMAIL_UNVERIFIED_DETAIL)
 
         self._reserve_cloud_run_attempt(user.id)
 

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -20,6 +20,7 @@ from rest_framework.test import APIRequestFactory
 from posthog.api.wizard.http import SETUP_WIZARD_CACHE_PREFIX, SETUP_WIZARD_CACHE_TIMEOUT
 from posthog.cloud_utils import get_api_host
 from posthog.llm.wizard_blocklist import WIZARD_BLOCKED_DETAIL
+from posthog.llm.wizard_email_verification import WIZARD_EMAIL_UNVERIFIED_DETAIL
 from posthog.llm.wizard_gateway_token import WizardGatewayMintError
 from posthog.models import Organization, PersonalAPIKey, User
 from posthog.models.utils import generate_random_token_personal, hash_key_value
@@ -62,6 +63,25 @@ class SetupWizardTests(APIBaseTest):
         assert response.json()["detail"] == WIZARD_BLOCKED_DETAIL
         # The proxy spends PostHog's own provider keys.
         mock_openai.return_value.chat.completions.create.assert_not_called()
+
+    @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
+    @patch("posthog.api.wizard.http.wizard_email_unverified", return_value=True)
+    @patch("posthog.api.wizard.http.OpenAI")
+    def test_query_from_an_unverified_identity_is_403(self, mock_openai, mock_unverified):
+        response = self.client.post(
+            self.query_url,
+            data=json.dumps(
+                {"message": "test", "json_schema": {"type": "object", "properties": {"name": {"type": "string"}}}}
+            ),
+            content_type="application/json",
+            headers={"x-posthog-wizard-hash": self.hash},
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
+        assert response.json()["detail"] == WIZARD_EMAIL_UNVERIFIED_DETAIL
+        # This surface spends PostHog's own provider keys too.
+        mock_openai.return_value.chat.completions.create.assert_not_called()
+        assert mock_unverified.call_args.kwargs["surface"] == "query"
 
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
     @patch("posthog.api.wizard.http.OpenAI")
@@ -580,6 +600,21 @@ class SetupWizardCloudRunTests(APIBaseTest):
         assert response.json()["detail"] == WIZARD_BLOCKED_DETAIL
         assert mock_blocked.call_args.kwargs["surface"] == "cloud_run"
 
+    @patch("posthog.api.wizard.http.SetupWizardViewSet._reserve_cloud_run_attempt")
+    @patch("posthog.api.wizard.http.wizard_email_unverified", return_value=True)
+    def test_an_unverified_identity_cannot_start_a_cloud_run(self, mock_unverified, mock_reserve):
+        response = self.client.post(
+            self.CLOUD_RUN_URL,
+            {"project_id": self.team.project_id, "repository": "PostHog/posthog"},
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
+        assert response.json()["detail"] == WIZARD_EMAIL_UNVERIFIED_DETAIL
+        assert mock_unverified.call_args.kwargs["surface"] == "cloud_run"
+        # Refused ahead of the reservation, so a refusal does not also burn one of
+        # the user's daily attempts.
+        mock_reserve.assert_not_called()
+
     @override_settings(WIZARD_CLOUD_RUN_OAUTH_CLIENT_ID="")
     def test_returns_404_when_feature_not_configured(self):
         response = self.client.post(
@@ -895,6 +930,26 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
         assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
         assert response.json()["detail"] == WIZARD_BLOCKED_DETAIL
         mock_mint.assert_not_called()
+
+    @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
+    @patch("posthog.api.wizard.http.mint_wizard_gateway_token", return_value=MINTED)
+    @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
+    @patch("posthog.api.wizard.http.wizard_email_unverified", return_value=True)
+    @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
+    def test_unverified_identity_is_403_and_never_mints(
+        self, mock_authentication, mock_unverified, mock_flag, mock_mint, mock_authorized
+    ):
+        # The mint is what buys inference, so refusing after it would still spend.
+        self._mock_oauth(mock_authentication)
+
+        response = self.client.post(
+            self.GATEWAY_TOKEN_URL, {"program": "integration"}, headers={"authorization": "Bearer pha_test"}
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
+        assert response.json()["detail"] == WIZARD_EMAIL_UNVERIFIED_DETAIL
+        mock_mint.assert_not_called()
+        assert mock_unverified.call_args.kwargs["surface"] == "gateway_token"
 
     @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
     @patch("posthog.api.wizard.http.mint_wizard_gateway_token", return_value=MINTED)

--- a/posthog/helpers/email_verification_state.py
+++ b/posthog/helpers/email_verification_state.py
@@ -1,0 +1,28 @@
+"""Whether an organization switched email verification off.
+
+Split out of `posthog.api.email_verification`, which reaches the Celery email
+tasks through its own imports. Modules that load before those tasks cannot import
+that one, and asking this question needs none of it.
+
+`posthog.api.email_verification` re-exports both names, so callers there keep
+importing from where they already do.
+"""
+
+from typing import TYPE_CHECKING
+
+from posthog.ph_client import feature_enabled_or_false
+
+if TYPE_CHECKING:
+    from posthog.models.user import User
+
+VERIFICATION_DISABLED_FLAG = "email-verification-disabled"
+
+
+def is_email_verification_disabled(user: "User") -> bool:
+    # using disabled here so that the default state (if no flag exists) is that verification defaults to ON.
+    return user.organization is not None and feature_enabled_or_false(
+        VERIFICATION_DISABLED_FLAG,
+        str(user.organization.id),
+        groups={"organization": str(user.organization.id)},
+        group_properties={"organization": {"id": str(user.organization.id)}},
+    )

--- a/posthog/llm/test_wizard_email_verification.py
+++ b/posthog/llm/test_wizard_email_verification.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from unittest.mock import patch
+
+from posthog.llm.wizard_email_verification import wizard_email_unverified
+from posthog.models.user import User
+
+
+def _user(is_email_verified: bool | None = False, email: str = "person@example.com") -> User:
+    # A stub keeps these off the database.
+    return cast(User, SimpleNamespace(is_email_verified=is_email_verified, email=email))
+
+
+class TestWizardEmailUnverified:
+    @pytest.mark.parametrize(
+        "is_email_verified,demo,email_available,verification_disabled,expected",
+        [
+            (True, False, True, False, False),
+            (False, False, True, False, True),
+            # A pre-verification account reads None. The login flow trusts those, so
+            # refusing them here would lock out accounts that predate the field.
+            (None, False, True, False, False),
+            (True, False, False, True, False),
+            # Every way the question was never asked, each leaving a legitimate
+            # account unverified.
+            (False, True, True, False, False),
+            (False, False, False, False, False),
+            (False, False, True, True, False),
+        ],
+    )
+    def test_refuses_only_an_account_that_was_asked_to_verify_and_did_not(
+        self, is_email_verified, demo, email_available, verification_disabled, expected
+    ):
+        with (
+            patch("posthog.llm.wizard_email_verification.settings.DEMO", demo),
+            patch("posthog.llm.wizard_email_verification.is_email_available", return_value=email_available),
+            patch(
+                "posthog.llm.wizard_email_verification.is_email_verification_disabled",
+                return_value=verification_disabled,
+            ),
+        ):
+            assert wizard_email_unverified(user=_user(is_email_verified), surface="gateway_token") is expected
+
+    def test_a_caller_without_a_user_is_allowed(self):
+        assert wizard_email_unverified(user=None, surface="query") is False
+
+    @pytest.mark.parametrize("failing_lookup", ["is_email_available", "is_email_verification_disabled"])
+    def test_a_lookup_failure_allows_rather_than_refusing_every_run(self, failing_lookup):
+        # Losing either lookup must not refuse the fleet.
+        with (
+            patch("posthog.llm.wizard_email_verification.settings.DEMO", False),
+            patch("posthog.llm.wizard_email_verification.is_email_available", return_value=True),
+            patch("posthog.llm.wizard_email_verification.is_email_verification_disabled", return_value=False),
+            patch(f"posthog.llm.wizard_email_verification.{failing_lookup}", side_effect=Exception("unavailable")),
+        ):
+            assert wizard_email_unverified(user=_user(is_email_verified=False), surface="cloud_run") is False
+
+    def test_a_verified_account_reaches_the_gateway_without_either_lookup(self):
+        # Moving the free field check below the lookups would put them on the hot path.
+        with (
+            patch("posthog.llm.wizard_email_verification.is_email_available") as email_available,
+            patch("posthog.llm.wizard_email_verification.is_email_verification_disabled") as verification_disabled,
+        ):
+            assert wizard_email_unverified(user=_user(is_email_verified=True), surface="oauth_authorize") is False
+
+        email_available.assert_not_called()
+        verification_disabled.assert_not_called()

--- a/posthog/llm/wizard_email_verification.py
+++ b/posthog/llm/wizard_email_verification.py
@@ -1,0 +1,87 @@
+"""Refuse the AI gateway to an identity that never verified its email address.
+
+Every other gateway limit is priced per account, so a free account is the hole
+underneath all of them. Checked at the same surfaces as the abuse blocklist,
+because a credential minted before the check reaches inference without passing
+it again.
+
+Allows whenever verification was never asked of the user: an instance with no
+email service, an organization that switched verification off, and demo mode all
+leave `is_email_verified` unset on legitimate accounts. Every lookup fails open,
+since losing the check must not refuse every wizard run.
+"""
+
+from typing import TYPE_CHECKING
+
+from django.conf import settings
+
+import structlog
+from prometheus_client import Counter
+
+from posthog.email import is_email_available
+from posthog.helpers.email_verification_state import is_email_verification_disabled
+
+if TYPE_CHECKING:
+    from posthog.models.user import User
+
+logger = structlog.get_logger(__name__)
+
+# The wizard shows this verbatim, so it reads the same at consent, at the mint,
+# and on a query.
+WIZARD_EMAIL_UNVERIFIED_DETAIL = (
+    "Verify your email address to use the PostHog AI gateway. Open PostHog to finish verifying, then try again."
+)
+
+# `not_applicable` keeps an instance that cannot verify from reading as a fleet
+# of refusals.
+WIZARD_EMAIL_VERIFICATION_CHECKS = Counter(
+    "posthog_wizard_email_verification_checks_total",
+    "Gateway email verification checks, by surface and outcome (verified/unverified/not_applicable)",
+    labelnames=["surface", "outcome"],
+)
+
+
+def wizard_email_unverified(*, user: "User | None", surface: str) -> bool:
+    """True when this identity must verify its address before reaching the gateway.
+
+    Answers False for every other case, including each way the question cannot be
+    asked.
+    """
+    if user is None:
+        # A caller that proved a distinct_id rather than a user has no address to
+        # judge, the same reading the blocklist takes.
+        _record(surface, "not_applicable")
+        return False
+
+    # None marks an account from before verification existed, which the login flow
+    # already trusts as verified, so only an explicit False is unverified. Free, and
+    # first, so a verified user reaches the gateway without the two lookups below.
+    if user.is_email_verified is not False:
+        _record(surface, "verified")
+        return False
+
+    if settings.DEMO:
+        _record(surface, "not_applicable")
+        return False
+
+    try:
+        if not is_email_available() or is_email_verification_disabled(user):
+            _record(surface, "not_applicable")
+            return False
+    except Exception as e:
+        logger.warning("wizard_email_verification: verification state unavailable", error=str(e), surface=surface)
+        _record(surface, "not_applicable")
+        return False
+
+    # The domain rather than the address, to keep mailboxes out of the logs.
+    logger.info(
+        "wizard_email_verification: unverified identity refused",
+        surface=surface,
+        email_domain=(user.email or "").rpartition("@")[2],
+    )
+    _record(surface, "unverified")
+    return True
+
+
+def _record(surface: str, outcome: str) -> None:
+    WIZARD_EMAIL_VERIFICATION_CHECKS.labels(surface=surface, outcome=outcome).inc()

--- a/posthog/temporal/oauth.py
+++ b/posthog/temporal/oauth.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 import structlog
 
 from posthog.llm.wizard_blocklist import WIZARD_BLOCKED_DETAIL, wizard_identity_blocked
+from posthog.llm.wizard_email_verification import WIZARD_EMAIL_UNVERIFIED_DETAIL, wizard_email_unverified
 from posthog.models import OAuthAccessToken, OAuthApplication
 from posthog.models.team.team import Team
 from posthog.models.utils import generate_random_oauth_access_token
@@ -604,6 +605,12 @@ class WizardIdentityBlockedError(Exception):
     a transient token failure must not retry this one."""
 
 
+class WizardEmailUnverifiedError(Exception):
+    """This identity has not verified its address, so it cannot hold a wizard
+    credential. Separate from WizardIdentityBlockedError because the user clears
+    this one themselves, and a caller may want to say so differently."""
+
+
 def create_wizard_oauth_access_token_for_user(user, team_id: int) -> str:
     """Mint an OAuth access token under the wizard's own app for a cloud wizard run.
 
@@ -622,6 +629,9 @@ def create_wizard_oauth_access_token_for_user(user, team_id: int) -> str:
         team_ids=[team_id],
     ):
         raise WizardIdentityBlockedError(WIZARD_BLOCKED_DETAIL)
+
+    if wizard_email_unverified(user=user, surface="wizard_mint"):
+        raise WizardEmailUnverifiedError(WIZARD_EMAIL_UNVERIFIED_DETAIL)
 
     app = get_wizard_app()
 

--- a/posthog/temporal/tests/test_oauth.py
+++ b/posthog/temporal/tests/test_oauth.py
@@ -30,6 +30,7 @@ from posthog.temporal.oauth import (
     PosthogMcpScopes,
     ScoutScopePosture,
     ScoutScopePreset,
+    WizardEmailUnverifiedError,
     WizardIdentityBlockedError,
     create_oauth_access_token_for_user,
     create_wizard_oauth_access_token_for_user,
@@ -459,6 +460,20 @@ class TestCreateWizardOAuthAccessTokenForUser(TestCase):
             create_wizard_oauth_access_token_for_user(user, team.id)
 
         assert not OAuthAccessToken.objects.exists()
+
+    @override_settings(WIZARD_CLOUD_RUN_OAUTH_CLIENT_ID=_WIZARD_CLIENT_ID)
+    @patch("posthog.temporal.oauth.wizard_email_unverified", return_value=True)
+    def test_an_unverified_identity_is_refused_a_wizard_token(self, mock_unverified) -> None:
+        # Gated at the mint for the same reason as the ban: a workflow retry or
+        # resume reaches here with no request in front of it.
+        self._create_wizard_app(scopes=["project:read", "llm_gateway:read"])
+        user, team = self._create_user_and_team()
+
+        with pytest.raises(WizardEmailUnverifiedError):
+            create_wizard_oauth_access_token_for_user(user, team.id)
+
+        assert not OAuthAccessToken.objects.exists()
+        assert mock_unverified.call_args.kwargs["surface"] == "wizard_mint"
 
     @override_settings(WIZARD_CLOUD_RUN_OAUTH_CLIENT_ID=_WIZARD_CLIENT_ID)
     def test_mints_token_under_wizard_app_with_its_scopes(self) -> None:


### PR DESCRIPTION
## Problem

Anyone can reach the PostHog AI gateway from an account that never verified its email address. Skipping verification costs nothing, so an unverified account is the cheapest identity to mint at scale.

Every other gateway control is priced per account: the per-run spend cap, the mint throttle, the cloud-run daily limit. A free account is the hole underneath all of them, because the cheapest way past a per-account limit is another account.

## Changes

- An account that has not verified its address now gets a 403 from the gateway, naming verification as the next step.
- The gate runs at all five gateway surfaces: OAuth consent, the wizard query, the gateway-token mint, the cloud-run kickoff, and the Temporal mint.
- The Temporal mint matters on its own. A workflow retry or resume reaches it with no request in front of it, so the HTTP surfaces alone would leak.
- A refusal spends nothing. It lands before the token mint, before the provider call, and before a cloud-run attempt is reserved.
- The gate stands down when verification was never asked of the user: no email service on the instance, an organization that switched verification off, or demo mode. Without this, a self-hosted instance without SMTP would lose the gateway outright.
- An account whose `is_email_verified` is null keeps its access. Null marks an account from before verification existed, and the login flow already trusts those. Only an explicit false is refused.
- Every lookup fails open. Losing the check must not refuse every wizard run.

Mechanical, with nothing user-visible:

- `is_email_verification_disabled` moves to `posthog/helpers/email_verification_state.py` and is re-exported. `posthog/api/email_verification.py` imports the Celery email tasks, and `posthog/temporal/oauth.py` loads before them, so importing it there was a circular import. Callers and their patch targets are unchanged.
- `_gateway_blocklist_block` becomes `_gateway_access_block`. It has three call sites, and putting the check inside it means all three get both gates.

> [!WARNING]
> This enforces on deploy, with no feature flag and no grace period. Accounts that hold gateway access today and have not verified lose it at once.

Scale of that, measured against the `posthog_user` table in each region:

- Explicitly unverified accounts are a low single-digit percentage of active accounts in both regions, and lower in EU than US.
- Accounts whose `is_email_verified` is null keep their access, so they sit outside that share.
- Most unverified accounts are old. Recent signups are a small fraction of them.
- Federated identity is unaffected. Google, SAML and GitHub signups verify at signup, and none of their gateway users are unverified.
- Partner-provisioned accounts start with `is_email_verified=False` by design (`ee/api/agentic_provisioning/accounts.py`), and their provisioning routes through `/oauth/authorize`. Four partner apps currently grant gateway-bearing scopes, so their provisioning would be refused until the user verifies.

## How did you test this code?

Automated only. No manual testing, and no browser or staging run.

- 11 unit tests over the decision matrix, with no database. They cover the null `is_email_verified` case, since the field is `BooleanField(null=True)` and an account predating verification must not read as verified.
- Two tests cover the fail-open paths, one per lookup. A regression to fail-closed would refuse every wizard run when the flag service or the instance setting is unreachable.
- One test asserts a verified account reaches the gateway without either lookup. It catches someone moving the free field check below the two lookups onto the hot path, which runs on every gateway call.
- Six wiring guards, one per surface. Each asserts the refusal and that nothing was spent: no mint, no provider call, no cloud-run slot.

- One test asserts a null `is_email_verified` keeps its access. An earlier revision refused it, which would have locked out every account predating the field.

Not checked:

- Which of the unverified accounts actually use the gateway. The account state and the gateway usage live in different stores, so the figures above bound the population rather than measure it.
- 10 failures in `posthog/api/oauth/test_views.py` and 21 in the signup and authentication suites are pre-existing. All fail with `TemplateDoesNotExist: index.html` because the worktree has no frontend build. Verified by running them at the base commit with this change absent; the failures are identical.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code ([session](https://claude.ai/code/session_016WGsBBRPeCFPm5cRSMBx2K)).

Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, `/asd-ste100`, and the LLM gateway abuse scout skill for the telemetry shape.

Decisions across the session:

- The gate was scoped to the same five call sites as the existing abuse blocklist, rather than a single choke point, because no single point covers both the HTTP surfaces and the Temporal mint.
- A rollout flag and a grace period were both considered and rejected by the human driver.
- The circular import surfaced only at runtime. Extracting the helper was chosen over a deferred import, per the repo rule to fix the structure first.
- No duplicate: `gh pr list` found no open PR covering this.
- Public artifact: the investigation behind this PR used production abuse telemetry. None of it reaches the diff or this description. No counts, identifiers, domains, or regions from that data appear here.

https://claude.ai/code/session_016WGsBBRPeCFPm5cRSMBx2K
