### PR TITLE
fix(replay): exclude JSON-LD URLs from navigation tracking

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/README.md
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/README.md
@@ -15,9 +15,9 @@ The `SessionRecordingIngester` consumes session recording events from Kafka and:
 
 ## Navigation URLs
 
-Navigation URL extraction accepts `data.href` on rrweb Meta events and `data.payload.href` on `$pageview` and `$url_changed` custom events.
-The custom events preserve navigation within single-page applications, which rrweb does not report through Meta events.
-URLs on other events, including `$json_ld`, do not add page visits or clear pending dead-click detection.
+Navigation URL extraction ignores `$json_ld` custom events, so their URLs do not add page visits or clear pending dead-click detection.
+Other events retain the existing extraction behavior: read `data.href`, then fall back to `data.payload.href`.
+This includes the `$pageview` and `$url_changed` custom events used for SPA navigation.
 
 The ML mirror extracts URL metadata separately through the native anonymizer.
 A URL on a mirrored JSON-LD event identifies its page; it does not represent a navigation.

--- a/nodejs/src/ingestion/pipelines/sessionreplay/README.md
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/README.md
@@ -13,6 +13,15 @@ The `SessionRecordingIngester` consumes session recording events from Kafka and:
 - **Extracts console logs** for separate storage and search
 - **Handles failures** via dead letter queue and overflow topics
 
+## Navigation URLs
+
+Navigation URL extraction accepts `data.href` on rrweb Meta events and `data.payload.href` on `$pageview` and `$url_changed` custom events.
+The custom events preserve navigation within single-page applications, which rrweb does not report through Meta events.
+URLs on other events, including `$json_ld`, do not add page visits or clear pending dead-click detection.
+
+The ML mirror extracts URL metadata separately through the native anonymizer.
+A URL on a mirrored JSON-LD event identifies its page; it does not represent a navigation.
+
 ## Local Development
 
 ### Prerequisites

