### PR TITLE
fix(visual-review): keep the supersession chain intact when a run is deleted

### DIFF
--- a/products/visual_review/backend/logic/retention.py
+++ b/products/visual_review/backend/logic/retention.py
@@ -168,6 +168,16 @@ class RetentionSweep:
             .values_list("id", flat=True)[:limit]
         )
 
+    def _splice_out_of_chain(self, run_id: UUID) -> None:
+        """Give the runs that name this run its own successor instead."""
+        successor_id = self._runs().filter(id=run_id).values_list("superseded_by_id", flat=True).first()
+        if successor_id is None:
+            # The run is the group's latest. Only the quiet-branch pass deletes
+            # one of those, and it takes a group where no run is superseded, so
+            # there is nothing to re-point.
+            return
+        self._runs().filter(superseded_by_id=run_id).update(superseded_by_id=successor_id)
+
     def _delete_runs(self, run_ids: list[UUID]) -> int:
         deleted = 0
         # One run per DELETE, in the order given (oldest first). Django applies
@@ -175,10 +185,18 @@ class RetentionSweep:
         # anything, so a batch that holds two links of one supersession chain
         # would set the older link to NULL while the group's latest run still
         # exists and break the unique_latest_run_per_group index.
+        #
+        # Oldest first is not enough on its own, because the retention class is
+        # a property of the row, not of its age: a run with no PR number counts
+        # as protected history and gets 180 days while the runs after it on the
+        # same branch get 30. Such a run survives the sweep that deletes the run
+        # it names, so it has to be re-pointed before the DELETE runs.
         for run_id in run_ids:
             if self._out_of_time():
                 break
-            _total, per_model = self._runs().filter(id=run_id).delete()
+            with transaction.atomic(using=WRITER_DB):
+                self._splice_out_of_chain(run_id)
+                _total, per_model = self._runs().filter(id=run_id).delete()
             deleted += per_model.get(Run._meta.label, 0)
         return deleted
 

--- a/products/visual_review/backend/tests/logic/test_retention.py
+++ b/products/visual_review/backend/tests/logic/test_retention.py
@@ -158,6 +158,20 @@ class TestRetentionSweep:
             == 1
         )
 
+    def test_protected_run_is_repointed_when_the_run_it_names_expires(self, repo, now):
+        latest = self._run(repo, now, age_days=5)
+        expired = self._run(repo, now, age_days=40, superseded_by=latest)
+        # No PR number counts as protected history, so this one keeps its 180
+        # days while the run it names goes at 30.
+        protected = self._run(repo, now, age_days=40, pr_number=None, superseded_by=expired)
+
+        result = retention.sweep_repo(repo, now=now)
+
+        assert result.runs_deleted == 1
+        assert not Run.objects.filter(id=expired.id).exists()
+        protected.refresh_from_db()
+        assert protected.superseded_by_id == latest.id
+
     @pytest.mark.parametrize(
         ("model", "extra_fields"),
         [


### PR DESCRIPTION
## Problem

Visual Review deletes nothing for PostHog/posthog. The nightly retention sweep has raised on that repo every night since #96449 shipped, so no run and no artifact goes, on the repo that holds nearly all of the data.

- The sweep deletes superseded runs oldest first. It assumes the deleted set is always a prefix of a supersession chain.
- The retention class is a property of the row, not of its age. A run with no PR number counts as protected history and keeps 180 days, while the runs after it on the same branch expire at 30.
- The protected run survives the sweep that deletes the run it names. Django sets its `superseded_by` to NULL before the DELETE.
- The group then holds two runs with a NULL pointer, and `unique_latest_run_per_group` rejects the statement with an `IntegrityError`.
- `sweep_repo` raises, so the repo loses its artifact pass too. The logs show `visual_review.retention_sweep_failed` for the repo on every invocation.

## Changes

- The sweep deletes expired runs and artifacts for PostHog/posthog again.
- `_delete_runs` re-points the predecessors at the deleted run's own successor before the DELETE, in one transaction with it.
- A run with no successor keeps the old behavior. Only the quiet-branch pass deletes the latest run of a group, and it takes a group where no run is superseded.
- Nothing user-visible changes. The sweep is a Celery task with no UI surface.

> [!NOTE]
> Risk surface for review:
>
> - The diff changes one method on a daily Celery task. No schema change, no migration, no API, no UI.
> - The deleted rows are the ones the merged policy already selects. The splice only changes which run a surviving row names.
> - Per-invocation caps and the time budget still bound the volume, and artifacts still go by reference.
> - A delete cannot be undone. That property comes from the retention policy in #96449, not from this change.
> - On the first nights after deploy the sweep drains a six-month backlog for PostHog/posthog. Watch `visual_review.retention_sweep_completed` and `retention_sweep_budget_exhausted`.

## How did you test this code?

- `test_protected_run_is_repointed_when_the_run_it_names_expires` builds a chain whose middle link expires while its predecessor stays protected. Without the fix it raises the same `IntegrityError` on `unique_latest_run_per_group` that production raises. With the fix the predecessor names the group's latest run.
- `test_supersession_chain_goes_oldest_first_in_one_sweep` covers a chain whose links share one retention class, so it never caught this.
- Ran `products/visual_review/backend/tests/logic/test_retention.py` locally.
- Not run: the rest of the backend suite. Nothing was changed or verified against production data.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The README documents the retention windows, which do not change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5). Skills invoked: `/writing-tests`, `/writing-code-comments`, `/simplify`, `/writing-pr-descriptions`.
- The failure surfaced during a review of the Visual Review roadmap, from the first production sweeps after #96449. The chain shape was then confirmed against the runs on `feat/visual-review-cli-build` through the visual review read tools.
- A one-time SQL repair of the affected rows was considered and dropped. The splice fixes the mechanism, so the repair buys only a few days.
- Considered and rejected: excluding runs that keep a surviving predecessor from the candidate query. That holds the rows past their window instead of deleting them.
- No duplicate. `gh pr list --state open` found no open PR for this constraint or for the sweep.
- Public artifact: everything here comes from this repository, its own tests, and its own logs.

https://claude.ai/code/session_014bw3ns7JLoPfXct2uQxfDg

