### PR TITLE
chore(devex): default test runs to persons-on-events v2

### DIFF
--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -1,3 +1,4 @@
+from posthog.settings.base_variables import TEST
 from posthog.settings.utils import get_from_env, str_to_bool
 
 CONSTANCE_DATABASE_PREFIX = "constance:posthog:"
@@ -56,7 +57,14 @@ CONSTANCE_CONFIG = {
         str,
     ),
     "PERSON_ON_EVENTS_V2_ENABLED": (
-        get_from_env("PERSON_ON_EVENTS_V2_ENABLED", False, type_cast=str_to_bool),
+        # Person-on-events v2 reads are the production default for every project created
+        # since 2024-06-14, and both CI lanes set this variable so their runs match it. A
+        # test run that leaves it unset, such as `hogli test products/<name>`, reads the
+        # legacy joined mode instead and fails against snapshots that CI recorded under
+        # v2. The test-mode default carries the same value so a local run matches CI.
+        # Production and self-hosted keep the off default. A test that needs the legacy
+        # mode pins it with override_settings or override_instance_config.
+        get_from_env("PERSON_ON_EVENTS_V2_ENABLED", TEST, type_cast=str_to_bool),
         "Whether to use query path using person_id and person_properties on events or the old query",
         bool,
     ),

--- a/posthog/test/test_team.py
+++ b/posthog/test/test_team.py
@@ -223,16 +223,6 @@ class TestTeam(BaseTest):
                     # It is ok if we check other feature flags, just not `persons-on-events-v2-reads-enabled`
                     assert args_list[0][0] != "persons-on-events-v2-reads-enabled"
 
-    def test_team_with_nothing_pinned_reads_persons_on_events_v2_under_test(self):
-        # Guards the test-mode default in dynamic_settings.py. Both CI lanes pin the
-        # variable themselves, so nothing else in CI would notice the default going back
-        # to the legacy joined mode, and product snapshots would then only fail locally.
-        with self.is_cloud(False):
-            assert not self.team.modifiers
-            self.assertEqual(
-                self.team.person_on_events_mode, PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS
-            )
-
     def test_each_team_gets_project_with_default_name_and_same_id(self):
         # Can be removed once environments are fully rolled out
         team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)

--- a/posthog/test/test_team.py
+++ b/posthog/test/test_team.py
@@ -223,6 +223,16 @@ class TestTeam(BaseTest):
                     # It is ok if we check other feature flags, just not `persons-on-events-v2-reads-enabled`
                     assert args_list[0][0] != "persons-on-events-v2-reads-enabled"
 
+    def test_team_with_nothing_pinned_reads_persons_on_events_v2_under_test(self):
+        # Guards the test-mode default in dynamic_settings.py. Both CI lanes pin the
+        # variable themselves, so nothing else in CI would notice the default going back
+        # to the legacy joined mode, and product snapshots would then only fail locally.
+        with self.is_cloud(False):
+            assert not self.team.modifiers
+            self.assertEqual(
+                self.team.person_on_events_mode, PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS
+            )
+
     def test_each_team_gets_project_with_default_name_and_same_id(self):
         # Can be removed once environments are fully rolled out
         team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)


### PR DESCRIPTION
## Problem

A developer running `hogli test products/<name>` gets failures on query snapshots they never touched.

- Product tests run with persons-on-events v2 in CI, so the committed snapshots record the SQL that mode produces.
- Nothing sets `PERSON_ON_EVENTS_V2_ENABLED` outside CI, so a local run reads the legacy joined mode instead.
- #96490 widens the gap by the 26 product snapshot files it rewrites. Core snapshot files that already carried the mode had the same trap.
- This is the fourth layer of the stack that starts at #96490, and it sits on #96199. It closes the last open review note on #96490.

## Changes

- `hogli test products/<name>` now runs the mode CI runs, so a local run passes against the committed snapshots.
- The instance-setting default follows `TEST`, which is the lever CI already uses.

