### PR TITLE
chore(ai): cover six critical journeys with real e2e tests

### DIFF
--- a/docs/internal/posthog-ai-e2e.md
+++ b/docs/internal/posthog-ai-e2e.md
@@ -53,7 +53,7 @@ The queue and steering layer adds the next five flows in `flows-queue-steering.s
 10. Escape with an empty saved queue cancels the active turn and preserves an unsent draft.
 
 An additional case within queue submission freezes the draft debounce and submits immediately.
-It reproduces queued text remaining in the composer after submission; this test also remains enabled.
+It checks that queued text clears from the composer after submission.
 The other queue cases advance that debounce with the browser clock so they independently exercise their delivery transitions.
 These are browser interaction checks with held task commands, not real agent-delivery checks.
 
@@ -65,9 +65,27 @@ The cancellation and history layer adds the last five flows in `flows-cancellati
 14. Sidebar attachment preserves the startup draft and focus at normal and narrow viewport widths.
 15. Reload, stream reconnect, and resolution from another client leave only the current run's unresolved approval actionable.
 
-These cases use controlled task commands and stream events. They currently reproduce two additional regressions:
-late task creation redirects back after navigation, and clicking the main transcript leaves focus outside its Escape boundary.
-Both assertions remain enabled.
+These cases use controlled task commands and stream events. They also guard against late task creation redirecting after
+navigation and main-transcript clicks leaving focus outside the Escape boundary.
+
+## Critical journeys through real services
+
+The next layer adds coverage across boundaries that the controlled browser cases cannot establish:
+
+| Journey               | Browser coverage                                                                                                            |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Deep links            | `/ai?ask=…` submits once with consent already accepted; a follow-up and reload retain the conversation.                     |
+| Cancellation          | Startup Stop reaches the owning agent; active-turn Stop prevents a pending insight creation; both accept a follow-up.       |
+| Queue and steering    | Two saved directions wait for real approval confirmation, arrive once in order, and preserve the separate draft.            |
+| History and reconnect | A real live response overlaps persisted history; reconnect uses its SSE cursor; a warm successor retains assistant history. |
+| Insight results       | MCP creates one saved insight, its SQL rows render in chat, and reload and the saved-insight link retain the result.        |
+| Sidebar apply-back    | A SQL suggestion reaches the submitting editor; late completion and history replay leave another editor unchanged.          |
+
+The first five run with Claude and Codex. The sidebar case uses Claude for the shared editor integration.
+Provider replies use synthetic fixtures; tool execution, query results, persistence, and application streaming remain real.
+The provider response barrier opens SSE before pausing so cancellation reaches an established SDK request.
+The approval-confirmation barrier holds the real successful response after execution starts; it never fabricates acceptance.
+These additions require ten repetitions on the actual CI runner before being described as stable.
 
 The original recovery browser suite runs three cases for each of Claude and Codex:
 

--- a/products/posthog_ai/eval_harness/test/e2e/attempt.py
+++ b/products/posthog_ai/eval_harness/test/e2e/attempt.py
@@ -31,7 +31,7 @@ class Attempt:
         self.output = output / self.id
         self.output.mkdir(parents=True)
         self.timeline: list[dict[str, JsonValue]] = []
-        names: tuple[FaultName, ...] = ("registration", "worker", "approval")
+        names: tuple[FaultName, ...] = ("registration", "worker", "approval", "approval_confirmation", "model")
         self.faults = {name: Fault(name, self.timeline) for name in names}
         self.errors: list[str] = []
         self.replay: Replay | None = None
@@ -96,6 +96,7 @@ class Attempt:
             self.user.current_team = self.team
             self.user.is_email_verified = True
             self.user.credentials_reviewed_at = timezone.now()
+            self.user.has_seen_product_intro_for = {"posthog_ai_onboarding": True}
             self.user.save()
             EventDefinition.objects.create(team=self.team, name="synthetic_workspace_opened")
             UserTasksConfig.objects.for_team(self.team.id).create(
@@ -158,6 +159,32 @@ class Attempt:
             self.insight = Insight.objects.create(
                 team=self.connected_team, created_by=self.connected_user, name="Synthetic original insight"
             )
+
+    def seed_editors(self) -> list[JsonValue]:
+        from posthog.models.file_system.file_system_view_log import log_file_system_view
+
+        from products.product_analytics.backend.models.insight import Insight
+
+        if self.task_id is not None or Insight.objects.filter(team=self.team).exists():
+            raise ValueError("Editor resources must be seeded once, before starting the attempt")
+        resources: list[JsonValue] = []
+        for suffix, value in (("A", 11), ("B", 22)):
+            query: dict[str, JsonValue] = {
+                "kind": "DataVisualizationNode",
+                "display": "ActionsTable",
+                "source": {"kind": "HogQLQuery", "query": f"SELECT {value} AS original_{suffix.lower()}"},
+            }
+            insight = Insight.objects.create(
+                team=self.team,
+                created_by=self.user,
+                name=f"Synthetic editor {suffix}",
+                query=query,
+                favorited=True,
+                saved=True,
+            )
+            log_file_system_view(user=self.user, obj=insight)
+            resources.append({"id": insight.id, "short_id": insight.short_id, "query": query})
+        return resources
 
     def public(self) -> dict[str, JsonValue]:
         return {

--- a/products/posthog_ai/eval_harness/test/e2e/controller.py
+++ b/products/posthog_ai/eval_harness/test/e2e/controller.py
@@ -4,6 +4,7 @@ import json
 import logging
 import secrets
 import threading
+from collections.abc import Iterator
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import cast
@@ -14,7 +15,7 @@ from pydantic import JsonValue
 
 from .attempt import Attempt
 from .faults import FaultName
-from .replay import ResponseStep, fixture_events, object_value, sse_frames
+from .replay import ResponseStep, encoded_text, fixture_events, object_value, sse_frames
 
 
 class Controller:
@@ -64,9 +65,21 @@ class Controller:
                     connections.close_all()
                 self.send_response(status)
                 self.send_header("Content-Type", content_type)
-                self.send_header("Content-Length", str(len(response)))
+                if isinstance(response, bytes):
+                    self.send_header("Content-Length", str(len(response)))
+                else:
+                    self.send_header("Connection", "close")
+                    self.close_connection = True
                 self.end_headers()
-                self.wfile.write(response)
+                try:
+                    for chunk in [response] if isinstance(response, bytes) else response:
+                        self.wfile.write(chunk)
+                        self.wfile.flush()
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+                except Exception as error:
+                    controller.record_error(f"{type(error).__name__}: {error}")
+                    raise
 
         self.server = ThreadingHTTPServer(("0.0.0.0", 0), Handler)
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
@@ -89,7 +102,7 @@ class Controller:
 
     def handle(
         self, method: str, path: str, headers: dict[str, str], body: dict[str, JsonValue]
-    ) -> tuple[int, str, bytes]:
+    ) -> tuple[int, str, bytes | Iterator[bytes]]:
         headers = {key.lower(): value for key, value in headers.items()}
         if path.startswith("/control/"):
             if not secrets.compare_digest(headers.get("authorization", ""), f"Bearer {self.token}"):
@@ -104,6 +117,10 @@ class Controller:
             return self.json({"customer": None})
         if method == "GET" and path == "/billing/api/products-v2":
             return self.json({"products": []})
+        if method == "GET" and path == "/billing/api/v2/usage/team_options/":
+            return self.json({"team_id_options": []})
+        if method == "GET" and path in {"/billing/api/v2/usage/", "/billing/api/v2/spend/"}:
+            return self.json({"status": "ok", "type": "timeseries", "customer_id": "synthetic", "results": []})
         if method == "PATCH" and path == "/billing/api/billing/":
             if body.get("org_customer_email") not in attempt.emails:
                 raise ValueError("Billing update belongs to another attempt")
@@ -131,6 +148,9 @@ class Controller:
                 f"{target}/command", json=body, headers={"Authorization": headers["authorization"]}, timeout=30
             )
             attempt.faults["approval"].record("forwarded", request_id=request_id, status=response.status_code)
