### PR TITLE
feat(tasks): chart hogql queries from the slack agent

### DIFF
--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -4467,7 +4467,8 @@ export class AgentServer {
 - To show a chart in Slack (a saved insight or an ad-hoc analytics query result), make a single call: POST to \`${endpoint}chart/\` with \`$POSTHOG_PERSONAL_API_KEY\` and body \`{"name": "<chart title>", "query": <query JSON, e.g. {"kind": "InsightVizNode", "source": {"kind": "TrendsQuery", ...}}>}\`, or \`{"name": "<chart title>", "insight_id": <numeric insight id>}\` for a saved insight. It renders the chart server-side and registers it for Slack delivery in one step, blocking until done (typically a few seconds).
 - The chart renders directly under your answer text with its name as the title, so do not restate the title or announce the chart ("Here's a chart of…"). Spend your answer text on the takeaway instead: the trend, inflection points, spikes, or drops a reader should notice, with numbers where they matter. Each chart is delivered with an "Open in PostHog" button, so do not paste the response \`url\` into your answer unless the user explicitly asks for a link. Do not download, view, or re-upload the image yourself.
 - Report a chart failure rather than retrying blindly: a 400 carries the reason in \`error\`, or in \`detail\` when the request body itself was rejected, and a 429 means the project's chart render limit is saturated, so answer without the chart.
-- SQL results cannot be charted yet, because the chart endpoint rejects SQL queries. Chart with an insight query (e.g. TrendsQuery) when the question can be expressed as one; otherwise summarize the SQL result in your answer text.`
+- A result you computed in SQL charts too: wrap the HogQL query in a DataVisualizationNode, e.g. \`{"kind": "DataVisualizationNode", "source": {"kind": "HogQLQuery", "query": "SELECT ..."}, "display": "ActionsLineGraph"}\`. Reach for it when the answer needs a calculation a TrendsQuery cannot express, and keep using an InsightVizNode when it can.
+- Never draw a chart with a local plotting library (matplotlib, plotly, seaborn, and similar) and upload the image as a file. The chart endpoint is the only chart path, so every chart keeps PostHog's styling and opens in PostHog. If a chart genuinely cannot go through the endpoint, give the numbers in your answer text instead.`
       : "";
 
     if (this.slackArtifactDelivery === "message") {
@@ -4648,9 +4649,14 @@ Optimize for the fewest shell round trips.
 - Read multiple files at once.
 - Never rerun a command solely to reproduce output you already have.`;
 
+    // A chart has a dedicated delivery path that keeps PostHog's styling and stays openable in
+    // PostHog, so it must not reach the user as an image a plotting library drew.
+    const chartCarveOut = this.slackChartDelivery
+      ? " A chart is not one of these files: render it through the chart endpoint described below, never as an uploaded image."
+      : "";
     const artifactInstructions = `
 ## Delivering non-code files (artifacts)
-When you create a non-code file the user should be able to download (such as a report, chart, image, archive, or data file), call the \`upload_artifact\` tool with its path before your final reply. In your final reply, link to the download URL returned by the tool—never link to the file's local workspace path. Files left in the workspace don't reach the user. Don't upload source code or repository changes—those belong in a commit or PR.`;
+When you create a non-code file the user should be able to download (such as a report, image, archive, or data file), call the \`upload_artifact\` tool with its path before your final reply.${chartCarveOut} In your final reply, link to the download URL returned by the tool—never link to the file's local workspace path. Files left in the workspace don't reach the user. Don't upload source code or repository changes—those belong in a commit or PR.`;
 
     // Closes out every branch below, so a new section is added once rather than five times.
     const commonInstructions = `${signedCommitInstructions}${stackInstructions}${prLinkInstructions}${shellEfficiencyInstructions}${artifactInstructions}${this.buildSlackDeliveryInstructions()}${this.buildGithubAccessInstructions(hasGithubToken)}${buildStoreSkillsInstructions(this.storeSkillsInstalledCount)}`;

--- a/products/exports/backend/facade/api.py
+++ b/products/exports/backend/facade/api.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Collection
 from datetime import datetime, timedelta
+from typing import Any
 
 from django.conf import settings
 from django.http.response import HttpResponseBase
@@ -145,18 +146,26 @@ def export_limit_context(export_context: dict | None) -> LimitContext:
     return LimitContext.QUERY
 
 
+def is_chartable_export_source(source: Any) -> bool:
+    """Whether the ad-hoc render pipeline draws a chart for ``source`` rather than a JSON dump.
+
+    The pipeline (viewport sizing, the exporter page's Query dispatch) charts an
+    InsightVizNode-wrapped source, or a DataVisualizationNode over HogQL. Callers that build
+    their own export_context gate on this instead of re-deriving the rule, so a caller cannot
+    accept less than the renderer supports.
+    """
+    if not isinstance(source, dict):
+        return False
+    kind = source.get("kind")
+    if kind == "InsightVizNode":
+        return True
+    inner = source.get("source")
+    return kind == "DataVisualizationNode" and isinstance(inner, dict) and inner.get("kind") == "HogQLQuery"
+
+
 def _validate_adhoc_export_context(export_context: dict) -> None:
-    """The ad-hoc render pipeline (viewport sizing, the exporter page's Query dispatch) draws a
-    chart for an InsightVizNode-wrapped source, or for a DataVisualizationNode over HogQL. Anything
-    else renders a JSON dump instead of a chart, so reject it here with a real error instead."""
-    source = export_context.get("source")
-    if isinstance(source, dict):
-        kind = source.get("kind")
-        if kind == "InsightVizNode":
-            return
-        inner = source.get("source")
-        if kind == "DataVisualizationNode" and isinstance(inner, dict) and inner.get("kind") == "HogQLQuery":
-            return
+    if is_chartable_export_source(export_context.get("source")):
+        return
     raise ValueError("export_context.source must be an InsightVizNode- or DataVisualizationNode-wrapped query")
 
 

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -1384,9 +1384,10 @@ class TaskRunLivingArtifactChartRequestSerializer(serializers.Serializer):
     query = InsightQueryJSONField(
         required=False,
         help_text=(
-            "Insight query JSON to render ad hoc, e.g. "
-            '{"kind": "InsightVizNode", "source": {"kind": "TrendsQuery", ...}}. '
-            "SQL queries (DataVisualizationNode, HogQLQuery) are not supported yet. "
+            "Query JSON to render ad hoc, e.g. "
+            '{"kind": "InsightVizNode", "source": {"kind": "TrendsQuery", ...}}, or a HogQL query '
+            'wrapped for charting: {"kind": "DataVisualizationNode", "source": {"kind": "HogQLQuery", '
+            '"query": "SELECT ..."}, "display": "ActionsLineGraph"}. '
             "Provide exactly one of query or insight_id."
         ),
     )

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -60,7 +60,7 @@ from posthog.schema_migrations.upgrade import upgrade
 from posthog.temporal.oauth import SANDBOX_OAUTH_APP_CLIENT_IDS, TASK_AGENT_OAUTH_APP_CLIENT_IDS
 from posthog.utils import absolute_uri
 
-from products.exports.backend.facade.api import render_png_export
+from products.exports.backend.facade.api import is_chartable_export_source, render_png_export
 
 if TYPE_CHECKING:
     from products.exports.backend.facade.api import ExportedAsset
@@ -3850,8 +3850,9 @@ class TaskRunLivingArtifactViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
         },
         summary="Render an insight chart and attach it as a living artifact",
         description=(
-            "Renders a PostHog insight (ad-hoc query JSON or a saved insight) to a PNG server-side and registers "
-            "it as a slack_file living artifact in one call. Blocks until the render finishes."
+            "Renders a PostHog chart (ad-hoc insight query JSON, a HogQL query wrapped in a "
+            "DataVisualizationNode, or a saved insight) to a PNG server-side and registers it as a "
+            "slack_file living artifact in one call. Blocks until the render finishes."
         ),
         strict_request_validation=True,
         operation_id="tasks_runs_living_artifacts_chart",
@@ -3876,7 +3877,8 @@ class TaskRunLivingArtifactViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
         started = perf_counter()
 
         def capture_render(*, failure_reason: str | None = None, export_asset_id: int | None = None) -> None:
-            raw_source = query.get("source") if isinstance(query, dict) else None
+            node: dict = query if isinstance(query, dict) else {}
+            raw_source = node.get("source")
             source: dict = raw_source if isinstance(raw_source, dict) else {}
             posthoganalytics.capture(
                 distinct_id=str(getattr(request.user, "distinct_id", None) or self.team.uuid),
@@ -3886,10 +3888,12 @@ class TaskRunLivingArtifactViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
                     "run_id": run_id,
                     "source": "query" if query is not None else "insight",
                     "insight_id": request.validated_data.get("insight_id"),
+                    "node_kind": node.get("kind"),
                     "query_kind": source.get("kind"),
-                    "display": next(
-                        (f["display"] for f in source.values() if isinstance(f, dict) and f.get("display")), None
-                    ),
+                    # A DataVisualizationNode carries display on the node; an InsightVizNode
+                    # carries it on the source's per-insight filter object.
+                    "display": node.get("display")
+                    or next((f["display"] for f in source.values() if isinstance(f, dict) and f.get("display")), None),
                     "duration_ms": round((perf_counter() - started) * 1000, 2),
                     "failure_reason": failure_reason,
                     "export_asset_id": export_asset_id,
@@ -3898,15 +3902,15 @@ class TaskRunLivingArtifactViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
             )
 
         if query is not None:
-            # Only InsightVizNode renders a chart deterministically; QuerySchemaRoot
-            # also admits kinds that render as table dumps or nothing.
-            if not isinstance(query, dict) or query.get("kind") != "InsightVizNode":
+            # QuerySchemaRoot also admits kinds that render as table dumps or nothing, so gate on
+            # the same predicate the render pipeline uses to decide whether it draws a chart.
+            if not is_chartable_export_source(query):
                 capture_render(failure_reason="unsupported_query")
                 return Response(
                     TaskRunErrorResponseSerializer(
                         {
-                            "error": "Only insight queries wrapped in an InsightVizNode can be charted — "
-                            "SQL and table queries are not supported yet"
+                            "error": "Only an insight query wrapped in an InsightVizNode, or a HogQL query "
+                            "wrapped in a DataVisualizationNode, can be charted"
                         }
                     ).data,
                     status=status.HTTP_400_BAD_REQUEST,
@@ -3995,6 +3999,11 @@ class TaskRunLivingArtifactViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
         if query is not None:
             # absolute_uri rejects the %5C that json.dumps escapes produce, so append the payload
             # after resolving the path (same shape as data_catalog's _deep_link).
+            if query.get("kind") == "DataVisualizationNode":
+                # The SQL editor is where a HogQL-backed chart is editable, and open_query keeps
+                # the node's display and chartSettings. The insight scene would drop both.
+                path = absolute_uri(f"/project/{self.team_id}/sql")
+                return path + f"?open_query={quote(json.dumps(query), safe='')}"
             return absolute_uri(f"/project/{self.team_id}/insights/new") + f"#q={quote(json.dumps(query))}"
         if asset.insight_id and asset.insight:
             return absolute_uri(f"/project/{self.team_id}/insights/{asset.insight.short_id}")

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -10619,21 +10619,48 @@ class TestTaskRunLivingArtifactChartAPI(BaseTaskAPITest):
             },
         )
 
