### PR TITLE
fix(data-imports): skip a snapshot file deleted by a concurrent compaction

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_sync.py
@@ -258,7 +258,13 @@ async def _merge_snapshot_files(s3_client, file_keys: list[str]) -> dict[str, st
     them oldest-first). Decodes off the event loop so a large parquet can't starve the heartbeater."""
     hashes: dict[str, str] = {}
     for key in file_keys:
-        data = await s3_client._cat_file(_s3_uri(key))
+        try:
+            data = await s3_client._cat_file(_s3_uri(key))
+        except FileNotFoundError:
+            # A concurrent _write_snapshot_hashes compacted this file into a new one and deleted it
+            # after we listed the folder but before we read it. Its rows survive in that new file (or
+            # whichever one replaces it next run) — skip rather than fail the whole read.
+            continue
         for record in await asyncio.to_thread(_decode_parquet_rows, data):
             hashes[record["distinct_id"]] = record["sent_hash"]
     return hashes

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_sync_test.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_sync_test.py
@@ -355,7 +355,10 @@ class _FakeS3:
         return entries
 
     async def _cat_file(self, path):
-        return self.store[pps._s3_key(path)]
+        key = pps._s3_key(path)
+        if key not in self.store:
+            raise FileNotFoundError(path)
+        return self.store[key]
 
     async def _pipe_file(self, path, data):
         self._clock += 1
@@ -411,6 +414,20 @@ class TestSnapshotCompaction:
 
         assert len(keys) == 1
         assert hashes == {"a": "h2", "b": "h2"}
+
+    @pytest.mark.asyncio
+    async def test_read_tolerates_file_deleted_by_concurrent_compaction(self):
+        """A concurrent _write_snapshot_hashes run can merge a listed file into a new one and delete it
+        between our listing and our read of it — the read must skip the vanished file, not crash."""
+        fake = _FakeS3()
+        with _fake_s3_patch(fake):
+            await pps._write_snapshot_hashes(1, _SCHEMA, "src", "job-1", {"a": "h1"})
+            keys = await pps._list_snapshot_files(fake, pps._snapshot_prefix(1, _SCHEMA, "src"))
+            await fake._rm(keys)
+
+            hashes = await pps._merge_snapshot_files(fake, keys)
+
+        assert hashes == {}
 
 
 class TestGroupTarget:


### PR DESCRIPTION
## Problem

A person-property backfill run crashed with `FileNotFoundError: The specified key does not exist.`, surfaced by [error tracking](https://us.posthog.com/project/2/error_tracking/01a0859b-dfee-7f71-a999-75fb8227805c).

- `_merge_snapshot_files` lists a source's snapshot folder, then reads each listed file.
- A concurrent writer (the incremental sync or another backfill for the same source) can compact those same files into a new one and delete them in between.
- The read then fails on a key that no longer exists, even though its rows survived in the new compacted file.

## Changes

- `_merge_snapshot_files` now skips a file that disappears between listing and reading instead of raising.
- Shared by both the incremental sync and the backfill, since both read snapshots through this function.
- The skipped file's rows are not lost: the concurrent writer that deleted it had already merged them into its own compacted file.

## How did you test this code?

Added a case to `TestSnapshotCompaction` that lists a written snapshot file, deletes it (simulating a concurrent compaction), then asserts `_merge_snapshot_files` returns without raising. Confirmed it reproduces the original `FileNotFoundError` when run against the pre-fix code.

Not run: the DB-backed tests in this file (`TestReconcilePropertyDefinitions*`), which fail locally on Postgres connectivity unrelated to this change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal pipeline behavior, no documented interface changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a `FileNotFoundError`/`NoSuchKey` error tracking issue in the data-imports pipeline (Claude Code). Read the stack trace to find the exact race in `_merge_snapshot_files`, then read `_write_snapshot_hashes`'s compaction logic to confirm a concurrent writer can delete a file this function had already listed. No `/writing-tests`-flagged skill deviation; extended the existing `TestSnapshotCompaction` class rather than adding a new one. Searched open PRs (including the maintainer's own `posthog/*` branches) for a duplicate fix before opening this one; found none touching `_merge_snapshot_files` or this race.