+            confirmation = attempt.faults["approval_confirmation"]
+            if response.ok and (generation := confirmation.reach(request_id)):
+                confirmation.wait_for_release(generation)
             return response.status_code, "application/json", response.content
         if method == "GET" and path in {"/v1/models", "/posthog_ai/v1/models", "/posthog_code/v1/models"}:
             project = headers.get("x-posthog-project-id")
@@ -214,8 +234,10 @@ class Controller:
                 or body.get("tools")
             ):
                 raise ValueError("Unexpected SDK title request")
-            message = json.dumps(body.get("messages"))
-            if attempt.replay is None or not any(step.user_message in message for step in attempt.replay.steps):
+            message = json.dumps(body.get("messages"), ensure_ascii=False)
+            if attempt.replay is None or not any(
+                encoded_text(step.user_message) in message for step in attempt.replay.steps
+            ):
                 raise ValueError("SDK title does not belong to the declared conversation")
             if message in attempt.sdk_titles:
                 raise ValueError("Duplicate SDK title request")
@@ -241,7 +263,19 @@ class Controller:
         )
         if provider is None or attempt.replay is None:
             raise ValueError(f"Unexpected provider endpoint {path}")
-        return 200, "text/event-stream", attempt.replay.respond(provider, body)
+        index, frames = attempt.replay.respond(provider, body)
+
+        def stream_response() -> Iterator[bytes]:
+            # Open the SDK's SSE reader before pausing, so cancellation can abort a real streaming request.
+            first, remainder = frames.split(b"\n\n", 1)
+            yield first + b"\n\n"
+            fault = attempt.faults["model"]
+            if generation := fault.reach(str(index)):
+                fault.wait_for_release(generation)
+            fault.record("response_released", step=index, run_id=run_id)
+            yield remainder
+
+        return 200, "text/event-stream", stream_response()
 
     def control(self, method: str, path: str, body: dict[str, JsonValue]) -> JsonValue:
         if path == "health" and method == "GET":
@@ -297,6 +331,8 @@ class Controller:
             if not isinstance(steps, list):
                 raise ValueError("Expected response steps")
             attempt.configure([ResponseStep.model_validate(step) for step in steps])
+        elif operation == "seed_editors":
+            return attempt.seed_editors()
         elif operation.startswith("fault/"):
             _, name, action = operation.split("/")
             fault = attempt.faults[cast(FaultName, name)]

--- a/products/posthog_ai/eval_harness/test/e2e/faults.py
+++ b/products/posthog_ai/eval_harness/test/e2e/faults.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 from pydantic import JsonValue
 
-FaultName = Literal["registration", "worker", "approval"]
+FaultName = Literal["registration", "worker", "approval", "approval_confirmation", "model"]
 
 
 class Fault:

--- a/products/posthog_ai/eval_harness/test/e2e/hooks.py
+++ b/products/posthog_ai/eval_harness/test/e2e/hooks.py
@@ -83,13 +83,16 @@ def install_hooks(stack: ExitStack, controller: Controller, image_id: str) -> No
                 raise ValueError("Approval command belongs to another attempt")
             controller.proxy_targets[attempt.id] = sandbox_url
             sandbox_url = f"{controller.url}/proxy/{attempt.id}"
