### PR TITLE
feat(data-modeling): notify in-app on every failed manual run

### DIFF
--- a/posthog/temporal/data_modeling/activities/notify_materialization_failure.py
+++ b/posthog/temporal/data_modeling/activities/notify_materialization_failure.py
@@ -153,6 +153,9 @@ def maybe_notify_materialization_failure(
             views=[_FailedView(job=job, saved_query=saved_query)],
             resolver=_SavedQueryViewers(saved_query),
             source_id=str(job.id),
+            # Someone asked for this run and is waiting on its result, so it outranks the
+            # scheduled failures a person did not ask for.
+            priority=Priority.CRITICAL,
         )
     )
     return True
@@ -184,7 +187,12 @@ def _dedupe_key(views: list[_FailedView]) -> str:
 
 
 def _failure_notification(
-    *, team_id: int, views: list[_FailedView], resolver: RecipientsResolver, source_id: str
+    *,
+    team_id: int,
+    views: list[_FailedView],
+    resolver: RecipientsResolver,
+    source_id: str,
+    priority: Priority = Priority.NORMAL,
 ) -> NotificationData:
     title, body = _failure_copy(views)
     source_url = f"/project/{team_id}/sql"
@@ -193,7 +201,7 @@ def _failure_notification(
     return NotificationData(
         team_id=team_id,
         notification_type=NotificationType.MATERIALIZATION_FAILURE,
-        priority=Priority.NORMAL,
+        priority=priority,
         title=title[:255],
         body=body[:400],
         target_type=TargetType.TEAM,

--- a/posthog/temporal/data_modeling/activities/notify_materialization_failure.py
+++ b/posthog/temporal/data_modeling/activities/notify_materialization_failure.py
@@ -131,21 +131,22 @@ class _PrecomputedViewers(RecipientsResolver):
 def maybe_notify_materialization_failure(
     job: DataModelingJob, saved_query: DataWarehouseSavedQuery, team_id: int
 ) -> bool:
-    """Notify on the first failure of a streak; repeats of an ongoing streak stay quiet."""
+    """Email on the first failure of a streak; a run started by hand also notifies in-app every time."""
     # An idempotent retry can land here with a job another path already completed or cancelled.
     if job.status != DataModelingJobStatus.FAILED:
         return False
-    if not starts_a_failure_streak(saved_query.id, job):
-        return False
 
-    # The email task dedupes per (recipient, job) via MessagingRecord, so an activity
-    # retry that already sent the in-app notification still can't double-send email.
-    send_matview_failure_immediate_email.delay(team_id, str(saved_query.id), str(job.id))
+    if starts_a_failure_streak(saved_query.id, job):
+        # The email task dedupes per (recipient, job) via MessagingRecord, so an activity
+        # retry that already sent the in-app notification still can't double-send email.
+        send_matview_failure_immediate_email.delay(team_id, str(saved_query.id), str(job.id))
 
     if job.parent_workflow_id:
         # The DAG run this belongs to notifies for every view it broke, once, at the end.
         return False
 
+    # A run with no parent was started by hand, usually to check a fix, and the person who started
+    # it may have moved on. Silence mid-streak would read as success, so every failure is told.
     create_notification(
         _failure_notification(
             team_id=team_id,

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -59,7 +59,7 @@ from products.data_modeling.backend.facade.models import (
     NodeType,
 )
 from products.data_warehouse.backend.facade.api import CreateTableResult
-from products.notifications.backend.facade.api import NotificationType, TargetType
+from products.notifications.backend.facade.api import NotificationType, Priority, TargetType
 from products.warehouse_sources.backend.facade.hooks import (
     AccountPropertySourceProjection,
     PersonPropertySourceProjection,
@@ -250,6 +250,7 @@ class TestFailMaterializationActivity:
             mock_create.assert_called_once()
             data = mock_create.call_args.args[0]
             assert data.notification_type == NotificationType.MATERIALIZATION_FAILURE
+            assert data.priority == Priority.CRITICAL
             assert data.target_id == str(ateam.pk)
             assert data.resource_id == str(asaved_query.id)
         else:

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -201,20 +201,32 @@ class TestFailMaterializationActivity:
         assert is_node_suspended(anode, DataModelingJobEngine.CLICKHOUSE) is True
 
     @pytest.mark.parametrize(
-        "previous_status,expect_notification",
+        "previous_status,parent_workflow_id,expect_email,expect_in_app",
         [
-            (None, True),
-            (DataModelingJob.Status.COMPLETED, True),
-            (DataModelingJob.Status.FAILED, False),
+            (None, None, True, True),
+            (DataModelingJob.Status.COMPLETED, None, True, True),
+            (DataModelingJob.Status.FAILED, None, False, True),
+            (DataModelingJob.Status.FAILED, "execute-dag-workflow", False, False),
         ],
     )
-    async def test_notifies_only_on_first_failure_of_streak(
-        self, activity_environment, ateam, anode, asaved_query, adag, previous_status, expect_notification
+    async def test_emails_at_streak_start_and_notifies_in_app_on_every_manual_run(
+        self,
+        activity_environment,
+        ateam,
+        anode,
+        asaved_query,
+        adag,
+        previous_status,
+        parent_workflow_id,
+        expect_email,
+        expect_in_app,
     ):
         if previous_status is not None:
             error = "boom" if previous_status == DataModelingJob.Status.FAILED else None
             await _make_job(ateam, asaved_query, previous_status, error=error)
-        current_job = await _make_job(ateam, asaved_query, DataModelingJob.Status.RUNNING)
+        current_job = await _make_job(
+            ateam, asaved_query, DataModelingJob.Status.RUNNING, parent_workflow_id=parent_workflow_id
+        )
 
         inputs = FailMaterializationInputs(
             team_id=ateam.pk,
@@ -223,12 +235,18 @@ class TestFailMaterializationActivity:
             job_id=str(current_job.id),
             error="Some non-timeout error",
         )
-        with unittest.mock.patch(
-            "posthog.temporal.data_modeling.activities.notify_materialization_failure.create_notification"
-        ) as mock_create:
+        with (
+            unittest.mock.patch(
+                "posthog.temporal.data_modeling.activities.notify_materialization_failure.create_notification"
+            ) as mock_create,
+            unittest.mock.patch(
+                "posthog.temporal.data_modeling.activities.notify_materialization_failure.send_matview_failure_immediate_email"
+            ) as mock_email,
+        ):
             await activity_environment.run(fail_materialization_activity, inputs)
 
-        if expect_notification:
+        assert mock_email.delay.called == expect_email
+        if expect_in_app:
             mock_create.assert_called_once()
             data = mock_create.call_args.args[0]
             assert data.notification_type == NotificationType.MATERIALIZATION_FAILURE
@@ -253,11 +271,11 @@ class TestFailMaterializationActivity:
             error="Some non-timeout error",
         )
         with unittest.mock.patch(
-            "posthog.temporal.data_modeling.activities.notify_materialization_failure.create_notification"
-        ) as mock_create:
+            "posthog.temporal.data_modeling.activities.notify_materialization_failure.send_matview_failure_immediate_email"
+        ) as mock_email:
             await activity_environment.run(fail_materialization_activity, inputs)
 
-        mock_create.assert_not_called()
+        mock_email.delay.assert_not_called()
 
     async def test_notifies_when_recovery_raises(self, activity_environment, ateam, anode, asaved_query, adag):
         current_job = await _make_job(ateam, asaved_query, DataModelingJob.Status.RUNNING)

--- a/posthog/temporal/tests/data_modeling/test_notify_materialization_failure.py
+++ b/posthog/temporal/tests/data_modeling/test_notify_materialization_failure.py
@@ -13,7 +13,7 @@ from posthog.temporal.data_modeling.activities import (
 from posthog.temporal.data_modeling.activities.notify_materialization_failure import _FailedView, _failure_copy
 
 from products.data_modeling.backend.facade.models import DataModelingJob, DataModelingJobEngine, DataWarehouseSavedQuery
-from products.notifications.backend.facade.api import TargetType
+from products.notifications.backend.facade.api import Priority, TargetType
 
 RUN_STARTED_AT = "2026-08-12T10:00:00+00:00"
 # The shape a tier schedule produces, rather than an arbitrary long string.
@@ -94,6 +94,7 @@ class TestNotifyDAGMaterializationFailures:
         data = mock_create.call_args.args[0]
         assert data.title == "3 views failed to materialize"
         assert data.body == "alpha, beta, gamma"
+        assert data.priority == Priority.NORMAL
 
     async def test_an_earlier_run_under_the_same_workflow_id_is_left_out(
         self, activity_environment, ateam, adag, auser, aorganization


### PR DESCRIPTION
## Problem

A person who edits a broken materialized view and clicks "Sync now" gets no in-app notification when the run fails again. They see nothing and assume the fix worked.

- Notifications fire only on the first failure of a streak, so a failing view stays quiet until it succeeds once.
- A manual run is usually a check on a fix. The person who started it may have moved on before it finishes.
- The email keeps the once-per-streak rule. It is the channel where repeats read as spam.

## Changes

- A failed run that someone started by hand now creates an in-app notification every time, even in the middle of a failure streak.
- The immediate email still goes out only on the first failure of a streak.
- The notification a manual failure creates carries Critical priority, so a client that ranks notifications puts it above the scheduled ones.
- DAG runs are unchanged. Their in-app notifications stay coalesced per run in the parent workflow, at Normal priority.
- The rule lives in `maybe_notify_materialization_failure`. The streak test now gates the email only, and a job with no parent workflow is treated as a manual run.
- `_failure_notification` takes the priority as an argument and defaults it to Normal, so only the manual path raises it.

> [!NOTE]
> https://github.com/PostHog/posthog/pull/97267 has landed, so one manual click writes one failed job row. A click on a broken query now sends one notification, not three.

## How did you test this code?

- Reshaped `test_notifies_only_on_first_failure_of_streak` into `test_emails_at_streak_start_and_notifies_in_app_on_every_manual_run`. It asserts both channels per case. The manual mid-streak case fails on master with `create_notification` called 0 times.
- `test_an_inconclusive_run_does_not_restart_the_streak` now asserts on the email, since the streak rule no longer governs the in-app channel.
- The manual test asserts Critical and the DAG test asserts Normal. Dropping the `priority` argument turns the three manual cases red.
- Ran `test_materialize_view_activities.py` and `test_notify_materialization_failure.py` locally. Four unrelated tests in the first file failed on S3 PUT timeouts to the local object store, which was not running.
- Not run: the full backend suite. CI covers it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No doc describes the in-app notification rule.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Nothing in the product reads the priority field today, so the raise changes no pixel. It marks the notification for whatever ranks them later.

The direction came from a customer conversation. The committed test data is invented. An explicit "manual" flag on the workflow inputs was considered and dropped, because a job with no parent workflow already identifies a manual run at the notification seam. No open PR was found for this change.


