### PR TITLE
feat(desktop): add change default row to the composer model popup

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
@@ -766,6 +766,35 @@ describe("ReasoningLevelSelector", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it("opens the default settings from the Change default row", async () => {
+    const onChange = vi.fn();
+    const onModelChange = vi.fn();
+    const onOpenDefaultSettings = vi.fn();
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(
+      <Theme>
+        <ReasoningLevelSelector
+          thoughtOption={thoughtOption({ currentValue: "max" })}
+          modelOption={claudeModelOption("claude-fable-5")}
+          adapter="claude"
+          onChange={onChange}
+          onModelChange={onModelChange}
+          onOpenDefaultSettings={onOpenDefaultSettings}
+        />
+      </Theme>,
+    );
+
+    // No Advanced click: the row sits under the slider face too.
+    await user.click(
+      screen.getByRole("button", { name: /Model and reasoning/ }),
+    );
+    await user.click(await screen.findByText("Change default"));
+
+    await pollUntil(() => onOpenDefaultSettings.mock.calls.length > 0);
+    expect(onModelChange).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it.each([
     [
       "shows a disabled reset on the slider face while on the default",

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
@@ -1,5 +1,5 @@
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
-import { ArrowCounterClockwise, Lightning } from "@phosphor-icons/react";
+import { ArrowCounterClockwise, Gear, Lightning } from "@phosphor-icons/react";
 import {
   getCapabilityLadder,
   getReasoningEffortOptions,
@@ -108,6 +108,13 @@ interface ReasoningLevelSelectorProps {
    */
   resetToDefaultDisabled?: boolean;
   /**
+   * Takes the user to where the default itself is configured. Passed as a
+   * callback rather than a route so the picker stays free of the app's
+   * settings navigation. Omit and the "Change default" row is absent. Matches
+   * the web composer's row.
+   */
+  onOpenDefaultSettings?: () => void;
+  /**
    * Position and size the popup against this element instead of the trigger.
    *
    * The popup takes both its placement and its width from its anchor, and the trigger
@@ -160,6 +167,7 @@ export function ReasoningLevelSelector({
   isDefaultSelection,
   onResetToDefault,
   resetToDefaultDisabled,
+  onOpenDefaultSettings,
   anchor,
 }: ReasoningLevelSelectorProps) {
   const [internalMenuOpen, setInternalMenuOpen] = useState(false);
@@ -456,6 +464,15 @@ export function ReasoningLevelSelector({
         <ArrowCounterClockwise size={12} weight="bold" />
         Reset to default
       </DropdownMenuItem>
+      {/* Sits under the reset row because that's where the question arises:
+          reverting to a default you disagree with is the moment you want to
+          change it. */}
+      {onOpenDefaultSettings && (
+        <DropdownMenuItem onClick={() => selectAndClose(onOpenDefaultSettings)}>
+          <Gear size={12} weight="bold" />
+          Change default
+        </DropdownMenuItem>
+      )}
     </>
   );
 

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -1696,6 +1696,9 @@ export function TaskInput({
                         isDefaultSelection={isDefaultSelection}
                         onResetToDefault={resetToDefault}
                         resetToDefaultDisabled={resetToDefaultDisabled}
+                        onOpenDefaultSettings={() =>
+                          openSettings("task-agent-defaults")
+                        }
                       />
                     )
                   }


### PR DESCRIPTION
## Problem

The web composer's model popup has a "Change default" row that jumps to where the default model is configured. The desktop composer's popup only has "Reset to default", so changing the default means finding the Model settings section by hand.

## Changes

- The new-task composer's model popup shows a "Change default" row under "Reset to default". Clicking it opens Settings on the Model section.
- `ReasoningLevelSelector` takes an optional `onOpenDefaultSettings` callback that renders the row; surfaces that omit it are unchanged.

<img width="411" height="297" alt="Screenshot 2026-09-09 at 12 04 40" src="https://github.com/user-attachments/assets/4cc88f56-9a63-4201-b12b-d85c5aca7afe" />


## How did you test this code?

- New unit test: the "Change default" row fires the callback and leaves model and effort untouched.
- `pnpm typecheck` and `pnpm lint` in `products/desktop` pass.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/posthog-desktop`, `/writing-pr-descriptions`. The change mirrors the web `ComposerModelEffortPickers` row onto the desktop `ReasoningLevelSelector`, wired only in the new-task composer (`TaskInput`).
