### PR TITLE
fix(dashboards): apply a pinned color saved without a breakdown type

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardBreakdownColors.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardBreakdownColors.test.ts
@@ -1105,6 +1105,25 @@ describe('dashboardBreakdownColors', () => {
             expect(findBreakdownColorConfig(configs, null, 'event')).toBeUndefined()
         })
 
+        // Separate configs, because giving the shared list an untyped entry would satisfy the
+        // 'breakdown type must match' case above and remove what it checks.
+        it.each([
+            ['an entry with no type matches an event series', undefined, 'event', 'preset-9'],
+            ['an entry with no type matches a series with no type', undefined, undefined, 'preset-9'],
+            ['a null type reads the same as an omitted one', null, 'event', 'preset-9'],
+            // The default is `event`, not a wildcard, so an untyped entry must not colour a person
+            // series that happens to share the value.
+            ['an entry with no type does not match a person series', undefined, 'person', undefined],
+        ] as const)('%s', (_name, configType, seriesType, expectedToken) => {
+            const untypedConfigs = [
+                { breakdownValue: 'Chrome', breakdownType: configType, colorToken: 'preset-9' },
+            ] as BreakdownColorConfig[]
+
+            expect(findBreakdownColorConfig(untypedConfigs, 'Chrome', seriesType as any)?.colorToken).toEqual(
+                expectedToken
+            )
+        })
+
         it('prefers a property-scoped entry and falls back to a property-less one', () => {
             const scopedConfigs: BreakdownColorConfig[] = [
                 { breakdownValue: 'Chrome', breakdownType: 'event', colorToken: 'preset-1' },

--- a/frontend/src/scenes/dashboard/dashboardBreakdownColors.ts
+++ b/frontend/src/scenes/dashboard/dashboardBreakdownColors.ts
@@ -115,9 +115,13 @@ export function breakdownConfigMatches(
     }
     // A property key already encodes each part's type, so scoped entries match on it alone;
     // property-less entries keep the legacy value-and-type match under any property.
+    //
+    // Both sides default a missing type to `event`, as breakdownConfigIdentityMatches does. An entry
+    // written without a type, which the API accepts, would otherwise compare `undefined` against a
+    // real type and never match any series.
     return config.breakdownProperty != null
         ? config.breakdownProperty === breakdownPropertyKey
-        : config.breakdownType === (breakdownType ?? 'event')
+        : (config.breakdownType ?? 'event') === (breakdownType ?? 'event')
 }
 
 /** True when two configs denote the same entry: same normalized value, type, and property


### PR DESCRIPTION
## Problem

- A color someone pinned to a breakdown value does nothing, on every tile, if the stored entry carries no breakdown type. The colors modal shows the value as unpinned, so there is no way to tell from the screen why the color never arrived.
- The comparison defaults a missing type to `event` on the series side only. `breakdownConfigMatches` reads `config.breakdownType === (breakdownType ?? 'event')`, so an entry with no type compares `undefined` against a real type and never agrees.
- `breakdownConfigIdentityMatches`, twelve lines below, already defaults both sides. Two functions compare the same field, and only one of them defaults the entry.
- The API accepts this shape. `breakdownValue` and `colorToken` are the only required keys, so an agent that follows the MCP schema stores an entry that can never apply and gets a success back.

Found in review of #96310, which is where the schema states those two keys are enough.

## Changes

- A pinned color with no breakdown type now colors its value, and the dashboard colors modal shows it as pinned. Nothing else about the entry changes.
- Both sides of the comparison default a missing type to `event`.
- The default stays `event` rather than a wildcard, so such an entry still does not color a person, session, or cohort series that happens to share the value.
- No API or schema change. This is one expression in `dashboardBreakdownColors.ts`.

| Stored entry | Series | Before | After |
| --- | --- | --- | --- |
| no type | event | no match | matches |
| no type | none | no match | matches |
| null type | event | no match | matches |
| no type | person | no match | no match |

> [!NOTE]
> This changes what a person sees without them acting: a color that never applied starts applying. It ships without an in-app notice, because the entry is a pin someone created, the colors modal shows and clears it in the place built for that, and a banner saying "some colors now work" would reach a minority and explain less than the modal already does. Judged against `/announcing-behavior-changes`; say so if you would rather it carried one.

## How did you test this code?

- Four cases added to the `findBreakdownColorConfig` matrix, which is the path both the charts and the colors modal use. They cover an entry with no type against an event series and against a series with no type, a null type reading the same as an omitted one, and the guard that a person series is still not colored.
- The cases have their own configs, because giving the shared list an untyped entry would satisfy the neighbouring `breakdown type must match` case and remove what it checks.
- Reverting the change fails three of the four. The fourth passes either way by design: it guards against widening the default into a wildcard.
- 837 tests across `scenes/dashboard`, `scenes/trends`, `scenes/funnels`, and `scenes/retention` pass, which covers the four logics that consume the matcher.
- Not run: `typescript:check`, because the whole-app `tsgo` pass is killed for memory in this sandbox. `breakdown_type` is typed `BreakdownType | null`, so the added `null` case needs no cast beyond the one already there.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented behavior changes.

## 🤖 Agent context

**Autonomy:** Supervised. A person chose the frontend fix over requiring a type on writes, having been given both options and the cost of each: requiring a type rejects a shape that is already stored, while this makes stored colors start applying.

Written by Claude Code. Skills invoked: `/announcing-behavior-changes`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The asymmetry with `breakdownConfigIdentityMatches` is what settled it as an oversight rather than intent. A serializer default would not have worked: `BreakdownColorsField` stores the raw input rather than the child's output, so a default would validate and never persist.

Public artifact: nothing here carries material from the agent session. The test fixtures use invented breakdown values, and no counts from production data appear in this description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9ESwEgEshJFC9pyVCPEW4

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9ESwEgEshJFC9pyVCPEW4)_