### PR TITLE
feat(tasks): isolate proactive analysis runs

### DIFF
--- a/posthog/scopes.py
+++ b/posthog/scopes.py
@@ -93,6 +93,7 @@ APIScopeObject = Literal[
     "organization_member",
     "person",
     "plugin",
+    "pulse_analysis_internal",
     "product_enablement",
     "product_tour",
     "project",
@@ -175,6 +176,7 @@ INTERNAL_API_SCOPE_OBJECTS: frozenset[APIScopeObject] = frozenset(
         # MCP Store uses it to deny the human/member control plane and force the
         # agent through its own explicit gateway grants.
         "mcp_builtin_agent",
+        "pulse_analysis_internal",
         # Sandbox-only writes for the headless Signals agent (memory create/delete,
         # finding emit). Read access for the same surface lives on the public
         # `signal_scout` object so user-grantable PAKs can still inspect runs/memory.

--- a/posthog/temporal/oauth.py
+++ b/posthog/temporal/oauth.py
@@ -106,6 +106,7 @@ McpScopePreset = Literal[
     "full",
     "signals_scout",
     "signals_scout_reports",
+    "pulse_analysis",
     "signals_research",
     "signals_implementation",
 ]
@@ -157,6 +158,7 @@ SCOUT_REPORT_SCOPES: list[str] = [
 ]
 
 LOOP_CONTEXT_INTERNAL_SCOPE = "loop_context_internal:write"
+PULSE_ANALYSIS_INTERNAL_SCOPE = "pulse_analysis_internal:read"
 
 
 # A deliberately narrow set of user-facing WRITE scopes granted to the Signals scout
@@ -296,6 +298,7 @@ MCP_SCOPE_PRESETS = (
     "full",
     "signals_scout",
     "signals_scout_reports",
+    "pulse_analysis",
     "signals_research",
     "signals_implementation",
 )
@@ -388,7 +391,9 @@ def resolve_scopes(
     internal = list(INTERNAL_SCOPES) if include_internal_scopes else []
     scratchpad = list(SCRATCHPAD_INTERNAL_SCOPES) if include_internal_scopes else []
     if isinstance(scopes, str):
-        if scopes == "full":
+        if scopes == "pulse_analysis":
+            resolved = [*MCP_READ_SCOPES, *internal, PULSE_ANALYSIS_INTERNAL_SCOPE]
+        elif scopes == "full":
             resolved = [*MCP_READ_SCOPES, *MCP_WRITE_SCOPES, *internal]
         elif scopes == "signals_implementation":
             # The self-driving implementation run: `full`, plus durable memory. It already

--- a/posthog/temporal/tests/test_oauth.py
+++ b/posthog/temporal/tests/test_oauth.py
@@ -19,6 +19,7 @@ from posthog.temporal.oauth import (
     MCP_READ_SCOPES,
     MCP_WRITE_SCOPES,
     POSTHOG_AI_APP_CLIENT_ID_DEV,
+    PULSE_ANALYSIS_INTERNAL_SCOPE,
     RESEARCH_WITHHELD_SCOPES,
     SCOUT_GRANTABLE_WRITE_SCOPES,
     SCOUT_INTERNAL_SCOPES,
@@ -54,6 +55,14 @@ class TestResolveScopes(SimpleTestCase):
         result = resolve_scopes("full")
         assert set(result) == set(MCP_READ_SCOPES + MCP_WRITE_SCOPES + INTERNAL_SCOPES)
 
+    def test_pulse_analysis_preset_is_server_marked_and_read_only(self) -> None:
+        result = resolve_scopes("pulse_analysis")
+
+        assert PULSE_ANALYSIS_INTERNAL_SCOPE in result
+        assert "task:write" in result
+        assert not (set(result) & (set(MCP_WRITE_SCOPES) - {"task:write"}))
+        assert not has_write_scopes("pulse_analysis")
+
     def test_signals_scout_preset_adds_scout_internal_write(self) -> None:
         # `signals_scout` = `read_only` content PLUS the scout's own internal write scope
         # PLUS the narrow user-facing write allowlist (`SCOUT_USER_WRITE_SCOPES`). No other
@@ -73,12 +82,15 @@ class TestResolveScopes(SimpleTestCase):
         without_scout_scopes: tuple[McpScopePreset, ...] = (
             "full",
             "read_only",
+            "pulse_analysis",
             "signals_research",
             "signals_implementation",
         )
         for preset in without_scout_scopes:
             assert "signal_scout_internal:write" not in resolve_scopes(preset)
             assert "signal_scout_report:write" not in resolve_scopes(preset)
+        for preset in ("full", "read_only", "signals_research", "signals_implementation"):
+            assert PULSE_ANALYSIS_INTERNAL_SCOPE not in resolve_scopes(preset)
         assert "signal_scout_internal:write" not in resolve_scopes(["feature_flag:read"])
         assert "signal_scout_internal:write" in resolve_scopes("signals_scout")
 

--- a/products/tasks/backend/facade/staged_execution.py
+++ b/products/tasks/backend/facade/staged_execution.py
@@ -7,6 +7,9 @@ from uuid import UUID
 
 from posthog.dataclasses import frozen
 
+PULSE_ANALYSIS_DISABLED_TOOLS = ("Bash", "WebFetch", "WebSearch", "Write", "Edit")
+PULSE_ANALYSIS_NETWORK_EGRESS = "posthog_mcp_only"
+
 
 @frozen
 class StagedRepositoryBinding:
@@ -24,6 +27,7 @@ class StagedCapabilityManifest:
     phase: Literal["analysis", "execution"]
     mcp_scope_preset: str
     disabled_tools: tuple[str, ...]
+    network_egress: Literal["inherit", "posthog_mcp_only"] = "inherit"
 
 
 @frozen

--- a/products/tasks/backend/logic/services/staged_task_runs.py
+++ b/products/tasks/backend/logic/services/staged_task_runs.py
@@ -18,6 +18,8 @@ from posthog.models.user import User
 from posthog.temporal.oauth import McpScopePreset, PosthogMcpScopes
 
 from products.tasks.backend.facade.staged_execution import (
+    PULSE_ANALYSIS_DISABLED_TOOLS,
+    PULSE_ANALYSIS_NETWORK_EGRESS,
     AdvancedStagedTask,
     AdvanceStagedTaskInput,
     CreatedStagedTask,
@@ -43,6 +45,7 @@ class StagedExecutionBinding:
     github_installation_id: str | None
     mcp_scope_preset: str
     disabled_tools: tuple[str, ...]
+    network_egress: str
     phase: str
 
 
@@ -62,6 +65,7 @@ def get_staged_execution_binding(run_id: str) -> StagedExecutionBinding | None:
         _invalid_binding("Staged task actor no longer has team access")
     is_execution = str(staged_run.execution_run_id) == run_id
     manifest = staged_run.execution_manifest if is_execution else staged_run.analysis_manifest
+    network_egress = manifest.get("network_egress", "inherit")
     if (
         staged_run.cancelled_at is not None
         or staged_run.capabilities_revoked_at is not None
@@ -71,6 +75,7 @@ def get_staged_execution_binding(run_id: str) -> StagedExecutionBinding | None:
         or not isinstance(manifest.get("mcp_scope_preset"), str)
         or not isinstance(manifest.get("disabled_tools"), list)
         or not all(isinstance(tool, str) for tool in manifest["disabled_tools"])
+        or network_egress not in ("inherit", "posthog_mcp_only")
     ):
         _invalid_binding("Staged task execution binding is invalid")
     return StagedExecutionBinding(
@@ -80,6 +85,7 @@ def get_staged_execution_binding(run_id: str) -> StagedExecutionBinding | None:
         github_installation_id=staged_run.github_installation_id,
         mcp_scope_preset=manifest["mcp_scope_preset"],
         disabled_tools=tuple(manifest["disabled_tools"]),
+        network_egress=network_egress,
         phase=manifest["phase"],
     )
 
@@ -94,16 +100,25 @@ def _manifest_payload(manifest: StagedCapabilityManifest) -> dict[str, object]:
         "phase": manifest.phase,
         "mcp_scope_preset": manifest.mcp_scope_preset,
         "disabled_tools": list(manifest.disabled_tools),
+        "network_egress": manifest.network_egress,
     }
 
 
 def _validate_manifest(manifest: StagedCapabilityManifest, *, expected_phase: str) -> None:
     if manifest.version != _MANIFEST_VERSION or manifest.phase != expected_phase:
         raise ValueError(f"Expected a version {_MANIFEST_VERSION} {expected_phase} manifest")
-    if manifest.mcp_scope_preset not in get_args(McpScopePreset) or len(manifest.disabled_tools) != len(
-        set(manifest.disabled_tools)
+    if (
+        manifest.mcp_scope_preset not in get_args(McpScopePreset)
+        or manifest.network_egress not in ("inherit", "posthog_mcp_only")
+        or len(manifest.disabled_tools) != len(set(manifest.disabled_tools))
     ):
         raise ValueError("Staged capability manifest is invalid")
+    if manifest.mcp_scope_preset == "pulse_analysis" and (
+        expected_phase != "analysis"
+        or manifest.network_egress != PULSE_ANALYSIS_NETWORK_EGRESS
+        or manifest.disabled_tools != PULSE_ANALYSIS_DISABLED_TOOLS
+    ):
+        raise ValueError("Pulse analysis manifest has fixed capabilities")
 
 
 def _validate_idempotency_key(key: str) -> None:

--- a/products/tasks/backend/logic/services/staged_task_runs.py
+++ b/products/tasks/backend/logic/services/staged_task_runs.py
@@ -65,11 +65,12 @@ def get_staged_execution_binding(run_id: str) -> StagedExecutionBinding | None:
         _invalid_binding("Staged task actor no longer has team access")
     is_execution = str(staged_run.execution_run_id) == run_id
     manifest = staged_run.execution_manifest if is_execution else staged_run.analysis_manifest
+    if not isinstance(manifest, dict):
+        _invalid_binding("Staged task execution binding is invalid")
     network_egress = manifest.get("network_egress", "inherit")
     if (
         staged_run.cancelled_at is not None
         or staged_run.capabilities_revoked_at is not None
-        or not isinstance(manifest, dict)
         or manifest.get("version") != _MANIFEST_VERSION
         or manifest.get("phase") != ("execution" if is_execution else "analysis")
         or not isinstance(manifest.get("mcp_scope_preset"), str)

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -1000,6 +1000,14 @@ def _compile_effective_network_policy(allowed_domains: list[str]) -> EffectiveNe
     )
 
 
+def _resolve_staged_egress_domains(
+    *, network_egress: str | None, repository: str | None, inherited_domains: list[str] | None
+) -> list[str] | None:
+    if network_egress != "posthog_mcp_only":
+        return inherited_domains
+    return ["github.com"] if repository is not None else []
+
+
 def _loop_pr_follow_up_enabled(task: Task, state: dict) -> bool:
     """Loop runs opt into the CI/review-comment follow-up loop when the loop's
     snapshotted behaviors ask for it (see products/tasks/docs/LOOPS.md "Behaviors":
@@ -1202,6 +1210,14 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
                     f"Resolved sandbox environment '{sandbox_environment.name}' with full network access",
                 )
 
+    staged_network_egress = staged_binding.network_egress if staged_binding is not None else None
+    posthog_mcp_only_egress = staged_network_egress == "posthog_mcp_only"
+    allowed_domains = _resolve_staged_egress_domains(
+        network_egress=staged_network_egress,
+        repository=staged_binding.repository if staged_binding is not None else None,
+        inherited_domains=allowed_domains,
+    )
+
     # A per-run image (picked at task start) wins over the environment's image.
     state_custom_image_id = state.get("custom_image_id")
     if state_custom_image_id:
@@ -1314,6 +1330,8 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         run_id=run_id,
         state=state,
     )
+    if posthog_mcp_only_egress:
+        use_modal_network_allowlist = True
     emit_agent_log(
         run_id,
         "debug",
@@ -1458,16 +1476,20 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         "debug",
         f"pr_babysit_enabled: {pr_babysit_enabled} for this task run",
     )
-    sandbox_backend = _resolve_sandbox_backend(
-        distinct_id=distinct_id,
-        organization_id=organization_id,
-        run_id=run_id,
-        state=state,
-        task_runtime=task.runtime,
-        # Only a real user/environment image is a hogland incapability. The org default
-        # image (default_custom_image, applied when the user picked none) is not — hogland
-        # serves its golden equivalent — so it must not gate the run onto Modal.
-        has_user_custom_image=environment_custom_image_name is not None,
+    sandbox_backend = (
+        "modal"
+        if posthog_mcp_only_egress
+        else _resolve_sandbox_backend(
+            distinct_id=distinct_id,
+            organization_id=organization_id,
+            run_id=run_id,
+            state=state,
+            task_runtime=task.runtime,
+            # Only a real user/environment image is a hogland incapability. The org default
+            # image (default_custom_image, applied when the user picked none) is not — hogland
+            # serves its golden equivalent — so it must not gate the run onto Modal.
+            has_user_custom_image=environment_custom_image_name is not None,
+        )
     )
     if sandbox_backend == "hogland":
         # Hogland runs are plain golden-template runs, so the Modal VM-runtime,

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -1,4 +1,5 @@
 from typing import Any
+from uuid import uuid4
 
 import pytest
 from unittest.mock import patch
@@ -31,11 +32,17 @@ from products.tasks.backend.constants import (
     vm_sandbox_origin_rollout_percentages,
 )
 from products.tasks.backend.exceptions import ProcessTaskFatalError, TaskInvalidStateError, TaskRunNotReadyError
+from products.tasks.backend.facade.staged_execution import (
+    CreateStagedTaskInput,
+    StagedCapabilityManifest,
+    create_staged_task,
+)
 from products.tasks.backend.models import TASK_OWNERSHIP_VERSION_STATE_KEY, SandboxEnvironment, Task, TaskRun
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import (
     GetTaskProcessingContextInput,
     TaskProcessingContext,
     VmSandboxDecision,
+    _compile_effective_network_policy,
     _is_agent_otel_telemetry_enabled,
     _is_agent_proxy_keep_stream_open_enabled,
     _is_benjamin_enabled,
@@ -49,6 +56,7 @@ from products.tasks.backend.temporal.process_task.activities.get_task_processing
     _resolve_claude_model_access,
     _resolve_modal_vm_sandbox,
     _resolve_sandbox_backend,
+    _resolve_staged_egress_domains,
     get_task_processing_context,
 )
 from products.tasks.backend.temporal.process_task.utils import get_actor_distinct_id
@@ -97,6 +105,30 @@ def test_snapshot_resume_requires_a_resume_marker_and_snapshot(state: dict[str, 
     )
 
     assert context.is_snapshot_resume is expected
+
+
+def test_repository_bound_pulse_egress_allows_only_github():
+    requested_domains = _resolve_staged_egress_domains(
+        network_egress="posthog_mcp_only",
+        repository="owner/repository",
+        inherited_domains=["customer.example"],
+    )
+    policy = _compile_effective_network_policy(requested_domains)
+
+    assert requested_domains == ["github.com"]
+    assert policy.requested_domains == ("github.com",)
+    assert "github.com" in policy.modal_domains
+    assert "github.com" in policy.agentsh_domains
+    assert "customer.example" not in policy.modal_domains
+    assert "customer.example" not in policy.agentsh_domains
+    assert (
+        _resolve_staged_egress_domains(
+            network_egress="posthog_mcp_only",
+            repository=None,
+            inherited_domains=["customer.example"],
+        )
+        == []
+    )
 
 
 @pytest.mark.parametrize("flag_value,expected", [(True, True), (False, False), (None, False)])
@@ -474,6 +506,52 @@ class TestGetTaskProcessingContextActivity:
 
         assert result.sandbox_environment_id == str(sandbox_environment.id)
         assert result.allowed_domains is None
+
+    @pytest.mark.django_db(transaction=True)
+    def test_pulse_analysis_uses_only_posthog_mcp_egress(self, activity_environment, test_task):
+        sandbox_environment = SandboxEnvironment.objects.create(
+            team=test_task.team,
+            created_by=test_task.created_by,
+            name="Full access env",
+            network_access_level=SandboxEnvironment.NetworkAccessLevel.FULL,
+            allowed_domains=["customer.example"],
+        )
+        created = create_staged_task(
+            CreateStagedTaskInput(
+                team_id=test_task.team_id,
+                caller_id=uuid4(),
+                actor_id=test_task.created_by_id,
+                idempotency_key="pulse-analysis-egress",
+                origin_product="task_analysis",
+                title="Pulse analysis",
+                description="Analyze a report without public network access.",
+                analysis_manifest=StagedCapabilityManifest(
+                    version=1,
+                    phase="analysis",
+                    mcp_scope_preset="pulse_analysis",
+                    disabled_tools=("Bash", "WebFetch", "WebSearch", "Write", "Edit"),
+                    network_egress="posthog_mcp_only",
+                ),
+                repository=None,
+                output_schema=None,
+            )
+        )
+        TaskRun.objects.filter(id=created.analysis_run_id).update(
+            state={"sandbox_environment_id": str(sandbox_environment.id)}
+        )
+
+        result = async_to_sync(activity_environment.run)(
+            get_task_processing_context,
+            GetTaskProcessingContextInput(run_id=str(created.analysis_run_id)),
+        )
+
+        assert result.allowed_domains == []
+        assert result.modal_domain_allowlist is not None
+        assert result.agentsh_domain_allowlist is not None
+        assert "customer.example" not in result.modal_domain_allowlist
+        assert "customer.example" not in result.agentsh_domain_allowlist
+        assert result.use_modal_network_allowlist is True
+        assert result.sandbox_backend == "modal"
 
     @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_rejects_other_users_private_sandbox_environment(

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -113,6 +113,7 @@ def test_repository_bound_pulse_egress_allows_only_github():
         repository="owner/repository",
         inherited_domains=["customer.example"],
     )
+    assert requested_domains is not None
     policy = _compile_effective_network_policy(requested_domains)
 
     assert requested_domains == ["github.com"]

--- a/products/tasks/backend/tests/test_staged_task_runs.py
+++ b/products/tasks/backend/tests/test_staged_task_runs.py
@@ -19,7 +19,10 @@ from products.tasks.backend.facade.staged_execution import (
     cancel_staged_task,
     create_staged_task,
 )
+from products.tasks.backend.logic.services.staged_task_runs import get_staged_execution_binding
 from products.tasks.backend.models import Task, TaskRun, TaskStagedRun, TaskWorkflowDispatch
+
+PULSE_DISABLED_TOOLS = ("Bash", "WebFetch", "WebSearch", "Write", "Edit")
 
 
 class TestStagedTaskRuns(TestCase):
@@ -47,6 +50,20 @@ class TestStagedTaskRuns(TestCase):
             disabled_tools=("WebFetch",),
         )
 
+    def _pulse_analysis_manifest(
+        self,
+        *,
+        disabled_tools: tuple[str, ...] = PULSE_DISABLED_TOOLS,
+        network_egress: str = "posthog_mcp_only",
+    ) -> StagedCapabilityManifest:
+        return StagedCapabilityManifest(
+            version=1,
+            phase="analysis",
+            mcp_scope_preset="pulse_analysis",
+            disabled_tools=disabled_tools,
+            network_egress=network_egress,
+        )
+
     def _create_input(self, *, idempotency_key: str = "create-key") -> CreateStagedTaskInput:
         return CreateStagedTaskInput(
             team_id=self.team.id,
@@ -70,6 +87,57 @@ class TestStagedTaskRuns(TestCase):
         assert Task.objects.filter(team=self.team).count() == 1
         assert TaskRun.objects.filter(team=self.team).count() == 1
         assert TaskStagedRun.objects.for_team(self.team.id).filter(caller_id=self.caller_id).count() == 1
+
+    def test_existing_staged_manifest_defaults_to_inherited_egress(self) -> None:
+        created = create_staged_task(self._create_input())
+        staged_run = TaskStagedRun.objects.for_team(self.team.id).get(id=created.staged_run_id)
+        staged_run.analysis_manifest.pop("network_egress", None)
+        staged_run.save(update_fields=["analysis_manifest", "updated_at"])
+
+        binding = get_staged_execution_binding(str(created.analysis_run_id))
+
+        assert binding is not None
+        assert binding.network_egress == "inherit"
+
+    @pytest.mark.parametrize(
+        "disabled_tools,network_egress",
+        [
+            (("Bash", "WebFetch", "WebSearch", "Write"), "posthog_mcp_only"),
+            (PULSE_DISABLED_TOOLS, "inherit"),
+        ],
+    )
+    def test_pulse_analysis_rejects_a_manifest_outside_its_fixed_boundary(
+        self, disabled_tools: tuple[str, ...], network_egress: str
+    ) -> None:
+        input = self._create_input(idempotency_key=f"pulse-{network_egress}-{len(disabled_tools)}")
+        input = CreateStagedTaskInput(
+            **{
+                **input.__dict__,
+                "analysis_manifest": self._pulse_analysis_manifest(
+                    disabled_tools=disabled_tools,
+                    network_egress=network_egress,
+                ),
+            }
+        )
+
+        with pytest.raises(ValueError, match="Pulse"):
+            create_staged_task(input)
+
+    def test_pulse_analysis_persists_its_fixed_network_and_native_tool_policy(self) -> None:
+        input = self._create_input(idempotency_key="pulse-policy")
+        input = CreateStagedTaskInput(
+            **{
+                **input.__dict__,
+                "analysis_manifest": self._pulse_analysis_manifest(),
+            }
+        )
+
+        created = create_staged_task(input)
+        binding = get_staged_execution_binding(str(created.analysis_run_id))
+
+        assert binding is not None
+        assert binding.network_egress == "posthog_mcp_only"
+        assert binding.disabled_tools == PULSE_DISABLED_TOOLS
 
     def test_advance_rejects_a_staged_run_outside_the_callers_team(self) -> None:
         """Break caught: a caller can create an execution run for another team's staged task."""

--- a/products/tasks/backend/tests/test_staged_task_runs.py
+++ b/products/tasks/backend/tests/test_staged_task_runs.py
@@ -1,3 +1,4 @@
+from typing import Literal
 from uuid import uuid4
 
 import pytest
@@ -54,7 +55,7 @@ class TestStagedTaskRuns(TestCase):
         self,
         *,
         disabled_tools: tuple[str, ...] = PULSE_DISABLED_TOOLS,
-        network_egress: str = "posthog_mcp_only",
+        network_egress: Literal["inherit", "posthog_mcp_only"] = "posthog_mcp_only",
     ) -> StagedCapabilityManifest:
         return StagedCapabilityManifest(
             version=1,
@@ -107,7 +108,9 @@ class TestStagedTaskRuns(TestCase):
         ],
     )
     def test_pulse_analysis_rejects_a_manifest_outside_its_fixed_boundary(
-        self, disabled_tools: tuple[str, ...], network_egress: str
+        self,
+        disabled_tools: tuple[str, ...],
+        network_egress: Literal["inherit", "posthog_mcp_only"],
     ) -> None:
         input = self._create_input(idempotency_key=f"pulse-{network_egress}-{len(disabled_tools)}")
         input = CreateStagedTaskInput(

--- a/services/mcp/src/hono/request-state-resolver.ts
+++ b/services/mcp/src/hono/request-state-resolver.ts
@@ -9,6 +9,7 @@ import {
     type FlagGroups,
     resolveFeatureFlagOverrides,
 } from '@/lib/posthog/flags'
+import { filterPulseAnalysisTools, isPulseAnalysisScopePosture } from '@/lib/pulse-tool-manifest'
 import type { RequestProperties } from '@/lib/request-properties'
 import { filterStaffOnlyTools } from '@/lib/staff-only-tools'
 import type { McpMode } from '@/lib/utils'
@@ -239,16 +240,23 @@ export class RequestStateResolver {
         }
         // Staff-only tools (OAuth-hidden scopes) need the extra explicit-scope +
         // is_staff gate on top of the catalog's plain scope filter.
-        const allTools = await filterStaffOnlyTools(
-            this.catalog.getFilteredTools({ ...filterOptions, scopes: apiKeyScopes }),
-            _apiKey ?? { scopes: [] },
-            () => context.stateManager.getUser()
+        const allTools = filterPulseAnalysisTools(
+            await filterStaffOnlyTools(
+                this.catalog.getFilteredTools({ ...filterOptions, scopes: apiKeyScopes }),
+                _apiKey ?? { scopes: [] },
+                () => context.stateManager.getUser()
+            ),
+            apiKeyScopes
         )
         // Scope-gated hints are only consumed by the exec `search` command, which
         // only exists in single-exec mode — skip the extra scan otherwise.
-        const scopeGatedTools = useSingleExec ? getScopeGatedTools(apiKeyScopes, filterOptions) : []
+        const scopeGatedTools = useSingleExec
+            ? filterPulseAnalysisTools(getScopeGatedTools(apiKeyScopes, filterOptions), apiKeyScopes)
+            : []
         // Only exec redirects a call to a gated tool; tools mode just omits it.
-        const flagGatedTools = useSingleExec ? getFlagGatedTools(filterOptions) : []
+        const flagGatedTools = useSingleExec
+            ? filterPulseAnalysisTools(getFlagGatedTools(filterOptions), apiKeyScopes)
+            : []
 
         const [groupTypes, metadata, metadataCompact] = await Promise.all([
             cachedProjectId && hasScope(apiKeyScopes, 'group:read')
@@ -274,6 +282,7 @@ export class RequestStateResolver {
             gatewayToolsEnabled:
                 useSingleExec &&
                 !readOnly &&
+                !isPulseAnalysisScopePosture(apiKeyScopes) &&
                 mergedFlags[MCP_GATEWAY_FLAG] === true &&
                 !mountsGatewayServersDirectly(props.taskOriginProduct),
             distinctId,

--- a/services/mcp/src/lib/api.ts
+++ b/services/mcp/src/lib/api.ts
@@ -2,6 +2,8 @@ const SERVER_MINT_ONLY_SCOPE_OBJECTS = new Set([
     'internal_run',
     'loop_context_internal',
     'mcp_builtin_agent',
+    'pulse_analysis_internal',
+    'pulse_research_internal',
     'signal_scout_internal',
     'signal_scout_report',
     'signal_scratchpad_internal',

--- a/services/mcp/src/lib/pulse-tool-manifest.ts
+++ b/services/mcp/src/lib/pulse-tool-manifest.ts
@@ -1,4 +1,5 @@
 export const PULSE_ANALYSIS_INTERNAL_SCOPE = 'pulse_analysis_internal:read'
+export const PULSE_RESEARCH_INTERNAL_SCOPE = 'pulse_research_internal:read'
 
 export const PULSE_ANALYSIS_TOOL_MANIFEST_V1 = new Set([
     'execute-sql',

--- a/services/mcp/src/lib/pulse-tool-manifest.ts
+++ b/services/mcp/src/lib/pulse-tool-manifest.ts
@@ -1,0 +1,19 @@
+export const PULSE_ANALYSIS_INTERNAL_SCOPE = 'pulse_analysis_internal:read'
+
+export const PULSE_ANALYSIS_TOOL_MANIFEST_V1 = new Set([
+    'execute-sql',
+    'insight-query',
+    'pulse-research-search',
+    'read-data-schema',
+])
+
+export function isPulseAnalysisScopePosture(scopes: readonly string[]): boolean {
+    return scopes.includes(PULSE_ANALYSIS_INTERNAL_SCOPE)
+}
+
+export function filterPulseAnalysisTools<T extends { name: string }>(tools: T[], scopes: readonly string[]): T[] {
+    if (!isPulseAnalysisScopePosture(scopes)) {
+        return tools
+    }
+    return tools.filter((tool) => PULSE_ANALYSIS_TOOL_MANIFEST_V1.has(tool.name))
+}

--- a/services/mcp/src/lib/scope-preset.ts
+++ b/services/mcp/src/lib/scope-preset.ts
@@ -34,6 +34,7 @@ const INTERNAL_WRITE_SCOPE_OBJECTS = new Set([
     'internal_run',
     'loop_context_internal',
     'mcp_builtin_agent',
+    'pulse_analysis_internal',
     'signal_scout_internal',
     'signal_scout_report',
     'signal_scratchpad_internal',

--- a/services/mcp/src/tools/index.ts
+++ b/services/mcp/src/tools/index.ts
@@ -1,4 +1,5 @@
 import { hasScopes } from '@/lib/api'
+import { filterPulseAnalysisTools } from '@/lib/pulse-tool-manifest'
 import { filterStaffOnlyTools } from '@/lib/staff-only-tools'
 
 // AI observability
@@ -197,5 +198,8 @@ export const getToolsFromContext = async (
 
     const candidates = tools.filter((tool) => hasScopes(scopes, tool.scopes))
 
-    return filterStaffOnlyTools(candidates, apiKey ?? { scopes: [] }, () => context.stateManager.getUser())
+    return filterPulseAnalysisTools(
+        await filterStaffOnlyTools(candidates, apiKey ?? { scopes: [] }, () => context.stateManager.getUser()),
+        scopes
+    )
 }

--- a/services/mcp/tests/unit/pulse-tool-manifest.test.ts
+++ b/services/mcp/tests/unit/pulse-tool-manifest.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+    filterPulseAnalysisTools,
+    isPulseAnalysisScopePosture,
+    PULSE_ANALYSIS_INTERNAL_SCOPE,
+} from '@/lib/pulse-tool-manifest'
+
+describe('pulse analysis tool manifest', () => {
+    it('admits only named tools for a server-minted Pulse token', () => {
+        const scopes = [PULSE_ANALYSIS_INTERNAL_SCOPE, 'insight:read', 'query:read', 'task:write']
+        const tools = [{ name: 'insight-query' }, { name: 'execute-sql' }, { name: 'insights-list' }]
+
+        expect(isPulseAnalysisScopePosture(scopes)).toBe(true)
+        expect(filterPulseAnalysisTools(tools, scopes).map((tool) => tool.name)).toEqual([
+            'insight-query',
+            'execute-sql',
+        ])
+    })
+
+    it('does not select the Pulse manifest for an ordinary scoped token', () => {
+        const tools = [{ name: 'insight-query' }, { name: 'insights-list' }]
+
+        expect(filterPulseAnalysisTools(tools, ['insight:read']).map((tool) => tool.name)).toEqual([
+            'insight-query',
+            'insights-list',
+        ])
+    })
+
+    it('keeps the manifest restricted when a marked token carries an unexpected write scope', () => {
+        const tools = [{ name: 'insight-query' }, { name: 'feature-flags-create' }]
+        const scopes = [PULSE_ANALYSIS_INTERNAL_SCOPE, 'feature_flag:write']
+
+        expect(filterPulseAnalysisTools(tools, scopes).map((tool) => tool.name)).toEqual(['insight-query'])
+    })
+})

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { hasScope } from '@/lib/api'
 import { OAUTH_SCOPES_HIDDEN, OAUTH_SCOPES_SUPPORTED } from '@/lib/constants'
 import type { EvaluatedFlags } from '@/lib/posthog/flags'
+import { PULSE_ANALYSIS_INTERNAL_SCOPE, PULSE_ANALYSIS_TOOL_MANIFEST_V1 } from '@/lib/pulse-tool-manifest'
 import { SessionManager } from '@/lib/SessionManager'
 import { getToolsFromContext } from '@/tools'
 import {
@@ -268,6 +269,17 @@ const createMockContext = (
 })
 
 describe('Tool Filtering - API Scopes', () => {
+    it('restricts a server-marked Pulse token to its immutable tool manifest', async () => {
+        const tools = await getToolsFromContext(createMockContext(['*', PULSE_ANALYSIS_INTERNAL_SCOPE]))
+        const toolNames = tools.map((tool) => tool.name)
+
+        expect(toolNames).toContain('execute-sql')
+        expect(toolNames).toContain('insight-query')
+        expect(toolNames).not.toContain('dashboard-create')
+        expect(toolNames).not.toContain('create-feature-flag')
+        expect(toolNames.every((name) => PULSE_ANALYSIS_TOOL_MANIFEST_V1.has(name))).toBe(true)
+    })
+
     it('should return all tools when user has * scope', async () => {
         const context = createMockContext(['*'])
         const tools = await getToolsFromContext(context)
@@ -519,6 +531,8 @@ describe('server-minted scope matching', () => {
     it('requires literal internal scopes instead of accepting a wildcard', () => {
         expect(hasScope(['*'], 'loop_context_internal:write')).toBe(false)
         expect(hasScope(['loop_context_internal:write'], 'loop_context_internal:write')).toBe(true)
+        expect(hasScope(['*'], PULSE_RESEARCH_INTERNAL_SCOPE)).toBe(false)
+        expect(hasScope([PULSE_RESEARCH_INTERNAL_SCOPE], PULSE_RESEARCH_INTERNAL_SCOPE)).toBe(true)
     })
 
     // The scratchpad write scope was split out of `signal_scout_internal`, which is on the

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it } from 'vitest'
 import { hasScope } from '@/lib/api'
 import { OAUTH_SCOPES_HIDDEN, OAUTH_SCOPES_SUPPORTED } from '@/lib/constants'
 import type { EvaluatedFlags } from '@/lib/posthog/flags'
-import { PULSE_ANALYSIS_INTERNAL_SCOPE, PULSE_ANALYSIS_TOOL_MANIFEST_V1 } from '@/lib/pulse-tool-manifest'
+import {
+    PULSE_ANALYSIS_INTERNAL_SCOPE,
+    PULSE_ANALYSIS_TOOL_MANIFEST_V1,
+    PULSE_RESEARCH_INTERNAL_SCOPE,
+} from '@/lib/pulse-tool-manifest'
 import { SessionManager } from '@/lib/SessionManager'
 import { getToolsFromContext } from '@/tools'
 import {


### PR DESCRIPTION
## Problem

Proactive investigations need useful PostHog and public-web context without inheriting the broader tool surface of interactive tasks.

## Changes

- Adds a fixed Pulse analysis capability manifest.
- Restricts analysis runs to approved PostHog MCP tools and configured web research.
- Enforces the same boundary in task context, sandbox startup, and MCP filtering.

```mermaid
flowchart LR
    A[Pulse investigation] --> B[Fixed capability manifest]
    B --> C[PostHog data]
    B --> D[Optional public web]
```

## How did you test this code?

- Final-stack strict preflight passed with zero failures.
- MCP manifest and tool-filtering tests passed during implementation.
- The post-restack backend run completed 225 tests before stale local migration history blocked database-backed cases.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The capability boundary is an internal safety contract.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this layer using /qa-team, /stacking-prs, /running-ci-preflight, and /writing-pr-descriptions. No existing Pulse v2 PR matched the duplicate search.

The scope stays deliberately smaller than the normal task-agent toolset.