--- a/nodejs/src/ingestion/pipelines/sessionreplay/rrweb-types.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/rrweb-types.ts
@@ -121,16 +121,12 @@ export function hrefFrom(inputEvent: SnapshotEvent): string | undefined {
     const event = inputEvent as
         | { type?: number; data?: { tag?: string; href?: string; payload?: { href?: string } } }
         | undefined
-    if (event?.type === RRWebEventType.Meta) {
-        return event.data?.href?.trim?.() || undefined
+    if (event?.type === RRWebEventType.Custom && event.data?.tag === '$json_ld') {
+        return undefined
     }
-    if (
-        event?.type === RRWebEventType.Custom &&
-        (event.data?.tag === '$pageview' || event.data?.tag === '$url_changed')
-    ) {
-        return event.data?.payload?.href?.trim?.() || undefined
-    }
-    return undefined
+    const metaHref = event?.data?.href?.trim?.()
+    const customHref = event?.data?.payload?.href?.trim?.()
+    return metaHref || customHref || undefined
 }
 
 // Constants for log levels

--- a/nodejs/src/ingestion/pipelines/sessionreplay/rrweb-types.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/rrweb-types.ts
@@ -118,10 +118,19 @@ export function isMouseActivity(inputEvent: SnapshotEvent): boolean {
 }
 
 export function hrefFrom(inputEvent: SnapshotEvent): string | undefined {
-    const event = inputEvent as { type?: number; data?: { href?: string; payload?: { href?: string } } } | undefined
-    const metaHref = event?.data?.href?.trim?.()
-    const customHref = event?.data?.payload?.href?.trim?.()
-    return metaHref || customHref || undefined
+    const event = inputEvent as
+        | { type?: number; data?: { tag?: string; href?: string; payload?: { href?: string } } }
+        | undefined
+    if (event?.type === RRWebEventType.Meta) {
+        return event.data?.href?.trim?.() || undefined
+    }
+    if (
+        event?.type === RRWebEventType.Custom &&
+        (event.data?.tag === '$pageview' || event.data?.tag === '$url_changed')
+    ) {
+        return event.data?.payload?.href?.trim?.() || undefined
+    }
+    return undefined
 }
 
 // Constants for log levels

--- a/nodejs/src/ingestion/pipelines/sessionreplay/sessions/session-feature-recorder.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/sessions/session-feature-recorder.test.ts
@@ -830,35 +830,32 @@ describe('SessionFeatureRecorder', () => {
                 name: 'other custom URL',
                 type: RRWebEventType.Custom,
                 data: { tag: 'other', payload: { href: 'https://example.com/page2' } },
-                navigation: false,
+                navigation: true,
             },
             {
                 name: 'non-custom event URL',
                 type: RRWebEventType.IncrementalSnapshot,
                 data: { href: 'https://example.com/page2' },
-                navigation: false,
+                navigation: true,
             },
-        ])(
-            'tracks navigation and clears dead clicks only for navigation events: $name',
-            ({ type, data, navigation }) => {
-                const events = [
-                    makeNavigationEvent(500, 'https://example.com/'),
-                    makeClickEvent(1000),
-                    { type, timestamp: 2000, data } as unknown as SnapshotEvent,
-                    makeClickEvent(5000),
-                ]
-                recorder.recordMessage(createMessage(events))
-                const result = recorder.end()!
+        ])('tracks navigation URLs while excluding JSON-LD: $name', ({ type, data, navigation }) => {
+            const events = [
+                makeNavigationEvent(500, 'https://example.com/'),
+                makeClickEvent(1000),
+                { type, timestamp: 2000, data } as unknown as SnapshotEvent,
+                makeClickEvent(5000),
+            ]
+            recorder.recordMessage(createMessage(events))
+            const result = recorder.end()!
 
-                expect(result.pageVisitCount).toBe(navigation ? 2 : 1)
-                expect(result.deadClickCount).toBe(navigation ? 0 : 1)
-                expect(result.visitedUrls).toEqual(
-                    navigation
-                        ? [md5Hex('https://example.com/'), md5Hex('https://example.com/page2')]
-                        : [md5Hex('https://example.com/')]
-                )
-            }
-        )
+            expect(result.pageVisitCount).toBe(navigation ? 2 : 1)
+            expect(result.deadClickCount).toBe(navigation ? 0 : 1)
+            expect(result.visitedUrls).toEqual(
+                navigation
+                    ? [md5Hex('https://example.com/'), md5Hex('https://example.com/page2')]
+                    : [md5Hex('https://example.com/')]
+            )
+        })
     })
 
     describe('Console error tracking', () => {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/sessions/session-feature-recorder.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/sessions/session-feature-recorder.test.ts
@@ -795,18 +795,70 @@ describe('SessionFeatureRecorder', () => {
             expect(result.quickBackCount).toBe(0)
         })
 
-        it('should set urlChangedSinceLastClick to allow dead click detection to be cleared', () => {
-            // Click, then navigation, then another click => first click should NOT be dead
-            const events = [
-                makeClickEvent(1000),
-                makeNavigationEvent(2000, 'https://example.com/page2'),
-                makeClickEvent(5000),
-            ]
-            recorder.recordMessage(createMessage(events))
-            const result = recorder.end()!
+        it.each([
+            {
+                name: 'Meta',
+                type: RRWebEventType.Meta,
+                data: { href: ' https://example.com/page2 ' },
+                navigation: true,
+            },
+            {
+                name: 'SPA pageview',
+                type: RRWebEventType.Custom,
+                data: { tag: '$pageview', payload: { href: ' https://example.com/page2 ' } },
+                navigation: true,
+            },
+            {
+                name: 'SPA URL change',
+                type: RRWebEventType.Custom,
+                data: { tag: '$url_changed', payload: { href: 'https://example.com/page2' } },
+                navigation: true,
+            },
+            {
+                name: 'JSON-LD URL',
+                type: RRWebEventType.Custom,
+                data: { tag: '$json_ld', href: 'https://example.com/page2', payload: {} },
+                navigation: false,
+            },
+            {
+                name: 'JSON-LD payload URL',
+                type: RRWebEventType.Custom,
+                data: { tag: '$json_ld', payload: { href: 'https://example.com/page2' } },
+                navigation: false,
+            },
+            {
+                name: 'other custom URL',
+                type: RRWebEventType.Custom,
+                data: { tag: 'other', payload: { href: 'https://example.com/page2' } },
+                navigation: false,
+            },
+            {
+                name: 'non-custom event URL',
+                type: RRWebEventType.IncrementalSnapshot,
+                data: { href: 'https://example.com/page2' },
+                navigation: false,
+            },
+        ])(
+            'tracks navigation and clears dead clicks only for navigation events: $name',
+            ({ type, data, navigation }) => {
+                const events = [
+                    makeNavigationEvent(500, 'https://example.com/'),
+                    makeClickEvent(1000),
+                    { type, timestamp: 2000, data } as unknown as SnapshotEvent,
+                    makeClickEvent(5000),
+                ]
+                recorder.recordMessage(createMessage(events))
+                const result = recorder.end()!
 
-            expect(result.deadClickCount).toBe(0)
-        })
+                expect(result.pageVisitCount).toBe(navigation ? 2 : 1)
+                expect(result.deadClickCount).toBe(navigation ? 0 : 1)
+                expect(result.visitedUrls).toEqual(
+                    navigation
+                        ? [md5Hex('https://example.com/'), md5Hex('https://example.com/page2')]
+                        : [md5Hex('https://example.com/')]
+                )
+            }
+        )
     })
 
     describe('Console error tracking', () => {


### PR DESCRIPTION
## Problem

Replay feature extraction treats JSON-LD event URLs as navigation, inflating page counts and suppressing dead-click detection.
The [SDK JSON-LD URL addition](https://github.com/PostHog/posthog-js/pull/4864) would trigger this behavior.

## Changes

- Exclude `$json_ld` custom events from navigation URL extraction.
- Preserve the existing `data.href` and `data.payload.href` handling for every other event type, including SPA navigation events.

The ML mirror extracts URL metadata separately through the native anonymizer, so its JSON-LD index remains supported.
No UI changes.

Deploy this fix before releasing the SDK URL addition, alongside [the anonymizer URL support](https://github.com/PostHog/posthog/pull/97197).

## How did you test this code?

Parameterized recorder tests check page counts, visited URLs, and dead-click detection for Meta, SPA, JSON-LD, and other event kinds.
The JSON-LD cases reproduce the bug without the guard; the other cases check compatibility with existing URL handling.
Not checked: infrastructure-backed end-to-end tests and production deployment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Documented the JSON-LD exclusion and separate ML-mirror URL extraction in the replay ingestion README.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Codex, Git, and the GitHub CLI in a separate worktree.
Skills: writing-tests, writing-code-comments, writing-pr-descriptions, writing-user-facing-copy, and Simplified Technical English.