+    @patch("products.tasks.backend.presentation.views.api.tasks_facade.create_task_run_living_artifact")
+    @patch("products.tasks.backend.presentation.views.api.render_png_export")
+    def test_renders_hogql_chart_and_links_to_the_sql_editor(self, mock_render, mock_create):
+        # An answer computed in SQL is only chartable through a DataVisualizationNode, and the
+        # insight scene would drop the node's display, so the link has to reach the SQL editor.
+        query = {
+            "kind": "DataVisualizationNode",
+            "source": {"kind": "HogQLQuery", "query": "SELECT toStartOfMonth(timestamp), count() FROM events"},
+            "display": "ActionsLineGraph",
+        }
+        mock_render.return_value = (self._rendered_asset(), b"png-bytes")
+        mock_create.return_value = (self._artifact_response(), None)
+        response = self._post_chart(["task:write", "query:read"], {"name": "Monthly creates", "query": query})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        sent_query = mock_render.call_args.kwargs["export_context"]["source"]
+        self.assertEqual(sent_query["kind"], "DataVisualizationNode")
+        self.assertEqual(sent_query["display"], "ActionsLineGraph")
+        self.assertEqual(sent_query["source"]["query"], query["source"]["query"])
+        expected_url = (
+            absolute_uri(f"/project/{self.team.id}/sql") + f"?open_query={quote(json.dumps(sent_query), safe='')}"
+        )
+        self.assertEqual(response.json()["url"], expected_url)
+        self.assertEqual(mock_create.call_args.kwargs["artifact"]["metadata"], {"posthog_url": expected_url})
+
     @parameterized.expand(
         [
+            # A DataVisualizationNode only charts over HogQL; over anything else the exporter
+            # page renders a JSON dump.
             (
-                "dataviz_node",
-                {"kind": "DataVisualizationNode", "source": {"kind": "HogQLQuery", "query": "SELECT 1"}},
-                "InsightVizNode",
+                "dataviz_over_trends",
+                {"kind": "DataVisualizationNode", "source": {"kind": "TrendsQuery"}},
+                "can be charted",
             ),
-            ("bare_hogql", {"kind": "HogQLQuery", "query": "SELECT 1"}, "InsightVizNode"),
+            ("dataviz_without_source", {"kind": "DataVisualizationNode"}, "can be charted"),
+            ("bare_hogql", {"kind": "HogQLQuery", "query": "SELECT 1"}, "can be charted"),
             (
                 "datatable_node",
                 {"kind": "DataTableNode", "source": {"kind": "HogQLQuery", "query": "SELECT 1"}},
-                "InsightVizNode",
+                "can be charted",
             ),
-            ("string_query", "SELECT 1", "InsightVizNode"),
-            ("list_kind", {"kind": ["TrendsQuery"]}, "InsightVizNode"),
+            ("string_query", "SELECT 1", "can be charted"),
+            ("list_kind", {"kind": ["TrendsQuery"]}, "can be charted"),
             (
                 "invalid_source_kind",
                 {"kind": "InsightVizNode", "source": {"kind": "NotAQuery"}},

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -4251,7 +4251,7 @@ export interface TaskRunLivingArtifactEditRequestApi {
 }
 
 /**
- * Insight query JSON to render ad hoc, e.g. {"kind": "InsightVizNode", "source": {"kind": "TrendsQuery", ...}}. SQL queries (DataVisualizationNode, HogQLQuery) are not supported yet. Provide exactly one of query or insight_id.
+ * Query JSON to render ad hoc, e.g. {"kind": "InsightVizNode", "source": {"kind": "TrendsQuery", ...}}, or a HogQL query wrapped for charting: {"kind": "DataVisualizationNode", "source": {"kind": "HogQLQuery", "query": "SELECT ..."}, "display": "ActionsLineGraph"}. Provide exactly one of query or insight_id.
  */
 export type TaskRunLivingArtifactChartRequestApiQuery = { [key: string]: unknown }
 
@@ -4261,7 +4261,7 @@ export interface TaskRunLivingArtifactChartRequestApi {
      * @maxLength 255
      */
     name: string
-    /** Insight query JSON to render ad hoc, e.g. {"kind": "InsightVizNode", "source": {"kind": "TrendsQuery", ...}}. SQL queries (DataVisualizationNode, HogQLQuery) are not supported yet. Provide exactly one of query or insight_id. */
+    /** Query JSON to render ad hoc, e.g. {"kind": "InsightVizNode", "source": {"kind": "TrendsQuery", ...}}, or a HogQL query wrapped for charting: {"kind": "DataVisualizationNode", "source": {"kind": "HogQLQuery", "query": "SELECT ..."}, "display": "ActionsLineGraph"}. Provide exactly one of query or insight_id. */
     query?: TaskRunLivingArtifactChartRequestApiQuery
     /** Numeric id of a saved insight to render. Provide exactly one of query or insight_id. */
     insight_id?: number

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -2513,7 +2513,7 @@ export const getTasksRunsLivingArtifactsChartUrl = (projectId: string, taskId: s
 }
 
 /**
- * Renders a PostHog insight (ad-hoc query JSON or a saved insight) to a PNG server-side and registers it as a slack_file living artifact in one call. Blocks until the render finishes.
+ * Renders a PostHog chart (ad-hoc insight query JSON, a HogQL query wrapped in a DataVisualizationNode, or a saved insight) to a PNG server-side and registers it as a slack_file living artifact in one call. Blocks until the render finishes.
  * @summary Render an insight chart and attach it as a living artifact
  */
 export const tasksRunsLivingArtifactsChart = async (

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -3340,7 +3340,7 @@ export const TasksRunsLivingArtifactsEditBody = /* @__PURE__ */ zod.object({
 })
 
 /**
- * Renders a PostHog insight (ad-hoc query JSON or a saved insight) to a PNG server-side and registers it as a slack_file living artifact in one call. Blocks until the render finishes.
+ * Renders a PostHog chart (ad-hoc insight query JSON, a HogQL query wrapped in a DataVisualizationNode, or a saved insight) to a PNG server-side and registers it as a slack_file living artifact in one call. Blocks until the render finishes.
  * @summary Render an insight chart and attach it as a living artifact
  */
 export const tasksRunsLivingArtifactsChartBodyNameMax = 255
@@ -3354,7 +3354,7 @@ export const TasksRunsLivingArtifactsChartBody = /* @__PURE__ */ zod.object({
         .record(zod.string(), zod.unknown())
         .optional()
         .describe(
-            'Insight query JSON to render ad hoc, e.g. {\"kind\": \"InsightVizNode\", \"source\": {\"kind\": \"TrendsQuery\", ...}}. SQL queries (DataVisualizationNode, HogQLQuery) are not supported yet. Provide exactly one of query or insight_id.'
+            'Query JSON to render ad hoc, e.g. {\"kind\": \"InsightVizNode\", \"source\": {\"kind\": \"TrendsQuery\", ...}}, or a HogQL query wrapped for charting: {\"kind\": \"DataVisualizationNode\", \"source\": {\"kind\": \"HogQLQuery\", \"query\": \"SELECT ...\"}, \"display\": \"ActionsLineGraph\"}. Provide exactly one of query or insight_id.'
         ),
     insight_id: zod
         .number()

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -86378,7 +86378,7 @@ export namespace Schemas {
     }
 
     /**
-     * Insight query JSON to render ad hoc, e.g. {"kind": "InsightVizNode", "source": {"kind": "TrendsQuery", ...}}. SQL queries (DataVisualizationNode, HogQLQuery) are not supported yet. Provide exactly one of query or insight_id.
+     * Query JSON to render ad hoc, e.g. {"kind": "InsightVizNode", "source": {"kind": "TrendsQuery", ...}}, or a HogQL query wrapped for charting: {"kind": "DataVisualizationNode", "source": {"kind": "HogQLQuery", "query": "SELECT ..."}, "display": "ActionsLineGraph"}. Provide exactly one of query or insight_id.
      */
     export type TaskRunLivingArtifactChartRequestQuery = { [key: string]: unknown };
 
@@ -86388,7 +86388,7 @@ export namespace Schemas {
          * @maxLength 255
          */
       name: string;
-      /** Insight query JSON to render ad hoc, e.g. {"kind": "InsightVizNode", "source": {"kind": "TrendsQuery", ...}}. SQL queries (DataVisualizationNode, HogQLQuery) are not supported yet. Provide exactly one of query or insight_id. */
+      /** Query JSON to render ad hoc, e.g. {"kind": "InsightVizNode", "source": {"kind": "TrendsQuery", ...}}, or a HogQL query wrapped for charting: {"kind": "DataVisualizationNode", "source": {"kind": "HogQLQuery", "query": "SELECT ..."}, "display": "ActionsLineGraph"}. Provide exactly one of query or insight_id. */
       query?: TaskRunLivingArtifactChartRequestQuery;
       /** Numeric id of a saved insight to render. Provide exactly one of query or insight_id. */
       insight_id?: number;


### PR DESCRIPTION
## Problem

When the Slack agent answers a question whose numbers come out of SQL, it cannot show a PostHog chart. The chart endpoint accepts only an `InsightVizNode`, so the agent falls back to drawing the chart with a local plotting library and uploading the PNG as a file. That image does not match PostHog's chart styling, does not open in PostHog, and arrives as a download link rather than a chart under the answer.

The renderer was never the limit. The export facade already charts a `DataVisualizationNode` over HogQL, and the SQL chart components render on `@posthog/quill-charts`. Only the tasks chart endpoint held the stricter rule.

No open PR or issue covers this — `gh pr list --search` and `gh issue list --search` over the chart endpoint and `DataVisualizationNode` returned nothing.

## Changes

- A HogQL query wrapped in a `DataVisualizationNode` now charts. A Slack answer computed in SQL gets a real PostHog chart instead of a plotting-library image.
- The chart's "Open in PostHog" button sends a SQL-backed chart to the SQL editor, so its display and chart settings survive the trip. The insight scene would drop both.
- The agent is now told to reach for `DataVisualizationNode` when a calculation does not fit a `TrendsQuery`, and never to draw a chart with a local plotting library and upload it as a file.
- Mechanical: the "is this source chartable" rule moves into `is_chartable_export_source` in the exports facade, so the endpoint and the render pipeline read one predicate instead of two copies that can drift.
- Mechanical: the render telemetry records the node kind, and reads `display` off the node for a `DataVisualizationNode`.

## How did you test this code?

Ran against a local dev stack (Postgres, ClickHouse, Kafka, Redis, object storage):

- `products/tasks/backend/tests/test_api.py::TestTaskRunLivingArtifactChartAPI` and `products/exports/backend/tests/test_facade.py` — 34 passed.

New coverage and the regression each case catches:

- `test_renders_hogql_chart_and_links_to_the_sql_editor` — catches re-tightening the endpoint to `InsightVizNode` only, and catches a SQL chart linking to `/insights/new`, where the node's display is dropped.
- `dataviz_over_trends` and `dataviz_without_source` rejection cases — catch widening the gate past what the exporter page draws, which would render a JSON dump as if it were a chart.

Not checked: no TypeScript typecheck for the desktop agent package, because its `node_modules` is not installed in this sandbox; the change there is two string constants and a boolean guard on an existing private member. No end-to-end render of a SQL chart through the exporter.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from a [Slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1788951504225629) asking why one answer arrived as a chart in PostHog's styling and another as a downloadable image from an unfamiliar plotting library, and whether the second case could use quill-charts instead.

Tools: PostHog Slack app (Claude Code agent). Repo skills consulted: `hog-charts-review` (for where `@posthog/quill-charts` lives and which adapters render SQL charts) and `writing-tests` (read from disk; the skill gate is why the rejection cases were folded into the existing parameterized test rather than added as new functions).

The first read of the problem was that arbitrary computed rows would need a new "render these rows" path. Reading the pipeline showed that was unnecessary: `_validate_adhoc_export_context` already blessed `DataVisualizationNode` over HogQL, and the exporter page renders it through `<Query cachedResults=…>`. That reduced the change to relaxing one gate and sharing the predicate. Extracting the predicate rather than duplicating the condition was chosen so the endpoint cannot silently accept less than the renderer supports.

No customer data, thread contents, or analytics figures are in this diff or description.
