### PR TITLE
feat(cdp): drop the customer.io PluginStorage dependency

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.test.ts
@@ -200,7 +200,6 @@ describe('CdpLegacyEventsConsumer', () => {
                 customerioSiteId: { value: '1234567890' },
                 customerioToken: { value: 'cio-token' },
                 email: { value: 'test@posthog.com' },
-                legacy_plugin_config_id: { value: pluginConfig.id },
             })
         })
 
@@ -236,7 +235,6 @@ describe('CdpLegacyEventsConsumer', () => {
             expect(result?.inputs).toMatchObject({
                 customerioSiteId: { value: '1234567890' },
                 customerioToken: { value: 'cio-token' },
-                legacy_plugin_config_id: { value: pluginConfig.id },
                 mappings: {
                     value: {
                         event1: 'action1',
@@ -271,9 +269,7 @@ describe('CdpLegacyEventsConsumer', () => {
             const result = consumer['convertPluginConfigToHogFunction'](lightweightConfig, attachments)
 
             expect(result).toBeTruthy()
-            expect(result?.inputs).toMatchObject({
-                legacy_plugin_config_id: { value: pluginConfig.id },
-            })
+            expect(result?.inputs).toEqual({})
             expect(result?.inputs?.mappings).toBeUndefined()
         })
 

--- a/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
@@ -244,11 +244,6 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase<CdpLegacyEventsCons
             }
         }
 
-        // Add legacy_plugin_config_id for plugins that use legacy storage
-        if (pluginId === 'customerio-plugin') {
-            inputs.legacy_plugin_config_id = { value: pluginConfig.id }
-        }
-
         // Create a HogFunctionType
         return {
             id: `legacy-${pluginConfig.id}`,

--- a/nodejs/src/cdp/legacy-plugins/_destinations/customerio/customer-status.test.ts
+++ b/nodejs/src/cdp/legacy-plugins/_destinations/customerio/customer-status.test.ts
@@ -1,0 +1,76 @@
+import { parseJSON } from '~/common/utils/json-parse'
+import { ProcessedPluginEvent } from '~/plugin-scaffold'
+
+import { onEvent, setupPlugin } from './index'
+
+describe('customer.io customer status', () => {
+    const run = async ({
+        mode,
+        person,
+        event,
+    }: {
+        mode: string
+        person?: Record<string, any>
+        event?: Partial<ProcessedPluginEvent>
+    }): Promise<{ sent: boolean; identifyBody: Record<string, any> | undefined }> => {
+        const calls: { url: string; body: any }[] = []
+        const meta: any = {
+            config: { customerioSiteId: 'site', customerioToken: 'token', sendEventsFromAnonymousUsers: mode },
+            global: {},
+            logger: { debug: jest.fn(), warn: jest.fn(), log: jest.fn(), error: jest.fn() },
+            fetch: jest.fn().mockImplementation((url: string, params: any) => {
+                calls.push({ url, body: params.body ? parseJSON(params.body) : undefined })
+                return Promise.resolve({ status: 200, json: () => Promise.resolve({}) })
+            }),
+            person: person ? { id: 'p', name: 'p', url: '', properties: person } : undefined,
+        }
+
+        await setupPlugin(meta)
+        calls.length = 0
+
+        await onEvent(
+            {
+                distinct_id: 'user-1',
+                event: 'purchase',
+                properties: {},
+                team_id: 1,
+                uuid: 'uuid',
+                ip: null,
+                ...event,
+            } as ProcessedPluginEvent,
+            meta
+        )
+
+        const identify = calls.find((c) => c.url.includes('/customers/') && !c.url.endsWith('/events'))
+        return { sent: calls.length > 0, identifyBody: identify?.body }
+    }
+
+    const WITH_EMAIL = 'Only send events from users with emails'
+    const IDENTIFIED = 'Only send events from users that have been identified'
+
+    test.each([
+        ['person carries an email the event does not', WITH_EMAIL, { email: 'a@example.com' }, {}, true],
+        ['neither event nor person carries an email', WITH_EMAIL, undefined, {}, false],
+        ['$is_identified is true', IDENTIFIED, undefined, { properties: { $is_identified: true } }, true],
+        ['$is_identified is the string true', IDENTIFIED, undefined, { properties: { $is_identified: 'true' } }, true],
+        ['$is_identified is false', IDENTIFIED, undefined, { properties: { $is_identified: false } }, false],
+        [
+            // Cookieless events always get a device id that differs from the distinct id
+            'the event is anonymous cookieless',
+            IDENTIFIED,
+            undefined,
+            { distinct_id: 'cookieless_a', properties: { $device_id: 'cookielessd_b' } },
+            false,
+        ],
+        ['no gate is configured', 'Send all events', undefined, {}, true],
+    ])('sends %s: %s', async (_name, mode, person, event, expected) => {
+        const { sent } = await run({ mode: mode as string, person: person as any, event: event as any })
+        expect(sent).toBe(expected)
+    })
+
+    it('identifies the customer by the person email when the event has none', async () => {
+        const { identifyBody } = await run({ mode: WITH_EMAIL, person: { email: 'a@example.com' } })
+
+        expect(identifyBody).toMatchObject({ email: 'a@example.com' })
+    })
+})

--- a/nodejs/src/cdp/legacy-plugins/_destinations/customerio/index.ts
+++ b/nodejs/src/cdp/legacy-plugins/_destinations/customerio/index.ts
@@ -40,7 +40,6 @@ const EVENTS_CONFIG_MAP = {
 
 interface Customer {
     status: Set<'seen' | 'identified' | 'with_email'>
-    existsAlready: boolean
     email: string | null
 }
 
@@ -126,7 +125,8 @@ export const onEvent = async (event: ProcessedPluginEvent, meta: CustomerIoMeta)
         return
     }
 
-    const customer: Customer = await syncCustomerMetadata(meta, event)
+    const customer = resolveCustomer(meta, event)
+    logger.debug('Detected email', customer.email)
     logger.debug(customer)
     logger.debug(shouldCustomerBeTracked(customer, global.eventsConfig))
     if (!shouldCustomerBeTracked(customer, global.eventsConfig)) {
@@ -143,35 +143,25 @@ export const onEvent = async (event: ProcessedPluginEvent, meta: CustomerIoMeta)
     )
 }
 
-async function syncCustomerMetadata(meta: CustomerIoMeta, event: ProcessedPluginEvent): Promise<Customer> {
-    const { storage, logger } = meta
+function resolveCustomer(meta: CustomerIoMeta, event: ProcessedPluginEvent): Customer {
+    const personProperties = meta.person?.properties ?? {}
+    const personEmail = isEmail(personProperties.email) ? (personProperties.email as string) : null
+    const email = getEmailFromEvent(event) ?? personEmail
 
-    const customerStatusKey = `customer-status/${event.distinct_id}`
-    const customerStatusArray = (await storage.get(customerStatusKey, [])) as string[]
-    const customerStatus = new Set(customerStatusArray) as Customer['status']
-    const customerExistsAlready = customerStatus.has('seen')
-    const email = getEmailFromEvent(event)
-
-    logger.debug('Detected email', email)
-
-    // Update customer status
-    customerStatus.add('seen')
-    if (event.event === '$identify') {
-        customerStatus.add('identified')
-    }
+    const status = new Set(['seen']) as Customer['status']
     if (email) {
-        customerStatus.add('with_email')
+        status.add('with_email')
+    }
+    if (isIdentified(event)) {
+        status.add('identified')
     }
 
-    if (customerStatus.size > customerStatusArray.length) {
-        await storage.set(customerStatusKey, Array.from(customerStatus))
-    }
+    return { status, email }
+}
 
-    return {
-        status: customerStatus,
-        existsAlready: customerExistsAlready,
-        email,
-    }
+// The native Customer.io template gates on $is_identified, so match it rather than inventing a second rule
+function isIdentified(event: ProcessedPluginEvent): boolean {
+    return event.event === '$identify' || String(event.properties?.$is_identified) === 'true'
 }
 
 function shouldCustomerBeTracked(customer: Customer, eventsConfig: EventsConfig): boolean {
@@ -203,7 +193,8 @@ async function exportSingleEvent(
 
     const customerPayload: Record<string, any> = {
         ...(event.$set || {}),
-        _update: customer.existsAlready,
+        // The endpoint upserts, so this flag only labels the write
+        _update: true,
         identifier: event.distinct_id,
     }
 

--- a/nodejs/src/cdp/legacy-plugins/_destinations/customerio/template.ts
+++ b/nodejs/src/cdp/legacy-plugins/_destinations/customerio/template.ts
@@ -88,14 +88,6 @@ export const customerioPlugin: LegacyDestinationPlugin = {
                 type: 'string',
                 description: 'If this is set, only the specified events (comma-separated) will be sent to Customer.io.',
             },
-            {
-                key: 'legacy_plugin_config_id',
-                label: 'Legacy plugin config ID',
-                description: 'The ID of the legacy plugin config that this was migrated from. (DO NOT MODIFY THIS)',
-                type: 'string',
-                default: '',
-                required: true,
-            },
         ],
     },
 }

--- a/nodejs/src/cdp/legacy-plugins/test-utils.ts
+++ b/nodejs/src/cdp/legacy-plugins/test-utils.ts
@@ -91,7 +91,6 @@ export function createCache(): {
 let testMeta: any = {
     config: {},
     cache: createCache(),
-    storage: createCache(),
     global: {},
     attachments: {},
 }
@@ -100,7 +99,6 @@ export function resetMeta(meta: Record<string, any> = {}): any {
     testMeta = {
         config: {},
         cache: createCache(),
-        storage: createCache(),
         global: {},
         attachments: {},
         ...meta,

--- a/nodejs/src/cdp/legacy-plugins/types.ts
+++ b/nodejs/src/cdp/legacy-plugins/types.ts
@@ -1,7 +1,7 @@
 import { FetchOptions, FetchResponse } from '~/common/utils/request'
-import { PluginEvent, ProcessedPluginEvent, StorageExtension } from '~/plugin-scaffold'
+import { PluginEvent, ProcessedPluginEvent } from '~/plugin-scaffold'
 
-import { HogFunctionTemplate } from '../types'
+import { CyclotronPerson, HogFunctionTemplate } from '../types'
 
 export type LegacyPluginLogger = {
     debug: (...args: any[]) => void
@@ -24,7 +24,7 @@ export type LegacyTransformationPluginMeta = LegacyPluginMeta & {
 
 export type LegacyDestinationPluginMeta = LegacyTransformationPluginMeta & {
     fetch: (url: string, fetchParams: FetchOptions) => Promise<FetchResponse>
-    storage: Pick<StorageExtension, 'get' | 'set'>
+    person?: CyclotronPerson
 }
 
 export type LegacyDestinationPlugin = {

--- a/nodejs/src/cdp/services/legacy-plugin-executor.service.test.ts
+++ b/nodejs/src/cdp/services/legacy-plugin-executor.service.test.ts
@@ -137,7 +137,6 @@ describe('LegacyPluginExecutorService', () => {
                 customerioSiteId: '1234567890',
                 customerioToken: 'cio-token',
                 email: 'test@posthog.com',
-                legacy_plugin_config_id: pluginConfigId,
             },
         }
     })
@@ -262,7 +261,7 @@ describe('LegacyPluginExecutorService', () => {
                   [
                     "https://track.customer.io/api/v1/customers/distinct_id",
                     {
-                      "body": "{"_update":false,"identifier":"distinct_id"}",
+                      "body": "{"_update":true,"identifier":"distinct_id","email":"test@posthog.com"}",
                       "headers": {
                         "Authorization": "Basic MTIzNDU2Nzg5MDpjaW8tdG9rZW4=",
                         "Content-Type": "application/json",
@@ -290,8 +289,8 @@ describe('LegacyPluginExecutorService', () => {
             expect(getLogMessages(res.logs)).toMatchInlineSnapshot(`
                 [
                   "Successfully authenticated with Customer.io. Completing setupPlugin.",
-                  "Detected email, null",
-                  "{"status":{},"existsAlready":false,"email":null}",
+                  "Detected email, test@posthog.com",
+                  "{"status":{},"email":"test@posthog.com"}",
                   "true",
                   "Function completed in REPLACED-TIME-ms.",
                 ]
@@ -318,8 +317,8 @@ describe('LegacyPluginExecutorService', () => {
             expect(forSnapshot(getLogMessages(res.logs))).toMatchInlineSnapshot(`
                 [
                   "Successfully authenticated with Customer.io. Completing setupPlugin.",
-                  "Detected email, null",
-                  "{"status":{},"existsAlready":false,"email":null}",
+                  "Detected email, test@posthog.com",
+                  "{"status":{},"email":"test@posthog.com"}",
                   "true",
                   "Fetch called but mocked due to test function, {"url":"https://track.customer.io/api/v1/customers/distinct_id","method":"PUT"}",
                   "Fetch called but mocked due to test function, {"url":"https://track.customer.io/api/v1/customers/distinct_id/events","method":"POST"}",
@@ -368,8 +367,8 @@ describe('LegacyPluginExecutorService', () => {
             expect(forSnapshot(getLogMessages(res.logs))).toMatchInlineSnapshot(`
                 [
                   "Successfully authenticated with Customer.io. Completing setupPlugin.",
-                  "Detected email, null",
-                  "{"status":{},"existsAlready":false,"email":null}",
+                  "Detected email, test@posthog.com",
+                  "{"status":{},"email":"test@posthog.com"}",
                   "true",
                   "Plugin execution failed: Received a potentially intermittent error from the Customer.io API. Response 500: {}",
                 ]
@@ -528,10 +527,6 @@ describe('LegacyPluginExecutorService', () => {
             const invocation = buildInvocation(plugin)
             invocation.hogFunction.name = name
             invocation.state.globals.event.event = '$identify' // Many plugins filter for this
-
-            if (plugin.template.id === 'plugin-customerio-plugin') {
-                invocation.state.globals.inputs.legacy_plugin_config_id = pluginConfigId
-            }
             const res = await service.execute(invocation)
             expect(getLogMessages(res.logs)).toMatchSnapshot()
         })

--- a/nodejs/src/cdp/services/legacy-plugin-executor.service.ts
+++ b/nodejs/src/cdp/services/legacy-plugin-executor.service.ts
@@ -166,9 +166,6 @@ export class LegacyPluginExecutorService {
 
             let state = this.pluginState[invocation.hogFunction.id]
 
-            // NOTE: If this is set then we can add in the legacy storage
-            const legacyPluginConfigId = invocation.state.globals.inputs?.legacy_plugin_config_id
-
             setupPromiseCacheCounter.labels({ result: state ? 'hit' : 'miss' }).inc()
 
             if (!state) {
@@ -204,7 +201,6 @@ export class LegacyPluginExecutorService {
                             ...meta,
                             // Setup receives the real fetch always
                             fetch,
-                            storage: this.legacyStorage(invocation.hogFunction.team_id, legacyPluginConfigId),
                         })
                     }
                 }
@@ -299,7 +295,8 @@ export class LegacyPluginExecutorService {
                     // NOTE: We override logger and fetch here so we can track the calls
                     logger: pluginLogger,
                     fetch: request,
-                    storage: this.legacyStorage(invocation.hogFunction.team_id, legacyPluginConfigId),
+                    // Not on state.meta because state is cached across invocations
+                    person: globals.person,
                 })
 
                 addLog('info', `Function completed in ${performance.now() - start}ms.`)
@@ -312,7 +309,10 @@ export class LegacyPluginExecutorService {
                             ...state.meta,
                             logger: pluginLogger,
                         },
-                        this.legacyStorage(invocation.hogFunction.team_id, legacyPluginConfigId)
+                        this.legacyStorage(
+                            invocation.hogFunction.team_id,
+                            invocation.state.globals.inputs?.legacy_plugin_config_id
+                        )
                     )
                     result.execResult = transformedEvent
                 } else {


### PR DESCRIPTION
## Problem

The customer.io destination reads a per-distinct-id status set out of `posthog_pluginstorage` on every invocation, to decide whether an event should be sent. That is a Postgres round trip on a large table with no read replica, and the stored set only knows events seen since the plugin config was enabled.

The event and the person already carry the same facts.

## Changes

- The plugin derives the customer status from the event and the person, and no longer reads or writes plugin storage.
- `person.properties.email` answers the "users with emails" gate.
- `properties.$is_identified` answers the "users that have been identified" gate, the same property the native Customer.io template filters on.
- Legacy destinations lose their `storage` meta field, so the executor stops building one for them. The `first-time-event-tracker` transformation keeps its storage path.
- The customer.io template drops its `legacy_plugin_config_id` input, and the legacy consumer stops injecting it.

The identify call now always sends `_update: true`, since that endpoint upserts.

No UI changes.

## How did you test this code?

`customer-status.test.ts` is new; no customer.io unit test existed, and the executor smoke test needs Postgres and Redis. Its parameterized cases pin both gates, so a send decision cannot flip unnoticed.

The derivation also ran in shadow against the stored value across the prod-US legacy consumer fleet (#97304).

Not run: `legacy-plugin-executor.service.test.ts` and the legacy consumer tests, which need Postgres and Redis this environment does not have. CI covers them.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/querying-production-databases-via-metabase`, `/writing-tests`, `/writing-pr-descriptions`.

The `identified` derivation first used a `$device_id` comparison, then moved to `$is_identified` to match the native Customer.io template. `existsAlready` became a constant once storage went, so the field was removed rather than left in place. This PR was briefly stacked on #97304 and squashed onto master, so the shadow metric does not appear in its diff.

No customer data, tenant identifiers, or operational figures are in this PR.