```diff
-        get_from_env("PERSON_ON_EVENTS_V2_ENABLED", False, type_cast=str_to_bool),
+        get_from_env("PERSON_ON_EVENTS_V2_ENABLED", TEST, type_cast=str_to_bool),
```

- Production and self-hosted keep the off default, because `TEST` is false in every non-test process.
- An explicit environment variable still wins, so each CI leg that pins the mode keeps it.

| Segment | Sets the variable | Mode before | Mode after |
| --- | --- | --- | --- |
| Product lane | `true` | v2 | v2 |
| Core rows | `true` | v2 | v2 |
| Core safeguard leg, compat rows | `false` | joined | joined |
| Temporal | no | joined | v2 |
| Dagster | no | joined | v2 |

- Temporal and Dagster move to the mode. Neither holds a snapshot with person-join SQL.
- The one Dagster job that resolves the mode reads the flag service rather than this setting.
- The review note proposed defaulting `PERSON_ON_EVENTS_V2_OVERRIDE` instead.
- That override short-circuits ahead of the cloud flag and the instance setting in `Team`.
- It would flip the two Core legs that cover the joined mode on purpose, despite them setting the variable to `false`.
- The default travels with the code rather than with the workflow, so a branch that has not rebased keeps the joined mode without a marker guard.
- Nothing looks different. The change reaches test processes only.

## How did you test this code?

No new test. An earlier commit here added one and `11077ad7e` removed it, because it could not fail when the default regressed. Every Core row that collects `posthog/test/test_team.py` sets `PERSON_ON_EVENTS_V2_ENABLED` to true, and `get_from_env` returns an explicit environment value in place of the default. The rows that set it to false run `posthog/clickhouse` and `ee/clickhouse` only, so they never collect that file. Credit to Greptile for catching it.

The default is read once at import, so an environment-independent assertion needs a settings reload or a helper extracted from the call site. Neither earns its cost for one argument, so the comment above the default carries the reason instead.

Existing coverage still exercises both resolution branches: `test_team_on_cloud_uses_feature_flag_to_determine_person_on_events` and `test_team_on_self_hosted_uses_instance_setting_to_determine_person_on_events` both pin their input, so this change does not touch them.

Not run here: this sandbox has no Python environment. `requires-python` pins CPython 3.13.13, and uv offers no download for that version, so `uv sync` cannot build the venv and no Django test executes. `hogli ci:preflight` fails on the same missing venv, and so does the `lint:python:fix` commit hook, so `ruff check` and `ruff format --check` were run directly instead and both pass. The commit and the push used `--no-verify` for that reason. CI on this head is the first execution.

The backend coverage report on this head reads 92.0% (7 of 88 changed lines uncovered), because it measures the whole stack against `origin/master` rather than this layer alone. All 7 are import statements from the trends move in #96095: one top-level import in `insight_actors_query_options_runner.py`, two in `calendar_heatmap_trends_query_runner.py`, and four deferred imports inside display-type branches of `query_runner.py`. Each replaces an import of the same class from its old location, and the deferred ones run only when that display type or query kind is requested. No test is added for them: executing an import line to lift a coverage number is not a regression this repo needs guarded.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No page under `docs/` names this setting.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/stacking-prs`.

The session restacked #96490, #96095 and #96199 into a linear chain, then fixed the two failures the mode flip surfaced. This change was first slated as a separate PR on master after #96490 merged. It moved into the stack instead so the whole chain can land together.

No duplicate: a search of open PRs for `persons-on-events` returns 25 results, and the only ones touching this area are #96490 and #96095 in this stack.

Patch coverage: the diff is one settings default. Every Core row that runs the Django suite evaluates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WX7S5RNZvmToUmtGfeVwn

---
_Generated by [Claude Code](https://claude.ai/code/session_012WX7S5RNZvmToUmtGfeVwn)_

---
_Generated by [Claude Code](https://claude.ai/code)_