### PR TITLE
feat(desktop): pick a space for a new command center task

### DIFF
--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.stories.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.stories.tsx
@@ -12,7 +12,7 @@ import { WorkspaceModeSelect } from "@posthog/ui/features/task-detail/components
 import { DotPatternBackground } from "@posthog/ui/primitives/DotPatternBackground";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useQueryClient } from "@tanstack/react-query";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import { CommandCenterEmptyCell } from "./CommandCenterPanel";
 
 const spaces = [
@@ -37,8 +37,12 @@ const spaces = [
 // here.
 function SeededSpaces({ children }: { children: ReactNode }) {
   const queryClient = useQueryClient();
-  useState(() => queryClient.setQueryData(TASK_CHANNELS_QUERY_KEY, spaces));
-  return children;
+  const [seeded, setSeeded] = useState(false);
+  useEffect(() => {
+    queryClient.setQueryData(TASK_CHANNELS_QUERY_KEY, spaces);
+    setSeeded(true);
+  }, [queryClient]);
+  return seeded ? children : null;
 }
 
 const modelOption = {

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.stories.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.stories.tsx
@@ -1,14 +1,45 @@
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 import { Plus, X } from "@phosphor-icons/react";
 import { Button } from "@posthog/quill";
+import type { TaskChannel } from "@posthog/shared/domain-types";
+import { SpaceSelect } from "@posthog/ui/features/canvas/components/SpaceSelect";
 import { TaskRepositoryChip } from "@posthog/ui/features/canvas/components/TaskRepositoryDialog";
+import { TASK_CHANNELS_QUERY_KEY } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { PromptHistoryDialog } from "@posthog/ui/features/message-editor/components/PromptHistoryDialog";
 import { PromptInput } from "@posthog/ui/features/message-editor/components/PromptInput";
 import { ReasoningLevelSelector } from "@posthog/ui/features/sessions/components/ReasoningLevelSelector";
 import { WorkspaceModeSelect } from "@posthog/ui/features/task-detail/components/WorkspaceModeSelect";
 import { DotPatternBackground } from "@posthog/ui/primitives/DotPatternBackground";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useQueryClient } from "@tanstack/react-query";
+import { type ReactNode, useState } from "react";
 import { CommandCenterEmptyCell } from "./CommandCenterPanel";
+
+const spaces = [
+  {
+    id: "space-me",
+    name: "me",
+    channel_type: "personal",
+    system_role: "personal",
+    starred: false,
+    created_at: "2026-08-28T00:00:00.000Z",
+  },
+  {
+    id: "space-growth",
+    name: "growth",
+    channel_type: "public",
+    starred: true,
+    created_at: "2026-08-28T00:00:00.000Z",
+  },
+] satisfies TaskChannel[];
+
+// The space chip reads the shared task-channels query, which has no backend
+// here.
+function SeededSpaces({ children }: { children: ReactNode }) {
+  const queryClient = useQueryClient();
+  useState(() => queryClient.setQueryData(TASK_CHANNELS_QUERY_KEY, spaces));
+  return children;
+}
 
 const modelOption = {
   id: "model",
@@ -53,6 +84,7 @@ function CloudTaskComposer() {
       <DotPatternBackground className="h-[100.333%]" />
       <div className="-translate-1/2 absolute top-1/2 left-1/2 z-1 flex w-[calc(100%-2rem)] max-w-[600px] flex-col gap-2">
         <div className="absolute bottom-full left-0 mb-2 flex min-w-0 items-center gap-1">
+          <SpaceSelect value="space-me" onChange={() => {}} />
           <WorkspaceModeSelect
             value="cloud"
             onChange={() => {}}
@@ -134,9 +166,11 @@ const meta: Meta<typeof StartingCloudTaskComposer> = {
   },
   decorators: [
     (Story) => (
-      <div className="h-[720px] w-[1200px] overflow-hidden border border-gray-6 bg-gray-1">
-        <Story />
-      </div>
+      <SeededSpaces>
+        <div className="h-[720px] w-[1200px] overflow-hidden border border-gray-6 bg-gray-1">
+          <Story />
+        </div>
+      </SeededSpaces>
     ),
   ],
 };

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.test.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.test.tsx
@@ -100,6 +100,31 @@ vi.mock("../../autoresearch/autoresearchDraftStore", () => ({
     getState: () => ({ clearDraft: mocks.clearAutoresearchDraft }),
   },
 }));
+vi.mock("../../feature-flags/useBluebirdFlag", () => ({
+  useBluebirdFlag: () => true,
+}));
+vi.mock("../../canvas/hooks/useTaskChannels", () => ({
+  useTaskChannels: () => ({
+    channels: [
+      { id: "me", name: "me" },
+      { id: "space-2", name: "growth" },
+    ],
+    personalChannel: { id: "me", name: "me" },
+  }),
+}));
+vi.mock("../../canvas/components/SpaceSelect", () => ({
+  SpaceSelect: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (id: string) => void;
+  }) => (
+    <button type="button" onClick={() => onChange("space-2")}>
+      Space {value}
+    </button>
+  ),
+}));
 vi.mock("../../settings/settingsStore", () => ({
   useSettingsStore: (selector: (state: unknown) => unknown) =>
     selector({ brainrotMode: false }),
@@ -109,17 +134,23 @@ vi.mock("../../task-detail/components/TaskInput", () => ({
     onTaskCreated,
     showNewTaskSuggestions,
     allowNoRepo,
+    channelId,
+    spaceSelector,
   }: {
     onTaskCreated?: (task: Task) => void;
     showNewTaskSuggestions?: boolean;
     allowNoRepo?: boolean;
+    channelId?: string;
+    spaceSelector?: (props: { disabled: boolean }) => ReactNode;
   }) => {
     mocks.taskCreatedCallback = onTaskCreated ?? null;
     return (
       <div
         data-allow-no-repo={allowNoRepo}
         data-suggestions={showNewTaskSuggestions}
+        data-channel-id={channelId}
       >
+        {spaceSelector?.({ disabled: false })}
         <button
           type="button"
           onClick={() => onTaskCreated?.(mocks.createdTask as Task)}
@@ -279,6 +310,27 @@ describe("CommandCenterPanel", () => {
     expect(screen.getByText("Send").parentElement).toHaveAttribute(
       "data-allow-no-repo",
       "true",
+    );
+  });
+
+  // The chip only helps if the pick reaches creation; without this the task
+  // silently lands in #me.
+  it("files a task composed in a tile into the space picked in the composer", () => {
+    mocks.store.composer = {
+      cellIndex: 2,
+      sessionId: "cc-cell-us:2:user-1-2",
+    };
+    render(<CommandCenterPanel cell={emptyCell} isActiveSession={false} />);
+    expect(screen.getByText("Send").parentElement).toHaveAttribute(
+      "data-channel-id",
+      "me",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Space me" }));
+
+    expect(screen.getByText("Send").parentElement).toHaveAttribute(
+      "data-channel-id",
+      "space-2",
     );
   });
 

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.test.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.test.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
     currentProjectId: 2,
   },
   createdTask: { id: "task-2", title: "Composed in a tile" },
+  spacesEnabled: true,
   store: {
     layout: "2x2",
     cells: [null, null, null, null] as (string | null)[],
@@ -101,7 +102,7 @@ vi.mock("../../autoresearch/autoresearchDraftStore", () => ({
   },
 }));
 vi.mock("../../feature-flags/useBluebirdFlag", () => ({
-  useBluebirdFlag: () => true,
+  useBluebirdFlag: () => mocks.spacesEnabled,
 }));
 vi.mock("../../canvas/hooks/useTaskChannels", () => ({
   useTaskChannels: () => ({
@@ -233,6 +234,7 @@ describe("CommandCenterPanel", () => {
     mocks.currentUserUuid = "user-1";
     mocks.taskCreatedCallback = null;
     mocks.store.composer = null;
+    mocks.spacesEnabled = true;
     mocks.store.finishCreating.mockReturnValue(true);
   });
 
@@ -334,6 +336,22 @@ describe("CommandCenterPanel", () => {
     );
   });
 
+  // A project without spaces has nowhere to file a task, and the shared
+  // task-channels cache can hold spaces another surface loaded.
+  it("hides the space chip when spaces are off", () => {
+    mocks.spacesEnabled = false;
+    mocks.store.composer = {
+      cellIndex: 2,
+      sessionId: "cc-cell-us:2:user-1-2",
+    };
+    render(<CommandCenterPanel cell={emptyCell} isActiveSession={false} />);
+
+    expect(screen.queryByRole("button", { name: "Space me" })).toBeNull();
+    expect(screen.getByText("Send").parentElement).not.toHaveAttribute(
+      "data-channel-id",
+    );
+  });
+
   it("does not open a created task when the auth scope changed", () => {
     mocks.store.composer = {
       cellIndex: 2,
@@ -389,6 +407,7 @@ describe("CommandCenterPanel", () => {
       sessionId: "cc-cell-us:2:user-1-2",
     };
     render(<CommandCenterPanel cell={emptyCell} isActiveSession={false} />);
+    fireEvent.click(screen.getByRole("button", { name: "Space me" }));
 
     fireEvent.click(screen.getByTitle("Cancel"));
 
@@ -398,6 +417,11 @@ describe("CommandCenterPanel", () => {
     expect(mocks.setDraft).toHaveBeenCalledWith("cc-cell-us:2:user-1-2", null);
     expect(mocks.clearAutoresearchDraft).toHaveBeenCalledWith(
       "cc-cell-us:2:user-1-2",
+    );
+    // A space picked for the abandoned task must not carry into the next one.
+    expect(screen.getByText("Send").parentElement).toHaveAttribute(
+      "data-channel-id",
+      "me",
     );
   });
 });

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.tsx
@@ -185,8 +185,12 @@ function EmptyCell({
     enabled: spacesEnabled,
   });
   const [pickedSpaceId, setPickedSpaceId] = useState<string | null>(null);
-  // A task created without a space lands in #me, so the chip starts there.
-  const spaceId = pickedSpaceId ?? personalChannel?.id ?? null;
+  // A task created without a space lands in #me, so the chip starts there. The
+  // flag gates the chip here rather than through the query, whose cache another
+  // surface may have already filled.
+  const spaceId = spacesEnabled
+    ? (pickedSpaceId ?? personalChannel?.id ?? null)
+    : null;
   const space = channels.find((c) => c.id === spaceId);
   const authIdentity = useAuthStateValue(getAuthIdentity);
   const client = useOptionalAuthenticatedClient();
@@ -248,6 +252,8 @@ function EmptyCell({
     if (!sessionId) return;
     stopCreating(sessionId);
     clearComposerDraft(sessionId);
+    // The next task in this tile starts from #me again, like its prompt draft.
+    setPickedSpaceId(null);
   }, [stopCreating, sessionId]);
 
   useEffect(() => {

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.tsx
@@ -50,6 +50,9 @@ import { useOptionalAuthenticatedClient } from "../../auth/authClient";
 import { useAuthStateValue } from "../../auth/store";
 import { useCurrentUser } from "../../auth/useCurrentUser";
 import { useAutoresearchDraftStore } from "../../autoresearch/autoresearchDraftStore";
+import { SpaceSelect } from "../../canvas/components/SpaceSelect";
+import { useTaskChannels } from "../../canvas/hooks/useTaskChannels";
+import { useBluebirdFlag } from "../../feature-flags/useBluebirdFlag";
 import { useFolders } from "../../folders/useFolders";
 import { useCloudPrUrl } from "../../git-interaction/useCloudPrUrl";
 import { useDraftStore } from "../../message-editor/draftStore";
@@ -177,6 +180,14 @@ function EmptyCell({
   const layout = useCommandCenterStore((s) => s.layout);
   const cells = useCommandCenterStore((s) => s.cells);
   const brainrotMode = useSettingsStore((s) => s.brainrotMode);
+  const spacesEnabled = useBluebirdFlag();
+  const { channels, personalChannel } = useTaskChannels({
+    enabled: spacesEnabled,
+  });
+  const [pickedSpaceId, setPickedSpaceId] = useState<string | null>(null);
+  // A task created without a space lands in #me, so the chip starts there.
+  const spaceId = pickedSpaceId ?? personalChannel?.id ?? null;
+  const space = channels.find((c) => c.id === spaceId);
   const authIdentity = useAuthStateValue(getAuthIdentity);
   const client = useOptionalAuthenticatedClient();
   const { data: currentUser } = useCurrentUser({ client });
@@ -274,6 +285,20 @@ function EmptyCell({
             onTaskCreated={handleTaskCreated}
             showNewTaskSuggestions={false}
             allowNoRepo
+            channelId={spaceId ?? undefined}
+            channelRepositories={space?.repositories}
+            channelGithubIntegration={space?.github_integration}
+            spaceSelector={
+              spaceId
+                ? ({ disabled }) => (
+                    <SpaceSelect
+                      value={spaceId}
+                      onChange={setPickedSpaceId}
+                      disabled={disabled}
+                    />
+                  )
+                : undefined
+            }
           />
         </div>
       </div>


### PR DESCRIPTION
## Problem

A person starting a task from the command center cannot choose the space it belongs to: every task lands in #me. The regular composer, on a space's new task screen, shows a space chip and files the task where the person picked.

## Changes

- The command center tile composer now shows the space chip, so a task created there files into the picked space.
- The chip starts on #me, which is where an unfiled task went before.
- The picked space also supplies the repository defaults, the same as the space composer.
- The chip is the shared `SpaceSelect`, and it is hidden when spaces are off for the project.
- The composer story gains the chip and seeds two spaces, so the row renders in Storybook.

Before:

![before](https://raw.githubusercontent.com/PostHog/pr-assets/10aa97e7386c65f118d26175dd1f8d2c8f091cde/2026/09/5f74f4b2-b5bd-4fba-abe1-d396b8b26b35.png)

After, in the running app against a local backend:

![live-app-chip](https://raw.githubusercontent.com/PostHog/pr-assets/3a8974ab4498800134ea6376bab0f8df5e5d0e5d/2026/09/a040853f-b621-403e-9d34-8a124eaa2259.png)

![live-app-chip-open](https://raw.githubusercontent.com/PostHog/pr-assets/04120edc25ea8501d77d5194468830b6a08381a6/2026/09/d4cfd71d-3b18-4783-9cd0-28f3e5705b9f.png)

The same row in Storybook, which the composer story now covers:

![after-closed](https://raw.githubusercontent.com/PostHog/pr-assets/e089fb47ed938587b06dabef50161f0537e976e2/2026/09/0b74aa6d-1699-437e-8546-fb762cab9b36.png)

## How did you test this code?

- One case added to `CommandCenterPanel.test.tsx`: it catches a chip that renders but never feeds the pick back to the composer, which would file the task in #me while showing another space.
- Ran the command center vitest suite and the package typecheck.
- Ran the browser host against a local PostHog stack, signed in to the dev region, and drove the command center in headless Chromium.
- Left untouched, the chip read `personal` and the created task landed in the `me` space. Set to `growth`, the created task landed in the `growth` space. Both were read back from the tasks table.
- The task's agent run then failed to start, which is expected: this sandbox has no agent runner.
- The before screenshot comes from the Storybook composer story.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a Slack request. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

Creation already accepts a channel id and writes it to the task's `channel` field, so the composer passes the picked id straight through rather than filing the task in a second call after creation. No duplicate PR: `gh pr list --state open --search "command center space selector"` found none. Nothing in this PR carries material from the session that is not already public.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1788947694604989?thread_ts=1788947694.604989&cid=C09G8Q32R6F)*