-        return proxy(
+        response = proxy(
             sandbox_url=sandbox_url,
             connection_token=connection_token,
             sandbox_connect_token=sandbox_connect_token,
             payload=payload,
             sandbox_token_param=sandbox_token_param,
         )
+        if attempt and payload.get("method") == "cancel":
+            attempt.faults["model"].record("cancel_forwarded", run_id=attempt.run_id, status=response.status_code)
+        return response
 
     stack.enter_context(
         patch("products.tasks.backend.logic.services.workflow_dispatch.execute_after_commit", transaction.on_commit)

--- a/products/posthog_ai/eval_harness/test/e2e/replay.py
+++ b/products/posthog_ai/eval_harness/test/e2e/replay.py
@@ -6,7 +6,7 @@ import threading
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, JsonValue
+from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
 
 class ToolResult(BaseModel):
@@ -22,6 +22,7 @@ class ResponseStep(BaseModel):
     fixture: Literal["text", "insight-update", "tool-search"]
     user_message: str
     tool_result: ToolResult | None = None
+    history_contains: list[str] = Field(default_factory=list)
     substitutions: dict[str, str]
 
 
@@ -66,14 +67,26 @@ def content_blocks(item: dict[str, JsonValue]) -> list[dict[str, JsonValue]]:
     return [block for block in content if isinstance(block, dict)] if isinstance(content, list) else []
 
 
+def encoded_text(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)[1:-1]
+
+
 def validate_step(step: ResponseStep, provider: str, body: dict[str, JsonValue]) -> None:
     if provider != step.provider or body.get("model") != step.model or body.get("stream") is not True:
         raise ValueError(f"Expected streaming {step.provider}/{step.model}")
     items = request_items(provider, body)
     users = [item for item in items if item.get("role") == "user"]
-    # Anthropic represents tool results as a user turn; they do not advance the human conversation.
-    users = [item for item in users if not any(block.get("type") == "tool_result" for block in content_blocks(item))]
-    if not users or step.user_message not in json.dumps(users[-1], ensure_ascii=False):
+    # Claude can combine a follow-up with tool results after interruption; tool payloads alone aren't human turns.
+    users = [
+        item
+        for item in users
+        if not any(block.get("type") == "tool_result" for block in content_blocks(item))
+        or any(
+            block.get("type") == "text" and step.user_message in str(block.get("text", ""))
+            for block in content_blocks(item)
+        )
+    ]
+    if not users or encoded_text(step.user_message) not in json.dumps(users[-1], ensure_ascii=False):
         raise ValueError("Unexpected human conversation step")
     results = [
         block
@@ -135,7 +148,7 @@ class Replay:
         for step in steps:
             fixture_events(step)
 
-    def respond(self, provider: str, body: dict[str, JsonValue]) -> bytes:
+    def respond(self, provider: str, body: dict[str, JsonValue]) -> tuple[int, bytes]:
         with self.lock:
             try:
                 if self.cursor == len(self.steps):
@@ -143,19 +156,22 @@ class Replay:
                 step = self.steps[self.cursor]
                 validate_step(step, provider, body)
                 transcript = json.dumps(request_items(provider, body), ensure_ascii=False)
+                if any(encoded_text(value) not in transcript for value in step.history_contains):
+                    raise ValueError("Expected assistant or tool history is missing")
                 expected_messages = list(dict.fromkeys(prior.user_message for prior in self.steps[: self.cursor + 1]))
-                positions = [transcript.find(message) for message in expected_messages]
+                positions = [transcript.find(encoded_text(message)) for message in expected_messages]
                 if any(position < 0 for position in positions) or positions != sorted(positions):
                     raise ValueError("Conversation history does not match the declared response sequence")
                 frames = sse_frames(fixture_events(step))
                 self.consumed.append(
                     {"step": self.cursor, "provider": provider, "model": step.model, "fixture": step.fixture}
                 )
+                index = self.cursor
                 self.cursor += 1
-                return frames
             except Exception as error:
                 self.errors.append(str(error))
                 raise
+        return index, frames
 
     def verify(self) -> None:
         if self.errors or self.cursor != len(self.steps):

--- a/products/posthog_ai/eval_harness/test/e2e/test_replay.py
+++ b/products/posthog_ai/eval_harness/test/e2e/test_replay.py
@@ -11,6 +11,47 @@ from products.posthog_ai.eval_harness.test.e2e.replay import Replay, ResponseSte
 
 
 class TestReplay(TestCase):
+    def test_followups_require_assistant_history_and_match_multiline_human_messages(self) -> None:
+        for provider in ("claude", "codex"):
+            with self.subTest(provider=provider):
+                prompt = 'First direction.\n\nSecond "direction" — synthetic.'
+                answer = 'The first "answer".\nNext line.'
+                step = ResponseStep.model_validate(
+                    {
+                        "provider": provider,
+                        "model": "synthetic-model",
+                        "fixture": "text",
+                        "user_message": prompt,
+                        "history_contains": [answer],
+                        "substitutions": {
+                            "message_id": "msg_synthetic",
+                            "model": "synthetic-model",
+                            "text": "Received.",
+                        },
+                    }
+                )
+                field = "messages" if provider == "claude" else "input"
+                body: dict[str, JsonValue] = {
+                    "model": step.model,
+                    "stream": True,
+                    field: [{"role": "user", "content": prompt}],
+                }
+                rejected = Replay([step])
+                with self.assertRaisesRegex(ValueError, "history is missing"):
+                    rejected.respond(provider, body)
+                self.assertEqual(rejected.cursor, 0)
+                replay = Replay([step])
+                index, frames = replay.respond(
+                    provider,
+                    {
+                        **body,
+                        field: [{"role": "assistant", "content": answer}, {"role": "user", "content": prompt}],
+                    },
+                )
+                self.assertEqual(index, 0)
+                self.assertIn(b"Received.", frames)
+                replay.verify()
+
     def test_codex_tool_calls_require_the_discovered_namespace(self) -> None:
         step = ResponseStep.model_validate(
             {
@@ -43,7 +84,7 @@ class TestReplay(TestCase):
             Replay([step]).respond("codex", body)
         discovered["tools"] = [{"type": "function", "name": "exec"}]
         replay = Replay([step])
-        self.assertIn(b'"namespace": "mcp__posthog"', replay.respond("codex", body))
+        self.assertIn(b'"namespace": "mcp__posthog"', replay.respond("codex", body)[1])
         replay.verify()
 
     def test_mismatches_never_advance_or_pass_verification(self) -> None:
@@ -79,14 +120,14 @@ class TestReplay(TestCase):
                     replay.verify()
 
     def test_real_tool_result_required_for_both_provider_encodings(self) -> None:
-        for provider in ("claude", "codex"):
-            with self.subTest(provider=provider):
+        for provider, mixed_followup in (("claude", False), ("claude", True), ("codex", False)):
+            with self.subTest(provider=provider, mixed_followup=mixed_followup):
                 step = ResponseStep.model_validate(
                     {
                         "provider": provider,
                         "model": "synthetic-model",
                         "fixture": "text",
-                        "user_message": "rename insight",
+                        "user_message": "Continue after stopping." if mixed_followup else "rename insight",
                         "tool_result": {"call_id": "call_synthetic", "contains": "Synthetic renamed insight"},
                         "substitutions": {
                             "model": "synthetic-model",
@@ -114,6 +155,10 @@ class TestReplay(TestCase):
                         "output": "Synthetic renamed insight",
                     }
                 )
+                if mixed_followup:
+                    content = result["content"]
+                    assert isinstance(content, list)
+                    content.append({"type": "text", "text": "Continue after stopping."})
                 field = "messages" if provider == "claude" else "input"
                 body: dict[str, JsonValue] = {"model": step.model, "stream": True, field: [user]}
                 with self.assertRaises(ValueError):
@@ -121,7 +166,7 @@ class TestReplay(TestCase):
                 replay = Replay([step])
                 with self.assertRaises(AssertionError):
                     replay.verify()
-                frames = replay.respond(provider, {**body, field: [user, result]}).decode()
+                frames = replay.respond(provider, {**body, field: [user, result]})[1].decode()
                 events = [
                     json.loads(line.removeprefix("data: ")) for line in frames.splitlines() if line.startswith("data: ")
                 ]

--- a/products/posthog_ai/frontend/e2e/aiTest.ts
+++ b/products/posthog_ai/frontend/e2e/aiTest.ts
@@ -10,7 +10,7 @@ declare global {
 }
 
 export type Provider = 'claude' | 'codex'
-type Fault = 'registration' | 'worker' | 'approval'
+type Fault = 'registration' | 'worker' | 'approval' | 'approval_confirmation' | 'model'
 
 export interface ResponseStep {
     provider: Provider
@@ -18,6 +18,7 @@ export interface ResponseStep {
     fixture: 'text' | 'insight-update' | 'tool-search'
     user_message: string
     tool_result?: { call_id: string; contains: string }
+    history_contains?: string[]
     substitutions: Record<string, string>
 }
 
@@ -42,7 +43,8 @@ interface Snapshot {
     run_count: number
     tool_executions: number
     runs: { status: string; state: Record<string, unknown> }[]
-    timeline: { fault: Fault; event: string; status?: number; request_id?: string }[]
+    consumed: { step: number }[]
+    timeline: { fault: Fault; event: string; status?: number; request_id?: string; run_id?: string }[]
 }
 
 export class AiAttempt {
@@ -60,20 +62,20 @@ export class AiAttempt {
     }
 
     fault(name: Fault): {
-        arm: () => Promise<unknown>
+        arm: (target?: string) => Promise<unknown>
         waitUntilReached: () => Promise<unknown>
         release: () => Promise<unknown>
         reset: () => Promise<unknown>
     } {
         return {
-            arm: () => this.control(`fault/${name}/arm`),
+            arm: (target) => this.control(`fault/${name}/arm`, target === undefined ? {} : { target }),
             waitUntilReached: () => this.control(`fault/${name}/waitUntilReached`),
             release: () => this.control(`fault/${name}/release`),
             reset: () => this.control(`fault/${name}/reset`),
         }
     }
 
-    async open(page: Page, options: { warm?: boolean } = {}): Promise<void> {
+    async open(page: Page, options: { warm?: boolean; path?: string } = {}): Promise<void> {
         this.seed = await this.control<Seed>('start', options)
         const login = await page.request.post('/api/login/', {
             data: { email: this.seed.email, password: this.seed.password },
@@ -89,8 +91,10 @@ export class AiAttempt {
         )
         // The controller seeds the exact warm target; speculative UI warming would create unrelated runs.
         await page.route(/\/tasks\/(?:[^/]+\/)?warm\/$/, (route) => route.fulfill({ json: {} }))
-        await page.goto(`/project/${this.seed.team_id}/tasks/new`)
-        await expect(page.getByTestId('task-composer-input')).toBeVisible()
+        await page.goto(options.path ?? `/project/${this.seed.team_id}/tasks/new`)
+        if (!options.path) {
+            await expect(page.getByTestId('task-composer-input')).toBeVisible()
+        }
     }
 
     async warmResume(): Promise<void> {
@@ -126,6 +130,37 @@ export class AiAttempt {
             fixture: 'text',
             user_message: userMessage,
             substitutions: { model: this.seed.model, message_id: `msg_${this.seed.id}_${step}`, text },
+        }
+    }
+
+    discover(message: string): ResponseStep {
+        return {
+            ...this.text(message, '', 0),
+            fixture: this.seed.provider === 'claude' ? 'insight-update' : 'tool-search',
+            substitutions: {
+                model: this.seed.model,
+                message_id: `msg_${this.seed.id}_0`,
+                tool_call_id: `discovery_${this.seed.id}`,
+                tool_name: this.seed.provider === 'claude' ? 'ToolSearch' : 'mcp__posthog__exec',
+                text: 'posthog exec',
+                arguments: JSON.stringify({ query: 'select:mcp__posthog__exec', max_results: 1 }),
+            },
+        }
+    }
+
+    exec(message: string, command: string, step: number, previous: ResponseStep['tool_result']): ResponseStep {
+        return {
+            ...this.text(message, '', step),
+            fixture: 'insight-update',
+            tool_result: previous,
+            substitutions: {
+                model: this.seed.model,
+                message_id: `msg_${this.seed.id}_${step}`,
+                tool_call_id: `call_${this.seed.id}_${step}`,
+                tool_name: this.seed.provider === 'claude' ? 'mcp__posthog__exec' : 'exec',
+                ...(this.seed.provider === 'codex' ? { tool_namespace: 'mcp__posthog' } : {}),
+                arguments: JSON.stringify({ command }),
+            },
         }
     }
 }

--- a/products/posthog_ai/frontend/e2e/architecture.md
+++ b/products/posthog_ai/frontend/e2e/architecture.md
@@ -1,7 +1,7 @@
 # AI browser recovery tests
 
 This suite exercises chat submission, workflow startup, and approval delivery with Claude and Codex.
-It uses the real application and sandbox agent with synthetic model responses. Chart coverage belongs in a later increment.
+It uses the real application and sandbox agent with synthetic model responses, including saved-insight table rendering.
 `run-surface.spec.ts` remains a separate, fast suite that mocks the tasks API and stream.
 The `flows-*.spec.ts` cases use held command responses and controlled SSE frames to check composer and approval interactions.
 They run in regular Playwright; `--surface` runs them against the launcher's isolated server without starting agents.
@@ -12,6 +12,19 @@ The browser suppresses speculative warming: the controller owns the exact warm t
 Task creation, initial submission, and follow-up delivery remain real.
 Resume completes the original workflow through its normal signal, then warms a successor behind the registration barrier.
 The attempt owns and cleans up every workflow and run in that conversation.
+
+`journeys.ai.spec.ts` covers accepted-consent deep links and real cancellation during startup and an active tool turn.
+The active-turn case releases an insight-creation response after cancellation and verifies that no insight was created.
+`delivery.ai.spec.ts` queues two directions while the real agent has accepted an approval but its HTTP confirmation is held.
+Queue and Steer must deliver those directions once, in order, while preserving a separate draft and one persisted insight update.
+`insight.ai.spec.ts` creates an insight through MCP, renders constant SQL rows, reloads, and opens the saved insight.
+These cases run with both runtimes. `sidebar.ai.spec.ts` uses Claude to cover the shared SQL editor integration: apply a
+suggestion to its submitting editor, navigate before another tool completes, and keep the destination editor unchanged on replay.
+
+The warm-resume case also holds a real history read while a provider response reaches the live stream. It releases history
+only after the same response is persisted, forcing overlap without fabricating frames. `liveTransport.ts` passes through
+real fetch bytes, records SSE IDs, and disconnects a reader. Reconnection must carry the last observed ID, and the successor
+must start without the previous run's cursor. The follow-up model request must contain the earlier assistant response.
 
 ## Boundaries
 
@@ -98,6 +111,7 @@ There is one locked cursor per attempt. Before advancing, the controller checks:
 - Project and run identity from legacy gateway headers or `X-PostHog-Properties`.
 - Provider, exact model, and streaming mode.
 - The expected human message and ordered conversation history.
+- Explicit `history_contains` fragments, including assistant responses required by resumed conversations.
 - The real tool result's call ID and expected content before sending a post-tool response.
 - The requested tool is present in the agent's offered tools.
 
@@ -125,11 +139,18 @@ Each control exposes `arm`, `waitUntilReached`, `release`, and `reset`. Its time
 release, and observations such as Temporal NOT_FOUND or the insight save. Reset releases a barrier but retains the audit of
 an arm that never fired. Teardown fails if any required fault was missed.
 
-| Control        | Boundary                                                                 | What remains live                                     |
-| -------------- | ------------------------------------------------------------------------ | ----------------------------------------------------- |
-| `registration` | In the dispatcher child, immediately before real `Client.start_workflow` | Outbox claiming, leases, Temporal, and signals        |
-| `worker`       | Before starting the attempt's tasks worker                               | Temporal registration and signal acceptance           |
-| `approval`     | Before forwarding the targeted `permission_response`                     | Agent session, approval card, and tool implementation |
+| Control                 | Boundary                                                                         | What remains live                                        |
+| ----------------------- | -------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `registration`          | In the dispatcher child, immediately before real `Client.start_workflow`         | Outbox claiming, leases, Temporal, and signals           |
+| `worker`                | Before starting the attempt's tasks worker                                       | Temporal registration and signal acceptance              |
+| `approval`              | Before forwarding the targeted `permission_response`                             | Agent session, approval card, and tool implementation    |
+| `approval_confirmation` | After the real agent accepts permission, before its HTTP response reaches Django | Actual tool execution and provider requests              |
+| `model`                 | After opening the provider SSE response, before its content/tool argument frames | SDK cancellation, Temporal commands, and application SSE |
+
+Arm `model` with a zero-based response-step index, for example `await ai.fault('model').arm('2')`.
+The replay cursor advances before pausing; a steering request can consume the next declared step while the old response is held.
+Cancelled responses may encounter a closed socket after release. Extra model requests and unconsumed steps still fail teardown.
+Every new case needs its own ten-repeat CI validation; the historical runner results below do not cover these additions.
 
 `approval` latches the first matching permission request ID and rejects retries of that request until released. A different
 request does not inherit the fault. This tests recovery from a known rejection before execution. It does not reproduce or

--- a/products/posthog_ai/frontend/e2e/delivery.ai.spec.ts
+++ b/products/posthog_ai/frontend/e2e/delivery.ai.spec.ts
@@ -1,0 +1,89 @@
+import { expect } from '@playwright/test'
+
+import { send, test } from './aiTest'
+
+for (const provider of ['claude', 'codex'] as const) {
+    test.describe(provider, () => {
+        test.use({ provider })
+
+        for (const delivery of ['queue', 'steer'] as const) {
+            test(`real ${delivery} preserves saved message order through approval confirmation`, async ({
+                ai,
+                page,
+            }) => {
+                const prompt = `Rename the connected insight ${ai.seed.id}.`
+                const name = `Synthetic approved rename ${ai.seed.id}`
+                const first = 'First saved direction.'
+                const second = 'Second saved direction.'
+                const queued = `${first}\n\n${second}`
+                const result = { call_id: `call_${ai.seed.id}_1`, contains: name }
+                await ai.configure([
+                    ai.discover(prompt),
+                    ai.exec(
+                        prompt,
+                        `call posthog-connection-call ${JSON.stringify({
+                            connection_id: ai.seed.connection_id,
+                            tool: 'insight-update',
+                            arguments: { id: ai.seed.insight_id, name },
+                        })}`,
+                        1,
+                        { call_id: `discovery_${ai.seed.id}`, contains: 'posthog' }
+                    ),
+                    { ...ai.text(prompt, 'The approved rename completed.', 2), tool_result: result },
+                    { ...ai.text(queued, 'Both saved directions arrived in order.', 3), tool_result: result },
+                ])
+                const confirmation = ai.fault('approval_confirmation')
+                const model = ai.fault('model')
+                await confirmation.arm()
+                await model.arm('2')
+                await ai.open(page)
+                await send(page, prompt)
+                await page.getByText(provider === 'claude' ? 'Yes' : 'Accept', { exact: true }).click()
+                await confirmation.waitUntilReached()
+                await model.waitUntilReached()
+                for (const [index, message] of [first, second].entries()) {
+                    await send(page, message)
+                    await expect(page.getByText(index === 0 ? first : queued, { exact: true })).toBeVisible()
+                    await expect(page.getByTestId('sandbox-composer-input')).toHaveValue('')
+                }
+                await page.getByTestId('sandbox-composer-input').fill('Keep this separate draft.')
+                const commands: { params: { content: string; steer?: boolean } }[] = []
+                page.on('request', (request) => {
+                    if (request.url().endsWith('/command/') && request.postDataJSON()?.method === 'user_message') {
+                        commands.push(request.postDataJSON())
+                    }
+                })
+                if (delivery === 'steer') {
+                    await page.getByTestId('run-queue-steer').click()
+                    await expect(page.getByTestId('run-queue-steer')).toBeDisabled()
+                }
+                expect(commands).toHaveLength(0)
+                expect(await ai.snapshot()).toMatchObject({ insight_name: name, tool_executions: 1 })
+                await confirmation.release()
+                if (delivery === 'queue') {
+                    await expect(page.getByTestId('run-approval')).toHaveCount(0)
+                    expect(commands).toHaveLength(0)
+                }
+                await model.release()
+                await expect(page.getByText('Both saved directions arrived in order.', { exact: true })).toBeVisible()
+                await expect(page.getByTestId('sandbox-composer-input')).toHaveValue('Keep this separate draft.')
+                await expect(page.getByText('Up next', { exact: true })).toBeHidden()
+                expect(commands).toHaveLength(1)
+                expect(commands[0].params.content).toBe(queued)
+                expect(commands[0].params.steer === true).toBe(delivery === 'steer')
+                await page.reload()
+                await expect(page.locator('p').filter({ hasText: /^(First|Second) saved direction\.$/ })).toHaveText([
+                    first,
+                    second,
+                ])
+                await expect(page.getByText('Both saved directions arrived in order.', { exact: true })).toHaveCount(1)
+                expect(await ai.snapshot()).toMatchObject({
+                    insight_name: name,
+                    tool_executions: 1,
+                    task_count: 1,
+                    run_count: 1,
+                })
+            })
+        }
+    })
+}

--- a/products/posthog_ai/frontend/e2e/flags.json
+++ b/products/posthog_ai/frontend/e2e/flags.json
@@ -1,5 +1,6 @@
 {
     "tasks": { "value": true, "consumers": ["browser", "backend"] },
+    "phai-sandbox-mode": { "value": true, "consumers": ["browser"] },
     "tasks-cloud-runs-sandbox-event-ingest": { "value": true, "consumers": ["backend"] },
     "tasks-stream-via-proxy": { "value": true, "consumers": ["browser", "backend"] },
     "tasks-agent-proxy-keep-stream-open": { "value": true, "consumers": ["backend"] },

--- a/products/posthog_ai/frontend/e2e/insight.ai.spec.ts
+++ b/products/posthog_ai/frontend/e2e/insight.ai.spec.ts
@@ -1,0 +1,61 @@
+import { expect } from '@playwright/test'
+
+import { send, test } from './aiTest'
+
+for (const provider of ['claude', 'codex'] as const) {
+    test.describe(provider, () => {
+        test.use({ provider })
+
+        test('a real insight tool renders query rows and opens the persisted insight after reload', async ({
+            ai,
+            page,
+        }) => {
+            const prompt = `Create the synthetic table ${ai.seed.id}.`
+            const name = `Synthetic result table ${ai.seed.id}`
+            const query = {
+                kind: 'DataVisualizationNode',
+                display: 'ActionsTable',
+                source: { kind: 'HogQLQuery', query: "SELECT 'synthetic_alpha' AS label, 7 AS total" },
+            }
+            await ai.configure([
+                ai.discover(prompt),
+                ai.exec(prompt, `call insight-create ${JSON.stringify({ name, query })}`, 1, {
+                    call_id: `discovery_${ai.seed.id}`,
+                    contains: 'posthog',
+                }),
+                {
+                    ...ai.text(prompt, 'The synthetic table is saved.', 2),
+                    tool_result: { call_id: `call_${ai.seed.id}_1`, contains: name },
+                },
+            ])
+            await ai.open(page)
+            await send(page, prompt)
+            await expect(page.getByText('The synthetic table is saved.', { exact: true })).toBeVisible()
+            const response = await page.request.get(
+                `/api/projects/${ai.seed.team_id}/insights/?search=${encodeURIComponent(name)}`
+            )
+            expect(response.ok()).toBeTruthy()
+            const saved = (await response.json()).results
+            expect(saved).toHaveLength(1)
+            expect(saved[0]).toMatchObject({ name, query })
+            const row = page.getByRole('row').filter({ has: page.getByText('synthetic_alpha', { exact: true }) })
+            await expect(row).toContainText('7')
+            await page.getByRole('button', { name: 'Hide visualization', exact: true }).click()
+            await expect(row).toBeHidden()
+            await page.getByRole('button', { name: 'Show visualization', exact: true }).click()
+            await expect(row).toContainText('7')
+            await page.reload()
+            await expect(row).toHaveCount(1)
+            await expect(row).toContainText('7')
+            const opened = page.waitForEvent('popup')
+            await page.locator(`a[href$="/insights/${saved[0].short_id}"]`).click({ timeout: 15_000 })
+            const insight = await opened
+            await expect(insight).toHaveURL(new RegExp(`/insights/${saved[0].short_id}`))
+            await expect(
+                insight.getByRole('row').filter({ has: insight.getByText('synthetic_alpha', { exact: true }) })
+            ).toContainText('7')
+            await insight.close()
+            expect(await ai.snapshot()).toMatchObject({ task_count: 1, run_count: 1 })
+        })
+    })
+}

--- a/products/posthog_ai/frontend/e2e/journeys.ai.spec.ts
+++ b/products/posthog_ai/frontend/e2e/journeys.ai.spec.ts
@@ -1,0 +1,111 @@
+import { expect } from '@playwright/test'
+
+import { send, test } from './aiTest'
+
+for (const provider of ['claude', 'codex'] as const) {
+    test.describe(provider, () => {
+        test.use({ provider })
+
+        test('an accepted-consent deep link submits once and keeps the conversation usable', async ({ ai, page }) => {
+            const prompt = `Describe the synthetic deep link ${ai.seed.id}.`
+            await ai.configure([
+                ai.text(prompt, 'The deep link reached this conversation.', 1),
+                {
+                    ...ai.text('Continue this conversation.', 'The follow-up reached the same conversation.', 2),
+                    history_contains: ['The deep link reached this conversation.'],
+                },
+            ])
+            await ai.open(page, {
+                warm: false,
+                path: `/project/${ai.seed.team_id}/ai?ask=${encodeURIComponent(prompt)}`,
+            })
+            await expect(page.getByText('The deep link reached this conversation.', { exact: true })).toBeVisible()
+            await send(page, 'Continue this conversation.')
+            await expect(page.getByText('The follow-up reached the same conversation.', { exact: true })).toBeVisible()
+            await page.reload()
+            for (const text of [
+                prompt,
+                'The deep link reached this conversation.',
+                'Continue this conversation.',
+                'The follow-up reached the same conversation.',
+            ]) {
+                await expect(page.getByText(text, { exact: true })).toHaveCount(1)
+            }
+            expect(await ai.snapshot()).toMatchObject({ task_count: 1, run_count: 1 })
+        })
+
+        for (const phase of ['startup', 'active turn'] as const) {
+            test(`real ${phase} Stop cancels the owning turn and accepts a follow-up`, async ({ ai, page }) => {
+                const prompt = `Start cancellable work ${ai.seed.id}.`
+                const discovery = { call_id: `discovery_${ai.seed.id}`, contains: 'posthog' }
+                const followup = ai.text('Continue after stopping.', 'The follow-up after stopping completed.', 2)
+                await ai.configure(
+                    phase === 'startup'
+                        ? [ai.text(prompt, 'This cancelled response must never appear.', 0), followup]
+                        : [
+                              ai.discover(prompt),
+                              ai.exec(
+                                  prompt,
+                                  `call insight-create ${JSON.stringify({
+                                      name: `Cancelled insight ${ai.seed.id}`,
+                                      query: {
+                                          kind: 'DataVisualizationNode',
+                                          display: 'ActionsTable',
+                                          source: { kind: 'HogQLQuery', query: 'SELECT 99 AS cancelled_value' },
+                                      },
+                                  })}`,
+                                  1,
+                                  discovery
+                              ),
+                              { ...followup, tool_result: discovery },
+                          ]
+                )
+                const model = ai.fault('model')
+                await model.arm(phase === 'startup' ? '0' : '1')
+                const worker = ai.fault('worker')
+                if (phase === 'startup') {
+                    await worker.arm()
+                }
+                await ai.open(page)
+                await send(page, prompt)
+                const cancellation = page.waitForResponse(
+                    (response) =>
+                        response.url().endsWith('/command/') && response.request().postDataJSON()?.method === 'cancel'
+                )
+                if (phase === 'startup') {
+                    await worker.waitUntilReached()
+                    await page.getByTestId('run-startup-stop').click()
+                    await expect(page.getByTestId('run-startup-stop')).toBeDisabled()
+                    expect(
+                        (await ai.snapshot()).timeline.filter((event) => event.event === 'cancel_forwarded')
+                    ).toHaveLength(0)
+                    await worker.release()
+                } else {
+                    await model.waitUntilReached()
+                    await page.getByRole('button', { name: 'Stop', exact: true }).click()
+                }
+                await model.waitUntilReached()
+                expect((await cancellation).ok()).toBeTruthy()
+                await model.release()
+                await expect(page.getByRole('button', { name: 'Stop', exact: true })).toBeHidden()
+                await send(page, 'Continue after stopping.')
+                await expect(page.getByText('The follow-up after stopping completed.', { exact: true })).toBeVisible()
+                await page.reload()
+                await expect(page.getByText('This cancelled response must never appear.', { exact: true })).toHaveCount(
+                    0
+                )
+                await expect(page.getByText(prompt, { exact: true })).toHaveCount(1)
+                await expect(page.getByText('Continue after stopping.', { exact: true })).toHaveCount(1)
+                await expect(page.getByText('The follow-up after stopping completed.', { exact: true })).toHaveCount(1)
+                const snapshot = await ai.snapshot()
+                expect(snapshot).toMatchObject({ task_count: 1, run_count: 1, tool_executions: 0 })
+                const insights = await page.request.get(`/api/projects/${ai.seed.team_id}/insights/`)
+                expect(insights.ok()).toBeTruthy()
+                expect((await insights.json()).results).toHaveLength(0)
+                expect(snapshot.timeline.filter((event) => event.event === 'cancel_forwarded')).toEqual([
+                    expect.objectContaining({ run_id: snapshot.run_id, status: 200 }),
+                ])
+            })
+        }
+    })
+}

--- a/products/posthog_ai/frontend/e2e/liveTransport.ts
+++ b/products/posthog_ai/frontend/e2e/liveTransport.ts
@@ -1,0 +1,102 @@
+import { Page, expect } from '@playwright/test'
+
+interface Connection {
+    url: string
+    cursor: string | null
+    ids: string[]
+    frames: string[]
+}
+
+declare global {
+    interface Window {
+        aiE2eTransport: { connections: Connection[]; disconnect: () => void }
+    }
+}
+
+export async function observeLiveTransport(page: Page): Promise<void> {
+    await page.addInitScript(() => {
+        const fetch = window.fetch.bind(window)
+        window.aiE2eTransport = {
+            connections: [],
+            disconnect: () => {
+                throw new Error('No live stream')
+            },
+        }
+        window.fetch = async (input, init) => {
+            const response = await fetch(input, init)
+            const url = input instanceof Request ? input.url : String(input)
+            if (!/\/runs\/[^/]+\/stream\/?(?:\?|$)/.test(url) || !response.ok || !response.body) {
+                return response
+            }
+            const connection: Connection = {
+                url,
+                cursor: new Headers(init?.headers ?? (input instanceof Request ? input.headers : undefined)).get(
+                    'Last-Event-ID'
+                ),
+                ids: [],
+                frames: [],
+            }
+            window.aiE2eTransport.connections.push(connection)
+            const reader = response.body.getReader()
+            const decoder = new TextDecoder()
+            let buffer = ''
+            let disconnected = false
+            const body = new ReadableStream<Uint8Array>({
+                start(controller) {
+                    window.aiE2eTransport.disconnect = () => {
+                        disconnected = true
+                        controller.error(new TypeError('Synthetic connection loss'))
+                        void reader.cancel()
+                    }
+                },
+                async pull(controller) {
+                    try {
+                        const { done, value } = await reader.read()
+                        if (disconnected) {
+                            return
+                        }
+                        if (done) {
+                            controller.close()
+                            return
+                        }
+                        buffer += decoder.decode(value, { stream: true })
+                        const frames = buffer.split(/\r?\n\r?\n/)
+                        buffer = frames.pop() ?? ''
+                        for (const frame of frames) {
+                            connection.frames.push(frame)
+                            const id = /^id: *(.+)$/m.exec(frame)?.[1]
+                            if (id) {
+                                connection.ids.push(id)
+                            }
+                        }
+                        controller.enqueue(value)
+                    } catch (error) {
+                        if (!disconnected) {
+                            controller.error(error)
+                        }
+                    }
+                },
+                cancel: () => reader.cancel(),
+            })
+            return new Response(body, { status: response.status, headers: response.headers })
+        }
+    })
+}
+
+export async function disconnectLiveTransport(page: Page): Promise<void> {
+    await expect
+        .poll(() => page.evaluate(() => window.aiE2eTransport.connections.at(-1)?.ids.length ?? 0))
+        .toBeGreaterThan(0)
+    const before = await page.evaluate(() => {
+        const connections = window.aiE2eTransport.connections
+        const last = connections.at(-1)!
+        window.aiE2eTransport.disconnect()
+        return { count: connections.length, id: last.ids.at(-1), url: last.url }
+    })
+    await expect.poll(() => page.evaluate(() => window.aiE2eTransport.connections.length)).toBe(before.count + 1)
+    const next = await page.evaluate(() => window.aiE2eTransport.connections.at(-1))
+    expect(next?.cursor).toBe(before.id)
+    expect(new URL(next!.url, page.url()).pathname.replace(/\/$/, '')).toBe(
+        new URL(before.url, page.url()).pathname.replace(/\/$/, '')
+    )
+}

--- a/products/posthog_ai/frontend/e2e/sidebar.ai.spec.ts
+++ b/products/posthog_ai/frontend/e2e/sidebar.ai.spec.ts
@@ -1,0 +1,57 @@
+import { expect } from '@playwright/test'
+
+import { send, test } from './aiTest'
+
+test('sidebar SQL suggestions belong to the submitting editor across navigation and replay', async ({ ai, page }) => {
+    const [editorA, editorB] = await ai.control<{ id: number; short_id: string; query: unknown }[]>('seed_editors')
+    const first = `Revise the original editor ${ai.seed.id}.`
+    const second = 'Prepare another change for this editor.'
+    const queryA = 'SELECT 33 AS suggested_a'
+    const lateQuery = 'SELECT 44 AS late_a'
+    const firstResult = { call_id: `call_${ai.seed.id}_1`, contains: 'suggested_a' }
+    await ai.configure([
+        ai.discover(first),
+        ai.exec(first, `call execute-sql ${JSON.stringify({ query: queryA })}`, 1, {
+            call_id: `discovery_${ai.seed.id}`,
+            contains: 'posthog',
+        }),
+        { ...ai.text(first, 'The first editor suggestion completed.', 2), tool_result: firstResult },
+        ai.exec(second, `call execute-sql ${JSON.stringify({ query: lateQuery })}`, 3, firstResult),
+        {
+            ...ai.text(second, 'The delayed editor suggestion completed.', 4),
+            tool_result: { call_id: `call_${ai.seed.id}_3`, contains: 'late_a' },
+        },
+    ])
+    await ai.open(page)
+    await page.goto(`/project/${ai.seed.team_id}/sql?open_insight=${editorA.short_id}#panel=max`)
+    const editor = page.getByTestId('hogql-query-editor')
+    await expect(editor).toContainText('original_a')
+    await send(page, first)
+    await expect(page.getByText('The first editor suggestion completed.', { exact: true })).toBeVisible()
+    await expect(editor).toContainText('suggested_a')
+    await page.getByRole('button', { name: 'Accept', exact: true }).click()
+    const model = ai.fault('model')
+    await model.arm('3')
+    await send(page, second)
+    await model.waitUntilReached()
+    await page.getByRole('button', { name: 'Recents', exact: true }).click()
+    await page.getByRole('link', { name: /^Synthetic editor B\b/ }).click({ timeout: 15_000 })
+    await page.getByTestId('insight-edit-button').click()
+    await expect(editor).toContainText('original_b')
+    await model.release()
+    await expect(page.getByText('The delayed editor suggestion completed.', { exact: true })).toBeVisible()
+    await expect(editor).not.toContainText('late_a')
+    await expect(page.getByRole('button', { name: 'Accept', exact: true })).toHaveCount(0)
+    await page.goto(`/project/${ai.seed.team_id}/sql?open_insight=${editorB.short_id}#panel=max`)
+    await page
+        .getByTestId('task-open-history-preview')
+        .filter({ hasText: 'Synthetic conversation' })
+        .click({ timeout: 15_000 })
+    await expect(editor).toContainText('original_b')
+    await expect(page.getByText('The delayed editor suggestion completed.', { exact: true })).toHaveCount(1)
+    await expect(editor).not.toContainText('late_a')
+    const persisted = await page.request.get(`/api/projects/${ai.seed.team_id}/insights/${editorB.id}/`)
+    expect(persisted.ok()).toBeTruthy()
+    expect((await persisted.json()).query).toEqual(editorB.query)
+    expect(await ai.snapshot()).toMatchObject({ task_count: 1, run_count: 1 })
+})

--- a/products/posthog_ai/frontend/e2e/startup.ai.spec.ts
+++ b/products/posthog_ai/frontend/e2e/startup.ai.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test'
 
 import { send, test } from './aiTest'
+import { disconnectLiveTransport, observeLiveTransport } from './liveTransport'
 
 for (const provider of ['claude', 'codex'] as const) {
     test.describe(provider, () => {
@@ -53,15 +54,62 @@ for (const provider of ['claude', 'codex'] as const) {
         })
 
         test('warm resume recovers on the intended successor with the original history', async ({ ai, page }) => {
+            await observeLiveTransport(page)
             await ai.configure([
                 ai.text('Remember the synthetic event example_opened.', 'I will remember example_opened.', 1),
-                ai.text('Which event did we choose?', 'We chose example_opened.', 2),
+                {
+                    ...ai.text('Which event did we choose?', 'We chose example_opened.', 2),
+                    history_contains: ['I will remember example_opened.'],
+                },
             ])
+            const model = ai.fault('model')
+            await model.arm('0')
             await ai.open(page)
             await send(page, 'Remember the synthetic event example_opened.')
-            await expect(page.getByText('I will remember example_opened.', { exact: true })).toBeVisible()
-            await expect(page.getByTestId('sandbox-composer-send')).toBeDisabled()
+            await model.waitUntilReached()
             const original = await ai.snapshot()
+            let releaseHistory!: () => void
+            const historyGate = new Promise<void>((resolve) => {
+                releaseHistory = resolve
+            })
+            let historyRequested!: (url: string) => void
+            const history = new Promise<string>((resolve) => {
+                historyRequested = resolve
+            })
+            await page.route(
+                '**/runs/*/logs/',
+                async (route) => {
+                    historyRequested(route.request().url())
+                    await historyGate
+                    const response = await route.fetch()
+                    await route.fulfill({ response })
+                },
+                { times: 1 }
+            )
+            try {
+                await page.reload()
+                const historyUrl = await history
+                await expect
+                    .poll(() => page.evaluate(() => window.aiE2eTransport.connections.length))
+                    .toBeGreaterThan(0)
+                await model.release()
+                await expect
+                    .poll(() =>
+                        page.evaluate(() =>
+                            window.aiE2eTransport.connections.flatMap((connection) => connection.frames).join('\n')
+                        )
+                    )
+                    .toContain('I will remember example_opened.')
+                await expect
+                    .poll(async () => (await page.request.get(historyUrl)).text())
+                    .toContain('I will remember example_opened.')
+            } finally {
+                releaseHistory()
+            }
+            await expect(page.getByText('Remember the synthetic event example_opened.', { exact: true })).toHaveCount(1)
+            await expect(page.getByText('I will remember example_opened.', { exact: true })).toHaveCount(1)
+            await disconnectLiveTransport(page)
+            await expect(page.getByText('I will remember example_opened.', { exact: true })).toHaveCount(1)
             await ai.control('complete_run')
             await page.reload()
             await expect(page.getByTestId('sandbox-composer-input')).toBeEditable()
@@ -75,6 +123,12 @@ for (const provider of ['claude', 'codex'] as const) {
             await expect(page.getByText('Which event did we choose?', { exact: true })).toBeVisible()
             await registration.release()
             await expect(page.getByText('We chose example_opened.', { exact: true })).toBeVisible()
+            const successor = await page.evaluate(
+                (runId) =>
+                    window.aiE2eTransport.connections.find((connection) => connection.url.includes(`/runs/${runId}/`)),
+                ai.seed.run_id
+            )
+            expect(successor?.cursor).toBeNull()
             await page.reload()
             for (const text of [
                 'Remember the synthetic event example_opened.',


### PR DESCRIPTION
## Problem

PostHog AI maintainers need regression coverage for six journeys that the controlled browser tests in #96720 cannot verify across real services.

## Changes

- Adds deep-link submission, real Stop, approval-delayed queueing and steering, saved-insight rendering, and SQL editor ownership checks.
- Extends warm resume with overlapping live/history responses, cursor-based reconnection, and preserved assistant context.
- Mechanical harness changes add response barriers and synthetic editor resources; production behavior stays unchanged.

## How did you test this code?

The new cases exercise real Django, Temporal, sandbox agents, MCP tools, query execution, and persistence with synthetic provider responses.

The stack now targets `master` at `7e5aaa1a709`, retaining the real agent proxy and durable dispatcher from #96178.
Focused harness and MCP tests, MCP type checking, eval discovery, and preflight pass after restacking.
The full browser suite has not been rerun on the current head.

Before the master restack, all four proxy-based queue/steer cases passed and the Claude insight-rendering case failed.
That browser run stopped for the requested restack; the complete results below describe the earlier runner.

| Coverage | Regression caught |
| --- | --- |
| Deep links | Automatic submission loses the created conversation or submits twice. |
| Stop during startup and active work | Cancellation misses its agent or allows a pending tool write. |
| Queue and Steer | Approval confirmation drops, reorders, or duplicates saved directions. |
| Stream/history and resume | Overlap duplicates replies, reconnect loses its cursor, or a successor loses context. |
| Saved insights | A successful tool write never becomes a rendered, reloadable result. |
| Sidebar SQL | A late suggestion or replay changes the wrong editor. |

Historical local baseline at `dbf8f22f647` (Django streaming): **17 passed, 6 failed**, combining the full 23-case run with focused reruns after harness corrections.
All runs used zero retries.

The historical failures reproduced on both Claude and Codex:

- Deep links create a conversation but lose its UI attachment.
- Insights persist correctly but never render their query rows.
- Overlapping live output and history render duplicate assistant replies.

The six failing cases pass with temporary diagnostic product fixes, excluded from this PR.
The original warm-resume cases also pass with #96752; the new overlap failure remains separate.
Sidebar ownership and replay pass on the unchanged baseline.

Harness unit tests, scoped Python type checking, frontend lint, and preflight completed locally.
CI patch coverage and ten repetitions per runtime on the actual CI runner remain unchecked.
The draft keeps the failing assertions enabled pending a full browser run on the current head.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updates `docs/internal/posthog-ai-e2e.md` and the E2E architecture guide with coverage, controls, and stability requirements.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored this layer using Git, GitHub CLI, hogli, Playwright, pytest, mypy, Ruff, and Oxlint. No session link is available.
All prompts and resources are synthetic. The public diff contains no customer material or private operational logs.
The existing #96752 addresses warm continuation; this layer adds separate coverage and reproduces additional failures.
Shared runner compatibility fixes land in #96718 alongside the Python file moves.

Skills used: `/qa-team`, `/stacking-prs`, `/hogli`, `/playwright-test`, `/writing-tests`, `/writing-code-comments`, `/writing-ui-components`, `/writing-kea-logics`, `/writing-evals`, `/posthog-desktop`, `/debugging-ci-failures`, `/writing-user-facing-copy`, `/running-ci-preflight`, `/writing-pr-descriptions`.


