### PR TITLE
fix(ai-research): retry transient s3 failures in the image-scrub lane

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-shard-store.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-shard-store.test.ts
@@ -11,17 +11,64 @@ describe('ImageShardStore', () => {
         sourceOffset: 9,
     }
 
-    it('aborts a shard write that exceeds the timeout so the flush throws and replays', async () => {
-        const s3 = {
-            send: (_cmd: unknown, opts: { abortSignal: AbortSignal }) =>
+    const s3Failure = (status?: number) =>
+        Object.assign(
+            new Error('s3 rejected the write'),
+            status === undefined ? {} : { $metadata: { httpStatusCode: status } }
+        )
+    const noSleep = () => Promise.resolve()
+
+    it('retries a shard write that exceeds the timeout, then gives up so the flush replays', async () => {
+        const send = jest.fn(
+            (_cmd: unknown, opts: { abortSignal: AbortSignal }) =>
                 new Promise((_resolve, reject) => {
                     opts.abortSignal.addEventListener('abort', () => reject(new Error('aborted')))
-                }),
-        } as unknown as S3Client
-        const store = new ImageShardStore(s3, 'bucket', 'prefix', 5)
+                })
+        )
+        const store = new ImageShardStore({ send } as unknown as S3Client, 'bucket', 'prefix', 5, 'node', noSleep)
 
-        await expect(store.writeShard([inlineImage])).rejects.toThrow()
+        await expect(store.writeShard([inlineImage])).rejects.toThrow('aborted')
+
+        expect(send).toHaveBeenCalledTimes(3)
     })
+
+    it.each([[500], [502], [503], [429], [undefined]])(
+        'retries a shard write rejected with status %s, so one bad response does not restart the consumer',
+        async (status) => {
+            const send = jest.fn().mockRejectedValueOnce(s3Failure(status)).mockResolvedValue({})
+            const store = new ImageShardStore(
+                { send } as unknown as S3Client,
+                'bucket',
+                'prefix',
+                1_000,
+                'node',
+                noSleep
+            )
+
+            await expect(store.writeShard([inlineImage])).resolves.toMatchObject({ bytes: 3 })
+
+            expect(send).toHaveBeenCalledTimes(3)
+        }
+    )
+
+    it.each([[400], [403], [404]])(
+        'fails a shard write rejected with status %s without retrying, so a refusal does not spend the poll budget',
+        async (status) => {
+            const send = jest.fn().mockRejectedValue(s3Failure(status))
+            const store = new ImageShardStore(
+                { send } as unknown as S3Client,
+                'bucket',
+                'prefix',
+                1_000,
+                'node',
+                noSleep
+            )
+
+            await expect(store.writeShard([inlineImage])).rejects.toThrow('s3 rejected the write')
+
+            expect(send).toHaveBeenCalledTimes(1)
+        }
+    )
 
     it('deletes the orphaned shard when the index write fails', async () => {
         const deleted: string[] = []
@@ -32,7 +79,9 @@ describe('ImageShardStore', () => {
                     return Promise.resolve()
                 }
                 return command.input.Key?.endsWith('.parquet')
-                    ? Promise.reject(new Error('index write failed'))
+                    ? Promise.reject(
+                          Object.assign(new Error('index write failed'), { $metadata: { httpStatusCode: 403 } })
+                      )
                     : Promise.resolve()
             },
         } as unknown as S3Client

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-shard-store.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-shard-store.ts
@@ -2,6 +2,7 @@ import { DeleteObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client
 import { ParquetSchema } from '@dsnp/parquetjs'
 import { randomUUID } from 'node:crypto'
 
+import { logger } from '~/common/utils/logger'
 import { parquetRecordsToBuffer } from '~/ingestion/pipelines/sessionreplay/shared/parquet'
 
 export interface ScrubbedImage {
@@ -31,6 +32,17 @@ const INDEX_FORMAT_VERSION = 1
 const URL_SOURCE_PARTITION_METADATA = 'source-partition'
 const URL_SOURCE_OFFSET_METADATA = 'source-offset'
 const URL_WRITE_MAX_ATTEMPTS = 8
+const S3_WRITE_MAX_ATTEMPTS = 3
+/**
+ * A ceiling on the time one object may spend in retries.
+ *
+ * Each attempt is already capped by writeTimeoutMs, so repeated timeouts across both objects of a
+ * shard write would otherwise approach the 300 second max.poll.interval.ms that governs the whole
+ * batch. The budget ends the retries before a slow flush can cost the pod its partitions.
+ */
+const S3_WRITE_RETRY_BUDGET_MS = 45_000
+const S3_WRITE_RETRY_BASE_MS = 100
+const S3_WRITE_RETRY_MAX_BACKOFF_MS = 2_000
 
 const INDEX_SCHEMA = new ParquetSchema({
     format_version: { type: 'INT64', compression: 'SNAPPY' },
@@ -64,19 +76,60 @@ export class ImageShardStore {
         private readonly bucket: string,
         private readonly prefix: string,
         private readonly writeTimeoutMs: number,
-        nodeId?: string
+        nodeId?: string,
+        // unref'd, so a backoff that is still pending cannot hold the event loop open through shutdown.
+        private readonly sleep: (ms: number) => Promise<void> = (ms) =>
+            new Promise((resolve) => setTimeout(resolve, ms).unref())
     ) {
         this.nodeId = nodeId || process.env.HOSTNAME || randomUUID().slice(0, 8)
     }
 
-    // S3 client has no request timeout; a hung write would stall the poll loop past Kafka's max.poll.interval.ms and evict us.
+    /**
+     * One S3 request, bounded by a timeout and repeated while the failure could still clear.
+     *
+     * The S3 client has no request timeout of its own, so a hung write would stall the poll loop
+     * past Kafka's max.poll.interval.ms and evict the pod. The timeout aborts the request instead,
+     * and the abort is retriable because it says nothing about whether S3 would accept the object.
+     *
+     * Every key this class writes is either unique to one call or created under IfNoneMatch, so a
+     * repeated request writes the same bytes to the same key, or reports the conflict that
+     * writeUrlImage already reads as a result. Retrying is therefore safe for all three commands.
+     */
     private async send(command: PutObjectCommand | DeleteObjectCommand): Promise<void> {
-        const controller = new AbortController()
-        const timer = setTimeout(() => controller.abort(), this.writeTimeoutMs)
-        try {
-            await this.s3.send(command, { abortSignal: controller.signal })
-        } finally {
-            clearTimeout(timer)
+        const startedAtMs = performance.now()
+        for (let attempt = 1; ; attempt++) {
+            const controller = new AbortController()
+            let timedOut = false
+            let failure: unknown
+            const timer = setTimeout(() => {
+                timedOut = true
+                controller.abort()
+            }, this.writeTimeoutMs)
+            try {
+                await this.s3.send(command, { abortSignal: controller.signal })
+                return
+            } catch (error) {
+                failure = error
+            } finally {
+                clearTimeout(timer)
+            }
+            if (
+                attempt >= S3_WRITE_MAX_ATTEMPTS ||
+                performance.now() - startedAtMs >= S3_WRITE_RETRY_BUDGET_MS ||
+                !(timedOut || isTransientS3Failure(failure))
+            ) {
+                throw failure
+            }
+            // The status is the one thing the shutdown path cannot report, and it is what separates
+            // an overloaded bucket from a request S3 refused.
+            logger.warn('🔁', 'image_scrub_s3_write_retry', {
+                key: command.input.Key,
+                attempt,
+                timedOut,
+                status: s3HttpStatus(failure),
+                errorName: s3ErrorName(failure),
+            })
+            await this.sleep(retryBackoffMs(attempt))
         }
     }
 
@@ -182,4 +235,25 @@ function isPreconditionFailed(error: unknown): boolean {
 
 function isConditionalRequestConflict(error: unknown): boolean {
     return s3HttpStatus(error) === 409 || s3ErrorName(error) === 'ConditionalRequestConflict'
+}
+
+/**
+ * Whether repeating the request could produce a different answer.
+ *
+ * A 5xx or a 429 is S3 declining to serve the request now. An error that carries no HTTP status
+ * never reached a response at all, which covers a dropped socket, a DNS failure, and an error body
+ * the SDK could not match to a known shape. The two conditional outcomes are excluded because
+ * writeUrlImage reads them as results rather than as failures.
+ */
+function isTransientS3Failure(error: unknown): boolean {
+    if (isPreconditionFailed(error) || isConditionalRequestConflict(error)) {
+        return false
+    }
+    const status = s3HttpStatus(error)
+    return status === undefined || status >= 500 || status === 429
+}
+
+/** Full jitter, so the pods that one S3 slowdown hits together do not retry in lockstep. */
+function retryBackoffMs(attempt: number): number {
+    return Math.round(Math.random() * Math.min(S3_WRITE_RETRY_MAX_BACKOFF_MS, S3_WRITE_RETRY_BASE_MS * 2 ** attempt))
 }


### PR DESCRIPTION
## Problem

A single transient S3 response restarts an image-scrub pod and raises an alert in #alerts-ai-research.

- Three pods restarted this way in the early hours of 2026-09-09, each raising `IngestionSessionReplayImageScrubConsumerLoopFailed`.
- Two failures were `Unknown: UnknownError`, an S3 error response that the AWS SDK could not match to a modelled shape.
- One failure was `AbortError: Request aborted`, which is the store's own 30 second write timeout.
- `ImageShardStore.writeShard` held no retry, so any rejection left the batch, stopped the consumer loop, and shut the process down.
- Each pod restarted in about six seconds and replayed its uncommitted work, so the lane lost no images. The cost is the restart and the alert.

## Changes

- A transient S3 failure now costs a retry instead of a pod restart.
- `send` repeats a request on a 5xx, on a 429, or on an error that carries no HTTP status.
- The store does not retry an error whose status shows that S3 refused the object.
- The 412 and 409 conditional outcomes stay excluded, so `writeUrlImage` still reads them as results rather than failures.
- Three attempts and a 45 second budget bound the added time, so a slow flush cannot approach `max.poll.interval.ms` and cost the pod its partitions.
- The retry log records the HTTP status, which the shutdown path never reported.
- Backoff uses full jitter, so the pods that one S3 slowdown hits together do not retry in lockstep.
- Nothing user-visible changes. The lane already retained every image, and this removes the restart.

## How did you test this code?

- Added 6 retry cases and 3 no-retry cases to `image-shard-store.test.ts`, parameterized by HTTP status.
- The retry cases catch this PR's regression: one 500, 502, 503, 429, or status-less error stops the consumer loop.
- The no-retry cases catch the opposite regression: a looser predicate would retry a 400, 403, or 404 and spend the poll budget on a refusal.
- Verified red-green. The 6 retry cases fail against the unfixed source and pass with the fix. The 3 no-retry cases pass against both, which is the expected result.
- The 45 second budget has no test. Exercising it needs an injected clock, and the attempt cap already bounds the fast-failure path.
- Not run: any check needing live S3 or the dev stack, because this session had neither.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus 5 in Claude Code, driven by Robbie. The work began as an investigation into two self-resolving alerts and reached this fix through production metrics and logs read over the Grafana MCP.

Skills invoked: `/writing-code-comments`, `/writing-tests`, `/asd-ste100`, `/writing-pr-descriptions`.

`promiseRetry` from `common/utils/retries.ts` was considered and rejected. It retries everything except listed error types, which would retry the 412 and 409 conditional outcomes that `writeUrlImage` treats as results. The file's existing status predicates were extended instead, which keeps the conditional-create path intact.

No duplicate: `gh pr list --state open` searches for "image-scrub s3 retry" and "image scrub consumer loop" returned no related PR.

Public artifact: the diagnosis used production metrics and logs. Everything stated here describes this repository's own service behavior and alert names. No customer data and no internal thread contents reached the diff or this description.

The alert changes that stop these failures paging on rollouts are in PostHog/charts#15365.

